### PR TITLE
fix: require admin role for destructive project mutations in GraphQL API

### DIFF
--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -36,6 +36,18 @@ export function useViewerCanModify() {
 }
 
 /**
+ * Returns true if the viewer can delete, clear, or edit projects
+ * Note: when the app is not configured with auth, we assume the user is an admin
+ */
+export function useViewerCanManageProjects() {
+  const { viewer } = useViewer();
+  if (viewer && viewer.role?.name !== "ADMIN") {
+    return false;
+  }
+  return true;
+}
+
+/**
  * Returns true if the viewer can manage retention policies
  * Note: when the app is not configured with auth, we assume the user is an admin
  */

--- a/app/src/pages/project/ProjectConfigPage.tsx
+++ b/app/src/pages/project/ProjectConfigPage.tsx
@@ -28,7 +28,11 @@ import {
   TextField,
   View,
 } from "@phoenix/components";
-import { useNotifySuccess, useProjectContext } from "@phoenix/contexts";
+import {
+  useNotifySuccess,
+  useProjectContext,
+  useViewerCanManageProjects,
+} from "@phoenix/contexts";
 
 import type { ProjectFormParams } from "../projects/ProjectForm";
 import { GRADIENT_PRESETS, ProjectForm } from "../projects/ProjectForm";
@@ -160,6 +164,7 @@ const ProjectConfigCard = ({
   const [isEditing, setIsEditing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const notifySuccess = useNotifySuccess();
+  const canManageProjects = useViewerCanManageProjects();
 
   const [commit, isCommitting] =
     useMutation<ProjectConfigPagePatchProjectMutation>(graphql`
@@ -208,7 +213,7 @@ const ProjectConfigCard = ({
     <Card
       title="Project Settings"
       extra={
-        isEditing ? undefined : (
+        isEditing || !canManageProjects ? undefined : (
           <Button
             variant="default"
             size="S"

--- a/app/src/pages/projects/ProjectActionMenu.tsx
+++ b/app/src/pages/projects/ProjectActionMenu.tsx
@@ -24,7 +24,10 @@ import {
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
-import { useNotifySuccess } from "@phoenix/contexts";
+import {
+  useNotifySuccess,
+  useViewerCanManageProjects,
+} from "@phoenix/contexts";
 
 import type { ProjectActionMenuClearMutation } from "./__generated__/ProjectActionMenuClearMutation.graphql";
 import type { ProjectActionMenuDeleteMutation } from "./__generated__/ProjectActionMenuDeleteMutation.graphql";
@@ -54,7 +57,8 @@ export function ProjectActionMenu({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showClearDialog, setShowClearDialog] = useState(false);
   const [showRemoveDataDialog, setShowRemoveDataDialog] = useState(false);
-  const canDelete = projectName !== "default";
+  const canManageProjects = useViewerCanManageProjects();
+  const canDelete = canManageProjects && projectName !== "default";
   const [commitDelete] = useMutation<ProjectActionMenuDeleteMutation>(graphql`
     mutation ProjectActionMenuDeleteMutation($projectId: ID!) {
       deleteProject(id: $projectId) {
@@ -155,28 +159,32 @@ export function ProjectActionMenu({
                 <Text>Copy Name</Text>
               </Flex>
             </MenuItem>
-            <MenuItem id={ProjectAction.CLEAR} textValue="Clear All Traces">
-              <Flex
-                direction={"row"}
-                gap="size-75"
-                justifyContent={"start"}
-                alignItems={"center"}
-              >
-                <Icon svg={<Icons.Refresh />} />
-                <Text>Clear All Data</Text>
-              </Flex>
-            </MenuItem>
-            <MenuItem id={ProjectAction.REMOVE_DATA} textValue="Remove Data">
-              <Flex
-                direction={"row"}
-                gap="size-75"
-                justifyContent={"start"}
-                alignItems={"center"}
-              >
-                <Icon svg={<Icons.CloseCircle />} />
-                <Text>Remove Data</Text>
-              </Flex>
-            </MenuItem>
+            {canManageProjects ? (
+              <MenuItem id={ProjectAction.CLEAR} textValue="Clear All Traces">
+                <Flex
+                  direction={"row"}
+                  gap="size-75"
+                  justifyContent={"start"}
+                  alignItems={"center"}
+                >
+                  <Icon svg={<Icons.Refresh />} />
+                  <Text>Clear All Data</Text>
+                </Flex>
+              </MenuItem>
+            ) : null}
+            {canManageProjects ? (
+              <MenuItem id={ProjectAction.REMOVE_DATA} textValue="Remove Data">
+                <Flex
+                  direction={"row"}
+                  gap="size-75"
+                  justifyContent={"start"}
+                  alignItems={"center"}
+                >
+                  <Icon svg={<Icons.CloseCircle />} />
+                  <Text>Remove Data</Text>
+                </Flex>
+              </MenuItem>
+            ) : null}
             {canDelete ? (
               <MenuItem id={ProjectAction.DELETE}>
                 <Flex

--- a/src/phoenix/server/api/mutations/project_mutations.py
+++ b/src/phoenix/server/api/mutations/project_mutations.py
@@ -9,7 +9,7 @@ from strawberry.types import Info
 
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
-from phoenix.server.api.auth import IsNotReadOnly, IsNotViewer
+from phoenix.server.api.auth import IsAdminIfAuthEnabled, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, Conflict
 from phoenix.server.api.input_types.ClearProjectInput import ClearProjectInput
@@ -54,7 +54,7 @@ class ProjectMutationMixin:
         info.context.event_queue.put(ProjectInsertEvent((project.id,)))
         return ProjectMutationPayload(project=to_gql_project(project), query=Query())
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled])  # type: ignore
     async def delete_project(self, info: Info[Context, None], id: GlobalID) -> Query:
         project_id = from_global_id_with_expected_type(global_id=id, expected_type_name="Project")
         async with info.context.db() as session:
@@ -71,7 +71,7 @@ class ProjectMutationMixin:
         info.context.event_queue.put(ProjectDeleteEvent((project_id,)))
         return Query()
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled])  # type: ignore
     async def clear_project(self, info: Info[Context, None], input: ClearProjectInput) -> Query:
         project_id = from_global_id_with_expected_type(
             global_id=input.id, expected_type_name="Project"
@@ -97,7 +97,7 @@ class ProjectMutationMixin:
         info.context.event_queue.put(SpanDeleteEvent((project_id,)))
         return Query()
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAdminIfAuthEnabled])  # type: ignore
     async def patch_project(
         self,
         info: Info[Context, None],

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -1107,6 +1107,78 @@ class TestGraphQLQuery:
             logged_in_user.gql(_app, query)
 
 
+class TestProjectMutationPermissions:
+    # createProject is member-allowed (IsNotViewer); deleteProject, clearProject,
+    # and patchProject are admin-only (IsAdminIfAuthEnabled), matching the REST API
+    # where PUT/DELETE /v1/projects require admin.
+
+    QUERY = """
+      mutation CreateProject($input: CreateProjectInput!) {
+        createProject(input: $input) {
+          project { id }
+        }
+      }
+
+      mutation PatchProject($input: PatchProjectInput!) {
+        patchProject(input: $input) {
+          project { id }
+        }
+      }
+
+      mutation ClearProject($input: ClearProjectInput!) {
+        clearProject(input: $input) { __typename }
+      }
+
+      mutation DeleteProject($projectId: ID!) {
+        deleteProject(id: $projectId) { __typename }
+      }
+    """
+
+    @pytest.mark.parametrize(
+        "role_or_user",
+        [_VIEWER, _MEMBER, _ADMIN, _DEFAULT_ADMIN],
+        ids=["viewer", "member", "admin", "default_admin"],
+    )
+    def test_role_based_access(
+        self,
+        role_or_user: _RoleOrUser,
+        _get_user: _GetUser,
+        _app: _AppInfo,
+    ) -> None:
+        is_admin = role_or_user in (_ADMIN, _DEFAULT_ADMIN)
+        is_viewer = role_or_user is _VIEWER
+
+        response, _ = _DEFAULT_ADMIN.gql(
+            _app,
+            query=self.QUERY,
+            operation_name="CreateProject",
+            variables={"input": {"name": f"auth-project-{token_hex(8)}"}},
+        )
+        project_id = response["data"]["createProject"]["project"]["id"]
+
+        user = _get_user(_app, role_or_user).log_in(_app)
+
+        def check(allowed: bool, operation: str, variables: dict[str, Any]) -> None:
+            if allowed:
+                user.gql(_app, query=self.QUERY, operation_name=operation, variables=variables)
+            else:
+                with pytest.raises(Unauthorized):
+                    user.gql(_app, query=self.QUERY, operation_name=operation, variables=variables)
+
+        check(
+            not is_viewer,
+            "CreateProject",
+            {"input": {"name": f"auth-project-{token_hex(8)}"}},
+        )
+        check(
+            is_admin,
+            "PatchProject",
+            {"input": {"id": project_id, "description": "updated"}},
+        )
+        check(is_admin, "ClearProject", {"input": {"id": project_id}})
+        check(is_admin, "DeleteProject", {"projectId": project_id})
+
+
 class TestSandboxAndCodeEvaluatorPermissions:
     # Tier 1 (admin-only): sandbox-config mutations + updateSandboxProvider.
     # Tier 2 (IsNotViewer): code-evaluator mutations + evaluatorPreviews.


### PR DESCRIPTION
resolves #14047

## Summary

When `PHOENIX_ENABLE_AUTH=true`, the GraphQL mutations `deleteProject`, `clearProject`, and `patchProject` only checked `IsNotViewer`, so any authenticated **MEMBER** could delete or wipe every project (and all associated traces, evaluations, and experiment data) in the instance. The equivalent REST endpoints (`PUT`/`DELETE /v1/projects/...`) already require admin via `require_admin`.

## Changes

- **Backend** (`src/phoenix/server/api/mutations/project_mutations.py`): add `IsAdminIfAuthEnabled` to the `permission_classes` of `deleteProject`, `clearProject`, and `patchProject`, matching the REST API and other sensitive GraphQL mutations. `createProject` keeps `IsNotViewer` only, matching `POST /v1/projects` which is member-allowed. When auth is disabled, behavior is unchanged (`IsAdminIfAuthEnabled` passes).
- **Frontend**: new `useViewerCanManageProjects` hook (admin-only, consistent with `useViewerCanManageRetentionPolicy` etc.); the project action menu now hides Clear All Data / Remove Data / Delete for non-admins, and the project settings Edit button (patchProject) is hidden for non-admins.
- **Tests** (`tests/integration/auth/test_auth.py`): new `TestProjectMutationPermissions` verifying per role (viewer/member/admin/default admin) that `createProject` is member-allowed while the three destructive mutations are admin-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUkuh6drCcqkwDMzKm9crm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUkuh6drCcqkwDMzKm9crm)_