### PR TITLE
feat(app): add version count, latest version, and version tags columns to prompts table

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3012,6 +3012,7 @@ type Prompt implements Node {
   metadata: JSON!
   createdAt: DateTime!
   version(versionId: ID = null, tagName: Identifier = null): PromptVersion!
+  versionCount: Int!
   versionTags: [PromptVersionTag!]!
   promptVersions(first: Int = 50, last: Int, after: String, before: String): PromptVersionConnection!
   sourcePrompt: Prompt

--- a/app/src/pages/prompts/PromptsTable.tsx
+++ b/app/src/pages/prompts/PromptsTable.tsx
@@ -37,6 +37,7 @@ import {
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useViewerCanModify } from "@phoenix/contexts";
 import { useInterval } from "@phoenix/hooks/useInterval";
+import { TagVersionLabel } from "@phoenix/pages/prompt/PromptVersionTagsList";
 import { usePromptsFilterContext } from "@phoenix/pages/prompts/PromptsFilterProvider";
 import { toggleArrayItem } from "@phoenix/utils/arrayUtils";
 
@@ -47,6 +48,14 @@ import { PromptsEmpty } from "./PromptsEmpty";
 
 const PAGE_SIZE = 100;
 const PROMPTS_POLL_INTERVAL_MS = 60_000;
+
+const tokenListCSS = css`
+  display: flex;
+  flex-direction: row;
+  gap: var(--global-dimension-size-100);
+  min-width: 0;
+  flex-wrap: wrap;
+`;
 
 type PromptsTableProps = {
   query: PromptsTable_prompts$key;
@@ -99,9 +108,16 @@ export function PromptsTable(props: PromptsTableProps) {
                 name
                 description
                 version {
+                  id
                   createdAt
                   modelName
                   modelProvider
+                }
+                versionCount
+                versionTags {
+                  id
+                  name
+                  promptVersionId
                 }
                 labels {
                   id
@@ -152,6 +168,7 @@ export function PromptsTable(props: PromptsTableProps) {
           lastUpdatedAt: edge.prompt.version.createdAt,
           modelName: edge.prompt.version.modelName,
           modelProvider: edge.prompt.version.modelProvider,
+          latestVersionId: edge.prompt.version.id,
           ...edge.prompt,
         };
       }),
@@ -198,15 +215,7 @@ export function PromptsTable(props: PromptsTableProps) {
         enableSorting: false,
         cell: ({ row }) => {
           return (
-            <ul
-              css={css`
-                display: flex;
-                flex-direction: row;
-                gap: var(--global-dimension-size-100);
-                min-width: 0;
-                flex-wrap: wrap;
-              `}
-            >
+            <ul css={tokenListCSS}>
               {row.original.labels.map((label) => (
                 <li key={label.id}>
                   <StopPropagation>
@@ -246,6 +255,52 @@ export function PromptsTable(props: PromptsTableProps) {
                 <Truncate>{modelName}</Truncate>
               </Text>
             </Flex>
+          );
+        },
+      },
+      {
+        header: "versions",
+        accessorKey: "versionCount",
+      },
+      {
+        header: "latest version",
+        accessorKey: "latestVersionId",
+        enableSorting: false,
+        cell: ({ row }) => {
+          return (
+            <CellWithControlsWrap
+              controls={
+                <CopyToClipboardButton text={row.original.latestVersionId} />
+              }
+            >
+              <Link
+                to={`${row.original.id}/versions/${row.original.latestVersionId}`}
+              >
+                <Truncate maxWidth={200} title={row.original.latestVersionId}>
+                  {row.original.latestVersionId}
+                </Truncate>
+              </Link>
+            </CellWithControlsWrap>
+          );
+        },
+      },
+      {
+        header: "version tags",
+        accessorKey: "versionTags",
+        enableSorting: false,
+        cell: ({ row }) => {
+          return (
+            <ul css={tokenListCSS}>
+              {row.original.versionTags.map((tag) => (
+                <li key={tag.id}>
+                  <Link
+                    to={`${row.original.id}/versions/${tag.promptVersionId}`}
+                  >
+                    <TagVersionLabel maxWidth={200}>{tag.name}</TagVersionLabel>
+                  </Link>
+                </li>
+              ))}
+            </ul>
           );
         },
       },

--- a/app/src/pages/prompts/__generated__/DeletePromptDialogMutation.graphql.ts
+++ b/app/src/pages/prompts/__generated__/DeletePromptDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aa97cb2ce61df2aef89a2a29183d34e2>>
+ * @generated SignedSource<<695b50d684088cc7f7aa83081fc4b323>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -168,6 +168,7 @@ return {
                             "name": "version",
                             "plural": false,
                             "selections": [
+                              (v3/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -188,8 +189,34 @@ return {
                                 "kind": "ScalarField",
                                 "name": "modelProvider",
                                 "storageKey": null
-                              },
-                              (v3/*: any*/)
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "versionCount",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "PromptVersionTag",
+                            "kind": "LinkedField",
+                            "name": "versionTags",
+                            "plural": true,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "promptVersionId",
+                                "storageKey": null
+                              }
                             ],
                             "storageKey": null
                           },
@@ -294,12 +321,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f98bcfbed3d7b46df48d0ca35974cd02",
+    "cacheID": "39d8a2aa1c6e3f060dfd6855744d2a22",
     "id": null,
     "metadata": {},
     "name": "DeletePromptDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation DeletePromptDialogMutation(\n  $promptId: ID!\n) {\n  deletePrompt(input: {promptId: $promptId}) {\n    query {\n      ...PromptsTable_prompts\n    }\n  }\n}\n\nfragment PromptsTable_prompts on Query {\n  prompts(first: 100) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          modelName\n          modelProvider\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "mutation DeletePromptDialogMutation(\n  $promptId: ID!\n) {\n  deletePrompt(input: {promptId: $promptId}) {\n    query {\n      ...PromptsTable_prompts\n    }\n  }\n}\n\nfragment PromptsTable_prompts on Query {\n  prompts(first: 100) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          id\n          createdAt\n          modelName\n          modelProvider\n        }\n        versionCount\n        versionTags {\n          id\n          name\n          promptVersionId\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/prompts/__generated__/PromptsTablePromptsQuery.graphql.ts
+++ b/app/src/pages/prompts/__generated__/PromptsTablePromptsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<429cf6b2bb3426aa3a1aa067bf610299>>
+ * @generated SignedSource<<c3b7ff4ceca244befbfc6ce358cb9c8a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -151,6 +151,7 @@ return {
                     "name": "version",
                     "plural": false,
                     "selections": [
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -171,8 +172,34 @@ return {
                         "kind": "ScalarField",
                         "name": "modelProvider",
                         "storageKey": null
-                      },
-                      (v2/*: any*/)
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "versionCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PromptVersionTag",
+                    "kind": "LinkedField",
+                    "name": "versionTags",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "promptVersionId",
+                        "storageKey": null
+                      }
                     ],
                     "storageKey": null
                   },
@@ -271,16 +298,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "aae65784dac1dd298f578f01e6adaaff",
+    "cacheID": "200e422ae60402f476b34c8b1e4d53b4",
     "id": null,
     "metadata": {},
     "name": "PromptsTablePromptsQuery",
     "operationKind": "query",
-    "text": "query PromptsTablePromptsQuery(\n  $after: String = null\n  $filter: PromptFilter = null\n  $first: Int = 100\n  $labelIds: [ID!] = null\n) {\n  ...PromptsTable_prompts_2FeKoo\n}\n\nfragment PromptsTable_prompts_2FeKoo on Query {\n  prompts(first: $first, after: $after, filter: $filter, labelIds: $labelIds) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          modelName\n          modelProvider\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query PromptsTablePromptsQuery(\n  $after: String = null\n  $filter: PromptFilter = null\n  $first: Int = 100\n  $labelIds: [ID!] = null\n) {\n  ...PromptsTable_prompts_2FeKoo\n}\n\nfragment PromptsTable_prompts_2FeKoo on Query {\n  prompts(first: $first, after: $after, filter: $filter, labelIds: $labelIds) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          id\n          createdAt\n          modelName\n          modelProvider\n        }\n        versionCount\n        versionTags {\n          id\n          name\n          promptVersionId\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d5dd38748ccb61e832bd17f8dab756cd";
+(node as any).hash = "b5fb70bb7de99fce33aaeac3b119d898";
 
 export default node;

--- a/app/src/pages/prompts/__generated__/PromptsTable_prompts.graphql.ts
+++ b/app/src/pages/prompts/__generated__/PromptsTable_prompts.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e121895d059280fde009adfe520b5fec>>
+ * @generated SignedSource<<d45c3777d024568d40476a068d77db8c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,9 +25,16 @@ export type PromptsTable_prompts$data = {
         readonly name: string;
         readonly version: {
           readonly createdAt: string;
+          readonly id: string;
           readonly modelName: string;
           readonly modelProvider: ModelProvider;
         };
+        readonly versionCount: number;
+        readonly versionTags: ReadonlyArray<{
+          readonly id: string;
+          readonly name: string;
+          readonly promptVersionId: string;
+        }>;
       };
     }>;
   };
@@ -158,6 +165,7 @@ return {
                   "name": "version",
                   "plural": false,
                   "selections": [
+                    (v1/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -177,6 +185,33 @@ return {
                       "args": null,
                       "kind": "ScalarField",
                       "name": "modelProvider",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "versionCount",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "PromptVersionTag",
+                  "kind": "LinkedField",
+                  "name": "versionTags",
+                  "plural": true,
+                  "selections": [
+                    (v1/*: any*/),
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "promptVersionId",
                       "storageKey": null
                     }
                   ],
@@ -267,6 +302,6 @@ return {
 };
 })();
 
-(node as any).hash = "d5dd38748ccb61e832bd17f8dab756cd";
+(node as any).hash = "b5fb70bb7de99fce33aaeac3b119d898";
 
 export default node;

--- a/app/src/pages/prompts/__generated__/promptsLoaderQuery.graphql.ts
+++ b/app/src/pages/prompts/__generated__/promptsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a0df19159c1e7aa29e494b267ea4e970>>
+ * @generated SignedSource<<e1acd478f5fff3d5c7e5343434b0f462>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -104,6 +104,7 @@ return {
                     "name": "version",
                     "plural": false,
                     "selections": [
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -124,8 +125,34 @@ return {
                         "kind": "ScalarField",
                         "name": "modelProvider",
                         "storageKey": null
-                      },
-                      (v1/*: any*/)
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "versionCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PromptVersionTag",
+                    "kind": "LinkedField",
+                    "name": "versionTags",
+                    "plural": true,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "promptVersionId",
+                        "storageKey": null
+                      }
                     ],
                     "storageKey": null
                   },
@@ -224,12 +251,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4373e9645545d729885b58f67a08898c",
+    "cacheID": "4eef355b3435a0bbd60c927fc459886d",
     "id": null,
     "metadata": {},
     "name": "promptsLoaderQuery",
     "operationKind": "query",
-    "text": "query promptsLoaderQuery {\n  ...PromptsTable_prompts\n}\n\nfragment PromptsTable_prompts on Query {\n  prompts(first: 100) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          createdAt\n          modelName\n          modelProvider\n          id\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query promptsLoaderQuery {\n  ...PromptsTable_prompts\n}\n\nfragment PromptsTable_prompts on Query {\n  prompts(first: 100) {\n    edges {\n      prompt: node {\n        id\n        name\n        description\n        version {\n          id\n          createdAt\n          modelName\n          modelProvider\n        }\n        versionCount\n        versionTags {\n          id\n          name\n          promptVersionId\n        }\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -65,7 +65,10 @@ from .project_by_name import ProjectByNameDataLoader
 from .project_has_traces import ProjectHasTracesDataLoader
 from .project_ids_by_trace_retention_policy_id import ProjectIdsByTraceRetentionPolicyIdDataLoader
 from .prompt_label_usage_counts import PromptLabelUsageCountsDataLoader
+from .prompt_labels_by_prompt import PromptLabelsByPromptDataLoader
+from .prompt_version_counts import PromptVersionCountDataLoader
 from .prompt_version_sequence_number import PromptVersionSequenceNumberDataLoader
+from .prompt_version_tags_by_prompt import PromptVersionTagsByPromptDataLoader
 from .prompt_versions import PromptVersionDataLoader
 from .record_counts import RecordCountCache, RecordCountDataLoader
 from .sandbox_configs_by_provider import SandboxConfigsByProviderDataLoader
@@ -214,9 +217,12 @@ class DataLoaders:
     prompt_fields: TableFieldsDataLoader
     prompt_label_fields: TableFieldsDataLoader
     prompt_label_usage_counts: PromptLabelUsageCountsDataLoader
+    prompt_labels_by_prompt: PromptLabelsByPromptDataLoader
     prompt_versions: PromptVersionDataLoader
+    prompt_version_counts: PromptVersionCountDataLoader
     prompt_version_sequence_number: PromptVersionSequenceNumberDataLoader
     prompt_version_tag_fields: TableFieldsDataLoader
+    prompt_version_tags_by_prompt: PromptVersionTagsByPromptDataLoader
     latest_prompt_version_ids: LatestPromptVersionIdDataLoader
     latest_code_evaluator_versions: LatestCodeEvaluatorVersionDataLoader
     project_session_annotation_fields: TableFieldsDataLoader
@@ -371,9 +377,12 @@ def build_data_loaders(
         prompt_fields=TableFieldsDataLoader(db, models.Prompt),
         prompt_label_fields=TableFieldsDataLoader(db, models.PromptLabel),
         prompt_label_usage_counts=PromptLabelUsageCountsDataLoader(db),
+        prompt_labels_by_prompt=PromptLabelsByPromptDataLoader(db),
         prompt_versions=PromptVersionDataLoader(db),
+        prompt_version_counts=PromptVersionCountDataLoader(db),
         prompt_version_sequence_number=PromptVersionSequenceNumberDataLoader(db),
         prompt_version_tag_fields=TableFieldsDataLoader(db, models.PromptVersionTag),
+        prompt_version_tags_by_prompt=PromptVersionTagsByPromptDataLoader(db),
         latest_prompt_version_ids=LatestPromptVersionIdDataLoader(db),
         latest_code_evaluator_versions=LatestCodeEvaluatorVersionDataLoader(db),
         project_session_annotation_fields=TableFieldsDataLoader(

--- a/src/phoenix/server/api/dataloaders/prompt_labels_by_prompt.py
+++ b/src/phoenix/server/api/dataloaders/prompt_labels_by_prompt.py
@@ -1,0 +1,30 @@
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+PromptId: TypeAlias = int
+Key: TypeAlias = PromptId
+Result: TypeAlias = list[models.PromptLabel]
+
+
+class PromptLabelsByPromptDataLoader(DataLoader[Key, Result]):
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        prompt_ids = list(set(keys))
+        labels: dict[Key, Result] = {}
+        stmt = (
+            select(models.PromptPromptLabel.prompt_id, models.PromptLabel)
+            .join_from(models.PromptPromptLabel, models.PromptLabel)
+            .where(models.PromptPromptLabel.prompt_id.in_(prompt_ids))
+            .order_by(models.PromptLabel.id)
+        )
+        async with self._db.read() as session:
+            async for prompt_id, label in await session.stream(stmt):
+                labels.setdefault(prompt_id, []).append(label)
+        return [labels.get(prompt_id, []) for prompt_id in keys]

--- a/src/phoenix/server/api/dataloaders/prompt_version_counts.py
+++ b/src/phoenix/server/api/dataloaders/prompt_version_counts.py
@@ -1,0 +1,35 @@
+from typing import Iterable
+
+from sqlalchemy import func, select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+PromptId: TypeAlias = int
+Key: TypeAlias = PromptId
+Result: TypeAlias = int
+
+
+class PromptVersionCountDataLoader(DataLoader[Key, Result]):
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: Iterable[Key]) -> list[Result]:
+        prompt_ids = list(set(keys))
+        result: dict[Key, Result] = {}
+        stmt = (
+            select(
+                models.PromptVersion.prompt_id,
+                func.count(),
+            )
+            .where(models.PromptVersion.prompt_id.in_(prompt_ids))
+            .group_by(models.PromptVersion.prompt_id)
+        )
+        async with self._db.read() as session:
+            data = await session.stream(stmt)
+            async for prompt_id, count in data:
+                result[prompt_id] = count
+        return [result.get(prompt_id, 0) for prompt_id in keys]

--- a/src/phoenix/server/api/dataloaders/prompt_version_tags_by_prompt.py
+++ b/src/phoenix/server/api/dataloaders/prompt_version_tags_by_prompt.py
@@ -1,0 +1,29 @@
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+PromptId: TypeAlias = int
+Key: TypeAlias = PromptId
+Result: TypeAlias = list[models.PromptVersionTag]
+
+
+class PromptVersionTagsByPromptDataLoader(DataLoader[Key, Result]):
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        prompt_ids = list(set(keys))
+        tags: dict[Key, Result] = {}
+        stmt = (
+            select(models.PromptVersionTag)
+            .where(models.PromptVersionTag.prompt_id.in_(prompt_ids))
+            .order_by(models.PromptVersionTag.id)
+        )
+        async with self._db.read() as session:
+            async for tag in await session.stream_scalars(stmt):
+                tags.setdefault(tag.prompt_id, []).append(tag)
+        return [tags.get(prompt_id, []) for prompt_id in keys]

--- a/src/phoenix/server/api/types/Prompt.py
+++ b/src/phoenix/server/api/types/Prompt.py
@@ -111,48 +111,45 @@ class Prompt(Node):
         version_id: Optional[GlobalID] = None,
         tag_name: Optional[Identifier] = None,
     ) -> PromptVersion:
-        async with info.context.db.read() as session:
-            if version_id:
-                v_id = from_global_id_with_expected_type(version_id, PromptVersion.__name__)
+        if version_id:
+            v_id = from_global_id_with_expected_type(version_id, PromptVersion.__name__)
+            async with info.context.db.read() as session:
                 version = await session.scalar(
                     select(models.PromptVersion).where(
                         models.PromptVersion.id == v_id,
                         models.PromptVersion.prompt_id == self.id,
                     )
                 )
-                if not version:
-                    raise NotFound(f"Prompt version not found: {version_id}")
-            elif tag_name:
+            if not version:
+                raise NotFound(f"Prompt version not found: {version_id}")
+            return to_gql_prompt_version(version)
+        if tag_name:
+            async with info.context.db.read() as session:
                 version = await session.scalar(
                     select(models.PromptVersion)
                     .where(models.PromptVersion.prompt_id == self.id)
                     .join_from(models.PromptVersion, models.PromptVersionTag)
                     .where(models.PromptVersionTag.name == tag_name)
                 )
-                if not version:
-                    raise NotFound(f"This prompt has no associated versions by tag {tag_name}")
-            else:
-                stmt = (
-                    select(models.PromptVersion)
-                    .where(models.PromptVersion.prompt_id == self.id)
-                    .order_by(models.PromptVersion.id.desc())
-                    .limit(1)
-                )
-                version = await session.scalar(stmt)
-                if not version:
-                    raise NotFound("This prompt has no associated versions")
+            if not version:
+                raise NotFound(f"This prompt has no associated versions by tag {tag_name}")
             return to_gql_prompt_version(version)
+        latest_version_id = await info.context.data_loaders.latest_prompt_version_ids.load(self.id)
+        if latest_version_id is None:
+            raise NotFound("This prompt has no associated versions")
+        version = await info.context.data_loaders.prompt_versions.load(latest_version_id)
+        if not version:
+            raise NotFound("This prompt has no associated versions")
+        return to_gql_prompt_version(version)
+
+    @strawberry.field
+    async def version_count(self, info: Info[Context, None]) -> int:
+        return await info.context.data_loaders.prompt_version_counts.load(self.id)
 
     @strawberry.field
     async def version_tags(self, info: Info[Context, None]) -> list[PromptVersionTag]:
-        async with info.context.db.read() as session:
-            stmt = select(models.PromptVersionTag).where(
-                models.PromptVersionTag.prompt_id == self.id
-            )
-            return [
-                PromptVersionTag(id=tag.id, db_record=tag)
-                async for tag in await session.stream_scalars(stmt)
-            ]
+        tags = await info.context.data_loaders.prompt_version_tags_by_prompt.load(self.id)
+        return [PromptVersionTag(id=tag.id, db_record=tag) for tag in tags]
 
     @strawberry.field
     async def prompt_versions(
@@ -200,10 +197,5 @@ class Prompt(Node):
 
     @strawberry.field
     async def labels(self, info: Info[Context, None]) -> list["PromptLabel"]:
-        async with info.context.db.read() as session:
-            labels = await session.scalars(
-                select(models.PromptLabel)
-                .join(models.PromptPromptLabel)
-                .where(models.PromptPromptLabel.prompt_id == self.id)
-            )
-            return [PromptLabel(id=label.id, db_record=label) for label in labels]
+        labels = await info.context.data_loaders.prompt_labels_by_prompt.load(self.id)
+        return [PromptLabel(id=label.id, db_record=label) for label in labels]

--- a/tests/unit/server/api/types/test_Prompt.py
+++ b/tests/unit/server/api/types/test_Prompt.py
@@ -1,0 +1,130 @@
+import pytest
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
+from phoenix.db.types.model_provider import ModelProvider
+from phoenix.db.types.prompts import (
+    PromptOpenAIInvocationParameters,
+    PromptOpenAIInvocationParametersContent,
+    PromptStringTemplate,
+    PromptTemplateFormat,
+    PromptTemplateType,
+)
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+
+def _prompt_version(prompt_id: int, description: str) -> models.PromptVersion:
+    return models.PromptVersion(
+        prompt_id=prompt_id,
+        description=description,
+        template_type=PromptTemplateType.STRING,
+        template_format=PromptTemplateFormat.F_STRING,
+        template=PromptStringTemplate(type="string", template="Hello, {name}!"),
+        invocation_parameters=PromptOpenAIInvocationParameters(
+            type="openai", openai=PromptOpenAIInvocationParametersContent()
+        ),
+        model_provider=ModelProvider.OPENAI,
+        model_name="gpt-4",
+        metadata_={},
+    )
+
+
+@pytest.fixture
+async def prompts_with_versions_and_tags(
+    db: DbSessionFactory,
+) -> dict[str, dict[str, object]]:
+    """
+    Two prompts: "prompt-a" with three versions ("production" and "staging" tags
+    on different versions), "prompt-b" with one untagged version.
+    Returns expected version counts, latest version IDs, and tag names by prompt name.
+    """
+    async with db() as session:
+        prompt_a = models.Prompt(name=Identifier(root="prompt-a"), metadata_={})
+        prompt_b = models.Prompt(name=Identifier(root="prompt-b"), metadata_={})
+        label = models.PromptLabel(name="prod-ready", color="#FF0000")
+        session.add_all([prompt_a, prompt_b, label])
+        await session.flush()
+        session.add(models.PromptPromptLabel(prompt_id=prompt_a.id, prompt_label_id=label.id))
+
+        prompt_a_versions = []
+        for i in range(3):
+            version = _prompt_version(prompt_a.id, f"prompt-a version {i + 1}")
+            session.add(version)
+            await session.flush()
+            prompt_a_versions.append(version)
+        prompt_b_version = _prompt_version(prompt_b.id, "prompt-b version 1")
+        session.add(prompt_b_version)
+        await session.flush()
+
+        session.add_all(
+            [
+                models.PromptVersionTag(
+                    name=Identifier(root="production"),
+                    prompt_id=prompt_a.id,
+                    prompt_version_id=prompt_a_versions[1].id,
+                ),
+                models.PromptVersionTag(
+                    name=Identifier(root="staging"),
+                    prompt_id=prompt_a.id,
+                    prompt_version_id=prompt_a_versions[2].id,
+                ),
+            ]
+        )
+        await session.commit()
+
+        return {
+            "prompt-a": {
+                "versionCount": 3,
+                "latestVersionId": str(GlobalID("PromptVersion", str(prompt_a_versions[-1].id))),
+                "tagNames": ["production", "staging"],
+                "labelNames": ["prod-ready"],
+            },
+            "prompt-b": {
+                "versionCount": 1,
+                "latestVersionId": str(GlobalID("PromptVersion", str(prompt_b_version.id))),
+                "tagNames": [],
+                "labelNames": [],
+            },
+        }
+
+
+async def test_version_count_latest_version_and_tags_resolve_per_prompt(
+    gql_client: AsyncGraphQLClient,
+    prompts_with_versions_and_tags: dict[str, dict[str, object]],
+) -> None:
+    query = """
+      query {
+        prompts {
+          edges {
+            node {
+              name
+              versionCount
+              version {
+                id
+              }
+              versionTags {
+                name
+              }
+              labels {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert response.data
+    actual = {
+        edge["node"]["name"]: {
+            "versionCount": edge["node"]["versionCount"],
+            "latestVersionId": edge["node"]["version"]["id"],
+            "tagNames": [tag["name"] for tag in edge["node"]["versionTags"]],
+            "labelNames": [label["name"] for label in edge["node"]["labels"]],
+        }
+        for edge in response.data["prompts"]["edges"]
+    }
+    assert actual == prompts_with_versions_and_tags


### PR DESCRIPTION
## Summary

Adds three columns to the prompts table, with batched (dataloader-backed) retrieval so the table issues a constant number of queries per page regardless of row count.

### Frontend (`app/src/pages/prompts/PromptsTable.tsx`)

- **versions** — version count per prompt
- **latest version** — the latest version's ID, linking to `/prompts/:promptId/versions/:versionId`, with copy-on-hover
- **version tags** — the prompt's version tags rendered as tokens (shared `TagVersionLabel` coloring), each linking to the tagged version

### Backend

- New `Prompt.versionCount` GraphQL field backed by a new `PromptVersionCountDataLoader` (single `COUNT ... GROUP BY prompt_id` per page)
- New `PromptVersionTagsByPromptDataLoader`; `Prompt.versionTags` now batches instead of one query per prompt
- New `PromptLabelsByPromptDataLoader`; `Prompt.labels` now batches instead of one query per prompt (was the remaining N+1 on this table)
- The no-arg branch of `Prompt.version` resolves through the existing `latest_prompt_version_ids` + `prompt_versions` loaders instead of a per-prompt `ORDER BY id DESC LIMIT 1` query, and the resolver is restructured into self-guarding branches
- Net effect: a 100-row table page previously issued ~300 queries (version, tags, labels per row); it now issues ~5 batched queries

## Testing

- New `tests/unit/server/api/types/test_Prompt.py` asserts `versionCount`, latest `version.id`, `versionTags`, and `labels` resolve per-prompt-correct values across prompts with differing shapes (exercises the batching paths)
- Existing prompt mutation/query suites pass; mypy, ruff, relay compiler, tsc, oxlint, oxfmt clean