### PR TITLE
feat(api): assign annotation configs to projects over REST

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -60,6 +60,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{project_identifier}/annotation_configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List annotation configurations assigned to a project
+         * @description Retrieve a paginated list of the annotation configurations assigned to a project, identified by either project ID or project name.
+         */
+        get: operations["getProjectAnnotationConfigs"];
+        /**
+         * Replace the set of annotation configurations assigned to a project
+         * @description Replace the project's entire set of assigned annotation configurations with the provided set. The server diffs the desired set against the current set: configs in the body but not assigned are added, and configs assigned but not in the body are removed. An empty array clears all assignments.
+         */
+        put: operations["setProjectAnnotationConfigs"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{project_identifier}/annotation_configs/{config_identifier}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Assign an annotation configuration to a project
+         * @description Assign an annotation configuration to a project. This operation is idempotent: re-assigning a config that is already assigned is a no-op that returns the config. Both the project and the config are identified by either ID or name.
+         */
+        put: operations["assignAnnotationConfigToProject"];
+        post?: never;
+        /**
+         * Unassign an annotation configuration from a project
+         * @description Unassign an annotation configuration from a project. This operation is idempotent: unassigning a config that is not currently assigned is a no-op. The underlying annotation config is not deleted. Both the project and the config are identified by either ID or name.
+         */
+        delete: operations["unassignAnnotationConfigFromProject"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/projects/{project_identifier}/span_annotations": {
         parameters: {
             query?: never;
@@ -1526,6 +1574,11 @@ export interface components {
             /** Timezone */
             timeZone: string;
         };
+        /** AssignAnnotationConfigToProjectResponseBody */
+        AssignAnnotationConfigToProjectResponseBody: {
+            /** Data */
+            data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
+        };
         /**
          * AssistantMessageMetadata
          * @description Wire schema for the chat stream's `message_metadata` payload.
@@ -2628,6 +2681,13 @@ export interface components {
         GetIncompleteExperimentRunsResponseBody: {
             /** Data */
             data: components["schemas"]["IncompleteExperimentRun"][];
+            /** Next Cursor */
+            next_cursor: string | null;
+        };
+        /** GetProjectAnnotationConfigsResponseBody */
+        GetProjectAnnotationConfigsResponseBody: {
+            /** Data */
+            data: (components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"])[];
             /** Next Cursor */
             next_cursor: string | null;
         };
@@ -4371,6 +4431,21 @@ export interface components {
              */
             end_time: string;
         };
+        /** SetProjectAnnotationConfigsRequestBody */
+        SetProjectAnnotationConfigsRequestBody: {
+            /**
+             * Annotation Config Ids
+             * @description The complete set of annotation configuration GlobalIDs that should be assigned to the project. Configs not in this list are unassigned; an empty list clears all assignments.
+             */
+            annotation_config_ids: string[];
+        };
+        /** SetProjectAnnotationConfigsResponseBody */
+        SetProjectAnnotationConfigsResponseBody: {
+            /** Data */
+            data: (components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"])[];
+            /** Next Cursor */
+            next_cursor: string | null;
+        };
         /**
          * SourceDocumentUIPart
          * @description A document source part of a message.
@@ -5677,6 +5752,217 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getProjectAnnotationConfigs: {
+        parameters: {
+            query?: {
+                /** @description Cursor for pagination (base64-encoded annotation config ID) */
+                cursor?: string | null;
+                /** @description Maximum number of configs to return */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description The project identifier: either project ID or project name. */
+                project_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A list of the project's annotation configurations with pagination information */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetProjectAnnotationConfigsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    setProjectAnnotationConfigs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project identifier: either project ID or project name. */
+                project_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetProjectAnnotationConfigsRequestBody"];
+            };
+        };
+        responses: {
+            /** @description The resulting set of annotation configurations assigned to the project */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetProjectAnnotationConfigsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    assignAnnotationConfigToProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project identifier: either project ID or project name. */
+                project_identifier: string;
+                /** @description The annotation configuration identifier: either ID or name. */
+                config_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The annotation configuration assigned to the project */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AssignAnnotationConfigToProjectResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    unassignAnnotationConfigFromProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project identifier: either project ID or project name. */
+                project_identifier: string;
+                /** @description The annotation configuration identifier: either ID or name. */
+                config_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No content returned on successful unassignment */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/docs.json
+++ b/docs.json
@@ -942,7 +942,11 @@
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/create-an-annotation-configuration",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/get-an-annotation-configuration-by-id-or-name",
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/update-an-annotation-configuration",
-                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/delete-an-annotation-configuration"
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/delete-an-annotation-configuration",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/list-annotation-configurations-assigned-to-a-project",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/assign-an-annotation-configuration-to-a-project",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/unassign-an-annotation-configuration-from-a-project",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/replace-the-set-of-annotation-configurations-assigned-to-a-project"
                     ]
                   },
                   {

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/assign-an-annotation-configuration-to-a-project.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/assign-an-annotation-configuration-to-a-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /v1/projects/{project_identifier}/annotation_configs/{config_identifier}
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/list-annotation-configurations-assigned-to-a-project.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/list-annotation-configurations-assigned-to-a-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/projects/{project_identifier}/annotation_configs
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/replace-the-set-of-annotation-configurations-assigned-to-a-project.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/replace-the-set-of-annotation-configurations-assigned-to-a-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /v1/projects/{project_identifier}/annotation_configs
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/unassign-an-annotation-configuration-from-a-project.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotation-configs/unassign-an-annotation-configuration-from-a-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/projects/{project_identifier}/annotation_configs/{config_identifier}
+---

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -60,6 +60,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{project_identifier}/annotation_configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List annotation configurations assigned to a project
+         * @description Retrieve a paginated list of the annotation configurations assigned to a project, identified by either project ID or project name.
+         */
+        get: operations["getProjectAnnotationConfigs"];
+        /**
+         * Replace the set of annotation configurations assigned to a project
+         * @description Replace the project's entire set of assigned annotation configurations with the provided set. The server diffs the desired set against the current set: configs in the body but not assigned are added, and configs assigned but not in the body are removed. An empty array clears all assignments.
+         */
+        put: operations["setProjectAnnotationConfigs"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{project_identifier}/annotation_configs/{config_identifier}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Assign an annotation configuration to a project
+         * @description Assign an annotation configuration to a project. This operation is idempotent: re-assigning a config that is already assigned is a no-op that returns the config. Both the project and the config are identified by either ID or name.
+         */
+        put: operations["assignAnnotationConfigToProject"];
+        post?: never;
+        /**
+         * Unassign an annotation configuration from a project
+         * @description Unassign an annotation configuration from a project. This operation is idempotent: unassigning a config that is not currently assigned is a no-op. The underlying annotation config is not deleted. Both the project and the config are identified by either ID or name.
+         */
+        delete: operations["unassignAnnotationConfigFromProject"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/projects/{project_identifier}/span_annotations": {
         parameters: {
             query?: never;
@@ -1526,6 +1574,11 @@ export interface components {
             /** Timezone */
             timeZone: string;
         };
+        /** AssignAnnotationConfigToProjectResponseBody */
+        AssignAnnotationConfigToProjectResponseBody: {
+            /** Data */
+            data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
+        };
         /**
          * AssistantMessageMetadata
          * @description Wire schema for the chat stream's `message_metadata` payload.
@@ -2628,6 +2681,13 @@ export interface components {
         GetIncompleteExperimentRunsResponseBody: {
             /** Data */
             data: components["schemas"]["IncompleteExperimentRun"][];
+            /** Next Cursor */
+            next_cursor: string | null;
+        };
+        /** GetProjectAnnotationConfigsResponseBody */
+        GetProjectAnnotationConfigsResponseBody: {
+            /** Data */
+            data: (components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"])[];
             /** Next Cursor */
             next_cursor: string | null;
         };
@@ -4371,6 +4431,21 @@ export interface components {
              */
             end_time: string;
         };
+        /** SetProjectAnnotationConfigsRequestBody */
+        SetProjectAnnotationConfigsRequestBody: {
+            /**
+             * Annotation Config Ids
+             * @description The complete set of annotation configuration GlobalIDs that should be assigned to the project. Configs not in this list are unassigned; an empty list clears all assignments.
+             */
+            annotation_config_ids: string[];
+        };
+        /** SetProjectAnnotationConfigsResponseBody */
+        SetProjectAnnotationConfigsResponseBody: {
+            /** Data */
+            data: (components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"])[];
+            /** Next Cursor */
+            next_cursor: string | null;
+        };
         /**
          * SourceDocumentUIPart
          * @description A document source part of a message.
@@ -5677,6 +5752,217 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getProjectAnnotationConfigs: {
+        parameters: {
+            query?: {
+                /** @description Cursor for pagination (base64-encoded annotation config ID) */
+                cursor?: string | null;
+                /** @description Maximum number of configs to return */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description The project identifier: either project ID or project name. */
+                project_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A list of the project's annotation configurations with pagination information */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetProjectAnnotationConfigsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    setProjectAnnotationConfigs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project identifier: either project ID or project name. */
+                project_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetProjectAnnotationConfigsRequestBody"];
+            };
+        };
+        responses: {
+            /** @description The resulting set of annotation configurations assigned to the project */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetProjectAnnotationConfigsResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    assignAnnotationConfigToProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project identifier: either project ID or project name. */
+                project_identifier: string;
+                /** @description The annotation configuration identifier: either ID or name. */
+                config_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The annotation configuration assigned to the project */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AssignAnnotationConfigToProjectResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    unassignAnnotationConfigFromProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The project identifier: either project ID or project name. */
+                project_identifier: string;
+                /** @description The annotation configuration identifier: either ID or name. */
+                config_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No content returned on successful unassignment */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -675,6 +675,10 @@ class SessionTraceData(TypedDict):
     end_time: str
 
 
+class SetProjectAnnotationConfigsRequestBody(TypedDict):
+    annotation_config_ids: Sequence[str]
+
+
 class SourceDocumentUIPart(TypedDict):
     type: Literal["source-document"]
     sourceId: str
@@ -1250,6 +1254,13 @@ class GetIncompleteExperimentRunsResponseBody(TypedDict):
     next_cursor: Optional[str]
 
 
+class GetProjectAnnotationConfigsResponseBody(TypedDict):
+    data: Sequence[
+        Union[CategoricalAnnotationConfig, ContinuousAnnotationConfig, FreeformAnnotationConfig]
+    ]
+    next_cursor: Optional[str]
+
+
 class GetProjectResponseBody(TypedDict):
     data: Project
 
@@ -1418,6 +1429,13 @@ class SessionData(TypedDict):
     token_count_total: NotRequired[int]
 
 
+class SetProjectAnnotationConfigsResponseBody(TypedDict):
+    data: Sequence[
+        Union[CategoricalAnnotationConfig, ContinuousAnnotationConfig, FreeformAnnotationConfig]
+    ]
+    next_cursor: Optional[str]
+
+
 class Span(TypedDict):
     name: str
     context: SpanContext
@@ -1511,6 +1529,10 @@ class FieldSummarizeRequest(TypedDict):
     ingestTraces: NotRequired[bool]
     exportRemoteTraces: NotRequired[bool]
     attachUserId: NotRequired[bool]
+
+
+class AssignAnnotationConfigToProjectResponseBody(TypedDict):
+    data: Union[CategoricalAnnotationConfig, ContinuousAnnotationConfig, FreeformAnnotationConfig]
 
 
 class AssistantMessageMetadata(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -300,6 +300,318 @@
         }
       }
     },
+    "/v1/projects/{project_identifier}/annotation_configs": {
+      "get": {
+        "tags": [
+          "annotation_configs"
+        ],
+        "summary": "List annotation configurations assigned to a project",
+        "description": "Retrieve a paginated list of the annotation configurations assigned to a project, identified by either project ID or project name.",
+        "operationId": "getProjectAnnotationConfigs",
+        "parameters": [
+          {
+            "name": "project_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The project identifier: either project ID or project name.",
+              "title": "Project Identifier"
+            },
+            "description": "The project identifier: either project ID or project name."
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Cursor for pagination (base64-encoded annotation config ID)",
+              "title": "Cursor"
+            },
+            "description": "Cursor for pagination (base64-encoded annotation config ID)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "description": "Maximum number of configs to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of configs to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of the project's annotation configurations with pagination information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetProjectAnnotationConfigsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "annotation_configs"
+        ],
+        "summary": "Replace the set of annotation configurations assigned to a project",
+        "description": "Replace the project's entire set of assigned annotation configurations with the provided set. The server diffs the desired set against the current set: configs in the body but not assigned are added, and configs assigned but not in the body are removed. An empty array clears all assignments.",
+        "operationId": "setProjectAnnotationConfigs",
+        "parameters": [
+          {
+            "name": "project_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The project identifier: either project ID or project name.",
+              "title": "Project Identifier"
+            },
+            "description": "The project identifier: either project ID or project name."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetProjectAnnotationConfigsRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The resulting set of annotation configurations assigned to the project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetProjectAnnotationConfigsResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_identifier}/annotation_configs/{config_identifier}": {
+      "put": {
+        "tags": [
+          "annotation_configs"
+        ],
+        "summary": "Assign an annotation configuration to a project",
+        "description": "Assign an annotation configuration to a project. This operation is idempotent: re-assigning a config that is already assigned is a no-op that returns the config. Both the project and the config are identified by either ID or name.",
+        "operationId": "assignAnnotationConfigToProject",
+        "parameters": [
+          {
+            "name": "project_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The project identifier: either project ID or project name.",
+              "title": "Project Identifier"
+            },
+            "description": "The project identifier: either project ID or project name."
+          },
+          {
+            "name": "config_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The annotation configuration identifier: either ID or name.",
+              "title": "Config Identifier"
+            },
+            "description": "The annotation configuration identifier: either ID or name."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The annotation configuration assigned to the project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignAnnotationConfigToProjectResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "annotation_configs"
+        ],
+        "summary": "Unassign an annotation configuration from a project",
+        "description": "Unassign an annotation configuration from a project. This operation is idempotent: unassigning a config that is not currently assigned is a no-op. The underlying annotation config is not deleted. Both the project and the config are identified by either ID or name.",
+        "operationId": "unassignAnnotationConfigFromProject",
+        "parameters": [
+          {
+            "name": "project_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The project identifier: either project ID or project name.",
+              "title": "Project Identifier"
+            },
+            "description": "The project identifier: either project ID or project name."
+          },
+          {
+            "name": "config_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The annotation configuration identifier: either ID or name.",
+              "title": "Config Identifier"
+            },
+            "description": "The annotation configuration identifier: either ID or name."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content returned on successful unassignment"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
     "/v1/projects/{project_identifier}/span_annotations": {
       "get": {
         "tags": [
@@ -7041,6 +7353,37 @@
         "title": "AppContext",
         "description": "Per-turn browser clock context for resolving relative time requests."
       },
+      "AssignAnnotationConfigToProjectResponseBody": {
+        "properties": {
+          "data": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CategoricalAnnotationConfig"
+              },
+              {
+                "$ref": "#/components/schemas/ContinuousAnnotationConfig"
+              },
+              {
+                "$ref": "#/components/schemas/FreeformAnnotationConfig"
+              }
+            ],
+            "title": "Data",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "CATEGORICAL": "#/components/schemas/CategoricalAnnotationConfig",
+                "CONTINUOUS": "#/components/schemas/ContinuousAnnotationConfig",
+                "FREEFORM": "#/components/schemas/FreeformAnnotationConfig"
+              }
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "AssignAnnotationConfigToProjectResponseBody"
+      },
       "AssistantMessageMetadata": {
         "properties": {
           "sessionId": {
@@ -9838,6 +10181,52 @@
           "next_cursor"
         ],
         "title": "GetIncompleteExperimentRunsResponseBody"
+      },
+      "GetProjectAnnotationConfigsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CategoricalAnnotationConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/ContinuousAnnotationConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/FreeformAnnotationConfig"
+                }
+              ],
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "CATEGORICAL": "#/components/schemas/CategoricalAnnotationConfig",
+                  "CONTINUOUS": "#/components/schemas/ContinuousAnnotationConfig",
+                  "FREEFORM": "#/components/schemas/FreeformAnnotationConfig"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_cursor"
+        ],
+        "title": "GetProjectAnnotationConfigsResponseBody"
       },
       "GetProjectResponseBody": {
         "properties": {
@@ -14031,6 +14420,69 @@
           "end_time"
         ],
         "title": "SessionTraceData"
+      },
+      "SetProjectAnnotationConfigsRequestBody": {
+        "properties": {
+          "annotation_config_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Annotation Config Ids",
+            "description": "The complete set of annotation configuration GlobalIDs that should be assigned to the project. Configs not in this list are unassigned; an empty list clears all assignments."
+          }
+        },
+        "type": "object",
+        "required": [
+          "annotation_config_ids"
+        ],
+        "title": "SetProjectAnnotationConfigsRequestBody"
+      },
+      "SetProjectAnnotationConfigsResponseBody": {
+        "properties": {
+          "data": {
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CategoricalAnnotationConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/ContinuousAnnotationConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/FreeformAnnotationConfig"
+                }
+              ],
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "CATEGORICAL": "#/components/schemas/CategoricalAnnotationConfig",
+                  "CONTINUOUS": "#/components/schemas/ContinuousAnnotationConfig",
+                  "FREEFORM": "#/components/schemas/FreeformAnnotationConfig"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_cursor"
+        ],
+        "title": "SetProjectAnnotationConfigsResponseBody"
       },
       "SourceDocumentUIPart": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/annotation_configs.py
+++ b/src/phoenix/server/api/routers/v1/annotation_configs.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import Field, RootModel
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from starlette.requests import Request
 from strawberry.relay import GlobalID
@@ -29,7 +30,12 @@ from phoenix.db.types.annotation_configs import (
     FreeformAnnotationConfig as FreeformAnnotationConfigModel,
 )
 from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
-from phoenix.server.api.routers.v1.utils import PaginatedResponseBody, ResponseBody
+from phoenix.server.api.routers.v1.utils import (
+    PaginatedResponseBody,
+    ResponseBody,
+    add_errors_to_responses,
+    get_project_by_identifier,
+)
 from phoenix.server.api.types.AnnotationConfig import (
     CategoricalAnnotationConfig as CategoricalAnnotationConfigType,
 )
@@ -185,6 +191,29 @@ class UpdateAnnotationConfigResponseBody(ResponseBody[AnnotationConfig]):
 
 
 class DeleteAnnotationConfigResponseBody(ResponseBody[AnnotationConfig]):
+    pass
+
+
+class GetProjectAnnotationConfigsResponseBody(PaginatedResponseBody[AnnotationConfig]):
+    pass
+
+
+class AssignAnnotationConfigToProjectResponseBody(ResponseBody[AnnotationConfig]):
+    pass
+
+
+class SetProjectAnnotationConfigsRequestBody(V1RoutesBaseModel):
+    annotation_config_ids: List[str] = Field(
+        ...,
+        description=(
+            "The complete set of annotation configuration GlobalIDs that should be assigned to "
+            "the project. Configs not in this list are unassigned; an empty list clears all "
+            "assignments."
+        ),
+    )
+
+
+class SetProjectAnnotationConfigsResponseBody(PaginatedResponseBody[AnnotationConfig]):
     pass
 
 
@@ -382,6 +411,323 @@ async def delete_annotation_config(
             raise HTTPException(status_code=404, detail="Annotation configuration not found")
         await session.commit()
     return DeleteAnnotationConfigResponseBody(data=db_to_api_annotation_config(annotation_config))
+
+
+@router.get(
+    "/projects/{project_identifier}/annotation_configs",
+    operation_id="getProjectAnnotationConfigs",
+    summary="List annotation configurations assigned to a project",
+    description=(
+        "Retrieve a paginated list of the annotation configurations assigned to a project, "
+        "identified by either project ID or project name."
+    ),
+    response_description="A list of the project's annotation configurations with pagination information",  # noqa: E501
+    responses=add_errors_to_responses([404, 422]),
+)
+async def list_project_annotation_configs(
+    request: Request,
+    project_identifier: str = Path(
+        ..., description="The project identifier: either project ID or project name."
+    ),
+    cursor: Optional[str] = Query(
+        default=None,
+        description="Cursor for pagination (base64-encoded annotation config ID)",
+    ),
+    limit: int = Query(100, gt=0, description="Maximum number of configs to return"),
+) -> GetProjectAnnotationConfigsResponseBody:
+    """
+    List the annotation configurations assigned to a project.
+
+    Args:
+        request (Request): The FastAPI request object.
+        project_identifier (str): The project ID or name.
+        cursor (Optional[str]): Pagination cursor (annotation config GlobalID).
+        limit (int): Maximum number of configs to return per request.
+
+    Returns:
+        GetProjectAnnotationConfigsResponseBody: The project's annotation configs and
+            pagination information.
+
+    Raises:
+        HTTPException: If the cursor is invalid or the project is not found.
+    """
+    cursor_id: Optional[int] = None
+    if cursor:
+        try:
+            cursor_gid = GlobalID.from_id(cursor)
+        except ValueError:
+            raise HTTPException(detail=f"Invalid cursor: {cursor}", status_code=400)
+        if cursor_gid.type_name not in (
+            CategoricalAnnotationConfigType.__name__,
+            ContinuousAnnotationConfigType.__name__,
+            FreeformAnnotationConfigType.__name__,
+        ):
+            raise HTTPException(detail=f"Invalid cursor: {cursor}", status_code=400)
+        cursor_id = int(cursor_gid.node_id)
+
+    async with request.app.state.db() as session:
+        project = await get_project_by_identifier(session, project_identifier)
+        query = (
+            select(models.AnnotationConfig)
+            .join(
+                models.ProjectAnnotationConfig,
+                models.ProjectAnnotationConfig.annotation_config_id == models.AnnotationConfig.id,
+            )
+            .where(models.ProjectAnnotationConfig.project_id == project.id)
+            .order_by(models.AnnotationConfig.id.desc())
+            .limit(limit + 1)  # overfetch by 1 to check if there are more results
+        )
+        if cursor_id is not None:
+            query = query.where(models.AnnotationConfig.id <= cursor_id)
+
+        result = await session.scalars(query)
+        configs = result.all()
+
+        next_cursor = None
+        if len(configs) == limit + 1:
+            last_config = configs[-1]
+            next_cursor = str(_get_annotation_global_id(last_config))
+            configs = configs[:-1]
+
+        return GetProjectAnnotationConfigsResponseBody(
+            next_cursor=next_cursor,
+            data=[db_to_api_annotation_config(config) for config in configs],
+        )
+
+
+@router.put(
+    "/projects/{project_identifier}/annotation_configs/{config_identifier}",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="assignAnnotationConfigToProject",
+    summary="Assign an annotation configuration to a project",
+    description=(
+        "Assign an annotation configuration to a project. This operation is idempotent: "
+        "re-assigning a config that is already assigned is a no-op that returns the config. "
+        "Both the project and the config are identified by either ID or name."
+    ),
+    response_description="The annotation configuration assigned to the project",
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def assign_annotation_config_to_project(
+    request: Request,
+    project_identifier: str = Path(
+        ..., description="The project identifier: either project ID or project name."
+    ),
+    config_identifier: str = Path(
+        ..., description="The annotation configuration identifier: either ID or name."
+    ),
+) -> AssignAnnotationConfigToProjectResponseBody:
+    """
+    Assign an annotation configuration to a project (idempotent).
+
+    Args:
+        request (Request): The FastAPI request object.
+        project_identifier (str): The project ID or name.
+        config_identifier (str): The annotation config ID or name.
+
+    Returns:
+        AssignAnnotationConfigToProjectResponseBody: The assigned annotation config.
+
+    Raises:
+        HTTPException: If the project or the annotation config is not found.
+    """
+    async with request.app.state.db() as session:
+        project = await get_project_by_identifier(session, project_identifier)
+        config = await _get_annotation_config_by_identifier(session, config_identifier)
+        # Serialize before mutating the session so the response is unaffected by the commit
+        # expiring the ORM instance.
+        data = db_to_api_annotation_config(config)
+        session.add(
+            models.ProjectAnnotationConfig(
+                project_id=project.id,
+                annotation_config_id=config.id,
+            )
+        )
+        try:
+            await session.commit()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            # The config is already assigned to the project. Assignment is idempotent, so the
+            # duplicate is swallowed and treated as a successful no-op rather than a 409.
+            await session.rollback()
+        return AssignAnnotationConfigToProjectResponseBody(data=data)
+
+
+@router.delete(
+    "/projects/{project_identifier}/annotation_configs/{config_identifier}",
+    operation_id="unassignAnnotationConfigFromProject",
+    summary="Unassign an annotation configuration from a project",
+    description=(
+        "Unassign an annotation configuration from a project. This operation is idempotent: "
+        "unassigning a config that is not currently assigned is a no-op. The underlying "
+        "annotation config is not deleted. Both the project and the config are identified by "
+        "either ID or name."
+    ),
+    response_description="No content returned on successful unassignment",
+    status_code=204,
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def unassign_annotation_config_from_project(
+    request: Request,
+    project_identifier: str = Path(
+        ..., description="The project identifier: either project ID or project name."
+    ),
+    config_identifier: str = Path(
+        ..., description="The annotation configuration identifier: either ID or name."
+    ),
+) -> None:
+    """
+    Unassign an annotation configuration from a project (idempotent).
+
+    Args:
+        request (Request): The FastAPI request object.
+        project_identifier (str): The project ID or name.
+        config_identifier (str): The annotation config ID or name.
+
+    Returns:
+        None: Returns a 204 No Content response on success.
+
+    Raises:
+        HTTPException: If the project or the annotation config is not found.
+    """
+    async with request.app.state.db() as session:
+        project = await get_project_by_identifier(session, project_identifier)
+        config = await _get_annotation_config_by_identifier(session, config_identifier)
+        await session.execute(
+            delete(models.ProjectAnnotationConfig).where(
+                models.ProjectAnnotationConfig.project_id == project.id,
+                models.ProjectAnnotationConfig.annotation_config_id == config.id,
+            )
+        )
+        # Deleting a non-existent assignment is a no-op (idempotent).
+    return None
+
+
+@router.put(
+    "/projects/{project_identifier}/annotation_configs",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="setProjectAnnotationConfigs",
+    summary="Replace the set of annotation configurations assigned to a project",
+    description=(
+        "Replace the project's entire set of assigned annotation configurations with the "
+        "provided set. The server diffs the desired set against the current set: configs in the "
+        "body but not assigned are added, and configs assigned but not in the body are removed. "
+        "An empty array clears all assignments."
+    ),
+    response_description="The resulting set of annotation configurations assigned to the project",
+    responses=add_errors_to_responses([403, 404, 422]),
+)
+async def set_project_annotation_configs(
+    request: Request,
+    request_body: SetProjectAnnotationConfigsRequestBody,
+    project_identifier: str = Path(
+        ..., description="The project identifier: either project ID or project name."
+    ),
+) -> SetProjectAnnotationConfigsResponseBody:
+    """
+    Replace the set of annotation configurations assigned to a project.
+
+    Args:
+        request (Request): The FastAPI request object.
+        request_body (SetProjectAnnotationConfigsRequestBody): The desired set of annotation
+            config GlobalIDs.
+        project_identifier (str): The project ID or name.
+
+    Returns:
+        SetProjectAnnotationConfigsResponseBody: The resulting set of assigned annotation configs.
+
+    Raises:
+        HTTPException: If the project is not found, or if any annotation config GlobalID in the
+            body is invalid or refers to a config that does not exist.
+    """
+    desired_ids: set[int] = set()
+    for config_id in request_body.annotation_config_ids:
+        try:
+            desired_ids.add(_get_annotation_config_db_id(config_id))
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid annotation configuration ID: {config_id}",
+            )
+
+    async with request.app.state.db() as session:
+        project = await get_project_by_identifier(session, project_identifier)
+
+        desired_configs: list[models.AnnotationConfig] = []
+        if desired_ids:
+            result = await session.scalars(
+                select(models.AnnotationConfig).where(models.AnnotationConfig.id.in_(desired_ids))
+            )
+            desired_configs = list(result.all())
+            if desired_ids - {config.id for config in desired_configs}:
+                raise HTTPException(
+                    status_code=422,
+                    detail="One or more annotation configurations were not found",
+                )
+
+        current_result = await session.scalars(
+            select(models.ProjectAnnotationConfig.annotation_config_id).where(
+                models.ProjectAnnotationConfig.project_id == project.id
+            )
+        )
+        current_ids = set(current_result.all())
+
+        to_add = desired_ids - current_ids
+        to_remove = current_ids - desired_ids
+
+        if to_remove:
+            await session.execute(
+                delete(models.ProjectAnnotationConfig).where(
+                    models.ProjectAnnotationConfig.project_id == project.id,
+                    models.ProjectAnnotationConfig.annotation_config_id.in_(to_remove),
+                )
+            )
+        for annotation_config_id in to_add:
+            session.add(
+                models.ProjectAnnotationConfig(
+                    project_id=project.id,
+                    annotation_config_id=annotation_config_id,
+                )
+            )
+
+        # Serialize before committing so the response is unaffected by the commit expiring the
+        # ORM instances. Order by ID descending to match the list endpoint.
+        data = [
+            db_to_api_annotation_config(config)
+            for config in sorted(desired_configs, key=lambda c: c.id, reverse=True)
+        ]
+        await session.commit()
+
+    return SetProjectAnnotationConfigsResponseBody(next_cursor=None, data=data)
+
+
+async def _get_annotation_config_by_identifier(
+    session: AsyncSession,
+    config_identifier: str,
+) -> models.AnnotationConfig:
+    """
+    Get an annotation configuration by its GlobalID or name.
+
+    Args:
+        session: The database session.
+        config_identifier: The annotation config GlobalID or name.
+
+    Returns:
+        The annotation config object.
+
+    Raises:
+        HTTPException: 404 if the annotation config is not found.
+    """
+    query = select(models.AnnotationConfig)
+    # Try to interpret the identifier as a GlobalID; if not, use it as a name.
+    try:
+        db_id = _get_annotation_config_db_id(config_identifier)
+        query = query.where(models.AnnotationConfig.id == db_id)
+    except ValueError:
+        query = query.where(models.AnnotationConfig.name == config_identifier)
+    config = await session.scalar(query)
+    if config is None:
+        raise HTTPException(status_code=404, detail="Annotation configuration not found")
+    return config
 
 
 def _get_annotation_config_db_id(config_gid: str) -> int:

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2203,6 +2203,8 @@ _COMMON_RESOURCE_ENDPOINTS = (
     # Annotation configs
     (200, "GET", "v1/annotation_configs"),
     (404, "GET", "v1/annotation_configs/fake-id-{}"),
+    # Project annotation config assignments (project-scoped)
+    (404, "GET", "v1/projects/fake-id-{}/annotation_configs"),
     # Spans (project-scoped)
     (404, "GET", "v1/projects/fake-id-{}/spans"),
     (404, "GET", "v1/projects/fake-id-{}/spans/otlpv1"),
@@ -2256,10 +2258,13 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (415, "POST", "v1/traces"),
     # PUT routes
     (422, "PUT", "v1/annotation_configs/fake-id-{}"),
+    (404, "PUT", "v1/projects/{0}/annotation_configs/{0}"),
+    (422, "PUT", "v1/projects/fake-id-{}/annotation_configs"),
     # PATCH routes
     (422, "PATCH", "v1/experiments/fake-id-{}"),
     # DELETE routes
     (422, "DELETE", "v1/annotation_configs/fake-id-{}"),
+    (404, "DELETE", "v1/projects/{0}/annotation_configs/{0}"),
     (422, "DELETE", "v1/datasets/fake-id-{}"),
     (422, "DELETE", "v1/experiments/fake-id-{}"),
     (404, "DELETE", "v1/sessions/fake-id-{}"),

--- a/tests/integration/annotation_configs/conftest.py
+++ b/tests/integration/annotation_configs/conftest.py
@@ -1,0 +1,29 @@
+from typing import Iterator, Mapping
+
+import pytest
+
+from .._helpers import _AppInfo, _server
+
+
+@pytest.fixture(scope="package")
+def _app(
+    _env: dict[str, str],
+) -> Iterator[_AppInfo]:
+    with _server(_AppInfo(_env)) as app:
+        yield app
+
+
+@pytest.fixture(scope="package")
+def _env(
+    _env_ports: Mapping[str, str],
+    _env_database: Mapping[str, str],
+    _env_auth: Mapping[str, str],
+    _env_smtp: Mapping[str, str],
+) -> dict[str, str]:
+    """Combine all environment variable configurations for testing."""
+    return {
+        **_env_ports,
+        **_env_database,
+        **_env_auth,
+        **_env_smtp,
+    }

--- a/tests/integration/annotation_configs/test_project_annotation_configs.py
+++ b/tests/integration/annotation_configs/test_project_annotation_configs.py
@@ -1,0 +1,186 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+from secrets import token_hex
+from typing import Any
+
+import httpx
+import pytest
+
+from .._helpers import _VIEWER, _AppInfo, _GetUser, _httpx_client
+
+
+def _create_project(client: httpx.Client) -> dict[str, Any]:
+    resp = client.post("v1/projects", json={"name": f"proj_{token_hex(8)}"})
+    resp.raise_for_status()
+    data: dict[str, Any] = resp.json()["data"]
+    return data
+
+
+def _create_config(client: httpx.Client) -> dict[str, Any]:
+    resp = client.post(
+        "v1/annotation_configs",
+        json={
+            "name": f"cfg_{token_hex(8)}",
+            "type": "CATEGORICAL",
+            "description": "Human review rubric",
+            "optimization_direction": "MAXIMIZE",
+            "values": [
+                {"label": "helpful", "score": 1},
+                {"label": "not_helpful", "score": 0},
+            ],
+        },
+    )
+    resp.raise_for_status()
+    data: dict[str, Any] = resp.json()["data"]
+    return data
+
+
+class TestProjectAnnotationConfigs:
+    """Integration tests for the project ↔ annotation-config membership REST endpoints."""
+
+    def test_assign_is_idempotent_and_lists(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app, _app.admin_secret)
+        project = _create_project(client)
+        config = _create_config(client)
+        config_id = config["id"]
+        base = f"v1/projects/{project['id']}/annotation_configs"
+        item = f"{base}/{config_id}"
+
+        # Assign returns 200 and echoes the assigned config.
+        resp = client.put(item)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["id"] == config_id
+        assert resp.json()["data"]["name"] == config["name"]
+        assert resp.json()["data"]["type"] == "CATEGORICAL"
+
+        # Re-assigning an already-assigned config is an idempotent no-op that still returns 200.
+        resp = client.put(item)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["id"] == config_id
+
+        # The config now shows up in the project's list.
+        resp = client.get(base)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert [item["id"] for item in body["data"]] == [config_id]
+        assert body["next_cursor"] is None
+
+    def test_assign_by_name(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app, _app.admin_secret)
+        project = _create_project(client)
+        config = _create_config(client)
+
+        # Both identifiers accept a name as well as a GlobalID.
+        item = f"v1/projects/{project['name']}/annotation_configs/{config['name']}"
+        resp = client.put(item)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["id"] == config["id"]
+
+    def test_unassign(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app, _app.admin_secret)
+        project = _create_project(client)
+        config = _create_config(client)
+        config_id = config["id"]
+        base = f"v1/projects/{project['id']}/annotation_configs"
+        item = f"{base}/{config_id}"
+
+        client.put(item).raise_for_status()
+
+        # Unassign removes the link without deleting the config.
+        resp = client.delete(item)
+        assert resp.status_code == 204, resp.text
+        assert client.get(base).json()["data"] == []
+        # The underlying config still exists.
+        assert client.get(f"v1/annotation_configs/{config_id}").status_code == 200
+
+    def test_unassign_missing_is_idempotent(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app, _app.admin_secret)
+        project = _create_project(client)
+        config = _create_config(client)
+
+        # Unassigning a config that was never assigned is a no-op (204).
+        item = f"v1/projects/{project['id']}/annotation_configs/{config['id']}"
+        resp = client.delete(item)
+        assert resp.status_code == 204, resp.text
+
+    def test_bulk_replace_adds_and_removes(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app, _app.admin_secret)
+        project = _create_project(client)
+        base = f"v1/projects/{project['id']}/annotation_configs"
+        config_a = _create_config(client)
+        config_b = _create_config(client)
+        config_c = _create_config(client)
+
+        # Start with A assigned.
+        client.put(f"{base}/{config_a['id']}").raise_for_status()
+
+        # Replace the set with {B, C}: A is removed, B and C are added.
+        body = {"annotation_config_ids": [config_b["id"], config_c["id"]]}
+        resp = client.put(base, json=body)
+        assert resp.status_code == 200, resp.text
+        assert {item["id"] for item in resp.json()["data"]} == {config_b["id"], config_c["id"]}
+
+        resp = client.get(base)
+        assert {item["id"] for item in resp.json()["data"]} == {config_b["id"], config_c["id"]}
+
+        # An empty array clears all assignments.
+        resp = client.put(base, json={"annotation_config_ids": []})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"] == []
+        assert client.get(base).json()["data"] == []
+
+    def test_assign_nonexistent_project_returns_404(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app, _app.admin_secret)
+        config = _create_config(client)
+        item = f"v1/projects/{token_hex(8)}/annotation_configs/{config['id']}"
+        resp = client.put(item)
+        assert resp.status_code == 404, resp.text
+
+    def test_assign_nonexistent_config_returns_404(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app, _app.admin_secret)
+        project = _create_project(client)
+        item = f"v1/projects/{project['id']}/annotation_configs/{token_hex(8)}"
+        resp = client.put(item)
+        assert resp.status_code == 404, resp.text
+
+    def test_bulk_replace_unknown_config_returns_422(self, _app: _AppInfo) -> None:
+        client = _httpx_client(_app, _app.admin_secret)
+        project = _create_project(client)
+        base = f"v1/projects/{project['id']}/annotation_configs"
+
+        # A malformed (non-GlobalID) value in the body is a 422.
+        resp = client.put(base, json={"annotation_config_ids": ["not-a-global-id"]})
+        assert resp.status_code == 422, resp.text
+
+        # A well-formed GlobalID that refers to a nonexistent config is also a 422.
+        config = _create_config(client)
+        client.delete(f"v1/annotation_configs/{config['id']}").raise_for_status()
+        resp = client.put(base, json={"annotation_config_ids": [config["id"]]})
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.parametrize(
+        "method",
+        ["put_single", "delete_single", "put_bulk"],
+    )
+    def test_viewer_is_forbidden_from_writes(
+        self,
+        method: str,
+        _app: _AppInfo,
+        _get_user: _GetUser,
+    ) -> None:
+        admin = _httpx_client(_app, _app.admin_secret)
+        project = _create_project(admin)
+        config = _create_config(admin)
+
+        viewer = _get_user(_app, _VIEWER)
+        viewer_client = _httpx_client(_app, viewer)
+
+        base = f"v1/projects/{project['id']}/annotation_configs"
+        if method == "put_single":
+            resp = viewer_client.put(f"{base}/{config['id']}")
+        elif method == "delete_single":
+            resp = viewer_client.delete(f"{base}/{config['id']}")
+        else:
+            resp = viewer_client.put(base, json={"annotation_config_ids": [config["id"]]})
+        assert resp.status_code == 403, resp.text

--- a/tests/unit/server/api/routers/v1/test_annotation_configs.py
+++ b/tests/unit/server/api/routers/v1/test_annotation_configs.py
@@ -421,6 +421,160 @@ async def test_create_freeform_annotation_config_with_invalid_bounds_returns_exp
     assert "Lower bound must be strictly less than upper bound" in response.text
 
 
+async def _create_project(httpx_client: AsyncClient, name: str) -> str:
+    response = await httpx_client.post("/v1/projects", json={"name": name})
+    assert response.status_code == 200, response.text
+    return str(response.json()["data"]["id"])
+
+
+async def _create_config(httpx_client: AsyncClient, name: str) -> dict[str, Any]:
+    response = await httpx_client.post(
+        "/v1/annotation_configs",
+        json={
+            "name": name,
+            "type": AnnotationType.CATEGORICAL.value,
+            "description": "Human review rubric",
+            "optimization_direction": OptimizationDirection.MAXIMIZE.value,
+            "values": [
+                {"label": "helpful", "score": 1.0},
+                {"label": "not_helpful", "score": 0.0},
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    data: dict[str, Any] = response.json()["data"]
+    return data
+
+
+async def test_assign_annotation_config_to_project_is_idempotent_and_listable(
+    httpx_client: AsyncClient,
+) -> None:
+    project_id = await _create_project(httpx_client, "assign-project")
+    config = await _create_config(httpx_client, "assign-config")
+    base = f"/v1/projects/{project_id}/annotation_configs"
+    item = f"{base}/{config['id']}"
+
+    # Assign returns 200 and echoes the assigned config.
+    response = await httpx_client.put(item)
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == config
+
+    # Re-assigning an already-assigned config is an idempotent no-op that still returns 200.
+    response = await httpx_client.put(item)
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == config
+
+    # The config now shows up in the project's list (paginated, same item shape as the collection).
+    response = await httpx_client.get(base)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"] == [config]
+    assert body["next_cursor"] is None
+
+
+async def test_assign_and_list_annotation_configs_by_name(
+    httpx_client: AsyncClient,
+) -> None:
+    await _create_project(httpx_client, "by-name-project")
+    config = await _create_config(httpx_client, "by-name-config")
+    base = "/v1/projects/by-name-project/annotation_configs"
+
+    # Both the project and the config identifiers accept a name as well as a GlobalID.
+    response = await httpx_client.put(f"{base}/by-name-config")
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == config
+
+    response = await httpx_client.get(base)
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == [config]
+
+
+async def test_unassign_annotation_config_from_project(
+    httpx_client: AsyncClient,
+) -> None:
+    project_id = await _create_project(httpx_client, "unassign-project")
+    config = await _create_config(httpx_client, "unassign-config")
+    config_id = config["id"]
+    base = f"/v1/projects/{project_id}/annotation_configs"
+    item = f"{base}/{config_id}"
+
+    await httpx_client.put(item)
+
+    # Unassigning removes the link without deleting the underlying config.
+    response = await httpx_client.delete(item)
+    assert response.status_code == 204, response.text
+    assert (await httpx_client.get(base)).json()["data"] == []
+    assert (await httpx_client.get(f"/v1/annotation_configs/{config_id}")).status_code == 200
+
+    # Unassigning a config that is not assigned is an idempotent no-op (204).
+    response = await httpx_client.delete(item)
+    assert response.status_code == 204, response.text
+
+
+async def test_set_project_annotation_configs_replaces_the_whole_set(
+    httpx_client: AsyncClient,
+) -> None:
+    project_id = await _create_project(httpx_client, "bulk-project")
+    config_a = await _create_config(httpx_client, "bulk-config-a")
+    config_b = await _create_config(httpx_client, "bulk-config-b")
+    config_c = await _create_config(httpx_client, "bulk-config-c")
+    base = f"/v1/projects/{project_id}/annotation_configs"
+
+    # Start with A assigned.
+    await httpx_client.put(f"{base}/{config_a['id']}")
+
+    # Replace the set with {B, C}: A is removed, B and C are added.
+    body = {"annotation_config_ids": [config_b["id"], config_c["id"]]}
+    response = await httpx_client.put(base, json=body)
+    assert response.status_code == 200, response.text
+    assert {item["id"] for item in response.json()["data"]} == {config_b["id"], config_c["id"]}
+
+    response = await httpx_client.get(base)
+    assert {item["id"] for item in response.json()["data"]} == {config_b["id"], config_c["id"]}
+
+    # An empty array clears all assignments.
+    response = await httpx_client.put(base, json={"annotation_config_ids": []})
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == []
+    assert (await httpx_client.get(base)).json()["data"] == []
+
+
+async def test_assign_with_missing_project_or_config_returns_404(
+    httpx_client: AsyncClient,
+) -> None:
+    project_id = await _create_project(httpx_client, "missing-project")
+    config = await _create_config(httpx_client, "missing-config")
+
+    # Unknown project.
+    response = await httpx_client.put(
+        f"/v1/projects/does-not-exist/annotation_configs/{config['id']}"
+    )
+    assert response.status_code == 404, response.text
+
+    # Unknown config.
+    response = await httpx_client.put(
+        f"/v1/projects/{project_id}/annotation_configs/does-not-exist"
+    )
+    assert response.status_code == 404, response.text
+
+
+async def test_set_project_annotation_configs_with_unknown_id_returns_422(
+    httpx_client: AsyncClient,
+) -> None:
+    project_id = await _create_project(httpx_client, "bulk-422-project")
+    base = f"/v1/projects/{project_id}/annotation_configs"
+
+    # A malformed (non-GlobalID) value in the body is a 422.
+    response = await httpx_client.put(base, json={"annotation_config_ids": ["not-a-global-id"]})
+    assert response.status_code == 422, response.text
+
+    # A well-formed GlobalID that refers to a nonexistent config is also a 422.
+    config = await _create_config(httpx_client, "bulk-422-config")
+    await httpx_client.delete(f"/v1/annotation_configs/{config['id']}")
+    response = await httpx_client.put(base, json={"annotation_config_ids": [config["id"]]})
+    assert response.status_code == 422, response.text
+
+
 @pytest.fixture
 async def annotation_configs(db: DbSessionFactory) -> list[models.AnnotationConfig]:
     """


### PR DESCRIPTION
Adds REST endpoints for managing the annotation configurations assigned to a project:

- `GET /v1/projects/{project_identifier}/annotation_configs` — list a project's assigned annotation configs (paginated)
- `PUT /v1/projects/{project_identifier}/annotation_configs/{config_identifier}` — assign a config to a project (idempotent)
- `DELETE /v1/projects/{project_identifier}/annotation_configs/{config_identifier}` — unassign a config from a project (idempotent)
- `PUT /v1/projects/{project_identifier}/annotation_configs` — replace the full set of assigned configs (empty array clears all)

Both projects and configs can be identified by ID or name.

Also includes:
- Regenerated `schemas/openapi.json` plus Python (`packages/phoenix-client`), TypeScript client (`js/packages/phoenix-client`), and app (`app/src/api`) generated types
- Unit tests for the new routes and integration tests covering auth/role access
- Mintlify docs pages for the four new endpoints

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTUBdvtcfKuozEbgYRKQK6)_