### PR TITLE
feat(ui): recent searches in the span filter typeahead

### DIFF
--- a/.agents/skills/phoenix-typescript/SKILL.md
+++ b/.agents/skills/phoenix-typescript/SKILL.md
@@ -116,6 +116,10 @@ const map: Partial<Record<string, string>> = {};
 const value = map["missing"]; // typed as string | undefined
 ```
 
+## Imports
+
+- Import lodash utilities via path imports so bundles only carry what's used: `import debounce from "lodash/debounce"`, not `import { debounce } from "lodash"` — the barrel import defeats tree shaking.
+
 ## Reuse
 
 Existing shared utilities must be checked before writing inline helpers. Duplicated logic should be extracted to a shared module. When working in `js/packages/`, check sibling packages for existing utilities before adding new dependencies or reimplementing.

--- a/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/app/src/components/filter/DSLFilterConditionField.tsx
@@ -1,7 +1,5 @@
 import type {
   Completion,
-  CompletionContext,
-  CompletionResult,
   CompletionSection,
   CompletionSource,
 } from "@codemirror/autocomplete";
@@ -40,11 +38,7 @@ import { pierreDark, pierreLight } from "@phoenix/components/code";
 import { useTheme } from "@phoenix/contexts";
 import { classNames } from "@phoenix/utils/classNames";
 
-import {
-  getDSLFilterCompletionTokenBeforeCursor,
-  shouldSuppressDSLFilterCompletionsInString,
-  validDSLFilterCompletionTokenPattern,
-} from "./dslFilterConditionFieldUtils";
+import { createDSLFilterCompletionSource } from "./dslFilterConditionFieldUtils";
 import {
   dslFilterCodeMirrorCSS,
   dslFilterErrorTooltipCSS,
@@ -117,56 +111,6 @@ function snippetToCompletion({ label, snippet }: DSLFilterSnippet): Completion {
     type: "text",
     section: suggestionsSection,
   });
-}
-
-/**
- * Builds a CodeMirror completion source over the given DSL vocabulary.
- * `getOptions` may be async (e.g. real values fetched from the server); each
- * source resolves independently so slow options don't block the rest of the
- * dropdown.
- */
-function createCompletionSource(
-  getOptions: (isBrowsing: boolean) => Completion[] | Promise<Completion[]>
-): CompletionSource {
-  return async (
-    context: CompletionContext
-  ): Promise<CompletionResult | null> => {
-    const textBeforeCursor = context.state.doc.sliceString(0, context.pos);
-    const word = getDSLFilterCompletionTokenBeforeCursor(textBeforeCursor);
-
-    if (word.from === word.to && !context.explicit) return null;
-    if (
-      shouldSuppressDSLFilterCompletionsInString({
-        textBeforeCursor,
-        tokenFrom: word.from,
-      })
-    ) {
-      return null;
-    }
-
-    // Browsing: the dropdown is open with nothing typed at the cursor, so
-    // there's no query to narrow the options — sources may return a curated
-    // subset rather than everything
-    const isBrowsing = word.from === word.to;
-
-    let options: Completion[];
-    try {
-      options = await getOptions(isBrowsing);
-    } catch {
-      // completions are a progressive enhancement — degrade silently
-      return null;
-    }
-    if (options.length === 0) return null;
-
-    return {
-      from: word.from,
-      options,
-      // A browse result may be a curated subset — force a fresh query on
-      // the next keystroke rather than letting CodeMirror filter the subset
-      // in place, so typing matches against the full vocabulary
-      validFor: isBrowsing ? undefined : validDSLFilterCompletionTokenPattern,
-    };
-  };
 }
 
 export type DSLFilterConditionFieldProps = {
@@ -349,9 +293,9 @@ export function DSLFilterConditionField(props: DSLFilterConditionFieldProps) {
       autocompletion({
         override: [
           ...completionSources,
-          createCompletionSource(staticOptions),
+          createDSLFilterCompletionSource(staticOptions),
           ...(loadCompletionsOnce
-            ? [createCompletionSource(loadCompletionsOnce)]
+            ? [createDSLFilterCompletionSource(loadCompletionsOnce)]
             : []),
         ],
         selectOnOpen: false,

--- a/app/src/components/filter/__tests__/useDSLFilterConditionHistory.test.tsx
+++ b/app/src/components/filter/__tests__/useDSLFilterConditionHistory.test.tsx
@@ -1,0 +1,238 @@
+import type {
+  CompletionContext,
+  CompletionResult,
+} from "@codemirror/autocomplete";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
+
+import {
+  DSL_FILTER_HISTORY_DWELL_MS,
+  type DSLFilterConditionHistory,
+  getDSLFilterConditionHistoryStorageKey,
+  pushDSLFilterConditionHistory,
+  readDSLFilterConditionHistory,
+  useDSLFilterConditionHistory,
+  type UseDSLFilterConditionHistoryProps,
+} from "../useDSLFilterConditionHistory";
+
+installTestStorage();
+
+const HISTORY_KEY = "test-filter";
+const STORAGE_KEY = getDSLFilterConditionHistoryStorageKey(HISTORY_KEY);
+
+describe("readDSLFilterConditionHistory", () => {
+  it("returns an empty history when nothing is stored", () => {
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([]);
+  });
+
+  it("tolerates malformed and foreign stored values", () => {
+    localStorage.setItem(STORAGE_KEY, "not json");
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([]);
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ nope: true }));
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([]);
+
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(["latency_ms > 100", 42, null])
+    );
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([
+      "latency_ms > 100",
+    ]);
+  });
+});
+
+describe("pushDSLFilterConditionHistory", () => {
+  it("adds the newest condition first", () => {
+    expect(pushDSLFilterConditionHistory(["a"], "b", 5)).toEqual(["b", "a"]);
+  });
+
+  it("moves a repeated condition to the front instead of duplicating it", () => {
+    expect(pushDSLFilterConditionHistory(["a", "b", "c"], "b", 5)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+  });
+
+  it("drops the oldest entries beyond the capacity", () => {
+    expect(pushDSLFilterConditionHistory(["a", "b", "c"], "d", 3)).toEqual([
+      "d",
+      "a",
+      "b",
+    ]);
+  });
+});
+
+describe("useDSLFilterConditionHistory", () => {
+  let root: Root | null = null;
+  let history: DSLFilterConditionHistory;
+
+  function Harness(props: UseDSLFilterConditionHistoryProps) {
+    history = useDSLFilterConditionHistory(props);
+    return null;
+  }
+
+  function mountHarness(
+    props: UseDSLFilterConditionHistoryProps = { historyKey: HISTORY_KEY }
+  ) {
+    root = createRoot(document.createElement("div"));
+    act(() => {
+      root?.render(<Harness {...props} />);
+    });
+  }
+
+  function unmountHarness() {
+    act(() => {
+      root?.unmount();
+    });
+    root = null;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (root) {
+      unmountHarness();
+    }
+    vi.useRealTimers();
+  });
+
+  it("commits a condition once it has stayed applied for the dwell", () => {
+    mountHarness();
+    history.recordValidCondition("status_code == 'ERROR'");
+
+    vi.advanceTimersByTime(DSL_FILTER_HISTORY_DWELL_MS - 1);
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([]);
+
+    vi.advanceTimersByTime(1);
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([
+      "status_code == 'ERROR'",
+    ]);
+  });
+
+  it("collapses intermediate conditions hit while typing", () => {
+    mountHarness();
+    history.recordValidCondition("latency_ms > 1");
+    vi.advanceTimersByTime(DSL_FILTER_HISTORY_DWELL_MS - 1);
+    history.recordValidCondition("latency_ms > 1000");
+
+    vi.advanceTimersByTime(DSL_FILTER_HISTORY_DWELL_MS);
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([
+      "latency_ms > 1000",
+    ]);
+  });
+
+  it("discards a pending condition when the field is cleared", () => {
+    mountHarness();
+    history.recordValidCondition("latency_ms > 1");
+    history.recordValidCondition("");
+
+    vi.advanceTimersByTime(DSL_FILTER_HISTORY_DWELL_MS);
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([]);
+  });
+
+  it("flushes a pending condition on unmount", () => {
+    mountHarness();
+    history.recordValidCondition("span_kind == 'LLM'");
+    unmountHarness();
+
+    expect(readDSLFilterConditionHistory(STORAGE_KEY)).toEqual([
+      "span_kind == 'LLM'",
+    ]);
+  });
+
+  it("keeps histories separate per history key", () => {
+    mountHarness({ historyKey: "project-a" });
+    history.recordValidCondition("latency_ms > 100");
+    unmountHarness();
+
+    mountHarness({ historyKey: "project-b" });
+    history.recordValidCondition("status_code == 'ERROR'");
+    unmountHarness();
+
+    expect(
+      readDSLFilterConditionHistory(
+        getDSLFilterConditionHistoryStorageKey("project-a")
+      )
+    ).toEqual(["latency_ms > 100"]);
+    expect(
+      readDSLFilterConditionHistory(
+        getDSLFilterConditionHistoryStorageKey("project-b")
+      )
+    ).toEqual(["status_code == 'ERROR'"]);
+  });
+
+  it("serves recent searches through the completion source in recency order", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(["latency_ms > 100", "status_code == 'ERROR'"])
+    );
+    mountHarness();
+
+    // A browsing context: the empty field was focused, opening the dropdown
+    const context = {
+      pos: 0,
+      explicit: true,
+      state: { doc: { sliceString: () => "" } },
+    } as unknown as CompletionContext;
+    const result = (await history.completionSource(
+      context
+    )) as CompletionResult;
+
+    expect(result.options.map((option) => option.label)).toEqual([
+      "latency_ms > 100",
+      "status_code == 'ERROR'",
+    ]);
+    // Newer entries are boosted so CodeMirror preserves recency order
+    expect(result.options[0]?.boost).toBeGreaterThan(
+      result.options[1]?.boost ?? 0
+    );
+    expect(
+      result.options.every(
+        (option) => option.section === result.options[0]?.section
+      )
+    ).toBe(true);
+  });
+
+  it("replaces the entire field contents when a recent search is accepted", async () => {
+    const condition = "latency_ms > 1000";
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([condition]));
+    mountHarness();
+
+    // The field already holds a partial expression; the recent surfaced at
+    // the trailing token must not be spliced in at that token
+    const typed = "latency_ms > ";
+    const context = {
+      pos: typed.length,
+      explicit: true,
+      state: { doc: { sliceString: () => typed } },
+    } as unknown as CompletionContext;
+    const result = (await history.completionSource(
+      context
+    )) as CompletionResult;
+
+    const option = result.options[0];
+    const apply = option?.apply;
+    if (!option || typeof apply !== "function") {
+      throw new Error("expected recent search to have a custom apply");
+    }
+    const dispatch = vi.fn();
+    const view = {
+      state: { doc: { length: typed.length } },
+      dispatch,
+    } as unknown as Parameters<typeof apply>[0];
+    apply(view, option, 0, typed.length);
+
+    expect(dispatch).toHaveBeenCalledExactlyOnceWith({
+      changes: { from: 0, to: typed.length, insert: condition },
+      selection: { anchor: condition.length },
+      userEvent: "input.complete",
+    });
+  });
+});

--- a/app/src/components/filter/dslFilterConditionFieldUtils.ts
+++ b/app/src/components/filter/dslFilterConditionFieldUtils.ts
@@ -1,3 +1,10 @@
+import type {
+  Completion,
+  CompletionContext,
+  CompletionResult,
+  CompletionSource,
+} from "@codemirror/autocomplete";
+
 const quotedSubscriptPattern = String.raw`(?:"(?:\\.|[^"\\])*"?|'(?:\\.|[^'\\])*'?)`;
 const integerSubscriptPattern = String.raw`\d+`;
 const subscriptPattern = String.raw`\[(?:${quotedSubscriptPattern}|${integerSubscriptPattern})?\]?`;
@@ -123,4 +130,55 @@ export function shouldSuppressDSLFilterCompletionsInString({
     return false;
   }
   return openStringStart < tokenFrom;
+}
+
+/**
+ * Builds a CodeMirror completion source over the given DSL vocabulary, with
+ * the token and string-literal awareness the filter DSL needs. `getOptions`
+ * may be async (e.g. real values fetched from the server); each source
+ * resolves independently so slow options don't block the rest of the
+ * dropdown.
+ */
+export function createDSLFilterCompletionSource(
+  getOptions: (isBrowsing: boolean) => Completion[] | Promise<Completion[]>
+): CompletionSource {
+  return async (
+    context: CompletionContext
+  ): Promise<CompletionResult | null> => {
+    const textBeforeCursor = context.state.doc.sliceString(0, context.pos);
+    const word = getDSLFilterCompletionTokenBeforeCursor(textBeforeCursor);
+
+    if (word.from === word.to && !context.explicit) return null;
+    if (
+      shouldSuppressDSLFilterCompletionsInString({
+        textBeforeCursor,
+        tokenFrom: word.from,
+      })
+    ) {
+      return null;
+    }
+
+    // Browsing: the dropdown is open with nothing typed at the cursor, so
+    // there's no query to narrow the options — sources may return a curated
+    // subset rather than everything
+    const isBrowsing = word.from === word.to;
+
+    let options: Completion[];
+    try {
+      options = await getOptions(isBrowsing);
+    } catch {
+      // completions are a progressive enhancement — degrade silently
+      return null;
+    }
+    if (options.length === 0) return null;
+
+    return {
+      from: word.from,
+      options,
+      // A browse result may be a curated subset — force a fresh query on
+      // the next keystroke rather than letting CodeMirror filter the subset
+      // in place, so typing matches against the full vocabulary
+      validFor: isBrowsing ? undefined : validDSLFilterCompletionTokenPattern,
+    };
+  };
 }

--- a/app/src/components/filter/index.tsx
+++ b/app/src/components/filter/index.tsx
@@ -1,3 +1,8 @@
 export * from "./Toolbar";
 export * from "./annotationCompletions";
 export * from "./DSLFilterConditionField";
+export {
+  type DSLFilterConditionHistory,
+  useDSLFilterConditionHistory,
+  type UseDSLFilterConditionHistoryProps,
+} from "./useDSLFilterConditionHistory";

--- a/app/src/components/filter/styles.ts
+++ b/app/src/components/filter/styles.ts
@@ -82,6 +82,13 @@ export const dslFilterCodeMirrorCSS = css`
     }
     .cm-completionLabel {
       font-family: "Geist Mono", monospace;
+      /* An option label can be an arbitrarily long expression (e.g. a
+         recent search) — truncate rather than wrap or overflow so every
+         row stays one line */
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
     li.dsl-filter-suggestion .cm-completionLabel {
       font-family: "Geist", sans-serif;

--- a/app/src/components/filter/useDSLFilterConditionHistory.ts
+++ b/app/src/components/filter/useDSLFilterConditionHistory.ts
@@ -1,0 +1,198 @@
+import type {
+  CompletionSection,
+  CompletionSource,
+} from "@codemirror/autocomplete";
+import debounce from "lodash/debounce";
+import { useCallback, useEffect, useMemo } from "react";
+
+import { createDSLFilterCompletionSource } from "./dslFilterConditionFieldUtils";
+
+/**
+ * The typeahead section recent searches appear under. Rank 0 places it above
+ * the built-in Suggestions (1), loaded (2), and Fields (3) groups — a
+ * condition the user already ran is the most likely thing they want again.
+ */
+const recentSearchesSection: CompletionSection = {
+  name: "Recent searches",
+  rank: 0,
+};
+
+const LOCAL_STORAGE_KEY_PREFIX = "arize-phoenix-filter-history";
+
+const DEFAULT_CAPACITY = 5;
+
+/**
+ * How long a valid condition must stay applied before it is committed to
+ * history. The filter applies live as the user types, so every pause long
+ * enough to validate yields an applied condition; the dwell separates
+ * searches the user actually sat with from stepping stones on the way to
+ * them (`latency_ms > 1` while typing `latency_ms > 1000`).
+ */
+export const DSL_FILTER_HISTORY_DWELL_MS = 3_000;
+
+/**
+ * The localStorage key a mount point's filter history is persisted under
+ */
+export function getDSLFilterConditionHistoryStorageKey(
+  historyKey: string
+): string {
+  return `${LOCAL_STORAGE_KEY_PREFIX}-${historyKey}`;
+}
+
+/**
+ * Reads a persisted history list, tolerating missing, malformed, or foreign
+ * values — history is a progressive enhancement, never an error
+ */
+export function readDSLFilterConditionHistory(storageKey: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Returns the history with `condition` as its most recent entry — deduped
+ * against earlier runs of the same expression and capped at `capacity`
+ */
+export function pushDSLFilterConditionHistory(
+  history: string[],
+  condition: string,
+  capacity: number
+): string[] {
+  return [condition, ...history.filter((entry) => entry !== condition)].slice(
+    0,
+    capacity
+  );
+}
+
+function commitConditionToHistory(
+  storageKey: string,
+  condition: string,
+  capacity: number
+) {
+  const history = pushDSLFilterConditionHistory(
+    readDSLFilterConditionHistory(storageKey),
+    condition,
+    capacity
+  );
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(history));
+  } catch {
+    // localStorage full or unavailable — degrade silently
+  }
+}
+
+export type UseDSLFilterConditionHistoryProps = {
+  /**
+   * Scopes the history to its mount point — histories are deliberately not
+   * global. Include the data scope in the key (e.g.
+   * `span-filter-${projectId}`): an expression referencing another project's
+   * annotation names is noise, not a suggestion.
+   */
+  historyKey: string;
+  /**
+   * How many recent searches to keep
+   */
+  capacity?: number;
+};
+
+export type DSLFilterConditionHistory = {
+  /**
+   * Surfaces the recent searches as a "Recent searches" typeahead group at
+   * the top of the dropdown — pass via the field's `completionSources`
+   */
+  completionSource: CompletionSource;
+  /**
+   * Report every applied condition — call from `onValidCondition`. A
+   * condition is committed to history only after it stays applied for a
+   * short dwell (or the hook unmounts with it applied), so the intermediate
+   * expressions hit while typing don't pollute the list. An empty condition
+   * discards whatever is pending.
+   */
+  recordValidCondition: (condition: string) => void;
+};
+
+/**
+ * Remembers the last few filter conditions the user actually ran and serves
+ * them back through the field's own typeahead — recents appear when the
+ * empty field is focused and fuzzy-match as the user types, with no extra UI
+ * surface. Plugs into `DSLFilterConditionField` through its existing
+ * composition seams: `completionSources` to display and `onValidCondition`
+ * to capture. History persists to localStorage per `historyKey`.
+ */
+export function useDSLFilterConditionHistory({
+  historyKey,
+  capacity = DEFAULT_CAPACITY,
+}: UseDSLFilterConditionHistoryProps): DSLFilterConditionHistory {
+  const storageKey = getDSLFilterConditionHistoryStorageKey(historyKey);
+
+  // The dwell is a trailing debounce: each applied condition replaces the
+  // pending one and restarts the clock, so a stepping stone hit while typing
+  // (`latency_ms > 1` on the way to `latency_ms > 1000`) is never committed
+  const commitAfterDwell = useMemo(
+    () =>
+      debounce((condition: string) => {
+        commitConditionToHistory(storageKey, condition, capacity);
+      }, DSL_FILTER_HISTORY_DWELL_MS),
+    [storageKey, capacity]
+  );
+
+  // Navigating away (or the history scope changing) while a condition is
+  // applied is the strongest signal it was a real search — flush the pending
+  // condition instead of losing it
+  useEffect(() => () => commitAfterDwell.flush(), [commitAfterDwell]);
+
+  const recordValidCondition = useCallback(
+    (condition: string) => {
+      const trimmed = condition.trim();
+      if (trimmed === "") {
+        // The field was cleared — whatever was pending was a stepping
+        // stone, not a search
+        commitAfterDwell.cancel();
+        return;
+      }
+      commitAfterDwell(trimmed);
+    },
+    [commitAfterDwell]
+  );
+
+  const completionSource = useMemo(
+    () =>
+      // Storage is read on each invocation so the dropdown always reflects
+      // the latest history, including entries committed by a sibling field
+      // sharing the same key (e.g. the spans and traces tabs)
+      createDSLFilterCompletionSource(() =>
+        readDSLFilterConditionHistory(storageKey).map((condition, index) => ({
+          label: condition,
+          type: "recent-search",
+          section: recentSearchesSection,
+          // Recency order — without a boost CodeMirror sorts a section's
+          // equally-scored options alphabetically
+          boost: -index,
+          // The label is a full expression, not a token — the default apply
+          // would splice it in at the token before the cursor, corrupting
+          // whatever is already typed. Replace the whole document instead.
+          apply: (view) => {
+            view.dispatch({
+              changes: {
+                from: 0,
+                to: view.state.doc.length,
+                insert: condition,
+              },
+              selection: { anchor: condition.length },
+              userEvent: "input.complete",
+            });
+          },
+        }))
+      ),
+    [storageKey]
+  );
+
+  return { completionSource, recordValidCondition };
+}

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -1,5 +1,5 @@
 import type { Completion } from "@codemirror/autocomplete";
-import { useDeferredValue, useMemo, useState } from "react";
+import { useCallback, useDeferredValue, useMemo, useState } from "react";
 import { fetchQuery, graphql } from "relay-runtime";
 
 import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
@@ -8,6 +8,7 @@ import {
   createAnnotationMemberCompletions,
   DSLFilterConditionField,
   type DSLFilterSnippet,
+  useDSLFilterConditionHistory,
 } from "@phoenix/components/filter";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import environment from "@phoenix/RelayEnvironment";
@@ -269,6 +270,29 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
     [projectId]
   );
 
+  // Recent searches are keyed per project rather than globally: filter
+  // expressions routinely reference project-specific names (annotations,
+  // metadata keys), so another project's history would be noise
+  const {
+    completionSource: recentSearchesCompletionSource,
+    recordValidCondition,
+  } = useDSLFilterConditionHistory({
+    historyKey: `span-filter-${projectId}`,
+  });
+
+  const completionSources = useMemo(
+    () => [recentSearchesCompletionSource, ...spanFilterCompletionSources],
+    [recentSearchesCompletionSource]
+  );
+
+  const handleValidCondition = useCallback(
+    (condition: string) => {
+      recordValidCondition(condition);
+      onValidCondition(condition);
+    },
+    [recordValidCondition, onValidCondition]
+  );
+
   // Advertise a project context that carries the current spanFilter while
   // the field is mounted. The merge in `selectActiveContexts` layers this
   // on top of the route-derived project context (which carries no filter)
@@ -300,10 +324,10 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
       placeholder={placeholder}
       completions={spanFilterCompletions}
       snippets={spanFilterSnippets}
-      completionSources={spanFilterCompletionSources}
+      completionSources={completionSources}
       loadCompletions={loadAnnotationCompletions}
       validateCondition={validateCondition}
-      onValidCondition={onValidCondition}
+      onValidCondition={handleValidCondition}
       onValidationStateChange={setIsConditionValid}
     />
   );


### PR DESCRIPTION
## Summary

Remembers the last few filter conditions the user actually ran and serves them back through the span filter field's own typeahead — no new UI surface. Recents appear as a top-ranked **Recent searches** section when the empty field is focused and fuzzy-match as the user types.

- **Per-project scope**: history is keyed `span-filter-${projectId}` in localStorage — filter expressions routinely reference project-specific annotation/metadata names, so another project's history would be noise.
- **Dwell before commit**: the filter applies live while typing, so every validation pause yields an applied condition. A condition only enters history after staying applied for 3s (trailing lodash debounce; flushed on unmount, cancelled on clear), keeping stepping stones like `latency_ms > 1` out while typing `latency_ms > 1000`.
- **Whole-field replace on accept**: a stored entry is a full expression, not a token, so recent-search completions carry a custom `apply` that replaces the entire document instead of splicing at the token before the cursor.
- Extracts the field's completion-source builder into `dslFilterConditionFieldUtils.ts` (`createDSLFilterCompletionSource`) so the history hook reuses the same token/string-literal handling, and truncates long option labels to one line.

The hook composes through `DSLFilterConditionField`'s existing seams (`completionSources` to display, `onValidCondition` to capture), so other filter fields can opt in later.

## Testing

- New unit suite `useDSLFilterConditionHistory.test.tsx` (12 tests): dwell commit, stepping-stone collapse, clear-discard, unmount flush, per-key isolation, recency-ordered completion serving, whole-document replace on accept.
- `pnpm lint`, `pnpm fmt:check`, `pnpm typecheck` clean.