### PR TITLE
fix: sync dashboards project selector with the project in the URL

### DIFF
--- a/app/src/components/project/ProjectMenu.tsx
+++ b/app/src/components/project/ProjectMenu.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
-import { startTransition, useState } from "react";
-import { graphql, usePaginationFragment } from "react-relay";
+import { startTransition, Suspense, useState } from "react";
+import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay";
 
 import {
   Autocomplete,
@@ -25,6 +25,7 @@ import type { StylableProps } from "@phoenix/components/core/types";
 
 import type { ProjectMenu_projects$key } from "./__generated__/ProjectMenu_projects.graphql";
 import type { ProjectMenuProjectsQuery } from "./__generated__/ProjectMenuProjectsQuery.graphql";
+import type { ProjectMenuSelectedProjectQuery } from "./__generated__/ProjectMenuSelectedProjectQuery.graphql";
 
 const PAGE_SIZE = 50;
 
@@ -48,6 +49,67 @@ export type ProjectMenuProps = StylableProps & {
   searchPlaceholder?: string;
   size?: MenuButtonProps["size"];
 };
+
+type ProjectMenuButtonProps = StylableProps & {
+  projectName: string | null;
+  placeholder: string;
+  size?: MenuButtonProps["size"];
+};
+
+function ProjectMenuButton({
+  projectName,
+  placeholder,
+  size,
+  css: propCSS,
+}: ProjectMenuButtonProps) {
+  return (
+    <MenuButton
+      aria-label={projectName ? `Project: ${projectName}` : "Project"}
+      css={propCSS}
+      leadingVisual={<Icon svg={<Icons.Trace />} />}
+      size={size}
+      trailingVisual={<SelectChevronUpDownIcon />}
+    >
+      {projectName ? (
+        <MenuButtonValue>{projectName}</MenuButtonValue>
+      ) : (
+        <MenuButtonValue isPlaceholder>{placeholder}</MenuButtonValue>
+      )}
+    </MenuButton>
+  );
+}
+
+/**
+ * A menu button that resolves the selected project's name by id. Used when
+ * the name is not available from data already fetched, e.g. when the route
+ * was entered client-side (so the route loader never fetched the selected
+ * project) and the project is not in the loaded pages of the connection.
+ */
+function SelectedProjectMenuButton({
+  projectId,
+  ...buttonProps
+}: Omit<ProjectMenuButtonProps, "projectName"> & { projectId: string }) {
+  const data = useLazyLoadQuery<ProjectMenuSelectedProjectQuery>(
+    graphql`
+      query ProjectMenuSelectedProjectQuery($id: ID!) {
+        node(id: $id) {
+          __typename
+          id
+          ... on Project {
+            name
+          }
+        }
+      }
+    `,
+    { id: projectId },
+    { fetchPolicy: "store-or-network" }
+  );
+  const projectName =
+    data.node?.__typename === "Project" && typeof data.node.name === "string"
+      ? data.node.name
+      : null;
+  return <ProjectMenuButton projectName={projectName} {...buttonProps} />;
+}
 
 export function ProjectMenu({
   query,
@@ -174,21 +236,32 @@ export function ProjectMenu({
         }
       }}
     >
-      <MenuButton
-        aria-label={
-          displayProjectName ? `Project: ${displayProjectName}` : "Project"
-        }
-        css={propCSS}
-        leadingVisual={<Icon svg={<Icons.Trace />} />}
-        size={size}
-        trailingVisual={<SelectChevronUpDownIcon />}
-      >
-        {displayProjectName ? (
-          <MenuButtonValue>{displayProjectName}</MenuButtonValue>
-        ) : (
-          <MenuButtonValue isPlaceholder>{placeholder}</MenuButtonValue>
-        )}
-      </MenuButton>
+      {selectedProjectId && displayProjectName == null ? (
+        <Suspense
+          fallback={
+            <ProjectMenuButton
+              css={propCSS}
+              placeholder={placeholder}
+              projectName={null}
+              size={size}
+            />
+          }
+        >
+          <SelectedProjectMenuButton
+            css={propCSS}
+            placeholder={placeholder}
+            projectId={selectedProjectId}
+            size={size}
+          />
+        </Suspense>
+      ) : (
+        <ProjectMenuButton
+          css={propCSS}
+          placeholder={placeholder}
+          projectName={displayProjectName}
+          size={size}
+        />
+      )}
       <MenuContainer placement="bottom start">
         <Autocomplete filter={contains}>
           <MenuHeader>

--- a/app/src/components/project/__generated__/ProjectMenuSelectedProjectQuery.graphql.ts
+++ b/app/src/components/project/__generated__/ProjectMenuSelectedProjectQuery.graphql.ts
@@ -1,0 +1,112 @@
+/**
+ * @generated SignedSource<<4003e269737679e68882fec237012ad3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ProjectMenuSelectedProjectQuery$variables = {
+  id: string;
+};
+export type ProjectMenuSelectedProjectQuery$data = {
+  readonly node: {
+    readonly __typename: string;
+    readonly id: string;
+    readonly name?: string;
+  };
+};
+export type ProjectMenuSelectedProjectQuery = {
+  response: ProjectMenuSelectedProjectQuery$data;
+  variables: ProjectMenuSelectedProjectQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      }
+    ],
+    "concreteType": null,
+    "kind": "LinkedField",
+    "name": "node",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          }
+        ],
+        "type": "Project",
+        "abstractKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectMenuSelectedProjectQuery",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectMenuSelectedProjectQuery",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "825b96fe121d54901eedb6421105d7fd",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectMenuSelectedProjectQuery",
+    "operationKind": "query",
+    "text": "query ProjectMenuSelectedProjectQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    id\n    ... on Project {\n      name\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "85a4afeedcc7da8dada83bfb4b293453";
+
+export default node;


### PR DESCRIPTION
## Problem

On the dashboards page, the project selector could show the "Select project" placeholder even though a project was selected in the URL (e.g. `/dashboards/projects/UHJvamVjdDoxNA==?timeRangeKey=45d`).

## Root cause

When the dashboards route is entered client-side — e.g. clicking **Dashboards** in the sidebar, which lands on `/dashboards` and then redirects to the last-selected project — the route loader runs *before* the redirect, with no `projectId` param (`hasSelectedProject: false`). React Router does not revalidate the parent route's loader on child-route navigations (and the route's `shouldRevalidate` keeps that default), so the `selectedProject: node(id:)` field is never fetched. `ProjectMenu` then falls back to finding the project in the loaded page of the `projects` connection — and if the project isn't in that first page, the button renders the placeholder.

Direct page loads of the same URL worked, because the loader then runs with the `projectId` param.

## Fix

Resolve the selected project's name declaratively: when the name isn't available from data already fetched (route loader data, the loaded connection pages, or the optimistic selection), the menu button renders a Suspense-wrapped variant that looks up the project via `node(id:)` with `useLazyLoadQuery` (`store-or-network`), falling back to the placeholder while loading. The Suspense boundary wraps the whole button so its `aria-label` includes the resolved name. No effects and no imperative refetches — the unresolved-name state is itself the condition for mounting the fetching component, so a deleted/unknown id can't cause a refetch loop.

## Verification

Reproduced and verified in a running Phoenix build with 60 projects (so the selected project is outside the first page of the connection):

- Before: sidebar → Dashboards → redirect to `/dashboards/projects/…` showed the placeholder despite the project in the URL.
- After: the same flow shows the project name (accessible name `Project: project-60`); direct loads, opening the menu from the lazily-resolved button, and search + select all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185m5cnCypM9b4HZt6kCcBE