### PR TITLE
feat(server): add name_contains filter to GET /v1/projects

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -8915,6 +8915,8 @@ export interface operations {
                 include_experiment_projects?: boolean;
                 /** @description Include dataset evaluator projects in the response. Dataset evaluator projects are created when running experiments with persisted evaluators. */
                 include_dataset_evaluator_projects?: boolean;
+                /** @description Return only projects whose name contains this substring (case-insensitive). */
+                name_contains?: string | null;
             };
             header?: never;
             path?: never;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -8915,6 +8915,8 @@ export interface operations {
                 include_experiment_projects?: boolean;
                 /** @description Include dataset evaluator projects in the response. Dataset evaluator projects are created when running experiments with persisted evaluators. */
                 include_dataset_evaluator_projects?: boolean;
+                /** @description Return only projects whose name contains this substring (case-insensitive). */
+                name_contains?: string | null;
             };
             header?: never;
             path?: never;

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -5770,6 +5770,24 @@
               "title": "Include Dataset Evaluator Projects"
             },
             "description": "Include dataset evaluator projects in the response. Dataset evaluator projects are created when running experiments with persisted evaluators."
+          },
+          {
+            "name": "name_contains",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only projects whose name contains this substring (case-insensitive).",
+              "title": "Name Contains"
+            },
+            "description": "Return only projects whose name contains this substring (case-insensitive)."
           }
         ],
         "responses": {

--- a/src/phoenix/server/api/routers/v1/projects.py
+++ b/src/phoenix/server/api/routers/v1/projects.py
@@ -87,6 +87,10 @@ async def get_projects(
         default=False,
         description="Include dataset evaluator projects in the response. Dataset evaluator projects are created when running experiments with persisted evaluators.",  # noqa: E501
     ),
+    name_contains: Optional[str] = Query(
+        default=None,
+        description="Return only projects whose name contains this substring (case-insensitive).",  # noqa: E501
+    ),
 ) -> GetProjectsResponseBody:
     """
     Retrieve a paginated list of all projects in the system.
@@ -99,6 +103,7 @@ async def get_projects(
             Experiment projects are created from running experiments.
         include_dataset_evaluator_projects (bool): Flag to include dataset evaluator projects in the response.
             Dataset evaluator projects are created from running dataset evaluators.
+        name_contains (Optional[str]): Case-insensitive substring to filter project names by.
 
     Returns:
         GetProjectsResponseBody: Response containing a list of projects and pagination information.
@@ -111,6 +116,8 @@ async def get_projects(
         stmt = exclude_experiment_projects(stmt)
     if not include_dataset_evaluator_projects:
         stmt = exclude_dataset_evaluator_projects(stmt)
+    if name_contains:
+        stmt = stmt.where(models.CaseInsensitiveContains(models.Project.name, name_contains))
     async with request.app.state.db() as session:
         if cursor:
             try:

--- a/tests/unit/server/api/routers/v1/test_projects.py
+++ b/tests/unit/server/api/routers/v1/test_projects.py
@@ -632,6 +632,100 @@ class TestProjects:
                 f"Project at index {i} should have ID {projects[i].id}, got {project_id}"
             )
 
+    async def test_list_projects_name_contains_filter(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        """
+        Test filtering projects by name substring with the name_contains parameter.
+
+        This test verifies that:
+        1. Only projects whose name contains the substring are returned
+        2. Matching is case-insensitive
+        3. SQL LIKE wildcards (% and _) in the filter are treated literally
+        4. Unicode names are matched correctly
+        5. The filter combines with cursor-based pagination
+        6. No projects are returned when nothing matches
+        """
+        names = [
+            "Alpha Project",
+            "alphabet soup",
+            "Beta Project",
+            "100% complete",
+            "under_score",
+            "项目名称",
+        ]
+        async with db() as session:
+            for name in names:
+                session.add(models.Project(name=name, description=token_hex(8)))
+            await session.flush()
+
+        url = "v1/projects"
+
+        # Case-insensitive substring match
+        response = await httpx_client.get(url, params={"name_contains": "ALPHA"})
+        assert response.status_code == 200, (
+            f"GET /projects with name_contains should return 200, got {response.status_code}: {response.text}"
+        )
+        returned_names = {p["name"] for p in response.json()["data"]}
+        assert returned_names == {"Alpha Project", "alphabet soup"}, (
+            f"name_contains='ALPHA' should match case-insensitively, got {returned_names}"
+        )
+
+        # LIKE wildcard % must be treated literally
+        response = await httpx_client.get(url, params={"name_contains": "100%"})
+        assert response.status_code == 200
+        returned_names = {p["name"] for p in response.json()["data"]}
+        assert returned_names == {"100% complete"}, (
+            f"name_contains='100%' should match the literal percent sign only, got {returned_names}"
+        )
+
+        # LIKE wildcard _ must be treated literally
+        response = await httpx_client.get(url, params={"name_contains": "under_"})
+        assert response.status_code == 200
+        returned_names = {p["name"] for p in response.json()["data"]}
+        assert returned_names == {"under_score"}, (
+            f"name_contains='under_' should match the literal underscore only, got {returned_names}"
+        )
+
+        # Unicode substring match
+        response = await httpx_client.get(url, params={"name_contains": "名称"})
+        assert response.status_code == 200
+        returned_names = {p["name"] for p in response.json()["data"]}
+        assert returned_names == {"项目名称"}, (
+            f"name_contains='名称' should match the unicode name, got {returned_names}"
+        )
+
+        # No match returns an empty list
+        response = await httpx_client.get(url, params={"name_contains": token_hex(16)})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["data"] == [], "No projects should match a random filter string"
+        assert data["next_cursor"] is None, "next_cursor should be null when nothing matches"
+
+        # Combines with pagination
+        response = await httpx_client.get(url, params={"name_contains": "project", "limit": 1})
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1, "limit=1 should return exactly 1 matching project"
+        assert data["next_cursor"] is not None, (
+            "next_cursor should be present when more matching projects remain"
+        )
+        first_page_name = data["data"][0]["name"]
+        response = await httpx_client.get(
+            url, params={"name_contains": "project", "cursor": data["next_cursor"]}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        returned_names = {p["name"] for p in data["data"]}
+        assert {first_page_name} | returned_names == {"Alpha Project", "Beta Project"}, (
+            f"Paginated pages should cover all matching projects, got {returned_names}"
+        )
+        assert data["next_cursor"] is None, (
+            "next_cursor should be null when all matching projects have been returned"
+        )
+
     async def test_include_experiment_projects_parameter(
         self,
         httpx_client: httpx.AsyncClient,


### PR DESCRIPTION
resolves #14025

## Summary

Adds a `name_contains` query param to `GET /v1/projects` for case-insensitive substring filtering on project name, unblocking CLI #12036 (`px projects --name-contains`).

- Filters via the existing `CaseInsensitiveContains` SQL construct, giving consistent behavior across backends: Postgres uses `ILIKE` with escaped `%`/`_`/`\`, SQLite uses sqlean `text_lower`/`text_contains` (handles non-ASCII). SQL LIKE wildcards in the filter value match literally.
- Combines with existing `cursor`/`limit` pagination and `include_experiment_projects`/`include_dataset_evaluator_projects` params; response shape unchanged.
- Regenerated `schemas/openapi.json` and TypeScript client types via `make openapi` (compatible change — new optional param only).
- Unit tests cover case-insensitivity, literal `%`/`_` matching, unicode names, empty result, and interaction with pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HV5C4T2ZQ1kj7mrC4JTYow

---
_Generated by [Claude Code](https://claude.ai/code/session_01HV5C4T2ZQ1kj7mrC4JTYow)_