### PR TITLE
fix(ui): admin-gate settings version status, stop caching failed fetches

### DIFF
--- a/app/src/components/nav/VersionUpdateNotice.tsx
+++ b/app/src/components/nav/VersionUpdateNotice.tsx
@@ -8,6 +8,7 @@ import {
   Icons,
   Text,
 } from "@phoenix/components";
+import { VERSION } from "@phoenix/config";
 import { useViewerCanSeeVersionUpdates } from "@phoenix/contexts";
 import { useLatestPhoenixVersion, usePersistedState } from "@phoenix/hooks";
 import {
@@ -181,12 +182,11 @@ export function VersionUpdateNotice({ isExpanded }: { isExpanded: boolean }) {
   const [dismissedVersion, setDismissedVersion] = usePersistedState<
     string | null
   >(LOCAL_STORAGE_DISMISSED_UPDATE_VERSION_KEY, null);
-  const currentVersion = window.Config.platformVersion;
 
   const hasSignificantUpdate =
     latestVersion != null &&
     isVersionNewerBy({
-      current: currentVersion,
+      current: VERSION,
       latest: latestVersion,
       minorVersions: MINOR_VERSIONS_BEHIND_THRESHOLD,
     });
@@ -221,19 +221,18 @@ export function VersionUpdateNotice({ isExpanded }: { isExpanded: boolean }) {
  * visits deliberately (Settings > General), so it reports any newer version
  * — including a single minor or patch bump — rather than applying the nav
  * notice's two-minor-version threshold, which exists specifically to avoid
- * pushing a banner for every minor release. Renders nothing while the latest
+ * pushing a banner for every minor release. Only admins see this status, for
+ * the same reason the nav notice is admin-only: they are the ones who can
+ * act on it by upgrading the server. Renders nothing while the latest
  * version is unknown or when the server is up to date.
  */
-export function PlatformVersionStatus({
-  currentVersion,
-}: {
-  currentVersion: string;
-}) {
+export function PlatformVersionStatus() {
+  const canSeeVersionUpdates = useViewerCanSeeVersionUpdates();
   const latestVersion = useLatestPhoenixVersion();
   const isLagging =
     latestVersion != null &&
-    isVersionNewer({ current: currentVersion, latest: latestVersion });
-  if (!isLagging) {
+    isVersionNewer({ current: VERSION, latest: latestVersion });
+  if (!canSeeVersionUpdates || !isLagging) {
     return null;
   }
   return (

--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -36,63 +36,47 @@ export function useViewerCanModify() {
 }
 
 /**
- * Returns true if the viewer can manage retention policies
+ * Returns true if the viewer is an admin.
  * Note: when the app is not configured with auth, we assume the user is an admin
  */
-export function useViewerCanManageRetentionPolicy() {
+function useIsAdmin() {
   const { viewer } = useViewer();
-  if (viewer && viewer?.role?.name !== "ADMIN") {
-    return false;
-  }
-  return true;
+  return !viewer || viewer.role?.name === "ADMIN";
+}
+
+/**
+ * Returns true if the viewer can manage retention policies
+ */
+export function useViewerCanManageRetentionPolicy() {
+  return useIsAdmin();
 }
 
 /**
  * Returns true if the viewer can manage sandboxes
- * Note: when the app is not configured with auth, we assume the user is an admin
  */
 export function useViewerCanManageSandboxes() {
-  const { viewer } = useViewer();
-  if (viewer && viewer?.role?.name !== "ADMIN") {
-    return false;
-  }
-  return true;
+  return useIsAdmin();
 }
 
 /**
  * Returns true if the viewer can manage secrets
- * Note: when the app is not configured with auth, we assume the user is an admin
  */
 export function useViewerCanManageSecrets() {
-  const { viewer } = useViewer();
-  if (viewer && viewer?.role?.name !== "ADMIN") {
-    return false;
-  }
-  return true;
+  return useIsAdmin();
 }
 
 /**
  * Returns true if the viewer should be shown platform version update notices
- * Note: when the app is not configured with auth, we assume the user is an admin
  */
 export function useViewerCanSeeVersionUpdates() {
-  const { viewer } = useViewer();
-  if (viewer && viewer?.role?.name !== "ADMIN") {
-    return false;
-  }
-  return true;
+  return useIsAdmin();
 }
 
 /**
  * Returns true if the viewer can bulk-delete a project's annotations
- * Note: when the app is not configured with auth, we assume the user is an admin
  */
 export function useViewerCanDeleteProjectAnnotations() {
-  const { viewer } = useViewer();
-  if (viewer && viewer.role?.name !== "ADMIN") {
-    return false;
-  }
-  return true;
+  return useIsAdmin();
 }
 
 export function ViewerProvider({

--- a/app/src/hooks/useLatestPhoenixVersion.ts
+++ b/app/src/hooks/useLatestPhoenixVersion.ts
@@ -18,7 +18,16 @@ function fetchLatestVersion(): Promise<string | null> {
         const version: unknown = data?.info?.version;
         return typeof version === "string" ? version : null;
       })
-      .catch(() => null);
+      .catch(() => null)
+      .then((version) => {
+        // Don't memoize a failed/empty result — let the next mount retry
+        // instead of silently suppressing the notice for the rest of the
+        // session after a transient network failure.
+        if (version == null) {
+          latestVersionPromise = null;
+        }
+        return version;
+      });
   }
   return latestVersionPromise;
 }

--- a/app/src/pages/settings/SettingsGeneralPage.tsx
+++ b/app/src/pages/settings/SettingsGeneralPage.tsx
@@ -58,7 +58,7 @@ export function SettingsGeneralPage() {
             <CopyInput />
             <Text slot="description">The version of the Phoenix server</Text>
           </CopyField>
-          <PlatformVersionStatus currentVersion={VERSION} />
+          <PlatformVersionStatus />
         </form>
       </Card>
       <Card title="Database Usage">


### PR DESCRIPTION
Follow-up to #14056 (already merged), which added a dismissable "new version available" notice to the side nav and a version status line on Settings > General.

A cloud code review of that PR (run after merge) found two real bugs and two cleanup issues, all fixed here:

## Bugs

- **`PlatformVersionStatus` wasn't admin-gated.** The settings-page version status rendered for any authenticated viewer, but the equivalent nav notice is intentionally admin-only ("they are the ones who can act on it by upgrading the server"). A non-admin visiting Settings > General would see an upgrade banner they can't act on. Now gated behind the same `useViewerCanSeeVersionUpdates()` check.
- **A failed PyPI fetch was cached forever.** The shared fetch cache in `useLatestPhoenixVersion` memoized a failed/empty response as a permanent `null` for the rest of the session — a single transient network blip (offline tab, PyPI hiccup) would silently suppress the update notice even after connectivity recovered, with no retry short of a full reload. Now only successful results are cached; a failure clears the cache so the next mount retries.

## Cleanup

- Consolidated the five identical admin-role-check hooks in `ViewerContext.tsx` (`useViewerCanManageRetentionPolicy`, `useViewerCanManageSandboxes`, `useViewerCanManageSecrets`, `useViewerCanSeeVersionUpdates`, `useViewerCanDeleteProjectAnnotations`) behind one shared `useIsAdmin()` helper instead of five copies of the same body.
- `VersionUpdateNotice` now reads the running version via the existing `VERSION` export from `@phoenix/config` instead of `window.Config.platformVersion` directly, matching how `SettingsGeneralPage` already reads it.

## Tests

- `pnpm typecheck`, `pnpm lint`, `pnpm prettier --check` — clean
- `pnpm vitest run src/utils/__tests__/versionUtils.test.ts` — 15 passing (unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
