### PR TITLE
feat(server): add dataset split create/update/delete REST endpoints

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -284,6 +284,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/datasets/{dataset_identifier}/splits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a dataset split */
+        post: operations["createDatasetSplit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/splits/{split_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a dataset split */
+        delete: operations["deleteDatasetSplit"];
+        options?: never;
+        head?: never;
+        /** Update a dataset split */
+        patch: operations["updateDatasetSplit"];
+        trace?: never;
+    };
     "/v1/datasets/{id}/csv": {
         parameters: {
             query?: never;
@@ -1808,6 +1843,40 @@ export interface components {
             /** Data */
             data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
         };
+        /** CreateDatasetSplitRequestBody */
+        CreateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A unique name for the split.
+             */
+            name: string;
+            /**
+             * Description
+             * @description An optional description of the split.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description An optional hex color for the split (e.g. #33c5e8). Omit for a default.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description Arbitrary JSON metadata for the split.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Example Ids
+             * @description Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
+             */
+            example_ids?: string[];
+        };
+        /** CreateDatasetSplitResponseBody */
+        CreateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * CreateExperimentRequestBody
          * @description Details of the experiment to be created
@@ -2070,6 +2139,33 @@ export interface components {
             metadata: {
                 [key: string]: unknown;
             };
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /** DatasetSplit */
+        DatasetSplit: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Color */
+            color: string;
+            /** Metadata */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Example Count */
+            example_count: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
             /**
              * Updated At
              * Format: date-time
@@ -5254,6 +5350,45 @@ export interface components {
             /** Data */
             data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
         };
+        /** UpdateDatasetSplitRequestBody */
+        UpdateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A new unique name for the split.
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description A new description, or null to clear it.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description A new hex color for the split.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description New JSON metadata that replaces the existing metadata.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Add Example Ids
+             * @description Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
+             */
+            add_example_ids?: string[];
+            /**
+             * Remove Example Ids
+             * @description Dataset example IDs (GlobalIDs) to remove from the split.
+             */
+            remove_example_ids?: string[];
+        };
+        /** UpdateDatasetSplitResponseBody */
+        UpdateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * UpdateExperimentRequestBody
          * @description Fields to update on an experiment. Omit a field to leave it unchanged.
@@ -6382,6 +6517,184 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or split not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset split ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    updateDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset, split, or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -423,6 +423,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/datasets/{dataset_identifier}/splits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a dataset split */
+        post: operations["createDatasetSplit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/splits/{split_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a dataset split */
+        delete: operations["deleteDatasetSplit"];
+        options?: never;
+        head?: never;
+        /** Update a dataset split */
+        patch: operations["updateDatasetSplit"];
+        trace?: never;
+    };
     "/v1/datasets/{id}/csv": {
         parameters: {
             query?: never;
@@ -2304,6 +2339,40 @@ export interface components {
         CreateDatasetLabelResponseBody: {
             data: components["schemas"]["DatasetLabel"];
         };
+        /** CreateDatasetSplitRequestBody */
+        CreateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A unique name for the split.
+             */
+            name: string;
+            /**
+             * Description
+             * @description An optional description of the split.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description An optional hex color for the split (e.g. #33c5e8). Omit for a default.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description Arbitrary JSON metadata for the split.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Example Ids
+             * @description Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
+             */
+            example_ids?: string[];
+        };
+        /** CreateDatasetSplitResponseBody */
+        CreateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * CreateExperimentRequestBody
          * @description Details of the experiment to be created
@@ -2611,6 +2680,33 @@ export interface components {
             description: string | null;
             /** Color */
             color: string;
+        };
+        /** DatasetSplit */
+        DatasetSplit: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Color */
+            color: string;
+            /** Metadata */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Example Count */
+            example_count: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
         };
         /** DatasetVersion */
         DatasetVersion: {
@@ -5924,6 +6020,45 @@ export interface components {
         UpdateDatasetLabelResponseBody: {
             data: components["schemas"]["DatasetLabel"];
         };
+        /** UpdateDatasetSplitRequestBody */
+        UpdateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A new unique name for the split.
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description A new description, or null to clear it.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description A new hex color for the split.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description New JSON metadata that replaces the existing metadata.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Add Example Ids
+             * @description Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
+             */
+            add_example_ids?: string[];
+            /**
+             * Remove Example Ids
+             * @description Dataset example IDs (GlobalIDs) to remove from the split.
+             */
+            remove_example_ids?: string[];
+        };
+        /** UpdateDatasetSplitResponseBody */
+        UpdateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * UpdateExperimentRequestBody
          * @description Fields to update on an experiment. Omit a field to leave it unchanged.
@@ -7789,6 +7924,184 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or split not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset split ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    updateDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset, split, or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -284,6 +284,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/datasets/{dataset_identifier}/splits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a dataset split */
+        post: operations["createDatasetSplit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/splits/{split_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a dataset split */
+        delete: operations["deleteDatasetSplit"];
+        options?: never;
+        head?: never;
+        /** Update a dataset split */
+        patch: operations["updateDatasetSplit"];
+        trace?: never;
+    };
     "/v1/datasets/{id}/csv": {
         parameters: {
             query?: never;
@@ -1808,6 +1843,40 @@ export interface components {
             /** Data */
             data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
         };
+        /** CreateDatasetSplitRequestBody */
+        CreateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A unique name for the split.
+             */
+            name: string;
+            /**
+             * Description
+             * @description An optional description of the split.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description An optional hex color for the split (e.g. #33c5e8). Omit for a default.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description Arbitrary JSON metadata for the split.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Example Ids
+             * @description Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
+             */
+            example_ids?: string[];
+        };
+        /** CreateDatasetSplitResponseBody */
+        CreateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * CreateExperimentRequestBody
          * @description Details of the experiment to be created
@@ -2070,6 +2139,33 @@ export interface components {
             metadata: {
                 [key: string]: unknown;
             };
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /** DatasetSplit */
+        DatasetSplit: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Color */
+            color: string;
+            /** Metadata */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Example Count */
+            example_count: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
             /**
              * Updated At
              * Format: date-time
@@ -5254,6 +5350,45 @@ export interface components {
             /** Data */
             data: components["schemas"]["CategoricalAnnotationConfig"] | components["schemas"]["ContinuousAnnotationConfig"] | components["schemas"]["FreeformAnnotationConfig"];
         };
+        /** UpdateDatasetSplitRequestBody */
+        UpdateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A new unique name for the split.
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description A new description, or null to clear it.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description A new hex color for the split.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description New JSON metadata that replaces the existing metadata.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Add Example Ids
+             * @description Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
+             */
+            add_example_ids?: string[];
+            /**
+             * Remove Example Ids
+             * @description Dataset example IDs (GlobalIDs) to remove from the split.
+             */
+            remove_example_ids?: string[];
+        };
+        /** UpdateDatasetSplitResponseBody */
+        UpdateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * UpdateExperimentRequestBody
          * @description Fields to update on an experiment. Omit a field to leave it unchanged.
@@ -6382,6 +6517,184 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or split not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset split ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    updateDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset, split, or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -423,6 +423,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/datasets/{dataset_identifier}/splits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a dataset split */
+        post: operations["createDatasetSplit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/splits/{split_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a dataset split */
+        delete: operations["deleteDatasetSplit"];
+        options?: never;
+        head?: never;
+        /** Update a dataset split */
+        patch: operations["updateDatasetSplit"];
+        trace?: never;
+    };
     "/v1/datasets/{id}/csv": {
         parameters: {
             query?: never;
@@ -2304,6 +2339,40 @@ export interface components {
         CreateDatasetLabelResponseBody: {
             data: components["schemas"]["DatasetLabel"];
         };
+        /** CreateDatasetSplitRequestBody */
+        CreateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A unique name for the split.
+             */
+            name: string;
+            /**
+             * Description
+             * @description An optional description of the split.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description An optional hex color for the split (e.g. #33c5e8). Omit for a default.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description Arbitrary JSON metadata for the split.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Example Ids
+             * @description Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
+             */
+            example_ids?: string[];
+        };
+        /** CreateDatasetSplitResponseBody */
+        CreateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * CreateExperimentRequestBody
          * @description Details of the experiment to be created
@@ -2611,6 +2680,33 @@ export interface components {
             description: string | null;
             /** Color */
             color: string;
+        };
+        /** DatasetSplit */
+        DatasetSplit: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Color */
+            color: string;
+            /** Metadata */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Example Count */
+            example_count: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
         };
         /** DatasetVersion */
         DatasetVersion: {
@@ -5924,6 +6020,45 @@ export interface components {
         UpdateDatasetLabelResponseBody: {
             data: components["schemas"]["DatasetLabel"];
         };
+        /** UpdateDatasetSplitRequestBody */
+        UpdateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A new unique name for the split.
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description A new description, or null to clear it.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description A new hex color for the split.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description New JSON metadata that replaces the existing metadata.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Add Example Ids
+             * @description Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
+             */
+            add_example_ids?: string[];
+            /**
+             * Remove Example Ids
+             * @description Dataset example IDs (GlobalIDs) to remove from the split.
+             */
+            remove_example_ids?: string[];
+        };
+        /** UpdateDatasetSplitResponseBody */
+        UpdateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * UpdateExperimentRequestBody
          * @description Fields to update on an experiment. Omit a field to leave it unchanged.
@@ -7789,6 +7924,184 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or split not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset split ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    updateDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset, split, or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -423,6 +423,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/datasets/{dataset_identifier}/splits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a dataset split */
+        post: operations["createDatasetSplit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/datasets/{dataset_identifier}/splits/{split_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a dataset split */
+        delete: operations["deleteDatasetSplit"];
+        options?: never;
+        head?: never;
+        /** Update a dataset split */
+        patch: operations["updateDatasetSplit"];
+        trace?: never;
+    };
     "/v1/datasets/{id}/csv": {
         parameters: {
             query?: never;
@@ -2304,6 +2339,40 @@ export interface components {
         CreateDatasetLabelResponseBody: {
             data: components["schemas"]["DatasetLabel"];
         };
+        /** CreateDatasetSplitRequestBody */
+        CreateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A unique name for the split.
+             */
+            name: string;
+            /**
+             * Description
+             * @description An optional description of the split.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description An optional hex color for the split (e.g. #33c5e8). Omit for a default.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description Arbitrary JSON metadata for the split.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Example Ids
+             * @description Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split.
+             */
+            example_ids?: string[];
+        };
+        /** CreateDatasetSplitResponseBody */
+        CreateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * CreateExperimentRequestBody
          * @description Details of the experiment to be created
@@ -2611,6 +2680,33 @@ export interface components {
             description: string | null;
             /** Color */
             color: string;
+        };
+        /** DatasetSplit */
+        DatasetSplit: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Color */
+            color: string;
+            /** Metadata */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Example Count */
+            example_count: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
         };
         /** DatasetVersion */
         DatasetVersion: {
@@ -5924,6 +6020,45 @@ export interface components {
         UpdateDatasetLabelResponseBody: {
             data: components["schemas"]["DatasetLabel"];
         };
+        /** UpdateDatasetSplitRequestBody */
+        UpdateDatasetSplitRequestBody: {
+            /**
+             * Name
+             * @description A new unique name for the split.
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description A new description, or null to clear it.
+             */
+            description?: string | null;
+            /**
+             * Color
+             * @description A new hex color for the split.
+             */
+            color?: string | null;
+            /**
+             * Metadata
+             * @description New JSON metadata that replaces the existing metadata.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Add Example Ids
+             * @description Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op.
+             */
+            add_example_ids?: string[];
+            /**
+             * Remove Example Ids
+             * @description Dataset example IDs (GlobalIDs) to remove from the split.
+             */
+            remove_example_ids?: string[];
+        };
+        /** UpdateDatasetSplitResponseBody */
+        UpdateDatasetSplitResponseBody: {
+            data: components["schemas"]["DatasetSplit"];
+        };
         /**
          * UpdateExperimentRequestBody
          * @description Fields to update on an experiment. Omit a field to leave it unchanged.
@@ -7789,6 +7924,184 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset or split not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid dataset split ID */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    updateDatasetSplit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The dataset identifier: either dataset ID or dataset name. */
+                dataset_identifier: string;
+                /** @description The ID (GlobalID) of the dataset split. */
+                split_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDatasetSplitRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateDatasetSplitResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Dataset, split, or example not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description A dataset split with the given name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Invalid request */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
                 };
             };
         };

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -57,6 +57,14 @@ class CodeEvaluatorContext(TypedDict):
     evaluatorNodeId: NotRequired[str]
 
 
+class CreateDatasetSplitRequestBody(TypedDict):
+    name: str
+    description: NotRequired[str]
+    color: NotRequired[str]
+    metadata: NotRequired[Mapping[str, Any]]
+    example_ids: NotRequired[Sequence[str]]
+
+
 class CreateExperimentRequestBody(TypedDict):
     name: NotRequired[str]
     description: NotRequired[str]
@@ -124,6 +132,17 @@ class DatasetExample(TypedDict):
     input: Mapping[str, Any]
     output: Mapping[str, Any]
     metadata: Mapping[str, Any]
+    updated_at: str
+
+
+class DatasetSplit(TypedDict):
+    id: str
+    name: str
+    description: Optional[str]
+    color: str
+    metadata: Mapping[str, Any]
+    example_count: int
+    created_at: str
     updated_at: str
 
 
@@ -905,6 +924,19 @@ class TraceSpanData(TypedDict):
     end_time: str
 
 
+class UpdateDatasetSplitRequestBody(TypedDict):
+    name: NotRequired[str]
+    description: NotRequired[str]
+    color: NotRequired[str]
+    metadata: NotRequired[Mapping[str, Any]]
+    add_example_ids: NotRequired[Sequence[str]]
+    remove_example_ids: NotRequired[Sequence[str]]
+
+
+class UpdateDatasetSplitResponseBody(TypedDict):
+    data: DatasetSplit
+
+
 class UpdateExperimentRequestBody(TypedDict):
     name: NotRequired[str]
     description: NotRequired[str]
@@ -1074,6 +1106,10 @@ class ContinuousAnnotationConfigData(TypedDict):
     description: NotRequired[str]
     lower_bound: NotRequired[float]
     upper_bound: NotRequired[float]
+
+
+class CreateDatasetSplitResponseBody(TypedDict):
+    data: DatasetSplit
 
 
 class CreateExperimentResponseBody(TypedDict):

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -118,6 +118,14 @@ class CreateDatasetLabelRequestBody(TypedDict):
     description: NotRequired[str]
 
 
+class CreateDatasetSplitRequestBody(TypedDict):
+    name: str
+    description: NotRequired[str]
+    color: NotRequired[str]
+    metadata: NotRequired[Mapping[str, Any]]
+    example_ids: NotRequired[Sequence[str]]
+
+
 class CreateExperimentRequestBody(TypedDict):
     name: NotRequired[str]
     description: NotRequired[str]
@@ -198,6 +206,17 @@ class DatasetLabel(TypedDict):
     name: str
     description: Optional[str]
     color: str
+
+
+class DatasetSplit(TypedDict):
+    id: str
+    name: str
+    description: Optional[str]
+    color: str
+    metadata: Mapping[str, Any]
+    example_count: int
+    created_at: str
+    updated_at: str
 
 
 class DatasetVersion(TypedDict):
@@ -1005,6 +1024,19 @@ class UpdateDatasetLabelResponseBody(TypedDict):
     data: DatasetLabel
 
 
+class UpdateDatasetSplitRequestBody(TypedDict):
+    name: NotRequired[str]
+    description: NotRequired[str]
+    color: NotRequired[str]
+    metadata: NotRequired[Mapping[str, Any]]
+    add_example_ids: NotRequired[Sequence[str]]
+    remove_example_ids: NotRequired[Sequence[str]]
+
+
+class UpdateDatasetSplitResponseBody(TypedDict):
+    data: DatasetSplit
+
+
 class UpdateExperimentRequestBody(TypedDict):
     name: NotRequired[str]
     description: NotRequired[str]
@@ -1239,6 +1271,10 @@ class CreateChatCompletionRequestBody(TypedDict):
 
 class CreateDatasetLabelResponseBody(TypedDict):
     data: DatasetLabel
+
+
+class CreateDatasetSplitResponseBody(TypedDict):
+    data: DatasetSplit
 
 
 class CreateExperimentResponseBody(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -1994,6 +1994,251 @@
         }
       }
     },
+    "/v1/datasets/{dataset_identifier}/splits": {
+      "post": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Create a dataset split",
+        "operationId": "createDatasetSplit",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either dataset ID or dataset name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either dataset ID or dataset name."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDatasetSplitRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateDatasetSplitResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset or example not found"
+          },
+          "409": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "A dataset split with the given name already exists"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid request"
+          }
+        }
+      }
+    },
+    "/v1/datasets/{dataset_identifier}/splits/{split_id}": {
+      "patch": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Update a dataset split",
+        "operationId": "updateDatasetSplit",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either dataset ID or dataset name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either dataset ID or dataset name."
+          },
+          {
+            "name": "split_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID (GlobalID) of the dataset split.",
+              "title": "Split Id"
+            },
+            "description": "The ID (GlobalID) of the dataset split."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDatasetSplitRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateDatasetSplitResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset, split, or example not found"
+          },
+          "409": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "A dataset split with the given name already exists"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid request"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Delete a dataset split",
+        "operationId": "deleteDatasetSplit",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either dataset ID or dataset name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either dataset ID or dataset name."
+          },
+          {
+            "name": "split_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID (GlobalID) of the dataset split.",
+              "title": "Split Id"
+            },
+            "description": "The ID (GlobalID) of the dataset split."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset or split not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset split ID"
+          }
+        }
+      }
+    },
     "/v1/datasets/{id}/csv": {
       "get": {
         "tags": [
@@ -7878,6 +8123,70 @@
         ],
         "title": "CreateAnnotationConfigResponseBody"
       },
+      "CreateDatasetSplitRequestBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "A unique name for the split."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "An optional description of the split."
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color",
+            "description": "An optional hex color for the split (e.g. #33c5e8). Omit for a default."
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata",
+            "description": "Arbitrary JSON metadata for the split."
+          },
+          "example_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Example Ids",
+            "description": "Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CreateDatasetSplitRequestBody"
+      },
+      "CreateDatasetSplitResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DatasetSplit"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateDatasetSplitResponseBody"
+      },
       "CreateExperimentRequestBody": {
         "properties": {
           "name": {
@@ -8478,6 +8787,64 @@
           "updated_at"
         ],
         "title": "DatasetExample"
+      },
+      "DatasetSplit": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "color": {
+            "type": "string",
+            "title": "Color"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "example_count": {
+            "type": "integer",
+            "title": "Example Count"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "color",
+          "metadata",
+          "example_count",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "DatasetSplit"
       },
       "DatasetVersion": {
         "properties": {
@@ -16020,6 +16387,89 @@
           "data"
         ],
         "title": "UpdateAnnotationConfigResponseBody"
+      },
+      "UpdateDatasetSplitRequestBody": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "A new unique name for the split."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "A new description, or null to clear it."
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color",
+            "description": "A new hex color for the split."
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "New JSON metadata that replaces the existing metadata."
+          },
+          "add_example_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Add Example Ids",
+            "description": "Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op."
+          },
+          "remove_example_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Remove Example Ids",
+            "description": "Dataset example IDs (GlobalIDs) to remove from the split."
+          }
+        },
+        "type": "object",
+        "title": "UpdateDatasetSplitRequestBody"
+      },
+      "UpdateDatasetSplitResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DatasetSplit"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "UpdateDatasetSplitResponseBody"
       },
       "UpdateExperimentRequestBody": {
         "properties": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2923,6 +2923,251 @@
         }
       }
     },
+    "/v1/datasets/{dataset_identifier}/splits": {
+      "post": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Create a dataset split",
+        "operationId": "createDatasetSplit",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either dataset ID or dataset name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either dataset ID or dataset name."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDatasetSplitRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateDatasetSplitResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset or example not found"
+          },
+          "409": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "A dataset split with the given name already exists"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid request"
+          }
+        }
+      }
+    },
+    "/v1/datasets/{dataset_identifier}/splits/{split_id}": {
+      "patch": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Update a dataset split",
+        "operationId": "updateDatasetSplit",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either dataset ID or dataset name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either dataset ID or dataset name."
+          },
+          {
+            "name": "split_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID (GlobalID) of the dataset split.",
+              "title": "Split Id"
+            },
+            "description": "The ID (GlobalID) of the dataset split."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDatasetSplitRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateDatasetSplitResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset, split, or example not found"
+          },
+          "409": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "A dataset split with the given name already exists"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid request"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Delete a dataset split",
+        "operationId": "deleteDatasetSplit",
+        "parameters": [
+          {
+            "name": "dataset_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The dataset identifier: either dataset ID or dataset name.",
+              "title": "Dataset Identifier"
+            },
+            "description": "The dataset identifier: either dataset ID or dataset name."
+          },
+          {
+            "name": "split_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID (GlobalID) of the dataset split.",
+              "title": "Split Id"
+            },
+            "description": "The ID (GlobalID) of the dataset split."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dataset or split not found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Invalid dataset split ID"
+          }
+        }
+      }
+    },
     "/v1/datasets/{id}/csv": {
       "get": {
         "tags": [
@@ -10028,6 +10273,70 @@
         ],
         "title": "CreateDatasetLabelResponseBody"
       },
+      "CreateDatasetSplitRequestBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "A unique name for the split."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "An optional description of the split."
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color",
+            "description": "An optional hex color for the split (e.g. #33c5e8). Omit for a default."
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata",
+            "description": "Arbitrary JSON metadata for the split."
+          },
+          "example_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Example Ids",
+            "description": "Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must belong to this dataset. Omit to create an empty split."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CreateDatasetSplitRequestBody"
+      },
+      "CreateDatasetSplitResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DatasetSplit"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateDatasetSplitResponseBody"
+      },
       "CreateExperimentRequestBody": {
         "properties": {
           "name": {
@@ -10744,6 +11053,64 @@
           "color"
         ],
         "title": "DatasetLabel"
+      },
+      "DatasetSplit": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "color": {
+            "type": "string",
+            "title": "Color"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "example_count": {
+            "type": "integer",
+            "title": "Example Count"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "color",
+          "metadata",
+          "example_count",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "DatasetSplit"
       },
       "DatasetVersion": {
         "properties": {
@@ -18757,6 +19124,89 @@
           "data"
         ],
         "title": "UpdateDatasetLabelResponseBody"
+      },
+      "UpdateDatasetSplitRequestBody": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "A new unique name for the split."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "A new description, or null to clear it."
+          },
+          "color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color",
+            "description": "A new hex color for the split."
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "New JSON metadata that replaces the existing metadata."
+          },
+          "add_example_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Add Example Ids",
+            "description": "Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to this dataset. Adding an example already in the split is a no-op."
+          },
+          "remove_example_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Remove Example Ids",
+            "description": "Dataset example IDs (GlobalIDs) to remove from the split."
+          }
+        },
+        "type": "object",
+        "title": "UpdateDatasetSplitRequestBody"
+      },
+      "UpdateDatasetSplitResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DatasetSplit"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "UpdateDatasetSplitResponseBody"
       },
       "UpdateExperimentRequestBody": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -19,9 +19,12 @@ import pyarrow as pa
 from anyio import to_thread
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, Query
 from fastapi.responses import PlainTextResponse, StreamingResponse
-from sqlalchemy import and_, case, delete, func, select
+from pydantic import Field
+from sqlalchemy import and_, case, delete, func, insert, select
+from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
+from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import FormData, UploadFile
 from starlette.requests import Request
@@ -61,6 +64,7 @@ from .utils import (
     ResponseBody,
     add_errors_to_responses,
     add_text_csv_content_to_responses,
+    get_dataset_by_identifier,
 )
 
 csv.field_size_limit(
@@ -72,6 +76,11 @@ logger = logging.getLogger(__name__)
 
 DATASET_NODE_NAME = DatasetNodeType.__name__
 DATASET_VERSION_NODE_NAME = DatasetVersionNodeType.__name__
+DATASET_SPLIT_NODE_NAME = DatasetSplitNodeType.__name__
+DATASET_EXAMPLE_NODE_NAME = DatasetExampleNodeType.__name__
+
+# Matches the dataset-split form's default color (app NewDatasetSplitForm).
+DEFAULT_DATASET_SPLIT_COLOR = "#33c5e8"
 
 
 router = APIRouter(tags=["datasets"])
@@ -1469,6 +1478,369 @@ async def get_dataset_examples(
             examples=examples,
         )
     )
+
+
+class DatasetSplit(V1RoutesBaseModel):
+    id: str
+    name: str
+    description: Optional[str]
+    color: str
+    metadata: dict[str, Any]
+    example_count: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class CreateDatasetSplitRequestBody(V1RoutesBaseModel):
+    name: str = Field(description="A unique name for the split.")
+    description: Optional[str] = Field(
+        default=None, description="An optional description of the split."
+    )
+    color: Optional[str] = Field(
+        default=None,
+        description="An optional hex color for the split (e.g. #33c5e8). Omit for a default.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Arbitrary JSON metadata for the split."
+    )
+    example_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must "
+            "belong to this dataset. Omit to create an empty split."
+        ),
+    )
+
+
+class CreateDatasetSplitResponseBody(ResponseBody[DatasetSplit]):
+    pass
+
+
+class UpdateDatasetSplitRequestBody(V1RoutesBaseModel):
+    name: Optional[str] = Field(default=None, description="A new unique name for the split.")
+    description: Optional[str] = Field(
+        default=None, description="A new description, or null to clear it."
+    )
+    color: Optional[str] = Field(default=None, description="A new hex color for the split.")
+    metadata: Optional[dict[str, Any]] = Field(
+        default=None, description="New JSON metadata that replaces the existing metadata."
+    )
+    add_example_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to "
+            "this dataset. Adding an example already in the split is a no-op."
+        ),
+    )
+    remove_example_ids: list[str] = Field(
+        default_factory=list,
+        description="Dataset example IDs (GlobalIDs) to remove from the split.",
+    )
+
+
+class UpdateDatasetSplitResponseBody(ResponseBody[DatasetSplit]):
+    pass
+
+
+async def _resolve_dataset_example_rowids(
+    session: AsyncSession,
+    dataset_id: int,
+    example_ids: list[str],
+) -> list[int]:
+    """Parse dataset example GlobalIDs and confirm each belongs to the dataset.
+
+    Returns the unique example row IDs, preserving the order in which they were
+    first seen. Raises 422 for malformed IDs and 404 if any example does not
+    exist in the dataset.
+    """
+    if not example_ids:
+        return []
+    unique_rowids: dict[int, None] = {}
+    for example_gid in example_ids:
+        try:
+            rowid = from_global_id_with_expected_type(
+                GlobalID.from_id(example_gid),
+                DATASET_EXAMPLE_NODE_NAME,
+            )
+        except Exception:
+            raise HTTPException(
+                detail=f"Invalid dataset example ID: {example_gid}",
+                status_code=422,
+            )
+        unique_rowids[rowid] = None
+    rowids = list(unique_rowids)
+    found = set(
+        await session.scalars(
+            select(models.DatasetExample.id).where(
+                models.DatasetExample.id.in_(rowids),
+                models.DatasetExample.dataset_id == dataset_id,
+            )
+        )
+    )
+    missing = [rowid for rowid in rowids if rowid not in found]
+    if missing:
+        missing_gids = ", ".join(
+            str(GlobalID(DATASET_EXAMPLE_NODE_NAME, str(rowid))) for rowid in missing
+        )
+        raise HTTPException(
+            detail=f"Dataset examples not found in this dataset: {missing_gids}",
+            status_code=404,
+        )
+    return rowids
+
+
+async def _dataset_scoped_example_count(
+    session: AsyncSession,
+    dataset_split_id: int,
+    dataset_id: int,
+) -> int:
+    """Count the split's examples that belong to the given dataset."""
+    count = await session.scalar(
+        select(func.count())
+        .select_from(models.DatasetSplitDatasetExample)
+        .join(
+            models.DatasetExample,
+            models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
+        )
+        .where(models.DatasetSplitDatasetExample.dataset_split_id == dataset_split_id)
+        .where(models.DatasetExample.dataset_id == dataset_id)
+    )
+    return count or 0
+
+
+def _to_dataset_split(split: models.DatasetSplit, *, example_count: int) -> DatasetSplit:
+    return DatasetSplit(
+        id=str(GlobalID(DATASET_SPLIT_NODE_NAME, str(split.id))),
+        name=split.name,
+        description=split.description,
+        color=split.color,
+        metadata=split.metadata_,
+        example_count=example_count,
+        created_at=split.created_at,
+        updated_at=split.updated_at,
+    )
+
+
+@router.post(
+    "/datasets/{dataset_identifier}/splits",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="createDatasetSplit",
+    summary="Create a dataset split",
+    status_code=201,
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset or example not found"},
+            {
+                "status_code": 409,
+                "description": "A dataset split with the given name already exists",
+            },
+            {"status_code": 422, "description": "Invalid request"},
+        ]
+    ),
+)
+async def create_dataset_split(
+    request: Request,
+    request_body: CreateDatasetSplitRequestBody,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either dataset ID or dataset name."
+    ),
+) -> CreateDatasetSplitResponseBody:
+    name = request_body.name.strip()
+    if not name:
+        raise HTTPException(detail="Dataset split name cannot be empty", status_code=422)
+    color = request_body.color if request_body.color is not None else DEFAULT_DATASET_SPLIT_COLOR
+    if not color.strip():
+        raise HTTPException(detail="Dataset split color cannot be empty", status_code=422)
+    user_id: Optional[int] = None
+    if request.app.state.authentication_enabled and isinstance(request.user, PhoenixUser):
+        user_id = int(request.user.identity)
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+        example_rowids = await _resolve_dataset_example_rowids(
+            session, dataset.id, request_body.example_ids
+        )
+        split = models.DatasetSplit(
+            name=name,
+            description=request_body.description or None,
+            color=color,
+            metadata_=request_body.metadata or {},
+            user_id=user_id,
+        )
+        session.add(split)
+        try:
+            await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            await session.rollback()
+            raise HTTPException(
+                detail=f"A dataset split named '{name}' already exists",
+                status_code=409,
+            )
+        if example_rowids:
+            await session.execute(
+                insert(models.DatasetSplitDatasetExample),
+                [
+                    {"dataset_split_id": split.id, "dataset_example_id": rowid}
+                    for rowid in example_rowids
+                ],
+            )
+        await session.refresh(split)
+        data = _to_dataset_split(split, example_count=len(example_rowids))
+    return CreateDatasetSplitResponseBody(data=data)
+
+
+@router.patch(
+    "/datasets/{dataset_identifier}/splits/{split_id}",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="updateDatasetSplit",
+    summary="Update a dataset split",
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset, split, or example not found"},
+            {
+                "status_code": 409,
+                "description": "A dataset split with the given name already exists",
+            },
+            {"status_code": 422, "description": "Invalid request"},
+        ]
+    ),
+)
+async def update_dataset_split(
+    request: Request,
+    request_body: UpdateDatasetSplitRequestBody,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either dataset ID or dataset name."
+    ),
+    split_id: str = Path(description="The ID (GlobalID) of the dataset split."),
+) -> UpdateDatasetSplitResponseBody:
+    try:
+        split_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(split_id), DATASET_SPLIT_NODE_NAME
+        )
+    except Exception:
+        raise HTTPException(detail=f"Invalid dataset split ID: {split_id}", status_code=422)
+
+    # Validate provided scalar fields up front so an invalid value fails before any DB work.
+    fields_set = request_body.model_fields_set
+    new_name: Optional[str] = None
+    if "name" in fields_set:
+        if request_body.name is None or not request_body.name.strip():
+            raise HTTPException(detail="Dataset split name cannot be empty", status_code=422)
+        new_name = request_body.name.strip()
+    new_color: Optional[str] = None
+    if "color" in fields_set:
+        if request_body.color is None or not request_body.color.strip():
+            raise HTTPException(detail="Dataset split color cannot be empty", status_code=422)
+        new_color = request_body.color
+
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+        split = await session.get(models.DatasetSplit, split_rowid)
+        if split is None:
+            raise HTTPException(
+                detail=f"Dataset split with ID {split_id} not found", status_code=404
+            )
+
+        # Only fields explicitly present in the request are changed; an omitted
+        # field is left untouched. An explicit null clears the description (the
+        # only nullable column) and is ignored for the non-nullable columns.
+        if new_name is not None:
+            split.name = new_name
+        if "description" in fields_set:
+            split.description = request_body.description or None
+        if new_color is not None:
+            split.color = new_color
+        if "metadata" in fields_set and isinstance(request_body.metadata, dict):
+            split.metadata_ = request_body.metadata
+
+        remove_rowids = await _resolve_dataset_example_rowids(
+            session, dataset.id, request_body.remove_example_ids
+        )
+        add_rowids = await _resolve_dataset_example_rowids(
+            session, dataset.id, request_body.add_example_ids
+        )
+        # Add first, then remove, so an example listed in both arrays ends up
+        # removed (removal wins). Adding an example already in the split is a
+        # no-op; removing one that isn't a member is a no-op.
+        if add_rowids:
+            already_present = set(
+                await session.scalars(
+                    select(models.DatasetSplitDatasetExample.dataset_example_id).where(
+                        models.DatasetSplitDatasetExample.dataset_split_id == split_rowid,
+                        models.DatasetSplitDatasetExample.dataset_example_id.in_(add_rowids),
+                    )
+                )
+            )
+            to_add = [rowid for rowid in add_rowids if rowid not in already_present]
+            if to_add:
+                await session.execute(
+                    insert(models.DatasetSplitDatasetExample),
+                    [
+                        {"dataset_split_id": split_rowid, "dataset_example_id": rowid}
+                        for rowid in to_add
+                    ],
+                )
+                await session.flush()
+        if remove_rowids:
+            await session.execute(
+                delete(models.DatasetSplitDatasetExample).where(
+                    models.DatasetSplitDatasetExample.dataset_split_id == split_rowid,
+                    models.DatasetSplitDatasetExample.dataset_example_id.in_(remove_rowids),
+                )
+            )
+
+        try:
+            await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            await session.rollback()
+            raise HTTPException(
+                detail="A dataset split with this name already exists",
+                status_code=409,
+            )
+        await session.refresh(split)
+        example_count = await _dataset_scoped_example_count(session, split_rowid, dataset.id)
+        data = _to_dataset_split(split, example_count=example_count)
+    return UpdateDatasetSplitResponseBody(data=data)
+
+
+@router.delete(
+    "/datasets/{dataset_identifier}/splits/{split_id}",
+    operation_id="deleteDatasetSplit",
+    summary="Delete a dataset split",
+    status_code=204,
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset or split not found"},
+            {"status_code": 422, "description": "Invalid dataset split ID"},
+        ]
+    ),
+)
+async def delete_dataset_split(
+    request: Request,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either dataset ID or dataset name."
+    ),
+    split_id: str = Path(description="The ID (GlobalID) of the dataset split."),
+) -> None:
+    try:
+        split_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(split_id), DATASET_SPLIT_NODE_NAME
+        )
+    except Exception:
+        raise HTTPException(detail=f"Invalid dataset split ID: {split_id}", status_code=422)
+    async with request.app.state.db() as session:
+        # Confirm the dataset exists so the path is meaningful, then delete the
+        # split globally. Its example memberships are removed via ON DELETE
+        # CASCADE; the underlying examples are left untouched.
+        await get_dataset_by_identifier(session, dataset_identifier)
+        deleted_id = await session.scalar(
+            delete(models.DatasetSplit)
+            .where(models.DatasetSplit.id == split_rowid)
+            .returning(models.DatasetSplit.id)
+        )
+        if deleted_id is None:
+            raise HTTPException(
+                detail=f"Dataset split with ID {split_id} not found", status_code=404
+            )
 
 
 @router.get(

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -19,9 +19,12 @@ import pyarrow as pa
 from anyio import to_thread
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, Query
 from fastapi.responses import PlainTextResponse, StreamingResponse
-from sqlalchemy import and_, case, delete, func, select
+from pydantic import Field
+from sqlalchemy import and_, case, delete, func, insert, select
+from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
+from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import FormData, UploadFile
 from starlette.requests import Request
@@ -61,6 +64,7 @@ from .utils import (
     ResponseBody,
     add_errors_to_responses,
     add_text_csv_content_to_responses,
+    get_dataset_by_identifier,
 )
 
 csv.field_size_limit(
@@ -72,6 +76,11 @@ logger = logging.getLogger(__name__)
 
 DATASET_NODE_NAME = DatasetNodeType.__name__
 DATASET_VERSION_NODE_NAME = DatasetVersionNodeType.__name__
+DATASET_SPLIT_NODE_NAME = DatasetSplitNodeType.__name__
+DATASET_EXAMPLE_NODE_NAME = DatasetExampleNodeType.__name__
+
+# Matches the dataset-split form's default color (app NewDatasetSplitForm).
+DEFAULT_DATASET_SPLIT_COLOR = "#33c5e8"
 
 
 router = APIRouter(tags=["datasets"])
@@ -1491,6 +1500,369 @@ async def get_dataset_examples(
             examples=examples,
         )
     )
+
+
+class DatasetSplit(V1RoutesBaseModel):
+    id: str
+    name: str
+    description: Optional[str]
+    color: str
+    metadata: dict[str, Any]
+    example_count: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class CreateDatasetSplitRequestBody(V1RoutesBaseModel):
+    name: str = Field(description="A unique name for the split.")
+    description: Optional[str] = Field(
+        default=None, description="An optional description of the split."
+    )
+    color: Optional[str] = Field(
+        default=None,
+        description="An optional hex color for the split (e.g. #33c5e8). Omit for a default.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Arbitrary JSON metadata for the split."
+    )
+    example_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional dataset example IDs (GlobalIDs) to seed the split with. Each example must "
+            "belong to this dataset. Omit to create an empty split."
+        ),
+    )
+
+
+class CreateDatasetSplitResponseBody(ResponseBody[DatasetSplit]):
+    pass
+
+
+class UpdateDatasetSplitRequestBody(V1RoutesBaseModel):
+    name: Optional[str] = Field(default=None, description="A new unique name for the split.")
+    description: Optional[str] = Field(
+        default=None, description="A new description, or null to clear it."
+    )
+    color: Optional[str] = Field(default=None, description="A new hex color for the split.")
+    metadata: Optional[dict[str, Any]] = Field(
+        default=None, description="New JSON metadata that replaces the existing metadata."
+    )
+    add_example_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Dataset example IDs (GlobalIDs) to add to the split. Each example must belong to "
+            "this dataset. Adding an example already in the split is a no-op."
+        ),
+    )
+    remove_example_ids: list[str] = Field(
+        default_factory=list,
+        description="Dataset example IDs (GlobalIDs) to remove from the split.",
+    )
+
+
+class UpdateDatasetSplitResponseBody(ResponseBody[DatasetSplit]):
+    pass
+
+
+async def _resolve_dataset_example_rowids(
+    session: AsyncSession,
+    dataset_id: int,
+    example_ids: list[str],
+) -> list[int]:
+    """Parse dataset example GlobalIDs and confirm each belongs to the dataset.
+
+    Returns the unique example row IDs, preserving the order in which they were
+    first seen. Raises 422 for malformed IDs and 404 if any example does not
+    exist in the dataset.
+    """
+    if not example_ids:
+        return []
+    unique_rowids: dict[int, None] = {}
+    for example_gid in example_ids:
+        try:
+            rowid = from_global_id_with_expected_type(
+                GlobalID.from_id(example_gid),
+                DATASET_EXAMPLE_NODE_NAME,
+            )
+        except Exception:
+            raise HTTPException(
+                detail=f"Invalid dataset example ID: {example_gid}",
+                status_code=422,
+            )
+        unique_rowids[rowid] = None
+    rowids = list(unique_rowids)
+    found = set(
+        await session.scalars(
+            select(models.DatasetExample.id).where(
+                models.DatasetExample.id.in_(rowids),
+                models.DatasetExample.dataset_id == dataset_id,
+            )
+        )
+    )
+    missing = [rowid for rowid in rowids if rowid not in found]
+    if missing:
+        missing_gids = ", ".join(
+            str(GlobalID(DATASET_EXAMPLE_NODE_NAME, str(rowid))) for rowid in missing
+        )
+        raise HTTPException(
+            detail=f"Dataset examples not found in this dataset: {missing_gids}",
+            status_code=404,
+        )
+    return rowids
+
+
+async def _dataset_scoped_example_count(
+    session: AsyncSession,
+    dataset_split_id: int,
+    dataset_id: int,
+) -> int:
+    """Count the split's examples that belong to the given dataset."""
+    count = await session.scalar(
+        select(func.count())
+        .select_from(models.DatasetSplitDatasetExample)
+        .join(
+            models.DatasetExample,
+            models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
+        )
+        .where(models.DatasetSplitDatasetExample.dataset_split_id == dataset_split_id)
+        .where(models.DatasetExample.dataset_id == dataset_id)
+    )
+    return count or 0
+
+
+def _to_dataset_split(split: models.DatasetSplit, *, example_count: int) -> DatasetSplit:
+    return DatasetSplit(
+        id=str(GlobalID(DATASET_SPLIT_NODE_NAME, str(split.id))),
+        name=split.name,
+        description=split.description,
+        color=split.color,
+        metadata=split.metadata_,
+        example_count=example_count,
+        created_at=split.created_at,
+        updated_at=split.updated_at,
+    )
+
+
+@router.post(
+    "/datasets/{dataset_identifier}/splits",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="createDatasetSplit",
+    summary="Create a dataset split",
+    status_code=201,
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset or example not found"},
+            {
+                "status_code": 409,
+                "description": "A dataset split with the given name already exists",
+            },
+            {"status_code": 422, "description": "Invalid request"},
+        ]
+    ),
+)
+async def create_dataset_split(
+    request: Request,
+    request_body: CreateDatasetSplitRequestBody,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either dataset ID or dataset name."
+    ),
+) -> CreateDatasetSplitResponseBody:
+    name = request_body.name.strip()
+    if not name:
+        raise HTTPException(detail="Dataset split name cannot be empty", status_code=422)
+    color = request_body.color if request_body.color is not None else DEFAULT_DATASET_SPLIT_COLOR
+    if not color.strip():
+        raise HTTPException(detail="Dataset split color cannot be empty", status_code=422)
+    user_id: Optional[int] = None
+    if request.app.state.authentication_enabled and isinstance(request.user, PhoenixUser):
+        user_id = int(request.user.identity)
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+        example_rowids = await _resolve_dataset_example_rowids(
+            session, dataset.id, request_body.example_ids
+        )
+        split = models.DatasetSplit(
+            name=name,
+            description=request_body.description or None,
+            color=color,
+            metadata_=request_body.metadata or {},
+            user_id=user_id,
+        )
+        session.add(split)
+        try:
+            await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            await session.rollback()
+            raise HTTPException(
+                detail=f"A dataset split named '{name}' already exists",
+                status_code=409,
+            )
+        if example_rowids:
+            await session.execute(
+                insert(models.DatasetSplitDatasetExample),
+                [
+                    {"dataset_split_id": split.id, "dataset_example_id": rowid}
+                    for rowid in example_rowids
+                ],
+            )
+        await session.refresh(split)
+        data = _to_dataset_split(split, example_count=len(example_rowids))
+    return CreateDatasetSplitResponseBody(data=data)
+
+
+@router.patch(
+    "/datasets/{dataset_identifier}/splits/{split_id}",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="updateDatasetSplit",
+    summary="Update a dataset split",
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset, split, or example not found"},
+            {
+                "status_code": 409,
+                "description": "A dataset split with the given name already exists",
+            },
+            {"status_code": 422, "description": "Invalid request"},
+        ]
+    ),
+)
+async def update_dataset_split(
+    request: Request,
+    request_body: UpdateDatasetSplitRequestBody,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either dataset ID or dataset name."
+    ),
+    split_id: str = Path(description="The ID (GlobalID) of the dataset split."),
+) -> UpdateDatasetSplitResponseBody:
+    try:
+        split_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(split_id), DATASET_SPLIT_NODE_NAME
+        )
+    except Exception:
+        raise HTTPException(detail=f"Invalid dataset split ID: {split_id}", status_code=422)
+
+    # Validate provided scalar fields up front so an invalid value fails before any DB work.
+    fields_set = request_body.model_fields_set
+    new_name: Optional[str] = None
+    if "name" in fields_set:
+        if request_body.name is None or not request_body.name.strip():
+            raise HTTPException(detail="Dataset split name cannot be empty", status_code=422)
+        new_name = request_body.name.strip()
+    new_color: Optional[str] = None
+    if "color" in fields_set:
+        if request_body.color is None or not request_body.color.strip():
+            raise HTTPException(detail="Dataset split color cannot be empty", status_code=422)
+        new_color = request_body.color
+
+    async with request.app.state.db() as session:
+        dataset = await get_dataset_by_identifier(session, dataset_identifier)
+        split = await session.get(models.DatasetSplit, split_rowid)
+        if split is None:
+            raise HTTPException(
+                detail=f"Dataset split with ID {split_id} not found", status_code=404
+            )
+
+        # Only fields explicitly present in the request are changed; an omitted
+        # field is left untouched. An explicit null clears the description (the
+        # only nullable column) and is ignored for the non-nullable columns.
+        if new_name is not None:
+            split.name = new_name
+        if "description" in fields_set:
+            split.description = request_body.description or None
+        if new_color is not None:
+            split.color = new_color
+        if "metadata" in fields_set and isinstance(request_body.metadata, dict):
+            split.metadata_ = request_body.metadata
+
+        remove_rowids = await _resolve_dataset_example_rowids(
+            session, dataset.id, request_body.remove_example_ids
+        )
+        add_rowids = await _resolve_dataset_example_rowids(
+            session, dataset.id, request_body.add_example_ids
+        )
+        # Add first, then remove, so an example listed in both arrays ends up
+        # removed (removal wins). Adding an example already in the split is a
+        # no-op; removing one that isn't a member is a no-op.
+        if add_rowids:
+            already_present = set(
+                await session.scalars(
+                    select(models.DatasetSplitDatasetExample.dataset_example_id).where(
+                        models.DatasetSplitDatasetExample.dataset_split_id == split_rowid,
+                        models.DatasetSplitDatasetExample.dataset_example_id.in_(add_rowids),
+                    )
+                )
+            )
+            to_add = [rowid for rowid in add_rowids if rowid not in already_present]
+            if to_add:
+                await session.execute(
+                    insert(models.DatasetSplitDatasetExample),
+                    [
+                        {"dataset_split_id": split_rowid, "dataset_example_id": rowid}
+                        for rowid in to_add
+                    ],
+                )
+                await session.flush()
+        if remove_rowids:
+            await session.execute(
+                delete(models.DatasetSplitDatasetExample).where(
+                    models.DatasetSplitDatasetExample.dataset_split_id == split_rowid,
+                    models.DatasetSplitDatasetExample.dataset_example_id.in_(remove_rowids),
+                )
+            )
+
+        try:
+            await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            await session.rollback()
+            raise HTTPException(
+                detail="A dataset split with this name already exists",
+                status_code=409,
+            )
+        await session.refresh(split)
+        example_count = await _dataset_scoped_example_count(session, split_rowid, dataset.id)
+        data = _to_dataset_split(split, example_count=example_count)
+    return UpdateDatasetSplitResponseBody(data=data)
+
+
+@router.delete(
+    "/datasets/{dataset_identifier}/splits/{split_id}",
+    operation_id="deleteDatasetSplit",
+    summary="Delete a dataset split",
+    status_code=204,
+    responses=add_errors_to_responses(
+        [
+            {"status_code": 404, "description": "Dataset or split not found"},
+            {"status_code": 422, "description": "Invalid dataset split ID"},
+        ]
+    ),
+)
+async def delete_dataset_split(
+    request: Request,
+    dataset_identifier: str = Path(
+        description="The dataset identifier: either dataset ID or dataset name."
+    ),
+    split_id: str = Path(description="The ID (GlobalID) of the dataset split."),
+) -> None:
+    try:
+        split_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(split_id), DATASET_SPLIT_NODE_NAME
+        )
+    except Exception:
+        raise HTTPException(detail=f"Invalid dataset split ID: {split_id}", status_code=422)
+    async with request.app.state.db() as session:
+        # Confirm the dataset exists so the path is meaningful, then delete the
+        # split globally. Its example memberships are removed via ON DELETE
+        # CASCADE; the underlying examples are left untouched.
+        await get_dataset_by_identifier(session, dataset_identifier)
+        deleted_id = await session.scalar(
+            delete(models.DatasetSplit)
+            .where(models.DatasetSplit.id == split_rowid)
+            .returning(models.DatasetSplit.id)
+        )
+        if deleted_id is None:
+            raise HTTPException(
+                detail=f"Dataset split with ID {split_id} not found", status_code=404
+            )
 
 
 @router.get(

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -1762,6 +1762,26 @@ async def update_dataset_split(
                 detail=f"Dataset split with ID {split_id} not found", status_code=404
             )
 
+        # Perform all reads before mutating the split: subsequent queries would
+        # otherwise autoflush pending changes and surface integrity errors
+        # (e.g. a duplicate name) outside the try/except below.
+        remove_rowids = await _resolve_dataset_example_rowids(
+            session, dataset.id, request_body.remove_example_ids
+        )
+        add_rowids = await _resolve_dataset_example_rowids(
+            session, dataset.id, request_body.add_example_ids
+        )
+        already_present = set(
+            await session.scalars(
+                select(models.DatasetSplitDatasetExample.dataset_example_id).where(
+                    models.DatasetSplitDatasetExample.dataset_split_id == split_rowid,
+                    models.DatasetSplitDatasetExample.dataset_example_id.in_(add_rowids),
+                )
+            )
+            if add_rowids
+            else []
+        )
+
         # Only fields explicitly present in the request are changed; an omitted
         # field is left untouched. An explicit null clears the description (the
         # only nullable column) and is ignored for the non-nullable columns.
@@ -1774,26 +1794,11 @@ async def update_dataset_split(
         if "metadata" in fields_set and isinstance(request_body.metadata, dict):
             split.metadata_ = request_body.metadata
 
-        remove_rowids = await _resolve_dataset_example_rowids(
-            session, dataset.id, request_body.remove_example_ids
-        )
-        add_rowids = await _resolve_dataset_example_rowids(
-            session, dataset.id, request_body.add_example_ids
-        )
-        # Add first, then remove, so an example listed in both arrays ends up
-        # removed (removal wins). Adding an example already in the split is a
-        # no-op; removing one that isn't a member is a no-op.
-        if add_rowids:
-            already_present = set(
-                await session.scalars(
-                    select(models.DatasetSplitDatasetExample.dataset_example_id).where(
-                        models.DatasetSplitDatasetExample.dataset_split_id == split_rowid,
-                        models.DatasetSplitDatasetExample.dataset_example_id.in_(add_rowids),
-                    )
-                )
-            )
-            to_add = [rowid for rowid in add_rowids if rowid not in already_present]
-            if to_add:
+        try:
+            # Add first, then remove, so an example listed in both arrays ends
+            # up removed (removal wins). Adding an example already in the split
+            # is a no-op; removing one that isn't a member is a no-op.
+            if to_add := [rowid for rowid in add_rowids if rowid not in already_present]:
                 await session.execute(
                     insert(models.DatasetSplitDatasetExample),
                     [
@@ -1801,18 +1806,17 @@ async def update_dataset_split(
                         for rowid in to_add
                     ],
                 )
-                await session.flush()
-        if remove_rowids:
-            await session.execute(
-                delete(models.DatasetSplitDatasetExample).where(
-                    models.DatasetSplitDatasetExample.dataset_split_id == split_rowid,
-                    models.DatasetSplitDatasetExample.dataset_example_id.in_(remove_rowids),
+            if remove_rowids:
+                await session.execute(
+                    delete(models.DatasetSplitDatasetExample).where(
+                        models.DatasetSplitDatasetExample.dataset_split_id == split_rowid,
+                        models.DatasetSplitDatasetExample.dataset_example_id.in_(remove_rowids),
+                    )
                 )
-            )
-
-        try:
             await session.flush()
         except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            # Membership inserts are pre-filtered against existing rows, so an
+            # integrity error here can only be the unique name constraint.
             await session.rollback()
             raise HTTPException(
                 detail="A dataset split with this name already exists",
@@ -1821,6 +1825,7 @@ async def update_dataset_split(
         await session.refresh(split)
         example_count = await _dataset_scoped_example_count(session, split_rowid, dataset.id)
         data = _to_dataset_split(split, example_count=example_count)
+
     return UpdateDatasetSplitResponseBody(data=data)
 
 

--- a/src/phoenix/server/api/routers/v1/utils.py
+++ b/src/phoenix/server/api/routers/v1/utils.py
@@ -7,6 +7,7 @@ from strawberry.relay import GlobalID
 from typing_extensions import TypeAlias, assert_never
 
 from phoenix.db import models
+from phoenix.server.api.types.Dataset import Dataset as DatasetNodeType
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Project import Project as ProjectNodeType
 
@@ -149,3 +150,44 @@ async def get_project_by_identifier(
                 detail=f"Project with ID {project_identifier} not found",
             )
     return project
+
+
+async def get_dataset_by_identifier(
+    session: AsyncSession,
+    dataset_identifier: str,
+) -> models.Dataset:
+    """
+    Get a dataset by its ID or name.
+
+    Args:
+        session: The database session.
+        dataset_identifier: The dataset GlobalID or name.
+
+    Returns:
+        The dataset object.
+
+    Raises:
+        HTTPException: If the identifier format is invalid or the dataset is not found.
+    """
+    # Try to parse as a GlobalID first; otherwise treat the identifier as a name.
+    try:
+        id_ = from_global_id_with_expected_type(
+            GlobalID.from_id(dataset_identifier),
+            DatasetNodeType.__name__,
+        )
+    except Exception:
+        stmt = select(models.Dataset).filter_by(name=dataset_identifier)
+        dataset = await session.scalar(stmt)
+        if dataset is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Dataset with name {dataset_identifier} not found",
+            )
+    else:
+        dataset = await session.get(models.Dataset, id_)
+        if dataset is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Dataset with ID {dataset_identifier} not found",
+            )
+    return dataset

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2239,6 +2239,7 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "POST", "v1/annotation_configs"),
     (400, "POST", "v1/datasets/upload"),
     (422, "POST", "v1/datasets/fake-id-{}/experiments"),
+    (422, "POST", "v1/datasets/fake-id-{}/splits"),
     (422, "POST", "v1/document_annotations"),
     (422, "POST", "v1/experiment_evaluations"),
     (422, "POST", "v1/experiments/fake-id-{}/runs"),
@@ -2258,9 +2259,11 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "PUT", "v1/annotation_configs/fake-id-{}"),
     # PATCH routes
     (422, "PATCH", "v1/experiments/fake-id-{}"),
+    (422, "PATCH", "v1/datasets/fake-id-{}/splits/test-split"),
     # DELETE routes
     (422, "DELETE", "v1/annotation_configs/fake-id-{}"),
     (422, "DELETE", "v1/datasets/fake-id-{}"),
+    (422, "DELETE", "v1/datasets/fake-id-{}/splits/test-split"),
     (422, "DELETE", "v1/experiments/fake-id-{}"),
     (404, "DELETE", "v1/sessions/fake-id-{}"),
     (404, "DELETE", "v1/spans/fake-id-{}"),
@@ -2322,6 +2325,7 @@ def _ensure_endpoint_coverage_is_exhaustive() -> None:
         path = re.sub(r"fake-id-\{\}", "{id}", path)
         path = re.sub(r"\{[^}]*\}", "{id}", path)
         path = re.sub(r"/tags/test-tag$", "/tags/{id}", path)
+        path = re.sub(r"/splits/test-split$", "/splits/{id}", path)
         return path
 
     # Map normalized paths back to original paths for error reporting

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2256,6 +2256,7 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "POST", "v1/dataset_labels"),
     (400, "POST", "v1/datasets/upload"),
     (422, "POST", "v1/datasets/fake-id-{}/experiments"),
+    (422, "POST", "v1/datasets/fake-id-{}/splits"),
     (422, "POST", "v1/document_annotations"),
     (422, "POST", "v1/experiment_evaluations"),
     (422, "POST", "v1/experiments/fake-id-{}/runs"),
@@ -2281,12 +2282,14 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "PATCH", "v1/experiments/fake-id-{}"),
     (422, "PATCH", "v1/dataset_labels/fake-id-{}"),
     (422, "PATCH", "v1/prompts/fake-id-{}"),
+    (422, "PATCH", "v1/datasets/fake-id-{}/splits/test-split"),
     # DELETE routes
     (422, "DELETE", "v1/annotation_configs/fake-id-{}"),
     (404, "DELETE", "v1/projects/{0}/annotation_configs/{0}"),
     (422, "DELETE", "v1/dataset_labels/fake-id-{}"),
     (422, "DELETE", "v1/datasets/fake-id-{}/labels/test-label"),
     (422, "DELETE", "v1/datasets/fake-id-{}"),
+    (422, "DELETE", "v1/datasets/fake-id-{}/splits/test-split"),
     (422, "DELETE", "v1/experiments/fake-id-{}"),
     (404, "DELETE", "v1/sessions/fake-id-{}"),
     (404, "DELETE", "v1/spans/fake-id-{}"),
@@ -2393,6 +2396,7 @@ def _ensure_endpoint_coverage_is_exhaustive() -> None:
         path = re.sub(r"\{[^}]*\}", "{id}", path)
         path = re.sub(r"/tags/test-tag$", "/tags/{id}", path)
         path = re.sub(r"/labels/test-label$", "/labels/{id}", path)
+        path = re.sub(r"/splits/test-split$", "/splits/{id}", path)
         return path
 
     # Map normalized paths back to original paths for error reporting

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -12,7 +12,7 @@ import pyarrow as pa
 import pytest
 from httpx import HTTPStatusError
 from pandas.testing import assert_frame_equal
-from sqlalchemy import insert, select
+from sqlalchemy import func, insert, select
 from sqlalchemy.orm import joinedload
 from strawberry.relay import GlobalID
 
@@ -4562,3 +4562,313 @@ async def test_update_roundtrip_all_eight_cases(
     germany = next(e for e in db_examples if e.external_id == "capital-germany")
     germany_rev = next(r for r in v2_only if r.dataset_example_id == germany.id)
     assert germany_rev.output == {"answer": "Berlin"}
+
+
+# ---------------------------------------------------------------------------
+# Dataset split create / update / delete endpoints
+# ---------------------------------------------------------------------------
+
+
+async def _create_dataset_with_examples(
+    httpx_client: httpx.AsyncClient,
+    name: str,
+    num_examples: int,
+) -> tuple[str, list[str]]:
+    """Create a dataset via upload and return (dataset_id, [example node_ids])."""
+    response = await httpx_client.post(
+        url="v1/datasets/upload?sync=true",
+        json={
+            "action": "create",
+            "name": name,
+            "inputs": [{"q": f"Q{i}"} for i in range(num_examples)],
+            "outputs": [{"a": f"A{i}"} for i in range(num_examples)],
+        },
+    )
+    assert response.status_code == 200
+    dataset_id = response.json()["data"]["dataset_id"]
+    examples_response = await httpx_client.get(f"/v1/datasets/{dataset_id}/examples")
+    assert examples_response.status_code == 200
+    example_ids = [e["node_id"] for e in examples_response.json()["data"]["examples"]]
+    assert len(example_ids) == num_examples
+    return dataset_id, example_ids
+
+
+async def test_create_dataset_split_empty(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_split_empty", 1)
+    response = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "train", "description": "training split"},
+    )
+    assert response.status_code == 201
+    split = response.json()["data"]
+    assert split["name"] == "train"
+    assert split["description"] == "training split"
+    assert split["color"] == "#33c5e8"  # default color
+    assert split["metadata"] == {}
+    assert split["example_count"] == 0
+    assert "created_at" in split and "updated_at" in split
+
+    async with db() as session:
+        db_split = await session.scalar(
+            select(models.DatasetSplit).where(models.DatasetSplit.name == "train")
+        )
+        assert db_split is not None
+
+
+async def test_create_dataset_split_with_examples(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    dataset_id, example_ids = await _create_dataset_with_examples(httpx_client, "ds_split_seed", 3)
+    response = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={
+            "name": "test",
+            "color": "#00cc88",
+            "metadata": {"k": "v"},
+            "example_ids": example_ids[:2],
+        },
+    )
+    assert response.status_code == 201
+    split = response.json()["data"]
+    assert split["color"] == "#00cc88"
+    assert split["metadata"] == {"k": "v"}
+    assert split["example_count"] == 2
+
+    split_rowid = int(GlobalID.from_id(split["id"]).node_id)
+    async with db() as session:
+        member_count = await session.scalar(
+            select(func.count())
+            .select_from(models.DatasetSplitDatasetExample)
+            .where(models.DatasetSplitDatasetExample.dataset_split_id == split_rowid)
+        )
+        assert member_count == 2
+
+
+async def test_create_dataset_split_accepts_dataset_name(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    await _create_dataset_with_examples(httpx_client, "named_dataset", 1)
+    response = await httpx_client.post(
+        url="/v1/datasets/named_dataset/splits",
+        json={"name": "validation"},
+    )
+    assert response.status_code == 201
+    assert response.json()["data"]["name"] == "validation"
+
+
+async def test_create_dataset_split_duplicate_name_conflict(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_split_dup", 1)
+    first = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "dup"},
+    )
+    assert first.status_code == 201
+    second = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "dup"},
+    )
+    assert second.status_code == 409
+
+
+async def test_create_dataset_split_empty_name_rejected(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_split_blank", 1)
+    response = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "   "},
+    )
+    assert response.status_code == 422
+
+
+async def test_create_dataset_split_example_not_in_dataset(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_a, _ = await _create_dataset_with_examples(httpx_client, "ds_split_a", 1)
+    _, other_examples = await _create_dataset_with_examples(httpx_client, "ds_split_b", 1)
+    response = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_a}/splits",
+        json={"name": "cross", "example_ids": other_examples},
+    )
+    assert response.status_code == 404
+
+
+async def test_create_dataset_split_dataset_not_found(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    missing = str(GlobalID("Dataset", "99999"))
+    response = await httpx_client.post(
+        url=f"/v1/datasets/{missing}/splits",
+        json={"name": "train"},
+    )
+    assert response.status_code == 404
+
+
+async def test_update_dataset_split_fields(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_patch_fields", 1)
+    created = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "train", "description": "orig", "metadata": {"a": 1}},
+    )
+    split_id = created.json()["data"]["id"]
+
+    response = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_id}/splits/{split_id}",
+        json={"name": "train-renamed", "color": "#123456", "metadata": {"b": 2}},
+    )
+    assert response.status_code == 200
+    split = response.json()["data"]
+    assert split["name"] == "train-renamed"
+    assert split["color"] == "#123456"
+    assert split["metadata"] == {"b": 2}
+    assert split["description"] == "orig"  # untouched
+
+
+async def test_update_dataset_split_clear_description(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_patch_clear", 1)
+    created = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "train", "description": "orig"},
+    )
+    split_id = created.json()["data"]["id"]
+    response = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_id}/splits/{split_id}",
+        json={"description": None},
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["description"] is None
+
+
+async def test_update_dataset_split_add_and_remove_examples(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, example_ids = await _create_dataset_with_examples(
+        httpx_client, "ds_patch_membership", 3
+    )
+    created = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "train", "example_ids": example_ids[:1]},
+    )
+    split_id = created.json()["data"]["id"]
+    assert created.json()["data"]["example_count"] == 1
+
+    # Add two more (one of which is already a member -> idempotent) and remove the first.
+    response = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_id}/splits/{split_id}",
+        json={
+            "add_example_ids": [example_ids[0], example_ids[1], example_ids[2]],
+            "remove_example_ids": [example_ids[0]],
+        },
+    )
+    assert response.status_code == 200
+    # example 0 removed, examples 1 and 2 added -> 2 members
+    assert response.json()["data"]["example_count"] == 2
+
+
+async def test_update_dataset_split_not_found(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_patch_404", 1)
+    missing = str(GlobalID("DatasetSplit", "99999"))
+    response = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_id}/splits/{missing}",
+        json={"name": "x"},
+    )
+    assert response.status_code == 404
+
+
+async def test_update_dataset_split_invalid_id(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_patch_422", 1)
+    response = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_id}/splits/not-a-global-id",
+        json={"name": "x"},
+    )
+    assert response.status_code == 422
+
+
+async def test_update_dataset_split_duplicate_name_conflict(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_patch_conflict", 1)
+    await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "train"},
+    )
+    other = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "test"},
+    )
+    other_id = other.json()["data"]["id"]
+    response = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_id}/splits/{other_id}",
+        json={"name": "train"},
+    )
+    assert response.status_code == 409
+
+
+async def test_delete_dataset_split(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    dataset_id, example_ids = await _create_dataset_with_examples(httpx_client, "ds_delete", 2)
+    created = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "train", "example_ids": example_ids},
+    )
+    split_id = created.json()["data"]["id"]
+    split_rowid = int(GlobalID.from_id(split_id).node_id)
+
+    response = await httpx_client.delete(f"/v1/datasets/{dataset_id}/splits/{split_id}")
+    assert response.status_code == 204
+
+    dataset_rowid = int(GlobalID.from_id(dataset_id).node_id)
+    async with db() as session:
+        # Split and its memberships are gone.
+        assert (
+            await session.scalar(
+                select(models.DatasetSplit).where(models.DatasetSplit.id == split_rowid)
+            )
+            is None
+        )
+        member_count = await session.scalar(
+            select(func.count())
+            .select_from(models.DatasetSplitDatasetExample)
+            .where(models.DatasetSplitDatasetExample.dataset_split_id == split_rowid)
+        )
+        assert member_count == 0
+        # Underlying examples are untouched.
+        example_count = await session.scalar(
+            select(func.count())
+            .select_from(models.DatasetExample)
+            .where(models.DatasetExample.dataset_id == dataset_rowid)
+        )
+        assert example_count == 2
+
+
+async def test_delete_dataset_split_not_found(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_delete_404", 1)
+    missing = str(GlobalID("DatasetSplit", "99999"))
+    response = await httpx_client.delete(f"/v1/datasets/{dataset_id}/splits/{missing}")
+    assert response.status_code == 404
+
+
+async def test_delete_dataset_split_invalid_id(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    dataset_id, _ = await _create_dataset_with_examples(httpx_client, "ds_delete_422", 1)
+    response = await httpx_client.delete(f"/v1/datasets/{dataset_id}/splits/not-a-global-id")
+    assert response.status_code == 422

--- a/tests/unit/server/api/routers/v1/test_datasets.py
+++ b/tests/unit/server/api/routers/v1/test_datasets.py
@@ -4818,6 +4818,33 @@ async def test_update_dataset_split_duplicate_name_conflict(
     assert response.status_code == 409
 
 
+async def test_update_dataset_split_duplicate_name_with_membership_edit_conflict(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    """A duplicate rename combined with a membership edit must still return 409, not 500.
+
+    Regression test: membership queries autoflush the pending name change, so
+    the IntegrityError can surface outside the final flush.
+    """
+    dataset_id, example_ids = await _create_dataset_with_examples(
+        httpx_client, "ds_patch_conflict_membership", 2
+    )
+    await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "train"},
+    )
+    other = await httpx_client.post(
+        url=f"/v1/datasets/{dataset_id}/splits",
+        json={"name": "test"},
+    )
+    other_id = other.json()["data"]["id"]
+    response = await httpx_client.patch(
+        url=f"/v1/datasets/{dataset_id}/splits/{other_id}",
+        json={"name": "train", "add_example_ids": example_ids[:1]},
+    )
+    assert response.status_code == 409
+
+
 async def test_delete_dataset_split(
     httpx_client: httpx.AsyncClient,
     db: DbSessionFactory,


### PR DESCRIPTION
## Summary

Adds the write verbs for dataset **splits** over REST, completing splits CRUD (the list verb is tracked separately in #12090):

- `POST /datasets/{dataset_identifier}/splits` — create a split. `name` is required; `description`, `color`, `metadata`, and `example_ids` are optional. `example_ids` (dataset-example GlobalIDs) seed the split and must belong to the dataset. Returns `201` with the split object (`id`, `name`, `description`, `color`, `metadata`, `example_count`, `created_at`, `updated_at`). `example_count` is scoped to the dataset.
- `PATCH /datasets/{dataset_identifier}/splits/{split_id}` — partial update. Only fields present in the body change; an explicit `null` clears `description` (the sole nullable column). Membership is edited inline via `add_example_ids` / `remove_example_ids` — adds are applied first, then removes, so an example listed in both ends up removed (removal wins). Adding an already-present example / removing a non-member is a no-op.
- `DELETE /datasets/{dataset_identifier}/splits/{split_id}` — deletes the split and (via `ON DELETE CASCADE`) its example memberships; the underlying examples are left intact. Returns `204`.

## Details

- `{dataset_identifier}` accepts a dataset name or GlobalID, resolved via a new `get_dataset_by_identifier` helper in `routers/v1/utils.py` (mirrors `get_project_by_identifier`).
- Validation semantics mirror the existing GraphQL split mutations: names are trimmed and globally unique (collision → `409`), `color` defaults to `#33c5e8` (matching the frontend form), and integrity errors from both SQLite and PostgreSQL backends are handled.
- Write verbs (`POST`/`PATCH`) are guarded by `Depends(is_not_locked)`; `DELETE` is not (it frees space), per REST conventions.
- Required role: **MEMBER+** (enforced at the router level).

## Testing

- 16 new unit tests in `tests/unit/server/api/routers/v1/test_datasets.py` covering create (empty, seeded, by name, duplicate → 409, empty name → 422, cross-dataset example → 404, missing dataset → 404), update (field changes, description clear, idempotent add/remove membership, not-found → 404, invalid id → 422, name conflict → 409), and delete (204 + membership removed + examples preserved, not-found → 404, invalid id → 422). Full file passes (166 passed).
- Added integration endpoint-coverage entries in `tests/integration/_helpers.py` (with a normalize rule for the two-param split path, mirroring the `tags/test-tag` pattern).
- `make openapi` regenerated the schema and Python/TS clients; lint (`ruff`) and type checks (`mypy`) pass.

Closes #14018