### PR TITLE
fix(ui): guard against nullish projects connection on Projects page

### DIFF
--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -235,7 +235,7 @@ export function ProjectsPageContent({
 
   useInterval(() => refetch({}), PROJECTS_POLL_INTERVAL_MS);
 
-  const projects = projectsData?.projects.edges.map((p) => p.project);
+  const projects = projectsData?.projects?.edges?.map((p) => p.project);
 
   const projectsContainerRef = useRef<HTMLDivElement>(null);
   const fetchMoreOnBottomReached = useCallback(


### PR DESCRIPTION
# Fix crash: `undefined is not an object (evaluating 'c?.projects.edges')`

Fixes #13870.

## What changed

On the Projects page, the projects list was derived with a partial optional chain:

```tsx
// app/src/pages/projects/ProjectsPage.tsx
const projects = projectsData?.projects.edges.map((p) => p.project);
```

The `?.` only guards `projectsData`. Once `projectsData` is present, `projects.edges`
is accessed non-defensively. If `projectsData.projects` (the connection) is nullish at
runtime, reading `.edges` throws `undefined is not an object (evaluating 'c?.projects.edges')`
(`c` is the minified name for `projectsData`) and the page crashes to the error boundary.

The fix extends the optional chain through the whole path:

```tsx
const projects = projectsData?.projects?.edges?.map((p) => p.project);
```

## Why

Although the generated Relay type marks `projects` and `edges` as non-null, a Relay
connection can transiently read as missing in the store (e.g. during
`store-and-network` refetch/pagination transitions, mutation-driven cache updates, or
store garbage collection). The reported error is exactly that runtime case. Extending
the optional chain makes the render resilient: `projects` becomes `undefined` instead of
throwing.

This is safe and does not change behavior in the normal case:

- The value is already treated as possibly-undefined downstream in the same file — e.g.
  `projects?.map(...)` in `ProjectsGrid` (`ProjectsPage.tsx:459`) — so a `undefined`
  result renders an empty list rather than crashing.
- Because `projects`/`edges` are typed non-null, `?.` on them does not widen the
  inferred type, so no prop types or call sites change.

The change is intentionally scoped to `ProjectsPage.tsx`. The other `.projects.edges`
readers (`ProjectMenu.tsx`, `TransferTracesButton.tsx`, `RetentionPoliciesTable.tsx`)
access data that is guaranteed present (`data`/`row.original`) with no leading `?.`, so
they do not match the reported error signature and are left unchanged.

## How to verify

1. Open Phoenix and navigate to the Projects page (`/projects`).
2. The page loads and lists projects as before.
3. Regression check: when the projects connection is momentarily unavailable (e.g. during
   a refetch/pagination transition or after a cache update), the page no longer crashes
   with `undefined is not an object (evaluating 'c?.projects.edges')`; it renders an empty
   list and recovers once data arrives.

## Notes

- No changeset was added: the change is confined to `app/` (`phoenix-ui`), which is not a
  published package under `js/`, so it is outside the changeset scope.
- No dedicated test was added: the repository has no page-level Relay component test
  pattern and does not depend on `relay-test-utils`; the fix is a defensive optional-chain
  guard that is verified by the type checker and follows the existing inline
  optional-chaining convention already used throughout this file.
