### PR TITLE
feat(app): consolidated account menu in the side nav

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -976,6 +976,7 @@ const menuCSS = (theme: Theme) => css`
       --global-dimension-static-size-300
     );
     --global-menu-item-gap: var(--global-dimension-static-size-50);
+    --global-menu-item-content-gap: var(--global-dimension-static-size-100);
   }
 `;
 

--- a/app/src/components/core/icon/Icons.tsx
+++ b/app/src/components/core/icon/Icons.tsx
@@ -443,6 +443,25 @@ export const ArrowUpRightCorner = () => (
   </svg>
 );
 
+// @src: lucide
+export const CircleUserRound = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path fill="none" d="M17.925 20.056a6 6 0 0 0-11.851.001" />
+    <circle fill="none" cx="12" cy="11" r="4" />
+    <circle fill="none" cx="12" cy="12" r="10" />
+  </svg>
+);
+
 export const Code = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g data-name="Layer 2">

--- a/app/src/components/core/menu/Menu.tsx
+++ b/app/src/components/core/menu/Menu.tsx
@@ -222,7 +222,7 @@ const MenuItemContent = ({
       `}
     >
       {leadingContent ? (
-        <Flex alignItems="center" gap="static-size-100">
+        <Flex alignItems="center" gap="var(--global-menu-item-content-gap)">
           {leadingContent} {children}
         </Flex>
       ) : (

--- a/app/src/components/core/menu/Menu.tsx
+++ b/app/src/components/core/menu/Menu.tsx
@@ -27,10 +27,11 @@ const menuCSS = css`
   overflow-y: auto;
   overflow-x: hidden;
   padding: var(--global-menu-item-gap);
+  /* The menu container itself takes focus when opened before focus moves to an
+     item. Suppress the container-level focus ring — keyboard focus is already
+     indicated on the focused item — so the whole menu doesn't get outlined. */
   &:focus-visible {
-    border-radius: var(--global-rounding-small);
-    outline: 2px solid var(--global-color-primary);
-    outline-offset: 0px;
+    outline: none;
   }
   &[data-empty] {
     align-items: center;
@@ -101,6 +102,7 @@ const menuItemCss = css`
   outline: none;
   cursor: default;
   color: var(--global-text-color-900);
+  text-decoration: none;
   position: relative;
   display: flex;
 
@@ -220,7 +222,7 @@ const MenuItemContent = ({
       `}
     >
       {leadingContent ? (
-        <Flex alignItems="center" gap="var(--global-menu-item-gap)">
+        <Flex alignItems="center" gap="static-size-100">
           {leadingContent} {children}
         </Flex>
       ) : (

--- a/app/src/components/nav/AccountMenu.tsx
+++ b/app/src/components/nav/AccountMenu.tsx
@@ -12,7 +12,6 @@ import {
   MenuHeader,
   MenuItem,
   MenuTrigger,
-  Separator,
   Text,
   Tooltip,
   TooltipTrigger,
@@ -116,17 +115,14 @@ export function AccountMenu({ isExpanded }: { isExpanded: boolean }) {
               </MenuItem>
             ) : null}
             {authenticationEnabled ? (
-              <>
-                <Separator />
-                <MenuItem
-                  onAction={() =>
-                    window.location.replace(prependBasename("/auth/logout"))
-                  }
-                  leadingContent={<Icon svg={<Icons.LogOut />} />}
-                >
-                  Log Out
-                </MenuItem>
-              </>
+              <MenuItem
+                onAction={() =>
+                  window.location.replace(prependBasename("/auth/logout"))
+                }
+                leadingContent={<Icon svg={<Icons.LogOut />} />}
+              >
+                Log Out
+              </MenuItem>
             ) : null}
           </Menu>
           <MenuFooter>

--- a/app/src/components/nav/AccountMenu.tsx
+++ b/app/src/components/nav/AccountMenu.tsx
@@ -1,0 +1,142 @@
+import { css } from "@emotion/react";
+import { Button } from "react-aria-components";
+import { useMatch, useNavigate } from "react-router";
+
+import {
+  Flex,
+  Icon,
+  Icons,
+  Menu,
+  MenuContainer,
+  MenuFooter,
+  MenuHeader,
+  MenuItem,
+  MenuTrigger,
+  Separator,
+  Text,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
+import { UserPicture } from "@phoenix/components/user/UserPicture";
+import { useViewer } from "@phoenix/contexts";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
+import { classNames } from "@phoenix/utils/classNames";
+import { prependBasename } from "@phoenix/utils/routingUtils";
+
+import { navLinkCSS } from "./Navbar";
+import { ThemeToggle } from "./ThemeToggle";
+
+const identityCSS = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--global-dimension-static-size-100);
+  padding: var(--global-dimension-static-size-100)
+    var(--global-dimension-static-size-150);
+  border-bottom: 1px solid var(--global-menu-border-color);
+`;
+
+/**
+ * The consolidated account menu that sits at the bottom of the side nav. It
+ * gathers the user's identity, profile settings, documentation, support, and
+ * the theme picker into a single popover so the nav itself stays uncluttered.
+ */
+export function AccountMenu({ isExpanded }: { isExpanded: boolean }) {
+  const navigate = useNavigate();
+  const { viewer } = useViewer();
+  const { authenticationEnabled } = useFunctionality();
+  const displayName = viewer?.username || "Account";
+  const managementUrl =
+    viewer?.isManagementUser && window.Config.managementUrl
+      ? window.Config.managementUrl
+      : null;
+  // The trigger is a button rather than a router NavLink, so it must compute
+  // the active state itself for the routes reachable only through this menu.
+  const profileMatch = useMatch("/profile/*");
+  const supportMatch = useMatch("/support/*");
+  const isOnAccountRoute = Boolean(profileMatch || supportMatch);
+  return (
+    <TooltipTrigger delay={0} isDisabled={isExpanded}>
+      <MenuTrigger>
+        <Button
+          css={navLinkCSS}
+          className={classNames("button--reset account-menu__trigger", {
+            active: isOnAccountRoute,
+          })}
+          aria-label="Account"
+        >
+          <Icon svg={<Icons.CircleUserRound />} />
+          <Text>Account</Text>
+        </Button>
+        <MenuContainer placement="right bottom" minHeight={0}>
+          {viewer ? (
+            <MenuHeader>
+              <div css={identityCSS} className="account-menu__identity">
+                <UserPicture
+                  name={displayName}
+                  profilePictureUrl={viewer.profilePictureUrl}
+                  size={32}
+                />
+                <Flex direction="column" minWidth={0}>
+                  <Text weight="heavy">{viewer.username}</Text>
+                  <Text size="XS" color="text-700">
+                    {viewer.email}
+                  </Text>
+                </Flex>
+              </div>
+            </MenuHeader>
+          ) : null}
+          <Menu aria-label="Account">
+            <MenuItem
+              onAction={() => navigate("/profile")}
+              leadingContent={<Icon svg={<Icons.Person />} />}
+            >
+              Profile
+            </MenuItem>
+            <MenuItem
+              href="https://arize.com/docs/phoenix"
+              target="_blank"
+              rel="noreferrer"
+              leadingContent={<Icon svg={<Icons.Book />} />}
+            >
+              Documentation
+            </MenuItem>
+            <MenuItem
+              onAction={() => navigate("/support")}
+              leadingContent={<Icon svg={<Icons.LifeBuoy />} />}
+            >
+              Support
+            </MenuItem>
+            {managementUrl ? (
+              <MenuItem
+                href={managementUrl}
+                leadingContent={<Icon svg={<Icons.Server />} />}
+              >
+                Management Console
+              </MenuItem>
+            ) : null}
+            {authenticationEnabled ? (
+              <>
+                <Separator />
+                <MenuItem
+                  onAction={() =>
+                    window.location.replace(prependBasename("/auth/logout"))
+                  }
+                  leadingContent={<Icon svg={<Icons.LogOut />} />}
+                >
+                  Log Out
+                </MenuItem>
+              </>
+            ) : null}
+          </Menu>
+          <MenuFooter>
+            <ThemeToggle />
+          </MenuFooter>
+        </MenuContainer>
+      </MenuTrigger>
+      <Tooltip placement="right" offset={10}>
+        Account
+      </Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -1,25 +1,16 @@
 import { css } from "@emotion/react";
 import type { PropsWithChildren, ReactNode } from "react";
-import { useMemo } from "react";
-import { Button, Pressable } from "react-aria-components";
+import { Pressable } from "react-aria-components";
 import { Link, NavLink as RRNavLink } from "react-router";
 
 import {
-  Flex,
   Icon,
   Icons,
-  Menu,
-  MenuItem,
-  MenuTrigger,
-  Popover,
-  PopoverArrow,
   Text,
   Tooltip,
   TooltipTrigger,
 } from "@phoenix/components";
 import { GitHubStarCount } from "@phoenix/components/nav/GitHubStarCount";
-import { isProviderThemeMode, useTheme, useViewer } from "@phoenix/contexts";
-import { assertUnreachable } from "@phoenix/typeUtils";
 
 import { Logo, LogoText } from "./Logo";
 
@@ -67,7 +58,7 @@ const sideNavCSS = css`
   }
 `;
 
-const navLinkCSS = css`
+export const navLinkCSS = css`
   --nav-link-icon-size: calc(
     var(--nav-collapsed-width) - var(--global-dimension-static-size-200)
   );
@@ -169,17 +160,6 @@ function ExternalLink(props: {
   );
 }
 
-export function DocsLink({ isExpanded }: { isExpanded: boolean }) {
-  return (
-    <ExternalLink
-      href="https://arize.com/docs/phoenix"
-      leadingVisual={<Icon svg={<Icons.Book />} />}
-      text="Documentation"
-      isExpanded={isExpanded}
-    />
-  );
-}
-
 export function GitHubLink({ isExpanded }: { isExpanded: boolean }) {
   return (
     <ExternalLink
@@ -189,97 +169,6 @@ export function GitHubLink({ isExpanded }: { isExpanded: boolean }) {
       text="Star on GitHub"
       isExpanded={isExpanded}
     />
-  );
-}
-
-export function ThemeSelector({ isExpanded }: { isExpanded: boolean }) {
-  const { theme, systemTheme, themeMode, setThemeMode } = useTheme();
-  const { themeText, themeIcon } = useMemo(() => {
-    let themeIcon: ReactNode;
-    let themeText: string;
-    switch (themeMode) {
-      case "light":
-        themeIcon = <Icons.Sun />;
-        themeText = "Light";
-        break;
-      case "dark":
-        themeIcon = <Icons.Moon />;
-        themeText = "Dark";
-        break;
-      case "system":
-        themeIcon = <Icons.HalfMoonHalfSun />;
-        themeText = `${theme === "light" ? "Light" : "Dark"} (auto)`;
-        break;
-      default:
-        assertUnreachable(themeMode);
-    }
-    return {
-      themeIcon,
-      themeText,
-    };
-  }, [theme, themeMode]);
-
-  return (
-    <TooltipTrigger delay={0} isDisabled={isExpanded}>
-      <MenuTrigger>
-        <Button css={navLinkCSS} className="button--reset">
-          <Icon svg={themeIcon} />
-          <Text>{themeText}</Text>
-        </Button>
-        <Popover placement="right top">
-          <PopoverArrow />
-          <Menu
-            aria-label="Theme selection"
-            selectedKeys={new Set([themeMode])}
-            selectionMode="single"
-            onSelectionChange={(keys) => {
-              const selectedKey =
-                keys instanceof Set ? Array.from(keys)[0] : null;
-              if (selectedKey && isProviderThemeMode(selectedKey)) {
-                setThemeMode(selectedKey);
-              }
-            }}
-          >
-            <MenuItem id="system">
-              <Flex
-                direction="row"
-                gap="size-100"
-                justifyContent="start"
-                alignItems="center"
-              >
-                <Icon svg={<Icons.HalfMoonHalfSun />} />
-                <Text>{`Auto (${systemTheme})`}</Text>
-              </Flex>
-            </MenuItem>
-            <MenuItem id="dark">
-              <Flex
-                direction="row"
-                gap="size-100"
-                justifyContent="start"
-                alignItems="center"
-              >
-                <Icon svg={<Icons.Moon />} />
-                <Text>Dark</Text>
-              </Flex>
-            </MenuItem>
-            <MenuItem id="light">
-              <Flex
-                direction="row"
-                gap="size-100"
-                justifyContent="start"
-                alignItems="center"
-              >
-                <Icon svg={<Icons.Sun />} />
-                <Text>Light</Text>
-              </Flex>
-            </MenuItem>
-          </Menu>
-        </Popover>
-      </MenuTrigger>
-      <Tooltip placement="right" offset={10}>
-        {themeText}
-      </Tooltip>
-    </TooltipTrigger>
   );
 }
 
@@ -337,35 +226,3 @@ export function NavLink(props: {
     </TooltipTrigger>
   );
 }
-
-export function NavButton(props: {
-  text: string;
-  leadingVisual: ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <button className="button--reset" css={navLinkCSS} onClick={props.onClick}>
-      {props.leadingVisual}
-      <Text>{props.text}</Text>
-    </button>
-  );
-}
-
-export const ManagementLink = ({ isExpanded }: { isExpanded: boolean }) => {
-  const { viewer } = useViewer();
-
-  if (viewer?.isManagementUser && window.Config.managementUrl) {
-    return (
-      <li key="management">
-        <ExternalLink
-          href={window.Config.managementUrl}
-          leadingVisual={<Icon svg={<Icons.Server />} />}
-          text="Management Console"
-          replaceTab
-          isExpanded={isExpanded}
-        />
-      </li>
-    );
-  }
-  return null;
-};

--- a/app/src/components/nav/ThemeToggle.tsx
+++ b/app/src/components/nav/ThemeToggle.tsx
@@ -1,0 +1,58 @@
+import { css } from "@emotion/react";
+
+import {
+  Icon,
+  Icons,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@phoenix/components";
+import { isProviderThemeMode, useTheme } from "@phoenix/contexts";
+
+const themeToggleCSS = css`
+  width: 100%;
+  & > .toggle-button {
+    flex: 1 1 0;
+    justify-content: center;
+  }
+`;
+
+/**
+ * A compact segmented control for picking the theme mode: light, dark, or
+ * system. Selecting "System" follows the OS preference.
+ */
+export function ThemeToggle() {
+  const { themeMode, setThemeMode } = useTheme();
+  return (
+    <ToggleButtonGroup
+      size="S"
+      aria-label="Theme"
+      selectionMode="single"
+      disallowEmptySelection
+      selectedKeys={[themeMode]}
+      onSelectionChange={(keys) => {
+        const selectedKey = Array.from(keys)[0];
+        if (
+          typeof selectedKey === "string" &&
+          isProviderThemeMode(selectedKey)
+        ) {
+          setThemeMode(selectedKey);
+        }
+      }}
+      css={themeToggleCSS}
+      className="theme-toggle"
+    >
+      <ToggleButton id="light" leadingVisual={<Icon svg={<Icons.Sun />} />}>
+        Light
+      </ToggleButton>
+      <ToggleButton id="dark" leadingVisual={<Icon svg={<Icons.Moon />} />}>
+        Dark
+      </ToggleButton>
+      <ToggleButton
+        id="system"
+        leadingVisual={<Icon svg={<Icons.HalfMoonHalfSun />} />}
+      >
+        System
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+}

--- a/app/src/components/nav/index.tsx
+++ b/app/src/components/nav/index.tsx
@@ -1,4 +1,6 @@
+export * from "./AccountMenu";
 export * from "./Navbar";
+export * from "./ThemeToggle";
 export * from "./NavBreadcrumb";
 export * from "./SideNavToggleButton";
 export * from "./NavTitle";

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { Suspense, useCallback, useRef } from "react";
+import { Suspense, useRef } from "react";
 import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import { Outlet, useLoaderData } from "react-router";
 
@@ -11,30 +11,25 @@ import {
   useAssistantAgentEnabled,
 } from "@phoenix/components/agent";
 import {
+  AccountMenu,
   Brand,
-  DocsLink,
   GitHubLink,
-  ManagementLink,
   NavBreadcrumb,
-  NavButton,
   NavLink,
   NavTitle,
   SideNavbar,
   SideNavToggleButton,
-  ThemeSelector,
   TopNavActionsProvider,
   TopNavActionsSlot,
   TopNavbar,
   VersionUpdateNotice,
 } from "@phoenix/components/nav";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
-import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import {
   useHasOpenDrawer,
   useHasOpenModal,
 } from "@phoenix/hooks/useHasOpenModal";
-import { prependBasename } from "@phoenix/utils/routingUtils";
 
 import type { LayoutLoaderData } from "./layoutLoader";
 
@@ -161,10 +156,6 @@ function SideNav() {
     (state) => state.isSideNavExpanded
   );
   const loaderData = useLoaderData<LayoutLoaderData>();
-  const { authenticationEnabled } = useFunctionality();
-  const onLogout = useCallback(() => {
-    window.location.replace(prependBasename("/auth/logout"));
-  }, []);
   return (
     <SideNavbar isExpanded={isSideNavExpanded}>
       <Brand />
@@ -264,46 +255,13 @@ function SideNav() {
             <NavLink
               to="/settings/general"
               text="Settings"
-              leadingVisual={<Icon svg={<Icons.Settings />} />}
+              leadingVisual={<Icon svg={<Icons.Options />} />}
               isExpanded={isSideNavExpanded}
             />
           </li>
-          <li key="docs">
-            <DocsLink isExpanded={isSideNavExpanded} />
+          <li key="account">
+            <AccountMenu isExpanded={isSideNavExpanded} />
           </li>
-          <li key="support">
-            <NavLink
-              to="/support"
-              text="Support"
-              leadingVisual={<Icon svg={<Icons.LifeBuoy />} />}
-              isExpanded={isSideNavExpanded}
-            />
-          </li>
-          <li key="theme-toggle">
-            <ThemeSelector isExpanded={isSideNavExpanded} />
-          </li>
-          <li key="profile">
-            <NavLink
-              to="/profile"
-              text="Profile"
-              leadingVisual={<Icon svg={<Icons.Person />} />}
-              isExpanded={isSideNavExpanded}
-            />
-          </li>
-          {authenticationEnabled && (
-            <>
-              <Suspense>
-                <ManagementLink isExpanded={isSideNavExpanded} />
-              </Suspense>
-              <li key="logout">
-                <NavButton
-                  text="Log Out"
-                  leadingVisual={<Icon svg={<Icons.LogOut />} />}
-                  onClick={onLogout}
-                />
-              </li>
-            </>
-          )}
         </ul>
       </Flex>
     </SideNavbar>

--- a/app/stories/ThemeToggle.stories.tsx
+++ b/app/stories/ThemeToggle.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { View } from "@phoenix/components";
+import { ThemeToggle } from "@phoenix/components/nav";
+
+/**
+ * A compact segmented control for switching between light, dark, and system
+ * theme modes. Lives in the account menu at the bottom of the side nav.
+ */
+const meta: Meta<typeof ThemeToggle> = {
+  title: "Nav/ThemeToggle",
+  component: ThemeToggle,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <View width="250px">
+        <Story />
+      </View>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ThemeToggle>;
+
+export const Default: Story = {};

--- a/app/tests/auth.setup.ts
+++ b/app/tests/auth.setup.ts
@@ -40,6 +40,11 @@ async function resetPassword({
   await page.getByRole("button", { name: "Reset Password" }).click();
 }
 
+async function logout({ page }: { page: Page }) {
+  await page.getByRole("button", { name: "Account" }).click();
+  await page.getByRole("menuitem", { name: "Log Out" }).click();
+}
+
 async function resetPasswordAndReLogin({
   page,
   baseURL,
@@ -121,7 +126,7 @@ setup(
       .click();
     await expect(page.getByTestId("dialog")).not.toBeVisible();
 
-    await page.getByRole("button", { name: "Log Out" }).click();
+    await logout({ page });
 
     await login({
       page,
@@ -136,7 +141,7 @@ setup(
       oldPassword: "member",
       newPassword: "member123",
     });
-    await page.getByRole("button", { name: "Log Out" }).click();
+    await logout({ page });
 
     await login({
       page,


### PR DESCRIPTION
## What

Consolidates the bottom of the side nav into a single **Account** menu. Previously the nav stacked separate items for Documentation, theme selection, Management Console, and Log Out; these now live in one popover anchored to an Account trigger, alongside the user's identity.

- New `AccountMenu` component: identity header (avatar, username, email), then a single keyboard-navigable menu with Profile, Documentation, Support, Management Console (management users only), and Log Out, with a theme-toggle footer
- New `ThemeToggle` segmented control (Light / Dark / System) with a Storybook story, replacing the old `ThemeSelector` popover
- The Account trigger highlights (`.active`) when on routes only reachable through the menu (`/profile`, `/support`), matching the behavior of router `NavLink`s
- New `CircleUserRound` icon (lucide)
- Removes dead nav exports: `DocsLink`, `ThemeSelector`, `NavButton`, `ManagementLink`
- Menu polish: suppress the container-level focus ring (keyboard focus is already shown on the focused item), no text decoration on link items
- New `--global-menu-item-content-gap` token for the icon↔label gap inside a menu item — it was previously borrowing `--global-menu-item-gap`, the structural menu-spacing token, coupling two unrelated concepts
- E2E auth setup updated to log out through the account menu

## Design notes

The popover keeps exactly two section borders — below the identity header and above the theme-toggle footer — so the item list reads as one uniform group. Log Out is part of the same menu as the other items so arrow-key navigation reaches it. Documentation intentionally has no external-link icon (it's expected to leave the app, and Management Console, also external, never had one).

## How I tested

- `pnpm typecheck`, `pnpm lint`, `pnpm fmt:check` all pass
- Verified in the running dev app (light and dark themes): menu structure and borders, theme toggle, log out, and active-state highlighting on `/profile` and `/support` (and not on other routes)

## Screenshots

Account menu open (dark): identity header, single uniform menu including Log Out, theme toggle as the footer.

![account menu dark](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14070-account-menu-dark.png)

Account menu open (light):

![account menu light](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14070-account-menu-light.png)

Account trigger highlighting while on `/profile`:

![account trigger active on profile](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14070-account-active-profile.png)

