### PR TITLE
feat(app): add trace tree search

### DIFF
--- a/.agents/skills/phoenix-frontend/references/components.md
+++ b/.agents/skills/phoenix-frontend/references/components.md
@@ -55,6 +55,10 @@ Name callback props after the **event** (`onProjectCreated`, `onDismiss`), not t
 
 Prefer declarative React and React Aria patterns over imperative `useEffect`. Reach for `useEffect` only when there is no declarative alternative.
 
+For debounced search/filter inputs, compose the shared `DebouncedSearch` field instead of hand-rolling `useEffect` + `setTimeout`.
+
+For expensive context-driven updates (tree filtering, list filtering, global expand/collapse), keep transition policy with the state owner: expose context actions whose provider wraps the underlying state update in `startTransition`, and let consumers call those actions directly.
+
 ## Overlays: Drawer vs. Modal
 
 Phoenix has two overlay components with different purposes. Choosing the wrong one breaks the interaction model.

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import type { PropsWithChildren } from "react";
 import { startTransition, useEffect, useRef, useState } from "react";
 
-import { DisclosureArrow, Empty, Flex } from "@phoenix/components";
+import { DisclosureArrow, Empty, Flex, Text } from "@phoenix/components";
 import type { TimelineBarProps } from "@phoenix/components/timeline/TimelineBar";
 import { TimelineBar } from "@phoenix/components/timeline/TimelineBar";
 import { SpanTokenCount } from "@phoenix/components/trace/SpanTokenCount";
@@ -66,8 +66,16 @@ export function TraceTree(props: TraceTreeProps) {
         data-testid="trace-tree"
       >
         {noSearchResults ? (
-          <li aria-live="polite">
-            <Empty message={`No spans match "${searchQuery}"`} size="S" />
+          <li
+            aria-live="polite"
+            css={css`
+              padding: var(--global-dimension-static-size-100)
+                var(--global-dimension-static-size-300);
+            `}
+          >
+            <Text color="text-700" size="XS">
+              {`No spans match "${searchQuery}"`}
+            </Text>
           </li>
         ) : null}
         {!rootSpan ? (

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -2,7 +2,14 @@ import { css } from "@emotion/react";
 import type { PropsWithChildren } from "react";
 import { startTransition, useEffect, useRef, useState } from "react";
 
-import { DisclosureArrow, Empty, Flex, Text } from "@phoenix/components";
+import {
+  DisclosureArrow,
+  Empty,
+  Flex,
+  Icon,
+  Icons,
+  Text,
+} from "@phoenix/components";
 import type { TimelineBarProps } from "@phoenix/components/timeline/TimelineBar";
 import { TimelineBar } from "@phoenix/components/timeline/TimelineBar";
 import { SpanTokenCount } from "@phoenix/components/trace/SpanTokenCount";
@@ -66,16 +73,8 @@ export function TraceTree(props: TraceTreeProps) {
         data-testid="trace-tree"
       >
         {noSearchResults ? (
-          <li
-            aria-live="polite"
-            css={css`
-              padding: var(--global-dimension-static-size-100)
-                var(--global-dimension-static-size-300);
-            `}
-          >
-            <Text color="text-700" size="XS">
-              {`No spans match "${searchQuery}"`}
-            </Text>
+          <li aria-live="polite">
+            <TraceTreeSearchEmpty searchQuery={searchQuery} />
           </li>
         ) : null}
         {!rootSpan ? (
@@ -94,6 +93,39 @@ export function TraceTree(props: TraceTreeProps) {
           />
         ))}
       </ul>
+    </div>
+  );
+}
+
+function TraceTreeSearchEmpty({ searchQuery }: { searchQuery: string }) {
+  return (
+    <div
+      className="trace-tree-search-empty"
+      css={css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--global-dimension-static-size-50);
+        padding: var(--global-dimension-static-size-300)
+          var(--global-dimension-static-size-200);
+        color: var(--global-text-color-700);
+        text-align: center;
+
+        .icon-wrap {
+          font-size: var(--global-font-size-l);
+          color: var(--global-text-color-500);
+        }
+
+        .text {
+          max-width: 180px;
+          text-wrap: balance;
+        }
+      `}
+    >
+      <Icon svg={<Icons.Trace />} />
+      <Text color="inherit" size="XS">
+        {`No spans match "${searchQuery}"`}
+      </Text>
     </div>
   );
 }

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import type { PropsWithChildren } from "react";
 import { startTransition, useEffect, useRef, useState } from "react";
 
-import { DisclosureArrow, Flex } from "@phoenix/components";
+import { DisclosureArrow, Empty, Flex } from "@phoenix/components";
 import type { TimelineBarProps } from "@phoenix/components/timeline/TimelineBar";
 import { TimelineBar } from "@phoenix/components/timeline/TimelineBar";
 import { SpanTokenCount } from "@phoenix/components/trace/SpanTokenCount";
@@ -17,7 +17,7 @@ import { useTraceTree } from "./TraceTreeContext";
 import { NESTING_INDENT, traceTreeListCSS } from "./traceTreeStyles";
 import type { ISpanItem, SpanStatusCodeType } from "./types";
 import type { SpanTreeNode } from "./utils";
-import { createSpanTree } from "./utils";
+import { createSpanTree, filterSpanTree } from "./utils";
 
 export type TraceTreeProps = {
   spans: ISpanItem[];
@@ -35,11 +35,15 @@ export function TraceTree(props: TraceTreeProps) {
     selectedSpanNodeId,
     scrollSelectedSpanIntoView = true,
   } = props;
+  const { searchQuery } = useTraceTree();
   const spanTree = createSpanTree(spans);
-  const rootSpan = spanTree[0].span;
+  const filteredSpanTree = filterSpanTree(spanTree, searchQuery);
+  const rootSpan = spanTree[0]?.span;
+  const hasSearchQuery = searchQuery.length > 0;
+  const noSearchResults = hasSearchQuery && filteredSpanTree.length === 0;
   const overallTimeRange = {
-    start: new Date(rootSpan.startTime),
-    end: rootSpan.endTime ? new Date(rootSpan.endTime) : new Date(),
+    start: rootSpan ? new Date(rootSpan.startTime) : new Date(),
+    end: rootSpan?.endTime ? new Date(rootSpan.endTime) : new Date(),
   };
   return (
     <div
@@ -61,7 +65,17 @@ export function TraceTree(props: TraceTreeProps) {
         ]}
         data-testid="trace-tree"
       >
-        {spanTree.map((spanNode) => (
+        {noSearchResults ? (
+          <li aria-live="polite">
+            <Empty message={`No spans match "${searchQuery}"`} size="S" />
+          </li>
+        ) : null}
+        {!rootSpan ? (
+          <li>
+            <Empty message="No spans" size="S" />
+          </li>
+        ) : null}
+        {filteredSpanTree.map((spanNode) => (
           <SpanTreeItem
             key={spanNode.span.id}
             node={spanNode}
@@ -111,8 +125,10 @@ function SpanTreeItem<TSpan extends ISpanItem>(
   } = props;
   const childNodes = node.children;
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const { isCollapsed: treeIsCollapsed } = useTraceTree();
+  const { isCollapsed: treeIsCollapsed, searchQuery } = useTraceTree();
   const hasChildren = childNodes.length > 0;
+  const isSearching = searchQuery.length > 0;
+  const effectiveIsCollapsed = isSearching ? false : isCollapsed;
   const showMetricsInTraceTree = usePreferencesContext(
     (state) => state.showMetricsInTraceTree
   );
@@ -211,7 +227,7 @@ function SpanTreeItem<TSpan extends ISpanItem>(
             data-testid="span-controls"
             className="span-controls"
           >
-            {hasChildren ? (
+            {hasChildren && !isSearching ? (
               <CollapseToggleButton
                 isCollapsed={isCollapsed}
                 onClick={() => {
@@ -225,7 +241,7 @@ function SpanTreeItem<TSpan extends ISpanItem>(
       {childNodes.length ? (
         <ul
           css={css`
-            display: ${isCollapsed ? "none" : "flex"};
+            display: ${effectiveIsCollapsed ? "none" : "flex"};
             flex-direction: column;
           `}
         >

--- a/app/src/components/trace/TraceTreeContext.tsx
+++ b/app/src/components/trace/TraceTreeContext.tsx
@@ -1,15 +1,11 @@
-import type { PropsWithChildren } from "react";
-import {
-  createContext,
-  startTransition,
-  useCallback,
-  useContext,
-  useState,
-} from "react";
+import type { Dispatch, PropsWithChildren, SetStateAction } from "react";
+import { createContext, useContext, useState } from "react";
 
 export type TraceTreeContextType = {
   isCollapsed: boolean;
-  setIsCollapsed: (collapsed: boolean) => void;
+  setIsCollapsed: Dispatch<SetStateAction<boolean>>;
+  searchQuery: string;
+  setSearchQuery: Dispatch<SetStateAction<string>>;
 };
 
 export const TraceTreeContext = createContext<TraceTreeContextType | null>(
@@ -25,15 +21,13 @@ export function useTraceTree() {
 }
 
 export function TraceTreeProvider(props: PropsWithChildren) {
-  const [isCollapsed, _setIsCollapsed] = useState<boolean>(false);
-  const setIsCollapsed = useCallback((collapsed: boolean) => {
-    startTransition(() => {
-      _setIsCollapsed(collapsed);
-    });
-  }, []);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   return (
-    <TraceTreeContext.Provider value={{ isCollapsed, setIsCollapsed }}>
+    <TraceTreeContext.Provider
+      value={{ isCollapsed, setIsCollapsed, searchQuery, setSearchQuery }}
+    >
       {props.children}
     </TraceTreeContext.Provider>
   );

--- a/app/src/components/trace/TraceTreeContext.tsx
+++ b/app/src/components/trace/TraceTreeContext.tsx
@@ -1,11 +1,11 @@
-import type { Dispatch, PropsWithChildren, SetStateAction } from "react";
-import { createContext, useContext, useState } from "react";
+import type { PropsWithChildren } from "react";
+import { createContext, startTransition, useContext, useState } from "react";
 
 export type TraceTreeContextType = {
   isCollapsed: boolean;
-  setIsCollapsed: Dispatch<SetStateAction<boolean>>;
+  setIsCollapsed: (isCollapsed: boolean) => void;
   searchQuery: string;
-  setSearchQuery: Dispatch<SetStateAction<string>>;
+  setSearchQuery: (searchQuery: string) => void;
 };
 
 export const TraceTreeContext = createContext<TraceTreeContextType | null>(
@@ -21,8 +21,20 @@ export function useTraceTree() {
 }
 
 export function TraceTreeProvider(props: PropsWithChildren) {
-  const [isCollapsed, setIsCollapsed] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [isCollapsed, setIsCollapsedState] = useState(false);
+  const [searchQuery, setSearchQueryState] = useState("");
+
+  const setIsCollapsed = (isCollapsed: boolean) => {
+    startTransition(() => {
+      setIsCollapsedState(isCollapsed);
+    });
+  };
+
+  const setSearchQuery = (searchQuery: string) => {
+    startTransition(() => {
+      setSearchQueryState(searchQuery.trim());
+    });
+  };
 
   return (
     <TraceTreeContext.Provider

--- a/app/src/components/trace/TraceTreeContext.tsx
+++ b/app/src/components/trace/TraceTreeContext.tsx
@@ -1,17 +1,53 @@
 import type { PropsWithChildren } from "react";
 import { createContext, startTransition, useContext, useState } from "react";
 
+/**
+ * View state shared between the trace tree and its toolbar.
+ *
+ * @remarks
+ * The actions intentionally hide the underlying React state setters. Filtering
+ * and global expand/collapse can update a large tree, so the provider owns the
+ * `startTransition` policy and consumers call these actions directly.
+ */
 export type TraceTreeContextType = {
+  /** Whether nested span nodes should be collapsed across the trace tree. */
   isCollapsed: boolean;
+
+  /**
+   * Sets the global collapse state for the trace tree.
+   *
+   * @param isCollapsed - `true` collapses nested spans; `false` expands them.
+   */
   setIsCollapsed: (isCollapsed: boolean) => void;
+
+  /** Trimmed query used to filter visible spans in the trace tree. */
   searchQuery: string;
+
+  /**
+   * Sets the trace tree search query.
+   *
+   * @param searchQuery - Raw search text. The provider trims the value before
+   * applying it so all consumers share the same normalized query.
+   */
   setSearchQuery: (searchQuery: string) => void;
 };
 
+/**
+ * Context backing trace tree view state.
+ *
+ * @remarks Use {@link useTraceTree} instead of reading this context directly so
+ * missing-provider errors fail with an actionable message.
+ */
 export const TraceTreeContext = createContext<TraceTreeContextType | null>(
   null
 );
 
+/**
+ * Returns trace tree view state and actions for descendants of
+ * {@link TraceTreeProvider}.
+ *
+ * @throws Error when called outside of a `TraceTreeProvider`.
+ */
 export function useTraceTree() {
   const context = useContext(TraceTreeContext);
   if (context === null) {
@@ -20,16 +56,35 @@ export function useTraceTree() {
   return context;
 }
 
+/**
+ * Provides trace tree view state to the toolbar and tree body.
+ *
+ * @remarks
+ * State updates that can cause broad tree re-rendering are wrapped in
+ * `startTransition` here so callers do not need to remember which actions are
+ * potentially expensive.
+ *
+ * @param props - Provider props.
+ * @param props.children - Trace tree UI that consumes the shared view state.
+ */
 export function TraceTreeProvider(props: PropsWithChildren) {
   const [isCollapsed, setIsCollapsedState] = useState(false);
   const [searchQuery, setSearchQueryState] = useState("");
 
+  /**
+   * Applies a global collapse/expand request as a non-urgent update because
+   * every rendered tree item may react to this value.
+   */
   const setIsCollapsed = (isCollapsed: boolean) => {
     startTransition(() => {
       setIsCollapsedState(isCollapsed);
     });
   };
 
+  /**
+   * Applies a normalized search query as a non-urgent update because filtering
+   * can rebuild the visible trace tree for large traces.
+   */
   const setSearchQuery = (searchQuery: string) => {
     startTransition(() => {
       setSearchQueryState(searchQuery.trim());

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   TooltipTrigger,
 } from "@phoenix/components";
+import { SearchIcon } from "@phoenix/components/core/field";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 
 import { useTraceTree } from "./TraceTreeContext";
@@ -77,6 +78,16 @@ export function TraceTreeToolbar() {
           color: var(--global-text-color-700);
           font-style: normal;
         }
+        .trace-tree-toolbar__search .search-field__icon {
+          left: var(--global-dimension-static-size-100);
+          color: var(--global-text-color-500);
+          font-size: var(--global-font-size-s);
+        }
+        .trace-tree-toolbar__search .search-field__icon ~ .react-aria-Input {
+          padding-left: calc(
+            var(--global-dimension-static-size-200) + var(--global-font-size-s)
+          ) !important;
+        }
       `}
     >
       <Flex
@@ -94,6 +105,7 @@ export function TraceTreeToolbar() {
             value={searchValue}
             variant="quiet"
           >
+            <SearchIcon />
             <Input placeholder="Search trace" />
           </SearchField>
         </div>

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -1,45 +1,28 @@
 import { css } from "@emotion/react";
-import { startTransition, useEffect, useState } from "react";
 
 import {
+  DebouncedSearch,
   Flex,
   Icon,
   IconButton,
   Icons,
-  Input,
-  SearchField,
   Tooltip,
   TooltipTrigger,
 } from "@phoenix/components";
-import { SearchIcon } from "@phoenix/components/core/field";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 
 import { useTraceTree } from "./TraceTreeContext";
 import { COMPACT_BREAKPOINT } from "./traceTreeStyles";
 
-const TRACE_TREE_SEARCH_DEBOUNCE_MS = 200;
-
 export function TraceTreeToolbar() {
-  const [searchValue, setSearchValue] = useState("");
   const showMetricsInTraceTree = usePreferencesContext(
     (state) => state.showMetricsInTraceTree
   );
   const setShowMetricsInTraceTree = usePreferencesContext(
     (state) => state.setShowMetricsInTraceTree
   );
-  const { isCollapsed, setIsCollapsed, setSearchQuery } = useTraceTree();
-
-  useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      startTransition(() => {
-        setSearchQuery(searchValue.trim());
-      });
-    }, TRACE_TREE_SEARCH_DEBOUNCE_MS);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [searchValue, setSearchQuery]);
+  const { isCollapsed, searchQuery, setIsCollapsed, setSearchQuery } =
+    useTraceTree();
 
   return (
     <div
@@ -99,15 +82,13 @@ export function TraceTreeToolbar() {
         width="100%"
       >
         <div className="trace-tree-toolbar__search">
-          <SearchField
+          <DebouncedSearch
             aria-label="Search trace tree"
-            onChange={setSearchValue}
-            value={searchValue}
+            defaultValue={searchQuery}
+            onChange={setSearchQuery}
+            placeholder="Search trace"
             variant="quiet"
-          >
-            <SearchIcon />
-            <Input placeholder="Search trace" />
-          </SearchField>
+          />
         </div>
         <Flex direction="row" gap="size-100" className="trace-tree-controls">
           <TooltipTrigger>
@@ -115,9 +96,7 @@ export function TraceTreeToolbar() {
               size="S"
               aria-label={isCollapsed ? "Expand all" : "Collapse all"}
               onPress={() => {
-                startTransition(() => {
-                  setIsCollapsed(!isCollapsed);
-                });
+                setIsCollapsed(!isCollapsed);
               }}
             >
               <Icon

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -81,11 +81,11 @@ export function TraceTreeToolbar() {
         .trace-tree-toolbar__search .search-field__icon {
           left: var(--global-dimension-static-size-100);
           color: var(--global-text-color-500);
-          font-size: var(--global-font-size-s);
+          font-size: var(--global-font-size-l);
         }
         .trace-tree-toolbar__search .search-field__icon ~ .react-aria-Input {
           padding-left: calc(
-            var(--global-dimension-static-size-200) + var(--global-font-size-s)
+            var(--global-dimension-static-size-200) + var(--global-font-size-l)
           ) !important;
         }
       `}

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -1,11 +1,13 @@
 import { css } from "@emotion/react";
+import { startTransition, useEffect, useState } from "react";
 
 import {
   Flex,
-  Heading,
   Icon,
   IconButton,
   Icons,
+  Input,
+  SearchField,
   Tooltip,
   TooltipTrigger,
 } from "@phoenix/components";
@@ -14,14 +16,30 @@ import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import { useTraceTree } from "./TraceTreeContext";
 import { COMPACT_BREAKPOINT } from "./traceTreeStyles";
 
+const TRACE_TREE_SEARCH_DEBOUNCE_MS = 200;
+
 export function TraceTreeToolbar() {
+  const [searchValue, setSearchValue] = useState("");
   const showMetricsInTraceTree = usePreferencesContext(
     (state) => state.showMetricsInTraceTree
   );
   const setShowMetricsInTraceTree = usePreferencesContext(
     (state) => state.setShowMetricsInTraceTree
   );
-  const { isCollapsed, setIsCollapsed } = useTraceTree();
+  const { isCollapsed, setIsCollapsed, setSearchQuery } = useTraceTree();
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      startTransition(() => {
+        setSearchQuery(searchValue.trim());
+      });
+    }, TRACE_TREE_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [searchValue, setSearchQuery]);
+
   return (
     <div
       className="trace-tree-toolbar"
@@ -40,6 +58,29 @@ export function TraceTreeToolbar() {
             display: none;
           }
         }
+        .trace-tree-toolbar__search {
+          flex: 1 1 auto;
+          min-width: 0;
+        }
+        .trace-tree-toolbar__search .search-field {
+          width: 100%;
+        }
+        .trace-tree-toolbar__search .react-aria-Input {
+          min-width: 0;
+          padding-left: 0 !important;
+          padding-right: var(--global-dimension-size-300) !important;
+          color: var(--global-text-color-900);
+          font-size: var(--global-font-size-m);
+          line-height: var(--global-line-height-m);
+        }
+        .trace-tree-toolbar__search .react-aria-Input::placeholder {
+          color: var(--global-text-color-700);
+          font-style: normal;
+        }
+        .trace-tree-toolbar__search .search-field:focus-within {
+          background-color: var(--global-color-gray-100);
+          border-radius: var(--global-rounding-small);
+        }
       `}
     >
       <Flex
@@ -50,14 +91,25 @@ export function TraceTreeToolbar() {
         gap="size-100"
         width="100%"
       >
-        <Heading level={3}>Trace</Heading>
+        <div className="trace-tree-toolbar__search">
+          <SearchField
+            aria-label="Search trace tree"
+            onChange={setSearchValue}
+            value={searchValue}
+            variant="quiet"
+          >
+            <Input placeholder="Search trace" />
+          </SearchField>
+        </div>
         <Flex direction="row" gap="size-100" className="trace-tree-controls">
           <TooltipTrigger>
             <IconButton
               size="S"
               aria-label={isCollapsed ? "Expand all" : "Collapse all"}
               onPress={() => {
-                setIsCollapsed(!isCollapsed);
+                startTransition(() => {
+                  setIsCollapsed(!isCollapsed);
+                });
               }}
             >
               <Icon

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -67,19 +67,15 @@ export function TraceTreeToolbar() {
         }
         .trace-tree-toolbar__search .react-aria-Input {
           min-width: 0;
-          padding-left: 0 !important;
-          padding-right: var(--global-dimension-size-300) !important;
+          padding-left: var(--global-dimension-static-size-200) !important;
+          padding-right: var(--global-dimension-static-size-300) !important;
           color: var(--global-text-color-900);
-          font-size: var(--global-font-size-m);
-          line-height: var(--global-line-height-m);
+          font-size: var(--global-font-size-s);
+          line-height: var(--global-line-height-s);
         }
         .trace-tree-toolbar__search .react-aria-Input::placeholder {
           color: var(--global-text-color-700);
           font-style: normal;
-        }
-        .trace-tree-toolbar__search .search-field:focus-within {
-          background-color: var(--global-color-gray-100);
-          border-radius: var(--global-rounding-small);
         }
       `}
     >

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -14,6 +14,15 @@ import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import { useTraceTree } from "./TraceTreeContext";
 import { COMPACT_BREAKPOINT } from "./traceTreeStyles";
 
+/**
+ * Header controls for the trace tree panel.
+ *
+ * @remarks
+ * Search input debouncing is delegated to `DebouncedSearch`, while transition
+ * policy for filtering and global collapse/expand is owned by
+ * `TraceTreeProvider`. Keeping those concerns out of the toolbar keeps this
+ * component focused on layout and control wiring.
+ */
 export function TraceTreeToolbar() {
   const showMetricsInTraceTree = usePreferencesContext(
     (state) => state.showMetricsInTraceTree

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -67,7 +67,7 @@ export function TraceTreeToolbar() {
         }
         .trace-tree-toolbar__search .react-aria-Input {
           min-width: 0;
-          padding-left: var(--global-dimension-static-size-200) !important;
+          padding-left: var(--global-dimension-static-size-100) !important;
           padding-right: var(--global-dimension-static-size-300) !important;
           color: var(--global-text-color-900);
           font-size: var(--global-font-size-s);

--- a/app/src/components/trace/__tests__/utils.test.ts
+++ b/app/src/components/trace/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import type { ISpanItem } from "../types";
-import { compareTimestamps, createSpanTree } from "../utils";
+import { compareTimestamps, createSpanTree, filterSpanTree } from "../utils";
 
 describe("compareTimestamps", () => {
   it("correctly orders timestamps with sub-millisecond precision", () => {
@@ -214,5 +214,78 @@ describe("createSpanTree", () => {
         },
       ]
     `);
+  });
+
+  it("filters matching spans while preserving ancestor context", () => {
+    expect(filterSpanTree(createSpanTree(traceSpans), "embed"))
+      .toMatchInlineSnapshot(`
+        [
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": [],
+                    "span": {
+                      "endTime": "2023-08-16T22:27:15.327439",
+                      "id": "5",
+                      "latencyMs": 118,
+                      "name": "embedding",
+                      "parentId": "de0d1e57-70d4-4b2b-a100-30b706902da3",
+                      "spanId": "86433110-f83a-429e-b6e9-5f23131d14f7",
+                      "spanKind": "embedding",
+                      "startTime": "2023-08-16T22:27:15.327439",
+                      "statusCode": "OK",
+                      "trace": {
+                        "traceId": "c399b6c1-2826-4e4c-90f4-068afccb81c2",
+                      },
+                    },
+                  },
+                ],
+                "span": {
+                  "endTime": "2023-08-16T22:27:15.327415",
+                  "id": "4",
+                  "latencyMs": 352,
+                  "name": "retrieve",
+                  "parentId": "86d5abea-ca78-4e59-a3f7-02548bb4e19a",
+                  "spanId": "de0d1e57-70d4-4b2b-a100-30b706902da3",
+                  "spanKind": "retriever",
+                  "startTime": "2023-08-16T22:27:15.327415",
+                  "statusCode": "OK",
+                  "tokenCountTotal": null,
+                  "trace": {
+                    "traceId": "c399b6c1-2826-4e4c-90f4-068afccb81c2",
+                  },
+                },
+              },
+            ],
+            "span": {
+              "endTime": "2023-08-16T22:27:15.327378",
+              "id": "1",
+              "latencyMs": 2275,
+              "name": "query",
+              "parentId": null,
+              "spanId": "86d5abea-ca78-4e59-a3f7-02548bb4e19a",
+              "spanKind": "chain",
+              "startTime": "2023-08-16T22:27:15.327378",
+              "statusCode": "OK",
+              "trace": {
+                "traceId": "c399b6c1-2826-4e4c-90f4-068afccb81c2",
+              },
+            },
+          },
+        ]
+      `);
+  });
+
+  it("returns the original tree for an empty search query", () => {
+    const spanTree = createSpanTree(traceSpans);
+    expect(filterSpanTree(spanTree, " ")).toBe(spanTree);
+  });
+
+  it("returns no branches when the search has no matches", () => {
+    expect(filterSpanTree(createSpanTree(traceSpans), "not-present")).toEqual(
+      []
+    );
   });
 });

--- a/app/src/components/trace/utils.ts
+++ b/app/src/components/trace/utils.ts
@@ -64,3 +64,43 @@ export function createSpanTree<TSpan extends ISpanItem>(
   );
   return rootSpans;
 }
+
+function spanMatchesSearchQuery(span: ISpanItem, normalizedQuery: string) {
+  return [span.name, span.spanKind, span.statusCode, span.id, span.spanId].some(
+    (value) => value.toLowerCase().includes(normalizedQuery)
+  );
+}
+
+function filterSpanTreeNode<TSpan extends ISpanItem>(
+  node: SpanTreeNode<TSpan>,
+  normalizedQuery: string
+): SpanTreeNode<TSpan> | null {
+  const children = node.children.flatMap((childNode) => {
+    const filteredChildNode = filterSpanTreeNode(childNode, normalizedQuery);
+    return filteredChildNode ? [filteredChildNode] : [];
+  });
+  if (spanMatchesSearchQuery(node.span, normalizedQuery) || children.length) {
+    return {
+      span: node.span,
+      children,
+    };
+  }
+  return null;
+}
+
+/**
+ * Filter a span tree to matching spans while preserving ancestor context.
+ */
+export function filterSpanTree<TSpan extends ISpanItem>(
+  spanTree: SpanTreeNode<TSpan>[],
+  searchQuery: string
+): SpanTreeNode<TSpan>[] {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return spanTree;
+  }
+  return spanTree.flatMap((node) => {
+    const filteredNode = filterSpanTreeNode(node, normalizedQuery);
+    return filteredNode ? [filteredNode] : [];
+  });
+}

--- a/app/src/components/trace/utils.ts
+++ b/app/src/components/trace/utils.ts
@@ -1,15 +1,32 @@
 import type { ISpanItem } from "./types";
 
+/**
+ * Tree node used by trace tree renderers.
+ *
+ * @typeParam TSpan - Span shape stored in the tree. Must include the span
+ * fields needed by the caller, and is commonly constrained to `ISpanItem`.
+ */
 export type SpanTreeNode<TSpan> = {
+  /** Span represented by this node. */
   span: TSpan;
+
+  /** Child spans whose `parentId` points to this node's `spanId`. */
   children: SpanTreeNode<TSpan>[];
 };
 
 /**
  * Compare two ISO 8601 timestamp strings with sub-millisecond precision.
  *
- * Handles timestamps with different timezone offsets by using Date for conversion.
- * Preserves sub-millisecond precision by comparing fractional seconds as floats.
+ * @remarks
+ * JavaScript `Date` normalizes timezone offsets but only preserves millisecond
+ * precision. When two timestamps normalize to the same millisecond, this
+ * comparator falls back to fractional-second comparison so traces with
+ * microsecond/nanosecond timestamps render in their original order.
+ *
+ * @param a - First ISO 8601 timestamp string.
+ * @param b - Second ISO 8601 timestamp string.
+ * @returns `-1` when `a` is earlier, `1` when `a` is later, and `0` when the
+ * timestamps are equal at their represented precision.
  */
 export function compareTimestamps(a: string, b: string): number {
   const dateA = new Date(a);
@@ -26,8 +43,20 @@ export function compareTimestamps(a: string, b: string): number {
 }
 
 /**
- * Create a span tree from a list of spans
- * @param spans
+ * Creates a chronologically sorted tree from a flat list of spans.
+ *
+ * @remarks
+ * Parent/child relationships are built from `spanId` and `parentId`. Spans with
+ * `parentId === null` become roots. Spans whose parent is absent from the input
+ * are also treated as roots so partially loaded traces still render instead of
+ * dropping orphaned spans.
+ *
+ * Root spans and each node's children are sorted by `startTime` using
+ * {@link compareTimestamps}, preserving sub-millisecond ordering.
+ *
+ * @typeParam TSpan - Span item type retained on each tree node.
+ * @param spans - Flat span list from a single trace or trace-like collection.
+ * @returns Root span nodes, each with recursively populated `children`.
  */
 export function createSpanTree<TSpan extends ISpanItem>(
   spans: TSpan[]
@@ -65,12 +94,34 @@ export function createSpanTree<TSpan extends ISpanItem>(
   return rootSpans;
 }
 
+/**
+ * Checks whether a span should be included for a normalized search query.
+ *
+ * @param span - Span to inspect.
+ * @param normalizedQuery - Lowercase, trimmed search query.
+ * @returns `true` when the query appears in the span name, kind, status, Relay
+ * node id, or OpenTelemetry span id.
+ */
 function spanMatchesSearchQuery(span: ISpanItem, normalizedQuery: string) {
   return [span.name, span.spanKind, span.statusCode, span.id, span.spanId].some(
     (value) => value.toLowerCase().includes(normalizedQuery)
   );
 }
 
+/**
+ * Filters a single span tree node while retaining matching descendants.
+ *
+ * @remarks
+ * A node is retained when it directly matches the query or when at least one of
+ * its descendants matches. In the descendant case, the returned node preserves
+ * ancestor context but contains only the filtered child branches.
+ *
+ * @typeParam TSpan - Span item type retained on each tree node.
+ * @param node - Node to filter.
+ * @param normalizedQuery - Lowercase, trimmed search query.
+ * @returns A filtered copy of `node`, or `null` when neither it nor any
+ * descendant matches.
+ */
 function filterSpanTreeNode<TSpan extends ISpanItem>(
   node: SpanTreeNode<TSpan>,
   normalizedQuery: string
@@ -90,6 +141,17 @@ function filterSpanTreeNode<TSpan extends ISpanItem>(
 
 /**
  * Filter a span tree to matching spans while preserving ancestor context.
+ *
+ * @remarks
+ * Search is case-insensitive and matches span name, kind, status, Relay node
+ * id, and OpenTelemetry span id. Ancestors of matching spans are kept so the UI
+ * can show how a matching span fits into the trace. Empty or whitespace-only
+ * queries return the original tree reference to avoid unnecessary re-rendering.
+ *
+ * @typeParam TSpan - Span item type retained on each tree node.
+ * @param spanTree - Root nodes to filter.
+ * @param searchQuery - Raw search text from the trace tree search field.
+ * @returns Filtered root nodes. Returns `spanTree` unchanged for an empty query.
  */
 export function filterSpanTree<TSpan extends ISpanItem>(
   spanTree: SpanTreeNode<TSpan>[],


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/7695
## Summary
- Replace the trace tree "Trace" header with a quiet "Search trace" field.
- Debounce trace-tree search updates and filter visible spans while preserving ancestor context.
- Keep matching branches expanded during search and add unit coverage for tree filtering.

## Validation
- make typecheck-frontend
- pnpm run --silent fmt:check
- make lint-frontend
- make relay-build
- pnpm run --silent generate:openapi
- make schema-generative-ui
- make test-frontend
- make build-frontend