### PR TITLE
fix(app): improve span filter completions

### DIFF
--- a/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/app/src/components/filter/DSLFilterConditionField.tsx
@@ -44,7 +44,7 @@ import {
   getDSLFilterCompletionTokenBeforeCursor,
   shouldSuppressDSLFilterCompletionsInString,
   validDSLFilterCompletionTokenPattern,
-} from "./DSLFilterConditionFieldUtils";
+} from "./dslFilterConditionFieldUtils";
 import {
   dslFilterCodeMirrorCSS,
   dslFilterErrorTooltipCSS,

--- a/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/app/src/components/filter/DSLFilterConditionField.tsx
@@ -41,6 +41,11 @@ import { useTheme } from "@phoenix/contexts";
 import { classNames } from "@phoenix/utils/classNames";
 
 import {
+  getDSLFilterCompletionTokenBeforeCursor,
+  shouldSuppressDSLFilterCompletionsInString,
+  validDSLFilterCompletionTokenPattern,
+} from "./DSLFilterConditionFieldUtils";
+import {
   dslFilterCodeMirrorCSS,
   dslFilterErrorTooltipCSS,
   dslFilterFieldCSS,
@@ -100,8 +105,10 @@ export function createLoadedCompletionSection(name: string): CompletionSection {
  * once the user types.
  */
 const MAX_BROWSE_SUGGESTIONS = 5;
+const MAX_BROWSE_FIELDS = 20;
 
 const defaultSnippets: DSLFilterSnippet[] = [];
+const defaultCompletionSources: CompletionSource[] = [];
 
 function snippetToCompletion({ label, snippet }: DSLFilterSnippet): Completion {
   return snippetCompletion(snippet, {
@@ -111,18 +118,6 @@ function snippetToCompletion({ label, snippet }: DSLFilterSnippet): Completion {
     section: suggestionsSection,
   });
 }
-
-/**
- * The DSL token under construction directly before the cursor: a dotted
- * identifier optionally followed by a (possibly still-unclosed) string
- * subscript and a trailing member access — e.g. `annotations['quality'].la`.
- * The subscript must be part of the match: accepting a completion replaces
- * exactly this range, so matching only `[\w.]*` would leave an already-typed
- * `annotations['quality']` in place and double it up.
- */
-const tokenBeforeCursor =
-  /(?:\w[\w.]*)?(?:\[(?:'[^']*'?|"[^"]*"?)?\]?)?(?:\.\w*)?/;
-const validTokenPattern = new RegExp(`^(?:${tokenBeforeCursor.source})$`);
 
 /**
  * Builds a CodeMirror completion source over the given DSL vocabulary.
@@ -136,10 +131,18 @@ function createCompletionSource(
   return async (
     context: CompletionContext
   ): Promise<CompletionResult | null> => {
-    const word = context.matchBefore(tokenBeforeCursor);
-    if (!word) return null;
+    const textBeforeCursor = context.state.doc.sliceString(0, context.pos);
+    const word = getDSLFilterCompletionTokenBeforeCursor(textBeforeCursor);
 
     if (word.from === word.to && !context.explicit) return null;
+    if (
+      shouldSuppressDSLFilterCompletionsInString({
+        textBeforeCursor,
+        tokenFrom: word.from,
+      })
+    ) {
+      return null;
+    }
 
     // Browsing: the dropdown is open with nothing typed at the cursor, so
     // there's no query to narrow the options — sources may return a curated
@@ -161,7 +164,7 @@ function createCompletionSource(
       // A browse result may be a curated subset — force a fresh query on
       // the next keystroke rather than letting CodeMirror filter the subset
       // in place, so typing matches against the full vocabulary
-      validFor: isBrowsing ? undefined : validTokenPattern,
+      validFor: isBrowsing ? undefined : validDSLFilterCompletionTokenPattern,
     };
   };
 }
@@ -199,6 +202,12 @@ export type DSLFilterConditionFieldProps = {
    * referentially stable function.
    */
   loadCompletions?: () => Promise<Completion[]>;
+  /**
+   * Additional CodeMirror completion sources for context-aware completions
+   * that need the editor state, e.g. suggesting allowed values after a known
+   * field comparison. Pass a referentially stable array.
+   */
+  completionSources?: CompletionSource[];
   /**
    * Async validation of the condition expression. Never called with an
    * empty (or whitespace-only) condition — the field resolves those as
@@ -246,6 +255,7 @@ export function DSLFilterConditionField(props: DSLFilterConditionFieldProps) {
     completions,
     snippets = defaultSnippets,
     loadCompletions,
+    completionSources = defaultCompletionSources,
     validateCondition,
     onValidCondition,
     onValidationStateChange,
@@ -300,7 +310,7 @@ export function DSLFilterConditionField(props: DSLFilterConditionFieldProps) {
       ...(isBrowsing
         ? snippetOptions.slice(0, MAX_BROWSE_SUGGESTIONS)
         : snippetOptions),
-      ...fieldOptions,
+      ...(isBrowsing ? fieldOptions.slice(0, MAX_BROWSE_FIELDS) : fieldOptions),
     ];
     return [
       keymap.of([
@@ -338,6 +348,7 @@ export function DSLFilterConditionField(props: DSLFilterConditionFieldProps) {
       }),
       autocompletion({
         override: [
+          ...completionSources,
           createCompletionSource(staticOptions),
           ...(loadCompletionsOnce
             ? [createCompletionSource(loadCompletionsOnce)]
@@ -352,7 +363,7 @@ export function DSLFilterConditionField(props: DSLFilterConditionFieldProps) {
           completion.type === "text" ? "dsl-filter-suggestion" : "",
       }),
     ];
-  }, [snippets, completions, loadCompletions, ariaLabel]);
+  }, [snippets, completions, loadCompletions, completionSources, ariaLabel]);
 
   // Validity attributes are applied directly to the contenteditable so
   // toggling them doesn't force a CodeMirror reconfigure

--- a/app/src/components/filter/DSLFilterConditionFieldUtils.ts
+++ b/app/src/components/filter/DSLFilterConditionFieldUtils.ts
@@ -1,0 +1,89 @@
+const quotedSubscriptPattern = String.raw`(?:"(?:\\.|[^"\\])*"?|'(?:\\.|[^'\\])*'?)`;
+const integerSubscriptPattern = String.raw`\d+`;
+const subscriptPattern = String.raw`\[(?:${quotedSubscriptPattern}|${integerSubscriptPattern})?\]?`;
+const dottedMemberPattern = String.raw`\.(?:[A-Za-z_]\w*)?`;
+
+/**
+ * The DSL token under construction directly before the cursor: a dotted
+ * identifier optionally followed by string or integer subscripts and a trailing
+ * member access — e.g. `annotations['quality'].la`. The subscript must be part
+ * of the match: accepting a completion replaces exactly this range, so matching
+ * only `[\w.]*` would leave an already-typed `annotations['quality']` in place
+ * and double it up.
+ */
+const dslFilterTokenPattern = new RegExp(
+  String.raw`[A-Za-z_]\w*(?:(?:${dottedMemberPattern})|(?:${subscriptPattern}))*`
+);
+const tokenBeforeCursorPattern = new RegExp(
+  String.raw`${dslFilterTokenPattern.source}$`
+);
+
+export const validDSLFilterCompletionTokenPattern = new RegExp(
+  String.raw`^(?:${dslFilterTokenPattern.source})?$`
+);
+
+export type DSLFilterCompletionToken = {
+  from: number;
+  to: number;
+  text: string;
+};
+
+export function getDSLFilterCompletionTokenBeforeCursor(
+  textBeforeCursor: string
+): DSLFilterCompletionToken {
+  const tokenMatch = textBeforeCursor.match(tokenBeforeCursorPattern);
+  const text = tokenMatch?.[0] ?? "";
+  return {
+    from: textBeforeCursor.length - text.length,
+    to: textBeforeCursor.length,
+    text,
+  };
+}
+
+function getOpenStringStartBeforeCursor(
+  textBeforeCursor: string
+): number | null {
+  let openQuote: "'" | '"' | null = null;
+  let openQuoteIndex: number | null = null;
+  let isEscaped = false;
+
+  for (let index = 0; index < textBeforeCursor.length; index++) {
+    const character = textBeforeCursor[index];
+
+    if (isEscaped) {
+      isEscaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      isEscaped = true;
+      continue;
+    }
+    if (openQuote) {
+      if (character === openQuote) {
+        openQuote = null;
+        openQuoteIndex = null;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      openQuote = character;
+      openQuoteIndex = index;
+    }
+  }
+
+  return openQuoteIndex;
+}
+
+export function shouldSuppressDSLFilterCompletionsInString({
+  textBeforeCursor,
+  tokenFrom,
+}: {
+  textBeforeCursor: string;
+  tokenFrom: number;
+}): boolean {
+  const openStringStart = getOpenStringStartBeforeCursor(textBeforeCursor);
+  if (openStringStart === null) {
+    return false;
+  }
+  return openStringStart < tokenFrom;
+}

--- a/app/src/components/filter/__tests__/DSLFilterConditionField.test.ts
+++ b/app/src/components/filter/__tests__/DSLFilterConditionField.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDSLFilterCompletionTokenBeforeCursor,
+  shouldSuppressDSLFilterCompletionsInString,
+} from "../DSLFilterConditionFieldUtils";
+
+describe("DSLFilterConditionField completion helpers", () => {
+  it("includes quoted subscripts with spaces in the replacement token", () => {
+    const textBeforeCursor = "annotations['Human Fee";
+    const token = getDSLFilterCompletionTokenBeforeCursor(textBeforeCursor);
+
+    expect(token).toEqual({
+      from: 0,
+      to: textBeforeCursor.length,
+      text: textBeforeCursor,
+    });
+    expect(
+      shouldSuppressDSLFilterCompletionsInString({
+        textBeforeCursor,
+        tokenFrom: token.from,
+      })
+    ).toBe(false);
+  });
+
+  it("includes integer-indexed attribute paths in the replacement token", () => {
+    const textBeforeCursor =
+      "attributes['llm']['input_messages'][0]['message']['role";
+
+    expect(getDSLFilterCompletionTokenBeforeCursor(textBeforeCursor)).toEqual({
+      from: 0,
+      to: textBeforeCursor.length,
+      text: textBeforeCursor,
+    });
+  });
+
+  it("includes trailing member-access dots in the replacement token", () => {
+    expect(getDSLFilterCompletionTokenBeforeCursor("input.")).toEqual({
+      from: 0,
+      to: "input.".length,
+      text: "input.",
+    });
+    expect(
+      getDSLFilterCompletionTokenBeforeCursor("annotations['quality'].")
+    ).toEqual({
+      from: 0,
+      to: "annotations['quality'].".length,
+      text: "annotations['quality'].",
+    });
+  });
+
+  it("suppresses field completions inside ordinary string values", () => {
+    const textBeforeCursor =
+      "attributes['input']['mime_type'] == 'application/js";
+    const token = getDSLFilterCompletionTokenBeforeCursor(textBeforeCursor);
+
+    expect(token.text).toBe("js");
+    expect(
+      shouldSuppressDSLFilterCompletionsInString({
+        textBeforeCursor,
+        tokenFrom: token.from,
+      })
+    ).toBe(true);
+  });
+
+  it("does not suppress completions after a closed string value", () => {
+    const textBeforeCursor = "span_kind == 'LLM' and sta";
+    const token = getDSLFilterCompletionTokenBeforeCursor(textBeforeCursor);
+
+    expect(token.text).toBe("sta");
+    expect(
+      shouldSuppressDSLFilterCompletionsInString({
+        textBeforeCursor,
+        tokenFrom: token.from,
+      })
+    ).toBe(false);
+  });
+});

--- a/app/src/components/filter/__tests__/DSLFilterConditionField.test.ts
+++ b/app/src/components/filter/__tests__/DSLFilterConditionField.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getDSLFilterCompletionTokenBeforeCursor,
   shouldSuppressDSLFilterCompletionsInString,
-} from "../DSLFilterConditionFieldUtils";
+} from "../dslFilterConditionFieldUtils";
 
 describe("DSLFilterConditionField completion helpers", () => {
   it("includes quoted subscripts with spaces in the replacement token", () => {

--- a/app/src/components/filter/dslFilterConditionFieldUtils.ts
+++ b/app/src/components/filter/dslFilterConditionFieldUtils.ts
@@ -18,16 +18,38 @@ const tokenBeforeCursorPattern = new RegExp(
   String.raw`${dslFilterTokenPattern.source}$`
 );
 
+/**
+ * CodeMirror's `validFor` guard for the token returned by
+ * `getDSLFilterCompletionTokenBeforeCursor`. If the user keeps typing inside
+ * a valid DSL accessor prefix, CodeMirror can filter the existing completion
+ * result instead of asking every completion source to recompute.
+ */
 export const validDSLFilterCompletionTokenPattern = new RegExp(
   String.raw`^(?:${dslFilterTokenPattern.source})?$`
 );
 
+/**
+ * The editable token range CodeMirror should replace when accepting a DSL
+ * completion. `text` is the partial token at the cursor, and `from`/`to` are
+ * offsets in the current document.
+ */
 export type DSLFilterCompletionToken = {
   from: number;
   to: number;
   text: string;
 };
 
+/**
+ * Returns the DSL accessor token immediately before the cursor.
+ *
+ * The span filter DSL allows partially typed dotted members and subscripts:
+ * `input.`, `annotations['Human Fee`, and
+ * `attributes['llm']['input_messages'][0]['message'].` are all valid
+ * completion prefixes. Keeping the whole prefix is important because
+ * CodeMirror replaces this range when a completion is accepted; if the matcher
+ * drops an existing subscript or trailing dot, accepting a suggestion can
+ * duplicate the accessor instead of completing it.
+ */
 export function getDSLFilterCompletionTokenBeforeCursor(
   textBeforeCursor: string
 ): DSLFilterCompletionToken {
@@ -40,6 +62,12 @@ export function getDSLFilterCompletionTokenBeforeCursor(
   };
 }
 
+/**
+ * Finds an unmatched quote before the cursor while respecting backslash
+ * escapes. This is intentionally lightweight: it only needs enough string
+ * awareness to avoid offering field completions while the user is typing a
+ * literal value such as `== 'application/js`.
+ */
 function getOpenStringStartBeforeCursor(
   textBeforeCursor: string
 ): number | null {
@@ -74,6 +102,15 @@ function getOpenStringStartBeforeCursor(
   return openQuoteIndex;
 }
 
+/**
+ * Determines whether normal field completions should be suppressed because
+ * the cursor is inside a string literal value.
+ *
+ * A quoted subscript such as `annotations['Human Fee` should still complete
+ * because the string starts inside the token being replaced. A value literal
+ * such as `span_kind == 'LL` should not show field completions because the
+ * open quote starts before the current token.
+ */
 export function shouldSuppressDSLFilterCompletionsInString({
   textBeforeCursor,
   tokenFrom,

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -15,6 +15,10 @@ import environment from "@phoenix/RelayEnvironment";
 import type { SpanFilterConditionFieldCompletionsQuery } from "./__generated__/SpanFilterConditionFieldCompletionsQuery.graphql";
 import { getNonNoteAnnotationNames } from "./spanAnnotationUtils";
 import { useSpanFilters } from "./SpanFiltersContext";
+import {
+  openInferenceAttributeCompletions,
+  openInferenceAttributeValueCompletionSource,
+} from "./spanFilterSemanticConventionCompletions";
 import { validateSpanFilterCondition } from "./spanFilterValidation";
 
 /**
@@ -79,7 +83,7 @@ const spanFilterCompletions: Completion[] = [
   {
     label: "attributes",
     type: "variable",
-    info: "Span attributes, accessed by key - e.x. attributes['llm.model_name']",
+    info: "Span attributes, accessed by key - e.x. attributes['llm']['provider']",
   },
   {
     label: "annotations",
@@ -121,6 +125,11 @@ const spanFilterCompletions: Completion[] = [
     type: "variable",
     info: "Sum of token count total (prompt + completion) from self and all child spans",
   },
+  ...openInferenceAttributeCompletions,
+];
+
+const spanFilterCompletionSources = [
+  openInferenceAttributeValueCompletionSource,
 ];
 
 /**
@@ -139,6 +148,10 @@ const spanFilterSnippets: DSLFilterSnippet[] = [
   {
     label: "filter by span kind",
     snippet: "span_kind == '${LLM}'",
+  },
+  {
+    label: "filter by LLM provider",
+    snippet: "attributes['llm']['provider'] == '${openai}'",
   },
   {
     label: "filter by latency",
@@ -287,6 +300,7 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
       placeholder={placeholder}
       completions={spanFilterCompletions}
       snippets={spanFilterSnippets}
+      completionSources={spanFilterCompletionSources}
       loadCompletions={loadAnnotationCompletions}
       validateCondition={validateCondition}
       onValidCondition={onValidCondition}

--- a/app/src/pages/project/__tests__/spanFilterSemanticConventionCompletions.test.ts
+++ b/app/src/pages/project/__tests__/spanFilterSemanticConventionCompletions.test.ts
@@ -1,0 +1,255 @@
+import type { Completion, CompletionContext } from "@codemirror/autocomplete";
+import type { EditorView } from "@uiw/react-codemirror";
+import { describe, expect, it } from "vitest";
+
+import {
+  createOpenInferenceAttributeCompletions,
+  createOpenInferenceAttributeValueCompletionSource,
+  getOpenInferenceAttributeValueCompletionContext,
+  normalizeOpenInferenceAttributeAccessor,
+  semanticConventionPathToAttributeAccessor,
+} from "../spanFilterSemanticConventionCompletions";
+
+function createCompletionContext(text: string): CompletionContext {
+  return {
+    pos: text.length,
+    state: {
+      doc: {
+        sliceString: (from: number, to?: number) => text.slice(from, to),
+      },
+    },
+  } as unknown as CompletionContext;
+}
+
+function createCompletionContextAt({
+  text,
+  pos = text.length,
+}: {
+  text: string;
+  pos?: number;
+}): CompletionContext {
+  return {
+    pos,
+    state: {
+      doc: {
+        sliceString: (from: number, to?: number) => text.slice(from, to),
+      },
+    },
+  } as unknown as CompletionContext;
+}
+
+function applyCompletion({
+  text,
+  completion,
+  from,
+  to,
+}: {
+  text: string;
+  completion: Completion;
+  from: number;
+  to: number;
+}): string {
+  let result = text;
+  const view = {
+    state: {
+      doc: {
+        length: text.length,
+        sliceString: (fromIndex: number, toIndex?: number) =>
+          text.slice(fromIndex, toIndex),
+      },
+    },
+    dispatch: ({
+      changes,
+    }: {
+      changes: { from: number; to: number; insert: string };
+    }) => {
+      result =
+        result.slice(0, changes.from) +
+        changes.insert +
+        result.slice(changes.to);
+    },
+  } as unknown as EditorView;
+
+  if (typeof completion.apply !== "function") {
+    throw new Error("Expected completion apply function");
+  }
+  completion.apply(view, completion, from, to);
+  return result;
+}
+
+describe("spanFilterSemanticConventionCompletions", () => {
+  it("converts semantic convention paths into nested attribute accessors", () => {
+    expect(semanticConventionPathToAttributeAccessor("llm.provider")).toBe(
+      "attributes['llm']['provider']"
+    );
+    expect(
+      semanticConventionPathToAttributeAccessor("openinference.span.kind")
+    ).toBe("attributes['openinference']['span']['kind']");
+  });
+
+  it("generates OpenInference attribute completions from semantic conventions", () => {
+    const completions = createOpenInferenceAttributeCompletions({
+      semanticConventions: {
+        LLM_PROVIDER: "llm.provider",
+        MESSAGE_ROLE: "message.role",
+        OPENINFERENCE_SPAN_KIND: "openinference.span.kind",
+      },
+    });
+
+    expect(completions.map((completion) => completion.label)).toEqual([
+      "attributes['llm']['provider']",
+    ]);
+    expect(completions[0].detail).toBe("llm.provider");
+  });
+
+  it("generates indexed completions for nested OpenInference list members", () => {
+    const labels = createOpenInferenceAttributeCompletions().map(
+      (completion) => completion.label
+    );
+
+    expect(labels).toContain("attributes['llm']['provider']");
+    expect(labels).toContain(
+      "attributes['llm']['input_messages'][0]['message']['role']"
+    );
+    expect(labels).toContain(
+      "attributes['llm']['output_messages'][0]['message']['contents'][0]['message_content']['text']"
+    );
+    expect(labels).toContain(
+      "attributes['llm']['input_messages'][0]['message']['tool_calls'][0]['tool_call']['function']['name']"
+    );
+    expect(labels).toContain(
+      "attributes['retrieval']['documents'][0]['document']['content']"
+    );
+    expect(labels).toContain(
+      "attributes['embedding']['embeddings'][0]['embedding']['text']"
+    );
+  });
+
+  it("does not generate top-level completions for nested-only conventions", () => {
+    const labels = createOpenInferenceAttributeCompletions().map(
+      (completion) => completion.label
+    );
+
+    expect(labels).not.toContain("attributes['message']['role']");
+    expect(labels).not.toContain("attributes['message_content']['data']");
+    expect(labels).not.toContain("attributes['tool_call']['function']['name']");
+    expect(labels).not.toContain("attributes['document']['content']");
+    expect(labels).not.toContain("attributes['embedding']['text']");
+    expect(labels).not.toContain("attributes['image']['url']");
+    expect(labels).not.toContain("attributes['audio']['mime_type']");
+    expect(labels).not.toContain("attributes['openinference']['span']['kind']");
+  });
+
+  it("normalizes double-quoted attribute accessors for value lookup", () => {
+    expect(
+      normalizeOpenInferenceAttributeAccessor('attributes["llm"]["provider"]')
+    ).toBe("attributes['llm']['provider']");
+  });
+
+  it("normalizes escaped path segments and integer indices", () => {
+    expect(
+      normalizeOpenInferenceAttributeAccessor(
+        String.raw`attributes['llm']['input_messages'][0]["Bob\"s"]`
+      )
+    ).toBe(String.raw`attributes['llm']['input_messages'][0]['Bob"s']`);
+  });
+
+  it("detects quoted values after known attribute comparisons", () => {
+    expect(
+      getOpenInferenceAttributeValueCompletionContext(
+        'attributes["llm"]["provider"] == "op'
+      )
+    ).toEqual({
+      accessor: "attributes['llm']['provider']",
+      quote: '"',
+      typedText: "op",
+    });
+  });
+
+  it("does not detect value completions inside longer identifiers", () => {
+    expect(
+      getOpenInferenceAttributeValueCompletionContext("my_span_kind == 'L")
+    ).toBeNull();
+  });
+
+  it("suggests enum values for semantic convention attributes", async () => {
+    const source = createOpenInferenceAttributeValueCompletionSource();
+    const result = await source(
+      createCompletionContext("attributes['llm']['provider'] == \"op")
+    );
+
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("Expected completion result");
+    }
+    expect(result.from).toBe("attributes['llm']['provider'] == \"".length);
+    expect(result.options.map((completion) => completion.label)).toContain(
+      "openai"
+    );
+    expect(result.options.map((completion) => completion.label)).toContain(
+      "anthropic"
+    );
+  });
+
+  it("suggests span kind values for the top-level span_kind field", async () => {
+    const source = createOpenInferenceAttributeValueCompletionSource();
+    const result = await source(createCompletionContext("span_kind == 'L"));
+
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("Expected completion result");
+    }
+    expect(result.from).toBe("span_kind == '".length);
+    expect(result.options.map((completion) => completion.label)).toContain(
+      "LLM"
+    );
+  });
+
+  it("does not suggest span kind values for openinference.span.kind attributes", async () => {
+    const source = createOpenInferenceAttributeValueCompletionSource();
+    const result = await source(
+      createCompletionContext(
+        "attributes['openinference']['span']['kind'] == 'L"
+      )
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("does not suggest MIME values for audio.mime_type", async () => {
+    const source = createOpenInferenceAttributeValueCompletionSource();
+    const result = await source(
+      createCompletionContext("attributes['audio']['mime_type'] == 'text")
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("replaces the whole existing quoted value on mid-value accept", async () => {
+    const source = createOpenInferenceAttributeValueCompletionSource();
+    const text = "span_kind == 'CHAIN'";
+    const pos = "span_kind == 'C".length;
+    const result = await source(createCompletionContextAt({ text, pos }));
+
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error("Expected completion result");
+    }
+    const chainCompletion = result.options.find(
+      (completion) => completion.label === "CHAIN"
+    );
+    expect(chainCompletion).toBeDefined();
+    if (!chainCompletion) {
+      throw new Error("Expected CHAIN completion");
+    }
+
+    expect(
+      applyCompletion({
+        text,
+        completion: chainCompletion,
+        from: result.from,
+        to: pos,
+      })
+    ).toBe("span_kind == 'CHAIN'");
+  });
+});

--- a/app/src/pages/project/spanFilterSemanticConventionCompletions.ts
+++ b/app/src/pages/project/spanFilterSemanticConventionCompletions.ts
@@ -23,21 +23,43 @@ import type {
 } from "@codemirror/autocomplete";
 import type { EditorView } from "@uiw/react-codemirror";
 
+/**
+ * Shape exposed by `@arizeai/openinference-semantic-conventions`: enum keys map
+ * to dotted OpenInference attribute paths such as `llm.provider`.
+ */
 type SemanticConventionMap = Readonly<Record<string, string>>;
+
+/**
+ * A segment in the backend filter DSL's attribute accessor syntax. Strings
+ * become quoted subscripts (`['llm']`), while numbers become list indexes
+ * (`[0]`).
+ */
 type AttributePathSegment = string | number;
 
+/**
+ * Enum values that should be offered after a specific field is compared with
+ * `==` or `!=`.
+ */
 type OpenInferenceAttributeValueCompletionConfig = {
   accessor: string;
   detail: string;
   values: readonly string[];
 };
 
+/**
+ * The partially typed enum-value expression immediately before the cursor.
+ */
 type OpenInferenceAttributeValueCompletionContext = {
   accessor: string;
   quote: "'" | '"';
   typedText: string;
 };
 
+/**
+ * A completion-ready attribute path plus the display path shown in the detail
+ * column. These can differ because indexed list traversals are shown as
+ * `llm.input_messages[0].message.role`, not as a raw accessor.
+ */
 type SemanticConventionAttributePath = {
   pathSegments: readonly AttributePathSegment[];
   detail: string;
@@ -45,6 +67,12 @@ type SemanticConventionAttributePath = {
 
 const DEFAULT_SEMANTIC_CONVENTIONS: SemanticConventionMap = SemanticConventions;
 const SPAN_KIND_FIELD = "span_kind";
+/**
+ * Completions must include an explicit list index for nested OpenInference
+ * structures. The backend DSL supports integer subscripts but does not provide
+ * wildcard traversal, so `attributes['llm']['input_messages']['message']...`
+ * is invalid whereas `attributes['llm']['input_messages'][0]...` is meaningful.
+ */
 const LIST_ITEM_INDEX = 0;
 
 const openInferenceAttributesSection: CompletionSection = {
@@ -66,6 +94,10 @@ const attributeAccessorSegmentPattern = new RegExp(
   "g"
 );
 
+/**
+ * Converts the semantic-conventions package's dotted path representation into
+ * independent DSL accessor segments.
+ */
 function semanticConventionPathToSegments(
   semanticConventionPath: string
 ): string[] {
@@ -82,6 +114,14 @@ function createNestedOnlySemanticConventionPaths({
   return Object.values(postfixes).map((postfix) => `${prefix}.${postfix}`);
 }
 
+/**
+ * Postfix convention groups describe objects nested inside list-valued
+ * attributes. The semantic-conventions package publishes them as standalone
+ * dotted paths (`message.role`, `document.id`, `tool_call.id`, etc.), but
+ * Phoenix stores them under list roots like `llm.input_messages[0]` and
+ * `retrieval.documents[0]`. Offering the standalone paths as top-level
+ * `attributes[...]` filters creates valid-looking filters that match no spans.
+ */
 const nestedOnlySemanticConventionPaths = new Set<string>([
   ...createNestedOnlySemanticConventionPaths({
     prefix: SemanticAttributePrefixes.message,
@@ -111,11 +151,21 @@ const nestedOnlySemanticConventionPaths = new Set<string>([
   `${SemanticAttributePrefixes.embedding}.${EmbeddingAttributePostfixes.vector}`,
 ]);
 
+/**
+ * Paths that are OpenInference conventions but should not be offered as
+ * `attributes[...]` filters. `openinference.span.kind` is ingested into the
+ * dedicated `span_kind` column in the REST v1 path, and metadata has its own
+ * typed filter surface.
+ */
 const hiddenTopLevelSemanticConventionPaths = new Set<string>([
   SemanticConventions.METADATA,
   SemanticConventions.OPENINFERENCE_SPAN_KIND,
 ]);
 
+/**
+ * Returns whether a semantic-convention path is stored as a top-level span
+ * attribute in Phoenix.
+ */
 function isTopLevelSemanticConventionPath(
   semanticConventionPath: string
 ): boolean {
@@ -125,6 +175,10 @@ function isTopLevelSemanticConventionPath(
   );
 }
 
+/**
+ * Formats path segments for the completion detail column. This intentionally
+ * resembles OpenInference dotted paths while keeping list indexes visible.
+ */
 function attributePathSegmentsToDetailPath(
   pathSegments: readonly AttributePathSegment[]
 ): string {
@@ -138,6 +192,10 @@ function attributePathSegmentsToDetailPath(
     .join("");
 }
 
+/**
+ * Builds a nested list traversal by inserting the required list item index
+ * between a list-valued root and the object's per-item convention path.
+ */
 function createIndexedNestedAttributePath({
   listRootPath,
   itemPathSegments,
@@ -156,6 +214,11 @@ function createIndexedNestedAttributePath({
   };
 }
 
+/**
+ * Expands LLM message list roots into the conventions that actually live on
+ * each message item: `message.*`, `message.contents[0].message_content.*`, and
+ * `message.tool_calls[0].tool_call.*`.
+ */
 function createMessageAttributePaths({
   listRootPath,
 }: {
@@ -219,6 +282,11 @@ function createMessageAttributePaths({
   ];
 }
 
+/**
+ * Nested OpenInference conventions that Phoenix can traverse when the filter
+ * includes a concrete list index. Each completion uses `[0]` as an editable
+ * placeholder index so users see the required shape of the DSL.
+ */
 const defaultNestedSemanticConventionAttributePaths: readonly SemanticConventionAttributePath[] =
   [
     ...createMessageAttributePaths({
@@ -271,14 +339,28 @@ const defaultNestedSemanticConventionAttributePaths: readonly SemanticConvention
     ),
   ];
 
+/**
+ * Escapes a path segment for the single-quoted subscript form used by inserted
+ * completions.
+ */
 function escapeAttributePathSegment(pathSegment: string): string {
   return pathSegment.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 
+/**
+ * Reverses escaping for path segments matched from either single- or
+ * double-quoted user input before re-emitting them in the canonical accessor
+ * form.
+ */
 function unescapeAttributePathSegment(pathSegment: string): string {
   return pathSegment.replace(/\\(["'\\])/g, "$1");
 }
 
+/**
+ * Converts a segment list into backend DSL subscript syntax. Bracket notation
+ * is used for every string segment so completions always produce the same
+ * filter shape as the backend attribute path parser expects.
+ */
 function attributePathSegmentsToAccessor(
   pathSegments: readonly AttributePathSegment[]
 ): string {
@@ -291,6 +373,10 @@ function attributePathSegmentsToAccessor(
     .join("");
 }
 
+/**
+ * Converts a dotted OpenInference path into the canonical Phoenix filter DSL
+ * accessor, e.g. `llm.provider` becomes `attributes['llm']['provider']`.
+ */
 export function semanticConventionPathToAttributeAccessor(
   semanticConventionPath: string
 ): string {
@@ -299,6 +385,11 @@ export function semanticConventionPathToAttributeAccessor(
   )}`;
 }
 
+/**
+ * Canonicalizes an accessor before comparing it to a value-completion config.
+ * Users may type double quotes or escaped characters, but completion configs
+ * use the single-quoted bracket form emitted by this module.
+ */
 export function normalizeOpenInferenceAttributeAccessor(
   accessor: string
 ): string {
@@ -331,6 +422,14 @@ export function normalizeOpenInferenceAttributeAccessor(
   return `attributes${attributePathSegmentsToAccessor(pathSegments)}`;
 }
 
+/**
+ * Creates field completions for OpenInference span attributes.
+ *
+ * Top-level semantic conventions are generated directly from the package enum,
+ * excluding per-item postfix groups that are only meaningful below list roots.
+ * Nested list conventions are provided separately so each one includes the
+ * required numeric index in the suggested DSL accessor.
+ */
 export function createOpenInferenceAttributeCompletions({
   semanticConventions,
   nestedSemanticConventionAttributePaths,
@@ -380,6 +479,12 @@ export function createOpenInferenceAttributeCompletions({
     });
 }
 
+/**
+ * Enum-value completions for fields Phoenix can evaluate reliably. Note that
+ * `openinference.span.kind` is intentionally omitted in favor of `span_kind`,
+ * and nested-only conventions such as `audio.mime_type` are not offered as
+ * value-completion roots.
+ */
 const defaultOpenInferenceAttributeValueCompletionConfigs = [
   {
     accessor: SPAN_KIND_FIELD,
@@ -416,6 +521,12 @@ const defaultOpenInferenceAttributeValueCompletionConfigs = [
   },
 ] satisfies readonly OpenInferenceAttributeValueCompletionConfig[];
 
+/**
+ * Returns the enum-value completion context when the cursor is inside a quoted
+ * right-hand-side literal for a supported comparison. The left boundary avoids
+ * treating identifiers that merely end with a supported field name, such as
+ * `my_span_kind`, as OpenInference fields.
+ */
 export function getOpenInferenceAttributeValueCompletionContext(
   textBeforeCursor: string
 ): OpenInferenceAttributeValueCompletionContext | null {
@@ -434,6 +545,11 @@ export function getOpenInferenceAttributeValueCompletionContext(
   };
 }
 
+/**
+ * Finds how much of the current quoted value should be replaced. When the user
+ * accepts a completion in the middle of an existing literal, the stale suffix
+ * is removed up to the closing quote instead of being left behind.
+ */
 function getValueCompletionReplacementEnd({
   view,
   to,
@@ -464,6 +580,10 @@ function getValueCompletionReplacementEnd({
   return { to: view.state.doc.length, hasClosingQuote: false };
 }
 
+/**
+ * Applies a value completion while preserving an existing closing quote or
+ * inserting one when the user is completing an unterminated string.
+ */
 function createValueCompletionApply({
   quote,
 }: {
@@ -487,6 +607,10 @@ function createValueCompletionApply({
   };
 }
 
+/**
+ * Creates CodeMirror completion items for the enum values of one OpenInference
+ * attribute.
+ */
 function createValueCompletions({
   valueCompletionConfig,
   quote,
@@ -506,6 +630,10 @@ function createValueCompletions({
   }));
 }
 
+/**
+ * Builds the completion source that offers enum values after supported
+ * OpenInference comparisons such as `span_kind == 'LL`.
+ */
 export function createOpenInferenceAttributeValueCompletionSource({
   valueCompletionConfigs = defaultOpenInferenceAttributeValueCompletionConfigs,
   section = openInferenceAttributeValuesSection,
@@ -547,7 +675,15 @@ export function createOpenInferenceAttributeValueCompletionSource({
   };
 }
 
+/**
+ * Default OpenInference field completions used by the span filter DSL editor.
+ */
 export const openInferenceAttributeCompletions =
   createOpenInferenceAttributeCompletions();
+
+/**
+ * Default OpenInference enum-value completion source used by the span filter
+ * DSL editor.
+ */
 export const openInferenceAttributeValueCompletionSource =
   createOpenInferenceAttributeValueCompletionSource();

--- a/app/src/pages/project/spanFilterSemanticConventionCompletions.ts
+++ b/app/src/pages/project/spanFilterSemanticConventionCompletions.ts
@@ -1,0 +1,553 @@
+import {
+  AudioAttributesPostfixes,
+  DocumentAttributePostfixes,
+  EmbeddingAttributePostfixes,
+  ImageAttributesPostfixes,
+  LLMProvider,
+  LLMSystem,
+  MessageAttributePostfixes,
+  MessageContentsAttributePostfixes,
+  MimeType,
+  OpenInferenceSpanKind,
+  SemanticAttributePrefixes,
+  SemanticConventions,
+  ToolAttributePostfixes,
+  ToolCallAttributePostfixes,
+} from "@arizeai/openinference-semantic-conventions";
+import type {
+  Completion,
+  CompletionContext,
+  CompletionResult,
+  CompletionSection,
+  CompletionSource,
+} from "@codemirror/autocomplete";
+import type { EditorView } from "@uiw/react-codemirror";
+
+type SemanticConventionMap = Readonly<Record<string, string>>;
+type AttributePathSegment = string | number;
+
+type OpenInferenceAttributeValueCompletionConfig = {
+  accessor: string;
+  detail: string;
+  values: readonly string[];
+};
+
+type OpenInferenceAttributeValueCompletionContext = {
+  accessor: string;
+  quote: "'" | '"';
+  typedText: string;
+};
+
+type SemanticConventionAttributePath = {
+  pathSegments: readonly AttributePathSegment[];
+  detail: string;
+};
+
+const DEFAULT_SEMANTIC_CONVENTIONS: SemanticConventionMap = SemanticConventions;
+const SPAN_KIND_FIELD = "span_kind";
+const LIST_ITEM_INDEX = 0;
+
+const openInferenceAttributesSection: CompletionSection = {
+  name: "Attributes",
+  rank: 4,
+};
+const openInferenceAttributeValuesSection: CompletionSection = {
+  name: "OpenInference values",
+  rank: 2,
+};
+
+const quotedAccessorSegmentSource = String.raw`(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|(\d+))`;
+const attributeAccessorSource = String.raw`attributes(?:\[(?:${quotedAccessorSegmentSource})\])+`;
+const attributeValueContextPattern = new RegExp(
+  String.raw`(?:^|[^\w.])(?<accessor>${SPAN_KIND_FIELD}|${attributeAccessorSource})\s*(?:==|!=)\s*(?<quote>['"])(?<typedText>[^'"]*)$`
+);
+const attributeAccessorSegmentPattern = new RegExp(
+  String.raw`\[${quotedAccessorSegmentSource}\]`,
+  "g"
+);
+
+function semanticConventionPathToSegments(
+  semanticConventionPath: string
+): string[] {
+  return semanticConventionPath.split(".");
+}
+
+function createNestedOnlySemanticConventionPaths({
+  prefix,
+  postfixes,
+}: {
+  prefix: string;
+  postfixes: Readonly<Record<string, string>>;
+}): string[] {
+  return Object.values(postfixes).map((postfix) => `${prefix}.${postfix}`);
+}
+
+const nestedOnlySemanticConventionPaths = new Set<string>([
+  ...createNestedOnlySemanticConventionPaths({
+    prefix: SemanticAttributePrefixes.message,
+    postfixes: MessageAttributePostfixes,
+  }),
+  ...createNestedOnlySemanticConventionPaths({
+    prefix: SemanticAttributePrefixes.message_content,
+    postfixes: MessageContentsAttributePostfixes,
+  }),
+  ...createNestedOnlySemanticConventionPaths({
+    prefix: SemanticAttributePrefixes.tool_call,
+    postfixes: ToolCallAttributePostfixes,
+  }),
+  ...createNestedOnlySemanticConventionPaths({
+    prefix: SemanticAttributePrefixes.document,
+    postfixes: DocumentAttributePostfixes,
+  }),
+  ...createNestedOnlySemanticConventionPaths({
+    prefix: SemanticAttributePrefixes.image,
+    postfixes: ImageAttributesPostfixes,
+  }),
+  ...createNestedOnlySemanticConventionPaths({
+    prefix: SemanticAttributePrefixes.audio,
+    postfixes: AudioAttributesPostfixes,
+  }),
+  `${SemanticAttributePrefixes.embedding}.${EmbeddingAttributePostfixes.text}`,
+  `${SemanticAttributePrefixes.embedding}.${EmbeddingAttributePostfixes.vector}`,
+]);
+
+const hiddenTopLevelSemanticConventionPaths = new Set<string>([
+  SemanticConventions.METADATA,
+  SemanticConventions.OPENINFERENCE_SPAN_KIND,
+]);
+
+function isTopLevelSemanticConventionPath(
+  semanticConventionPath: string
+): boolean {
+  return (
+    !hiddenTopLevelSemanticConventionPaths.has(semanticConventionPath) &&
+    !nestedOnlySemanticConventionPaths.has(semanticConventionPath)
+  );
+}
+
+function attributePathSegmentsToDetailPath(
+  pathSegments: readonly AttributePathSegment[]
+): string {
+  return pathSegments
+    .map((pathSegment, index) => {
+      if (typeof pathSegment === "number") {
+        return `[${pathSegment}]`;
+      }
+      return index === 0 ? pathSegment : `.${pathSegment}`;
+    })
+    .join("");
+}
+
+function createIndexedNestedAttributePath({
+  listRootPath,
+  itemPathSegments,
+}: {
+  listRootPath: string;
+  itemPathSegments: readonly AttributePathSegment[];
+}): SemanticConventionAttributePath {
+  const pathSegments = [
+    ...semanticConventionPathToSegments(listRootPath),
+    LIST_ITEM_INDEX,
+    ...itemPathSegments,
+  ];
+  return {
+    pathSegments,
+    detail: attributePathSegmentsToDetailPath(pathSegments),
+  };
+}
+
+function createMessageAttributePaths({
+  listRootPath,
+}: {
+  listRootPath: string;
+}): SemanticConventionAttributePath[] {
+  const messageAttributePaths = Object.values(MessageAttributePostfixes).map(
+    (postfix) =>
+      createIndexedNestedAttributePath({
+        listRootPath,
+        itemPathSegments: [
+          SemanticAttributePrefixes.message,
+          ...semanticConventionPathToSegments(postfix),
+        ],
+      })
+  );
+  const messageContentAttributePaths = Object.values(
+    MessageContentsAttributePostfixes
+  ).map((postfix) =>
+    createIndexedNestedAttributePath({
+      listRootPath,
+      itemPathSegments: [
+        SemanticAttributePrefixes.message,
+        MessageAttributePostfixes.contents,
+        LIST_ITEM_INDEX,
+        SemanticAttributePrefixes.message_content,
+        ...semanticConventionPathToSegments(postfix),
+      ],
+    })
+  );
+  const messageContentImageAttributePath = createIndexedNestedAttributePath({
+    listRootPath,
+    itemPathSegments: [
+      SemanticAttributePrefixes.message,
+      MessageAttributePostfixes.contents,
+      LIST_ITEM_INDEX,
+      ...semanticConventionPathToSegments(
+        SemanticConventions.MESSAGE_CONTENT_IMAGE
+      ),
+      ...semanticConventionPathToSegments(SemanticConventions.IMAGE_URL),
+    ],
+  });
+  const toolCallAttributePaths = Object.values(ToolCallAttributePostfixes).map(
+    (postfix) =>
+      createIndexedNestedAttributePath({
+        listRootPath,
+        itemPathSegments: [
+          SemanticAttributePrefixes.message,
+          MessageAttributePostfixes.tool_calls,
+          LIST_ITEM_INDEX,
+          SemanticAttributePrefixes.tool_call,
+          ...semanticConventionPathToSegments(postfix),
+        ],
+      })
+  );
+
+  return [
+    ...messageAttributePaths,
+    ...messageContentAttributePaths,
+    messageContentImageAttributePath,
+    ...toolCallAttributePaths,
+  ];
+}
+
+const defaultNestedSemanticConventionAttributePaths: readonly SemanticConventionAttributePath[] =
+  [
+    ...createMessageAttributePaths({
+      listRootPath: SemanticConventions.LLM_INPUT_MESSAGES,
+    }),
+    ...createMessageAttributePaths({
+      listRootPath: SemanticConventions.LLM_OUTPUT_MESSAGES,
+    }),
+    createIndexedNestedAttributePath({
+      listRootPath: SemanticConventions.LLM_TOOLS,
+      itemPathSegments: [
+        SemanticAttributePrefixes.tool,
+        ToolAttributePostfixes.json_schema,
+      ],
+    }),
+    ...Object.values(DocumentAttributePostfixes).flatMap((postfix) => [
+      createIndexedNestedAttributePath({
+        listRootPath: SemanticConventions.RETRIEVAL_DOCUMENTS,
+        itemPathSegments: [
+          SemanticAttributePrefixes.document,
+          ...semanticConventionPathToSegments(postfix),
+        ],
+      }),
+      createIndexedNestedAttributePath({
+        listRootPath: SemanticConventions.RERANKER_INPUT_DOCUMENTS,
+        itemPathSegments: [
+          SemanticAttributePrefixes.document,
+          ...semanticConventionPathToSegments(postfix),
+        ],
+      }),
+      createIndexedNestedAttributePath({
+        listRootPath: SemanticConventions.RERANKER_OUTPUT_DOCUMENTS,
+        itemPathSegments: [
+          SemanticAttributePrefixes.document,
+          ...semanticConventionPathToSegments(postfix),
+        ],
+      }),
+    ]),
+    ...[
+      EmbeddingAttributePostfixes.text,
+      EmbeddingAttributePostfixes.vector,
+    ].map((postfix) =>
+      createIndexedNestedAttributePath({
+        listRootPath: SemanticConventions.EMBEDDING_EMBEDDINGS,
+        itemPathSegments: [
+          SemanticAttributePrefixes.embedding,
+          ...semanticConventionPathToSegments(postfix),
+        ],
+      })
+    ),
+  ];
+
+function escapeAttributePathSegment(pathSegment: string): string {
+  return pathSegment.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+function unescapeAttributePathSegment(pathSegment: string): string {
+  return pathSegment.replace(/\\(["'\\])/g, "$1");
+}
+
+function attributePathSegmentsToAccessor(
+  pathSegments: readonly AttributePathSegment[]
+): string {
+  return pathSegments
+    .map((pathSegment) =>
+      typeof pathSegment === "number"
+        ? `[${pathSegment}]`
+        : `['${escapeAttributePathSegment(pathSegment)}']`
+    )
+    .join("");
+}
+
+export function semanticConventionPathToAttributeAccessor(
+  semanticConventionPath: string
+): string {
+  return `attributes${attributePathSegmentsToAccessor(
+    semanticConventionPathToSegments(semanticConventionPath)
+  )}`;
+}
+
+export function normalizeOpenInferenceAttributeAccessor(
+  accessor: string
+): string {
+  if (accessor === SPAN_KIND_FIELD) {
+    return accessor;
+  }
+  if (!accessor.startsWith("attributes")) {
+    return accessor;
+  }
+
+  const pathSegments: AttributePathSegment[] = [];
+  for (const segmentMatch of accessor.matchAll(
+    attributeAccessorSegmentPattern
+  )) {
+    const doubleQuotedPathSegment = segmentMatch[1];
+    const singleQuotedPathSegment = segmentMatch[2];
+    const indexPathSegment = segmentMatch[3];
+    if (typeof indexPathSegment === "string") {
+      pathSegments.push(Number(indexPathSegment));
+      continue;
+    }
+    const pathSegment = doubleQuotedPathSegment ?? singleQuotedPathSegment;
+    if (typeof pathSegment === "string") {
+      pathSegments.push(unescapeAttributePathSegment(pathSegment));
+    }
+  }
+  if (pathSegments.length === 0) {
+    return accessor;
+  }
+  return `attributes${attributePathSegmentsToAccessor(pathSegments)}`;
+}
+
+export function createOpenInferenceAttributeCompletions({
+  semanticConventions,
+  nestedSemanticConventionAttributePaths,
+  section = openInferenceAttributesSection,
+}: {
+  semanticConventions?: SemanticConventionMap;
+  nestedSemanticConventionAttributePaths?: readonly SemanticConventionAttributePath[];
+  section?: CompletionSection;
+} = {}): Completion[] {
+  const resolvedSemanticConventions =
+    semanticConventions ?? DEFAULT_SEMANTIC_CONVENTIONS;
+  const resolvedNestedSemanticConventionAttributePaths =
+    nestedSemanticConventionAttributePaths ??
+    (semanticConventions ? [] : defaultNestedSemanticConventionAttributePaths);
+  const seenAccessors = new Set<string>();
+  const topLevelSemanticConventionAttributePaths = Object.values(
+    resolvedSemanticConventions
+  )
+    .filter(isTopLevelSemanticConventionPath)
+    .map((semanticConventionPath) => ({
+      pathSegments: semanticConventionPathToSegments(semanticConventionPath),
+      detail: semanticConventionPath,
+    }));
+
+  return [
+    ...topLevelSemanticConventionAttributePaths,
+    ...resolvedNestedSemanticConventionAttributePaths,
+  ]
+    .sort((firstPath, secondPath) =>
+      firstPath.detail.localeCompare(secondPath.detail)
+    )
+    .flatMap(({ pathSegments, detail }) => {
+      const label = `attributes${attributePathSegmentsToAccessor(pathSegments)}`;
+      if (seenAccessors.has(label)) {
+        return [];
+      }
+      seenAccessors.add(label);
+      return [
+        {
+          label,
+          type: "variable",
+          detail,
+          info: `OpenInference semantic convention: ${detail}`,
+          section,
+        },
+      ];
+    });
+}
+
+const defaultOpenInferenceAttributeValueCompletionConfigs = [
+  {
+    accessor: SPAN_KIND_FIELD,
+    detail: "span kind",
+    values: Object.values(OpenInferenceSpanKind),
+  },
+  {
+    accessor: semanticConventionPathToAttributeAccessor(
+      SemanticConventions.LLM_PROVIDER
+    ),
+    detail: "LLM provider",
+    values: Object.values(LLMProvider),
+  },
+  {
+    accessor: semanticConventionPathToAttributeAccessor(
+      SemanticConventions.LLM_SYSTEM
+    ),
+    detail: "LLM system",
+    values: Object.values(LLMSystem),
+  },
+  {
+    accessor: semanticConventionPathToAttributeAccessor(
+      SemanticConventions.INPUT_MIME_TYPE
+    ),
+    detail: "input MIME type",
+    values: Object.values(MimeType),
+  },
+  {
+    accessor: semanticConventionPathToAttributeAccessor(
+      SemanticConventions.OUTPUT_MIME_TYPE
+    ),
+    detail: "output MIME type",
+    values: Object.values(MimeType),
+  },
+] satisfies readonly OpenInferenceAttributeValueCompletionConfig[];
+
+export function getOpenInferenceAttributeValueCompletionContext(
+  textBeforeCursor: string
+): OpenInferenceAttributeValueCompletionContext | null {
+  const match = textBeforeCursor.match(attributeValueContextPattern);
+  if (!match?.groups) {
+    return null;
+  }
+  const quote = match.groups.quote;
+  if (quote !== "'" && quote !== '"') {
+    return null;
+  }
+  return {
+    accessor: normalizeOpenInferenceAttributeAccessor(match.groups.accessor),
+    quote,
+    typedText: match.groups.typedText,
+  };
+}
+
+function getValueCompletionReplacementEnd({
+  view,
+  to,
+  quote,
+}: {
+  view: EditorView;
+  to: number;
+  quote: "'" | '"';
+}): { to: number; hasClosingQuote: boolean } {
+  let isEscaped = false;
+  for (let position = to; position < view.state.doc.length; position++) {
+    const character = view.state.doc.sliceString(position, position + 1);
+    if (isEscaped) {
+      isEscaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      isEscaped = true;
+      continue;
+    }
+    if (character === quote) {
+      return { to: position, hasClosingQuote: true };
+    }
+    if (character === "\n") {
+      return { to: position, hasClosingQuote: false };
+    }
+  }
+  return { to: view.state.doc.length, hasClosingQuote: false };
+}
+
+function createValueCompletionApply({
+  quote,
+}: {
+  quote: "'" | '"';
+}): Completion["apply"] {
+  return (
+    view: EditorView,
+    completion: Completion,
+    from: number,
+    to: number
+  ) => {
+    const { to: replacementTo, hasClosingQuote } =
+      getValueCompletionReplacementEnd({ view, to, quote });
+    const insertion = hasClosingQuote
+      ? completion.label
+      : `${completion.label}${quote}`;
+    view.dispatch({
+      changes: { from, to: replacementTo, insert: insertion },
+      selection: { anchor: from + completion.label.length + 1 },
+    });
+  };
+}
+
+function createValueCompletions({
+  valueCompletionConfig,
+  quote,
+  section,
+}: {
+  valueCompletionConfig: OpenInferenceAttributeValueCompletionConfig;
+  quote: "'" | '"';
+  section: CompletionSection;
+}): Completion[] {
+  return valueCompletionConfig.values.map((value) => ({
+    label: value,
+    type: "constant",
+    detail: valueCompletionConfig.detail,
+    info: `OpenInference ${valueCompletionConfig.detail} value`,
+    section,
+    apply: createValueCompletionApply({ quote }),
+  }));
+}
+
+export function createOpenInferenceAttributeValueCompletionSource({
+  valueCompletionConfigs = defaultOpenInferenceAttributeValueCompletionConfigs,
+  section = openInferenceAttributeValuesSection,
+}: {
+  valueCompletionConfigs?: readonly OpenInferenceAttributeValueCompletionConfig[];
+  section?: CompletionSection;
+} = {}): CompletionSource {
+  const valueCompletionConfigByAccessor = new Map(
+    valueCompletionConfigs.map((valueCompletionConfig) => [
+      normalizeOpenInferenceAttributeAccessor(valueCompletionConfig.accessor),
+      valueCompletionConfig,
+    ])
+  );
+
+  return (context: CompletionContext): CompletionResult | null => {
+    const textBeforeCursor = context.state.doc.sliceString(0, context.pos);
+    const valueCompletionContext =
+      getOpenInferenceAttributeValueCompletionContext(textBeforeCursor);
+    if (!valueCompletionContext) {
+      return null;
+    }
+
+    const valueCompletionConfig = valueCompletionConfigByAccessor.get(
+      valueCompletionContext.accessor
+    );
+    if (!valueCompletionConfig) {
+      return null;
+    }
+
+    return {
+      from: context.pos - valueCompletionContext.typedText.length,
+      options: createValueCompletions({
+        valueCompletionConfig,
+        quote: valueCompletionContext.quote,
+        section,
+      }),
+      validFor: /^[^'"]*$/,
+    };
+  };
+}
+
+export const openInferenceAttributeCompletions =
+  createOpenInferenceAttributeCompletions();
+export const openInferenceAttributeValueCompletionSource =
+  createOpenInferenceAttributeValueCompletionSource();


### PR DESCRIPTION
## Summary
- add OpenInference semantic convention completions for span filters while filtering nested-only postfix groups from top-level attribute suggestions
- suggest list-member semantic conventions with explicit `[0]` indices so generated accessors traverse `llm.input_messages`, `llm.output_messages`, documents, tools, and embeddings correctly
- harden the shared DSL completion tokenizer for quoted subscripts, trailing member dots, in-string suppression, browse caps, and value completion replacement

## Root Cause
The semantic convention completion source treated every exported OpenInference convention as a top-level span attribute, including postfix groups that only exist inside list items. The shared token matcher also failed to preserve some partially typed DSL accessors, which could corrupt accepted completions.

## Validation
- `pnpm test src/components/filter/__tests__/DSLFilterConditionField.test.ts src/pages/project/__tests__/spanFilterSemanticConventionCompletions.test.ts`
- `make typecheck-frontend`
- `make lint-frontend`
- `make test-frontend`