### PR TITLE
feat(server): add dataset label REST endpoints

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -198,6 +198,97 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/dataset_labels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List dataset labels
+         * @description Retrieve a paginated list of all dataset labels in the system.
+         */
+        get: operations["listDatasetLabels"];
+        put?: never;
+        /** Create a dataset label */
+        post: operations["createDatasetLabel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/dataset_labels/{label_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a dataset label by ID */
+        get: operations["getDatasetLabel"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a dataset label by ID
+         * @description Delete a dataset label. This also removes the label from every dataset it is applied to.
+         */
+        delete: operations["deleteDatasetLabel"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a dataset label by ID
+         * @description Partially update a dataset label's name, color, and/or description. Only the fields included in the request body are changed; omitted fields are left as-is.
+         */
+        patch: operations["updateDatasetLabel"];
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/labels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the labels applied to a dataset */
+        get: operations["listDatasetLabelsForDataset"];
+        /**
+         * Replace the set of labels applied to a dataset
+         * @description Replace the entire set of labels applied to a dataset. Labels present in the request but not currently applied are added; labels currently applied but absent from the request are removed. An empty list removes all labels.
+         */
+        put: operations["setDatasetLabelsForDataset"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/labels/{label_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Apply a label to a dataset
+         * @description Apply an existing label to a dataset. This operation is idempotent: applying a label that is already applied is a no-op that returns the label.
+         */
+        put: operations["addDatasetLabelToDataset"];
+        post?: never;
+        /**
+         * Remove a label from a dataset
+         * @description Remove a label from a dataset without deleting the label itself. This operation is idempotent: removing a label that is not applied is a no-op.
+         */
+        delete: operations["removeDatasetLabelFromDataset"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/datasets": {
         parameters: {
             query?: never;
@@ -1421,6 +1512,10 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** AddDatasetLabelToDatasetResponseBody */
+        AddDatasetLabelToDatasetResponseBody: {
+            data: components["schemas"]["DatasetLabel"];
+        };
         /**
          * AgentSpanContext
          * @description Span the user has selected.
@@ -1808,6 +1903,28 @@ export interface components {
             /** Data */
             data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
         };
+        /** CreateDatasetLabelRequestBody */
+        CreateDatasetLabelRequestBody: {
+            /**
+             * Name
+             * @description The name of the dataset label
+             */
+            name: string;
+            /**
+             * Color
+             * @description A lowercase hex color code (e.g. '#00cc88') used to display the label
+             */
+            color: string;
+            /**
+             * Description
+             * @description An optional description of the dataset label
+             */
+            description?: string | null;
+        };
+        /** CreateDatasetLabelResponseBody */
+        CreateDatasetLabelResponseBody: {
+            data: components["schemas"]["DatasetLabel"];
+        };
         /**
          * CreateExperimentRequestBody
          * @description Details of the experiment to be created
@@ -2075,6 +2192,17 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+        };
+        /** DatasetLabel */
+        DatasetLabel: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Color */
+            color: string;
         };
         /** DatasetVersion */
         DatasetVersion: {
@@ -2609,6 +2737,17 @@ export interface components {
             /** Next Cursor */
             next_cursor: string | null;
         };
+        /** GetDatasetLabelResponseBody */
+        GetDatasetLabelResponseBody: {
+            data: components["schemas"]["DatasetLabel"];
+        };
+        /** GetDatasetLabelsResponseBody */
+        GetDatasetLabelsResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetLabel"][];
+            /** Next Cursor */
+            next_cursor: string | null;
+        };
         /** GetDatasetResponseBody */
         GetDatasetResponseBody: {
             data: components["schemas"]["DatasetWithExampleCount"];
@@ -2837,6 +2976,11 @@ export interface components {
         /** ListDatasetExamplesResponseBody */
         ListDatasetExamplesResponseBody: {
             data: components["schemas"]["ListDatasetExamplesData"];
+        };
+        /** ListDatasetLabelsForDatasetResponseBody */
+        ListDatasetLabelsForDatasetResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetLabel"][];
         };
         /** ListDatasetVersionsResponseBody */
         ListDatasetVersionsResponseBody: {
@@ -4371,6 +4515,19 @@ export interface components {
              */
             end_time: string;
         };
+        /** SetDatasetLabelsForDatasetResponseBody */
+        SetDatasetLabelsForDatasetResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetLabel"][];
+        };
+        /** SetDatasetLabelsRequestBody */
+        SetDatasetLabelsRequestBody: {
+            /**
+             * Dataset Label Ids
+             * @description The complete set of dataset label GlobalIDs to apply to the dataset. Labels not in this list are removed from the dataset; an empty list removes all labels.
+             */
+            dataset_label_ids?: string[];
+        };
         /**
          * SourceDocumentUIPart
          * @description A document source part of a message.
@@ -5255,6 +5412,31 @@ export interface components {
             data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
         };
         /**
+         * UpdateDatasetLabelRequestBody
+         * @description Fields to update on a dataset label. Omit a field to leave it unchanged.
+         */
+        UpdateDatasetLabelRequestBody: {
+            /**
+             * Name
+             * @description New name for the label (null is rejected; name is required)
+             */
+            name?: string | null;
+            /**
+             * Color
+             * @description New lowercase hex color code for the label (null is rejected)
+             */
+            color?: string | null;
+            /**
+             * Description
+             * @description New description for the label (null clears the description)
+             */
+            description?: string | null;
+        };
+        /** UpdateDatasetLabelResponseBody */
+        UpdateDatasetLabelResponseBody: {
+            data: components["schemas"]["DatasetLabel"];
+        };
+        /**
          * UpdateExperimentRequestBody
          * @description Fields to update on an experiment. Omit a field to leave it unchanged.
          */
@@ -6043,6 +6225,467 @@ export interface operations {
                 };
             };
             /** @description Invalid parameters */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listDatasetLabels: {
+        parameters: {
+            query?: {
+                /** @description Cursor for pagination (a dataset label GlobalID) */
+                cursor?: string | null;
+                /** @description The max number of dataset labels to return at a time. */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetDatasetLabelsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createDatasetLabel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDatasetLabelRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateDatasetLabelResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset label with the same name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request body */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    getDatasetLabel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the dataset label */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetDatasetLabelResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset label not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset label ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteDatasetLabel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the dataset label */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset label not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset label ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    updateDatasetLabel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the dataset label */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDatasetLabelRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateDatasetLabelResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset label not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset label with the same name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset label ID or request body */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listDatasetLabelsForDataset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either the dataset ID (GlobalID) or its name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListDatasetLabelsForDatasetResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset identifier */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    setDatasetLabelsForDataset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either the dataset ID (GlobalID) or its name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetDatasetLabelsRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetDatasetLabelsForDatasetResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or one or more dataset labels not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset identifier or request body */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    addDatasetLabelToDataset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either the dataset ID (GlobalID) or its name. */
+                dataset_identifier: string;
+                /** @description The ID of the dataset label to apply */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AddDatasetLabelToDatasetResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or dataset label not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset identifier or dataset label ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    removeDatasetLabelFromDataset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either the dataset ID (GlobalID) or its name. */
+                dataset_identifier: string;
+                /** @description The ID of the dataset label to remove */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset identifier or dataset label ID */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -198,6 +198,97 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/dataset_labels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List dataset labels
+         * @description Retrieve a paginated list of all dataset labels in the system.
+         */
+        get: operations["listDatasetLabels"];
+        put?: never;
+        /** Create a dataset label */
+        post: operations["createDatasetLabel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/dataset_labels/{label_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a dataset label by ID */
+        get: operations["getDatasetLabel"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a dataset label by ID
+         * @description Delete a dataset label. This also removes the label from every dataset it is applied to.
+         */
+        delete: operations["deleteDatasetLabel"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a dataset label by ID
+         * @description Partially update a dataset label's name, color, and/or description. Only the fields included in the request body are changed; omitted fields are left as-is.
+         */
+        patch: operations["updateDatasetLabel"];
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/labels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the labels applied to a dataset */
+        get: operations["listDatasetLabelsForDataset"];
+        /**
+         * Replace the set of labels applied to a dataset
+         * @description Replace the entire set of labels applied to a dataset. Labels present in the request but not currently applied are added; labels currently applied but absent from the request are removed. An empty list removes all labels.
+         */
+        put: operations["setDatasetLabelsForDataset"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/labels/{label_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Apply a label to a dataset
+         * @description Apply an existing label to a dataset. This operation is idempotent: applying a label that is already applied is a no-op that returns the label.
+         */
+        put: operations["addDatasetLabelToDataset"];
+        post?: never;
+        /**
+         * Remove a label from a dataset
+         * @description Remove a label from a dataset without deleting the label itself. This operation is idempotent: removing a label that is not applied is a no-op.
+         */
+        delete: operations["removeDatasetLabelFromDataset"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/datasets": {
         parameters: {
             query?: never;
@@ -1421,6 +1512,10 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** AddDatasetLabelToDatasetResponseBody */
+        AddDatasetLabelToDatasetResponseBody: {
+            data: components["schemas"]["DatasetLabel"];
+        };
         /**
          * AgentSpanContext
          * @description Span the user has selected.
@@ -1808,6 +1903,28 @@ export interface components {
             /** Data */
             data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
         };
+        /** CreateDatasetLabelRequestBody */
+        CreateDatasetLabelRequestBody: {
+            /**
+             * Name
+             * @description The name of the dataset label
+             */
+            name: string;
+            /**
+             * Color
+             * @description A lowercase hex color code (e.g. '#00cc88') used to display the label
+             */
+            color: string;
+            /**
+             * Description
+             * @description An optional description of the dataset label
+             */
+            description?: string | null;
+        };
+        /** CreateDatasetLabelResponseBody */
+        CreateDatasetLabelResponseBody: {
+            data: components["schemas"]["DatasetLabel"];
+        };
         /**
          * CreateExperimentRequestBody
          * @description Details of the experiment to be created
@@ -2075,6 +2192,17 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+        };
+        /** DatasetLabel */
+        DatasetLabel: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Color */
+            color: string;
         };
         /** DatasetVersion */
         DatasetVersion: {
@@ -2609,6 +2737,17 @@ export interface components {
             /** Next Cursor */
             next_cursor: string | null;
         };
+        /** GetDatasetLabelResponseBody */
+        GetDatasetLabelResponseBody: {
+            data: components["schemas"]["DatasetLabel"];
+        };
+        /** GetDatasetLabelsResponseBody */
+        GetDatasetLabelsResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetLabel"][];
+            /** Next Cursor */
+            next_cursor: string | null;
+        };
         /** GetDatasetResponseBody */
         GetDatasetResponseBody: {
             data: components["schemas"]["DatasetWithExampleCount"];
@@ -2837,6 +2976,11 @@ export interface components {
         /** ListDatasetExamplesResponseBody */
         ListDatasetExamplesResponseBody: {
             data: components["schemas"]["ListDatasetExamplesData"];
+        };
+        /** ListDatasetLabelsForDatasetResponseBody */
+        ListDatasetLabelsForDatasetResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetLabel"][];
         };
         /** ListDatasetVersionsResponseBody */
         ListDatasetVersionsResponseBody: {
@@ -4371,6 +4515,19 @@ export interface components {
              */
             end_time: string;
         };
+        /** SetDatasetLabelsForDatasetResponseBody */
+        SetDatasetLabelsForDatasetResponseBody: {
+            /** Data */
+            data: components["schemas"]["DatasetLabel"][];
+        };
+        /** SetDatasetLabelsRequestBody */
+        SetDatasetLabelsRequestBody: {
+            /**
+             * Dataset Label Ids
+             * @description The complete set of dataset label GlobalIDs to apply to the dataset. Labels not in this list are removed from the dataset; an empty list removes all labels.
+             */
+            dataset_label_ids?: string[];
+        };
         /**
          * SourceDocumentUIPart
          * @description A document source part of a message.
@@ -5255,6 +5412,31 @@ export interface components {
             data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
         };
         /**
+         * UpdateDatasetLabelRequestBody
+         * @description Fields to update on a dataset label. Omit a field to leave it unchanged.
+         */
+        UpdateDatasetLabelRequestBody: {
+            /**
+             * Name
+             * @description New name for the label (null is rejected; name is required)
+             */
+            name?: string | null;
+            /**
+             * Color
+             * @description New lowercase hex color code for the label (null is rejected)
+             */
+            color?: string | null;
+            /**
+             * Description
+             * @description New description for the label (null clears the description)
+             */
+            description?: string | null;
+        };
+        /** UpdateDatasetLabelResponseBody */
+        UpdateDatasetLabelResponseBody: {
+            data: components["schemas"]["DatasetLabel"];
+        };
+        /**
          * UpdateExperimentRequestBody
          * @description Fields to update on an experiment. Omit a field to leave it unchanged.
          */
@@ -6043,6 +6225,467 @@ export interface operations {
                 };
             };
             /** @description Invalid parameters */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listDatasetLabels: {
+        parameters: {
+            query?: {
+                /** @description Cursor for pagination (a dataset label GlobalID) */
+                cursor?: string | null;
+                /** @description The max number of dataset labels to return at a time. */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetDatasetLabelsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createDatasetLabel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDatasetLabelRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateDatasetLabelResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset label with the same name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request body */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    getDatasetLabel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the dataset label */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetDatasetLabelResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset label not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset label ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteDatasetLabel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the dataset label */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset label not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset label ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    updateDatasetLabel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the dataset label */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDatasetLabelRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateDatasetLabelResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset label not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset label with the same name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset label ID or request body */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    listDatasetLabelsForDataset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either the dataset ID (GlobalID) or its name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListDatasetLabelsForDatasetResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset identifier */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    setDatasetLabelsForDataset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either the dataset ID (GlobalID) or its name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetDatasetLabelsRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetDatasetLabelsForDatasetResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or one or more dataset labels not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset identifier or request body */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    addDatasetLabelToDataset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either the dataset ID (GlobalID) or its name. */
+                dataset_identifier: string;
+                /** @description The ID of the dataset label to apply */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AddDatasetLabelToDatasetResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or dataset label not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset identifier or dataset label ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    removeDatasetLabelFromDataset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either the dataset ID (GlobalID) or its name. */
+                dataset_identifier: string;
+                /** @description The ID of the dataset label to remove */
+                label_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset identifier or dataset label ID */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -57,6 +57,12 @@ class CodeEvaluatorContext(TypedDict):
     evaluatorNodeId: NotRequired[str]
 
 
+class CreateDatasetLabelRequestBody(TypedDict):
+    name: str
+    color: str
+    description: NotRequired[str]
+
+
 class CreateExperimentRequestBody(TypedDict):
     name: NotRequired[str]
     description: NotRequired[str]
@@ -127,6 +133,13 @@ class DatasetExample(TypedDict):
     updated_at: str
 
 
+class DatasetLabel(TypedDict):
+    id: str
+    name: str
+    description: Optional[str]
+    color: str
+
+
 class DatasetVersion(TypedDict):
     version_id: str
     description: Optional[str]
@@ -189,6 +202,15 @@ class FileUIPart(TypedDict):
     url: str
     filename: NotRequired[str]
     providerMetadata: NotRequired[Mapping[str, Mapping[str, Any]]]
+
+
+class GetDatasetLabelResponseBody(TypedDict):
+    data: DatasetLabel
+
+
+class GetDatasetLabelsResponseBody(TypedDict):
+    data: Sequence[DatasetLabel]
+    next_cursor: Optional[str]
 
 
 class GetDatasetResponseBody(TypedDict):
@@ -257,6 +279,10 @@ class ListDatasetExamplesData(TypedDict):
 
 class ListDatasetExamplesResponseBody(TypedDict):
     data: ListDatasetExamplesData
+
+
+class ListDatasetLabelsForDatasetResponseBody(TypedDict):
+    data: Sequence[DatasetLabel]
 
 
 class ListDatasetVersionsResponseBody(TypedDict):
@@ -675,6 +701,14 @@ class SessionTraceData(TypedDict):
     end_time: str
 
 
+class SetDatasetLabelsForDatasetResponseBody(TypedDict):
+    data: Sequence[DatasetLabel]
+
+
+class SetDatasetLabelsRequestBody(TypedDict):
+    dataset_label_ids: NotRequired[Sequence[str]]
+
+
 class SourceDocumentUIPart(TypedDict):
     type: Literal["source-document"]
     sourceId: str
@@ -905,6 +939,16 @@ class TraceSpanData(TypedDict):
     end_time: str
 
 
+class UpdateDatasetLabelRequestBody(TypedDict):
+    name: NotRequired[str]
+    color: NotRequired[str]
+    description: NotRequired[str]
+
+
+class UpdateDatasetLabelResponseBody(TypedDict):
+    data: DatasetLabel
+
+
 class UpdateExperimentRequestBody(TypedDict):
     name: NotRequired[str]
     description: NotRequired[str]
@@ -979,6 +1023,10 @@ class FieldSummarizeResponse(TypedDict):
 
 class ToolCallProviderMetadata(TypedDict):
     tool_execution_environment: Literal["client", "server"]
+
+
+class AddDatasetLabelToDatasetResponseBody(TypedDict):
+    data: DatasetLabel
 
 
 class AnnotateSessionsRequestBody(TypedDict):
@@ -1074,6 +1122,10 @@ class ContinuousAnnotationConfigData(TypedDict):
     description: NotRequired[str]
     lower_bound: NotRequired[float]
     upper_bound: NotRequired[float]
+
+
+class CreateDatasetLabelResponseBody(TypedDict):
+    data: DatasetLabel
 
 
 class CreateExperimentResponseBody(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -16836,7 +16836,8 @@
             "anyOf": [
               {
                 "type": "string",
-                "pattern": "^#([0-9a-f]{6})$"
+                "pattern": "^#([0-9a-f]{6})$",
+                "description": "A lowercase six-digit hex color code (e.g. '#00cc88')"
               },
               {
                 "type": "null"

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -1347,6 +1347,623 @@
         }
       }
     },
+    "/v1/dataset_labels": {
+      "get": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "List dataset labels",
+        "description": "Retrieve a paginated list of all dataset labels in the system.",
+        "operationId": "listDatasetLabels",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Cursor for pagination (a dataset label GlobalID)",
+              "title": "Cursor"
+            },
+            "description": "Cursor for pagination (a dataset label GlobalID)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "description": "The max number of dataset labels to return at a time.",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "The max number of dataset labels to return at a time."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDatasetLabelsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Create a dataset label",
+        "operationId": "createDatasetLabel",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDatasetLabelRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateDatasetLabelResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "A dataset label with the same name already exists"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid request body"
+          }
+        }
+      }
+    },
+    "/v1/dataset_labels/{label_id}": {
+      "get": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Get a dataset label by ID",
+        "operationId": "getDatasetLabel",
+        "parameters": [
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID of the dataset label",
+              "title": "Label Id"
+            },
+            "description": "The ID of the dataset label"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDatasetLabelResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset label not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset label ID"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Update a dataset label by ID",
+        "description": "Partially update a dataset label's name, color, and/or description. Only the fields included in the request body are changed; omitted fields are left as-is.",
+        "operationId": "updateDatasetLabel",
+        "parameters": [
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID of the dataset label",
+              "title": "Label Id"
+            },
+            "description": "The ID of the dataset label"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDatasetLabelRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateDatasetLabelResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset label not found"
+          },
+          "409": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "A dataset label with the same name already exists"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset label ID or request body"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Delete a dataset label by ID",
+        "description": "Delete a dataset label. This also removes the label from every dataset it is applied to.",
+        "operationId": "deleteDatasetLabel",
+        "parameters": [
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID of the dataset label",
+              "title": "Label Id"
+            },
+            "description": "The ID of the dataset label"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset label not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset label ID"
+          }
+        }
+      }
+    },
+    "/v1/datasets/{dataset_identifier}/labels": {
+      "get": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "List the labels applied to a dataset",
+        "operationId": "listDatasetLabelsForDataset",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either the dataset ID (GlobalID) or its name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either the dataset ID (GlobalID) or its name."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDatasetLabelsForDatasetResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset identifier"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Replace the set of labels applied to a dataset",
+        "description": "Replace the entire set of labels applied to a dataset. Labels present in the request but not currently applied are added; labels currently applied but absent from the request are removed. An empty list removes all labels.",
+        "operationId": "setDatasetLabelsForDataset",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either the dataset ID (GlobalID) or its name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either the dataset ID (GlobalID) or its name."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetDatasetLabelsRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetDatasetLabelsForDatasetResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset or one or more dataset labels not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset identifier or request body"
+          }
+        }
+      }
+    },
+    "/v1/datasets/{dataset_identifier}/labels/{label_id}": {
+      "put": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Apply a label to a dataset",
+        "description": "Apply an existing label to a dataset. This operation is idempotent: applying a label that is already applied is a no-op that returns the label.",
+        "operationId": "addDatasetLabelToDataset",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either the dataset ID (GlobalID) or its name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either the dataset ID (GlobalID) or its name."
+          },
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID of the dataset label to apply",
+              "title": "Label Id"
+            },
+            "description": "The ID of the dataset label to apply"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddDatasetLabelToDatasetResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset or dataset label not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset identifier or dataset label ID"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Remove a label from a dataset",
+        "description": "Remove a label from a dataset without deleting the label itself. This operation is idempotent: removing a label that is not applied is a no-op.",
+        "operationId": "removeDatasetLabelFromDataset",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either the dataset ID (GlobalID) or its name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either the dataset ID (GlobalID) or its name."
+          },
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID of the dataset label to remove",
+              "title": "Label Id"
+            },
+            "description": "The ID of the dataset label to remove"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset identifier or dataset label ID"
+          }
+        }
+      }
+    },
     "/v1/datasets": {
       "get": {
         "tags": [
@@ -6783,6 +7400,18 @@
   },
   "components": {
     "schemas": {
+      "AddDatasetLabelToDatasetResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DatasetLabel"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "AddDatasetLabelToDatasetResponseBody"
+      },
       "AgentSpanContext": {
         "properties": {
           "type": {
@@ -7878,6 +8507,52 @@
         ],
         "title": "CreateAnnotationConfigResponseBody"
       },
+      "CreateDatasetLabelRequestBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Name",
+            "description": "The name of the dataset label"
+          },
+          "color": {
+            "type": "string",
+            "pattern": "^#([0-9a-f]{6})$",
+            "title": "Color",
+            "description": "A lowercase hex color code (e.g. '#00cc88') used to display the label"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "An optional description of the dataset label"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "color"
+        ],
+        "title": "CreateDatasetLabelRequestBody"
+      },
+      "CreateDatasetLabelResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DatasetLabel"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateDatasetLabelResponseBody"
+      },
       "CreateExperimentRequestBody": {
         "properties": {
           "name": {
@@ -8478,6 +9153,41 @@
           "updated_at"
         ],
         "title": "DatasetExample"
+      },
+      "DatasetLabel": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "color": {
+            "type": "string",
+            "title": "Color"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "color"
+        ],
+        "title": "DatasetLabel"
       },
       "DatasetVersion": {
         "properties": {
@@ -9759,6 +10469,46 @@
         ],
         "title": "GetAnnotationConfigsResponseBody"
       },
+      "GetDatasetLabelResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DatasetLabel"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GetDatasetLabelResponseBody"
+      },
+      "GetDatasetLabelsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetLabel"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_cursor"
+        ],
+        "title": "GetDatasetLabelsResponseBody"
+      },
       "GetDatasetResponseBody": {
         "properties": {
           "data": {
@@ -10400,6 +11150,22 @@
           "data"
         ],
         "title": "ListDatasetExamplesResponseBody"
+      },
+      "ListDatasetLabelsForDatasetResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetLabel"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListDatasetLabelsForDatasetResponseBody"
       },
       "ListDatasetVersionsResponseBody": {
         "properties": {
@@ -14032,6 +14798,36 @@
         ],
         "title": "SessionTraceData"
       },
+      "SetDatasetLabelsForDatasetResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetLabel"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "SetDatasetLabelsForDatasetResponseBody"
+      },
+      "SetDatasetLabelsRequestBody": {
+        "properties": {
+          "dataset_label_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Dataset Label Ids",
+            "description": "The complete set of dataset label GlobalIDs to apply to the dataset. Labels not in this list are removed from the dataset; an empty list removes all labels."
+          }
+        },
+        "type": "object",
+        "title": "SetDatasetLabelsRequestBody"
+      },
       "SourceDocumentUIPart": {
         "properties": {
           "type": {
@@ -16020,6 +16816,63 @@
           "data"
         ],
         "title": "UpdateAnnotationConfigResponseBody"
+      },
+      "UpdateDatasetLabelRequestBody": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "New name for the label (null is rejected; name is required)"
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^#([0-9a-f]{6})$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color",
+            "description": "New lowercase hex color code for the label (null is rejected)"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "New description for the label (null clears the description)"
+          }
+        },
+        "type": "object",
+        "title": "UpdateDatasetLabelRequestBody",
+        "description": "Fields to update on a dataset label. Omit a field to leave it unchanged."
+      },
+      "UpdateDatasetLabelResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DatasetLabel"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "UpdateDatasetLabelResponseBody"
       },
       "UpdateExperimentRequestBody": {
         "properties": {

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -549,7 +549,11 @@ class _RegexStr(TypeDecorator[re.Pattern[str]]):
         return re.compile(value)
 
 
-_HEX_COLOR_PATTERN = re.compile(r"^#([0-9a-f]{6})$")
+# Regex for a lowercase six-digit hex color (e.g. '#00cc88'). Shared with API
+# request validation (see `HexColor` in `phoenix.server.api.routers.v1.utils`)
+# so invalid colors are rejected before reaching the database.
+HEX_COLOR_REGEX = r"^#([0-9a-f]{6})$"
+_HEX_COLOR_PATTERN = re.compile(HEX_COLOR_REGEX)
 
 
 class _HexColor(TypeDecorator[str]):

--- a/src/phoenix/server/api/routers/v1/__init__.py
+++ b/src/phoenix/server/api/routers/v1/__init__.py
@@ -9,6 +9,7 @@ from phoenix.server.bearer_auth import is_authenticated
 
 from .annotation_configs import router as annotation_configs_router
 from .annotations import router as annotations_router
+from .dataset_labels import router as dataset_labels_router
 from .datasets import router as datasets_router
 from .documents import router as documents_router
 from .experiment_evaluations import router as experiment_evaluations_router
@@ -56,6 +57,7 @@ def create_v1_router(authentication_enabled: bool) -> APIRouter:
     )
     router.include_router(annotation_configs_router)
     router.include_router(annotations_router)
+    router.include_router(dataset_labels_router)
     router.include_router(datasets_router)
     router.include_router(experiments_router)
     router.include_router(experiment_runs_router)

--- a/src/phoenix/server/api/routers/v1/dataset_labels.py
+++ b/src/phoenix/server/api/routers/v1/dataset_labels.py
@@ -14,6 +14,7 @@ from phoenix.db import models
 from phoenix.db.types.db_helper_types import UNDEFINED
 from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
 from phoenix.server.api.routers.v1.utils import (
+    HexColor,
     PaginatedResponseBody,
     ResponseBody,
     add_errors_to_responses,
@@ -29,11 +30,6 @@ router = APIRouter(tags=["datasets"])
 
 DATASET_LABEL_NODE_NAME = DatasetLabelNodeType.__name__
 
-# Mirror the DB-level hex color constraint (see `_HexColor` in `phoenix.db.models`)
-# so that invalid colors are rejected at request-validation time (422) rather than
-# surfacing as an opaque database error.
-_HEX_COLOR_PATTERN = r"^#([0-9a-f]{6})$"
-
 
 class DatasetLabel(V1RoutesBaseModel):
     id: str
@@ -44,9 +40,8 @@ class DatasetLabel(V1RoutesBaseModel):
 
 class DatasetLabelData(V1RoutesBaseModel):
     name: str = Field(..., min_length=1, description="The name of the dataset label")
-    color: str = Field(
+    color: HexColor = Field(
         ...,
-        pattern=_HEX_COLOR_PATTERN,
         description="A lowercase hex color code (e.g. '#00cc88') used to display the label",
     )
     description: Optional[str] = Field(
@@ -68,9 +63,8 @@ class UpdateDatasetLabelRequestBody(V1RoutesBaseModel):
         min_length=1,
         description="New name for the label (null is rejected; name is required)",
     )
-    color: Optional[str] = Field(
+    color: Optional[HexColor] = Field(
         default=UNDEFINED,
-        pattern=_HEX_COLOR_PATTERN,
         description="New lowercase hex color code for the label (null is rejected)",
     )
     description: Optional[str] = Field(

--- a/src/phoenix/server/api/routers/v1/dataset_labels.py
+++ b/src/phoenix/server/api/routers/v1/dataset_labels.py
@@ -1,0 +1,563 @@
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from pydantic import Field
+from sqlalchemy import delete, select, update
+from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
+from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
+from starlette.requests import Request
+from starlette.responses import Response
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.db.types.db_helper_types import UNDEFINED
+from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+from phoenix.server.api.routers.v1.utils import (
+    PaginatedResponseBody,
+    ResponseBody,
+    add_errors_to_responses,
+    get_dataset_by_identifier,
+)
+from phoenix.server.api.types.DatasetLabel import DatasetLabel as DatasetLabelNodeType
+from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.authorization import is_not_locked
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["datasets"])
+
+DATASET_LABEL_NODE_NAME = DatasetLabelNodeType.__name__
+
+# Mirror the DB-level hex color constraint (see `_HexColor` in `phoenix.db.models`)
+# so that invalid colors are rejected at request-validation time (422) rather than
+# surfacing as an opaque database error.
+_HEX_COLOR_PATTERN = r"^#([0-9a-f]{6})$"
+
+
+class DatasetLabel(V1RoutesBaseModel):
+    id: str
+    name: str
+    description: Optional[str]
+    color: str
+
+
+class DatasetLabelData(V1RoutesBaseModel):
+    name: str = Field(..., min_length=1, description="The name of the dataset label")
+    color: str = Field(
+        ...,
+        pattern=_HEX_COLOR_PATTERN,
+        description="A lowercase hex color code (e.g. '#00cc88') used to display the label",
+    )
+    description: Optional[str] = Field(
+        default=None, description="An optional description of the dataset label"
+    )
+
+
+class CreateDatasetLabelRequestBody(DatasetLabelData):
+    pass
+
+
+class UpdateDatasetLabelRequestBody(V1RoutesBaseModel):
+    """
+    Fields to update on a dataset label. Omit a field to leave it unchanged.
+    """
+
+    name: Optional[str] = Field(
+        default=UNDEFINED,
+        min_length=1,
+        description="New name for the label (null is rejected; name is required)",
+    )
+    color: Optional[str] = Field(
+        default=UNDEFINED,
+        pattern=_HEX_COLOR_PATTERN,
+        description="New lowercase hex color code for the label (null is rejected)",
+    )
+    description: Optional[str] = Field(
+        default=UNDEFINED,
+        description="New description for the label (null clears the description)",
+    )
+
+
+class SetDatasetLabelsRequestBody(V1RoutesBaseModel):
+    dataset_label_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "The complete set of dataset label GlobalIDs to apply to the dataset. "
+            "Labels not in this list are removed from the dataset; an empty list "
+            "removes all labels."
+        ),
+    )
+
+
+class GetDatasetLabelsResponseBody(PaginatedResponseBody[DatasetLabel]):
+    pass
+
+
+class GetDatasetLabelResponseBody(ResponseBody[DatasetLabel]):
+    pass
+
+
+class CreateDatasetLabelResponseBody(ResponseBody[DatasetLabel]):
+    pass
+
+
+class UpdateDatasetLabelResponseBody(ResponseBody[DatasetLabel]):
+    pass
+
+
+class ListDatasetLabelsForDatasetResponseBody(ResponseBody[list[DatasetLabel]]):
+    pass
+
+
+class AddDatasetLabelToDatasetResponseBody(ResponseBody[DatasetLabel]):
+    pass
+
+
+class SetDatasetLabelsForDatasetResponseBody(ResponseBody[list[DatasetLabel]]):
+    pass
+
+
+def _db_to_api_dataset_label(dataset_label: models.DatasetLabel) -> DatasetLabel:
+    return DatasetLabel(
+        id=str(GlobalID(DATASET_LABEL_NODE_NAME, str(dataset_label.id))),
+        name=dataset_label.name,
+        description=dataset_label.description,
+        color=dataset_label.color,
+    )
+
+
+def _get_dataset_label_rowid(label_id: str) -> int:
+    try:
+        return from_global_id_with_expected_type(
+            GlobalID.from_id(label_id), DATASET_LABEL_NODE_NAME
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid dataset label ID: {label_id}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Global dataset label CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/dataset_labels",
+    operation_id="listDatasetLabels",
+    summary="List dataset labels",
+    description="Retrieve a paginated list of all dataset labels in the system.",
+    responses=add_errors_to_responses([422]),
+)
+async def list_dataset_labels(
+    request: Request,
+    cursor: Optional[str] = Query(
+        default=None,
+        description="Cursor for pagination (a dataset label GlobalID)",
+    ),
+    limit: int = Query(
+        default=100, gt=0, description="The max number of dataset labels to return at a time."
+    ),
+) -> GetDatasetLabelsResponseBody:
+    cursor_id: Optional[int] = None
+    if cursor:
+        try:
+            cursor_gid = GlobalID.from_id(cursor)
+            if cursor_gid.type_name != DATASET_LABEL_NODE_NAME:
+                raise ValueError
+            cursor_id = int(cursor_gid.node_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail=f"Invalid cursor: {cursor}")
+    async with request.app.state.db() as session:
+        query = (
+            select(models.DatasetLabel)
+            .order_by(models.DatasetLabel.id.desc())
+            .limit(limit + 1)  # overfetch by 1 to check whether there are more results
+        )
+        if cursor_id is not None:
+            query = query.where(models.DatasetLabel.id <= cursor_id)
+        dataset_labels = (await session.scalars(query)).all()
+
+        next_cursor: Optional[str] = None
+        if len(dataset_labels) == limit + 1:
+            last_label = dataset_labels[-1]
+            next_cursor = str(GlobalID(DATASET_LABEL_NODE_NAME, str(last_label.id)))
+            dataset_labels = dataset_labels[:-1]
+
+        return GetDatasetLabelsResponseBody(
+            next_cursor=next_cursor,
+            data=[_db_to_api_dataset_label(label) for label in dataset_labels],
+        )
+
+
+@router.get(
+    "/dataset_labels/{label_id}",
+    operation_id="getDatasetLabel",
+    summary="Get a dataset label by ID",
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset label not found"},
+            {"status_code": 422, "description": "Invalid dataset label ID"},
+        ]
+    ),
+)
+async def get_dataset_label(
+    request: Request,
+    label_id: str = Path(description="The ID of the dataset label"),
+) -> GetDatasetLabelResponseBody:
+    label_rowid = _get_dataset_label_rowid(label_id)
+    async with request.app.state.db() as session:
+        dataset_label = await session.get(models.DatasetLabel, label_rowid)
+        if dataset_label is None:
+            raise HTTPException(status_code=404, detail="Dataset label not found")
+        return GetDatasetLabelResponseBody(data=_db_to_api_dataset_label(dataset_label))
+
+
+@router.post(
+    "/dataset_labels",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="createDatasetLabel",
+    summary="Create a dataset label",
+    status_code=201,
+    responses=add_errors_to_responses(
+        [
+            {
+                "status_code": 409,
+                "description": "A dataset label with the same name already exists",
+            },
+            {"status_code": 422, "description": "Invalid request body"},
+        ]
+    ),
+)
+async def create_dataset_label(
+    request: Request,
+    request_body: CreateDatasetLabelRequestBody,
+) -> CreateDatasetLabelResponseBody:
+    async with request.app.state.db() as session:
+        dataset_label = models.DatasetLabel(
+            name=request_body.name,
+            description=request_body.description,
+            color=request_body.color,
+        )
+        session.add(dataset_label)
+        try:
+            await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise HTTPException(
+                status_code=409,
+                detail=f"A dataset label named '{request_body.name}' already exists",
+            )
+        data = _db_to_api_dataset_label(dataset_label)
+    return CreateDatasetLabelResponseBody(data=data)
+
+
+@router.patch(
+    "/dataset_labels/{label_id}",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="updateDatasetLabel",
+    summary="Update a dataset label by ID",
+    description=(
+        "Partially update a dataset label's name, color, and/or description. Only the "
+        "fields included in the request body are changed; omitted fields are left as-is."
+    ),
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset label not found"},
+            {
+                "status_code": 409,
+                "description": "A dataset label with the same name already exists",
+            },
+            {"status_code": 422, "description": "Invalid dataset label ID or request body"},
+        ]
+    ),
+)
+async def update_dataset_label(
+    request: Request,
+    request_body: UpdateDatasetLabelRequestBody,
+    label_id: str = Path(description="The ID of the dataset label"),
+) -> UpdateDatasetLabelResponseBody:
+    label_rowid = _get_dataset_label_rowid(label_id)
+
+    patch = {
+        column.key: patch_value
+        for column, patch_value, column_is_nullable in (
+            (models.DatasetLabel.name, request_body.name, False),
+            (models.DatasetLabel.color, request_body.color, False),
+            (models.DatasetLabel.description, request_body.description, True),
+        )
+        if patch_value is not UNDEFINED and (patch_value is not None or column_is_nullable)
+    }
+    if not patch:
+        raise HTTPException(status_code=422, detail="No fields to update")
+
+    async with request.app.state.db() as session:
+        try:
+            dataset_label = await session.scalar(
+                update(models.DatasetLabel)
+                .where(models.DatasetLabel.id == label_rowid)
+                .values(**patch)
+                .returning(models.DatasetLabel)
+            )
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise HTTPException(
+                status_code=409,
+                detail=f"A dataset label named '{request_body.name}' already exists",
+            )
+        if dataset_label is None:
+            raise HTTPException(status_code=404, detail="Dataset label not found")
+        data = _db_to_api_dataset_label(dataset_label)
+    return UpdateDatasetLabelResponseBody(data=data)
+
+
+@router.delete(
+    "/dataset_labels/{label_id}",
+    operation_id="deleteDatasetLabel",
+    summary="Delete a dataset label by ID",
+    description=(
+        "Delete a dataset label. This also removes the label from every dataset it is applied to."
+    ),
+    status_code=204,
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset label not found"},
+            {"status_code": 422, "description": "Invalid dataset label ID"},
+        ]
+    ),
+)
+async def delete_dataset_label(
+    request: Request,
+    label_id: str = Path(description="The ID of the dataset label"),
+) -> Response:
+    label_rowid = _get_dataset_label_rowid(label_id)
+    async with request.app.state.db() as session:
+        deleted = await session.scalar(
+            delete(models.DatasetLabel)
+            .where(models.DatasetLabel.id == label_rowid)
+            .returning(models.DatasetLabel.id)
+        )
+        if deleted is None:
+            raise HTTPException(status_code=404, detail="Dataset label not found")
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Dataset <-> label membership
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/datasets/{dataset_identifier}/labels",
+    operation_id="listDatasetLabelsForDataset",
+    summary="List the labels applied to a dataset",
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset not found"},
+            {"status_code": 422, "description": "Invalid dataset identifier"},
+        ]
+    ),
+)
+async def list_dataset_labels_for_dataset(
+    request: Request,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either the dataset ID (GlobalID) or its name.",
+    ),
+) -> ListDatasetLabelsForDatasetResponseBody:
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+        dataset_labels = (
+            await session.scalars(
+                select(models.DatasetLabel)
+                .join(
+                    models.DatasetsDatasetLabel,
+                    models.DatasetsDatasetLabel.dataset_label_id == models.DatasetLabel.id,
+                )
+                .where(models.DatasetsDatasetLabel.dataset_id == dataset.id)
+                .order_by(models.DatasetLabel.id.desc())
+            )
+        ).all()
+    return ListDatasetLabelsForDatasetResponseBody(
+        data=[_db_to_api_dataset_label(label) for label in dataset_labels]
+    )
+
+
+@router.put(
+    "/datasets/{dataset_identifier}/labels/{label_id}",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="addDatasetLabelToDataset",
+    summary="Apply a label to a dataset",
+    description=(
+        "Apply an existing label to a dataset. This operation is idempotent: applying a "
+        "label that is already applied is a no-op that returns the label."
+    ),
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset or dataset label not found"},
+            {"status_code": 422, "description": "Invalid dataset identifier or dataset label ID"},
+        ]
+    ),
+)
+async def add_dataset_label_to_dataset(
+    request: Request,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either the dataset ID (GlobalID) or its name.",
+    ),
+    label_id: str = Path(description="The ID of the dataset label to apply"),
+) -> AddDatasetLabelToDatasetResponseBody:
+    label_rowid = _get_dataset_label_rowid(label_id)
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+        dataset_label = await session.get(models.DatasetLabel, label_rowid)
+        if dataset_label is None:
+            raise HTTPException(status_code=404, detail="Dataset label not found")
+        data = _db_to_api_dataset_label(dataset_label)
+        already_applied = await session.scalar(
+            select(models.DatasetsDatasetLabel).where(
+                models.DatasetsDatasetLabel.dataset_id == dataset.id,
+                models.DatasetsDatasetLabel.dataset_label_id == label_rowid,
+            )
+        )
+        if already_applied is None:
+            session.add(
+                models.DatasetsDatasetLabel(
+                    dataset_id=dataset.id,
+                    dataset_label_id=label_rowid,
+                )
+            )
+            try:
+                await session.flush()
+            except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+                # A concurrent request applied the same label; treat as an idempotent no-op.
+                await session.rollback()
+    return AddDatasetLabelToDatasetResponseBody(data=data)
+
+
+@router.delete(
+    "/datasets/{dataset_identifier}/labels/{label_id}",
+    operation_id="removeDatasetLabelFromDataset",
+    summary="Remove a label from a dataset",
+    description=(
+        "Remove a label from a dataset without deleting the label itself. This operation "
+        "is idempotent: removing a label that is not applied is a no-op."
+    ),
+    status_code=204,
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset not found"},
+            {"status_code": 422, "description": "Invalid dataset identifier or dataset label ID"},
+        ]
+    ),
+)
+async def remove_dataset_label_from_dataset(
+    request: Request,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either the dataset ID (GlobalID) or its name.",
+    ),
+    label_id: str = Path(description="The ID of the dataset label to remove"),
+) -> Response:
+    label_rowid = _get_dataset_label_rowid(label_id)
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+        await session.execute(
+            delete(models.DatasetsDatasetLabel).where(
+                models.DatasetsDatasetLabel.dataset_id == dataset.id,
+                models.DatasetsDatasetLabel.dataset_label_id == label_rowid,
+            )
+        )
+    return Response(status_code=204)
+
+
+@router.put(
+    "/datasets/{dataset_identifier}/labels",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="setDatasetLabelsForDataset",
+    summary="Replace the set of labels applied to a dataset",
+    description=(
+        "Replace the entire set of labels applied to a dataset. Labels present in the "
+        "request but not currently applied are added; labels currently applied but absent "
+        "from the request are removed. An empty list removes all labels."
+    ),
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset or one or more dataset labels not found"},
+            {"status_code": 422, "description": "Invalid dataset identifier or request body"},
+        ]
+    ),
+)
+async def set_dataset_labels_for_dataset(
+    request: Request,
+    request_body: SetDatasetLabelsRequestBody,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either the dataset ID (GlobalID) or its name.",
+    ),
+) -> SetDatasetLabelsForDatasetResponseBody:
+    # De-duplicate while preserving order.
+    label_rowids: dict[int, None] = {}
+    for label_id in request_body.dataset_label_ids:
+        label_rowids[_get_dataset_label_rowid(label_id)] = None
+
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+
+        if label_rowids:
+            existing_label_rowids = set(
+                (
+                    await session.scalars(
+                        select(models.DatasetLabel.id).where(
+                            models.DatasetLabel.id.in_(label_rowids.keys())
+                        )
+                    )
+                ).all()
+            )
+            if len(existing_label_rowids) != len(label_rowids):
+                raise HTTPException(status_code=404, detail="One or more dataset labels not found")
+
+        currently_applied = {
+            row.dataset_label_id
+            for row in (
+                await session.scalars(
+                    select(models.DatasetsDatasetLabel).where(
+                        models.DatasetsDatasetLabel.dataset_id == dataset.id
+                    )
+                )
+            ).all()
+        }
+
+        to_add = [rowid for rowid in label_rowids if rowid not in currently_applied]
+        if to_add:
+            session.add_all(
+                [
+                    models.DatasetsDatasetLabel(
+                        dataset_id=dataset.id,
+                        dataset_label_id=rowid,
+                    )
+                    for rowid in to_add
+                ]
+            )
+
+        to_remove = [rowid for rowid in currently_applied if rowid not in label_rowids]
+        if to_remove:
+            await session.execute(
+                delete(models.DatasetsDatasetLabel).where(
+                    models.DatasetsDatasetLabel.dataset_id == dataset.id,
+                    models.DatasetsDatasetLabel.dataset_label_id.in_(to_remove),
+                )
+            )
+
+        await session.flush()
+
+        dataset_labels = (
+            await session.scalars(
+                select(models.DatasetLabel)
+                .join(
+                    models.DatasetsDatasetLabel,
+                    models.DatasetsDatasetLabel.dataset_label_id == models.DatasetLabel.id,
+                )
+                .where(models.DatasetsDatasetLabel.dataset_id == dataset.id)
+                .order_by(models.DatasetLabel.id.desc())
+            )
+        ).all()
+    return SetDatasetLabelsForDatasetResponseBody(
+        data=[_db_to_api_dataset_label(label) for label in dataset_labels]
+    )

--- a/src/phoenix/server/api/routers/v1/utils.py
+++ b/src/phoenix/server/api/routers/v1/utils.py
@@ -1,6 +1,7 @@
-from typing import Any, Generic, Optional, TypedDict, TypeVar, Union
+from typing import Annotated, Any, Generic, Optional, TypedDict, TypeVar, Union
 
 from fastapi import HTTPException
+from pydantic import Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
@@ -18,6 +19,20 @@ DataType = TypeVar("DataType")
 Responses: TypeAlias = dict[
     Union[int, str], dict[str, Any]
 ]  # input type for the `responses` parameter of a fastapi route
+
+HexColor: TypeAlias = Annotated[
+    str,
+    Field(
+        pattern=models.HEX_COLOR_REGEX,
+        description="A lowercase six-digit hex color code (e.g. '#00cc88')",
+    ),
+]
+"""
+A request-body field type for hex colors. Validates against the same pattern
+enforced at the database layer (`_HexColor` in `phoenix.db.models`) so that
+invalid colors are rejected at request-validation time (422) rather than
+surfacing as an opaque database error.
+"""
 
 
 class StatusCodeWithDescription(TypedDict):

--- a/src/phoenix/server/api/routers/v1/utils.py
+++ b/src/phoenix/server/api/routers/v1/utils.py
@@ -7,6 +7,7 @@ from strawberry.relay import GlobalID
 from typing_extensions import TypeAlias, assert_never
 
 from phoenix.db import models
+from phoenix.server.api.types.Dataset import Dataset as DatasetNodeType
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Project import Project as ProjectNodeType
 
@@ -149,3 +150,44 @@ async def get_project_by_identifier(
                 detail=f"Project with ID {project_identifier} not found",
             )
     return project
+
+
+async def get_dataset_by_identifier(
+    session: AsyncSession,
+    dataset_identifier: str,
+) -> models.Dataset:
+    """
+    Get a dataset by its ID or name.
+
+    Args:
+        session: The database session.
+        dataset_identifier: The dataset ID (GlobalID) or name.
+
+    Returns:
+        The dataset object.
+
+    Raises:
+        HTTPException: If the identifier format is invalid or the dataset is not found.
+    """
+    # Try to parse as a GlobalID first; otherwise, treat the identifier as a name.
+    try:
+        id_ = from_global_id_with_expected_type(
+            GlobalID.from_id(dataset_identifier),
+            DatasetNodeType.__name__,
+        )
+    except Exception:
+        stmt = select(models.Dataset).filter_by(name=dataset_identifier)
+        dataset = await session.scalar(stmt)
+        if dataset is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Dataset with name {dataset_identifier} not found",
+            )
+    else:
+        dataset = await session.get(models.Dataset, id_)
+        if dataset is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Dataset with ID {dataset_identifier} not found",
+            )
+    return dataset

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2185,6 +2185,10 @@ _COMMON_RESOURCE_ENDPOINTS = (
     (422, "GET", "v1/datasets/fake-id-{}/jsonl"),
     (422, "GET", "v1/datasets/fake-id-{}/jsonl/openai_ft"),
     (422, "GET", "v1/datasets/fake-id-{}/jsonl/openai_evals"),
+    # Dataset labels
+    (200, "GET", "v1/dataset_labels"),
+    (422, "GET", "v1/dataset_labels/fake-id-{}"),
+    (404, "GET", "v1/datasets/fake-id-{}/labels"),
     # Experiments
     (422, "GET", "v1/experiments/fake-id-{}"),
     (422, "GET", "v1/datasets/fake-id-{}/experiments"),
@@ -2237,6 +2241,7 @@ _ADMIN_ONLY_ENDPOINTS = (
 _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     # POST routes
     (422, "POST", "v1/annotation_configs"),
+    (422, "POST", "v1/dataset_labels"),
     (400, "POST", "v1/datasets/upload"),
     (422, "POST", "v1/datasets/fake-id-{}/experiments"),
     (422, "POST", "v1/document_annotations"),
@@ -2256,10 +2261,15 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (415, "POST", "v1/traces"),
     # PUT routes
     (422, "PUT", "v1/annotation_configs/fake-id-{}"),
+    (422, "PUT", "v1/datasets/fake-id-{}/labels"),
+    (422, "PUT", "v1/datasets/fake-id-{}/labels/test-label"),
     # PATCH routes
     (422, "PATCH", "v1/experiments/fake-id-{}"),
+    (422, "PATCH", "v1/dataset_labels/fake-id-{}"),
     # DELETE routes
     (422, "DELETE", "v1/annotation_configs/fake-id-{}"),
+    (422, "DELETE", "v1/dataset_labels/fake-id-{}"),
+    (422, "DELETE", "v1/datasets/fake-id-{}/labels/test-label"),
     (422, "DELETE", "v1/datasets/fake-id-{}"),
     (422, "DELETE", "v1/experiments/fake-id-{}"),
     (404, "DELETE", "v1/sessions/fake-id-{}"),
@@ -2322,6 +2332,7 @@ def _ensure_endpoint_coverage_is_exhaustive() -> None:
         path = re.sub(r"fake-id-\{\}", "{id}", path)
         path = re.sub(r"\{[^}]*\}", "{id}", path)
         path = re.sub(r"/tags/test-tag$", "/tags/{id}", path)
+        path = re.sub(r"/labels/test-label$", "/labels/{id}", path)
         return path
 
     # Map normalized paths back to original paths for error reporting

--- a/tests/integration/dataset_labels/conftest.py
+++ b/tests/integration/dataset_labels/conftest.py
@@ -1,0 +1,25 @@
+from typing import Iterator, Mapping
+
+import pytest
+
+from .._helpers import _AppInfo, _server
+
+
+@pytest.fixture(scope="package")
+def _app(
+    _env: dict[str, str],
+) -> Iterator[_AppInfo]:
+    with _server(_AppInfo(_env)) as app:
+        yield app
+
+
+@pytest.fixture(scope="package")
+def _env(
+    _env_ports: Mapping[str, str],
+    _env_database: Mapping[str, str],
+) -> dict[str, str]:
+    """Combine all environment variable configurations for testing."""
+    return {
+        **_env_ports,
+        **_env_database,
+    }

--- a/tests/integration/dataset_labels/test_dataset_labels.py
+++ b/tests/integration/dataset_labels/test_dataset_labels.py
@@ -1,0 +1,187 @@
+from secrets import token_hex
+from typing import Any
+
+from .._helpers import _AppInfo, _gql, _httpx_client
+
+
+def _create_dataset(app: _AppInfo, name: str) -> str:
+    """Create a dataset via GraphQL and return its GlobalID."""
+    resp, _ = _gql(
+        app,
+        query=(
+            "mutation ($name: String!) {"
+            "  createDataset(input: {name: $name}) { dataset { id name } }"
+            "}"
+        ),
+        variables={"name": name},
+    )
+    assert not resp.get("errors"), resp.get("errors")
+    return str(resp["data"]["createDataset"]["dataset"]["id"])
+
+
+def _create_label(app: _AppInfo, **body: Any) -> dict[str, Any]:
+    resp = _httpx_client(app).post("v1/dataset_labels", json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["data"]
+
+
+class TestDatasetLabelCRUD:
+    def test_create_get_update_delete(self, _app: _AppInfo) -> None:
+        name = f"label-{token_hex(4)}"
+        # create
+        label = _create_label(_app, name=name, color="#00cc88", description="curated reference set")
+        label_id = label["id"]
+        assert label["name"] == name
+        assert label["color"] == "#00cc88"
+        assert label["description"] == "curated reference set"
+
+        client = _httpx_client(_app)
+
+        # get by id
+        got = client.get(f"v1/dataset_labels/{label_id}")
+        assert got.status_code == 200, got.text
+        assert got.json()["data"] == label
+
+        # list includes it
+        listed = client.get("v1/dataset_labels")
+        assert listed.status_code == 200, listed.text
+        assert any(item["id"] == label_id for item in listed.json()["data"])
+
+        # partial update: change color only, leave name/description untouched
+        patched = client.patch(f"v1/dataset_labels/{label_id}", json={"color": "#123456"})
+        assert patched.status_code == 200, patched.text
+        patched_data = patched.json()["data"]
+        assert patched_data["color"] == "#123456"
+        assert patched_data["name"] == name
+        assert patched_data["description"] == "curated reference set"
+
+        # partial update: clear description with explicit null
+        cleared = client.patch(f"v1/dataset_labels/{label_id}", json={"description": None})
+        assert cleared.status_code == 200, cleared.text
+        assert cleared.json()["data"]["description"] is None
+
+        # delete
+        deleted = client.delete(f"v1/dataset_labels/{label_id}")
+        assert deleted.status_code == 204, deleted.text
+
+        # subsequent get is 404
+        assert client.get(f"v1/dataset_labels/{label_id}").status_code == 404
+
+    def test_duplicate_name_conflicts(self, _app: _AppInfo) -> None:
+        name = f"label-{token_hex(4)}"
+        _create_label(_app, name=name, color="#abcdef")
+        dup = _httpx_client(_app).post("v1/dataset_labels", json={"name": name, "color": "#fedcba"})
+        assert dup.status_code == 409, dup.text
+
+    def test_invalid_color_is_rejected(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app)
+        for bad_color in ("not-a-color", "#GGGGGG", "#FFF", "#FFFFFF"):
+            resp = client.post(
+                "v1/dataset_labels",
+                json={"name": f"label-{token_hex(4)}", "color": bad_color},
+            )
+            assert resp.status_code == 422, f"{bad_color!r} -> {resp.status_code}"
+
+    def test_get_unknown_label_is_404(self, _app: _AppInfo) -> None:
+        # Delete a freshly created label, then look it up.
+        label = _create_label(_app, name=f"label-{token_hex(4)}", color="#00cc88")
+        client = _httpx_client(_app)
+        client.delete(f"v1/dataset_labels/{label['id']}")
+        assert client.get(f"v1/dataset_labels/{label['id']}").status_code == 404
+
+    def test_invalid_label_id_is_422(self, _app: _AppInfo) -> None:
+        assert _httpx_client(_app).get("v1/dataset_labels/not-a-global-id").status_code == 422
+
+
+class TestDatasetLabelMembership:
+    def test_assign_list_and_unassign(self, _app: _AppInfo) -> None:
+        dataset_id = _create_dataset(_app, f"ds-{token_hex(4)}")
+        label = _create_label(_app, name=f"label-{token_hex(4)}", color="#00cc88")
+        label_id = label["id"]
+        client = _httpx_client(_app)
+
+        # initially no labels
+        empty = client.get(f"v1/datasets/{dataset_id}/labels")
+        assert empty.status_code == 200, empty.text
+        assert empty.json()["data"] == []
+
+        # assign (returns the label)
+        assigned = client.put(f"v1/datasets/{dataset_id}/labels/{label_id}")
+        assert assigned.status_code == 200, assigned.text
+        assert assigned.json()["data"]["id"] == label_id
+
+        # idempotent re-assign is a no-op success
+        again = client.put(f"v1/datasets/{dataset_id}/labels/{label_id}")
+        assert again.status_code == 200, again.text
+
+        # the label now shows on the dataset (exactly once)
+        listed = client.get(f"v1/datasets/{dataset_id}/labels")
+        assert listed.status_code == 200, listed.text
+        ids = [item["id"] for item in listed.json()["data"]]
+        assert ids == [label_id]
+
+        # unassign
+        removed = client.delete(f"v1/datasets/{dataset_id}/labels/{label_id}")
+        assert removed.status_code == 204, removed.text
+
+        # idempotent re-remove is a no-op success
+        removed_again = client.delete(f"v1/datasets/{dataset_id}/labels/{label_id}")
+        assert removed_again.status_code == 204, removed_again.text
+
+        # gone from the dataset, but the label itself still exists
+        assert client.get(f"v1/datasets/{dataset_id}/labels").json()["data"] == []
+        assert client.get(f"v1/dataset_labels/{label_id}").status_code == 200
+
+    def test_assign_by_dataset_name(self, _app: _AppInfo) -> None:
+        name = f"ds-{token_hex(4)}"
+        _create_dataset(_app, name)
+        label = _create_label(_app, name=f"label-{token_hex(4)}", color="#00cc88")
+        client = _httpx_client(_app)
+        assigned = client.put(f"v1/datasets/{name}/labels/{label['id']}")
+        assert assigned.status_code == 200, assigned.text
+        listed = client.get(f"v1/datasets/{name}/labels")
+        assert [item["id"] for item in listed.json()["data"]] == [label["id"]]
+
+    def test_assign_to_unknown_dataset_is_404(self, _app: _AppInfo) -> None:
+        label = _create_label(_app, name=f"label-{token_hex(4)}", color="#00cc88")
+        resp = _httpx_client(_app).put(f"v1/datasets/no-such-dataset/labels/{label['id']}")
+        assert resp.status_code == 404, resp.text
+
+    def test_bulk_replace(self, _app: _AppInfo) -> None:
+        dataset_id = _create_dataset(_app, f"ds-{token_hex(4)}")
+        label_a = _create_label(_app, name=f"label-{token_hex(4)}", color="#00cc88")["id"]
+        label_b = _create_label(_app, name=f"label-{token_hex(4)}", color="#112233")["id"]
+        label_c = _create_label(_app, name=f"label-{token_hex(4)}", color="#445566")["id"]
+        client = _httpx_client(_app)
+
+        # set {a, b}
+        resp = client.put(
+            f"v1/datasets/{dataset_id}/labels",
+            json={"dataset_label_ids": [label_a, label_b]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert {item["id"] for item in resp.json()["data"]} == {label_a, label_b}
+
+        # replace with {b, c} (adds c, removes a)
+        resp = client.put(
+            f"v1/datasets/{dataset_id}/labels",
+            json={"dataset_label_ids": [label_b, label_c]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert {item["id"] for item in resp.json()["data"]} == {label_b, label_c}
+
+        # clearing with an empty list removes all
+        resp = client.put(f"v1/datasets/{dataset_id}/labels", json={"dataset_label_ids": []})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"] == []
+
+    def test_bulk_replace_with_unknown_label_is_404(self, _app: _AppInfo) -> None:
+        dataset_id = _create_dataset(_app, f"ds-{token_hex(4)}")
+        # A well-formed but non-existent label GlobalID.
+        missing_label = _create_label(_app, name=f"label-{token_hex(4)}", color="#00cc88")["id"]
+        _httpx_client(_app).delete(f"v1/dataset_labels/{missing_label}")
+        resp = _httpx_client(_app).put(
+            f"v1/datasets/{dataset_id}/labels",
+            json={"dataset_label_ids": [missing_label]},
+        )
+        assert resp.status_code == 404, resp.text

--- a/tests/integration/dataset_labels/test_dataset_labels.py
+++ b/tests/integration/dataset_labels/test_dataset_labels.py
@@ -22,7 +22,8 @@ def _create_dataset(app: _AppInfo, name: str) -> str:
 def _create_label(app: _AppInfo, **body: Any) -> dict[str, Any]:
     resp = _httpx_client(app).post("v1/dataset_labels", json=body)
     assert resp.status_code == 201, resp.text
-    return resp.json()["data"]
+    data: dict[str, Any] = resp.json()["data"]
+    return data
 
 
 class TestDatasetLabelCRUD:


### PR DESCRIPTION
resolves #14019

## Summary

Dataset labels previously had no REST coverage. Inspecting the DB model confirmed the issue's **option 1**: a dataset label is a **global, reusable entity** (`dataset_labels`, unique `name`) assigned to datasets **many-to-many** through the `datasets_dataset_labels` join table. Per the issue guidance, this follows the **idempotent membership pattern** (from #14016) for the dataset↔label association, plus **separate global label CRUD**.

### Global label CRUD — `/v1/dataset_labels`
| Method | Path | Notes |
|---|---|---|
| `GET` | `/dataset_labels` | Paginated list (cursor-based) |
| `POST` | `/dataset_labels` | Create → `201`; `409` on duplicate name |
| `GET` | `/dataset_labels/{label_id}` | Fetch one |
| `PATCH` | `/dataset_labels/{label_id}` | Partial update (omitted fields untouched; `null` clears description) |
| `DELETE` | `/dataset_labels/{label_id}` | Delete → `204` (also detaches from all datasets) |

### Dataset ↔ label membership — nested under `/v1/datasets`
| Method | Path | Notes |
|---|---|---|
| `GET` | `/datasets/{dataset_identifier}/labels` | List labels applied to the dataset |
| `PUT` | `/datasets/{dataset_identifier}/labels/{label_id}` | Apply a label — **idempotent**, returns the label |
| `DELETE` | `/datasets/{dataset_identifier}/labels/{label_id}` | Remove a label — `204`, idempotent, label itself untouched |
| `PUT` | `/datasets/{dataset_identifier}/labels` | Replace the entire label set (settings-screen fit; empty list clears) |

## Details

- `{dataset_identifier}` accepts a **dataset name or GlobalID** via a new reusable `get_dataset_by_identifier()` helper in `utils.py` (mirrors `get_project_by_identifier()`).
- `{label_id}` is a GlobalID; malformed IDs → `422`, missing resources → `404`.
- Hex colors are validated at request time against the DB constraint (`^#([0-9a-f]{6})$`) so bad input returns `422` rather than a DB error.
- Write endpoints are guarded with `Depends(is_not_locked)`; read = all authenticated, write = MEMBER+ (enforced at the router level).
- Follows existing `datasets.py` conventions (`V1RoutesBaseModel`, `ResponseBody`/`PaginatedResponseBody`, `data`-wrapped responses).

## Testing

- Regenerated the OpenAPI schema and Python/TypeScript clients (`make schema-openapi` + codegen).
- Added `tests/integration/dataset_labels/` covering create/get/update/delete, duplicate-name `409`, invalid-color `422`, assign/idempotent re-assign, list, unassign/idempotent re-remove, assign-by-name, bulk replace (add + remove + clear), and unknown-label `404`.
- Registered all nine endpoints in `tests/integration/_helpers.py` so the exhaustive role-based auth test (`test_role_based_access_control`) verifies VIEWER is blocked from writes — passes for all roles.
- `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TxDBHUysEd5FZPLCV3DvPC)_