### PR TITLE
feat(server): add error-status and latency filters to trace list endpoint

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -8136,6 +8136,12 @@ export interface operations {
                 include_spans?: boolean;
                 /** @description List of session identifiers to filter traces by. Each value can be either a session_id string or a session GlobalID. Only traces belonging to the specified sessions will be returned. */
                 session_identifier?: string[] | null;
+                /** @description Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI. */
+                error?: boolean | null;
+                /** @description Inclusive lower bound on trace latency in milliseconds. */
+                min_latency_ms?: number | null;
+                /** @description Inclusive upper bound on trace latency in milliseconds. */
+                max_latency_ms?: number | null;
             };
             header?: never;
             path: {

--- a/js/app/src/api/__generated__/v1.ts
+++ b/js/app/src/api/__generated__/v1.ts
@@ -10061,6 +10061,12 @@ export interface operations {
                 include_spans?: boolean;
                 /** @description List of session identifiers to filter traces by. Each value can be either a session_id string or a session GlobalID. Only traces belonging to the specified sessions will be returned. */
                 session_identifier?: string[] | null;
+                /** @description Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI. */
+                error?: boolean | null;
+                /** @description Inclusive lower bound on trace latency in milliseconds. */
+                min_latency_ms?: number | null;
+                /** @description Inclusive upper bound on trace latency in milliseconds. */
+                max_latency_ms?: number | null;
             };
             header?: never;
             path: {

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -8136,6 +8136,12 @@ export interface operations {
                 include_spans?: boolean;
                 /** @description List of session identifiers to filter traces by. Each value can be either a session_id string or a session GlobalID. Only traces belonging to the specified sessions will be returned. */
                 session_identifier?: string[] | null;
+                /** @description Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI. */
+                error?: boolean | null;
+                /** @description Inclusive lower bound on trace latency in milliseconds. */
+                min_latency_ms?: number | null;
+                /** @description Inclusive upper bound on trace latency in milliseconds. */
+                max_latency_ms?: number | null;
             };
             header?: never;
             path: {

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -10061,6 +10061,12 @@ export interface operations {
                 include_spans?: boolean;
                 /** @description List of session identifiers to filter traces by. Each value can be either a session_id string or a session GlobalID. Only traces belonging to the specified sessions will be returned. */
                 session_identifier?: string[] | null;
+                /** @description Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI. */
+                error?: boolean | null;
+                /** @description Inclusive lower bound on trace latency in milliseconds. */
+                min_latency_ms?: number | null;
+                /** @description Inclusive upper bound on trace latency in milliseconds. */
+                max_latency_ms?: number | null;
             };
             header?: never;
             path: {

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -10061,6 +10061,12 @@ export interface operations {
                 include_spans?: boolean;
                 /** @description List of session identifiers to filter traces by. Each value can be either a session_id string or a session GlobalID. Only traces belonging to the specified sessions will be returned. */
                 session_identifier?: string[] | null;
+                /** @description Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI. */
+                error?: boolean | null;
+                /** @description Inclusive lower bound on trace latency in milliseconds. */
+                min_latency_ms?: number | null;
+                /** @description Inclusive upper bound on trace latency in milliseconds. */
+                max_latency_ms?: number | null;
             };
             header?: never;
             path: {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -4289,6 +4289,62 @@
               "title": "Session Identifier"
             },
             "description": "List of session identifiers to filter traces by. Each value can be either a session_id string or a session GlobalID. Only traces belonging to the specified sessions will be returned."
+          },
+          {
+            "name": "error",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI.",
+              "title": "Error"
+            },
+            "description": "Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI."
+          },
+          {
+            "name": "min_latency_ms",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Inclusive lower bound on trace latency in milliseconds.",
+              "title": "Min Latency Ms"
+            },
+            "description": "Inclusive lower bound on trace latency in milliseconds."
+          },
+          {
+            "name": "max_latency_ms",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Inclusive upper bound on trace latency in milliseconds.",
+              "title": "Max Latency Ms"
+            },
+            "description": "Inclusive upper bound on trace latency in milliseconds."
           }
         ],
         "responses": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -4741,6 +4741,62 @@
               "title": "Session Identifier"
             },
             "description": "List of session identifiers to filter traces by. Each value can be either a session_id string or a session GlobalID. Only traces belonging to the specified sessions will be returned."
+          },
+          {
+            "name": "error",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI.",
+              "title": "Error"
+            },
+            "description": "Filter by trace error status. If true, only return traces that contain at least one span with `status_code == ERROR`. If false, only return traces with no errored spans. If omitted, traces are not filtered by error status. Matches the error indicator shown in the UI."
+          },
+          {
+            "name": "min_latency_ms",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Inclusive lower bound on trace latency in milliseconds.",
+              "title": "Min Latency Ms"
+            },
+            "description": "Inclusive lower bound on trace latency in milliseconds."
+          },
+          {
+            "name": "max_latency_ms",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Inclusive upper bound on trace latency in milliseconds.",
+              "title": "Max Latency Ms"
+            },
+            "description": "Inclusive upper bound on trace latency in milliseconds."
           }
         ],
         "responses": {

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -155,6 +155,25 @@ async def list_project_traces(
             "to the specified sessions will be returned."
         ),
     ),
+    error: Optional[bool] = Query(
+        default=None,
+        description=(
+            "Filter by trace error status. If true, only return traces that contain "
+            "at least one span with `status_code == ERROR`. If false, only return "
+            "traces with no errored spans. If omitted, traces are not filtered by "
+            "error status. Matches the error indicator shown in the UI."
+        ),
+    ),
+    min_latency_ms: Optional[float] = Query(
+        default=None,
+        ge=0,
+        description="Inclusive lower bound on trace latency in milliseconds.",
+    ),
+    max_latency_ms: Optional[float] = Query(
+        default=None,
+        ge=0,
+        description="Inclusive upper bound on trace latency in milliseconds.",
+    ),
 ) -> GetTracesResponseBody:
     async with request.app.state.db.read() as session:
         project = await get_project_by_identifier(session, project_identifier)
@@ -205,6 +224,22 @@ async def list_project_traces(
             )
         if end_time:
             stmt = stmt.where(models.Trace.start_time < normalize_datetime(end_time, timezone.utc))
+
+        if error is not None:
+            # A trace "has an error" if any of its spans has status_code == ERROR,
+            # matching the error indicator shown in the UI (see Trace.error_count).
+            errored_traces = select(models.Span.trace_rowid).where(
+                models.Span.status_code == "ERROR"
+            )
+            if error:
+                stmt = stmt.where(models.Trace.id.in_(errored_traces))
+            else:
+                stmt = stmt.where(models.Trace.id.notin_(errored_traces))
+
+        if min_latency_ms is not None:
+            stmt = stmt.where(models.Trace.latency_ms >= min_latency_ms)
+        if max_latency_ms is not None:
+            stmt = stmt.where(models.Trace.latency_ms <= max_latency_ms)
 
         if cursor:
             try:

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -23,6 +23,7 @@ from phoenix.datetime_utils import normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect, token_counts_by_trace
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
+from phoenix.db.trace_aggregates import error_count_by_trace
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.v1.annotations import TraceAnnotationData
 from phoenix.server.api.routers.v1.models import IsoDatetime
@@ -256,13 +257,11 @@ async def list_project_traces(
         if error is not None:
             # A trace "has an error" if any of its spans has status_code == ERROR,
             # matching the error indicator shown in the UI (see Trace.error_count).
-            errored_traces = select(models.Span.trace_rowid).where(
-                models.Span.status_code == "ERROR"
-            )
-            if error:
-                stmt = stmt.where(models.Trace.id.in_(errored_traces))
-            else:
-                stmt = stmt.where(models.Trace.id.notin_(errored_traces))
+            # Correlated on the trace rowid so the predicate is a per-candidate index
+            # probe on `ix_spans_trace_rowid` rather than a scan of every span row in
+            # the database, and so the outer query keeps its ordering index.
+            errored = error_count_by_trace().as_correlated_scalar(models.Trace.id) > 0
+            stmt = stmt.where(errored if error else ~errored)
 
         if min_latency_ms is not None:
             stmt = stmt.where(models.Trace.latency_ms >= min_latency_ms)

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -182,6 +182,25 @@ async def list_project_traces(
             "to the specified sessions will be returned."
         ),
     ),
+    error: Optional[bool] = Query(
+        default=None,
+        description=(
+            "Filter by trace error status. If true, only return traces that contain "
+            "at least one span with `status_code == ERROR`. If false, only return "
+            "traces with no errored spans. If omitted, traces are not filtered by "
+            "error status. Matches the error indicator shown in the UI."
+        ),
+    ),
+    min_latency_ms: Optional[float] = Query(
+        default=None,
+        ge=0,
+        description="Inclusive lower bound on trace latency in milliseconds.",
+    ),
+    max_latency_ms: Optional[float] = Query(
+        default=None,
+        ge=0,
+        description="Inclusive upper bound on trace latency in milliseconds.",
+    ),
 ) -> GetTracesResponseBody:
     async with request.app.state.db.read() as session:
         project = await get_project_by_identifier(session, project_identifier)
@@ -233,6 +252,22 @@ async def list_project_traces(
             )
         if end_time:
             stmt = stmt.where(models.Trace.start_time < normalize_datetime(end_time, timezone.utc))
+
+        if error is not None:
+            # A trace "has an error" if any of its spans has status_code == ERROR,
+            # matching the error indicator shown in the UI (see Trace.error_count).
+            errored_traces = select(models.Span.trace_rowid).where(
+                models.Span.status_code == "ERROR"
+            )
+            if error:
+                stmt = stmt.where(models.Trace.id.in_(errored_traces))
+            else:
+                stmt = stmt.where(models.Trace.id.notin_(errored_traces))
+
+        if min_latency_ms is not None:
+            stmt = stmt.where(models.Trace.latency_ms >= min_latency_ms)
+        if max_latency_ms is not None:
+            stmt = stmt.where(models.Trace.latency_ms <= max_latency_ms)
 
         if cursor:
             parsed_cursor = _parse_trace_cursor(cursor, sort)

--- a/tests/unit/server/api/routers/v1/test_list_project_traces.py
+++ b/tests/unit/server/api/routers/v1/test_list_project_traces.py
@@ -575,3 +575,306 @@ class TestListProjectTraces:
         assert trace_data["token_count_prompt"] == 100
         assert trace_data["token_count_completion"] == 50
         assert trace_data["token_count_total"] == 150
+
+
+async def _insert_trace(
+    db: DbSessionFactory,
+    project_row_id: int,
+    *,
+    start_time: datetime,
+    latency_ms: float,
+    span_status_codes: list[str],
+) -> models.Trace:
+    """Insert a single trace with a given latency and one span per status code."""
+    end_time = start_time + timedelta(milliseconds=latency_ms)
+    async with db() as session:
+        trace_row_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id=token_hex(16),
+                project_rowid=project_row_id,
+                start_time=start_time,
+                end_time=end_time,
+            )
+            .returning(models.Trace.id)
+        )
+        assert trace_row_id is not None
+        for i, status_code in enumerate(span_status_codes):
+            await session.scalar(
+                insert(models.Span)
+                .values(
+                    trace_rowid=trace_row_id,
+                    span_id=token_hex(8),
+                    parent_id=None if i == 0 else token_hex(8),
+                    name=f"span-{i}",
+                    span_kind="LLM" if i == 0 else "CHAIN",
+                    start_time=start_time,
+                    end_time=end_time,
+                    attributes={},
+                    events=[],
+                    status_code=status_code,
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                )
+                .returning(models.Span.id)
+            )
+        trace = await session.get(models.Trace, trace_row_id)
+        assert trace is not None
+    return trace
+
+
+class TestListProjectTracesErrorAndLatencyFilters:
+    async def test_filter_error_true_returns_only_errored_traces(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        ok_trace = await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK", "OK"]
+        )
+        error_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=200,
+            span_status_codes=["OK", "ERROR"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"error": "true"}
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {error_trace.trace_id}
+        assert ok_trace.trace_id not in returned
+
+    async def test_filter_error_false_returns_only_clean_traces(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        ok_trace = await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK", "OK"]
+        )
+        error_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=200,
+            span_status_codes=["OK", "ERROR"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"error": "false"}
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {ok_trace.trace_id}
+        assert error_trace.trace_id not in returned
+
+    async def test_no_error_filter_returns_all_traces(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK"]
+        )
+        await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=200,
+            span_status_codes=["ERROR"],
+        )
+
+        response = await httpx_client.get(f"v1/projects/{project.name}/traces")
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 2
+
+    async def test_filter_min_latency(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK"]
+        )
+        slow_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=500,
+            span_status_codes=["OK"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"min_latency_ms": 300}
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {slow_trace.trace_id}
+
+    async def test_filter_max_latency(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        fast_trace = await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK"]
+        )
+        await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=500,
+            span_status_codes=["OK"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"max_latency_ms": 300}
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {fast_trace.trace_id}
+
+    async def test_filter_latency_range(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK"]
+        )
+        mid_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=300,
+            span_status_codes=["OK"],
+        )
+        await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=2),
+            latency_ms=800,
+            span_status_codes=["OK"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces",
+            params={"min_latency_ms": 200, "max_latency_ms": 500},
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {mid_trace.trace_id}
+
+    async def test_filter_error_and_latency_compose(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        # errored but fast -> excluded by latency
+        await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=50, span_status_codes=["ERROR"]
+        )
+        # clean and slow -> excluded by error
+        await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=500,
+            span_status_codes=["OK"],
+        )
+        # errored and slow -> matches
+        match_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=2),
+            latency_ms=500,
+            span_status_codes=["ERROR"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces",
+            params={"error": "true", "min_latency_ms": 300},
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {match_trace.trace_id}
+
+    async def test_negative_latency_rejected(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        project, _, _, _ = await _insert_project_with_traces(db, num_traces=1)
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"min_latency_ms": -1}
+        )
+        assert response.status_code == 422

--- a/tests/unit/server/api/routers/v1/test_list_project_traces.py
+++ b/tests/unit/server/api/routers/v1/test_list_project_traces.py
@@ -673,3 +673,306 @@ class TestListProjectTracesKeysetPagination:
             params={"limit": 2, "cursor": str(Cursor(rowid=1))},
         )
         assert response.status_code == 422
+
+
+async def _insert_trace(
+    db: DbSessionFactory,
+    project_row_id: int,
+    *,
+    start_time: datetime,
+    latency_ms: float,
+    span_status_codes: list[str],
+) -> models.Trace:
+    """Insert a single trace with a given latency and one span per status code."""
+    end_time = start_time + timedelta(milliseconds=latency_ms)
+    async with db() as session:
+        trace_row_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id=token_hex(16),
+                project_rowid=project_row_id,
+                start_time=start_time,
+                end_time=end_time,
+            )
+            .returning(models.Trace.id)
+        )
+        assert trace_row_id is not None
+        for i, status_code in enumerate(span_status_codes):
+            await session.scalar(
+                insert(models.Span)
+                .values(
+                    trace_rowid=trace_row_id,
+                    span_id=token_hex(8),
+                    parent_id=None if i == 0 else token_hex(8),
+                    name=f"span-{i}",
+                    span_kind="LLM" if i == 0 else "CHAIN",
+                    start_time=start_time,
+                    end_time=end_time,
+                    attributes={},
+                    events=[],
+                    status_code=status_code,
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                )
+                .returning(models.Span.id)
+            )
+        trace = await session.get(models.Trace, trace_row_id)
+        assert trace is not None
+    return trace
+
+
+class TestListProjectTracesErrorAndLatencyFilters:
+    async def test_filter_error_true_returns_only_errored_traces(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        ok_trace = await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK", "OK"]
+        )
+        error_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=200,
+            span_status_codes=["OK", "ERROR"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"error": "true"}
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {error_trace.trace_id}
+        assert ok_trace.trace_id not in returned
+
+    async def test_filter_error_false_returns_only_clean_traces(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        ok_trace = await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK", "OK"]
+        )
+        error_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=200,
+            span_status_codes=["OK", "ERROR"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"error": "false"}
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {ok_trace.trace_id}
+        assert error_trace.trace_id not in returned
+
+    async def test_no_error_filter_returns_all_traces(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK"]
+        )
+        await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=200,
+            span_status_codes=["ERROR"],
+        )
+
+        response = await httpx_client.get(f"v1/projects/{project.name}/traces")
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 2
+
+    async def test_filter_min_latency(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK"]
+        )
+        slow_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=500,
+            span_status_codes=["OK"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"min_latency_ms": 300}
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {slow_trace.trace_id}
+
+    async def test_filter_max_latency(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        fast_trace = await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK"]
+        )
+        await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=500,
+            span_status_codes=["OK"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"max_latency_ms": 300}
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {fast_trace.trace_id}
+
+    async def test_filter_latency_range(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=100, span_status_codes=["OK"]
+        )
+        mid_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=300,
+            span_status_codes=["OK"],
+        )
+        await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=2),
+            latency_ms=800,
+            span_status_codes=["OK"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces",
+            params={"min_latency_ms": 200, "max_latency_ms": 500},
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {mid_trace.trace_id}
+
+    async def test_filter_error_and_latency_compose(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+        assert project_row_id is not None
+
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        # errored but fast -> excluded by latency
+        await _insert_trace(
+            db, project_row_id, start_time=base_time, latency_ms=50, span_status_codes=["ERROR"]
+        )
+        # clean and slow -> excluded by error
+        await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=1),
+            latency_ms=500,
+            span_status_codes=["OK"],
+        )
+        # errored and slow -> matches
+        match_trace = await _insert_trace(
+            db,
+            project_row_id,
+            start_time=base_time + timedelta(hours=2),
+            latency_ms=500,
+            span_status_codes=["ERROR"],
+        )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces",
+            params={"error": "true", "min_latency_ms": 300},
+        )
+        assert response.status_code == 200
+        returned = {t["trace_id"] for t in response.json()["data"]}
+        assert returned == {match_trace.trace_id}
+
+    async def test_negative_latency_rejected(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        project, _, _, _ = await _insert_project_with_traces(db, num_traces=1)
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces", params={"min_latency_ms": -1}
+        )
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary

Adds first-class, ergonomic filter params to `GET /v1/projects/{project_identifier}/traces` (shipped filter-less in #12052). This unblocks CLI #12008 (`px traces --error/--no-error`) and #12011 (`px traces --min-latency/--max-latency`), which cannot correctly filter client-side over paginated results.

New query params (mirroring the explicit-filter pattern from the spans list endpoint in #12048):

- `error=true|false` — filter by trace error status. `true` returns only traces that contain at least one span with `status_code == ERROR`; `false` returns only traces with no errored spans; omitted means no error filtering. This matches the UI's error indicator (`Trace.error_count`, which counts spans with `status_code == ERROR` regardless of parent/child topology), so the CLI and UI agree.
- `min_latency_ms` / `max_latency_ms` — inclusive lower/upper bounds on trace latency in milliseconds, independently combinable and validated as `>= 0` (422 otherwise).

All three compose with the existing time-range, session, sort, and cursor params.

## Implementation

- `src/phoenix/server/api/routers/v1/traces.py` — added the three `Query` params and applied them to the select statement.
  - Error status reuses the shared `error_count_by_trace()` aggregate from `phoenix/db/trace_aggregates.py` as a scalar subquery correlated on the trace rowid — the same helper and shape the trace-filter DSL already uses for `error_count`. Correlating it keeps the predicate a per-candidate index probe on `ix_spans_trace_rowid` and lets `traces` keep its covering index, rather than scanning every span row in the database on each request.
  - Latency uses the `Trace.latency_ms` hybrid expression, so the bounds compare against the same rounded SQL value this endpoint already sorts by.
- Regenerated OpenAPI schema + Python/TS client types via `make openapi`.

Note: this is server-side only. The hand-written Python and TypeScript client wrappers build an explicit param allowlist, so plumbing these filters through `get_traces` is follow-up work alongside the CLI issues above.

## Testing

- Added unit tests under `tests/unit/server/api/routers/v1/test_list_project_traces.py` covering error true/false/omitted, min/max/range latency, error+latency composition, and negative-latency rejection.
- Verified the correlated error predicate selects the same set as the previous `IN`/`NOT IN` form for both `error=true` and `error=false` (`COUNT` never returns NULL, so `~(count > 0)` is exactly `count = 0`).
- `make lint-python`, `mypy`, and the full test file pass.

Closes #14026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoukJpS8vB4stGbrZg3ggR