### PR TITLE
feat(server): add GET /traces/{trace_identifier} REST endpoint

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -549,6 +549,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/traces/{trace_identifier}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a single trace by identifier
+         * @description Fetch a single trace by its identifier, without requiring a project. The identifier can be either:
+         *     1. A Relay node ID (base64-encoded GlobalID)
+         *     2. An OpenTelemetry trace_id (hex string)
+         *
+         *     Returns the same trace shape as the project traces list endpoint, including cumulative token counts and the owning project_id. Span details are not included; use `GET /projects/{project_identifier}/spans?trace_id=...` to retrieve spans.
+         */
+        get: operations["getTrace"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a trace by identifier
+         * @description Delete an entire trace by its identifier. The identifier can be either:
+         *     1. A Relay node ID (base64-encoded)
+         *     2. An OpenTelemetry trace_id (hex string)
+         *
+         *     This will permanently remove all spans in the trace and their associated data.
+         */
+        delete: operations["deleteTrace"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/trace_annotations": {
         parameters: {
             query?: never;
@@ -581,30 +613,6 @@ export interface paths {
          */
         post: operations["createTraceNote"];
         delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/traces/{trace_identifier}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete a trace by identifier
-         * @description Delete an entire trace by its identifier. The identifier can be either:
-         *     1. A Relay node ID (base64-encoded)
-         *     2. An OpenTelemetry trace_id (hex string)
-         *
-         *     This will permanently remove all spans in the trace and their associated data.
-         */
-        delete: operations["deleteTrace"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2677,6 +2685,10 @@ export interface components {
             data: components["schemas"]["SessionData"][];
             /** Next Cursor */
             next_cursor: string | null;
+        };
+        /** GetTraceResponseBody */
+        GetTraceResponseBody: {
+            data: components["schemas"]["TraceData"];
         };
         /** GetTracesResponseBody */
         GetTracesResponseBody: {
@@ -7255,6 +7267,104 @@ export interface operations {
             };
         };
     };
+    getTrace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The trace identifier: either a relay GlobalID or OpenTelemetry trace_id */
+                trace_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetTraceResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    deleteTrace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The trace identifier: either a relay GlobalID or OpenTelemetry trace_id */
+                trace_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     annotateTraces: {
         parameters: {
             query?: {
@@ -7341,54 +7451,6 @@ export interface operations {
                 };
             };
             /** @description Trace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": string;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    deleteTrace: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The trace identifier: either a relay GlobalID or OpenTelemetry trace_id */
-                trace_identifier: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": string;
-                };
-            };
-            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -549,6 +549,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/traces/{trace_identifier}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a single trace by identifier
+         * @description Fetch a single trace by its identifier, without requiring a project. The identifier can be either:
+         *     1. A Relay node ID (base64-encoded GlobalID)
+         *     2. An OpenTelemetry trace_id (hex string)
+         *
+         *     Returns the same trace shape as the project traces list endpoint, including cumulative token counts and the owning project_id. Span details are not included; use `GET /projects/{project_identifier}/spans?trace_id=...` to retrieve spans.
+         */
+        get: operations["getTrace"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a trace by identifier
+         * @description Delete an entire trace by its identifier. The identifier can be either:
+         *     1. A Relay node ID (base64-encoded)
+         *     2. An OpenTelemetry trace_id (hex string)
+         *
+         *     This will permanently remove all spans in the trace and their associated data.
+         */
+        delete: operations["deleteTrace"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/trace_annotations": {
         parameters: {
             query?: never;
@@ -581,30 +613,6 @@ export interface paths {
          */
         post: operations["createTraceNote"];
         delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/traces/{trace_identifier}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete a trace by identifier
-         * @description Delete an entire trace by its identifier. The identifier can be either:
-         *     1. A Relay node ID (base64-encoded)
-         *     2. An OpenTelemetry trace_id (hex string)
-         *
-         *     This will permanently remove all spans in the trace and their associated data.
-         */
-        delete: operations["deleteTrace"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2677,6 +2685,10 @@ export interface components {
             data: components["schemas"]["SessionData"][];
             /** Next Cursor */
             next_cursor: string | null;
+        };
+        /** GetTraceResponseBody */
+        GetTraceResponseBody: {
+            data: components["schemas"]["TraceData"];
         };
         /** GetTracesResponseBody */
         GetTracesResponseBody: {
@@ -7255,6 +7267,104 @@ export interface operations {
             };
         };
     };
+    getTrace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The trace identifier: either a relay GlobalID or OpenTelemetry trace_id */
+                trace_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetTraceResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    deleteTrace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The trace identifier: either a relay GlobalID or OpenTelemetry trace_id */
+                trace_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     annotateTraces: {
         parameters: {
             query?: {
@@ -7341,54 +7451,6 @@ export interface operations {
                 };
             };
             /** @description Trace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": string;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    deleteTrace: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The trace identifier: either a relay GlobalID or OpenTelemetry trace_id */
-                trace_identifier: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": string;
-                };
-            };
-            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1636,6 +1636,10 @@ class GetSessionsResponseBody(TypedDict):
     next_cursor: Optional[str]
 
 
+class GetTraceResponseBody(TypedDict):
+    data: TraceData
+
+
 class GetTracesResponseBody(TypedDict):
     data: Sequence[TraceData]
     next_cursor: Optional[str]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -3406,6 +3406,127 @@
         }
       }
     },
+    "/v1/traces/{trace_identifier}": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "Get a single trace by identifier",
+        "description": "Fetch a single trace by its identifier, without requiring a project. The identifier can be either:\n1. A Relay node ID (base64-encoded GlobalID)\n2. An OpenTelemetry trace_id (hex string)\n\nReturns the same trace shape as the project traces list endpoint, including cumulative token counts and the owning project_id. Span details are not included; use `GET /projects/{project_identifier}/spans?trace_id=...` to retrieve spans.",
+        "operationId": "getTrace",
+        "parameters": [
+          {
+            "name": "trace_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The trace identifier: either a relay GlobalID or OpenTelemetry trace_id",
+              "title": "Trace Identifier"
+            },
+            "description": "The trace identifier: either a relay GlobalID or OpenTelemetry trace_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTraceResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "Delete a trace by identifier",
+        "description": "Delete an entire trace by its identifier. The identifier can be either:\n1. A Relay node ID (base64-encoded)\n2. An OpenTelemetry trace_id (hex string)\n\nThis will permanently remove all spans in the trace and their associated data.",
+        "operationId": "deleteTrace",
+        "parameters": [
+          {
+            "name": "trace_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The trace identifier: either a relay GlobalID or OpenTelemetry trace_id",
+              "title": "Trace Identifier"
+            },
+            "description": "The trace identifier: either a relay GlobalID or OpenTelemetry trace_id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/trace_annotations": {
       "post": {
         "tags": [
@@ -3529,64 +3650,6 @@
                 }
               }
             }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/traces/{trace_identifier}": {
-      "delete": {
-        "tags": [
-          "traces"
-        ],
-        "summary": "Delete a trace by identifier",
-        "description": "Delete an entire trace by its identifier. The identifier can be either:\n1. A Relay node ID (base64-encoded)\n2. An OpenTelemetry trace_id (hex string)\n\nThis will permanently remove all spans in the trace and their associated data.",
-        "operationId": "deleteTrace",
-        "parameters": [
-          {
-            "name": "trace_identifier",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The trace identifier: either a relay GlobalID or OpenTelemetry trace_id",
-              "title": "Trace Identifier"
-            },
-            "description": "The trace identifier: either a relay GlobalID or OpenTelemetry trace_id"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "403": {
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Not Found"
           },
           "422": {
             "description": "Validation Error",
@@ -10014,6 +10077,18 @@
           "next_cursor"
         ],
         "title": "GetSessionsResponseBody"
+      },
+      "GetTraceResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TraceData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GetTraceResponseBody"
       },
       "GetTracesResponseBody": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -92,6 +92,10 @@ class GetTracesResponseBody(PaginatedResponseBody[TraceData]):
     pass
 
 
+class GetTraceResponseBody(ResponseBody[TraceData]):
+    pass
+
+
 def _to_trace_data(
     trace: models.Trace,
     project_id: int,
@@ -279,6 +283,55 @@ async def list_project_traces(
             for t in traces
         ]
     return GetTracesResponseBody(next_cursor=next_cursor, data=data)
+
+
+@router.get(
+    "/traces/{trace_identifier}",
+    operation_id="getTrace",
+    summary="Get a single trace by identifier",
+    description=(
+        "Fetch a single trace by its identifier, without requiring a project. "
+        "The identifier can be either:\n"
+        "1. A Relay node ID (base64-encoded GlobalID)\n"
+        "2. An OpenTelemetry trace_id (hex string)\n\n"
+        "Returns the same trace shape as the project traces list endpoint, "
+        "including cumulative token counts and the owning project_id. "
+        "Span details are not included; use "
+        "`GET /projects/{project_identifier}/spans?trace_id=...` to retrieve spans."
+    ),
+    responses=add_errors_to_responses([404]),
+)
+async def get_trace(
+    request: Request,
+    trace_identifier: str = Path(
+        description="The trace identifier: either a relay GlobalID or OpenTelemetry trace_id",
+    ),
+) -> GetTraceResponseBody:
+    async with request.app.state.db.read() as session:
+        # Try to parse as GlobalID first, then fall back to OTel trace_id
+        try:
+            trace_rowid = from_global_id_with_expected_type(
+                GlobalID.from_id(trace_identifier),
+                TraceNodeType.__name__,
+            )
+            stmt = select(models.Trace).where(models.Trace.id == trace_rowid)
+            error_detail = f"Trace with relay ID '{trace_identifier}' not found"
+        except Exception:
+            stmt = select(models.Trace).where(models.Trace.trace_id == trace_identifier)
+            error_detail = f"Trace with trace_id '{trace_identifier}' not found"
+
+        trace = await session.scalar(stmt)
+        if trace is None:
+            raise HTTPException(status_code=404, detail=error_detail)
+
+        # Fetch leaf-LLM token counts for this trace
+        token_counts: Optional[tuple[int, int]] = None
+        row = (await session.execute(token_counts_by_trace([trace.id]))).first()
+        if row is not None:
+            token_counts = (row.prompt, row.completion)
+
+        data = _to_trace_data(trace, trace.project_rowid, token_counts=token_counts)
+    return GetTraceResponseBody(data=data)
 
 
 def is_not_at_capacity(request: Request) -> None:

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2217,6 +2217,8 @@ _COMMON_RESOURCE_ENDPOINTS = (
     (404, "GET", "v1/sessions/fake-id-{}"),
     # Traces (project-scoped)
     (404, "GET", "v1/projects/fake-id-{}/traces"),
+    # Traces (single trace by identifier)
+    (404, "GET", "v1/traces/fake-id-{}"),
     # Viewer (authenticated user profile)
     (200, "GET", "v1/user"),
 )

--- a/tests/unit/server/api/routers/v1/test_get_trace.py
+++ b/tests/unit/server/api/routers/v1/test_get_trace.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+
+import httpx
+from sqlalchemy import insert
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.api.types.Project import Project as ProjectNodeType
+from phoenix.server.api.types.Trace import Trace as TraceNodeType
+from phoenix.server.types import DbSessionFactory
+
+
+async def _insert_trace(
+    db: DbSessionFactory,
+    *,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+) -> tuple[models.Project, models.Trace]:
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+        )
+        assert project_row_id is not None
+        trace_row_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id=token_hex(16),
+                project_rowid=project_row_id,
+                start_time=base_time,
+                end_time=base_time + timedelta(minutes=5),
+            )
+            .returning(models.Trace.id)
+        )
+        assert trace_row_id is not None
+        await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_row_id,
+                span_id=token_hex(8),
+                parent_id=None,
+                name="root",
+                span_kind="LLM",
+                start_time=base_time,
+                end_time=base_time + timedelta(seconds=5),
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=prompt_tokens,
+                cumulative_llm_token_count_completion=completion_tokens,
+                llm_token_count_prompt=prompt_tokens,
+                llm_token_count_completion=completion_tokens,
+            )
+            .returning(models.Span.id)
+        )
+        project = await session.get(models.Project, project_row_id)
+        trace = await session.get(models.Trace, trace_row_id)
+        assert project is not None
+        assert trace is not None
+    return project, trace
+
+
+class TestGetTrace:
+    async def test_get_trace_by_otel_trace_id(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        project, trace = await _insert_trace(db)
+        response = await httpx_client.get(f"v1/traces/{trace.trace_id}")
+        assert response.status_code == 200
+
+        trace_data = response.json()["data"]
+        assert trace_data["trace_id"] == trace.trace_id
+
+        trace_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(trace_data["id"]), TraceNodeType.__name__
+        )
+        assert trace_rowid == trace.id
+
+        project_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(trace_data["project_id"]), ProjectNodeType.__name__
+        )
+        assert project_rowid == project.id
+
+    async def test_get_trace_by_global_id(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        project, trace = await _insert_trace(db)
+        trace_global_id = str(GlobalID(TraceNodeType.__name__, str(trace.id)))
+
+        response = await httpx_client.get(f"v1/traces/{trace_global_id}")
+        assert response.status_code == 200
+
+        trace_data = response.json()["data"]
+        assert trace_data["trace_id"] == trace.trace_id
+        assert trace_data["id"] == trace_global_id
+
+    async def test_get_trace_response_fields(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, trace = await _insert_trace(db)
+        response = await httpx_client.get(f"v1/traces/{trace.trace_id}")
+        assert response.status_code == 200
+
+        trace_data = response.json()["data"]
+        assert "id" in trace_data
+        assert "trace_id" in trace_data
+        assert "project_id" in trace_data
+        assert "start_time" in trace_data
+        assert "end_time" in trace_data
+        assert "token_count_prompt" in trace_data
+        assert "token_count_completion" in trace_data
+        assert "token_count_total" in trace_data
+
+    async def test_get_trace_token_counts(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, trace = await _insert_trace(db, prompt_tokens=100, completion_tokens=50)
+        response = await httpx_client.get(f"v1/traces/{trace.trace_id}")
+        assert response.status_code == 200
+
+        trace_data = response.json()["data"]
+        assert trace_data["token_count_prompt"] == 100
+        assert trace_data["token_count_completion"] == 50
+        assert trace_data["token_count_total"] == 150
+
+    async def test_get_trace_not_found_by_trace_id(
+        self,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        response = await httpx_client.get(f"v1/traces/{token_hex(16)}")
+        assert response.status_code == 404
+
+    async def test_get_trace_not_found_by_global_id(
+        self,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        missing_global_id = str(GlobalID(TraceNodeType.__name__, "123456789"))
+        response = await httpx_client.get(f"v1/traces/{missing_global_id}")
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

Adds `GET /v1/traces/{trace_identifier}` — fetch a single trace by ID without requiring a project scope (part of the REST API roadmap #11985 §11).

- Resolves `{trace_identifier}` as either a Relay **GlobalID** or an OpenTelemetry **trace_id** (hex), mirroring the existing `DELETE /traces/{trace_identifier}` convention (and the sibling `GET /spans/{id}` #14017 plan).
- Returns the **same trace shape** as the project traces list endpoint (#12052), including the cumulative `token_count_*` fields (#12349) and the owning `project_id` so clients can navigate back to the project.
- Returns **404** when no trace matches.
- Span details are intentionally not included — callers use `GET /projects/{project_identifier}/spans?trace_id=...` for spans. An `include_spans` param can be a follow-up.

Unblocks CLI #12663 (`px trace <id>`), which currently fetches all project spans and filters client-side.

## Changes

- `src/phoenix/server/api/routers/v1/traces.py` — new `get_trace` handler + `GetTraceResponseBody`, reusing `_to_trace_data` and `token_counts_by_trace`.
- `tests/unit/server/api/routers/v1/test_get_trace.py` — unit tests (by trace_id, by GlobalID, response fields, token counts, 404s).
- `tests/integration/_helpers.py` — registered the GET route in `_COMMON_RESOURCE_ENDPOINTS`.
- Regenerated OpenAPI schema + Python/TS client types (`make openapi`).

## Testing

- `pytest tests/unit/server/api/routers/v1/test_get_trace.py` — 6 passed
- `make lint-python` — passed
- `mypy` on the modified module — passed

Closes #14027