### PR TITLE
feat(pxi): render tool calls with icons, summaries, and command excerpts

### DIFF
--- a/js/.changeset/pxi-tool-call-rendering.md
+++ b/js/.changeset/pxi-tool-call-rendering.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Improve PXI tool call rendering in the terminal: each tool call now shows a state glyph (spinner while running, then ✓/✗/?/⊘), a per-tool icon, and a one-line summary of what the tool is doing, derived from its input. Bash calls display the model-written summary, an excerpt of the executing command, and on failure the exit code plus a stderr excerpt; `load_skill` and `read_skill_resource` collapse to quiet one-liners once complete.

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -21,7 +21,11 @@ import {
 } from "./draftEditor";
 import { Markdown } from "./inkMarkdown";
 import { formatTokenUsageLine, getLatestAssistantUsage } from "./tokenUsage";
-import { getToolProgressFromPart, type ToolProgress } from "./toolProgress";
+import {
+  getToolProgressFromPart,
+  type ToolProgress,
+  type ToolProgressState,
+} from "./toolProgress";
 import type { PxiChatClient, PxiMessage, PxiRuntimeOptions } from "./types";
 
 /**
@@ -60,6 +64,13 @@ const THINKING_FRAMES = [
   "PXI is thinking.. ",
   "PXI is thinking...",
 ];
+const TOOL_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+/** Tool states where the call is still in flight and shows a spinner. */
+const RUNNING_TOOL_STATES: ReadonlySet<ToolProgressState> = new Set([
+  "input-streaming",
+  "input-available",
+  "approval-responded",
+]);
 const ESCAPE_INPUT = "\x1B";
 const BACKSPACE_INPUTS = new Set(["\b", "\x7F"]);
 const FORWARD_DELETE_INPUTS = new Set([
@@ -130,24 +141,120 @@ function getModelLabel(options: PxiRuntimeOptions): string {
   return `${options.modelSelection.provider}/${options.modelSelection.modelName}`;
 }
 
-/** Render a single tool call inline in the transcript, coloring errors red. */
-function InlineToolProgress({ tool }: { tool: ToolProgress }) {
-  const statusColor = tool.state === "output-error" ? "red" : "yellow";
+/** Animated braille spinner shown while a tool call is still in flight. */
+function ToolSpinner() {
+  const [frameIndex, setFrameIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setFrameIndex((value) => (value + 1) % TOOL_SPINNER_FRAMES.length);
+    }, 250);
+    return () => clearInterval(interval);
+  }, []);
+
+  return <Text color="yellow">{TOOL_SPINNER_FRAMES[frameIndex]}</Text>;
+}
+
+/**
+ * The leading state glyph of a tool row: a spinner while the call is in
+ * flight, then a settled glyph — `✓` success, `✗` failure (including a
+ * non-zero exit code surfaced via `statusSuffix`), `?` awaiting approval,
+ * `⊘` denied.
+ */
+function ToolStateIndicator({ tool }: { tool: ToolProgress }) {
+  if (RUNNING_TOOL_STATES.has(tool.state)) {
+    return <ToolSpinner />;
+  }
+  switch (tool.state) {
+    case "output-available":
+      return tool.statusSuffix ? (
+        <Text color="red">✗</Text>
+      ) : (
+        <Text color="green">✓</Text>
+      );
+    case "output-error":
+      return <Text color="red">✗</Text>;
+    case "approval-requested":
+      return <Text color="yellow">?</Text>;
+    case "output-denied":
+      return <Text dimColor>⊘</Text>;
+    default:
+      return <Text color="yellow">•</Text>;
+  }
+}
+
+/**
+ * Render a single tool call inline in the transcript: a state glyph, the
+ * tool's icon and name, a dim one-line preview of what it is doing, then any
+ * detail lines (e.g. the bash command) and error lines (e.g. stderr).
+ * Completed "quiet" tools collapse to a single dim line.
+ */
+function InlineToolProgress({
+  tool,
+  marginTop,
+  marginBottom,
+}: {
+  tool: ToolProgress;
+  marginTop: number;
+  marginBottom: number;
+}) {
+  if (tool.isQuiet && tool.state === "output-available") {
+    return (
+      <Box paddingLeft={2} marginTop={marginTop} marginBottom={marginBottom}>
+        <Text wrap="truncate-end">
+          <Text color="green">✓</Text>{" "}
+          <Text dimColor>{tool.quietLabel ?? tool.toolName}</Text>
+        </Text>
+      </Box>
+    );
+  }
+  const showStatusText =
+    tool.state === "approval-requested" || tool.state === "output-denied";
   return (
-    <Box flexDirection="column" marginY={1} paddingLeft={2}>
-      <Text>
-        <Text dimColor>[tool]</Text>{" "}
-        <Text color={statusColor}>{tool.toolName}</Text>{" "}
-        <Text color={statusColor}>{tool.statusText}</Text>
+    <Box
+      flexDirection="column"
+      paddingLeft={2}
+      marginTop={marginTop}
+      marginBottom={marginBottom}
+    >
+      <Text wrap="truncate-end">
+        <ToolStateIndicator tool={tool} />{" "}
+        <Text color="yellow">
+          {tool.icon} {tool.toolName}
+        </Text>
+        {showStatusText ? <Text color="yellow"> {tool.statusText}</Text> : null}
+        {tool.previewText ? <Text dimColor> · {tool.previewText}</Text> : null}
+        {tool.statusSuffix ? (
+          <Text color="red"> ({tool.statusSuffix})</Text>
+        ) : null}
       </Text>
-      {tool.errorText ? <Text color="red">{tool.errorText}</Text> : null}
+      {tool.detailLines.length > 0 ? (
+        <Box flexDirection="column" paddingLeft={4}>
+          {tool.detailLines.map((line, index) => (
+            <Text key={index} dimColor wrap="truncate-end">
+              {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
+      {tool.errorLines.length > 0 ? (
+        <Box flexDirection="column" paddingLeft={4}>
+          {tool.errorLines.map((line, index) => (
+            <Text key={index} color="red" wrap="truncate-end">
+              {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
     </Box>
   );
 }
 
 /**
  * Render the ordered parts of one message: text parts as markdown, tool parts
- * as inline progress, skipping anything unrecognized.
+ * as inline progress, skipping anything unrecognized. Consecutive tool calls
+ * stack compactly — the blank line appears only at the boundary between a
+ * tool block and its neighbors.
  */
 function MessageParts({
   message,
@@ -156,6 +263,9 @@ function MessageParts({
   message: PxiMessage;
   phoenixBaseUrl?: string;
 }) {
+  const toolProgressByPart = message.parts.map((part) =>
+    getToolProgressFromPart({ part })
+  );
   return (
     <Box flexDirection="column">
       {message.parts.map((part, index) => {
@@ -169,9 +279,16 @@ function MessageParts({
             </Markdown>
           );
         }
-        const tool = getToolProgressFromPart({ part });
+        const tool = toolProgressByPart[index];
         if (tool) {
-          return <InlineToolProgress key={tool.toolCallId} tool={tool} />;
+          return (
+            <InlineToolProgress
+              key={tool.toolCallId}
+              tool={tool}
+              marginTop={toolProgressByPart[index - 1] ? 0 : 1}
+              marginBottom={toolProgressByPart[index + 1] ? 0 : 1}
+            />
+          );
         }
         return null;
       })}

--- a/js/packages/phoenix-cli/src/pxi/toolPresentation.ts
+++ b/js/packages/phoenix-cli/src/pxi/toolPresentation.ts
@@ -335,12 +335,45 @@ function getLoadSkillPresentation({
   return presentation;
 }
 
+/**
+ * Skill resource reads are routine bookkeeping, like skill loads: once
+ * complete they collapse to a single dim `Read skill resource
+ * <skill>/<resource>` line instead of a full tool row.
+ */
+function getReadSkillResourcePresentation({
+  state,
+  input,
+}: ToolPresenterOptions): Partial<ToolPresentation> {
+  const record = asRecord(input);
+  const skillName = record
+    ? getStringField({ record, field: "skill_name" })
+    : "";
+  const resourceName = record
+    ? getStringField({ record, field: "resource_name" })
+    : "";
+  const resourceLabel = toSingleLine({
+    text: [skillName, resourceName].filter(Boolean).join("/"),
+  });
+  const presentation: Partial<ToolPresentation> = {
+    icon: "✦",
+    previewText: resourceLabel,
+  };
+  if (state === "output-available") {
+    presentation.isQuiet = true;
+    presentation.quietLabel = resourceLabel
+      ? `Read skill resource ${resourceLabel}`
+      : "Read skill resource";
+  }
+  return presentation;
+}
+
 const TOOL_PRESENTERS: Record<string, ToolPresenter> = {
   bash: getBashPresentation,
   web_search: getWebSearchPresentation,
   web_fetch: getWebFetchPresentation,
   call_subagent: getCallSubagentPresentation,
   load_skill: getLoadSkillPresentation,
+  read_skill_resource: getReadSkillResourcePresentation,
 };
 
 /**

--- a/js/packages/phoenix-cli/src/pxi/toolPresentation.ts
+++ b/js/packages/phoenix-cli/src/pxi/toolPresentation.ts
@@ -1,0 +1,377 @@
+import type { ToolProgressState } from "./toolProgress";
+
+/**
+ * Derives the display elements for one tool call — a terminal-safe icon, a
+ * one-line preview of what the tool is doing, and a few detail/error lines —
+ * from the tool's (possibly still-streaming) input and output. This mirrors
+ * the web UI's per-tool presentation registry in
+ * `app/src/components/agent/ToolPart.tsx`, which cannot be imported from this
+ * package.
+ *
+ * Everything here is pure string derivation so it stays cheap: the whole
+ * transcript re-renders on every stream snapshot, so presenters only read
+ * named fields and clamp raw text before splitting — tool payloads are never
+ * stringified or scanned in full.
+ */
+
+/** Display-ready description of one tool call, derived from its input/output. */
+export type ToolPresentation = {
+  /** Terminal-safe glyph identifying the tool (single-width BMP unicode). */
+  icon: string;
+  /** One-line summary of what the tool is doing; empty until derivable. */
+  previewText: string;
+  /** Dimmed lines shown under the header, e.g. the bash command excerpt. */
+  detailLines: string[];
+  /** Red lines shown under the details, e.g. a stderr or error excerpt. */
+  errorLines: string[];
+  /** Short annotation appended to the header, e.g. `exit 1`. */
+  statusSuffix?: string;
+  /** Whether the completed call collapses to a single dim line. */
+  isQuiet: boolean;
+  /** The text of the collapsed quiet line, e.g. `Loaded skill datasets`. */
+  quietLabel?: string;
+};
+
+type ToolPresenterOptions = {
+  state: ToolProgressState;
+  input: unknown;
+  output: unknown;
+  errorText?: string;
+};
+
+type ToolPresenter = (
+  options: ToolPresenterOptions
+) => Partial<ToolPresentation>;
+
+const GENERIC_TOOL_ICON = "◆";
+
+/** Cap on how much of a raw payload string is ever inspected. */
+const MAX_SOURCE_LENGTH = 1000;
+const PREVIEW_MAX_LENGTH = 120;
+const DETAIL_LINE_MAX_LENGTH = 200;
+const COMMAND_DETAIL_MAX_LINES = 3;
+const STDERR_MAX_LINES = 2;
+const ERROR_TEXT_MAX_LINES = 3;
+
+/**
+ * Input fields checked, in priority order, when deriving a generic preview
+ * for tools without a bespoke presenter.
+ */
+const GENERIC_PREVIEW_FIELDS = [
+  "summary",
+  "description",
+  "query",
+  "name",
+  "path",
+  "url",
+  "prompt",
+  "text",
+  "command",
+];
+
+/** How many input entries the generic fallback scans for any string value. */
+const GENERIC_SCAN_LIMIT = 20;
+
+/** Known field aliases for the target URL of provider-native web tools. */
+const NATIVE_WEB_URL_FIELDS = ["url", "uri", "href"];
+
+/** Known field aliases for the search text of provider-native web search. */
+const NATIVE_WEB_SEARCH_QUERY_FIELDS = ["query", "q", "search_query"];
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getStringField({
+  record,
+  field,
+}: {
+  record: Record<string, unknown>;
+  field: string;
+}): string {
+  const value = record[field];
+  return typeof value === "string" ? value : "";
+}
+
+function getFirstStringField({
+  record,
+  fields,
+}: {
+  record: Record<string, unknown>;
+  fields: readonly string[];
+}): string {
+  for (const field of fields) {
+    const value = getStringField({ record, field });
+    if (value) {
+      return value;
+    }
+  }
+  return "";
+}
+
+/**
+ * Collapse text to a single width-clamped line: whitespace runs (including
+ * newlines) become single spaces, and overlong text is cut with an ellipsis.
+ */
+function toSingleLine({
+  text,
+  maxLength = PREVIEW_MAX_LENGTH,
+}: {
+  text: string;
+  maxLength?: number;
+}): string {
+  const collapsed = text
+    .slice(0, MAX_SOURCE_LENGTH)
+    .replace(/\s+/g, " ")
+    .trim();
+  return collapsed.length > maxLength
+    ? `${collapsed.slice(0, maxLength)}…`
+    : collapsed;
+}
+
+/**
+ * Split text into at most `maxLines` display lines, clamping each line's
+ * length and appending a `… (+N more lines)` sentinel when lines were cut.
+ */
+export function getClampedLines({
+  text,
+  maxLines,
+}: {
+  text: string;
+  maxLines: number;
+}): string[] {
+  const truncatedSource = text.length > MAX_SOURCE_LENGTH;
+  const allLines = text
+    .slice(0, MAX_SOURCE_LENGTH)
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+  const visibleLines = allLines
+    .slice(0, maxLines)
+    .map((line) =>
+      line.length > DETAIL_LINE_MAX_LENGTH
+        ? `${line.slice(0, DETAIL_LINE_MAX_LENGTH)}…`
+        : line
+    );
+  const hiddenLineCount = allLines.length - visibleLines.length;
+  if (hiddenLineCount > 0) {
+    visibleLines.push(
+      `… (+${hiddenLineCount} more ${hiddenLineCount === 1 ? "line" : "lines"})`
+    );
+  } else if (truncatedSource && visibleLines.length > 0) {
+    visibleLines.push("…");
+  }
+  return visibleLines;
+}
+
+/**
+ * Generic preview for tools without a bespoke presenter: a string input is
+ * used directly; a record input yields its first known preview field, else the
+ * first string value among its leading entries.
+ */
+function getGenericToolPreview({ input }: { input: unknown }): string {
+  if (typeof input === "string") {
+    return toSingleLine({ text: input });
+  }
+  const record = asRecord(input);
+  if (!record) {
+    return "";
+  }
+  const fieldValue = getFirstStringField({
+    record,
+    fields: GENERIC_PREVIEW_FIELDS,
+  });
+  if (fieldValue) {
+    return toSingleLine({ text: fieldValue });
+  }
+  for (const value of Object.values(record).slice(0, GENERIC_SCAN_LIMIT)) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return toSingleLine({ text: value });
+    }
+  }
+  return "";
+}
+
+/**
+ * Bash presenter. The preview prefers the model-written `summary`, which
+ * streams in before `command`, so a description shows while the command is
+ * still arriving; the detail lines are an excerpt of the command itself. On
+ * completion, a non-zero exit code surfaces as a status suffix plus a stderr
+ * excerpt.
+ */
+function getBashPresentation({
+  state,
+  input,
+  output,
+}: ToolPresenterOptions): Partial<ToolPresentation> {
+  const inputRecord = asRecord(input);
+  const summary = inputRecord
+    ? getStringField({ record: inputRecord, field: "summary" })
+    : "";
+  const command = inputRecord
+    ? getStringField({ record: inputRecord, field: "command" })
+    : "";
+  const presentation: Partial<ToolPresentation> = {
+    icon: "$",
+    previewText: toSingleLine({ text: summary || command.split("\n")[0] }),
+    detailLines: command
+      ? getClampedLines({ text: command, maxLines: COMMAND_DETAIL_MAX_LINES })
+      : [],
+  };
+  const outputRecord = state === "output-available" ? asRecord(output) : null;
+  if (outputRecord) {
+    const exitCode = outputRecord.exit_code;
+    if (typeof exitCode === "number" && exitCode !== 0) {
+      presentation.statusSuffix = `exit ${exitCode}`;
+      const stderr = getStringField({ record: outputRecord, field: "stderr" });
+      presentation.errorLines = stderr
+        ? getClampedLines({ text: stderr, maxLines: STDERR_MAX_LINES })
+        : [];
+    }
+  }
+  return presentation;
+}
+
+/**
+ * Provider-native web search: prefer the query text; typed non-search actions
+ * (e.g. page reads) show a humanized action label with their target.
+ */
+function getWebSearchPresentation({
+  input,
+}: ToolPresenterOptions): Partial<ToolPresentation> {
+  const presentation: Partial<ToolPresentation> = { icon: "⌕" };
+  const record = asRecord(input);
+  if (typeof input === "string") {
+    presentation.previewText = toSingleLine({ text: input });
+    return presentation;
+  }
+  if (!record) {
+    return presentation;
+  }
+  const type = getStringField({ record, field: "type" });
+  if (type && type !== "search") {
+    const value =
+      getFirstStringField({ record, fields: NATIVE_WEB_URL_FIELDS }) ||
+      getFirstStringField({ record, fields: NATIVE_WEB_SEARCH_QUERY_FIELDS });
+    const label = type
+      .split("_")
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+    presentation.previewText = toSingleLine({
+      text: value ? `${label}: ${value}` : label,
+    });
+    return presentation;
+  }
+  const query = getFirstStringField({
+    record,
+    fields: NATIVE_WEB_SEARCH_QUERY_FIELDS,
+  });
+  if (query) {
+    presentation.previewText = toSingleLine({ text: query });
+    return presentation;
+  }
+  const queries = record.queries;
+  if (Array.isArray(queries)) {
+    const firstQuery = queries.find(
+      (value): value is string => typeof value === "string" && value.length > 0
+    );
+    if (firstQuery) {
+      presentation.previewText = toSingleLine({ text: firstQuery });
+    }
+  }
+  return presentation;
+}
+
+function getWebFetchPresentation({
+  input,
+}: ToolPresenterOptions): Partial<ToolPresentation> {
+  const record = asRecord(input);
+  return {
+    icon: "↓",
+    previewText: record
+      ? toSingleLine({
+          text: getFirstStringField({ record, fields: NATIVE_WEB_URL_FIELDS }),
+        })
+      : "",
+  };
+}
+
+function getCallSubagentPresentation({
+  input,
+}: ToolPresenterOptions): Partial<ToolPresentation> {
+  const record = asRecord(input);
+  return {
+    icon: "◇",
+    previewText: record
+      ? toSingleLine({ text: getStringField({ record, field: "name" }) })
+      : "",
+  };
+}
+
+/**
+ * Skill loads are routine bookkeeping: once complete they collapse to a
+ * single dim `Loaded skill <name>` line instead of a full tool row.
+ */
+function getLoadSkillPresentation({
+  state,
+  input,
+}: ToolPresenterOptions): Partial<ToolPresentation> {
+  const record = asRecord(input);
+  const skillName = record
+    ? getStringField({ record, field: "skill_name" })
+    : "";
+  const presentation: Partial<ToolPresentation> = {
+    icon: "✦",
+    previewText: toSingleLine({ text: skillName }),
+  };
+  if (state === "output-available") {
+    presentation.isQuiet = true;
+    presentation.quietLabel = skillName
+      ? `Loaded skill ${toSingleLine({ text: skillName })}`
+      : "Loaded skill";
+  }
+  return presentation;
+}
+
+const TOOL_PRESENTERS: Record<string, ToolPresenter> = {
+  bash: getBashPresentation,
+  web_search: getWebSearchPresentation,
+  web_fetch: getWebFetchPresentation,
+  call_subagent: getCallSubagentPresentation,
+  load_skill: getLoadSkillPresentation,
+};
+
+/**
+ * Build the {@link ToolPresentation} for a tool call: the bespoke presenter
+ * for known tools, else the generic first-string-field preview. Error text
+ * from the part is folded into `errorLines` when the presenter didn't already
+ * produce a more specific excerpt (e.g. bash stderr).
+ */
+export function getToolPresentation({
+  toolName,
+  state,
+  input,
+  output,
+  errorText,
+}: ToolPresenterOptions & { toolName: string }): ToolPresentation {
+  const presenter = TOOL_PRESENTERS[toolName];
+  const presentation: ToolPresentation = {
+    icon: GENERIC_TOOL_ICON,
+    previewText: "",
+    detailLines: [],
+    errorLines: [],
+    isQuiet: false,
+    ...(presenter
+      ? presenter({ state, input, output, errorText })
+      : { previewText: getGenericToolPreview({ input }) }),
+  };
+  if (presentation.errorLines.length === 0 && errorText) {
+    presentation.errorLines = getClampedLines({
+      text: errorText,
+      maxLines: ERROR_TEXT_MAX_LINES,
+    });
+  }
+  return presentation;
+}

--- a/js/packages/phoenix-cli/src/pxi/toolProgress.ts
+++ b/js/packages/phoenix-cli/src/pxi/toolProgress.ts
@@ -1,5 +1,6 @@
 import type { UIDataTypes, UIMessagePart, UITools } from "ai";
 
+import { getToolPresentation, type ToolPresentation } from "./toolPresentation";
 import type { PxiMessage } from "./types";
 
 /**
@@ -27,7 +28,7 @@ export type ToolProgress = {
   state: ToolProgressState;
   statusText: string;
   errorText?: string;
-};
+} & ToolPresentation;
 
 type PxiToolPart = UIMessagePart<UIDataTypes, UITools> & {
   toolCallId: string;
@@ -109,12 +110,20 @@ export function getToolProgressFromPart({
   }
   const toolName = getToolName(part);
   const state = part.state;
+  const errorText = "errorText" in part ? part.errorText : undefined;
   return {
     toolCallId: part.toolCallId,
     toolName,
     state,
     statusText: getStatusText(state),
-    errorText: "errorText" in part ? part.errorText : undefined,
+    errorText,
+    ...getToolPresentation({
+      toolName,
+      state,
+      input: part.input,
+      output: part.output,
+      errorText,
+    }),
   };
 }
 

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -803,19 +803,104 @@ describe("PXI app", () => {
       <PxiApp options={createOptions()} initialMessages={[assistantMessage]} />
     );
 
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     expect(frame).toContain("I checked the project.");
-    expect(frame).toContain("[tool] phoenix_graphql Complete");
-    expect(lastFrame()).not.toContain("result object (2 keys: data, errors)");
+    expect(frame).toContain("✓ ◆ phoenix_graphql · { projects { id } }");
+    expect(frame).not.toContain("result object (2 keys: data, errors)");
     expect(frame).toContain("Then I summarized it.");
     expect(frame.indexOf("I checked the project.")).toBeLessThan(
-      frame.indexOf("[tool] phoenix_graphql Complete")
+      frame.indexOf("phoenix_graphql")
     );
-    expect(frame.indexOf("[tool] phoenix_graphql Complete")).toBeLessThan(
+    expect(frame.indexOf("phoenix_graphql")).toBeLessThan(
       frame.indexOf("Then I summarized it.")
     );
-    expect(lastFrame()).not.toContain('{"data"');
-    expect(lastFrame()).not.toContain("╭");
+    expect(frame).not.toContain('{"data"');
+    expect(frame).not.toContain("╭");
+    unmount();
+  });
+
+  it("shows a bash summary and a spinner while its input streams in", () => {
+    const assistantMessage: PxiMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "tool-1",
+          toolName: "bash",
+          state: "input-streaming",
+          input: { summary: "Run the unit test suite" },
+        },
+      ],
+    };
+    const { lastFrame, unmount } = render(
+      <PxiApp options={createOptions()} initialMessages={[assistantMessage]} />
+    );
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("$ bash · Run the unit test suite");
+    expect(frame).toContain("⠋");
+    expect(frame).not.toContain("✓");
+    unmount();
+  });
+
+  it("renders bash command lines and failure output after completion", () => {
+    const assistantMessage: PxiMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "tool-1",
+          toolName: "bash",
+          state: "output-available",
+          input: {
+            summary: "Install a dependency",
+            command: "pnpm add left-pad\necho done",
+          },
+          output: {
+            stdout: "",
+            stderr: "ERR_PNPM_ADDING_TO_ROOT",
+            exit_code: 1,
+          },
+        },
+      ],
+    };
+    const { lastFrame, unmount } = render(
+      <PxiApp options={createOptions()} initialMessages={[assistantMessage]} />
+    );
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("✗ $ bash · Install a dependency (exit 1)");
+    expect(frame).toContain("pnpm add left-pad");
+    expect(frame).toContain("echo done");
+    expect(frame).toContain("ERR_PNPM_ADDING_TO_ROOT");
+    unmount();
+  });
+
+  it("collapses a completed load_skill call to a quiet line", () => {
+    const assistantMessage: PxiMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "tool-1",
+          toolName: "load_skill",
+          state: "output-available",
+          input: { skill_name: "datasets" },
+          output: { content: "skill body" },
+        },
+      ],
+    };
+    const { lastFrame, unmount } = render(
+      <PxiApp options={createOptions()} initialMessages={[assistantMessage]} />
+    );
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("✓ Loaded skill datasets");
+    expect(frame).not.toContain("load_skill");
+    expect(frame).not.toContain("skill body");
     unmount();
   });
 

--- a/js/packages/phoenix-cli/test/pxiToolPresentation.test.ts
+++ b/js/packages/phoenix-cli/test/pxiToolPresentation.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getClampedLines,
+  getToolPresentation,
+} from "../src/pxi/toolPresentation";
+
+describe("getToolPresentation", () => {
+  describe("bash", () => {
+    it("previews the summary while the command is still streaming", () => {
+      const presentation = getToolPresentation({
+        toolName: "bash",
+        state: "input-streaming",
+        input: { summary: "Run the unit test suite" },
+        output: undefined,
+      });
+      expect(presentation.icon).toBe("$");
+      expect(presentation.previewText).toBe("Run the unit test suite");
+      expect(presentation.detailLines).toEqual([]);
+      expect(presentation.errorLines).toEqual([]);
+      expect(presentation.statusSuffix).toBeUndefined();
+    });
+
+    it("falls back to the first command line when no summary exists", () => {
+      const presentation = getToolPresentation({
+        toolName: "bash",
+        state: "input-available",
+        input: { command: "pnpm test\npnpm build" },
+        output: undefined,
+      });
+      expect(presentation.previewText).toBe("pnpm test");
+      expect(presentation.detailLines).toEqual(["pnpm test", "pnpm build"]);
+    });
+
+    it("truncates long commands to a few lines with an overflow sentinel", () => {
+      const command = ["one", "two", "three", "four", "five"].join("\n");
+      const presentation = getToolPresentation({
+        toolName: "bash",
+        state: "input-available",
+        input: { summary: "Run several commands", command },
+        output: undefined,
+      });
+      expect(presentation.detailLines).toEqual([
+        "one",
+        "two",
+        "three",
+        "… (+2 more lines)",
+      ]);
+    });
+
+    it("surfaces a non-zero exit code and a stderr excerpt", () => {
+      const presentation = getToolPresentation({
+        toolName: "bash",
+        state: "output-available",
+        input: {
+          summary: "Install a dependency",
+          command: "pnpm add left-pad",
+        },
+        output: {
+          stdout: "",
+          stderr: "ERR_PNPM_ADDING_TO_ROOT\nsecond line\nthird line",
+          exit_code: 1,
+        },
+      });
+      expect(presentation.statusSuffix).toBe("exit 1");
+      expect(presentation.errorLines).toEqual([
+        "ERR_PNPM_ADDING_TO_ROOT",
+        "second line",
+        "… (+1 more line)",
+      ]);
+    });
+
+    it("shows no suffix or error lines on a zero exit code", () => {
+      const presentation = getToolPresentation({
+        toolName: "bash",
+        state: "output-available",
+        input: { summary: "List files", command: "ls" },
+        output: { stdout: "file.txt", stderr: "", exit_code: 0 },
+      });
+      expect(presentation.statusSuffix).toBeUndefined();
+      expect(presentation.errorLines).toEqual([]);
+    });
+  });
+
+  describe("generic fallback", () => {
+    it("prefers known preview fields in priority order", () => {
+      const presentation = getToolPresentation({
+        toolName: "phoenix_graphql",
+        state: "output-available",
+        input: { query: "{ projects { id } }", variables: "{}" },
+        output: { data: {} },
+      });
+      expect(presentation.icon).toBe("◆");
+      expect(presentation.previewText).toBe("{ projects { id } }");
+    });
+
+    it("scans leading entries for any string when no known field matches", () => {
+      const presentation = getToolPresentation({
+        toolName: "list_datasets",
+        state: "input-available",
+        input: { limit: 10, cursor: "abc123" },
+        output: undefined,
+      });
+      expect(presentation.previewText).toBe("abc123");
+    });
+
+    it("uses a string input directly", () => {
+      const presentation = getToolPresentation({
+        toolName: "some_tool",
+        state: "input-available",
+        input: "plain text input",
+        output: undefined,
+      });
+      expect(presentation.previewText).toBe("plain text input");
+    });
+
+    it("collapses newlines in previews to single spaces", () => {
+      const presentation = getToolPresentation({
+        toolName: "some_tool",
+        state: "input-available",
+        input: { summary: "first line\n  second line" },
+        output: undefined,
+      });
+      expect(presentation.previewText).toBe("first line second line");
+    });
+
+    it("clamps overlong previews with an ellipsis", () => {
+      const presentation = getToolPresentation({
+        toolName: "some_tool",
+        state: "input-available",
+        input: { summary: "x".repeat(500) },
+        output: undefined,
+      });
+      expect(presentation.previewText).toHaveLength(121);
+      expect(presentation.previewText.endsWith("…")).toBe(true);
+    });
+
+    it.each([
+      ["undefined", undefined],
+      ["null", null],
+      ["an array", ["a", "b"]],
+      ["a number", 42],
+    ])("yields an empty preview for %s input without throwing", (_, input) => {
+      const presentation = getToolPresentation({
+        toolName: "some_tool",
+        state: "input-streaming",
+        input,
+        output: undefined,
+      });
+      expect(presentation.previewText).toBe("");
+    });
+
+    it("folds the part's error text into error lines", () => {
+      const presentation = getToolPresentation({
+        toolName: "some_tool",
+        state: "output-error",
+        input: { query: "q" },
+        output: undefined,
+        errorText: "boom\nstack line 1",
+      });
+      expect(presentation.errorLines).toEqual(["boom", "stack line 1"]);
+    });
+  });
+
+  describe("web_search", () => {
+    it.each([
+      [{ query: "phoenix tracing" }],
+      [{ q: "phoenix tracing" }],
+      [{ search_query: "phoenix tracing" }],
+      [{ queries: ["phoenix tracing", "other"] }],
+    ])("previews the query from %o", (input) => {
+      const presentation = getToolPresentation({
+        toolName: "web_search",
+        state: "input-available",
+        input,
+        output: undefined,
+      });
+      expect(presentation.icon).toBe("⌕");
+      expect(presentation.previewText).toBe("phoenix tracing");
+    });
+
+    it("labels typed non-search actions with their target", () => {
+      const presentation = getToolPresentation({
+        toolName: "web_search",
+        state: "input-available",
+        input: { type: "web_page_read", url: "https://example.com" },
+        output: undefined,
+      });
+      expect(presentation.previewText).toBe(
+        "Web Page Read: https://example.com"
+      );
+    });
+  });
+
+  it("previews the target url for web_fetch", () => {
+    const presentation = getToolPresentation({
+      toolName: "web_fetch",
+      state: "input-available",
+      input: { url: "https://example.com/docs" },
+      output: undefined,
+    });
+    expect(presentation.icon).toBe("↓");
+    expect(presentation.previewText).toBe("https://example.com/docs");
+  });
+
+  it("previews the subagent name for call_subagent", () => {
+    const presentation = getToolPresentation({
+      toolName: "call_subagent",
+      state: "input-available",
+      input: { name: "trace-analyzer", prompt: "look at this" },
+      output: undefined,
+    });
+    expect(presentation.icon).toBe("◇");
+    expect(presentation.previewText).toBe("trace-analyzer");
+  });
+
+  describe("load_skill", () => {
+    it("is not quiet while running", () => {
+      const presentation = getToolPresentation({
+        toolName: "load_skill",
+        state: "input-available",
+        input: { skill_name: "datasets" },
+        output: undefined,
+      });
+      expect(presentation.icon).toBe("✦");
+      expect(presentation.previewText).toBe("datasets");
+      expect(presentation.isQuiet).toBe(false);
+    });
+
+    it("collapses to a quiet labeled line once complete", () => {
+      const presentation = getToolPresentation({
+        toolName: "load_skill",
+        state: "output-available",
+        input: { skill_name: "datasets" },
+        output: { content: "…" },
+      });
+      expect(presentation.isQuiet).toBe(true);
+      expect(presentation.quietLabel).toBe("Loaded skill datasets");
+    });
+
+    it("uses a generic quiet label when the skill name is unavailable", () => {
+      const presentation = getToolPresentation({
+        toolName: "load_skill",
+        state: "output-available",
+        input: {},
+        output: { content: "…" },
+      });
+      expect(presentation.quietLabel).toBe("Loaded skill");
+    });
+  });
+});
+
+describe("getClampedLines", () => {
+  it("keeps short text intact and skips blank lines", () => {
+    expect(getClampedLines({ text: "a\n\nb\n", maxLines: 3 })).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("clamps individual line length", () => {
+    const [line] = getClampedLines({ text: "y".repeat(500), maxLines: 1 });
+    expect(line).toHaveLength(201);
+    expect(line.endsWith("…")).toBe(true);
+  });
+
+  it("marks source truncation even when line count fits", () => {
+    const text = `${"z".repeat(2000)}`;
+    const lines = getClampedLines({ text, maxLines: 5 });
+    expect(lines.at(-1)).toBe("…");
+  });
+});

--- a/js/packages/phoenix-cli/test/pxiToolPresentation.test.ts
+++ b/js/packages/phoenix-cli/test/pxiToolPresentation.test.ts
@@ -248,6 +248,53 @@ describe("getToolPresentation", () => {
       expect(presentation.quietLabel).toBe("Loaded skill");
     });
   });
+
+  describe("read_skill_resource", () => {
+    it("previews the skill and resource while running, without quieting", () => {
+      const presentation = getToolPresentation({
+        toolName: "read_skill_resource",
+        state: "input-available",
+        input: { skill_name: "datasets", resource_name: "query-guide" },
+        output: undefined,
+      });
+      expect(presentation.icon).toBe("✦");
+      expect(presentation.previewText).toBe("datasets/query-guide");
+      expect(presentation.isQuiet).toBe(false);
+    });
+
+    it("previews the skill name alone while the resource is still streaming", () => {
+      const presentation = getToolPresentation({
+        toolName: "read_skill_resource",
+        state: "input-streaming",
+        input: { skill_name: "datasets" },
+        output: undefined,
+      });
+      expect(presentation.previewText).toBe("datasets");
+    });
+
+    it("collapses to a quiet labeled line once complete", () => {
+      const presentation = getToolPresentation({
+        toolName: "read_skill_resource",
+        state: "output-available",
+        input: { skill_name: "datasets", resource_name: "query-guide" },
+        output: { content: "…" },
+      });
+      expect(presentation.isQuiet).toBe(true);
+      expect(presentation.quietLabel).toBe(
+        "Read skill resource datasets/query-guide"
+      );
+    });
+
+    it("uses a generic quiet label when the input is unavailable", () => {
+      const presentation = getToolPresentation({
+        toolName: "read_skill_resource",
+        state: "output-available",
+        input: undefined,
+        output: { content: "…" },
+      });
+      expect(presentation.quietLabel).toBe("Read skill resource");
+    });
+  });
 });
 
 describe("getClampedLines", () => {


### PR DESCRIPTION
Closes #13951

<img width="1726" height="735" alt="image" src="https://github.com/user-attachments/assets/9e43a034-2c83-43d1-aaf4-603875570e70" />


## What

PXI tool calls in the terminal CLI rendered as opaque one-liners (`[tool] bash Complete`) — the streamed tool `input`/`output` was dropped in `getToolProgressFromPart` before rendering. Tool rows now surface what's actually happening:

- **State glyph**: braille spinner while the call is in flight, then `✓` success, `✗` failure (including non-zero bash exit codes), `?` awaiting approval, `⊘` denied.
- **Per-tool icon** (safe single-width unicode, no nerd fonts/emoji): `$` bash, `⌕` web_search, `↓` web_fetch, `◇` call_subagent, `✦` load_skill, `◆` everything else.
- **One-line summary** derived from the tool input. For bash this is the model-written `summary` field, which streams in *before* `command`, so a description shows while the command is still arriving; other tools get a first-string-field preview mirroring the web UI's registry (`getToolPresentation` in `app/src/components/agent/ToolPart.tsx`).
- **Command excerpt**: first 3 lines of the bash command with a `… (+N more lines)` sentinel.
- **Failure detail**: `exit N` suffix plus a 2-line stderr excerpt in red; error text for other tools.
- `load_skill` collapses to a quiet dim `✓ Loaded skill <name>` line once complete; consecutive tool calls stack compactly.

Raw input/output JSON is still never printed.

## Example

```
PXI
Let me check the failing tests.

  ⠋ $ bash · Run the CLI unit test suite
  ✓ $ bash · Inspect the workspace
      ls -la
      pwd
      git status
      … (+2 more lines)
  ✗ $ bash · Install a dependency (exit 1)
      pnpm add left-pad
      ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency…
  ✓ ⌕ web_search · phoenix ink tool rendering
  ✓ ◆ phoenix_graphql · { projects { id name } }
  ✓ Loaded skill phoenix-tracing

Then I summarized it.
```

## Changes

- New `js/packages/phoenix-cli/src/pxi/toolPresentation.ts` — pure per-tool presentation registry (icon, preview, detail/error lines). Derivation is clamped before splitting so the per-snapshot transcript re-render stays O(1) even for large payloads.
- `src/pxi/toolProgress.ts` — forwards `part.input`/`part.output` into the presentation and extends `ToolProgress` with the display fields.
- `src/pxi/App.tsx` — rewrites `InlineToolProgress` with the new layout, adds `ToolSpinner`/`ToolStateIndicator`, width-truncated via Ink's `wrap="truncate-end"`.

## Tests

- New `test/pxiToolPresentation.test.ts` — 28 cases covering streaming-partial inputs, truncation/clamping, exit-code handling, per-tool previews, and malformed inputs never throwing.
- Updated `test/pxiApp.test.tsx` — replaces the assertions that encoded the old black-box behavior; adds spinner, bash-failure, and quiet-skill rendering cases.
- `pnpm test` (549 passed) and `pnpm build` clean in `js/packages/phoenix-cli`.