### PR TITLE
fix(skills): tighten PXI trigger scoping and close benchmark coverage gap

### DIFF
--- a/evals/pxi/datasets/annotate_spans_skill_trigger.yaml
+++ b/evals/pxi/datasets/annotate_spans_skill_trigger.yaml
@@ -1,0 +1,235 @@
+dataset_name: annotate_spans_skill_trigger
+description: >-
+  PXI server-side eval suite for the annotate-spans skill trigger correctness.
+  Tests whether the agent calls load_skill(skill_name="annotate-spans") when the
+  user wants to record structured feedback on spans/traces — annotate, label,
+  score, review — or asks how to annotate or build a feedback taxonomy (positive
+  cases), and correctly avoids triggering it for pure analysis with no intent to
+  save feedback, latency/cost statistics, trace filtering, and prompt authoring
+  that route to a sibling skill or no skill (negative cases). annotate-spans is
+  always available (it is in the base skill list), so positives use the default
+  project context.
+  NOTE: authored from the skill spec without a live model run. Examples sit in
+  the `dev` split until a maintainer validates them against the live PXI agent
+  (requires model credentials) and promotes the passing ones to `regression`.
+evaluators:
+  - correct_tools_called
+  - tool_call_args_match
+  - forbidden_tool_call_args_match
+
+examples:
+
+  # ===== Positive triggers: annotate-spans skill should fire =====
+
+  - id: annotate-relevance
+    splits: [dev]
+    input:
+      messages:
+        - role: user
+          content: Annotate these spans with whether the answer was relevant to the question.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      category: write_annotations
+      difficulty: obvious
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Explicit request to record structured feedback with a named
+          dimension — core annotate-spans use. Awaiting live regression run.
+
+  - id: label-failing-traces
+    splits: [dev]
+    input:
+      messages:
+        - role: user
+          content: Label the failing traces so I can filter on them later.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      category: write_annotations
+      difficulty: obvious
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Labeling for later filtering is the annotate-spans "filterable"
+          rationale. Awaiting live run.
+
+  - id: how-to-annotate-hallucinations
+    splits: [dev]
+    input:
+      messages:
+        - role: user
+          content: How should I annotate my traces to keep track of hallucinations?
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      category: coaching
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          "How do I annotate" coaching request — Mode A of the skill. Awaiting
+          live run.
+
+  - id: build-failure-taxonomy
+    splits: [dev]
+    input:
+      messages:
+        - role: user
+          content: Help me build a failure taxonomy I can review my traces against.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      category: taxonomy_design
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: medium
+        n_opinions: 1
+        notes: >-
+          Feedback-taxonomy design is named in the skill description. Medium
+          because taxonomy work can start in debug-trace to surface failure
+          modes first; the review/label framing routes it here. Awaiting live
+          run.
+
+  - id: score-and-save-feedback
+    splits: [dev]
+    input:
+      messages:
+        - role: user
+          content: Score these responses pass or fail and save the feedback on the spans.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      category: write_annotations
+      difficulty: obvious
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Explicit score + persist feedback — batch_span_annotate territory.
+          Awaiting live run.
+
+  # ===== Negative triggers: annotate-spans skill should NOT fire =====
+  # Uses forbidden_tool_call_args so a legitimate load_skill for the correct
+  # sibling skill in the same turn does not fail the example.
+
+  - id: negative-debug-traces
+    splits: [dev]
+    input:
+      messages:
+        - role: user
+          content: What's going wrong with my agent?
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      negative: true
+      category: negative_pure_analysis
+      difficulty: obvious
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Pure diagnosis with no intent to save feedback routes to debug-trace.
+          The skill description excludes this explicitly. Awaiting live run.
+
+  - id: negative-average-latency
+    splits: [dev]
+    input:
+      messages:
+        - role: user
+          content: What's the average latency of my spans?
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      negative: true
+      category: negative_statistics
+      difficulty: obvious
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Latency statistic answerable with a direct read; the skill excludes
+          latency/cost stats. Awaiting live run.
+
+  - id: negative-filter-errors
+    splits: [dev]
+    input:
+      messages:
+        - role: user
+          content: Show me only traces with errors.
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      negative: true
+      category: negative_filter
+      difficulty: moderate
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Trace filter intent maps to set_spans_filter, not annotation.
+          Awaiting live run.
+
+  - id: negative-rewrite-prompt
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: Make this prompt clearer and shorter.
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: annotate-spans
+    metadata:
+      negative: true
+      category: negative_prompt_authoring
+      difficulty: moderate
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Prompt authoring routes to playground; the skill excludes prompt
+          authoring explicitly. Awaiting live run.

--- a/evals/pxi/datasets/datasets_skill_trigger.yaml
+++ b/evals/pxi/datasets/datasets_skill_trigger.yaml
@@ -1,0 +1,293 @@
+dataset_name: datasets_skill_trigger
+description: >-
+  PXI server-side eval suite for the datasets skill trigger correctness.
+  Tests whether the agent calls load_skill(skill_name="datasets") when the
+  user, with a dataset mounted, asks a conceptual/judgment question about the
+  dataset itself — what a dataset is, how splits work, what a saved output
+  "means" (golden vs. baseline/reference), row consistency, or aligning a
+  dataset's fields with a prompt's variables (positive cases) — and correctly
+  avoids triggering it for running/comparing experiments, evaluator authoring,
+  prompt iteration, closed-form reads, and trace diagnosis that route to a
+  sibling skill or no skill (negative cases). Every positive carries a dataset
+  context, because the datasets skill is gated into the catalog on
+  dataset-context presence; without it load_skill cannot resolve the name.
+  NOTE: authored from the skill spec without a live model run. Examples sit in
+  the `dev` split until a maintainer validates them against the live PXI agent
+  (requires model credentials) and promotes the passing ones to `regression`.
+evaluators:
+  - correct_tools_called
+  - tool_call_args_match
+  - forbidden_tool_call_args_match
+
+examples:
+
+  # ===== Positive triggers: datasets skill should fire =====
+
+  - id: what-does-output-mean
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: What does the output saved on this row actually mean — is it the correct answer?
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      category: output_provenance
+      difficulty: obvious
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Golden-vs-baseline output-provenance question — the central judgment
+          the datasets skill teaches. Lead-annotated from the skill spec;
+          awaiting a live regression run.
+
+  - id: how-do-splits-work
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: How do the train and test splits work here, and is it OK to tune on the test split?
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      category: splits_semantics
+      difficulty: obvious
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Split-semantics + held-out-test judgment, directly covered by the
+          skill's Splits section. Lead-annotated; awaiting live validation.
+
+  - id: what-is-this-dataset
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: I'm new to this — what even is this dataset and what am I looking at?
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      category: dataset_concept
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: medium
+        n_opinions: 1
+        notes: >-
+          Conceptual "what is a dataset" question. Medium because the agent
+          could also answer definitionally without loading the skill; the
+          skill's reasoning guidance is the intended route. Awaiting live run.
+
+  - id: prompt-variable-binding
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: My prompt has a {{customer_message}} variable but the run comes back empty. Help me understand why.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      category: field_variable_alignment
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: medium
+        n_opinions: 1
+        notes: >-
+          Field-to-template-variable binding failure — the skill's "matching a
+          dataset to the prompt" section names the empty-output symptom exactly.
+          Sits near playground; the ask is to understand the dataset binding,
+          not to author a prompt. Awaiting live validation.
+
+  - id: row-shape-consistency
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: Some rows have a "question" field and others have "prompt". Is that a problem?
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      category: row_consistency
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: medium
+        n_opinions: 1
+        notes: >-
+          Row-shape consistency judgment from the skill's "keep rows uniform"
+          guidance. Lead-annotated; awaiting live run.
+
+  # ===== Negative triggers: datasets skill should NOT fire =====
+  # Uses forbidden_tool_call_args so a legitimate load_skill for the correct
+  # sibling skill in the same turn does not fail the example.
+
+  - id: negative-example-count
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: How many examples are in this dataset?
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      negative: true
+      category: negative_closed_form_read
+      difficulty: obvious
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Closed-form count answerable with a direct phoenix-gql read; needs no
+          dataset-reasoning methodology. Mirrors the experiments suite's
+          negative-tell-me-about-dataset. Awaiting live run.
+
+  - id: negative-run-experiment
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: Run my prompt over this dataset and tell me how it does.
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      negative: true
+      category: negative_experiment_run
+      difficulty: obvious
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Dataset-backed experiment run routes to experiments, not the datasets
+          reasoning skill, even though both surface on a mounted dataset.
+          Awaiting live run.
+
+  - id: negative-author-evaluator
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: Write an evaluator that scores whether the answer is correct on this dataset.
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      negative: true
+      category: negative_evaluator_authoring
+      difficulty: moderate
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Authoring a scorer routes to evaluators, not datasets. Awaiting live
+          run.
+
+  - id: negative-rewrite-prompt
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: Rewrite this system prompt to be more concise.
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      negative: true
+      category: negative_prompt_iteration
+      difficulty: moderate
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Pure prompt rewrite routes to playground, not datasets. Awaiting live
+          run.
+
+  - id: negative-debug-traces
+    splits: [dev]
+    input:
+      contexts:
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: What's going wrong with my agent's traces?
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: datasets
+    metadata:
+      negative: true
+      category: negative_trace_diagnosis
+      difficulty: obvious
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Cross-trace failure diagnosis routes to debug-trace. Dataset presence
+          must not pull the datasets skill onto a diagnosis ask. Awaiting live
+          run.

--- a/evals/pxi/datasets/playground_skill_trigger.yaml
+++ b/evals/pxi/datasets/playground_skill_trigger.yaml
@@ -1,0 +1,302 @@
+dataset_name: playground_skill_trigger
+description: >-
+  PXI server-side eval suite for the playground skill trigger correctness.
+  Tests whether the agent calls load_skill(skill_name="playground") when the
+  user, with a playground instance mounted, asks to author, edit, run, compare,
+  or save a prompt, or to add/refine a function tool (positive cases), and
+  correctly avoids triggering it for experiment-results interpretation,
+  evaluator authoring, dataset-concept questions, and trace diagnosis that route
+  to a sibling skill (negative cases). Every positive carries a playground
+  context, because the playground skill is gated into the catalog on
+  playground-context presence; without it load_skill cannot resolve the name.
+  NOTE: authored from the skill spec without a live model run. Examples sit in
+  the `dev` split until a maintainer validates them against the live PXI agent
+  (requires model credentials) and promotes the passing ones to `regression`.
+evaluators:
+  - correct_tools_called
+  - tool_call_args_match
+  - forbidden_tool_call_args_match
+
+examples:
+
+  # ===== Positive triggers: playground skill should fire =====
+
+  - id: rewrite-prompt-concise
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: Rewrite this system prompt to be more concise.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      category: single_shot_rewrite
+      difficulty: obvious
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Single-shot prompt rewrite — the skill description names this as a
+          load trigger explicitly ("including single-shot prompt rewrites").
+          Awaiting live regression run.
+
+  - id: add-output-format
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: Add an instruction so the model always replies with JSON matching my schema.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      category: prompt_edit
+      difficulty: obvious
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Prompt edit to the mounted instance (output contract). Playground
+          authoring mechanics. Awaiting live run.
+
+  - id: add-function-tool
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: Give the model a get_weather function it can call from this prompt.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      category: function_tool_authoring
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Function-tool authoring on the playground instance — covered by the
+          skill's "author, refine, or remove a function tool" workflow.
+          Awaiting live run.
+
+  - id: run-and-see-output
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: Try running this prompt and show me what it produces.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      category: run_playground
+      difficulty: obvious
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Manual run of the mounted prompt (no dataset loop). Playground
+          run/read mechanics. Awaiting live run.
+
+  - id: create-comparison-variant
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: Make a second version so I can compare two phrasings side by side.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      category: add_instance
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Adding/cloning a comparison instance — the skill's variant-comparison
+          mechanic. Manual comparison, no dataset-scored experiment. Awaiting
+          live run.
+
+  - id: save-prompt
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: This looks good — save it.
+    expected:
+      tools:
+        required: [load_skill]
+      tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      category: save_prompt
+      difficulty: moderate
+      polarity: positive
+      annotation:
+        agreement: medium
+        n_opinions: 1
+        notes: >-
+          Save request maps to the playground save_prompt mechanic. Medium
+          because a terse "save it" leans on mounted-context to disambiguate.
+          Awaiting live run.
+
+  # ===== Negative triggers: playground skill should NOT fire =====
+  # Uses forbidden_tool_call_args so a legitimate load_skill for the correct
+  # sibling skill in the same turn does not fail the example.
+
+  - id: negative-compare-experiments
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: Which of my two experiment runs scored higher overall?
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      negative: true
+      category: negative_experiment_comparison
+      difficulty: moderate
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Interpreting/comparing experiment results routes to experiments, not
+          playground — the new "Do NOT trigger" boundary on the playground
+          skill. Awaiting live run.
+
+  - id: negative-author-judge
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+        - type: llm_evaluator
+      messages:
+        - role: user
+          content: Write a judge that scores whether the answer is grounded in the context.
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      negative: true
+      category: negative_evaluator_authoring
+      difficulty: moderate
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Evaluator authoring routes to evaluators, not playground, even with a
+          playground instance mounted. Awaiting live run.
+
+  - id: negative-debug-traces
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+      messages:
+        - role: user
+          content: What's going wrong with my agent?
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      negative: true
+      category: negative_trace_diagnosis
+      difficulty: obvious
+      polarity: negative
+      annotation:
+        agreement: high
+        n_opinions: 1
+        notes: >-
+          Cross-trace diagnosis routes to debug-trace. Awaiting live run.
+
+  - id: negative-dataset-output-meaning
+    splits: [dev]
+    input:
+      contexts:
+        - type: playground
+          instances:
+            - instanceId: 101
+        - type: dataset
+          datasetNodeId: RGF0YXNldDox
+      messages:
+        - role: user
+          content: What does a saved output on a dataset row actually mean?
+    expected:
+      forbidden_tool_call_args:
+        load_skill:
+          skill_name: playground
+    metadata:
+      negative: true
+      category: negative_dataset_concept
+      difficulty: tricky
+      polarity: negative
+      annotation:
+        agreement: medium
+        n_opinions: 1
+        notes: >-
+          Dataset output-provenance question routes to the datasets skill, not
+          playground. Tricky because a playground instance is mounted, but the
+          ask is conceptual about the dataset. Awaiting live run.

--- a/src/phoenix/server/agents/prompts/skills/datasets/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/datasets/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: datasets
 description: >
-  Understand what a Phoenix dataset is and reason well about its examples, outputs, splits, and how it feeds evaluators and experiments. Load this whenever a dataset is in view or the user asks what a dataset is, how splits work, what an output "means", or how datasets relate to experiments and evals. This skill governs the judgment; any tool descriptions govern the mechanics.
+  Understand what a Phoenix dataset is and reason well about its examples, outputs, splits, and how it feeds evaluators and experiments. Load when the user asks what a dataset is, how splits work, what a saved output "means" (golden vs. baseline/reference), how to keep rows consistent, or how to align a dataset's fields with a prompt's variables. Do NOT trigger on: (1) running or comparing dataset-backed experiments (use `experiments`), (2) authoring or refining an evaluator (use `evaluators`), (3) prompt authoring in the playground (use `playground`), (4) closed-form reads answerable with a direct query, e.g. "how many examples are in this dataset" (no skill needed). This skill governs the judgment; any tool descriptions govern the mechanics.
 summary: Reason well about Phoenix datasets — examples, outputs, splits, labels — and how they feed evaluators and experiments.
 ---
 

--- a/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
+++ b/src/phoenix/server/agents/prompts/skills/playground/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: playground
-description: Author, edit, or iterate on prompts in the Phoenix prompt playground, including running experiments over a dataset. Load before any playground tool call, including single-shot prompt rewrites.
+description: >
+  Author, edit, or iterate on prompts in the Phoenix prompt playground, including setting up and starting a run over a dataset. Load before any playground tool call, including single-shot prompt rewrites. Do NOT trigger on: (1) interpreting or comparing dataset-backed experiment results, or the run-and-compare methodology itself (use `experiments`), (2) designing or refining an evaluator's logic or rubric (use `evaluators`), (3) cross-trace failure diagnosis (use `debug-trace`).
 summary: Author, edit, run, compare, and improve prompts in the Phoenix playground.
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A complete audit of the repo's agent skills, focused on making the PXI server-side product skills (the ones a Sonnet/Opus/GPT-class agent loads at runtime via `load_skill`) **well scoped** and **benchmarked**. Two skill systems exist:

- **`.agents/skills/` (28 coding-agent skills)** — audited via a deterministic frontmatter-compliance lint. All are spec-compliant (kebab-case names ≤64 chars, descriptions present and ≤1024 chars, names match directories). No structural fixes needed.
- **`src/phoenix/server/agents/prompts/skills/` (7 PXI product skills)** — where scoping and benchmark gaps were found and patched.

### Findings & fixes (PXI product skills)

**1. Scoping gaps — skill descriptions gate/route `load_skill` triggering.**
- `playground` had **no "Do NOT trigger" boundary** — the only user-triggered skill missing one (every sibling has one). Added boundaries routing results-interpretation → `experiments`, evaluator design → `evaluators`, trace diagnosis → `debug-trace`.
- `datasets` triggered "**whenever a dataset is in view**" — over-broad, since dataset context also gates `experiments` and `evaluators` into the catalog. Narrowed to intent-based conceptual questions and added a "Do NOT trigger" boundary (run/compare → `experiments`, author scorer → `evaluators`, prompt work → `playground`, closed-form reads → no skill).

**2. Benchmark coverage gap.** Only 3 of the triggerable skills had trigger benchmarks (`debug-trace`, `evaluators`, `experiments`). Added trigger suites for the three missing user-triggered skills — `datasets`, `playground`, `annotate-spans` — with balanced positive/negative examples grounded in each skill's description and the context-gating in `build_skills`.

### Testing

Live model-triggering benchmarks require model credentials (`OPENAI_API_KEY`/`ANTHROPIC_API_KEY`) and a running Phoenix server, which are **not available in this environment**, so the new examples are in the `dev` split (CI's `regression` gate skips them) pending one live run before promotion. Everything offline-verifiable was run:

- ✅ `uv run python -m pytest tests/unit/pxi/` — 174 passed
- ✅ `uv run python -m pytest tests/unit/server/agents/.../skills/ test_skill_requests.py test_server_agents.py` — 39 passed (edited descriptions still parse and render into the skill catalog)
- ✅ Schema validation of all 16 datasets via `load_dataset`
- ✅ New datasets: evaluators + `skill_name` references resolve, ids unique, contexts/messages build through the harness, and **every positive example's target skill is gated into the catalog for its declared contexts** (the exact `load_skill` name-resolution failure the dataset-authoring skill warns about)
- ⚠️ Live PXI trigger runs (`run_experiment.py`) not executed — no model credentials in this env

### Follow-up
A maintainer with model credentials should run the three new suites (`run_experiment.py --dataset <name> --splits dev`), triage any misses, and promote passing examples to `regression`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3599-3e44-7649-95a9-0bff2d1c3f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3599-3e44-7649-95a9-0bff2d1c3f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

