### PR TITLE
feat(evals): add Evaluators tab to the project page

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -66,6 +66,7 @@ import {
   PlaygroundPage,
   playgroundPageLoader,
   ProfilePage,
+  ProjectEvaluatorsPage,
   ProjectIndexPage,
   projectLoader,
   ProjectMetricsPage,
@@ -305,6 +306,17 @@ export const appRouteObjects = createRoutesFromElements(
                     label: "Project Metrics",
                     description:
                       "View project time-series metrics, token usage breakdowns, cache read/write token charts, and observability panels.",
+                  },
+                }}
+              />
+              <Route
+                path="evaluators"
+                element={<ProjectEvaluatorsPage />}
+                handle={{
+                  agentRoute: {
+                    label: "Project Evaluators",
+                    description:
+                      "View and add project evaluators — online evals that automatically run against live spans, traces, and sessions.",
                   },
                 }}
               />

--- a/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
@@ -9,8 +9,11 @@ import {
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
+import { CodeEvaluatorForm } from "@phoenix/components/evaluators/CodeEvaluatorForm";
+import { EvaluatorDatasetTestPanel } from "@phoenix/components/evaluators/EvaluatorDatasetTestPanel";
 import { EvaluatorForm } from "@phoenix/components/evaluators/EvaluatorForm";
 import { CodeEvaluatorInputVariablesProvider } from "@phoenix/components/evaluators/EvaluatorInputVariablesContext/CodeEvaluatorInputVariablesProvider";
+import { EvaluatorNameAndDescriptionFields } from "@phoenix/components/evaluators/EvaluatorNameAndDescriptionFields";
 import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 
 export const EditBuiltInEvaluatorDialogContent = ({
@@ -95,7 +98,15 @@ export const EditBuiltInEvaluatorDialogContent = ({
         <CodeEvaluatorInputVariablesProvider
           evaluatorInputSchema={evaluatorInputSchema}
         >
-          <EvaluatorForm />
+          <EvaluatorForm
+            left={
+              <>
+                <EvaluatorNameAndDescriptionFields />
+                <CodeEvaluatorForm />
+              </>
+            }
+            right={<EvaluatorDatasetTestPanel />}
+          />
         </CodeEvaluatorInputVariablesProvider>
       </fieldset>
     </DialogContent>

--- a/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -11,8 +11,11 @@ import {
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
+import { EvaluatorDatasetTestPanel } from "@phoenix/components/evaluators/EvaluatorDatasetTestPanel";
 import { EvaluatorForm } from "@phoenix/components/evaluators/EvaluatorForm";
 import { LLMEvaluatorInputVariablesProvider } from "@phoenix/components/evaluators/EvaluatorInputVariablesContext/LLMEvaluatorInputVariablesProvider";
+import { EvaluatorNameAndDescriptionFields } from "@phoenix/components/evaluators/EvaluatorNameAndDescriptionFields";
+import { LLMEvaluatorForm } from "@phoenix/components/evaluators/LLMEvaluatorForm";
 import { useLlmEvaluatorDraftRegistration } from "@phoenix/components/evaluators/useLlmEvaluatorDraftRegistration";
 import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 
@@ -128,8 +131,14 @@ export const EditLLMEvaluatorDialogContent = ({
         )}
         <LLMEvaluatorInputVariablesProvider>
           <EvaluatorForm
-            leftPanelExtra={formLeftPanelExtra}
-            rightPanel={formRightPanel}
+            left={
+              <>
+                <EvaluatorNameAndDescriptionFields />
+                {formLeftPanelExtra}
+                <LLMEvaluatorForm />
+              </>
+            }
+            right={formRightPanel ?? <EvaluatorDatasetTestPanel />}
           />
         </LLMEvaluatorInputVariablesProvider>
       </fieldset>

--- a/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { useMemo, useRef, useState } from "react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
@@ -22,6 +22,8 @@ export const EditLLMEvaluatorDialogContent = ({
   mode,
   error,
   evaluatorNodeId,
+  formLeftPanelExtra,
+  formRightPanel,
 }: {
   onClose: () => void;
   onSubmit: () => Promise<EvaluatorSubmitResult>;
@@ -29,6 +31,14 @@ export const EditLLMEvaluatorDialogContent = ({
   mode: "create" | "update";
   error?: string;
   evaluatorNodeId?: string | null;
+  /**
+   * Optional section rendered in the form's left panel below name/description.
+   */
+  formLeftPanelExtra?: ReactNode;
+  /**
+   * Replaces the form's right (test) panel.
+   */
+  formRightPanel?: ReactNode;
 }) => {
   const store = useEvaluatorStoreInstance();
 
@@ -117,7 +127,10 @@ export const EditLLMEvaluatorDialogContent = ({
           </Alert>
         )}
         <LLMEvaluatorInputVariablesProvider>
-          <EvaluatorForm />
+          <EvaluatorForm
+            leftPanelExtra={formLeftPanelExtra}
+            rightPanel={formRightPanel}
+          />
         </LLMEvaluatorInputVariablesProvider>
       </fieldset>
     </DialogContent>

--- a/app/src/components/evaluators/EvaluatorDatasetTestPanel.tsx
+++ b/app/src/components/evaluators/EvaluatorDatasetTestPanel.tsx
@@ -1,0 +1,20 @@
+import { Flex, View } from "@phoenix/components";
+import { EvaluatorExampleDataset } from "@phoenix/components/evaluators/EvaluatorExampleDataset";
+import { EvaluatorInputPreview } from "@phoenix/components/evaluators/EvaluatorInputPreview";
+import { EvaluatorOutputPreview } from "@phoenix/components/evaluators/EvaluatorOutputPreview";
+
+/**
+ * Test an evaluator against dataset examples.
+ * Requires `dataset` to be set in the evaluator store.
+ */
+export const EvaluatorDatasetTestPanel = () => (
+  <Flex direction="column" gap="size-200">
+    <View paddingX="size-200">
+      <Flex direction="column" gap="size-100">
+        <EvaluatorOutputPreview />
+        <EvaluatorExampleDataset />
+      </Flex>
+    </View>
+    <EvaluatorInputPreview />
+  </Flex>
+);

--- a/app/src/components/evaluators/EvaluatorForm.tsx
+++ b/app/src/components/evaluators/EvaluatorForm.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import type { PropsWithChildren } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { useShallow } from "zustand/react/shallow";
@@ -115,7 +115,19 @@ const evaluatorFormSelector = (state: EvaluatorStore) => ({
  * );
  * ```
  */
-export const EvaluatorForm = () => {
+export const EvaluatorForm = ({
+  leftPanelExtra,
+  rightPanel,
+}: {
+  /**
+   * Optional section rendered in the left panel below the name/description row.
+   */
+  leftPanelExtra?: ReactNode;
+  /**
+   * Replaces the right (test) panel. Defaults to the dataset test panel.
+   */
+  rightPanel?: ReactNode;
+}) => {
   const { evaluatorKind } = useEvaluatorStore(
     useShallow(evaluatorFormSelector)
   );
@@ -143,6 +155,7 @@ export const EvaluatorForm = () => {
             <EvaluatorDescriptionInput />
           </Flex>
         </View>
+        {leftPanelExtra}
         {evaluatorKind === "LLM" && <LLMEvaluatorForm />}
         {evaluatorKind === "BUILTIN" && <CodeEvaluatorForm />}
       </Panel>
@@ -158,19 +171,27 @@ export const EvaluatorForm = () => {
           box-sizing: border-box;
         `}
       >
-        <Flex direction="column" gap="size-200">
-          <View paddingX="size-200">
-            <Flex direction="column" gap="size-100">
-              <EvaluatorOutputPreview />
-              <EvaluatorExampleDataset />
-            </Flex>
-          </View>
-          <EvaluatorInputPreview />
-        </Flex>
+        {rightPanel ?? <DatasetTestPanel />}
       </Panel>
     </Group>
   );
 };
+
+/**
+ * The default right panel: test an evaluator against dataset examples.
+ * Requires `dataset` to be set in the evaluator store.
+ */
+const DatasetTestPanel = () => (
+  <Flex direction="column" gap="size-200">
+    <View paddingX="size-200">
+      <Flex direction="column" gap="size-100">
+        <EvaluatorOutputPreview />
+        <EvaluatorExampleDataset />
+      </Flex>
+    </View>
+    <EvaluatorInputPreview />
+  </Flex>
+);
 
 const panelStyle = {
   height: "100%",

--- a/app/src/components/evaluators/EvaluatorForm.tsx
+++ b/app/src/components/evaluators/EvaluatorForm.tsx
@@ -2,24 +2,11 @@ import { css } from "@emotion/react";
 import type { PropsWithChildren, ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Group, Panel, Separator } from "react-resizable-panels";
-import { useShallow } from "zustand/react/shallow";
 
-import { Flex, View } from "@phoenix/components";
-import { CodeEvaluatorForm } from "@phoenix/components/evaluators/CodeEvaluatorForm";
-import { EvaluatorDescriptionInput } from "@phoenix/components/evaluators/EvaluatorDescriptionInput";
-import { EvaluatorExampleDataset } from "@phoenix/components/evaluators/EvaluatorExampleDataset";
-import { EvaluatorInputPreview } from "@phoenix/components/evaluators/EvaluatorInputPreview";
-import { EvaluatorNameInput } from "@phoenix/components/evaluators/EvaluatorNameInput";
-import { EvaluatorOutputPreview } from "@phoenix/components/evaluators/EvaluatorOutputPreview";
 import { EvaluatorPlaygroundProvider } from "@phoenix/components/evaluators/EvaluatorPlaygroundProvider";
-import { LLMEvaluatorForm } from "@phoenix/components/evaluators/LLMEvaluatorForm";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
-import { useEvaluatorStore } from "@phoenix/contexts/EvaluatorContext";
 import type { fetchPlaygroundPrompt_promptVersionToInstance_promptVersion$key } from "@phoenix/pages/playground/__generated__/fetchPlaygroundPrompt_promptVersionToInstance_promptVersion.graphql";
-import {
-  DEFAULT_STORE_VALUES,
-  type EvaluatorStore,
-} from "@phoenix/store/evaluatorStore";
+import { DEFAULT_STORE_VALUES } from "@phoenix/store/evaluatorStore";
 import type { ClassificationEvaluatorAnnotationConfig } from "@phoenix/types";
 import type {
   EvaluatorInputMapping as EvaluatorInputMappingType,
@@ -95,42 +82,31 @@ export const EvaluatorFormProvider = ({
   );
 };
 
-const evaluatorFormSelector = (state: EvaluatorStore) => ({
-  evaluatorKind: state.evaluator.kind,
-  isBuiltin: state.evaluator.isBuiltin,
-});
-
 /**
- * A form for configuring evaluators.
- * Depends on the EvaluatorFormProvider to provide the react-hook-form instance for the evaluator form and new
- * default playground state for the evaluator chat template.
+ * The two-panel resizable layout for configuring evaluators. Callers provide
+ * the content of each panel.
  *
  * @example
  * ```tsx
- * const form = useEvaluatorForm();
- * return (
- *   <EvaluatorFormProvider form={form}>
- *     <EvaluatorForm />
- *   </EvaluatorFormProvider>
- * );
+ * <EvaluatorForm
+ *   left={<LLMEvaluatorForm />}
+ *   right={<EvaluatorDatasetTestPanel />}
+ * />
  * ```
  */
 export const EvaluatorForm = ({
-  leftPanelExtra,
-  rightPanel,
+  left,
+  right,
 }: {
   /**
-   * Optional section rendered in the left panel below the name/description row.
+   * The content of the left (configuration) panel.
    */
-  leftPanelExtra?: ReactNode;
+  left: ReactNode;
   /**
-   * Replaces the right (test) panel. Defaults to the dataset test panel.
+   * The content of the right (test) panel.
    */
-  rightPanel?: ReactNode;
+  right: ReactNode;
 }) => {
-  const { evaluatorKind } = useEvaluatorStore(
-    useShallow(evaluatorFormSelector)
-  );
   return (
     <Group orientation="horizontal" style={{ flex: 1, minHeight: 0 }}>
       <Panel
@@ -144,20 +120,7 @@ export const EvaluatorForm = ({
           box-sizing: border-box;
         `}
       >
-        <View marginBottom="size-200" flex="none">
-          <Flex
-            direction="row"
-            alignItems="baseline"
-            width="100%"
-            gap="size-100"
-          >
-            <EvaluatorNameInput />
-            <EvaluatorDescriptionInput />
-          </Flex>
-        </View>
-        {leftPanelExtra}
-        {evaluatorKind === "LLM" && <LLMEvaluatorForm />}
-        {evaluatorKind === "BUILTIN" && <CodeEvaluatorForm />}
+        {left}
       </Panel>
       <Separator css={compactResizeHandleCSS} />
       <Panel
@@ -171,27 +134,11 @@ export const EvaluatorForm = ({
           box-sizing: border-box;
         `}
       >
-        {rightPanel ?? <DatasetTestPanel />}
+        {right}
       </Panel>
     </Group>
   );
 };
-
-/**
- * The default right panel: test an evaluator against dataset examples.
- * Requires `dataset` to be set in the evaluator store.
- */
-const DatasetTestPanel = () => (
-  <Flex direction="column" gap="size-200">
-    <View paddingX="size-200">
-      <Flex direction="column" gap="size-100">
-        <EvaluatorOutputPreview />
-        <EvaluatorExampleDataset />
-      </Flex>
-    </View>
-    <EvaluatorInputPreview />
-  </Flex>
-);
 
 const panelStyle = {
   height: "100%",

--- a/app/src/components/evaluators/EvaluatorNameAndDescriptionFields.tsx
+++ b/app/src/components/evaluators/EvaluatorNameAndDescriptionFields.tsx
@@ -1,0 +1,16 @@
+import { Flex, View } from "@phoenix/components";
+import { EvaluatorDescriptionInput } from "@phoenix/components/evaluators/EvaluatorDescriptionInput";
+import { EvaluatorNameInput } from "@phoenix/components/evaluators/EvaluatorNameInput";
+
+/**
+ * The name and description inputs rendered at the top of an evaluator form's
+ * left panel.
+ */
+export const EvaluatorNameAndDescriptionFields = () => (
+  <View marginBottom="size-200" flex="none">
+    <Flex direction="row" alignItems="baseline" width="100%" gap="size-100">
+      <EvaluatorNameInput />
+      <EvaluatorDescriptionInput />
+    </Flex>
+  </View>
+);

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -83,7 +83,14 @@ export function ProjectPage() {
   );
 }
 
-const TABS = ["spans", "traces", "sessions", "config", "metrics"] as const;
+const TABS = [
+  "spans",
+  "traces",
+  "sessions",
+  "config",
+  "metrics",
+  "evaluators",
+] as const;
 
 /**
  * Type guard for the tab path in the URL
@@ -98,6 +105,7 @@ const TAB_INDEX_MAP: Record<(typeof TABS)[number], number> = {
   sessions: 2,
   metrics: 3,
   config: 4,
+  evaluators: 5,
 };
 
 const TAB_PATH_BY_INDEX = Object.fromEntries(
@@ -246,6 +254,7 @@ function ProjectPageContentBody({
             <Tab id="traces">Traces</Tab>
             <Tab id="sessions">Sessions</Tab>
             <Tab id="metrics">Metrics</Tab>
+            <Tab id="evaluators">Evaluators</Tab>
             <Tab id="config">Config</Tab>
           </TabList>
           <LazyTabPanel padded={false} id="spans">
@@ -261,6 +270,9 @@ function ProjectPageContentBody({
             <Outlet />
           </LazyTabPanel>
           <LazyTabPanel padded={false} id="config">
+            <Outlet />
+          </LazyTabPanel>
+          <LazyTabPanel padded={false} id="evaluators">
             <Outlet />
           </LazyTabPanel>
         </Tabs>

--- a/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
+++ b/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import type { MenuTriggerProps } from "react-aria-components";
+import { MenuSection } from "react-aria-components";
+
+import type { ButtonProps } from "@phoenix/components/core/button";
+import { Button } from "@phoenix/components/core/button";
+import { Icon, Icons } from "@phoenix/components/core/icon";
+import {
+  Menu,
+  MenuContainer,
+  MenuItem,
+  MenuSectionTitle,
+  MenuTrigger,
+} from "@phoenix/components/core/menu";
+import { CreateLLMProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/CreateLLMProjectEvaluatorSlideover";
+
+/**
+ * Entry point for adding evaluators to a project. Only LLM evaluators are
+ * supported for now; code, built-in, and template options will be added as
+ * additional menu sections like AddEvaluatorMenu does for datasets.
+ */
+export const AddProjectEvaluatorMenu = ({
+  size,
+  projectId,
+  ...props
+}: {
+  size: ButtonProps["size"];
+  projectId: string;
+} & Omit<MenuTriggerProps, "children">) => {
+  const [isCreateLLMEvaluatorOpen, setIsCreateLLMEvaluatorOpen] =
+    useState(false);
+  return (
+    <>
+      <MenuTrigger {...props}>
+        <Button
+          variant="primary"
+          size={size}
+          leadingVisual={<Icon svg={<Icons.Plus />} />}
+        >
+          Add evaluator
+        </Button>
+        {/* TODO: Remove minHeight once we have more items in the menu */}
+        <MenuContainer minHeight={"auto"}>
+          <Menu
+            aria-label="Add evaluator"
+            onAction={(action) => {
+              if (action === "createEvaluator") {
+                setIsCreateLLMEvaluatorOpen(true);
+              }
+            }}
+          >
+            <MenuSection>
+              <MenuSectionTitle title="New LLM evaluator" />
+              <MenuItem
+                leadingContent={<Icon svg={<Icons.Plus />} />}
+                id="createEvaluator"
+              >
+                Create new LLM evaluator
+              </MenuItem>
+            </MenuSection>
+          </Menu>
+        </MenuContainer>
+      </MenuTrigger>
+      <CreateLLMProjectEvaluatorSlideover
+        isOpen={isCreateLLMEvaluatorOpen}
+        onOpenChange={setIsCreateLLMEvaluatorOpen}
+        projectId={projectId}
+      />
+    </>
+  );
+};

--- a/app/src/pages/project/evaluators/CreateLLMProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/CreateLLMProjectEvaluatorSlideover.tsx
@@ -1,0 +1,138 @@
+import { Suspense, useState } from "react";
+import type { ModalOverlayProps } from "react-aria-components";
+import invariant from "tiny-invariant";
+
+import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
+import { Dialog } from "@phoenix/components/core/dialog";
+import { Loading } from "@phoenix/components/core/loading";
+import { Modal, ModalOverlay } from "@phoenix/components/core/overlay/Modal";
+import { EditLLMEvaluatorDialogContent } from "@phoenix/components/evaluators/EditLLMEvaluatorDialogContent";
+import { EvaluatorPlaygroundProvider } from "@phoenix/components/evaluators/EvaluatorPlaygroundProvider";
+import { getOutputConfigValidationErrors } from "@phoenix/components/evaluators/utils";
+import { EvaluatorStoreProvider } from "@phoenix/contexts/EvaluatorContext";
+import { useNotifySuccess } from "@phoenix/contexts/NotificationContext";
+import { createProjectLlmEvaluator } from "@phoenix/pages/project/evaluators/createProjectLlmEvaluator";
+import { ProjectEvaluatorTargetField } from "@phoenix/pages/project/evaluators/ProjectEvaluatorTargetField";
+import { ProjectEvaluatorTestPlaceholder } from "@phoenix/pages/project/evaluators/ProjectEvaluatorTestPlaceholder";
+import type { ProjectEvaluatorTarget } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import {
+  DEFAULT_LLM_EVALUATOR_STORE_VALUES,
+  type EvaluatorStoreInstance,
+  type EvaluatorStoreProps,
+} from "@phoenix/store/evaluatorStore";
+
+export const CreateLLMProjectEvaluatorSlideover = ({
+  projectId,
+  ...props
+}: {
+  projectId: string;
+} & ModalOverlayProps) => {
+  return (
+    <ModalOverlay {...props}>
+      <Modal variant="slideover" size="fullscreen">
+        <Dialog>
+          {({ close }) => (
+            <Suspense fallback={<Loading />}>
+              <EvaluatorPlaygroundProvider>
+                <CreateProjectEvaluatorDialog
+                  onClose={close}
+                  projectId={projectId}
+                />
+              </EvaluatorPlaygroundProvider>
+            </Suspense>
+          )}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+};
+
+const CreateProjectEvaluatorDialog = ({
+  onClose,
+  projectId,
+}: {
+  onClose: () => void;
+  projectId: string;
+}) => {
+  const notifySuccess = useNotifySuccess();
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [targetType, setTargetType] = useState<ProjectEvaluatorTarget>("span");
+
+  const defaultOutputConfig =
+    DEFAULT_LLM_EVALUATOR_STORE_VALUES.outputConfigs[0];
+  const defaultEvaluatorName =
+    DEFAULT_LLM_EVALUATOR_STORE_VALUES.evaluator.globalName;
+  const initialState = {
+    ...DEFAULT_LLM_EVALUATOR_STORE_VALUES,
+    // Keep the output config name in sync with the evaluator name, as the
+    // dataset create dialog does
+    outputConfigs: [{ ...defaultOutputConfig, name: defaultEvaluatorName }],
+  } satisfies EvaluatorStoreProps;
+
+  const onSubmit = async (
+    store: EvaluatorStoreInstance
+  ): Promise<EvaluatorSubmitResult> => {
+    const {
+      evaluator: { globalName },
+      outputConfigs,
+    } = store.getState();
+    invariant(
+      outputConfigs && outputConfigs.length > 0,
+      "At least one output config is required"
+    );
+
+    const validationErrors = getOutputConfigValidationErrors(outputConfigs);
+    if (validationErrors.length > 0) {
+      const message = validationErrors.join("\n");
+      setError(message);
+      return { ok: false, error: message };
+    }
+
+    setIsSubmitting(true);
+    try {
+      const evaluator = await createProjectLlmEvaluator({
+        projectId,
+        targetType,
+        name: globalName.trim(),
+      });
+      onClose();
+      notifySuccess({
+        title: "Evaluator created",
+      });
+      return {
+        ok: true,
+        acceptedBy: "user",
+        evaluator,
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to create evaluator";
+      setError(message);
+      return { ok: false, error: message };
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <EvaluatorStoreProvider initialState={initialState}>
+      {({ store }) => (
+        <EditLLMEvaluatorDialogContent
+          onClose={onClose}
+          onSubmit={() => onSubmit(store)}
+          isSubmitting={isSubmitting}
+          mode="create"
+          error={error}
+          formLeftPanelExtra={
+            <ProjectEvaluatorTargetField
+              value={targetType}
+              onChange={setTargetType}
+            />
+          }
+          formRightPanel={<ProjectEvaluatorTestPlaceholder />}
+        />
+      )}
+    </EvaluatorStoreProvider>
+  );
+};

--- a/app/src/pages/project/evaluators/ProjectEvaluatorTargetField.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorTargetField.tsx
@@ -1,0 +1,60 @@
+import {
+  Flex,
+  Heading,
+  Radio,
+  RadioGroup,
+  Text,
+  View,
+} from "@phoenix/components";
+import {
+  isProjectEvaluatorTarget,
+  PROJECT_EVALUATOR_TARGETS,
+  type ProjectEvaluatorTarget,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+
+const TARGET_LABELS: Record<ProjectEvaluatorTarget, string> = {
+  span: "Span",
+  trace: "Trace",
+  session: "Session",
+};
+
+/**
+ * Picks the artifact type a project evaluator runs against. This section is
+ * where project-evaluator settings such as sampling rate, filters, and
+ * completion behavior will be added later.
+ */
+export const ProjectEvaluatorTargetField = ({
+  value,
+  onChange,
+}: {
+  value: ProjectEvaluatorTarget;
+  onChange: (target: ProjectEvaluatorTarget) => void;
+}) => {
+  return (
+    <View marginBottom="size-200" flex="none">
+      <Flex direction="column" gap="size-100">
+        <Heading level={2} weight="heavy">
+          Target
+        </Heading>
+        <Text color="text-500">
+          Choose what this evaluator runs against as new data arrives.
+        </Text>
+        <RadioGroup
+          value={value}
+          aria-label="Evaluator target"
+          onChange={(newValue) => {
+            if (isProjectEvaluatorTarget(newValue)) {
+              onChange(newValue);
+            }
+          }}
+        >
+          {PROJECT_EVALUATOR_TARGETS.map((target) => (
+            <Radio key={target} value={target}>
+              {TARGET_LABELS[target]}
+            </Radio>
+          ))}
+        </RadioGroup>
+      </Flex>
+    </View>
+  );
+};

--- a/app/src/pages/project/evaluators/ProjectEvaluatorTestPlaceholder.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorTestPlaceholder.tsx
@@ -1,0 +1,19 @@
+import { Empty, Flex, Heading, View } from "@phoenix/components";
+
+/**
+ * Placeholder for the project evaluator test section. Unlike dataset
+ * evaluators, which test against dataset examples, project evaluators will
+ * test against recent spans, traces, or sessions — that flow is not built yet.
+ */
+export const ProjectEvaluatorTestPlaceholder = () => {
+  return (
+    <View paddingX="size-200">
+      <Flex direction="column" gap="size-100">
+        <Heading level={2} weight="heavy">
+          Test
+        </Heading>
+        <Empty message="Testing against live spans, traces, and sessions is coming soon." />
+      </Flex>
+    </View>
+  );
+};

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
@@ -1,0 +1,33 @@
+import { css } from "@emotion/react";
+import { useParams } from "react-router";
+import invariant from "tiny-invariant";
+
+import { Empty, Flex, View } from "@phoenix/components";
+import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
+
+/**
+ * Lists the evaluators that run against a project's live spans, traces, and
+ * sessions. The list itself is not built yet — the tab currently offers the
+ * create flow with a stubbed submit.
+ */
+export function ProjectEvaluatorsPage() {
+  const { projectId } = useParams();
+  invariant(projectId, "projectId is required");
+  return (
+    <main
+      css={css`
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      `}
+    >
+      <View padding="size-100" flex="none">
+        <Flex direction="row" justifyContent="end">
+          <AddProjectEvaluatorMenu size="M" projectId={projectId} />
+        </Flex>
+      </View>
+      <Empty message="No evaluators are set up for this project" />
+    </main>
+  );
+}

--- a/app/src/pages/project/evaluators/createProjectLlmEvaluator.ts
+++ b/app/src/pages/project/evaluators/createProjectLlmEvaluator.ts
@@ -1,0 +1,25 @@
+import type { ProjectEvaluatorTarget } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+
+export type CreateProjectLLMEvaluatorResult = {
+  id: string;
+  name: string;
+};
+
+/**
+ * TODO(project-evaluators): replace with a createProjectLlmEvaluator Relay
+ * mutation once the project-evaluator GraphQL schema lands. Building the full
+ * mutation input (prompt version, output configs, input mapping) comes with
+ * that swap — see CreateLLMDatasetEvaluatorSlideover for the pattern.
+ */
+export async function createProjectLlmEvaluator({
+  name,
+}: {
+  projectId: string;
+  targetType: ProjectEvaluatorTarget;
+  name: string;
+}): Promise<CreateProjectLLMEvaluatorResult> {
+  return {
+    id: `stub-project-evaluator:${name}`,
+    name,
+  };
+}

--- a/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -1,0 +1,11 @@
+/**
+ * The artifact types a project evaluator can run against.
+ */
+export const PROJECT_EVALUATOR_TARGETS = ["span", "trace", "session"] as const;
+
+export type ProjectEvaluatorTarget = (typeof PROJECT_EVALUATOR_TARGETS)[number];
+
+export const isProjectEvaluatorTarget = (
+  value: string
+): value is ProjectEvaluatorTarget =>
+  PROJECT_EVALUATOR_TARGETS.includes(value as ProjectEvaluatorTarget);

--- a/app/src/pages/project/index.tsx
+++ b/app/src/pages/project/index.tsx
@@ -4,4 +4,5 @@ export * from "./ProjectSessionsPage";
 export * from "./ProjectSpansPage";
 export * from "./ProjectTracesPage";
 export * from "./projectLoader";
+export * from "./evaluators/ProjectEvaluatorsPage";
 export * from "./metrics/ProjectMetricsPage";


### PR DESCRIPTION
## Summary

First UI increment for project evaluators (online evals, see `internal_docs/specs/online-evals.md` on the spec branches). Adds an **Evaluators** tab to the project page with an "Add evaluator" flow that mirrors the Dataset Evaluators page. Project evaluators will run against live **spans, traces, or sessions** rather than dataset examples.

- New **Evaluators** tab (between Metrics and Config) showing an empty state and an **Add evaluator** menu with one item for now: *Create new LLM evaluator*. The menu is structured so code/built-in/template options can slot in later, matching the dataset `AddEvaluatorMenu`.
- **Create Project Evaluator slideover** reuses the dataset LLM evaluator form — name/description, prompt editor, annotation config, and input mapping — and adds a project-specific **Target** picker (Span | Trace | Session). This section is where sampling rate, filters, and completion behavior will land next.
- The right-hand **Test panel is a placeholder**: dataset evaluators test against dataset examples; testing against live spans/traces/sessions will come with the backend.
- **Submit is a client-side stub** (`createProjectLlmEvaluator.ts`): it validates the form, shows the success toast, and closes. No GraphQL/server changes in this PR — the TODO marks where the real mutation drops in.

<img width="1726" height="858" alt="image" src="https://github.com/user-attachments/assets/8b2441f7-ff4e-4353-a939-02556496da8e" />

<img width="1726" height="858" alt="image" src="https://github.com/user-attachments/assets/884bfd03-85cc-4087-afa5-f11a93280a30" />



## Component reuse

To keep the dataset dialog and the new project dialog on the same components:

- `EvaluatorForm` gains two optional slots — `leftPanelExtra` (renders below name/description) and `rightPanel` (replaces the test panel, defaulting to the existing dataset test panel).
- `EditLLMEvaluatorDialogContent` forwards those slots. With no props passed, both components render byte-identically to before, so the dataset create/edit flows are unchanged.

## Test plan

- `pnpm typecheck`, `pnpm lint`, `pnpm fmt`, and the full vitest suite pass.
- Verified in a running Phoenix build:
  - Dataset regression: Create LLM Evaluator dialog unchanged; creating a dataset evaluator still works (mutation, table append, toast).
  - New flow: `/projects/:id/evaluators` renders empty state + button; dialog opens with target picker, prompt editor, annotation config, mapping, and Test placeholder; empty-name submit shows the validation alert; valid submit closes with "Evaluator created".
  - The Config page's default-tab select intentionally does not offer the stub tab.