### PR TITLE
feat(server): add GET /spans/{span_identifier} REST endpoint

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -698,7 +698,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Get a single span by span_identifier
+         * @description Fetch a single span by identifier. The identifier may be either a relay GlobalID or an OpenTelemetry span_id. The returned payload matches the span schema emitted by the project span list endpoint.
+         */
+        get: operations["getSpan"];
         put?: never;
         post?: never;
         /**
@@ -2677,6 +2681,10 @@ export interface components {
             data: components["schemas"]["SessionData"][];
             /** Next Cursor */
             next_cursor: string | null;
+        };
+        /** GetSpanResponseBody */
+        GetSpanResponseBody: {
+            data: components["schemas"]["Span"];
         };
         /** GetTracesResponseBody */
         GetTracesResponseBody: {
@@ -7697,6 +7705,56 @@ export interface operations {
                 };
             };
             /** @description Span not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getSpan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The span identifier: either a relay GlobalID or OpenTelemetry span_id */
+                span_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetSpanResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -698,7 +698,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Get a single span by span_identifier
+         * @description Fetch a single span by identifier. The identifier may be either a relay GlobalID or an OpenTelemetry span_id. The returned payload matches the span schema emitted by the project span list endpoint.
+         */
+        get: operations["getSpan"];
         put?: never;
         post?: never;
         /**
@@ -2677,6 +2681,10 @@ export interface components {
             data: components["schemas"]["SessionData"][];
             /** Next Cursor */
             next_cursor: string | null;
+        };
+        /** GetSpanResponseBody */
+        GetSpanResponseBody: {
+            data: components["schemas"]["Span"];
         };
         /** GetTracesResponseBody */
         GetTracesResponseBody: {
@@ -7697,6 +7705,56 @@ export interface operations {
                 };
             };
             /** @description Span not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getSpan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The span identifier: either a relay GlobalID or OpenTelemetry span_id */
+                span_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetSpanResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1636,6 +1636,10 @@ class GetSessionsResponseBody(TypedDict):
     next_cursor: Optional[str]
 
 
+class GetSpanResponseBody(TypedDict):
+    data: Span
+
+
 class GetTracesResponseBody(TypedDict):
     data: Sequence[TraceData]
     next_cursor: Optional[str]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -4317,6 +4317,69 @@
       }
     },
     "/v1/spans/{span_identifier}": {
+      "get": {
+        "tags": [
+          "spans"
+        ],
+        "summary": "Get a single span by span_identifier",
+        "description": "Fetch a single span by identifier. The identifier may be either a relay GlobalID or an OpenTelemetry span_id. The returned payload matches the span schema emitted by the project span list endpoint.",
+        "operationId": "getSpan",
+        "parameters": [
+          {
+            "name": "span_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The span identifier: either a relay GlobalID or OpenTelemetry span_id",
+              "title": "Span Identifier"
+            },
+            "description": "The span identifier: either a relay GlobalID or OpenTelemetry span_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSpanResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "spans"
@@ -10014,6 +10077,18 @@
           "next_cursor"
         ],
         "title": "GetSessionsResponseBody"
+      },
+      "GetSpanResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Span"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GetSpanResponseBody"
       },
       "GetTracesResponseBody": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -583,6 +583,78 @@ class SpansResponseBody(PaginatedResponseBody[Span]):
     pass
 
 
+class GetSpanResponseBody(ResponseBody[Span]):
+    pass
+
+
+def _span_orm_to_pydantic_span(span_orm: models.Span, trace_id: str) -> Span:
+    """Serialize a ``models.Span`` ORM row into the API :class:`Span` payload.
+
+    Shared by the project span list endpoint and the single-span GET endpoint
+    so both surfaces emit an identical span schema.
+    """
+    # Convert events to Phoenix Event list
+    events: list[SpanEvent] = []
+    for event in span_orm.events:
+        event_time = event.get("timestamp")
+        parsed_time = None
+
+        if event_time:
+            if isinstance(event_time, datetime):
+                parsed_time = normalize_datetime(event_time, timezone.utc)
+            elif isinstance(event_time, str):
+                try:
+                    naive_time = datetime.fromisoformat(event_time)
+                    parsed_time = normalize_datetime(naive_time, timezone.utc)
+                except ValueError:
+                    # If ISO format fails, try to parse as timestamp
+                    try:
+                        parsed_time = datetime.fromtimestamp(float(event_time), tz=timezone.utc)
+                    except (ValueError, TypeError):
+                        parsed_time = datetime.now(timezone.utc)  # fallback
+            elif isinstance(event_time, (int, float)):
+                try:
+                    # Assume nanoseconds if very large, otherwise seconds
+                    if event_time > 1e12:  # nanoseconds
+                        parsed_time = datetime.fromtimestamp(
+                            event_time / 1_000_000_000, tz=timezone.utc
+                        )
+                    else:  # seconds
+                        parsed_time = datetime.fromtimestamp(event_time, tz=timezone.utc)
+                except (ValueError, OSError):
+                    parsed_time = datetime.now(timezone.utc)  # fallback
+        else:
+            parsed_time = datetime.now(timezone.utc)  # fallback
+
+        events.append(
+            SpanEvent(
+                name=event.get("name", ""),
+                timestamp=parsed_time,
+                attributes=event.get("attributes", {}),
+            )
+        )
+
+    attributes = {k: v for k, v in flatten(span_orm.attributes or dict(), recurse_on_sequence=True)}
+    openinference_span_kind = attributes.pop("openinference.span.kind", "UNKNOWN")
+
+    return Span(
+        id=str(GlobalID("Span", str(span_orm.id))),
+        name=span_orm.name or "",
+        context=SpanContext(
+            trace_id=trace_id,
+            span_id=span_orm.span_id or "",
+        ),
+        span_kind=openinference_span_kind,
+        parent_id=span_orm.parent_id,
+        start_time=span_orm.start_time,
+        end_time=span_orm.end_time,
+        status_code=span_orm.status_code,
+        status_message=span_orm.status_message or "",
+        attributes=attributes,
+        events=events,
+    )
+
+
 # TODO: Add property details to SpanQuery schema
 @router.post(
     "/spans",
@@ -1012,72 +1084,9 @@ async def span_search(
         next_cursor = str(GlobalID("Span", str(span_extra.id)))
 
     # Convert ORM rows -> Phoenix spans
-    result_spans: list[Span] = []
-    for span_orm, span_trace_id in rows:
-        # Convert events to Phoenix Event list
-        events: list[SpanEvent] = []
-        for event in span_orm.events:
-            event_time = event.get("timestamp")
-            parsed_time = None
-
-            if event_time:
-                if isinstance(event_time, datetime):
-                    parsed_time = normalize_datetime(event_time, timezone.utc)
-                elif isinstance(event_time, str):
-                    try:
-                        naive_time = datetime.fromisoformat(event_time)
-                        parsed_time = normalize_datetime(naive_time, timezone.utc)
-                    except ValueError:
-                        # If ISO format fails, try to parse as timestamp
-                        try:
-                            parsed_time = datetime.fromtimestamp(float(event_time), tz=timezone.utc)
-                        except (ValueError, TypeError):
-                            parsed_time = datetime.now(timezone.utc)  # fallback
-                elif isinstance(event_time, (int, float)):
-                    try:
-                        # Assume nanoseconds if very large, otherwise seconds
-                        if event_time > 1e12:  # nanoseconds
-                            parsed_time = datetime.fromtimestamp(
-                                event_time / 1_000_000_000, tz=timezone.utc
-                            )
-                        else:  # seconds
-                            parsed_time = datetime.fromtimestamp(event_time, tz=timezone.utc)
-                    except (ValueError, OSError):
-                        parsed_time = datetime.now(timezone.utc)  # fallback
-            else:
-                parsed_time = datetime.now(timezone.utc)  # fallback
-
-            events.append(
-                SpanEvent(
-                    name=event.get("name", ""),
-                    timestamp=parsed_time,
-                    attributes=event.get("attributes", {}),
-                )
-            )
-
-        attributes = {
-            k: v for k, v in flatten(span_orm.attributes or dict(), recurse_on_sequence=True)
-        }
-        openinference_span_kind = attributes.pop("openinference.span.kind", "UNKNOWN")
-
-        result_spans.append(
-            Span(
-                id=str(GlobalID("Span", str(span_orm.id))),
-                name=span_orm.name or "",
-                context=SpanContext(
-                    trace_id=span_trace_id,
-                    span_id=span_orm.span_id or "",
-                ),
-                span_kind=openinference_span_kind,
-                parent_id=span_orm.parent_id,
-                start_time=span_orm.start_time,
-                end_time=span_orm.end_time,
-                status_code=span_orm.status_code,
-                status_message=span_orm.status_message or "",
-                attributes=attributes,
-                events=events,
-            )
-        )
+    result_spans: list[Span] = [
+        _span_orm_to_pydantic_span(span_orm, span_trace_id) for span_orm, span_trace_id in rows
+    ]
 
     return SpansResponseBody(next_cursor=next_cursor, data=result_spans)
 
@@ -1459,6 +1468,52 @@ async def create_spans(
         total_received=total_received,
         total_queued=len(spans_to_queue),
     )
+
+
+@router.get(
+    "/spans/{span_identifier}",
+    operation_id="getSpan",
+    summary="Get a single span by span_identifier",
+    description=(
+        "Fetch a single span by identifier. The identifier may be either a relay "
+        "GlobalID or an OpenTelemetry span_id. The returned payload matches the span "
+        "schema emitted by the project span list endpoint."
+    ),
+    responses=add_errors_to_responses([404]),
+)
+async def get_span(
+    request: Request,
+    span_identifier: str = Path(
+        description="The span identifier: either a relay GlobalID or OpenTelemetry span_id"
+    ),
+) -> GetSpanResponseBody:
+    # Resolve the identifier the same way deleteSpan does: accept a relay
+    # GlobalID or a raw OpenTelemetry span_id.
+    try:
+        span_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(span_identifier),
+            "Span",
+        )
+        predicate = models.Span.id == span_rowid
+        error_detail = f"Span with relay ID '{span_identifier}' not found"
+    except Exception:
+        predicate = models.Span.span_id == span_identifier
+        error_detail = f"Span with span_id '{span_identifier}' not found"
+
+    stmt = (
+        select(models.Span, models.Trace.trace_id)
+        .join(models.Trace, onclause=models.Trace.id == models.Span.trace_rowid)
+        .where(predicate)
+    )
+
+    async with request.app.state.db.read() as session:
+        row = (await session.execute(stmt)).first()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail=error_detail)
+
+    span_orm, span_trace_id = row
+    return GetSpanResponseBody(data=_span_orm_to_pydantic_span(span_orm, span_trace_id))
 
 
 @router.delete(

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2212,6 +2212,7 @@ _COMMON_RESOURCE_ENDPOINTS = (
     (422, "GET", "v1/projects/fake-id-{}/session_annotations"),
     # Spans
     (422, "GET", "v1/spans"),
+    (404, "GET", "v1/spans/fake-id-{}"),
     # Sessions
     (404, "GET", "v1/projects/fake-id-{}/sessions"),
     (404, "GET", "v1/sessions/fake-id-{}"),

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -1138,6 +1138,68 @@ async def test_phoenix_openinference_span_kind_extraction(
     assert "openinference.span.kind" not in span.attributes
 
 
+async def test_get_span_by_otel_span_id(
+    httpx_client: httpx.AsyncClient, project_with_a_single_trace_and_span: None
+) -> None:
+    resp = await httpx_client.get("v1/spans/7e2f08cb43bbf521")
+    assert resp.is_success
+    span = Span.model_validate(resp.json()["data"])
+    assert span.context.span_id == "7e2f08cb43bbf521"
+    assert span.context.trace_id == "649993371fa95c788177f739b7423818"
+    assert span.name == "chain span"
+    # span_kind is derived from the openinference.span.kind attribute (absent here),
+    # mirroring the list endpoint's behavior.
+    assert span.span_kind == "UNKNOWN"
+    assert span.status_code == "OK"
+    assert span.status_message == "okay"
+    assert span.parent_id is None
+    assert span.attributes["input.value"] == "chain-span-input-value"
+    assert span.attributes["output.value"] == "chain-span-output-value"
+
+
+async def test_get_span_by_global_id(
+    httpx_client: httpx.AsyncClient, project_with_a_single_trace_and_span: None
+) -> None:
+    # First look up the span's relay GlobalID via the list endpoint.
+    list_resp = await httpx_client.get("v1/projects/project-name/spans")
+    assert list_resp.is_success
+    span_global_id = list_resp.json()["data"][0]["id"]
+
+    resp = await httpx_client.get(f"v1/spans/{span_global_id}")
+    assert resp.is_success
+    span = Span.model_validate(resp.json()["data"])
+    assert span.id == span_global_id
+    assert span.context.span_id == "7e2f08cb43bbf521"
+
+
+async def test_get_span_matches_list_endpoint_payload(
+    httpx_client: httpx.AsyncClient, project_with_a_single_trace_and_span_with_events: None
+) -> None:
+    # The single-span GET must emit the exact same schema as the list endpoint.
+    list_resp = await httpx_client.get("v1/projects/project-name/spans")
+    assert list_resp.is_success
+    list_span = list_resp.json()["data"][0]
+
+    resp = await httpx_client.get(f"v1/spans/{list_span['id']}")
+    assert resp.is_success
+    assert resp.json()["data"] == list_span
+
+
+async def test_get_span_not_found_with_global_id(
+    httpx_client: httpx.AsyncClient, project_with_a_single_trace_and_span: None
+) -> None:
+    missing_global_id = str(GlobalID("Span", "123456789"))
+    resp = await httpx_client.get(f"v1/spans/{missing_global_id}")
+    assert resp.status_code == 404
+
+
+async def test_get_span_not_found_with_otel_span_id(
+    httpx_client: httpx.AsyncClient, project_with_a_single_trace_and_span: None
+) -> None:
+    resp = await httpx_client.get("v1/spans/non-existent-span")
+    assert resp.status_code == 404
+
+
 @pytest.fixture
 async def multi_trace_project(db: DbSessionFactory) -> None:
     """Insert a project with two traces, each containing spans."""


### PR DESCRIPTION
## Summary

Adds `GET /spans/{span_identifier}` — fetch a single span by ID over REST. Previously the only ways to read a span were the project-scoped list/search endpoints or the query DSL, both of which require knowing the project and filtering down. This unblocks simple "look up this one span" flows (and CLI #12024).

## Details

- New `getSpan` operation in `src/phoenix/server/api/routers/v1/spans.py`.
- `{span_identifier}` accepts either a relay **GlobalID** or an **OpenTelemetry span_id**, resolved exactly the way `deleteSpan` already resolves the path param.
- Returns `200 OK` with the payload wrapped in `data`, using the **same `Span` schema** emitted by `GET /projects/{project_identifier}/spans` — the per-row serialization was extracted into a shared `_span_orm_to_pydantic_span` helper so the list and single-span endpoints can never drift.
- Returns `404` when no span matches the identifier.
- Read access: all authenticated users (mirrors the list endpoint; viewer/read-only restrictions apply at the router level).

## Tests

- Unit tests in `tests/unit/server/api/routers/v1/test_spans.py`: lookup by OTel span_id, lookup by GlobalID, byte-for-byte payload parity with the list endpoint, and 404s for both identifier forms.
- Registered in `_COMMON_RESOURCE_ENDPOINTS` in `tests/integration/_helpers.py`.
- Regenerated OpenAPI schema + Python/TypeScript clients (`make openapi`); `make lint-python` and `make typecheck-python` pass.

Closes #14017
