### PR TITLE
feat(app): add shift-click range selection to tables

### DIFF
--- a/app/src/components/table/RowSelectionColumn.tsx
+++ b/app/src/components/table/RowSelectionColumn.tsx
@@ -1,0 +1,75 @@
+import type { ColumnDef, Row, Table } from "@tanstack/react-table";
+import type { MouseEvent } from "react";
+
+import { IndeterminateCheckboxCell } from "./IndeterminateCheckboxCell";
+import { CHECKBOX_COLUMN_ID } from "./selectionUtils";
+
+export type SelectRowHandler<TData> = ({
+  event,
+  row,
+  table,
+}: {
+  event: MouseEvent;
+  row: Row<TData>;
+  table: Table<TData>;
+}) => void;
+
+/**
+ * Creates the standard TanStack row-selection checkbox column.
+ *
+ * @param params - selection column options
+ * @param params.selectRow - optional custom row selection handler
+ * @param params.shouldRenderCell - returns false for rows that should not show a checkbox
+ * @param params.size - column size in pixels
+ * @param params.minSize - minimum column size in pixels
+ * @param params.maxSize - maximum column size in pixels
+ */
+export function createRowSelectionColumn<TData>({
+  selectRow,
+  shouldRenderCell = () => true,
+  size = 30,
+  minSize = size,
+  maxSize = size,
+}: {
+  selectRow?: SelectRowHandler<TData>;
+  shouldRenderCell?: (row: Row<TData>) => boolean;
+  size?: number;
+  minSize?: number;
+  maxSize?: number;
+} = {}): ColumnDef<TData> {
+  return {
+    id: CHECKBOX_COLUMN_ID,
+    enableResizing: false,
+    enableSorting: false,
+    size,
+    minSize,
+    maxSize,
+    header: ({ table }) => (
+      <IndeterminateCheckboxCell
+        isSelected={table.getIsAllRowsSelected()}
+        isIndeterminate={table.getIsSomeRowsSelected()}
+        onChange={table.toggleAllRowsSelected}
+      />
+    ),
+    cell: ({ row, table }) => {
+      if (!shouldRenderCell(row)) {
+        return null;
+      }
+      return (
+        <IndeterminateCheckboxCell
+          isSelected={row.getIsSelected()}
+          isDisabled={!row.getCanSelect()}
+          isIndeterminate={row.getIsSomeSelected()}
+          onChange={row.toggleSelected}
+          onCellClick={
+            selectRow
+              ? (event) => {
+                  selectRow({ event, row, table });
+                }
+              : undefined
+          }
+        />
+      );
+    },
+  };
+}

--- a/app/src/components/table/__tests__/selectionUtils.test.ts
+++ b/app/src/components/table/__tests__/selectionUtils.test.ts
@@ -1,4 +1,4 @@
-import { addRangeToSelection } from "../selectionUtils";
+import { addRangeToSelection, addRowRangeToSelection } from "../selectionUtils";
 
 describe("addRangeToSelection", () => {
   const items = [
@@ -48,5 +48,51 @@ describe("addRangeToSelection", () => {
     const originalSelection = { a: true };
     addRangeToSelection(items, 1, 2, originalSelection);
     expect(originalSelection).toEqual({ a: true });
+  });
+});
+
+describe("addRowRangeToSelection", () => {
+  const rows = [
+    { id: "0", getCanSelect: () => true },
+    { id: "1", getCanSelect: () => true },
+    { id: "2", getCanSelect: () => true },
+    { id: "3", getCanSelect: () => true },
+  ];
+
+  it("selects rows by row id instead of original data id", () => {
+    const result = addRowRangeToSelection({
+      rows,
+      lastSelectedIndex: 1,
+      currentIndex: 3,
+      currentSelection: {},
+    });
+
+    expect(result).toEqual({ "1": true, "2": true, "3": true });
+  });
+
+  it("skips rows that cannot be selected", () => {
+    const result = addRowRangeToSelection({
+      rows: [
+        { id: "0", getCanSelect: () => true },
+        { id: "1", getCanSelect: () => false },
+        { id: "2", getCanSelect: () => true },
+      ],
+      lastSelectedIndex: 0,
+      currentIndex: 2,
+      currentSelection: {},
+    });
+
+    expect(result).toEqual({ "0": true, "2": true });
+  });
+
+  it("preserves existing row selections", () => {
+    const result = addRowRangeToSelection({
+      rows,
+      lastSelectedIndex: 1,
+      currentIndex: 2,
+      currentSelection: { "0": true },
+    });
+
+    expect(result).toEqual({ "0": true, "1": true, "2": true });
   });
 });

--- a/app/src/components/table/index.tsx
+++ b/app/src/components/table/index.tsx
@@ -12,3 +12,7 @@ export * from "./CellTop";
 export * from "./LargeTextWrap";
 export * from "./JSONCell";
 export * from "./PaddedCell";
+export * from "./IndeterminateCheckboxCell";
+export * from "./RowSelectionColumn";
+export * from "./selectionUtils";
+export * from "./useShiftClickRowSelection";

--- a/app/src/components/table/selectionUtils.ts
+++ b/app/src/components/table/selectionUtils.ts
@@ -1,3 +1,19 @@
+import type {
+  ColumnPinningState,
+  RowSelectionState,
+} from "@tanstack/react-table";
+
+export const CHECKBOX_COLUMN_ID = "select";
+
+export const CHECKBOX_COLUMN_PINNING = {
+  left: [CHECKBOX_COLUMN_ID],
+} satisfies ColumnPinningState;
+
+type SelectableRow = {
+  id: string;
+  getCanSelect: () => boolean;
+};
+
 /**
  * Given an array of items with IDs and a selection range,
  * returns a new selection object that includes all items in the range.
@@ -21,6 +37,41 @@ export function addRangeToSelection<T extends { id: string }>(
   const newSelection = { ...currentSelection };
   itemsToSelect.forEach((item) => {
     newSelection[item.id] = true;
+  });
+  return newSelection;
+}
+
+/**
+ * Given an ordered row model and a selection range, returns a new selection
+ * object that includes all selectable rows in the range.
+ *
+ * @param params - range selection parameters
+ * @param params.rows - ordered TanStack rows from the current row model
+ * @param params.lastSelectedIndex - index of the previously selected row
+ * @param params.currentIndex - index of the clicked row
+ * @param params.currentSelection - current TanStack row selection state
+ * @returns A new selection object with all selectable rows in the range selected
+ */
+export function addRowRangeToSelection<TRow extends SelectableRow>({
+  rows,
+  lastSelectedIndex,
+  currentIndex,
+  currentSelection,
+}: {
+  rows: TRow[];
+  lastSelectedIndex: number;
+  currentIndex: number;
+  currentSelection: RowSelectionState;
+}): RowSelectionState {
+  const start = Math.min(lastSelectedIndex, currentIndex);
+  const end = Math.max(lastSelectedIndex, currentIndex);
+  const rowsToSelect = rows.slice(start, end + 1);
+
+  const newSelection = { ...currentSelection };
+  rowsToSelect.forEach((row) => {
+    if (row.getCanSelect()) {
+      newSelection[row.id] = true;
+    }
   });
   return newSelection;
 }

--- a/app/src/components/table/useShiftClickRowSelection.ts
+++ b/app/src/components/table/useShiftClickRowSelection.ts
@@ -1,0 +1,65 @@
+import type { Row, Table } from "@tanstack/react-table";
+import type { MouseEvent } from "react";
+import { useEffect, useRef } from "react";
+
+import { addRowRangeToSelection } from "./selectionUtils";
+
+/**
+ * Tracks a row-selection anchor and applies shift-click range selection to the
+ * current TanStack row model.
+ *
+ * @param params - hook configuration
+ * @param params.resetKey - value whose identity change clears the range anchor
+ */
+export function useShiftClickRowSelection<TData>({
+  resetKey,
+}: {
+  resetKey?: unknown;
+} = {}) {
+  const lastSelectedRowIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    lastSelectedRowIdRef.current = null;
+  }, [resetKey]);
+
+  function selectRow({
+    event,
+    row,
+    table,
+  }: {
+    event: MouseEvent;
+    row: Row<TData>;
+    table: Table<TData>;
+  }) {
+    if (!row.getCanSelect()) {
+      return;
+    }
+
+    const rows = table.getRowModel().rows;
+    const currentIndex = rows.findIndex((tableRow) => tableRow.id === row.id);
+    const lastSelectedIndex =
+      lastSelectedRowIdRef.current == null
+        ? -1
+        : rows.findIndex(
+            (tableRow) => tableRow.id === lastSelectedRowIdRef.current
+          );
+    const hasRangeAnchor = lastSelectedIndex !== -1 && currentIndex !== -1;
+
+    if (event.shiftKey && hasRangeAnchor) {
+      table.setRowSelection((currentSelection) =>
+        addRowRangeToSelection({
+          rows,
+          lastSelectedIndex,
+          currentIndex,
+          currentSelection,
+        })
+      );
+    } else {
+      row.toggleSelected();
+    }
+
+    lastSelectedRowIdRef.current = row.id;
+  }
+
+  return { selectRow };
+}

--- a/app/src/pages/examples/ExamplesTable.tsx
+++ b/app/src/pages/examples/ExamplesTable.tsx
@@ -6,7 +6,6 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import {
-  type MouseEvent,
   startTransition,
   useCallback,
   useEffect,
@@ -24,14 +23,18 @@ import { DatasetSplits } from "@phoenix/components/datasetSplit/DatasetSplits";
 import {
   CellWithControlsWrap,
   CompactJSONCell,
+  createRowSelectionColumn,
 } from "@phoenix/components/table";
-import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
-import { addRangeToSelection } from "@phoenix/components/table/selectionUtils";
+import {
+  CHECKBOX_COLUMN_ID,
+  CHECKBOX_COLUMN_PINNING,
+} from "@phoenix/components/table/selectionUtils";
 import {
   getCommonPinningStyles,
   selectableTableCSS,
 } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
+import { useShiftClickRowSelection } from "@phoenix/components/table/useShiftClickRowSelection";
 import { useDatasetContext } from "@phoenix/contexts/DatasetContext";
 import type { ExamplesCache } from "@phoenix/pages/examples/ExamplesFilterContext";
 import { useExamplesFilterContext } from "@phoenix/pages/examples/ExamplesFilterContext";
@@ -67,7 +70,6 @@ export function ExamplesTable({
   const { exampleId: selectedExampleId } = useParams();
   const latestVersion = useDatasetContext((state) => state.latestVersion);
   const tableContainerRef = useRef<HTMLDivElement>(null);
-  const lastSelectedRowIndexRef = useRef<number | null>(null);
   const [columnSizing, setColumnSizing] = useState({});
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<ExamplesTableQuery, ExamplesTableFragment$key>(
@@ -188,81 +190,18 @@ export function ExamplesTable({
     [data]
   );
   type TableRow = (typeof tableData)[number];
-
-  // Reset the shift-click anchor when table data changes
-  // to prevent stale index references after refetch
-  useEffect(() => {
-    lastSelectedRowIndexRef.current = null;
-  }, [tableData]);
-
-  /**
-   * Shared row selection handler that handles both normal clicks and shift-clicks.
-   * - Always updates lastSelectedRowIndexRef to the current row index
-   * - If shift+click with a previous anchor, calls addRangeToSelection for range selection
-   * - Otherwise toggles the single row's selection
-   */
-  const handleRowSelection = useCallback(
-    (
-      event: MouseEvent,
-      rowIndex: number,
-      toggleSelected: (value?: boolean) => void
-    ) => {
-      if (event.shiftKey && lastSelectedRowIndexRef.current !== null) {
-        // Shift-click: select range from anchor to current row
-        setRowSelection((prev) =>
-          addRangeToSelection(
-            tableData,
-            lastSelectedRowIndexRef.current!,
-            rowIndex,
-            prev
-          )
-        );
-      } else {
-        // Normal click: toggle single row
-        toggleSelected();
-      }
-      // Always update the anchor point
-      lastSelectedRowIndexRef.current = rowIndex;
-    },
-    [setRowSelection, tableData]
-  );
+  const { selectRow } = useShiftClickRowSelection<TableRow>({
+    resetKey: tableData,
+  });
 
   const columns = useMemo(() => {
     const cols: ColumnDef<TableRow>[] = [
-      {
-        id: "select",
-        enableResizing: false,
+      createRowSelectionColumn<TableRow>({
+        selectRow,
         size: 30,
         minSize: 30,
         maxSize: 30,
-        header: ({ table }) => (
-          <IndeterminateCheckboxCell
-            {...{
-              isSelected: table.getIsAllRowsSelected(),
-              isIndeterminate: table.getIsSomeRowsSelected(),
-              onChange: table.toggleAllRowsSelected,
-            }}
-          />
-        ),
-        cell: ({ row, table }) => {
-          const rowIndex = table
-            .getRowModel()
-            .rows.findIndex((r) => r.id === row.id);
-          return (
-            <IndeterminateCheckboxCell
-              {...{
-                isSelected: row.getIsSelected(),
-                isDisabled: !row.getCanSelect(),
-                isIndeterminate: row.getIsSomeSelected(),
-                onChange: row.toggleSelected,
-                onCellClick: (event: React.MouseEvent) => {
-                  handleRowSelection(event, rowIndex, row.toggleSelected);
-                },
-              }}
-            />
-          );
-        },
-      },
+      }),
       {
         header: "id",
         accessorKey: "id",
@@ -316,7 +255,7 @@ export function ExamplesTable({
       cell: ({ row }) => <DatasetSplits labels={row.original.splits} />,
     });
     return cols;
-  }, [handleRowSelection]);
+  }, [selectRow]);
 
   const table = useReactTable<TableRow>({
     columns,
@@ -324,9 +263,7 @@ export function ExamplesTable({
     state: {
       rowSelection,
       columnSizing,
-      columnPinning: {
-        left: ["select"],
-      },
+      columnPinning: CHECKBOX_COLUMN_PINNING,
     },
     defaultColumn: defaultColumnSettings,
     columnResizeMode: "onChange",
@@ -459,13 +396,9 @@ export function ExamplesTable({
                         key={cell.id}
                         onClick={(e) => {
                           // prevent the row click event from firing on the select cell
-                          if (cell.column.columnDef.id === "select") {
+                          if (cell.column.id === CHECKBOX_COLUMN_ID) {
                             e.stopPropagation();
-                            handleRowSelection(
-                              e,
-                              row.index,
-                              row.toggleSelected
-                            );
+                            selectRow({ event: e, row, table });
                           }
                         }}
                         style={{
@@ -475,7 +408,7 @@ export function ExamplesTable({
                           overflowWrap: "anywhere",
                           // prevent text selection on the select cell
                           userSelect:
-                            cell.column.columnDef.id === "select"
+                            cell.column.id === CHECKBOX_COLUMN_ID
                               ? "none"
                               : undefined,
                         }}

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -53,17 +53,22 @@ import { ExperimentTokenCosts } from "@phoenix/components/experiment/ExperimentT
 import { StopPropagation } from "@phoenix/components/StopPropagation";
 import {
   CompactJSONCell,
+  createRowSelectionColumn,
   IntCell,
   LoadMoreRow,
 } from "@phoenix/components/table";
 import { CellWithControlsWrap } from "@phoenix/components/table/CellWithControlsWrap";
-import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
+import {
+  CHECKBOX_COLUMN_ID,
+  CHECKBOX_COLUMN_PINNING,
+} from "@phoenix/components/table/selectionUtils";
 import {
   getCommonPinningStyles,
   selectableTableCSS,
 } from "@phoenix/components/table/styles";
 import { TextCell } from "@phoenix/components/table/TextCell";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
+import { useShiftClickRowSelection } from "@phoenix/components/table/useShiftClickRowSelection";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { UserPicture } from "@phoenix/components/user/UserPicture";
 import { usePersistedState } from "@phoenix/hooks";
@@ -131,9 +136,13 @@ const TableBody = <T extends { id: string }>({
                 <td
                   key={cell.id}
                   style={{
+                    ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,
                     maxWidth: `calc(var(${colSizeVar}) * 1px)`,
-                    ...getCommonPinningStyles(cell.column),
+                    userSelect:
+                      cell.column.id === CHECKBOX_COLUMN_ID
+                        ? "none"
+                        : undefined,
                   }}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -304,31 +313,17 @@ export function ExperimentsTable({
   );
 
   type TableRow = (typeof tableData)[number];
+  const { selectRow } = useShiftClickRowSelection<TableRow>({
+    resetKey: tableData,
+  });
 
   const baseColumns: ColumnDef<TableRow>[] = [
-    {
-      id: "select",
+    createRowSelectionColumn<TableRow>({
+      selectRow,
+      size: 50,
+      minSize: 50,
       maxSize: 50,
-      header: ({ table }) => (
-        <IndeterminateCheckboxCell
-          {...{
-            isSelected: table.getIsAllRowsSelected(),
-            isIndeterminate: table.getIsSomeRowsSelected(),
-            onChange: table.toggleAllRowsSelected,
-          }}
-        />
-      ),
-      cell: ({ row }) => (
-        <IndeterminateCheckboxCell
-          {...{
-            isSelected: row.getIsSelected(),
-            isDisabled: !row.getCanSelect(),
-            isIndeterminate: row.getIsSomeSelected(),
-            onChange: row.toggleSelected,
-          }}
-        />
-      ),
-    },
+    }),
     {
       header: "id",
       id: "id",
@@ -646,6 +641,7 @@ export function ExperimentsTable({
       columnSizing,
       columnVisibility,
       columnPinning: {
+        ...CHECKBOX_COLUMN_PINNING,
         right: ["actions"],
       },
     },
@@ -762,8 +758,8 @@ export function ExperimentsTable({
                     colSpan={header.colSpan}
                     key={header.id}
                     style={{
-                      width: `calc(var(--header-${makeSafeColumnId(header.id)}-size) * 1px)`,
                       ...getCommonPinningStyles(header.column),
+                      width: `calc(var(--header-${makeSafeColumnId(header.id)}-size) * 1px)`,
                     }}
                     align={header.column.columnDef?.meta?.textAlign}
                   >

--- a/app/src/pages/project/ProjectAnnotationConfigCard.tsx
+++ b/app/src/pages/project/ProjectAnnotationConfigCard.tsx
@@ -34,7 +34,14 @@ import {
 import { AnnotationLabel } from "@phoenix/components/annotation";
 import { CompactEmptyState } from "@phoenix/components/core/empty";
 import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
-import { tableCSS } from "@phoenix/components/table/styles";
+import {
+  CHECKBOX_COLUMN_ID,
+  CHECKBOX_COLUMN_PINNING,
+} from "@phoenix/components/table/selectionUtils";
+import {
+  getCommonPinningStyles,
+  tableCSS,
+} from "@phoenix/components/table/styles";
 import { useNotifySuccess } from "@phoenix/contexts";
 
 import type { ProjectAnnotationConfigCardContent_project_annotations$key } from "./__generated__/ProjectAnnotationConfigCardContent_project_annotations.graphql";
@@ -90,7 +97,7 @@ interface AnnotationConfigTableRow {
 
 const columns: ColumnDef<AnnotationConfigTableRow>[] = [
   {
-    id: "select",
+    id: CHECKBOX_COLUMN_ID,
     maxSize: 10,
     header: () => null,
     cell: ({ row }: CellContext<AnnotationConfigTableRow, unknown>) => (
@@ -347,6 +354,9 @@ const ProjectAnnotationConfigCardContent = (
   const table = useReactTable({
     data: tableData,
     columns,
+    state: {
+      columnPinning: CHECKBOX_COLUMN_PINNING,
+    },
     getCoreRowModel: getCoreRowModel(),
   });
 
@@ -380,7 +390,11 @@ const ProjectAnnotationConfigCardContent = (
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <th colSpan={header.colSpan} key={header.id}>
+                  <th
+                    colSpan={header.colSpan}
+                    key={header.id}
+                    style={getCommonPinningStyles(header.column)}
+                  >
                     {header.isPlaceholder ? null : (
                       <div
                         style={{
@@ -406,8 +420,13 @@ const ProjectAnnotationConfigCardContent = (
                   <td
                     key={cell.id}
                     style={{
+                      ...getCommonPinningStyles(cell.column),
                       width: cell.column.getSize(),
                       maxWidth: cell.column.getSize(),
+                      userSelect:
+                        cell.column.id === CHECKBOX_COLUMN_ID
+                          ? "none"
+                          : undefined,
                     }}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -48,11 +48,22 @@ import { TraceAnnotationSummaryGroupTokens } from "@phoenix/components/annotatio
 import { ContextualHelp } from "@phoenix/components/core/tooltip/ContextualHelp";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
-import { CellWithControlsWrap, LoadMoreRow } from "@phoenix/components/table";
-import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
-import { selectableTableCSS } from "@phoenix/components/table/styles";
+import {
+  CellWithControlsWrap,
+  createRowSelectionColumn,
+  LoadMoreRow,
+} from "@phoenix/components/table";
+import {
+  CHECKBOX_COLUMN_ID,
+  CHECKBOX_COLUMN_PINNING,
+} from "@phoenix/components/table/selectionUtils";
+import {
+  getCommonPinningStyles,
+  selectableTableCSS,
+} from "@phoenix/components/table/styles";
 import { TextCell } from "@phoenix/components/table/TextCell";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
+import { useShiftClickRowSelection } from "@phoenix/components/table/useShiftClickRowSelection";
 import { TraceTokenCosts } from "@phoenix/components/trace";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanCumulativeTokenCount } from "@phoenix/components/trace/SpanCumulativeTokenCount";
@@ -156,6 +167,7 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
                 <td
                   key={cell.id}
                   style={{
+                    ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,
                     maxWidth: `calc(var(${colSizeVar}) * 1px)`,
                     // prevent all wrapping, just show an ellipsis and let users expand if necessary
@@ -163,6 +175,10 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
+                    userSelect:
+                      cell.column.id === CHECKBOX_COLUMN_ID
+                        ? "none"
+                        : undefined,
                   }}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -392,6 +408,9 @@ export function SpansTable(props: SpansTableProps) {
     return tableData;
   }, [data]);
   type TableRow = (typeof tableData)[number];
+  const { selectRow } = useShiftClickRowSelection<TableRow>({
+    resetKey: tableData,
+  });
 
   const dynamicAnnotationColumns: ColumnDef<TableRow>[] =
     visibleAnnotationColumnNames.map((name) => {
@@ -558,29 +577,12 @@ export function SpansTable(props: SpansTableProps) {
     ...dynamicTraceAnnotationColumns,
   ];
   const columns: ColumnDef<TableRow>[] = [
-    {
-      id: "select",
+    createRowSelectionColumn<TableRow>({
+      selectRow,
+      size: 24,
+      minSize: 24,
       maxSize: 24,
-      header: ({ table }) => (
-        <IndeterminateCheckboxCell
-          {...{
-            isSelected: table.getIsAllRowsSelected(),
-            isIndeterminate: table.getIsSomeRowsSelected(),
-            onChange: table.toggleAllRowsSelected,
-          }}
-        />
-      ),
-      cell: ({ row }) => (
-        <IndeterminateCheckboxCell
-          {...{
-            isSelected: row.getIsSelected(),
-            isDisabled: !row.getCanSelect(),
-            isIndeterminate: row.getIsSomeSelected(),
-            onChange: row.toggleSelected,
-          }}
-        />
-      ),
-    },
+    }),
     {
       header: "status",
       accessorKey: "statusCode",
@@ -855,6 +857,7 @@ export function SpansTable(props: SpansTableProps) {
       columnVisibility,
       rowSelection,
       columnSizing,
+      columnPinning: CHECKBOX_COLUMN_PINNING,
     },
     defaultColumn: defaultColumnSettings,
     columnResizeMode: "onChange",
@@ -1009,6 +1012,7 @@ export function SpansTable(props: SpansTableProps) {
                       <th
                         colSpan={header.colSpan}
                         style={{
+                          ...getCommonPinningStyles(header.column),
                           width: `calc(var(--header-${header.id}-size) * 1px)`,
                         }}
                         key={header.id}

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -42,11 +42,22 @@ import { MeanScore } from "@phoenix/components/annotation/MeanScore";
 import { TraceAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/TraceAnnotationSummaryGroup";
 import { ContextualHelp } from "@phoenix/components/core/tooltip/ContextualHelp";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
-import { CellWithControlsWrap, TextCell } from "@phoenix/components/table";
-import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
-import { selectableTableCSS } from "@phoenix/components/table/styles";
+import {
+  CellWithControlsWrap,
+  createRowSelectionColumn,
+  TextCell,
+} from "@phoenix/components/table";
+import {
+  CHECKBOX_COLUMN_ID,
+  CHECKBOX_COLUMN_PINNING,
+} from "@phoenix/components/table/selectionUtils";
+import {
+  getCommonPinningStyles,
+  selectableTableCSS,
+} from "@phoenix/components/table/styles";
 import { TableExpandButton } from "@phoenix/components/table/TableExpandButton";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
+import { useShiftClickRowSelection } from "@phoenix/components/table/useShiftClickRowSelection";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanKindToken } from "@phoenix/components/trace/SpanKindToken";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
@@ -145,6 +156,7 @@ const TableBody = <
                 <td
                   key={cell.id}
                   style={{
+                    ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,
                     maxWidth: `calc(var(${colSizeVar}) * 1px)`,
                     // prevent all wrapping, just show an ellipsis and let users expand if necessary
@@ -152,6 +164,10 @@ const TableBody = <
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
+                    userSelect:
+                      cell.column.id === CHECKBOX_COLUMN_ID
+                        ? "none"
+                        : undefined,
                   }}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -409,6 +425,9 @@ export function TracesTable(props: TracesTableProps) {
     });
   }, [data]);
   type TableRow = (typeof tableData)[number];
+  const { selectRow } = useShiftClickRowSelection<TableRow>({
+    resetKey: tableData,
+  });
 
   const dynamicAnnotationColumns: ColumnDef<TableRow>[] = useMemo(
     () =>
@@ -619,34 +638,13 @@ export function TracesTable(props: TracesTableProps) {
 
   const columns: ColumnDef<TableRow>[] = useMemo(
     () => [
-      {
-        id: "select",
+      createRowSelectionColumn<TableRow>({
+        selectRow,
+        shouldRenderCell: (row) => !row.original.__additionalRow,
+        size: 24,
+        minSize: 24,
         maxSize: 24,
-        header: ({ table }) => (
-          <IndeterminateCheckboxCell
-            {...{
-              isSelected: table.getIsAllRowsSelected(),
-              isIndeterminate: table.getIsSomeRowsSelected(),
-              onChange: table.toggleAllRowsSelected,
-            }}
-          />
-        ),
-        cell: ({ row }) => {
-          if (row.original.__additionalRow) {
-            return null;
-          }
-          return (
-            <IndeterminateCheckboxCell
-              {...{
-                isSelected: row.getIsSelected(),
-                isDisabled: !row.getCanSelect(),
-                isIndeterminate: row.getIsSomeSelected(),
-                onChange: row.toggleSelected,
-              }}
-            />
-          );
-        },
-      },
+      }),
       {
         header: "status",
         accessorKey: "statusCode",
@@ -891,7 +889,7 @@ export function TracesTable(props: TracesTableProps) {
         },
       },
     ],
-    [annotationColumns, searchParams]
+    [annotationColumns, searchParams, selectRow]
   );
 
   useEffect(() => {
@@ -968,9 +966,11 @@ export function TracesTable(props: TracesTableProps) {
       columnVisibility,
       rowSelection,
       columnSizing,
+      columnPinning: CHECKBOX_COLUMN_PINNING,
     },
     columnResizeMode: "onChange",
     onRowSelectionChange: setRowSelection,
+    enableRowSelection: (row) => !row.original.__additionalRow,
     enableSubRowSelection: false,
     onSortingChange: setSorting,
     onColumnSizingChange: setColumnSizing,
@@ -1055,6 +1055,7 @@ export function TracesTable(props: TracesTableProps) {
                 {headerGroup.headers.map((header) => (
                   <th
                     style={{
+                      ...getCommonPinningStyles(header.column),
                       width: `calc(var(--header-${header.id}-size) * 1px)`,
                     }}
                     colSpan={header.colSpan}

--- a/app/src/pages/settings/AnnotationConfigTable.tsx
+++ b/app/src/pages/settings/AnnotationConfigTable.tsx
@@ -28,7 +28,14 @@ import { AnnotationLabel } from "@phoenix/components/annotation";
 import { EmptyState, EmptyStateGraphic } from "@phoenix/components/core/empty";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
-import { tableCSS } from "@phoenix/components/table/styles";
+import {
+  CHECKBOX_COLUMN_ID,
+  CHECKBOX_COLUMN_PINNING,
+} from "@phoenix/components/table/selectionUtils";
+import {
+  getCommonPinningStyles,
+  tableCSS,
+} from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import type { AnnotationConfigTableFragment$key } from "@phoenix/pages/settings/__generated__/AnnotationConfigTableFragment.graphql";
 import { AnnotationConfigSelectionToolbar } from "@phoenix/pages/settings/AnnotationConfigSelectionToolbar";
@@ -36,7 +43,7 @@ import type { AnnotationConfig } from "@phoenix/pages/settings/types";
 
 const columns = [
   {
-    id: "select",
+    id: CHECKBOX_COLUMN_ID,
     maxSize: 10,
     header: () => null,
     cell: ({ row }: CellContext<AnnotationConfig, unknown>) => (
@@ -232,6 +239,7 @@ export const AnnotationConfigTable = ({
     enableMultiRowSelection: false,
     state: {
       rowSelection,
+      columnPinning: CHECKBOX_COLUMN_PINNING,
     },
   });
   const isEmpty = table.getRowCount() === 0;
@@ -261,7 +269,11 @@ export const AnnotationConfigTable = ({
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <th colSpan={header.colSpan} key={header.id}>
+                <th
+                  colSpan={header.colSpan}
+                  key={header.id}
+                  style={getCommonPinningStyles(header.column)}
+                >
                   {header.isPlaceholder ? null : (
                     <div
                       {...{
@@ -318,8 +330,13 @@ export const AnnotationConfigTable = ({
                   <td
                     key={cell.id}
                     style={{
+                      ...getCommonPinningStyles(cell.column),
                       width: cell.column.getSize(),
                       maxWidth: cell.column.getSize(),
+                      userSelect:
+                        cell.column.id === CHECKBOX_COLUMN_ID
+                          ? "none"
+                          : undefined,
                     }}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/app/stories/Table.stories.tsx
+++ b/app/stories/Table.stories.tsx
@@ -26,10 +26,20 @@ import {
 } from "@phoenix/components";
 import { Toolbar } from "@phoenix/components/core/toolbar";
 import { FloatingToolbarContainer } from "@phoenix/components/core/toolbar/FloatingToolbarContainer";
-import { FloatCell, IntCell, TextCell } from "@phoenix/components/table";
+import {
+  CHECKBOX_COLUMN_ID,
+  CHECKBOX_COLUMN_PINNING,
+  createRowSelectionColumn,
+  FloatCell,
+  IntCell,
+  TextCell,
+  useShiftClickRowSelection,
+} from "@phoenix/components/table";
 
-import { IndeterminateCheckboxCell } from "../src/components/table/IndeterminateCheckboxCell";
-import { selectableTableCSS } from "../src/components/table/styles";
+import {
+  getCommonPinningStyles,
+  selectableTableCSS,
+} from "../src/components/table/styles";
 import { TableEmpty } from "../src/components/table/TableEmpty";
 
 // Mock data types
@@ -246,19 +256,19 @@ function BaseTable<T>({
       columnSizing,
       sorting,
       rowSelection,
+      columnPinning: CHECKBOX_COLUMN_PINNING,
     },
     columnResizeMode: enableResizing ? "onChange" : undefined,
     manualSorting: false,
     enableRowSelection: true,
     onColumnSizingChange: setColumnSizing,
     onSortingChange: setSorting,
-    onRowSelectionChange: (updater) =>
-      setRowSelection((prev) => {
-        const next =
-          typeof updater === "function" ? updater(prev) : (updater ?? {});
-        onSelectionChange?.(Object.keys(next).length);
-        return next;
-      }),
+    onRowSelectionChange: (updater) => {
+      const next =
+        typeof updater === "function" ? updater(rowSelection) : (updater ?? {});
+      setRowSelection(next);
+      onSelectionChange?.(Object.keys(next).length);
+    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
@@ -296,12 +306,17 @@ function BaseTable<T>({
                 <td
                   key={cell.id}
                   style={{
+                    ...getCommonPinningStyles(cell.column),
                     width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     maxWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     textWrap: "nowrap",
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
+                    userSelect:
+                      cell.column.id === CHECKBOX_COLUMN_ID
+                        ? "none"
+                        : undefined,
                   }}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -340,6 +355,7 @@ function BaseTable<T>({
                   colSpan={header.colSpan}
                   key={header.id}
                   style={{
+                    ...getCommonPinningStyles(header.column),
                     width: `calc(var(--header-${header.id}-size) * 1px)`,
                   }}
                 >
@@ -494,29 +510,6 @@ const productColumns: ColumnDef<Product>[] = [
 // Selection Support
 // ------------------------------
 
-// Column used to display row selection checkboxes – adapted from project SpansTable
-const selectionColumn: ColumnDef<Person> = {
-  id: "select",
-  size: 30,
-  maxSize: 30,
-  header: ({ table }) => (
-    <IndeterminateCheckboxCell
-      isSelected={table.getIsAllRowsSelected()}
-      isIndeterminate={table.getIsSomeRowsSelected()}
-      onChange={table.toggleAllRowsSelected}
-    />
-  ),
-  cell: ({ row }) => (
-    <IndeterminateCheckboxCell
-      isSelected={row.getIsSelected()}
-      isDisabled={!row.getCanSelect()}
-      isIndeterminate={row.getIsSomeSelected()}
-      onChange={row.toggleSelected}
-    />
-  ),
-  enableSorting: false,
-};
-
 // Table component that prepends the selection column
 const PersonTableSelectable = (props: {
   enableResizing?: boolean;
@@ -524,15 +517,27 @@ const PersonTableSelectable = (props: {
   data?: Person[];
   onSelectionChange?: (count: number) => void;
 }) => {
+  const tableData = props.data || mockPeople;
+  const { selectRow } = useShiftClickRowSelection<Person>({
+    resetKey: tableData,
+  });
   const columns = useMemo<ColumnDef<Person>[]>(
-    () => [selectionColumn, ...personColumns],
-    []
+    () => [
+      createRowSelectionColumn<Person>({
+        selectRow,
+        size: 30,
+        minSize: 30,
+        maxSize: 30,
+      }),
+      ...personColumns,
+    ],
+    [selectRow]
   );
 
   return (
     <BaseTable
       columns={columns}
-      data={props.data || mockPeople}
+      data={tableData}
       enableResizing={props.enableResizing}
       enableSorting={props.enableSorting}
       onSelectionChange={props.onSelectionChange}


### PR DESCRIPTION
## Summary
- Adds `createRowSelectionColumn` and `useShiftClickRowSelection` to `app/src/components/table` so shift-clicking a row checkbox selects the full contiguous range since the last selected row.
- Wires the new selection column/hook into examples, experiments, spans, traces, and annotation config tables, replacing bespoke per-table selection logic.

## Test plan
- [ ] `pnpm test` for `app/src/components/table/__tests__/selectionUtils.test.ts`
- [ ] Manually verify shift-click range selection in the Storybook `Table` story
- [ ] Manually verify shift-click range selection on the examples, experiments, spans, traces, and annotation config tables