### PR TITLE
test: assert fixture sandbox config is present, not the only config

### DIFF
--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -104,21 +104,29 @@ async def test_sandbox_providers_returns_nested_configs(
         SANDBOX_ADAPTER_METADATA[provider.backend_type].supported_languages
     )
     assert provider_result["enabled"] is True
-    assert provider_result["configs"] == [
-        {
-            "id": str(GlobalID("SandboxConfig", str(sandbox_config.id))),
-            "name": sandbox_config.name.root,
-            "description": sandbox_config.description,
-            "language": sandbox_config.language,
-            "timeout": sandbox_config.timeout,
-            "enabled": sandbox_config.enabled,
-            "config": {
-                "envVars": [],
-                "internetAccess": None,
-                "dependencies": None,
-            },
-        }
-    ]
+
+    # `configs` holds every config for the provider. Built-in defaults may be seeded at
+    # startup (e.g. `default-wasm-python` when the WASM adapter registers because
+    # `wasmtime` is installed), so assert the fixture config is present by id rather than
+    # that it is the only config. See issue #13925.
+    config_result = next(
+        config
+        for config in provider_result["configs"]
+        if config["id"] == str(GlobalID("SandboxConfig", str(sandbox_config.id)))
+    )
+    assert config_result == {
+        "id": str(GlobalID("SandboxConfig", str(sandbox_config.id))),
+        "name": sandbox_config.name.root,
+        "description": sandbox_config.description,
+        "language": sandbox_config.language,
+        "timeout": sandbox_config.timeout,
+        "enabled": sandbox_config.enabled,
+        "config": {
+            "envVars": [],
+            "internetAccess": None,
+            "dependencies": None,
+        },
+    }
 
 
 async def test_sandbox_backends_and_providers_can_be_loaded_together(


### PR DESCRIPTION
resolves #13925

## Root cause

`test_sandbox_providers_returns_nested_configs` asserted that the WASM provider returns *exactly* the fixture-created `test-sandbox-config`. That assertion is environment-dependent: when `wasmtime` is importable, the WASM adapter registers and app startup seeds `default-wasm-python` before the fixture inserts its row, so `sandboxProviders.configs` comes back with the seeded default **and** the fixture config, and the exact-list equality fails.

A default local `uv sync` installs `wasmtime` (the dev group), so the test is red locally. CI's `unit_tests` tox env does not install `wasmtime`, so nothing is seeded and the test stays green — the local-vs-CI split described in the issue.

## Fix (test only)

Treat `sandboxProviders.configs` as "all configs for the provider": look the fixture config up by id (mirroring the existing `provider_result = next(...)` lookup just above) and assert its full shape, rather than asserting it is the only config. No product code is touched.

## Verification

Reproduced on a clean `uv sync`, which installs `wasmtime==45.0.0`:

- **Before:** `test_sandbox_providers_returns_nested_configs[sqlite]` fails — the query returns `default-wasm-python` plus `test-sandbox-config`, so the count differs.
- **After, with `wasmtime` installed:** `tests/unit/server/api/test_sandbox_queries.py` passes (4 passed, 4 skipped — the `[postgresql]` variants skip under the default `--db sqlite` run).
- **After, without `wasmtime`** (uninstalled from the venv to match the CI env): same file passes (4 passed, 4 skipped).
