### PR TITLE
refactor(ui): consolidate pending-approval PXI tool-call state behind one seam

### DIFF
--- a/app/src/agent/extensions/__tests__/toolRegistry.test.ts
+++ b/app/src/agent/extensions/__tests__/toolRegistry.test.ts
@@ -160,7 +160,8 @@ describe("toolRegistry", () => {
     });
     const action = createSavePromptClientAction({
       playgroundStore,
-      setPendingSavePrompt: store.getState().setPendingSavePrompt,
+      setPendingApproval: store.getState().setPendingApproval,
+      clearPendingApproval: store.getState().clearPendingApproval,
       savePrompt,
     });
     store.getState().registerClientAction(SAVE_PROMPT_TOOL_NAME, action);
@@ -181,7 +182,7 @@ describe("toolRegistry", () => {
     expect(savePrompt).not.toHaveBeenCalled();
     expect(addToolOutput).not.toHaveBeenCalled();
     const pendingSave =
-      store.getState().pendingSavePromptsByToolCallId["tool-call-save-prompt"];
+      store.getState().pendingApprovalsByToolCallId["tool-call-save-prompt"];
     expect(pendingSave).toEqual(
       expect.objectContaining({
         toolCallId: "tool-call-save-prompt",
@@ -213,7 +214,7 @@ describe("toolRegistry", () => {
       })
     );
     expect(
-      store.getState().pendingSavePromptsByToolCallId["tool-call-save-prompt"]
+      store.getState().pendingApprovalsByToolCallId["tool-call-save-prompt"]
     ).toBeUndefined();
   });
 
@@ -362,7 +363,8 @@ describe("toolRegistry", () => {
     });
     const action = createSavePromptClientAction({
       playgroundStore,
-      setPendingSavePrompt: store.getState().setPendingSavePrompt,
+      setPendingApproval: store.getState().setPendingApproval,
+      clearPendingApproval: store.getState().clearPendingApproval,
       shouldAutoAccept: () => store.getState().permissions.edits === "bypass",
       savePrompt,
     });
@@ -387,7 +389,7 @@ describe("toolRegistry", () => {
       input,
     });
     expect(
-      store.getState().pendingSavePromptsByToolCallId[
+      store.getState().pendingApprovalsByToolCallId[
         "tool-call-save-prompt-bypass"
       ]
     ).toBeUndefined();

--- a/app/src/agent/extensions/registry/defineTool.ts
+++ b/app/src/agent/extensions/registry/defineTool.ts
@@ -65,9 +65,14 @@ export type AgentToolDefinition = {
    * only after the server-environment guard and capability gate have passed.
    */
   dispatch: (context: AgentToolDispatchContext) => Promise<void>;
-  // TODO(pending-tool-rehydration): a future `rehydration?` field can declare
-  // how a pending tool serializes its UI state and rebinds runtime
-  // dependencies, replacing each tool's bespoke Zustand + page-level logic.
+  // Approval-gated tools (edit_prompt_instance, save_prompt, …) do not declare
+  // their pending state here: `accept`/`reject`/`cancel` capture
+  // non-serializable runtime deps (Relay mutations, store setters,
+  // `addToolOutput`) that cannot live on this static registry entry. Instead the
+  // shared `bindPendingApproval` (agent/shared/pendingApproval) binds those
+  // callbacks at dispatch/mount time and the data lands in the single
+  // `pendingApprovalsByToolCallId` store slice — the "data in the store,
+  // behavior rebound at dispatch" split the rehydration seam was reserved for.
 };
 
 /** Resolves a tool's invalid-input message, which may depend on the input. */

--- a/app/src/agent/shared/pendingApproval/__tests__/cancelPendingApprovals.test.ts
+++ b/app/src/agent/shared/pendingApproval/__tests__/cancelPendingApprovals.test.ts
@@ -1,0 +1,70 @@
+import { cancelPendingApprovalsForTools } from "../cancelPendingApprovals";
+import type {
+  PendingApproval,
+  PendingApprovalsByToolCallId,
+} from "../registry";
+import { selectPendingApproval } from "../selectPendingApproval";
+
+/**
+ * Builds a minimal pending-approval stand-in. The union is exercised
+ * structurally here (only the identity + `cancel` matter to these helpers), so
+ * a cast keeps the fixtures free of each tool's full preview payload.
+ */
+function fakePending(
+  toolCallId: string,
+  toolName: string,
+  cancel: () => Promise<void>
+): PendingApproval {
+  return { toolCallId, toolName, cancel } as unknown as PendingApproval;
+}
+
+describe("selectPendingApproval", () => {
+  it("returns the staged approval for a tool call, or null when absent", () => {
+    const pending = fakePending("call-1", "save_prompt", async () => {});
+    const state = {
+      pendingApprovalsByToolCallId: {
+        "call-1": pending,
+      } satisfies PendingApprovalsByToolCallId,
+    };
+    expect(selectPendingApproval(state, "call-1")).toBe(pending);
+    expect(selectPendingApproval(state, "missing")).toBeNull();
+  });
+});
+
+describe("cancelPendingApprovalsForTools", () => {
+  it("cancels only approvals owned by the given tool names", () => {
+    const calls: string[] = [];
+    const record: PendingApprovalsByToolCallId = {
+      "call-save": fakePending("call-save", "save_prompt", async () => {
+        calls.push("call-save");
+      }),
+      "call-load": fakePending("call-load", "load_dataset", async () => {
+        calls.push("call-load");
+      }),
+      "call-eval": fakePending(
+        "call-eval",
+        "edit_code_evaluator_draft",
+        async () => {
+          calls.push("call-eval");
+        }
+      ),
+    };
+
+    cancelPendingApprovalsForTools({
+      pendingApprovalsByToolCallId: record,
+      toolNames: ["save_prompt", "load_dataset"],
+    });
+
+    // The evaluator approval is owned by a different surface and left untouched.
+    expect(calls.sort()).toEqual(["call-load", "call-save"]);
+  });
+
+  it("ignores tool names with no staged approval", () => {
+    expect(() =>
+      cancelPendingApprovalsForTools({
+        pendingApprovalsByToolCallId: {},
+        toolNames: ["save_prompt"],
+      })
+    ).not.toThrow();
+  });
+});

--- a/app/src/agent/shared/pendingApproval/__tests__/pendingApproval.test.ts
+++ b/app/src/agent/shared/pendingApproval/__tests__/pendingApproval.test.ts
@@ -1,61 +1,93 @@
 import { bindPendingApproval } from "../index";
-import type { ApprovalApplyResult, PendingApproval } from "../types";
+import type {
+  ApprovalCommitResult,
+  ApprovalSource,
+  PendingApprovalActions,
+  PendingApprovalIdentity,
+} from "../types";
 
 type ToolOutputCall = Record<string, unknown>;
 
-function setup(applyResult: ApprovalApplyResult) {
+type DemoPending = PendingApprovalIdentity &
+  PendingApprovalActions & {
+    kind: string;
+  };
+
+function setup(commitResult: ApprovalCommitResult) {
   const outputs: ToolOutputCall[] = [];
-  const pendingSets: Array<PendingApproval<{ kind: string }> | null> = [];
-  let applyCalls = 0;
-  const pending = bindPendingApproval<{ kind: string }>({
+  const cleared: string[] = [];
+  let commitCalls = 0;
+  let lastApprovalSource: ApprovalSource | null = null;
+  const pending = bindPendingApproval<DemoPending>({
     pending: {
       toolCallId: "call-1",
       toolName: "some_write_tool",
-      preview: { kind: "demo" },
+      kind: "demo",
     },
-    apply: async () => {
-      applyCalls += 1;
-      return applyResult;
+    commit: async ({ approvalSource }) => {
+      commitCalls += 1;
+      lastApprovalSource = approvalSource;
+      return commitResult;
     },
+    buildRejectedOutput: () => ({ status: "rejected", message: "nothing written" }),
+    navigationCancelError: "surface closed",
     addToolOutput: (async (out: ToolOutputCall) => {
       outputs.push(out);
     }) as never,
-    setPending: (_toolCallId, value) => {
-      pendingSets.push(value);
+    clearPending: (toolCallId) => {
+      cleared.push(toolCallId);
     },
-    rejectedMessage: "nothing written",
   });
-  return { pending, outputs, pendingSets, getApplyCalls: () => applyCalls };
+  return {
+    pending,
+    outputs,
+    cleared,
+    getCommitCalls: () => commitCalls,
+    getLastApprovalSource: () => lastApprovalSource,
+  };
 }
 
 describe("bindPendingApproval", () => {
-  it("accept clears the pending entry, applies, and emits an accepted output", async () => {
-    const { pending, outputs, pendingSets, getApplyCalls } = setup({
-      ok: true,
-      output: "done",
-    });
+  it("preserves the serializable pending data alongside the bound actions", () => {
+    const { pending } = setup({ ok: true, output: "done" });
+    expect(pending.toolCallId).toBe("call-1");
+    expect(pending.toolName).toBe("some_write_tool");
+    expect(pending.kind).toBe("demo");
+    expect(typeof pending.accept).toBe("function");
+    expect(typeof pending.reject).toBe("function");
+    expect(typeof pending.cancel).toBe("function");
+  });
+
+  it("accept clears the pending entry, commits, and emits the commit output", async () => {
+    const { pending, outputs, cleared, getCommitCalls, getLastApprovalSource } =
+      setup({ ok: true, output: { status: "accepted", message: "done" } });
     await pending.accept?.();
-    expect(getApplyCalls()).toBe(1);
-    expect(pendingSets).toEqual([null]);
+    expect(getCommitCalls()).toBe(1);
+    expect(getLastApprovalSource()).toBe("user");
+    expect(cleared).toEqual(["call-1"]);
     expect(outputs).toEqual([
       {
         state: "output-available",
         tool: "some_write_tool",
         toolCallId: "call-1",
-        output: { status: "accepted", acceptedBy: "user", message: "done" },
+        output: { status: "accepted", message: "done" },
       },
     ]);
   });
 
-  it("records the approval source for an auto (bypass) accept", async () => {
-    const { pending, outputs } = setup({ ok: true, output: "done" });
+  it("forwards the approval source for an auto (bypass) accept", async () => {
+    const { pending, getLastApprovalSource } = setup({
+      ok: true,
+      output: "done",
+    });
     await pending.accept?.({ approvalSource: "auto" });
-    expect(outputs[0].output).toMatchObject({ acceptedBy: "auto" });
+    expect(getLastApprovalSource()).toBe("auto");
   });
 
-  it("emits an error output without applying again when apply fails", async () => {
-    const { pending, outputs } = setup({ ok: false, error: "boom" });
+  it("emits an error output when the commit fails", async () => {
+    const { pending, outputs, cleared } = setup({ ok: false, error: "boom" });
     await pending.accept?.();
+    expect(cleared).toEqual(["call-1"]);
     expect(outputs).toEqual([
       {
         state: "output-error",
@@ -66,20 +98,38 @@ describe("bindPendingApproval", () => {
     ]);
   });
 
-  it("reject clears the entry and reports the rejected message without applying", async () => {
-    const { pending, outputs, pendingSets, getApplyCalls } = setup({
+  it("reject clears the entry and reports the rejected output without committing", async () => {
+    const { pending, outputs, cleared, getCommitCalls } = setup({
       ok: true,
       output: "done",
     });
     await pending.reject?.();
-    expect(getApplyCalls()).toBe(0);
-    expect(pendingSets).toEqual([null]);
+    expect(getCommitCalls()).toBe(0);
+    expect(cleared).toEqual(["call-1"]);
     expect(outputs).toEqual([
       {
         state: "output-available",
         tool: "some_write_tool",
         toolCallId: "call-1",
         output: { status: "rejected", message: "nothing written" },
+      },
+    ]);
+  });
+
+  it("cancel clears the entry and reports the navigation-cancel error", async () => {
+    const { pending, outputs, cleared, getCommitCalls } = setup({
+      ok: true,
+      output: "done",
+    });
+    await pending.cancel?.();
+    expect(getCommitCalls()).toBe(0);
+    expect(cleared).toEqual(["call-1"]);
+    expect(outputs).toEqual([
+      {
+        state: "output-error",
+        tool: "some_write_tool",
+        toolCallId: "call-1",
+        errorText: "surface closed",
       },
     ]);
   });

--- a/app/src/agent/shared/pendingApproval/bindPendingApproval.ts
+++ b/app/src/agent/shared/pendingApproval/bindPendingApproval.ts
@@ -1,28 +1,44 @@
-import type { BindPendingApprovalOptions, PendingApproval } from "./types";
+import type {
+  BindPendingApprovalOptions,
+  PendingApprovalActions,
+  PendingApprovalIdentity,
+} from "./types";
 
 /**
- * Attach accept/reject callbacks to a proposed, approval-gated write. `accept`
- * clears the pending entry, runs the write via `apply`, and reports the outcome
- * to the model; `reject` clears the entry and reports `rejectedMessage`. In
- * bypass edit mode the caller invokes `accept({ approvalSource: "auto" })`
- * directly; in manual mode the inline card calls these on the user's click.
+ * Attach accept/reject/cancel callbacks to an approval-gated write proposal.
  *
- * This is the generic core shared by every approval-gated write tool — supply a
- * `TPreview` for the card payload and a per-domain `rejectedMessage`.
+ * This is the single generic lifecycle shared by every approval tool. Each
+ * path clears the pending entry from the store first, then:
+ * - `accept` runs the tool's `commit` and emits its `output` (or an error);
+ * - `reject` emits the tool's rejected output;
+ * - `cancel` (navigation-cancel) emits the tool's `navigationCancelError`.
+ *
+ * In bypass edit mode the caller invokes `accept({ approvalSource: "auto" })`
+ * directly; in manual mode the inline Accept/Reject card calls `accept`/`reject`
+ * on the user's click, and the owning surface's unmount cleanup calls `cancel`.
+ *
+ * The tool-specific `commit` returns the full model-facing output object, so
+ * consolidating the lifecycle preserves each tool's existing output shape.
+ *
+ * @param options - the pending data plus tool-specific behaviors; see
+ *   {@link BindPendingApprovalOptions}
+ * @returns the pending member `T` with `accept`/`reject`/`cancel` attached
  */
-export function bindPendingApproval<TPreview>({
+export function bindPendingApproval<
+  T extends PendingApprovalIdentity & PendingApprovalActions,
+>({
   pending,
-  apply,
+  commit,
+  buildRejectedOutput,
+  navigationCancelError,
   addToolOutput,
-  setPending,
-  rejectedMessage,
-}: BindPendingApprovalOptions<TPreview>): PendingApproval<TPreview> {
+  clearPending,
+}: BindPendingApprovalOptions<T>): T {
   const { toolCallId, toolName } = pending;
-  return {
-    ...pending,
+  const actions: PendingApprovalActions = {
     accept: async ({ approvalSource = "user" } = {}) => {
-      setPending(toolCallId, null);
-      const result = await apply();
+      clearPending(toolCallId);
+      const result = await commit({ approvalSource });
       if (!result.ok) {
         await addToolOutput({
           state: "output-error",
@@ -36,21 +52,34 @@ export function bindPendingApproval<TPreview>({
         state: "output-available",
         tool: toolName,
         toolCallId,
-        output: {
-          status: "accepted",
-          acceptedBy: approvalSource,
-          message: result.output,
-        },
+        output: result.output,
       });
     },
     reject: async () => {
-      setPending(toolCallId, null);
+      clearPending(toolCallId);
       await addToolOutput({
         state: "output-available",
         tool: toolName,
         toolCallId,
-        output: { status: "rejected", message: rejectedMessage },
+        output: buildRejectedOutput(),
       });
     },
+    // Only approvals with a navigation-cancel path get a `cancel` callback.
+    ...(navigationCancelError != null
+      ? {
+          cancel: async () => {
+            clearPending(toolCallId);
+            await addToolOutput({
+              state: "output-error",
+              tool: toolName,
+              toolCallId,
+              errorText: navigationCancelError,
+            });
+          },
+        }
+      : {}),
   };
+  // The spread reunites the serializable data with the freshly bound behavior;
+  // TypeScript cannot prove the result is exactly `T`, hence the assertion.
+  return { ...pending, ...actions } as T;
 }

--- a/app/src/agent/shared/pendingApproval/cancelPendingApprovals.ts
+++ b/app/src/agent/shared/pendingApproval/cancelPendingApprovals.ts
@@ -1,0 +1,25 @@
+import type { PendingApprovalsByToolCallId } from "./registry";
+
+/**
+ * Navigation-cancel every pending approval owned by one of `toolNames`,
+ * discarding the proposal and reporting the cancel to the model.
+ *
+ * A surface (e.g. the playground, or an evaluator dialog) calls this from its
+ * unmount cleanup for the approval tools it hosts, so a proposal left
+ * unresolved when its editor closes is not silently stranded. Approvals owned
+ * by other surfaces are left untouched.
+ */
+export function cancelPendingApprovalsForTools({
+  pendingApprovalsByToolCallId,
+  toolNames,
+}: {
+  pendingApprovalsByToolCallId: PendingApprovalsByToolCallId;
+  toolNames: readonly string[];
+}): void {
+  const owned = new Set(toolNames);
+  for (const pending of Object.values(pendingApprovalsByToolCallId)) {
+    if (pending && owned.has(pending.toolName)) {
+      void pending.cancel?.();
+    }
+  }
+}

--- a/app/src/agent/shared/pendingApproval/index.ts
+++ b/app/src/agent/shared/pendingApproval/index.ts
@@ -1,8 +1,15 @@
 export { bindPendingApproval } from "./bindPendingApproval";
+export { cancelPendingApprovalsForTools } from "./cancelPendingApprovals";
 export type {
-  ApprovalApplyResult,
+  PendingApproval,
+  PendingApprovalsByToolCallId,
+} from "./registry";
+export { selectPendingApproval } from "./selectPendingApproval";
+export type {
+  ApprovalCommitResult,
   ApprovalSource,
   ApprovalToolOutputSender,
   BindPendingApprovalOptions,
-  PendingApproval,
+  PendingApprovalActions,
+  PendingApprovalIdentity,
 } from "./types";

--- a/app/src/agent/shared/pendingApproval/registry.ts
+++ b/app/src/agent/shared/pendingApproval/registry.ts
@@ -1,0 +1,34 @@
+import type { PendingBatchSpanAnnotate } from "@phoenix/agent/tools/batchSpanAnnotate";
+import type { PendingCodeEvaluatorEdit } from "@phoenix/agent/tools/codeEvaluatorDraft";
+import type { PendingLlmEvaluatorEdit } from "@phoenix/agent/tools/llmEvaluatorDraft";
+import type { PendingLoadDataset } from "@phoenix/agent/tools/playgroundLoadDataset";
+import type {
+  PendingPromptEdit,
+  PendingPromptInstanceRemoval,
+} from "@phoenix/agent/tools/playgroundPrompt";
+import type { PendingPromptToolWrite } from "@phoenix/agent/tools/playgroundPromptTools";
+import type { PendingSavePrompt } from "@phoenix/agent/tools/playgroundSavePrompt";
+
+/**
+ * The single discriminated union of every approval-gated pending write,
+ * discriminated by `toolName`. Each member carries its own preview data plus
+ * the lifecycle callbacks bound by `bindPendingApproval` at dispatch/mount time.
+ *
+ * Adding a new approval tool means adding one member here and one arm to the
+ * consuming ToolDetails switch — the store slice, setters, selector, and
+ * navigation-cancel are all generic and need no per-tool change.
+ */
+export type PendingApproval =
+  | PendingPromptEdit
+  | PendingPromptInstanceRemoval
+  | PendingBatchSpanAnnotate
+  | PendingPromptToolWrite
+  | PendingSavePrompt
+  | PendingCodeEvaluatorEdit
+  | PendingLlmEvaluatorEdit
+  | PendingLoadDataset;
+
+/** The store slice keying pending approvals by their originating tool-call id. */
+export type PendingApprovalsByToolCallId = Partial<
+  Record<string, PendingApproval>
+>;

--- a/app/src/agent/shared/pendingApproval/selectPendingApproval.ts
+++ b/app/src/agent/shared/pendingApproval/selectPendingApproval.ts
@@ -1,0 +1,18 @@
+import type {
+  PendingApproval,
+  PendingApprovalsByToolCallId,
+} from "./registry";
+
+/**
+ * Reads the pending approval staged for a tool call, if any.
+ *
+ * This is the single state-read seam every approval `*ToolDetails` component
+ * uses (replacing the per-tool `state.pending*ByToolCallId[toolCallId]` reads).
+ * Callers narrow the returned union by `toolName` to render their own preview.
+ */
+export function selectPendingApproval(
+  state: { pendingApprovalsByToolCallId: PendingApprovalsByToolCallId },
+  toolCallId: string
+): PendingApproval | null {
+  return state.pendingApprovalsByToolCallId[toolCallId] ?? null;
+}

--- a/app/src/agent/shared/pendingApproval/types.ts
+++ b/app/src/agent/shared/pendingApproval/types.ts
@@ -5,40 +5,62 @@ import type { ApprovalSource } from "@phoenix/agent/tools/approval";
 
 export type { ApprovalSource };
 
+/** AI SDK callback used to surface a tool's output back to the model. */
 export type ApprovalToolOutputSender = Chat<UIMessage>["addToolOutput"];
 
-/** The result of applying an approved write (returned by each tool's commit fn). */
-export type ApprovalApplyResult =
-  | { ok: true; output: string }
+/**
+ * Outcome of committing an approved write. `output` is the full, model-facing
+ * payload each tool builds — its shape stays tool-specific and is emitted
+ * verbatim, so consolidating the lifecycle does not flatten per-tool outputs.
+ */
+export type ApprovalCommitResult =
+  | { ok: true; output: unknown }
   | { ok: false; error: string };
 
 /**
- * A write proposed by a tool call and awaiting the user's Accept/Reject in
- * manual edit mode, generic over the `TPreview` payload the tool's card
- * renders. `accept`/`reject` are bound by {@link bindPendingApproval}; they are
- * absent once the proposal can no longer be acted on (e.g. after a refresh).
+ * Accept/reject/cancel callbacks bound onto a pending approval at dispatch or
+ * mount time. They capture non-serializable runtime dependencies (Relay
+ * mutations, store setters, the AI SDK `addToolOutput`), which is why only the
+ * plain data is ever persisted and the behavior is rebound here.
  */
-export type PendingApproval<TPreview> = {
-  toolCallId: string;
-  /** Server tool name, so output is attributed to the right tool. */
-  toolName: string;
-  preview: TPreview;
+export type PendingApprovalActions = {
   accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
   reject?: () => Promise<void>;
+  cancel?: () => Promise<void>;
 };
 
-export type BindPendingApprovalOptions<TPreview> = {
-  pending: Pick<
-    PendingApproval<TPreview>,
-    "toolCallId" | "toolName" | "preview"
-  >;
-  /** Performs the actual write; called only on accept (or auto-accept). */
-  apply: () => Promise<ApprovalApplyResult>;
+/** The serializable identity every pending approval shares. */
+export type PendingApprovalIdentity = {
+  toolCallId: string;
+  /** Server tool name; the discriminant of the stored pending-approval union. */
+  toolName: string;
+};
+
+/**
+ * Configuration for {@link bindPendingApproval}, generic over the concrete
+ * pending-approval member `T` (e.g. `PendingPromptEdit`). The tool supplies its
+ * serializable `pending` data plus the three tool-specific behaviors (`commit`,
+ * `buildRejectedOutput`, `navigationCancelError`); the generic core owns the
+ * shared lifecycle (clear-on-resolve and output emission).
+ */
+export type BindPendingApprovalOptions<
+  T extends PendingApprovalIdentity & PendingApprovalActions,
+> = {
+  /** The serializable pending data, without the lifecycle callbacks. */
+  pending: Omit<T, keyof PendingApprovalActions>;
+  /** Applies the approved write; called only on accept (or auto-accept). */
+  commit: (options: {
+    approvalSource: ApprovalSource;
+  }) => Promise<ApprovalCommitResult>;
+  /** Builds the model-facing output reported when the user rejects. */
+  buildRejectedOutput: () => unknown;
+  /**
+   * Error reported when the owning surface unmounts before review. When omitted,
+   * no `cancel` callback is bound — the case for approvals with no
+   * navigation-cancel path (e.g. dataset writes).
+   */
+  navigationCancelError?: string;
   addToolOutput: ApprovalToolOutputSender;
-  setPending: (
-    toolCallId: string,
-    pending: PendingApproval<TPreview> | null
-  ) => void;
-  /** Message reported to the model when the user rejects. */
-  rejectedMessage: string;
+  /** Clears this proposal from the store; runs first in every lifecycle path. */
+  clearPending: (toolCallId: string) => void;
 };

--- a/app/src/agent/shared/pendingDatasetWrite/bindPendingDatasetWrite.ts
+++ b/app/src/agent/shared/pendingDatasetWrite/bindPendingDatasetWrite.ts
@@ -9,9 +9,11 @@ const REJECTED_MESSAGE =
   "You rejected the proposed dataset change, so nothing was written.";
 
 /**
- * Dataset-specific wrapper over the generic {@link bindPendingApproval}: fills
- * in the dataset reject message and adapts the dataset-named store setter. The
- * accept/reject/apply mechanics live in the generic core.
+ * Dataset-specific wrapper over the generic {@link bindPendingApproval}: adapts
+ * the dataset `apply` (which returns a plain success message) into the generic
+ * commit's `{ status: "accepted", ... }` output, fills in the dataset reject
+ * message, and adapts the dataset-named store setter. Dataset writes have no
+ * navigation-cancel path, so no `navigationCancelError` is supplied.
  */
 export function bindPendingDatasetWrite({
   pending,
@@ -19,11 +21,27 @@ export function bindPendingDatasetWrite({
   addToolOutput,
   setPendingDatasetWrite,
 }: BindPendingDatasetWriteOptions): PendingDatasetWrite {
-  return bindPendingApproval({
+  return bindPendingApproval<PendingDatasetWrite>({
     pending,
-    apply,
     addToolOutput,
-    setPending: setPendingDatasetWrite,
-    rejectedMessage: REJECTED_MESSAGE,
+    clearPending: (toolCallId) => setPendingDatasetWrite(toolCallId, null),
+    commit: async ({ approvalSource }) => {
+      const result = await apply();
+      if (!result.ok) {
+        return { ok: false, error: result.error };
+      }
+      return {
+        ok: true,
+        output: {
+          status: "accepted",
+          acceptedBy: approvalSource,
+          message: result.output,
+        },
+      };
+    },
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      message: REJECTED_MESSAGE,
+    }),
   });
 }

--- a/app/src/agent/shared/pendingDatasetWrite/types.ts
+++ b/app/src/agent/shared/pendingDatasetWrite/types.ts
@@ -1,7 +1,6 @@
 import type {
-  ApprovalApplyResult,
   ApprovalToolOutputSender,
-  PendingApproval,
+  PendingApprovalActions,
 } from "@phoenix/agent/shared/pendingApproval";
 
 export type { ApprovalSource } from "@phoenix/agent/shared/pendingApproval";
@@ -74,15 +73,23 @@ export type DatasetWritePreview =
   | { kind: "delete-labels"; labelNames: string[] }
   | { kind: "add-spans"; datasetName: string; spanCount: number };
 
-/** Outcome of applying a dataset write (the generic apply result). */
-export type DatasetWriteApplyResult = ApprovalApplyResult;
+/** Outcome of applying a dataset write: a success message or an error. */
+export type DatasetWriteApplyResult =
+  | { ok: true; output: string }
+  | { ok: false; error: string };
 
 /**
  * A dataset write (create dataset / add examples / split & label changes)
  * proposed by a tool call and awaiting the user's Accept/Reject in manual edit
- * mode — the generic {@link PendingApproval} specialized to the dataset preview.
+ * mode. Unlike the toolCallId-keyed approval union, dataset writes carry their
+ * data in a `preview` discriminated by `kind` and live in their own store slice;
+ * they share only the generic accept/reject lifecycle via `bindPendingApproval`.
  */
-export type PendingDatasetWrite = PendingApproval<DatasetWritePreview>;
+export type PendingDatasetWrite = {
+  toolCallId: string;
+  toolName: string;
+  preview: DatasetWritePreview;
+} & PendingApprovalActions;
 
 export type BindPendingDatasetWriteOptions = {
   pending: Pick<PendingDatasetWrite, "toolCallId" | "toolName" | "preview">;

--- a/app/src/agent/tools/batchSpanAnnotate/batchSpanAnnotateAgentTool.ts
+++ b/app/src/agent/tools/batchSpanAnnotate/batchSpanAnnotateAgentTool.ts
@@ -46,13 +46,13 @@ export const batchSpanAnnotateAgentTool = defineTool<BatchSpanAnnotateInput>({
     const pendingAnnotation = bindPendingBatchSpanAnnotateActions({
       pendingAnnotation: {
         toolCallId: context.toolCallId,
+        toolName: BATCH_SPAN_ANNOTATE_TOOL_NAME,
         sessionId: context.sessionId,
         annotations: input,
       },
       applyAnnotations: applySpanAnnotations,
       addToolOutput: context.addToolOutput,
-      setPendingBatchSpanAnnotate:
-        agentStore.getState().setPendingBatchSpanAnnotate,
+      clearPending: agentStore.getState().clearPendingApproval,
     });
 
     if (agentStore.getState().permissions.edits === "bypass") {
@@ -62,6 +62,6 @@ export const batchSpanAnnotateAgentTool = defineTool<BatchSpanAnnotateInput>({
 
     agentStore
       .getState()
-      .setPendingBatchSpanAnnotate(toolCall.toolCallId, pendingAnnotation);
+      .setPendingApproval(toolCall.toolCallId, pendingAnnotation);
   },
 });

--- a/app/src/agent/tools/batchSpanAnnotate/pendingBatchSpanAnnotate.ts
+++ b/app/src/agent/tools/batchSpanAnnotate/pendingBatchSpanAnnotate.ts
@@ -1,4 +1,5 @@
-import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "./constants";
+import { bindPendingApproval } from "@phoenix/agent/shared/pendingApproval";
+
 import type {
   AnnotateSpanInput,
   BindPendingBatchSpanAnnotateOptions,
@@ -20,38 +21,39 @@ function toAnnotationOutput(annotation: AnnotateSpanInput) {
   };
 }
 
-/** Attaches accept/reject callbacks to a pending batch span annotate proposal. */
+/**
+ * Attaches accept/reject/cancel callbacks to a pending batch span annotate
+ * proposal. The generic lifecycle lives in {@link bindPendingApproval}; only the
+ * commit (applying the annotations) is annotation-specific.
+ */
 export function bindPendingBatchSpanAnnotateActions({
   pendingAnnotation,
   applyAnnotations,
   addToolOutput,
-  setPendingBatchSpanAnnotate,
+  clearPending,
 }: BindPendingBatchSpanAnnotateOptions): PendingBatchSpanAnnotate {
   const { annotations } = pendingAnnotation;
   const count = annotations.length;
   const noun = count === 1 ? "annotation" : "annotations";
-  return {
-    ...pendingAnnotation,
-    accept: async ({ approvalSource = "user" } = {}) => {
-      setPendingBatchSpanAnnotate(pendingAnnotation.toolCallId, null);
+  return bindPendingApproval<PendingBatchSpanAnnotate>({
+    pending: pendingAnnotation,
+    addToolOutput,
+    clearPending,
+    navigationCancelError: BATCH_SPAN_ANNOTATE_NAVIGATION_CANCEL_ERROR,
+    commit: async ({ approvalSource }) => {
       try {
         await applyAnnotations(annotations);
       } catch (error) {
-        await addToolOutput({
-          state: "output-error",
-          tool: BATCH_SPAN_ANNOTATE_TOOL_NAME,
-          toolCallId: pendingAnnotation.toolCallId,
-          errorText:
+        return {
+          ok: false,
+          error:
             error instanceof Error
               ? error.message
               : "Failed to apply span annotations.",
-        });
-        return;
+        };
       }
-      await addToolOutput({
-        state: "output-available",
-        tool: BATCH_SPAN_ANNOTATE_TOOL_NAME,
-        toolCallId: pendingAnnotation.toolCallId,
+      return {
+        ok: true,
         output: {
           status: "accepted",
           acceptedBy: approvalSource,
@@ -62,30 +64,13 @@ export function bindPendingBatchSpanAnnotateActions({
               ? `${count} span ${noun} auto-approved.`
               : `${count} span ${noun} applied.`,
         },
-      });
+      };
     },
-    reject: async () => {
-      setPendingBatchSpanAnnotate(pendingAnnotation.toolCallId, null);
-      await addToolOutput({
-        state: "output-available",
-        tool: BATCH_SPAN_ANNOTATE_TOOL_NAME,
-        toolCallId: pendingAnnotation.toolCallId,
-        output: {
-          status: "rejected",
-          count,
-          annotations: annotations.map(toAnnotationOutput),
-          message: `User rejected the proposed span ${noun}.`,
-        },
-      });
-    },
-    cancel: async () => {
-      setPendingBatchSpanAnnotate(pendingAnnotation.toolCallId, null);
-      await addToolOutput({
-        state: "output-error",
-        tool: BATCH_SPAN_ANNOTATE_TOOL_NAME,
-        toolCallId: pendingAnnotation.toolCallId,
-        errorText: BATCH_SPAN_ANNOTATE_NAVIGATION_CANCEL_ERROR,
-      });
-    },
-  };
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      count,
+      annotations: annotations.map(toAnnotationOutput),
+      message: `User rejected the proposed span ${noun}.`,
+    }),
+  });
 }

--- a/app/src/agent/tools/batchSpanAnnotate/types.ts
+++ b/app/src/agent/tools/batchSpanAnnotate/types.ts
@@ -1,7 +1,9 @@
 import type { z } from "zod";
 
+import type { PendingApprovalActions } from "@phoenix/agent/shared/pendingApproval";
 import type { ApprovalSource } from "@phoenix/agent/tools/approval";
 
+import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "./constants";
 import type {
   annotateSpanInputSchema,
   batchSpanAnnotateActionContextSchema,
@@ -25,21 +27,20 @@ export type BatchSpanAnnotateActionContext = z.output<
 
 export type PendingBatchSpanAnnotate = {
   toolCallId: string;
+  toolName: typeof BATCH_SPAN_ANNOTATE_TOOL_NAME;
   /** Agent session that owns the unresolved batch_span_annotate tool call. */
   sessionId: string;
   /** The one or more annotations proposed by this tool call. */
   annotations: AnnotateSpanInput[];
-  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
-  reject?: () => Promise<void>;
-  cancel?: () => Promise<void>;
-};
+} & PendingApprovalActions;
 
 export type BindPendingBatchSpanAnnotateOptions = {
-  pendingAnnotation: PendingBatchSpanAnnotate;
+  pendingAnnotation: Omit<
+    PendingBatchSpanAnnotate,
+    keyof PendingApprovalActions
+  >;
   applyAnnotations: (annotations: AnnotateSpanInput[]) => Promise<void>;
   addToolOutput: BatchSpanAnnotateToolOutputSender;
-  setPendingBatchSpanAnnotate: (
-    toolCallId: string,
-    annotation: PendingBatchSpanAnnotate | null
-  ) => void;
+  /** Clears this proposal from the unified pending-approval store slice. */
+  clearPending: (toolCallId: string) => void;
 };

--- a/app/src/agent/tools/codeEvaluatorDraft/__tests__/codeEvaluatorDraft.test.ts
+++ b/app/src/agent/tools/codeEvaluatorDraft/__tests__/codeEvaluatorDraft.test.ts
@@ -328,9 +328,10 @@ describe("code evaluator draft agent tools", () => {
     let pending: PendingCodeEvaluatorEdit | null = null;
     const action = createEditCodeEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingCodeEvaluatorEdit: (_, edit) => {
-        pending = edit;
+      setPendingApproval: (_, edit) => {
+        pending = edit as PendingCodeEvaluatorEdit;
       },
+      clearPendingApproval: () => {},
     });
     const result = await action(
       {
@@ -354,9 +355,10 @@ describe("code evaluator draft agent tools", () => {
     const outputs: Array<Record<string, unknown>> = [];
     const action = createEditCodeEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingCodeEvaluatorEdit: (_, edit) => {
-        pending = edit;
+      setPendingApproval: (_, edit) => {
+        pending = edit as PendingCodeEvaluatorEdit;
       },
+      clearPendingApproval: () => {},
     });
     await action(
       {
@@ -382,9 +384,10 @@ describe("code evaluator draft agent tools", () => {
     const outputs: Array<Record<string, unknown>> = [];
     const action = createEditCodeEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingCodeEvaluatorEdit: (_, edit) => {
-        pending = edit;
+      setPendingApproval: (_, edit) => {
+        pending = edit as PendingCodeEvaluatorEdit;
       },
+      clearPendingApproval: () => {},
     });
     await action(
       {
@@ -413,9 +416,10 @@ describe("code evaluator draft agent tools", () => {
     const outputs: Array<Record<string, unknown>> = [];
     const action = createEditCodeEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingCodeEvaluatorEdit: (_, edit) => {
+      setPendingApproval: (_, edit) => {
         if (edit) surfacedPending = true;
       },
+      clearPendingApproval: () => {},
       shouldAutoAccept: () => true,
     });
     const result = await action(
@@ -459,9 +463,10 @@ describe("code evaluator draft agent tools", () => {
     let pending: PendingCodeEvaluatorEdit | null = null;
     const action = createEditCodeEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingCodeEvaluatorEdit: (_, edit) => {
-        pending = edit;
+      setPendingApproval: (_, edit) => {
+        pending = edit as PendingCodeEvaluatorEdit;
       },
+      clearPendingApproval: () => {},
       shouldAutoAccept: () => true,
     });
     await action(

--- a/app/src/agent/tools/codeEvaluatorDraft/clientActions.ts
+++ b/app/src/agent/tools/codeEvaluatorDraft/clientActions.ts
@@ -1,8 +1,12 @@
+import type { PendingApproval } from "@phoenix/agent/shared/pendingApproval";
 import { createEvaluatorSubmitClientAction } from "@phoenix/agent/tools/approval";
 import { parseEmptyToolInput } from "@phoenix/agent/tools/emptyToolInput";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
 
-import { SUBMIT_CODE_EVALUATOR_DRAFT_TOOL_NAME } from "./constants";
+import {
+  EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
+  SUBMIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
+} from "./constants";
 import {
   parseEditCodeEvaluatorDraftActionContext,
   parseEditCodeEvaluatorDraftInput,
@@ -13,7 +17,6 @@ import { bindPendingCodeEvaluatorEditActions } from "./pendingCodeEvaluatorEdit"
 import type {
   CodeEvaluatorActionResult,
   CodeEvaluatorDraftHost,
-  PendingCodeEvaluatorEdit,
 } from "./types";
 
 export function createReadCodeEvaluatorDraftClientAction({
@@ -42,14 +45,13 @@ export function createReadCodeEvaluatorDraftClientAction({
 
 export function createEditCodeEvaluatorDraftClientAction({
   getDraftHost,
-  setPendingCodeEvaluatorEdit,
+  setPendingApproval,
+  clearPendingApproval,
   shouldAutoAccept = () => false,
 }: {
   getDraftHost: () => CodeEvaluatorDraftHost | null;
-  setPendingCodeEvaluatorEdit: (
-    toolCallId: string,
-    edit: PendingCodeEvaluatorEdit | null
-  ) => void;
+  setPendingApproval: (toolCallId: string, pending: PendingApproval) => void;
+  clearPendingApproval: (toolCallId: string) => void;
   shouldAutoAccept?: () => boolean;
 }) {
   return async (
@@ -85,6 +87,7 @@ export function createEditCodeEvaluatorDraftClientAction({
     const pendingEdit = bindPendingCodeEvaluatorEditActions({
       pendingEdit: {
         toolCallId: editContext.toolCallId,
+        toolName: EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
         sessionId: editContext.sessionId,
         before,
         after: proposed.output,
@@ -92,7 +95,7 @@ export function createEditCodeEvaluatorDraftClientAction({
       },
       draftHost: host,
       addToolOutput: editContext.addToolOutput,
-      setPendingCodeEvaluatorEdit,
+      clearPending: clearPendingApproval,
     });
 
     if (shouldAutoAccept()) {
@@ -100,7 +103,7 @@ export function createEditCodeEvaluatorDraftClientAction({
       return { ok: true };
     }
 
-    setPendingCodeEvaluatorEdit(editContext.toolCallId, pendingEdit);
+    setPendingApproval(editContext.toolCallId, pendingEdit);
     return { ok: true };
   };
 }

--- a/app/src/agent/tools/codeEvaluatorDraft/pendingCodeEvaluatorEdit.ts
+++ b/app/src/agent/tools/codeEvaluatorDraft/pendingCodeEvaluatorEdit.ts
@@ -1,36 +1,34 @@
-import {
-  EDIT_CODE_EVALUATOR_DRAFT_NAVIGATION_CANCEL_ERROR,
-  EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
-} from "./constants";
+import { bindPendingApproval } from "@phoenix/agent/shared/pendingApproval";
+
+import { EDIT_CODE_EVALUATOR_DRAFT_NAVIGATION_CANCEL_ERROR } from "./constants";
 import type {
   BindPendingCodeEvaluatorEditOptions,
   PendingCodeEvaluatorEdit,
 } from "./types";
 
+/**
+ * Attaches accept/reject/cancel callbacks to a pending code-evaluator draft
+ * edit. The generic lifecycle lives in {@link bindPendingApproval}; the commit
+ * applies the operations to the mounted draft host.
+ */
 export function bindPendingCodeEvaluatorEditActions({
   pendingEdit,
   draftHost,
   addToolOutput,
-  setPendingCodeEvaluatorEdit,
+  clearPending,
 }: BindPendingCodeEvaluatorEditOptions): PendingCodeEvaluatorEdit {
-  return {
-    ...pendingEdit,
-    accept: async ({ approvalSource = "user" } = {}) => {
-      setPendingCodeEvaluatorEdit(pendingEdit.toolCallId, null);
+  return bindPendingApproval<PendingCodeEvaluatorEdit>({
+    pending: pendingEdit,
+    addToolOutput,
+    clearPending,
+    navigationCancelError: EDIT_CODE_EVALUATOR_DRAFT_NAVIGATION_CANCEL_ERROR,
+    commit: async ({ approvalSource }) => {
       const applied = draftHost.applyOperations(pendingEdit.operations);
       if (!applied.ok) {
-        await addToolOutput({
-          state: "output-error",
-          tool: EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
-          toolCallId: pendingEdit.toolCallId,
-          errorText: applied.error,
-        });
-        return;
+        return { ok: false, error: applied.error };
       }
-      await addToolOutput({
-        state: "output-available",
-        tool: EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
+      return {
+        ok: true,
         output: {
           status: "accepted",
           acceptedBy: approvalSource,
@@ -39,28 +37,11 @@ export function bindPendingCodeEvaluatorEditActions({
               ? "Code-evaluator draft edit auto-approved."
               : "Code-evaluator draft edit applied.",
         },
-      });
+      };
     },
-    reject: async () => {
-      setPendingCodeEvaluatorEdit(pendingEdit.toolCallId, null);
-      await addToolOutput({
-        state: "output-available",
-        tool: EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
-        output: {
-          status: "rejected",
-          message: "User rejected the proposed code-evaluator draft edit.",
-        },
-      });
-    },
-    cancel: async () => {
-      setPendingCodeEvaluatorEdit(pendingEdit.toolCallId, null);
-      await addToolOutput({
-        state: "output-error",
-        tool: EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
-        errorText: EDIT_CODE_EVALUATOR_DRAFT_NAVIGATION_CANCEL_ERROR,
-      });
-    },
-  };
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      message: "User rejected the proposed code-evaluator draft edit.",
+    }),
+  });
 }

--- a/app/src/agent/tools/codeEvaluatorDraft/types.ts
+++ b/app/src/agent/tools/codeEvaluatorDraft/types.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 
+import type { PendingApprovalActions } from "@phoenix/agent/shared/pendingApproval";
 import type {
   ApprovalSource,
   EvaluatorSubmitResult,
@@ -20,6 +21,7 @@ export type {
   EvaluatorSubmitToolOutput,
 };
 
+import { EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME } from "./constants";
 import type {
   CodeEvaluatorEditToolOutputSender,
   editCodeEvaluatorDraftActionContextSchema,
@@ -112,21 +114,17 @@ export type CodeEvaluatorDraftHost = {
 
 export type PendingCodeEvaluatorEdit = {
   toolCallId: string;
+  toolName: typeof EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME;
   sessionId: string;
   before: CodeEvaluatorDraftSnapshot;
   after: CodeEvaluatorDraftSnapshot;
   operations: EditCodeEvaluatorDraftOperation[];
-  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
-  reject?: () => Promise<void>;
-  cancel?: () => Promise<void>;
-};
+} & PendingApprovalActions;
 
 export type BindPendingCodeEvaluatorEditOptions = {
-  pendingEdit: PendingCodeEvaluatorEdit;
+  pendingEdit: Omit<PendingCodeEvaluatorEdit, keyof PendingApprovalActions>;
   draftHost: CodeEvaluatorDraftHost;
   addToolOutput: CodeEvaluatorEditToolOutputSender;
-  setPendingCodeEvaluatorEdit: (
-    toolCallId: string,
-    edit: PendingCodeEvaluatorEdit | null
-  ) => void;
+  /** Clears this proposal from the unified pending-approval store slice. */
+  clearPending: (toolCallId: string) => void;
 };

--- a/app/src/agent/tools/llmEvaluatorDraft/__tests__/llmEvaluatorDraft.test.ts
+++ b/app/src/agent/tools/llmEvaluatorDraft/__tests__/llmEvaluatorDraft.test.ts
@@ -301,9 +301,10 @@ describe("llm evaluator draft edit lifecycle", () => {
     let pending: PendingLlmEvaluatorEdit | null = null;
     const action = createEditLlmEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingLlmEvaluatorEdit: (_, edit) => {
-        pending = edit;
+      setPendingApproval: (_, edit) => {
+        pending = edit as PendingLlmEvaluatorEdit;
       },
+      clearPendingApproval: () => {},
     });
     const result = await action(
       { operations: [{ type: "set_description", description: "from model" }] },
@@ -320,9 +321,10 @@ describe("llm evaluator draft edit lifecycle", () => {
     const outputs: Array<Record<string, unknown>> = [];
     const action = createEditLlmEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingLlmEvaluatorEdit: (_, edit) => {
-        pending = edit;
+      setPendingApproval: (_, edit) => {
+        pending = edit as PendingLlmEvaluatorEdit;
       },
+      clearPendingApproval: () => {},
     });
     await action(
       { operations: [{ type: "set_description", description: "accepted" }] },
@@ -347,9 +349,10 @@ describe("llm evaluator draft edit lifecycle", () => {
     const outputs: Array<Record<string, unknown>> = [];
     const action = createEditLlmEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingLlmEvaluatorEdit: (_, edit) => {
-        pending = edit;
+      setPendingApproval: (_, edit) => {
+        pending = edit as PendingLlmEvaluatorEdit;
       },
+      clearPendingApproval: () => {},
     });
     await action(
       { operations: [{ type: "set_description", description: "from model" }] },
@@ -377,9 +380,10 @@ describe("llm evaluator draft edit lifecycle", () => {
     const outputs: Array<Record<string, unknown>> = [];
     const action = createEditLlmEvaluatorDraftClientAction({
       getDraftHost: () => host,
-      setPendingLlmEvaluatorEdit: (_, edit) => {
+      setPendingApproval: (_, edit) => {
         if (edit) surfacedPending = true;
       },
+      clearPendingApproval: () => {},
       shouldAutoAccept: () => true,
     });
     const result = await action(

--- a/app/src/agent/tools/llmEvaluatorDraft/clientActions.ts
+++ b/app/src/agent/tools/llmEvaluatorDraft/clientActions.ts
@@ -1,8 +1,12 @@
+import type { PendingApproval } from "@phoenix/agent/shared/pendingApproval";
 import { createEvaluatorSubmitClientAction } from "@phoenix/agent/tools/approval";
 import { parseEmptyToolInput } from "@phoenix/agent/tools/emptyToolInput";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
 
-import { SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_NAME } from "./constants";
+import {
+  EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
+  SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
+} from "./constants";
 import {
   parseEditLlmEvaluatorDraftActionContext,
   parseEditLlmEvaluatorDraftInput,
@@ -13,7 +17,6 @@ import { bindPendingLlmEvaluatorEditActions } from "./pendingLlmEvaluatorEdit";
 import type {
   LlmEvaluatorActionResult,
   LlmEvaluatorDraftHost,
-  PendingLlmEvaluatorEdit,
 } from "./types";
 
 export function createReadLlmEvaluatorDraftClientAction({
@@ -42,14 +45,13 @@ export function createReadLlmEvaluatorDraftClientAction({
 
 export function createEditLlmEvaluatorDraftClientAction({
   getDraftHost,
-  setPendingLlmEvaluatorEdit,
+  setPendingApproval,
+  clearPendingApproval,
   shouldAutoAccept = () => false,
 }: {
   getDraftHost: () => LlmEvaluatorDraftHost | null;
-  setPendingLlmEvaluatorEdit: (
-    toolCallId: string,
-    edit: PendingLlmEvaluatorEdit | null
-  ) => void;
+  setPendingApproval: (toolCallId: string, pending: PendingApproval) => void;
+  clearPendingApproval: (toolCallId: string) => void;
   shouldAutoAccept?: () => boolean;
 }) {
   return async (
@@ -85,6 +87,7 @@ export function createEditLlmEvaluatorDraftClientAction({
     const pendingEdit = bindPendingLlmEvaluatorEditActions({
       pendingEdit: {
         toolCallId: editContext.toolCallId,
+        toolName: EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
         sessionId: editContext.sessionId,
         before,
         after: proposed.output,
@@ -92,7 +95,7 @@ export function createEditLlmEvaluatorDraftClientAction({
       },
       draftHost: host,
       addToolOutput: editContext.addToolOutput,
-      setPendingLlmEvaluatorEdit,
+      clearPending: clearPendingApproval,
     });
 
     if (shouldAutoAccept()) {
@@ -100,7 +103,7 @@ export function createEditLlmEvaluatorDraftClientAction({
       return { ok: true };
     }
 
-    setPendingLlmEvaluatorEdit(editContext.toolCallId, pendingEdit);
+    setPendingApproval(editContext.toolCallId, pendingEdit);
     return { ok: true };
   };
 }

--- a/app/src/agent/tools/llmEvaluatorDraft/pendingLlmEvaluatorEdit.ts
+++ b/app/src/agent/tools/llmEvaluatorDraft/pendingLlmEvaluatorEdit.ts
@@ -1,36 +1,34 @@
-import {
-  EDIT_LLM_EVALUATOR_DRAFT_NAVIGATION_CANCEL_ERROR,
-  EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
-} from "./constants";
+import { bindPendingApproval } from "@phoenix/agent/shared/pendingApproval";
+
+import { EDIT_LLM_EVALUATOR_DRAFT_NAVIGATION_CANCEL_ERROR } from "./constants";
 import type {
   BindPendingLlmEvaluatorEditOptions,
   PendingLlmEvaluatorEdit,
 } from "./types";
 
+/**
+ * Attaches accept/reject/cancel callbacks to a pending LLM-evaluator draft
+ * edit. The generic lifecycle lives in {@link bindPendingApproval}; the commit
+ * applies the operations to the mounted draft host.
+ */
 export function bindPendingLlmEvaluatorEditActions({
   pendingEdit,
   draftHost,
   addToolOutput,
-  setPendingLlmEvaluatorEdit,
+  clearPending,
 }: BindPendingLlmEvaluatorEditOptions): PendingLlmEvaluatorEdit {
-  return {
-    ...pendingEdit,
-    accept: async ({ approvalSource = "user" } = {}) => {
-      setPendingLlmEvaluatorEdit(pendingEdit.toolCallId, null);
+  return bindPendingApproval<PendingLlmEvaluatorEdit>({
+    pending: pendingEdit,
+    addToolOutput,
+    clearPending,
+    navigationCancelError: EDIT_LLM_EVALUATOR_DRAFT_NAVIGATION_CANCEL_ERROR,
+    commit: async ({ approvalSource }) => {
       const applied = draftHost.applyOperations(pendingEdit.operations);
       if (!applied.ok) {
-        await addToolOutput({
-          state: "output-error",
-          tool: EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
-          toolCallId: pendingEdit.toolCallId,
-          errorText: applied.error,
-        });
-        return;
+        return { ok: false, error: applied.error };
       }
-      await addToolOutput({
-        state: "output-available",
-        tool: EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
+      return {
+        ok: true,
         output: {
           status: "accepted",
           acceptedBy: approvalSource,
@@ -39,28 +37,11 @@ export function bindPendingLlmEvaluatorEditActions({
               ? "LLM-evaluator draft edit auto-approved."
               : "LLM-evaluator draft edit applied.",
         },
-      });
+      };
     },
-    reject: async () => {
-      setPendingLlmEvaluatorEdit(pendingEdit.toolCallId, null);
-      await addToolOutput({
-        state: "output-available",
-        tool: EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
-        output: {
-          status: "rejected",
-          message: "User rejected the proposed LLM-evaluator draft edit.",
-        },
-      });
-    },
-    cancel: async () => {
-      setPendingLlmEvaluatorEdit(pendingEdit.toolCallId, null);
-      await addToolOutput({
-        state: "output-error",
-        tool: EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
-        errorText: EDIT_LLM_EVALUATOR_DRAFT_NAVIGATION_CANCEL_ERROR,
-      });
-    },
-  };
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      message: "User rejected the proposed LLM-evaluator draft edit.",
+    }),
+  });
 }

--- a/app/src/agent/tools/llmEvaluatorDraft/types.ts
+++ b/app/src/agent/tools/llmEvaluatorDraft/types.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 
+import type { PendingApprovalActions } from "@phoenix/agent/shared/pendingApproval";
 import type {
   ApprovalSource,
   EvaluatorSubmitResult,
@@ -18,6 +19,7 @@ export type {
   EvaluatorSubmitToolOutput,
 };
 
+import { EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME } from "./constants";
 import type {
   editLlmEvaluatorDraftActionContextSchema,
   editLlmEvaluatorDraftInputSchema,
@@ -97,21 +99,17 @@ export type LlmEvaluatorDraftHost = {
 
 export type PendingLlmEvaluatorEdit = {
   toolCallId: string;
+  toolName: typeof EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME;
   sessionId: string;
   before: LLMEvaluatorDraftSnapshot;
   after: LLMEvaluatorDraftSnapshot;
   operations: EditLlmEvaluatorDraftOperation[];
-  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
-  reject?: () => Promise<void>;
-  cancel?: () => Promise<void>;
-};
+} & PendingApprovalActions;
 
 export type BindPendingLlmEvaluatorEditOptions = {
-  pendingEdit: PendingLlmEvaluatorEdit;
+  pendingEdit: Omit<PendingLlmEvaluatorEdit, keyof PendingApprovalActions>;
   draftHost: LlmEvaluatorDraftHost;
   addToolOutput: LlmEvaluatorEditToolOutputSender;
-  setPendingLlmEvaluatorEdit: (
-    toolCallId: string,
-    edit: PendingLlmEvaluatorEdit | null
-  ) => void;
+  /** Clears this proposal from the unified pending-approval store slice. */
+  clearPending: (toolCallId: string) => void;
 };

--- a/app/src/agent/tools/playgroundLoadDataset/__tests__/playgroundLoadDataset.test.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/__tests__/playgroundLoadDataset.test.ts
@@ -130,13 +130,15 @@ describe("playground load dataset agent tool", () => {
       datasetId: null,
       modelConfigByProvider: {},
     });
-    const setPendingLoadDataset = vi.fn();
+    const setPendingApproval = vi.fn();
+    const clearPendingApproval = vi.fn();
     const harness = createSearchParamsHarness();
     const action = createLoadDatasetClientAction({
       playgroundStore,
       setSearchParams: harness.setSearchParams,
       getSearchParams: harness.getSearchParams,
-      setPendingLoadDataset,
+      setPendingApproval,
+      clearPendingApproval,
       resolveDatasetTarget: resolverFor({
         ok: false,
         error: 'No dataset named "Ghost" was found.',
@@ -149,7 +151,7 @@ describe("playground load dataset agent tool", () => {
       ok: false,
       error: 'No dataset named "Ghost" was found.',
     });
-    expect(setPendingLoadDataset).not.toHaveBeenCalled();
+    expect(setPendingApproval).not.toHaveBeenCalled();
   });
 
   it("registers a pending load and dual-writes store + URL on accept", async () => {
@@ -157,13 +159,15 @@ describe("playground load dataset agent tool", () => {
       datasetId: null,
       modelConfigByProvider: {},
     });
-    const setPendingLoadDataset = vi.fn();
+    const setPendingApproval = vi.fn();
+    const clearPendingApproval = vi.fn();
     const harness = createSearchParamsHarness("exampleId=ex-old");
     const action = createLoadDatasetClientAction({
       playgroundStore,
       setSearchParams: harness.setSearchParams,
       getSearchParams: harness.getSearchParams,
-      setPendingLoadDataset,
+      setPendingApproval,
+      clearPendingApproval,
       resolveDatasetTarget: resolverFor({
         ok: true,
         output: {
@@ -180,8 +184,8 @@ describe("playground load dataset agent tool", () => {
       toolCallContext
     );
 
-    expect(setPendingLoadDataset).toHaveBeenCalledTimes(1);
-    const pendingLoad = setPendingLoadDataset.mock
+    expect(setPendingApproval).toHaveBeenCalledTimes(1);
+    const pendingLoad = setPendingApproval.mock
       .calls[0]![1] as PendingLoadDataset;
     expect(pendingLoad.snapshot).toEqual({
       datasetId: "d1",
@@ -193,7 +197,7 @@ describe("playground load dataset agent tool", () => {
     await pendingLoad.accept?.();
 
     // Pending state cleared before the write.
-    expect(setPendingLoadDataset).toHaveBeenLastCalledWith("call-1", null);
+    expect(clearPendingApproval).toHaveBeenCalledWith("call-1");
     // Store write flips dataset mode for the experiment path.
     expect(playgroundStore.getState().datasetId).toBe("d1");
     // URL write sets datasetId + repeated splitId and clears the stale exampleId.
@@ -216,7 +220,8 @@ describe("playground load dataset agent tool", () => {
       datasetId: null,
       modelConfigByProvider: {},
     });
-    const setPendingLoadDataset = vi.fn();
+    const setPendingApproval = vi.fn();
+    const clearPendingApproval = vi.fn();
     const harness = createSearchParamsHarness();
     const resolveDatasetTarget = resolverFor({
       ok: true,
@@ -231,12 +236,13 @@ describe("playground load dataset agent tool", () => {
       playgroundStore,
       setSearchParams: harness.setSearchParams,
       getSearchParams: harness.getSearchParams,
-      setPendingLoadDataset,
+      setPendingApproval,
+      clearPendingApproval,
       resolveDatasetTarget,
     });
 
     await action({ datasetName: "Support" }, toolCallContext);
-    const pendingLoad = setPendingLoadDataset.mock
+    const pendingLoad = setPendingApproval.mock
       .calls[0]![1] as PendingLoadDataset;
 
     // The user picked a different dataset after the proposal.
@@ -259,7 +265,8 @@ describe("playground load dataset agent tool", () => {
       datasetId: null,
       modelConfigByProvider: {},
     });
-    const setPendingLoadDataset = vi.fn();
+    const setPendingApproval = vi.fn();
+    const clearPendingApproval = vi.fn();
     const harness = createSearchParamsHarness();
     const resolveDatasetTarget = vi
       .fn<ResolveDatasetTarget>()
@@ -280,12 +287,13 @@ describe("playground load dataset agent tool", () => {
       playgroundStore,
       setSearchParams: harness.setSearchParams,
       getSearchParams: harness.getSearchParams,
-      setPendingLoadDataset,
+      setPendingApproval,
+      clearPendingApproval,
       resolveDatasetTarget,
     });
 
     await action({ datasetName: "Support" }, toolCallContext);
-    const pendingLoad = setPendingLoadDataset.mock
+    const pendingLoad = setPendingApproval.mock
       .calls[0]![1] as PendingLoadDataset;
 
     await pendingLoad.accept?.();
@@ -306,13 +314,15 @@ describe("playground load dataset agent tool", () => {
       datasetId: null,
       modelConfigByProvider: {},
     });
-    const setPendingLoadDataset = vi.fn();
+    const setPendingApproval = vi.fn();
+    const clearPendingApproval = vi.fn();
     const harness = createSearchParamsHarness();
     const action = createLoadDatasetClientAction({
       playgroundStore,
       setSearchParams: harness.setSearchParams,
       getSearchParams: harness.getSearchParams,
-      setPendingLoadDataset,
+      setPendingApproval,
+      clearPendingApproval,
       shouldAutoAccept: () => true,
       resolveDatasetTarget: resolverFor({
         ok: true,

--- a/app/src/agent/tools/playgroundLoadDataset/clientActions.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/clientActions.ts
@@ -1,8 +1,10 @@
 import type { SetURLSearchParams } from "react-router";
 
+import type { PendingApproval } from "@phoenix/agent/shared/pendingApproval";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
 import type { PlaygroundStore } from "@phoenix/store/playground";
 
+import { LOAD_DATASET_TOOL_NAME } from "./constants";
 import {
   buildDatasetSelectionSnapshot,
   buildSelectionRevision,
@@ -16,7 +18,6 @@ import { bindPendingLoadDatasetActions } from "./pendingLoadDataset";
 import type {
   DatasetSelectionSnapshot,
   ExpectedSelection,
-  PendingLoadDataset,
   ResolveDatasetTarget,
 } from "./types";
 
@@ -57,17 +58,16 @@ export function createLoadDatasetClientAction({
   playgroundStore,
   setSearchParams,
   getSearchParams,
-  setPendingLoadDataset,
+  setPendingApproval,
+  clearPendingApproval,
   shouldAutoAccept = () => false,
   resolveDatasetTarget = resolveLoadDatasetTarget,
 }: {
   playgroundStore: PlaygroundStore;
   setSearchParams: SetURLSearchParams;
   getSearchParams: () => URLSearchParams;
-  setPendingLoadDataset: (
-    toolCallId: string,
-    pendingLoad: PendingLoadDataset | null
-  ) => void;
+  setPendingApproval: (toolCallId: string, pending: PendingApproval) => void;
+  clearPendingApproval: (toolCallId: string) => void;
   shouldAutoAccept?: () => boolean;
   resolveDatasetTarget?: ResolveDatasetTarget;
 }) {
@@ -97,6 +97,7 @@ export function createLoadDatasetClientAction({
     const pendingLoad = bindPendingLoadDatasetActions({
       pendingLoad: {
         toolCallId: actionContext.toolCallId,
+        toolName: LOAD_DATASET_TOOL_NAME,
         sessionId: actionContext.sessionId,
         input: parsed,
         snapshot: buildDatasetSelectionSnapshot(resolution.output),
@@ -108,7 +109,7 @@ export function createLoadDatasetClientAction({
       applyDatasetSelection: (snapshot) =>
         applyDatasetSelection({ snapshot, playgroundStore, setSearchParams }),
       addToolOutput: actionContext.addToolOutput,
-      setPendingLoadDataset,
+      clearPending: clearPendingApproval,
     });
 
     if (shouldAutoAccept()) {
@@ -116,7 +117,7 @@ export function createLoadDatasetClientAction({
       return { ok: true };
     }
 
-    setPendingLoadDataset(actionContext.toolCallId, pendingLoad);
+    setPendingApproval(actionContext.toolCallId, pendingLoad);
     return { ok: true };
   };
 }

--- a/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts
@@ -1,46 +1,43 @@
-import {
-  LOAD_DATASET_NAVIGATION_CANCEL_ERROR,
-  LOAD_DATASET_TOOL_NAME,
-} from "./constants";
+import { bindPendingApproval } from "@phoenix/agent/shared/pendingApproval";
+
+import { LOAD_DATASET_NAVIGATION_CANCEL_ERROR } from "./constants";
 import type {
   BindPendingLoadDatasetOptions,
   PendingLoadDataset,
 } from "./types";
 
+/**
+ * Attaches accept/reject/cancel callbacks to a pending dataset load. The
+ * generic lifecycle lives in {@link bindPendingApproval}; the commit re-checks
+ * that the playground selection and resolved target have not drifted since the
+ * proposal, then writes the dataset/split ids.
+ */
 export function bindPendingLoadDatasetActions({
   pendingLoad,
   resolveDatasetTarget,
   readSelectionRevision,
   applyDatasetSelection,
   addToolOutput,
-  setPendingLoadDataset,
+  clearPending,
 }: BindPendingLoadDatasetOptions): PendingLoadDataset {
-  return {
-    ...pendingLoad,
-    accept: async ({ approvalSource = "user" } = {}) => {
-      setPendingLoadDataset(pendingLoad.toolCallId, null);
-
+  return bindPendingApproval<PendingLoadDataset>({
+    pending: pendingLoad,
+    addToolOutput,
+    clearPending,
+    navigationCancelError: LOAD_DATASET_NAVIGATION_CANCEL_ERROR,
+    commit: async ({ approvalSource }) => {
       if (readSelectionRevision() !== pendingLoad.expectedRevision) {
-        await addToolOutput({
-          state: "output-error",
-          tool: LOAD_DATASET_TOOL_NAME,
-          toolCallId: pendingLoad.toolCallId,
-          errorText:
+        return {
+          ok: false,
+          error:
             "The playground dataset selection changed after this load was proposed, so it can no longer be applied.",
-        });
-        return;
+        };
       }
 
       // Dataset or split may have been deleted since the proposal — re-resolve before writing ids.
       const resolution = await resolveDatasetTarget(pendingLoad.input);
       if (!resolution.ok) {
-        await addToolOutput({
-          state: "output-error",
-          tool: LOAD_DATASET_TOOL_NAME,
-          toolCallId: pendingLoad.toolCallId,
-          errorText: resolution.error,
-        });
-        return;
+        return { ok: false, error: resolution.error };
       }
       const resolvedSplitId = resolution.output.splitId;
       const proposedSplitId = pendingLoad.snapshot.splitIds[0] ?? null;
@@ -48,22 +45,17 @@ export function bindPendingLoadDatasetActions({
         resolution.output.datasetId !== pendingLoad.snapshot.datasetId ||
         resolvedSplitId !== proposedSplitId
       ) {
-        await addToolOutput({
-          state: "output-error",
-          tool: LOAD_DATASET_TOOL_NAME,
-          toolCallId: pendingLoad.toolCallId,
-          errorText:
+        return {
+          ok: false,
+          error:
             "The proposed dataset or split changed after this load was proposed, so it can no longer be applied.",
-        });
-        return;
+        };
       }
 
       applyDatasetSelection(pendingLoad.snapshot);
 
-      await addToolOutput({
-        state: "output-available",
-        tool: LOAD_DATASET_TOOL_NAME,
-        toolCallId: pendingLoad.toolCallId,
+      return {
+        ok: true,
         output: {
           status: "loaded",
           acceptedBy: approvalSource,
@@ -76,28 +68,11 @@ export function bindPendingLoadDatasetActions({
               ? "Dataset load auto-approved."
               : "Playground switched to dataset mode.",
         },
-      });
+      };
     },
-    reject: async () => {
-      setPendingLoadDataset(pendingLoad.toolCallId, null);
-      await addToolOutput({
-        state: "output-available",
-        tool: LOAD_DATASET_TOOL_NAME,
-        toolCallId: pendingLoad.toolCallId,
-        output: {
-          status: "rejected",
-          message: "User rejected the proposed dataset load.",
-        },
-      });
-    },
-    cancel: async () => {
-      setPendingLoadDataset(pendingLoad.toolCallId, null);
-      await addToolOutput({
-        state: "output-error",
-        tool: LOAD_DATASET_TOOL_NAME,
-        toolCallId: pendingLoad.toolCallId,
-        errorText: LOAD_DATASET_NAVIGATION_CANCEL_ERROR,
-      });
-    },
-  };
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      message: "User rejected the proposed dataset load.",
+    }),
+  });
 }

--- a/app/src/agent/tools/playgroundLoadDataset/types.ts
+++ b/app/src/agent/tools/playgroundLoadDataset/types.ts
@@ -1,7 +1,8 @@
 import type { z } from "zod";
 
-import type { ApprovalSource } from "@phoenix/agent/tools/approval";
+import type { PendingApprovalActions } from "@phoenix/agent/shared/pendingApproval";
 
+import { LOAD_DATASET_TOOL_NAME } from "./constants";
 import type {
   loadDatasetActionContextSchema,
   loadDatasetInputSchema,
@@ -46,28 +47,24 @@ export type ResolveDatasetTarget = (
 
 export type PendingLoadDataset = {
   toolCallId: string;
+  toolName: typeof LOAD_DATASET_TOOL_NAME;
   sessionId: string;
   input: LoadDatasetInput;
   snapshot: DatasetSelectionSnapshot;
   expectedSelection: ExpectedSelection;
   expectedRevision: string;
-  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
-  reject?: () => Promise<void>;
-  cancel?: () => Promise<void>;
-};
+} & PendingApprovalActions;
 
 export type ApplyDatasetSelection = (
   snapshot: DatasetSelectionSnapshot
 ) => void;
 
 export type BindPendingLoadDatasetOptions = {
-  pendingLoad: PendingLoadDataset;
+  pendingLoad: Omit<PendingLoadDataset, keyof PendingApprovalActions>;
   resolveDatasetTarget: ResolveDatasetTarget;
   readSelectionRevision: () => string;
   applyDatasetSelection: ApplyDatasetSelection;
   addToolOutput: LoadDatasetToolOutputSender;
-  setPendingLoadDataset: (
-    toolCallId: string,
-    pendingLoad: PendingLoadDataset | null
-  ) => void;
+  /** Clears this proposal from the unified pending-approval store slice. */
+  clearPending: (toolCallId: string) => void;
 };

--- a/app/src/agent/tools/playgroundPrompt/__tests__/playgroundPrompt.test.ts
+++ b/app/src/agent/tools/playgroundPrompt/__tests__/playgroundPrompt.test.ts
@@ -229,8 +229,8 @@ describe("playground prompt agent tools", () => {
     const agentStore = createAgentStore();
     const removeAction = createRemovePromptInstanceClientAction({
       playgroundStore,
-      setPendingPromptInstanceRemoval:
-        agentStore.getState().setPendingPromptInstanceRemoval,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     const addToolOutput = vi.fn();
 
@@ -276,8 +276,8 @@ describe("playground prompt agent tools", () => {
     const agentStore = createAgentStore();
     const removeAction = createRemovePromptInstanceClientAction({
       playgroundStore,
-      setPendingPromptInstanceRemoval:
-        agentStore.getState().setPendingPromptInstanceRemoval,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     const addToolOutput = vi.fn().mockResolvedValue(undefined);
     const instanceId = playgroundStore.getState().instances[1]!.id;
@@ -290,7 +290,7 @@ describe("playground prompt agent tools", () => {
     expect(result.ok).toBe(true);
     expect(addToolOutput).not.toHaveBeenCalled();
     const pendingRemoval =
-      agentStore.getState().pendingPromptInstanceRemovalsByToolCallId[
+      agentStore.getState().pendingApprovalsByToolCallId[
         "tool-call-remove"
       ];
     expect(pendingRemoval).toBeDefined();
@@ -298,7 +298,7 @@ describe("playground prompt agent tools", () => {
     await pendingRemoval!.accept!();
 
     expect(
-      agentStore.getState().pendingPromptInstanceRemovalsByToolCallId[
+      agentStore.getState().pendingApprovalsByToolCallId[
         "tool-call-remove"
       ]
     ).toBeUndefined();
@@ -338,8 +338,8 @@ describe("playground prompt agent tools", () => {
     const agentStore = createAgentStore();
     const removeAction = createRemovePromptInstanceClientAction({
       playgroundStore,
-      setPendingPromptInstanceRemoval:
-        agentStore.getState().setPendingPromptInstanceRemoval,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     const addToolOutput = vi.fn().mockResolvedValue(undefined);
     const instanceId = playgroundStore.getState().instances[1]!.id;
@@ -349,7 +349,7 @@ describe("playground prompt agent tools", () => {
       { toolCallId: "tool-call-reject", sessionId: "session-1", addToolOutput }
     );
     const pendingRemoval =
-      agentStore.getState().pendingPromptInstanceRemovalsByToolCallId[
+      agentStore.getState().pendingApprovalsByToolCallId[
         "tool-call-reject"
       ];
     expect(pendingRemoval).toBeDefined();
@@ -390,8 +390,8 @@ describe("playground prompt agent tools", () => {
     const agentStore = createAgentStore();
     const removeAction = createRemovePromptInstanceClientAction({
       playgroundStore,
-      setPendingPromptInstanceRemoval:
-        agentStore.getState().setPendingPromptInstanceRemoval,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
       shouldAutoAccept: () => true,
     });
     const addToolOutput = vi.fn().mockResolvedValue(undefined);
@@ -405,7 +405,7 @@ describe("playground prompt agent tools", () => {
     expect(result.ok).toBe(true);
     expect(playgroundStore.getState().instances).toHaveLength(1);
     expect(
-      agentStore.getState().pendingPromptInstanceRemovalsByToolCallId[
+      agentStore.getState().pendingApprovalsByToolCallId[
         "tool-call-auto"
       ]
     ).toBeUndefined();
@@ -442,8 +442,8 @@ describe("playground prompt agent tools", () => {
     const agentStore = createAgentStore();
     const removeAction = createRemovePromptInstanceClientAction({
       playgroundStore,
-      setPendingPromptInstanceRemoval:
-        agentStore.getState().setPendingPromptInstanceRemoval,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     const addToolOutput = vi.fn().mockResolvedValue(undefined);
     const instanceId = playgroundStore.getState().instances[1]!.id;
@@ -453,7 +453,7 @@ describe("playground prompt agent tools", () => {
       { toolCallId: "tool-call-stale", sessionId: "session-1", addToolOutput }
     );
     const pendingRemoval =
-      agentStore.getState().pendingPromptInstanceRemovalsByToolCallId[
+      agentStore.getState().pendingApprovalsByToolCallId[
         "tool-call-stale"
       ];
     playgroundStore.getState().deleteInstance(instanceId);
@@ -480,8 +480,8 @@ describe("playground prompt agent tools", () => {
     const agentStore = createAgentStore();
     const removeAction = createRemovePromptInstanceClientAction({
       playgroundStore,
-      setPendingPromptInstanceRemoval:
-        agentStore.getState().setPendingPromptInstanceRemoval,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     let resolveToolOutput: (() => void) | undefined;
     const toolOutputPromise = new Promise<void>((resolve) => {
@@ -501,7 +501,7 @@ describe("playground prompt agent tools", () => {
 
     expect(result.ok).toBe(true);
     const pendingRemoval =
-      agentStore.getState().pendingPromptInstanceRemovalsByToolCallId[
+      agentStore.getState().pendingApprovalsByToolCallId[
         "tool-call-remove-cancel"
       ];
     expect(pendingRemoval).toBeDefined();
@@ -509,7 +509,7 @@ describe("playground prompt agent tools", () => {
     const cancelPromise = pendingRemoval!.cancel!();
 
     expect(
-      agentStore.getState().pendingPromptInstanceRemovalsByToolCallId[
+      agentStore.getState().pendingApprovalsByToolCallId[
         "tool-call-remove-cancel"
       ]
     ).toBeUndefined();
@@ -536,7 +536,8 @@ describe("playground prompt agent tools", () => {
     const readAction = createReadPromptClientAction({ playgroundStore });
     const editAction = createEditPromptClientAction({
       playgroundStore,
-      setPendingPromptEdit: agentStore.getState().setPendingPromptEdit,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     const readResult = await readAction({});
     expect(readResult.ok).toBe(true);
@@ -566,13 +567,13 @@ describe("playground prompt agent tools", () => {
     expect(editResult.ok).toBe(true);
     expect(addToolOutput).not.toHaveBeenCalled();
     const pendingEdit =
-      agentStore.getState().pendingPromptEditsByToolCallId["tool-call-1"];
+      agentStore.getState().pendingApprovalsByToolCallId["tool-call-1"];
     expect(pendingEdit).toBeDefined();
 
     const acceptPromise = pendingEdit!.accept!();
 
     expect(
-      agentStore.getState().pendingPromptEditsByToolCallId["tool-call-1"]
+      agentStore.getState().pendingApprovalsByToolCallId["tool-call-1"]
     ).toBeUndefined();
     resolveToolOutput?.();
     await acceptPromise;
@@ -605,7 +606,8 @@ describe("playground prompt agent tools", () => {
     const readAction = createReadPromptClientAction({ playgroundStore });
     const editAction = createEditPromptClientAction({
       playgroundStore,
-      setPendingPromptEdit: agentStore.getState().setPendingPromptEdit,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     const readResult = await readAction({});
     expect(readResult.ok).toBe(true);
@@ -634,13 +636,13 @@ describe("playground prompt agent tools", () => {
 
     expect(editResult.ok).toBe(true);
     const pendingEdit =
-      agentStore.getState().pendingPromptEditsByToolCallId["tool-call-cancel"];
+      agentStore.getState().pendingApprovalsByToolCallId["tool-call-cancel"];
     expect(pendingEdit).toBeDefined();
 
     const cancelPromise = pendingEdit!.cancel!();
 
     expect(
-      agentStore.getState().pendingPromptEditsByToolCallId["tool-call-cancel"]
+      agentStore.getState().pendingApprovalsByToolCallId["tool-call-cancel"]
     ).toBeUndefined();
     resolveToolOutput?.();
     await cancelPromise;
@@ -668,7 +670,8 @@ describe("playground prompt agent tools", () => {
     const readAction = createReadPromptClientAction({ playgroundStore });
     const editAction = createEditPromptClientAction({
       playgroundStore,
-      setPendingPromptEdit: agentStore.getState().setPendingPromptEdit,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     const readResult = await readAction({});
     expect(readResult.ok).toBe(true);
@@ -716,7 +719,8 @@ describe("playground prompt agent tools", () => {
     const readAction = createReadPromptClientAction({ playgroundStore });
     const editAction = createEditPromptClientAction({
       playgroundStore,
-      setPendingPromptEdit: agentStore.getState().setPendingPromptEdit,
+      setPendingApproval: agentStore.getState().setPendingApproval,
+      clearPendingApproval: agentStore.getState().clearPendingApproval,
     });
     const readResult = await readAction({});
     expect(readResult.ok).toBe(true);
@@ -742,7 +746,7 @@ describe("playground prompt agent tools", () => {
 
     expect(result.ok).toBe(true);
     expect(
-      agentStore.getState().pendingPromptEditsByToolCallId["tool-call-3"]
+      agentStore.getState().pendingApprovalsByToolCallId["tool-call-3"]
     ).toBeDefined();
   });
 });

--- a/app/src/agent/tools/playgroundPrompt/clientActions.ts
+++ b/app/src/agent/tools/playgroundPrompt/clientActions.ts
@@ -1,6 +1,11 @@
+import type { PendingApproval } from "@phoenix/agent/shared/pendingApproval";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
 import type { PlaygroundStore } from "@phoenix/store/playground";
 
+import {
+  EDIT_PROMPT_TOOL_NAME,
+  REMOVE_PROMPT_INSTANCE_TOOL_NAME,
+} from "./constants";
 import {
   parseAddPromptInstanceInput,
   parseClonePromptInstanceInput,
@@ -18,7 +23,6 @@ import {
   getPromptSnapshot,
   resolveRemovablePromptInstance,
 } from "./promptStore";
-import type { PendingPromptEdit, PendingPromptInstanceRemoval } from "./types";
 
 /**
  * Creates the client action handler for the read_prompt_instance tool.
@@ -101,14 +105,13 @@ export function createAddPromptInstanceClientAction({
  */
 export function createRemovePromptInstanceClientAction({
   playgroundStore,
-  setPendingPromptInstanceRemoval,
+  setPendingApproval,
+  clearPendingApproval,
   shouldAutoAccept = () => false,
 }: {
   playgroundStore: PlaygroundStore;
-  setPendingPromptInstanceRemoval: (
-    toolCallId: string,
-    removal: PendingPromptInstanceRemoval | null
-  ) => void;
+  setPendingApproval: (toolCallId: string, pending: PendingApproval) => void;
+  clearPendingApproval: (toolCallId: string) => void;
   shouldAutoAccept?: () => boolean;
 }) {
   return async (
@@ -136,13 +139,14 @@ export function createRemovePromptInstanceClientAction({
     const pendingRemoval = bindPendingPromptInstanceRemovalActions({
       pendingRemoval: {
         toolCallId: actionContext.toolCallId,
+        toolName: REMOVE_PROMPT_INSTANCE_TOOL_NAME,
         sessionId: actionContext.sessionId,
         instanceId: preview.output.instanceId,
         label: preview.output.label,
       },
       playgroundStore,
       addToolOutput: actionContext.addToolOutput,
-      setPendingPromptInstanceRemoval,
+      clearPending: clearPendingApproval,
     });
 
     if (shouldAutoAccept()) {
@@ -150,7 +154,7 @@ export function createRemovePromptInstanceClientAction({
       return { ok: true };
     }
 
-    setPendingPromptInstanceRemoval(actionContext.toolCallId, pendingRemoval);
+    setPendingApproval(actionContext.toolCallId, pendingRemoval);
     return { ok: true };
   };
 }
@@ -162,14 +166,13 @@ export function createRemovePromptInstanceClientAction({
  */
 export function createEditPromptClientAction({
   playgroundStore,
-  setPendingPromptEdit,
+  setPendingApproval,
+  clearPendingApproval,
   shouldAutoAccept = () => false,
 }: {
   playgroundStore: PlaygroundStore;
-  setPendingPromptEdit: (
-    toolCallId: string,
-    edit: PendingPromptEdit | null
-  ) => void;
+  setPendingApproval: (toolCallId: string, pending: PendingApproval) => void;
+  clearPendingApproval: (toolCallId: string) => void;
   shouldAutoAccept?: () => boolean;
 }) {
   return async (
@@ -207,6 +210,7 @@ export function createEditPromptClientAction({
     const pendingEdit = bindPendingPromptEditActions({
       pendingEdit: {
         toolCallId: editContext.toolCallId,
+        toolName: EDIT_PROMPT_TOOL_NAME,
         sessionId: editContext.sessionId,
         instanceId: parsed.instanceId,
         expectedRevision: parsed.expectedRevision,
@@ -216,7 +220,7 @@ export function createEditPromptClientAction({
       },
       playgroundStore,
       addToolOutput: editContext.addToolOutput,
-      setPendingPromptEdit,
+      clearPending: clearPendingApproval,
     });
 
     if (shouldAutoAccept()) {
@@ -224,7 +228,7 @@ export function createEditPromptClientAction({
       return { ok: true };
     }
 
-    setPendingPromptEdit(editContext.toolCallId, pendingEdit);
+    setPendingApproval(editContext.toolCallId, pendingEdit);
     return { ok: true };
   };
 }

--- a/app/src/agent/tools/playgroundPrompt/pendingPromptEdit.ts
+++ b/app/src/agent/tools/playgroundPrompt/pendingPromptEdit.ts
@@ -1,47 +1,42 @@
-import {
-  EDIT_PROMPT_NAVIGATION_CANCEL_ERROR,
-  EDIT_PROMPT_TOOL_NAME,
-} from "./constants";
+import { bindPendingApproval } from "@phoenix/agent/shared/pendingApproval";
+
+import { EDIT_PROMPT_NAVIGATION_CANCEL_ERROR } from "./constants";
 import { computePromptEditSummary } from "./diffSummary";
 import { applyPromptOperations, getPromptSnapshot } from "./promptStore";
 import type { BindPendingPromptEditOptions, PendingPromptEdit } from "./types";
 
 /**
- * Attaches accept/reject callbacks to a pending prompt edit using the live
- * AI SDK tool-call context that created the proposal.
+ * Attaches accept/reject/cancel callbacks to a pending prompt edit using the
+ * live AI SDK tool-call context that created the proposal. The generic
+ * lifecycle (clear-on-resolve, output emission, navigation-cancel) lives in
+ * {@link bindPendingApproval}; only the commit — a revision re-check followed by
+ * applying the operations — is prompt-specific.
  */
 export function bindPendingPromptEditActions({
   pendingEdit,
   playgroundStore,
   addToolOutput,
-  setPendingPromptEdit,
+  clearPending,
 }: BindPendingPromptEditOptions): PendingPromptEdit {
-  return {
-    ...pendingEdit,
-    accept: async ({ approvalSource = "user" } = {}) => {
-      setPendingPromptEdit(pendingEdit.toolCallId, null);
+  return bindPendingApproval<PendingPromptEdit>({
+    pending: pendingEdit,
+    addToolOutput,
+    clearPending,
+    navigationCancelError: EDIT_PROMPT_NAVIGATION_CANCEL_ERROR,
+    commit: async ({ approvalSource }) => {
       const current = getPromptSnapshot({
         playgroundStore,
         instanceId: pendingEdit.instanceId,
       });
       if (!current.ok) {
-        await addToolOutput({
-          state: "output-error",
-          tool: EDIT_PROMPT_TOOL_NAME,
-          toolCallId: pendingEdit.toolCallId,
-          errorText: current.error,
-        });
-        return;
+        return { ok: false, error: current.error };
       }
       if (current.output.revision !== pendingEdit.expectedRevision) {
-        await addToolOutput({
-          state: "output-error",
-          tool: EDIT_PROMPT_TOOL_NAME,
-          toolCallId: pendingEdit.toolCallId,
-          errorText:
+        return {
+          ok: false,
+          error:
             "The prompt was changed after this edit was proposed, so it can no longer be applied.",
-        });
-        return;
+        };
       }
       applyPromptOperations({
         playgroundStore,
@@ -56,10 +51,8 @@ export function bindPendingPromptEditActions({
         pendingEdit.before,
         afterApply.ok ? afterApply.output : pendingEdit.after
       );
-      await addToolOutput({
-        state: "output-available",
-        tool: EDIT_PROMPT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
+      return {
+        ok: true,
         output: {
           status: "accepted",
           acceptedBy: approvalSource,
@@ -73,29 +66,12 @@ export function bindPendingPromptEditActions({
               ? "Prompt edit auto-approved."
               : "Prompt edit applied.",
         },
-      });
+      };
     },
-    reject: async () => {
-      setPendingPromptEdit(pendingEdit.toolCallId, null);
-      await addToolOutput({
-        state: "output-available",
-        tool: EDIT_PROMPT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
-        output: {
-          status: "rejected",
-          instanceId: pendingEdit.instanceId,
-          message: "User rejected the proposed prompt edit.",
-        },
-      });
-    },
-    cancel: async () => {
-      setPendingPromptEdit(pendingEdit.toolCallId, null);
-      await addToolOutput({
-        state: "output-error",
-        tool: EDIT_PROMPT_TOOL_NAME,
-        toolCallId: pendingEdit.toolCallId,
-        errorText: EDIT_PROMPT_NAVIGATION_CANCEL_ERROR,
-      });
-    },
-  };
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      instanceId: pendingEdit.instanceId,
+      message: "User rejected the proposed prompt edit.",
+    }),
+  });
 }

--- a/app/src/agent/tools/playgroundPrompt/pendingPromptInstanceRemoval.ts
+++ b/app/src/agent/tools/playgroundPrompt/pendingPromptInstanceRemoval.ts
@@ -1,6 +1,7 @@
+import { bindPendingApproval } from "@phoenix/agent/shared/pendingApproval";
+
 import {
   REMOVE_PROMPT_INSTANCE_NAVIGATION_CANCEL_ERROR,
-  REMOVE_PROMPT_INSTANCE_TOOL_NAME,
 } from "./constants";
 import { removePromptInstance } from "./promptStore";
 import type {
@@ -8,33 +9,32 @@ import type {
   PendingPromptInstanceRemoval,
 } from "./types";
 
+/**
+ * Attaches accept/reject/cancel callbacks to a pending prompt-instance removal.
+ * The generic lifecycle lives in {@link bindPendingApproval}; only the commit
+ * (removing the instance from the playground store) is removal-specific.
+ */
 export function bindPendingPromptInstanceRemovalActions({
   pendingRemoval,
   playgroundStore,
   addToolOutput,
-  setPendingPromptInstanceRemoval,
+  clearPending,
 }: BindPendingPromptInstanceRemovalOptions): PendingPromptInstanceRemoval {
-  return {
-    ...pendingRemoval,
-    accept: async ({ approvalSource = "user" } = {}) => {
-      setPendingPromptInstanceRemoval(pendingRemoval.toolCallId, null);
+  return bindPendingApproval<PendingPromptInstanceRemoval>({
+    pending: pendingRemoval,
+    addToolOutput,
+    clearPending,
+    navigationCancelError: REMOVE_PROMPT_INSTANCE_NAVIGATION_CANCEL_ERROR,
+    commit: async ({ approvalSource }) => {
       const result = removePromptInstance({
         playgroundStore,
         instanceId: pendingRemoval.instanceId,
       });
       if (!result.ok) {
-        await addToolOutput({
-          state: "output-error",
-          tool: REMOVE_PROMPT_INSTANCE_TOOL_NAME,
-          toolCallId: pendingRemoval.toolCallId,
-          errorText: result.error,
-        });
-        return;
+        return { ok: false, error: result.error };
       }
-      await addToolOutput({
-        state: "output-available",
-        tool: REMOVE_PROMPT_INSTANCE_TOOL_NAME,
-        toolCallId: pendingRemoval.toolCallId,
+      return {
+        ok: true,
         output: {
           ...result.output,
           acceptedBy: approvalSource,
@@ -43,30 +43,13 @@ export function bindPendingPromptInstanceRemovalActions({
               ? "Prompt instance removal auto-approved."
               : "Prompt instance removed.",
         },
-      });
+      };
     },
-    reject: async () => {
-      setPendingPromptInstanceRemoval(pendingRemoval.toolCallId, null);
-      await addToolOutput({
-        state: "output-available",
-        tool: REMOVE_PROMPT_INSTANCE_TOOL_NAME,
-        toolCallId: pendingRemoval.toolCallId,
-        output: {
-          status: "rejected",
-          instanceId: pendingRemoval.instanceId,
-          label: pendingRemoval.label,
-          message: "User rejected the prompt instance removal.",
-        },
-      });
-    },
-    cancel: async () => {
-      setPendingPromptInstanceRemoval(pendingRemoval.toolCallId, null);
-      await addToolOutput({
-        state: "output-error",
-        tool: REMOVE_PROMPT_INSTANCE_TOOL_NAME,
-        toolCallId: pendingRemoval.toolCallId,
-        errorText: REMOVE_PROMPT_INSTANCE_NAVIGATION_CANCEL_ERROR,
-      });
-    },
-  };
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      instanceId: pendingRemoval.instanceId,
+      label: pendingRemoval.label,
+      message: "User rejected the prompt instance removal.",
+    }),
+  });
 }

--- a/app/src/agent/tools/playgroundPrompt/types.ts
+++ b/app/src/agent/tools/playgroundPrompt/types.ts
@@ -1,8 +1,12 @@
 import type { z } from "zod";
 
-import type { ApprovalSource } from "@phoenix/agent/tools/approval";
+import type { PendingApprovalActions } from "@phoenix/agent/shared/pendingApproval";
 import type { ChatMessage, PlaygroundStore } from "@phoenix/store/playground";
 
+import {
+  EDIT_PROMPT_TOOL_NAME,
+  REMOVE_PROMPT_INSTANCE_TOOL_NAME,
+} from "./constants";
 import type {
   addPromptInstanceInputSchema,
   clonePromptInstanceInputSchema,
@@ -111,6 +115,7 @@ export type PromptEditSummary = {
 
 export type PendingPromptEdit = {
   toolCallId: string;
+  toolName: typeof EDIT_PROMPT_TOOL_NAME;
   /** Agent session that owns the unresolved edit_prompt_instance tool call. */
   sessionId: string;
   instanceId: number;
@@ -118,47 +123,38 @@ export type PendingPromptEdit = {
   before: PromptSnapshot;
   after: PromptSnapshot;
   operations: MaterializedEditPromptOperation[];
-  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
-  reject?: () => Promise<void>;
-  cancel?: () => Promise<void>;
-};
+} & PendingApprovalActions;
 
 export type PendingPromptInstanceRemoval = {
   toolCallId: string;
+  toolName: typeof REMOVE_PROMPT_INSTANCE_TOOL_NAME;
   /** Agent session that owns the unresolved remove_prompt_instance tool call. */
   sessionId: string;
   instanceId: number;
   label: string;
-  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
-  reject?: () => Promise<void>;
-  cancel?: () => Promise<void>;
-};
+} & PendingApprovalActions;
 
 export type EditPromptActionContext = z.output<
   typeof editPromptActionContextSchema
 >;
 
 export type BindPendingPromptEditOptions = {
-  /** Serializable pending edit proposal, possibly restored from Zustand. */
-  pendingEdit: PendingPromptEdit;
+  /** Serializable pending edit proposal (no bound lifecycle callbacks yet). */
+  pendingEdit: Omit<PendingPromptEdit, keyof PendingApprovalActions>;
   /** Live playground store used to re-check revisions and apply accepted edits. */
   playgroundStore: PlaygroundStore;
   /** Live AI SDK tool-output sender for the original tool call. */
   addToolOutput: PromptEditToolOutputSender;
-  setPendingPromptEdit: (
-    toolCallId: string,
-    edit: PendingPromptEdit | null
-  ) => void;
+  /** Clears this proposal from the unified pending-approval store slice. */
+  clearPending: (toolCallId: string) => void;
 };
 
 export type BindPendingPromptInstanceRemovalOptions = {
-  pendingRemoval: PendingPromptInstanceRemoval;
+  pendingRemoval: Omit<PendingPromptInstanceRemoval, keyof PendingApprovalActions>;
   playgroundStore: PlaygroundStore;
   addToolOutput: PromptEditToolOutputSender;
-  setPendingPromptInstanceRemoval: (
-    toolCallId: string,
-    removal: PendingPromptInstanceRemoval | null
-  ) => void;
+  /** Clears this proposal from the unified pending-approval store slice. */
+  clearPending: (toolCallId: string) => void;
 };
 
 export type PromptActionResult<TOutput> =

--- a/app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts
+++ b/app/src/agent/tools/playgroundPromptTools/__tests__/playgroundPromptTools.test.ts
@@ -4,6 +4,7 @@ import {
   createWritePromptToolsClientAction,
   getPromptToolsSnapshot,
   parseWritePromptToolsInput,
+  type PendingPromptToolWrite,
   type PromptToolsSnapshot,
   WRITE_PROMPT_TOOLS_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundPromptTools";
@@ -18,6 +19,12 @@ import {
 
 const newStore = () =>
   createPlaygroundStore({ datasetId: null, modelConfigByProvider: {} });
+
+/** Reads the unified approval slice as the narrowed write-prompt-tools type. */
+const pendingWrites = (agentStore: ReturnType<typeof createAgentStore>) =>
+  agentStore.getState().pendingApprovalsByToolCallId as Partial<
+    Record<string, PendingPromptToolWrite>
+  >;
 
 /** Replace the tool list on the default instance (id 0). */
 const seedTools = (playgroundStore: PlaygroundStore, tools: Tool[]) => {
@@ -728,8 +735,8 @@ describe("playground prompt tools agent tools", () => {
     ) =>
       createWritePromptToolsClientAction({
         playgroundStore,
-        setPendingPromptToolWrite:
-          agentStore.getState().setPendingPromptToolWrite,
+        setPendingApproval: agentStore.getState().setPendingApproval,
+        clearPendingApproval: agentStore.getState().clearPendingApproval,
         ...(shouldAutoAccept ? { shouldAutoAccept } : {}),
       });
 
@@ -752,7 +759,7 @@ describe("playground prompt tools agent tools", () => {
       expect(addToolOutput).not.toHaveBeenCalled();
       expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(0);
       const pending =
-        agentStore.getState().pendingPromptToolWritesByToolCallId["tc-1"];
+        pendingWrites(agentStore)["tc-1"];
       expect(pending).toBeDefined();
       expect(pending!.summary.created).toEqual(["get_weather"]);
       expect(pending!.before.entries).toHaveLength(0);
@@ -771,7 +778,7 @@ describe("playground prompt tools agent tools", () => {
         })
       );
       expect(
-        agentStore.getState().pendingPromptToolWritesByToolCallId["tc-1"]
+        pendingWrites(agentStore)["tc-1"]
       ).toBeUndefined();
     });
 
@@ -791,7 +798,7 @@ describe("playground prompt tools agent tools", () => {
         { toolCallId: "tc-reject", sessionId: "s-1", addToolOutput }
       );
       const pending =
-        agentStore.getState().pendingPromptToolWritesByToolCallId["tc-reject"];
+        pendingWrites(agentStore)["tc-reject"];
       expect(pending).toBeDefined();
       expect(pending!.summary.deleted).toEqual(["get_weather"]);
 
@@ -826,7 +833,7 @@ describe("playground prompt tools agent tools", () => {
       expect(result.ok).toBe(true);
       expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(1);
       expect(
-        agentStore.getState().pendingPromptToolWritesByToolCallId["tc-auto"]
+        pendingWrites(agentStore)["tc-auto"]
       ).toBeUndefined();
       expect(addToolOutput).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -860,7 +867,7 @@ describe("playground prompt tools agent tools", () => {
       expect(result.error).toContain("tools[1]");
       expect(result.error).toContain("9999");
       expect(
-        agentStore.getState().pendingPromptToolWritesByToolCallId["tc-bad"]
+        pendingWrites(agentStore)["tc-bad"]
       ).toBeUndefined();
       expect(addToolOutput).not.toHaveBeenCalled();
       expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(1);
@@ -883,7 +890,7 @@ describe("playground prompt tools agent tools", () => {
       seedTools(playgroundStore, [functionTool(101, "added_later")]);
 
       const pending =
-        agentStore.getState().pendingPromptToolWritesByToolCallId["tc-stale"];
+        pendingWrites(agentStore)["tc-stale"];
       await pending!.accept!();
 
       expect(addToolOutput).toHaveBeenCalledWith(
@@ -918,7 +925,7 @@ describe("playground prompt tools agent tools", () => {
         { toolCallId: "tc-provider-stale", sessionId: "s-1", addToolOutput }
       );
       const pending =
-        agentStore.getState().pendingPromptToolWritesByToolCallId[
+        pendingWrites(agentStore)[
           "tc-provider-stale"
         ];
       playgroundStore.getState().updateInstance({
@@ -944,7 +951,7 @@ describe("playground prompt tools agent tools", () => {
       );
       expect(playgroundStore.getState().instances[0]!.tools).toHaveLength(0);
       expect(
-        agentStore.getState().pendingPromptToolWritesByToolCallId[
+        pendingWrites(agentStore)[
           "tc-provider-stale"
         ]
       ).toBeUndefined();

--- a/app/src/agent/tools/playgroundPromptTools/clientActions.ts
+++ b/app/src/agent/tools/playgroundPromptTools/clientActions.ts
@@ -1,6 +1,8 @@
+import type { PendingApproval } from "@phoenix/agent/shared/pendingApproval";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
 import type { PlaygroundStore } from "@phoenix/store/playground";
 
+import { WRITE_PROMPT_TOOLS_TOOL_NAME } from "./constants";
 import {
   buildPromptToolsDisplaySnapshot,
   computePromptToolsWriteSummary,
@@ -15,7 +17,6 @@ import {
   getPromptToolsSnapshot,
   planWritePromptTools,
 } from "./promptToolsStore";
-import type { PendingPromptToolWrite } from "./types";
 
 /** Returns the current prompt tool list snapshot as JSON. */
 export function createReadPromptToolsClientAction({
@@ -48,14 +49,13 @@ export function createReadPromptToolsClientAction({
  */
 export function createWritePromptToolsClientAction({
   playgroundStore,
-  setPendingPromptToolWrite,
+  setPendingApproval,
+  clearPendingApproval,
   shouldAutoAccept = () => false,
 }: {
   playgroundStore: PlaygroundStore;
-  setPendingPromptToolWrite: (
-    toolCallId: string,
-    write: PendingPromptToolWrite | null
-  ) => void;
+  setPendingApproval: (toolCallId: string, pending: PendingApproval) => void;
+  clearPendingApproval: (toolCallId: string) => void;
   shouldAutoAccept?: () => boolean;
 }) {
   return async (
@@ -95,6 +95,7 @@ export function createWritePromptToolsClientAction({
     const pendingWrite = bindPendingPromptToolWriteActions({
       pendingWrite: {
         toolCallId: writeContext.toolCallId,
+        toolName: WRITE_PROMPT_TOOLS_TOOL_NAME,
         sessionId: writeContext.sessionId,
         instanceId,
         expectedRevision: parsed.expectedRevision,
@@ -106,7 +107,7 @@ export function createWritePromptToolsClientAction({
       },
       playgroundStore,
       addToolOutput: writeContext.addToolOutput,
-      setPendingPromptToolWrite,
+      clearPending: clearPendingApproval,
     });
 
     if (shouldAutoAccept()) {
@@ -114,7 +115,7 @@ export function createWritePromptToolsClientAction({
       return { ok: true };
     }
 
-    setPendingPromptToolWrite(writeContext.toolCallId, pendingWrite);
+    setPendingApproval(writeContext.toolCallId, pendingWrite);
     return { ok: true };
   };
 }

--- a/app/src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts
+++ b/app/src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts
@@ -1,7 +1,6 @@
-import {
-  WRITE_PROMPT_TOOLS_NAVIGATION_CANCEL_ERROR,
-  WRITE_PROMPT_TOOLS_TOOL_NAME,
-} from "./constants";
+import { bindPendingApproval } from "@phoenix/agent/shared/pendingApproval";
+
+import { WRITE_PROMPT_TOOLS_NAVIGATION_CANCEL_ERROR } from "./constants";
 import { applyWritePromptTools } from "./promptToolsStore";
 import type {
   BindPendingPromptToolWriteOptions,
@@ -9,22 +8,23 @@ import type {
 } from "./types";
 
 /**
- * Attaches accept/reject/cancel callbacks to a pending tool-write batch using
- * the live AI SDK tool-call context that created the proposal. Mirrors
- * `bindPendingPromptEditActions`: the batch is re-applied on accept (which
- * re-checks the revision against the current store), so a tool list that
- * drifted between propose and accept is rejected with the stale error.
+ * Attaches accept/reject/cancel callbacks to a pending tool-write batch. The
+ * generic lifecycle lives in {@link bindPendingApproval}; the commit is
+ * write-specific: it re-checks the provider hasn't drifted since the diff was
+ * proposed, then re-applies the batch (which re-checks the revision).
  */
 export function bindPendingPromptToolWriteActions({
   pendingWrite,
   playgroundStore,
   addToolOutput,
-  setPendingPromptToolWrite,
+  clearPending,
 }: BindPendingPromptToolWriteOptions): PendingPromptToolWrite {
-  return {
-    ...pendingWrite,
-    accept: async ({ approvalSource = "user" } = {}) => {
-      setPendingPromptToolWrite(pendingWrite.toolCallId, null);
+  return bindPendingApproval<PendingPromptToolWrite>({
+    pending: pendingWrite,
+    addToolOutput,
+    clearPending,
+    navigationCancelError: WRITE_PROMPT_TOOLS_NAVIGATION_CANCEL_ERROR,
+    commit: async ({ approvalSource }) => {
       const currentInstance = playgroundStore
         .getState()
         .instances.find((instance) => instance.id === pendingWrite.instanceId);
@@ -32,32 +32,21 @@ export function bindPendingPromptToolWriteActions({
         currentInstance != null &&
         currentInstance.model.provider !== pendingWrite.provider
       ) {
-        await addToolOutput({
-          state: "output-error",
-          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
-          toolCallId: pendingWrite.toolCallId,
-          errorText:
+        return {
+          ok: false,
+          error:
             "The playground provider changed after this prompt tool diff was proposed. Please run write_prompt_tools again so the diff can be reviewed in the current provider format.",
-        });
-        return;
+        };
       }
       const result = applyWritePromptTools({
         playgroundStore,
         input: pendingWrite.input,
       });
       if (!result.ok) {
-        await addToolOutput({
-          state: "output-error",
-          tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
-          toolCallId: pendingWrite.toolCallId,
-          errorText: result.error,
-        });
-        return;
+        return { ok: false, error: result.error };
       }
-      await addToolOutput({
-        state: "output-available",
-        tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
-        toolCallId: pendingWrite.toolCallId,
+      return {
+        ok: true,
         output: {
           status: "accepted",
           acceptedBy: approvalSource,
@@ -68,29 +57,12 @@ export function bindPendingPromptToolWriteActions({
               ? "Prompt tool changes auto-approved."
               : "Prompt tool changes applied.",
         },
-      });
+      };
     },
-    reject: async () => {
-      setPendingPromptToolWrite(pendingWrite.toolCallId, null);
-      await addToolOutput({
-        state: "output-available",
-        tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
-        toolCallId: pendingWrite.toolCallId,
-        output: {
-          status: "rejected",
-          instanceId: pendingWrite.instanceId,
-          message: "User rejected the proposed prompt tool changes.",
-        },
-      });
-    },
-    cancel: async () => {
-      setPendingPromptToolWrite(pendingWrite.toolCallId, null);
-      await addToolOutput({
-        state: "output-error",
-        tool: WRITE_PROMPT_TOOLS_TOOL_NAME,
-        toolCallId: pendingWrite.toolCallId,
-        errorText: WRITE_PROMPT_TOOLS_NAVIGATION_CANCEL_ERROR,
-      });
-    },
-  };
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      instanceId: pendingWrite.instanceId,
+      message: "User rejected the proposed prompt tool changes.",
+    }),
+  });
 }

--- a/app/src/agent/tools/playgroundPromptTools/types.ts
+++ b/app/src/agent/tools/playgroundPromptTools/types.ts
@@ -1,12 +1,13 @@
 import type { z } from "zod";
 
-import type { ApprovalSource } from "@phoenix/agent/tools/approval";
+import type { PendingApprovalActions } from "@phoenix/agent/shared/pendingApproval";
 import type {
   CanonicalToolChoice,
   PlaygroundStore,
   Tool,
 } from "@phoenix/store/playground";
 
+import { WRITE_PROMPT_TOOLS_TOOL_NAME } from "./constants";
 import type {
   promptToolsActionContextSchema,
   PromptToolsWriteToolOutputSender,
@@ -153,6 +154,7 @@ export type PromptToolsWriteSummary = {
  */
 export type PendingPromptToolWrite = {
   toolCallId: string;
+  toolName: typeof WRITE_PROMPT_TOOLS_TOOL_NAME;
   /** Agent session that owns the unresolved write_prompt_tools tool call. */
   sessionId: string;
   instanceId: number;
@@ -164,24 +166,19 @@ export type PendingPromptToolWrite = {
   before: PromptToolsDisplaySnapshot;
   after: PromptToolsDisplaySnapshot;
   summary: PromptToolsWriteSummary;
-  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
-  reject?: () => Promise<void>;
-  cancel?: () => Promise<void>;
-};
+} & PendingApprovalActions;
 
 export type PromptToolsActionContext = z.output<
   typeof promptToolsActionContextSchema
 >;
 
 export type BindPendingPromptToolWriteOptions = {
-  /** Serializable pending batch proposal, possibly restored from Zustand. */
-  pendingWrite: PendingPromptToolWrite;
+  /** Serializable pending batch proposal (no bound lifecycle callbacks yet). */
+  pendingWrite: Omit<PendingPromptToolWrite, keyof PendingApprovalActions>;
   /** Live playground store used to re-check the revision and apply the batch. */
   playgroundStore: PlaygroundStore;
   /** Live AI SDK tool-output sender for the original tool call. */
   addToolOutput: PromptToolsWriteToolOutputSender;
-  setPendingPromptToolWrite: (
-    toolCallId: string,
-    write: PendingPromptToolWrite | null
-  ) => void;
+  /** Clears this proposal from the unified pending-approval store slice. */
+  clearPending: (toolCallId: string) => void;
 };

--- a/app/src/agent/tools/playgroundSavePrompt/clientActions.ts
+++ b/app/src/agent/tools/playgroundSavePrompt/clientActions.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
+import type { PendingApproval } from "@phoenix/agent/shared/pendingApproval";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
 import type { PlaygroundStore } from "@phoenix/store/playground";
 
+import { SAVE_PROMPT_TOOL_NAME } from "./constants";
 import { parseSavePromptInput } from "./parsers";
 import { bindPendingSavePromptActions } from "./pendingSavePrompt";
 import {
@@ -12,7 +14,6 @@ import {
 import type {
   SavePlaygroundPromptParams,
   SavePromptToolOutputSender,
-  PendingSavePrompt,
 } from "./types";
 
 type SavePlaygroundPrompt = (
@@ -37,15 +38,14 @@ function parseSavePromptActionContext(context: unknown) {
  */
 export function createSavePromptClientAction({
   playgroundStore,
-  setPendingSavePrompt,
+  setPendingApproval,
+  clearPendingApproval,
   shouldAutoAccept = () => false,
   savePrompt = savePlaygroundPrompt,
 }: {
   playgroundStore: PlaygroundStore;
-  setPendingSavePrompt: (
-    toolCallId: string,
-    pendingSave: PendingSavePrompt | null
-  ) => void;
+  setPendingApproval: (toolCallId: string, pending: PendingApproval) => void;
+  clearPendingApproval: (toolCallId: string) => void;
   shouldAutoAccept?: () => boolean;
   savePrompt?: SavePlaygroundPrompt;
 }) {
@@ -71,6 +71,7 @@ export function createSavePromptClientAction({
     const pendingSave = bindPendingSavePromptActions({
       pendingSave: {
         toolCallId: actionContext.toolCallId,
+        toolName: SAVE_PROMPT_TOOL_NAME,
         sessionId: actionContext.sessionId,
         input: parsed,
         preview: preview.output,
@@ -87,7 +88,7 @@ export function createSavePromptClientAction({
         };
       },
       addToolOutput: actionContext.addToolOutput,
-      setPendingSavePrompt,
+      clearPending: clearPendingApproval,
     });
 
     if (shouldAutoAccept()) {
@@ -95,7 +96,7 @@ export function createSavePromptClientAction({
       return { ok: true };
     }
 
-    setPendingSavePrompt(actionContext.toolCallId, pendingSave);
+    setPendingApproval(actionContext.toolCallId, pendingSave);
     return { ok: true };
   };
 }

--- a/app/src/agent/tools/playgroundSavePrompt/pendingSavePrompt.ts
+++ b/app/src/agent/tools/playgroundSavePrompt/pendingSavePrompt.ts
@@ -1,6 +1,6 @@
+import { bindPendingApproval } from "@phoenix/agent/shared/pendingApproval";
 import { isPlainObject } from "@phoenix/utils/jsonUtils";
 
-import { SAVE_PROMPT_TOOL_NAME } from "./constants";
 import type { BindPendingSavePromptOptions, PendingSavePrompt } from "./types";
 
 export const SAVE_PROMPT_NAVIGATION_CANCEL_ERROR =
@@ -44,58 +44,34 @@ function buildAcceptedOutput({
 }
 
 /**
- * Attaches accept/reject callbacks to a pending save_prompt proposal.
+ * Attaches accept/reject/cancel callbacks to a pending save_prompt proposal.
+ * The generic lifecycle lives in {@link bindPendingApproval}; the commit runs
+ * the prompt-save mutation and shapes its output.
  */
 export function bindPendingSavePromptActions({
   pendingSave,
   savePrompt,
   addToolOutput,
-  setPendingSavePrompt,
+  clearPending,
 }: BindPendingSavePromptOptions): PendingSavePrompt {
-  return {
-    ...pendingSave,
-    accept: async ({ approvalSource = "user" } = {}) => {
-      setPendingSavePrompt(pendingSave.toolCallId, null);
+  return bindPendingApproval<PendingSavePrompt>({
+    pending: pendingSave,
+    addToolOutput,
+    clearPending,
+    navigationCancelError: SAVE_PROMPT_NAVIGATION_CANCEL_ERROR,
+    commit: async ({ approvalSource }) => {
       const result = await savePrompt(pendingSave.input);
       if (!result.ok) {
-        await addToolOutput({
-          state: "output-error",
-          tool: SAVE_PROMPT_TOOL_NAME,
-          toolCallId: pendingSave.toolCallId,
-          errorText: result.error,
-        });
-        return;
+        return { ok: false, error: result.error };
       }
-      await addToolOutput({
-        state: "output-available",
-        tool: SAVE_PROMPT_TOOL_NAME,
-        toolCallId: pendingSave.toolCallId,
-        output: buildAcceptedOutput({
-          output: result.output,
-          approvalSource,
-        }),
-      });
+      return {
+        ok: true,
+        output: buildAcceptedOutput({ output: result.output, approvalSource }),
+      };
     },
-    reject: async () => {
-      setPendingSavePrompt(pendingSave.toolCallId, null);
-      await addToolOutput({
-        state: "output-available",
-        tool: SAVE_PROMPT_TOOL_NAME,
-        toolCallId: pendingSave.toolCallId,
-        output: {
-          status: "rejected",
-          message: "User rejected the proposed prompt save.",
-        },
-      });
-    },
-    cancel: async () => {
-      setPendingSavePrompt(pendingSave.toolCallId, null);
-      await addToolOutput({
-        state: "output-error",
-        tool: SAVE_PROMPT_TOOL_NAME,
-        toolCallId: pendingSave.toolCallId,
-        errorText: SAVE_PROMPT_NAVIGATION_CANCEL_ERROR,
-      });
-    },
-  };
+    buildRejectedOutput: () => ({
+      status: "rejected",
+      message: "User rejected the proposed prompt save.",
+    }),
+  });
 }

--- a/app/src/agent/tools/playgroundSavePrompt/types.ts
+++ b/app/src/agent/tools/playgroundSavePrompt/types.ts
@@ -2,8 +2,10 @@ import type { Chat } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import type { z } from "zod";
 
-import type { ApprovalSource } from "@phoenix/agent/tools/approval";
+import type { PendingApprovalActions } from "@phoenix/agent/shared/pendingApproval";
 import type { PlaygroundStore } from "@phoenix/store/playground";
+
+import { SAVE_PROMPT_TOOL_NAME } from "./constants";
 
 import type {
   CreateChatPromptInput,
@@ -79,25 +81,21 @@ export type SavePromptAction = (
 
 export type PendingSavePrompt = {
   toolCallId: string;
+  toolName: typeof SAVE_PROMPT_TOOL_NAME;
   /** Agent session that owns the unresolved save_prompt tool call. */
   sessionId: string;
   /** Parsed save_prompt input awaiting user approval. */
   input: SavePromptInput;
   /** Effective save target and metadata shown to the user before approval. */
   preview: SavePromptPreview;
-  accept?: (options?: { approvalSource?: ApprovalSource }) => Promise<void>;
-  reject?: () => Promise<void>;
-  cancel?: () => Promise<void>;
-};
+} & PendingApprovalActions;
 
 export type BindPendingSavePromptOptions = {
-  pendingSave: PendingSavePrompt;
+  pendingSave: Omit<PendingSavePrompt, keyof PendingApprovalActions>;
   savePrompt: SavePromptAction;
   addToolOutput: SavePromptToolOutputSender;
-  setPendingSavePrompt: (
-    toolCallId: string,
-    pendingSave: PendingSavePrompt | null
-  ) => void;
+  /** Clears this proposal from the unified pending-approval store slice. */
+  clearPending: (toolCallId: string) => void;
 };
 
 export type CreatePromptResponse =

--- a/app/src/components/agent/BatchSpanAnnotateToolDetails.tsx
+++ b/app/src/components/agent/BatchSpanAnnotateToolDetails.tsx
@@ -12,7 +12,6 @@ import { baseAnnotationLabelCSS } from "@phoenix/components/annotation/Annotatio
 import { AnnotationNameAndValue } from "@phoenix/components/annotation/AnnotationNameAndValue";
 import { AnnotationTooltip } from "@phoenix/components/annotation/AnnotationTooltip";
 import type { Annotation } from "@phoenix/components/annotation/types";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import {
   ToolPartApprovalActions,
@@ -21,6 +20,7 @@ import {
 } from "./ToolPartPrimitives";
 import type { ToolInvocationPart } from "./toolPartTypes";
 import { formatToolState, stringifyToolValue } from "./toolPartTypes";
+import { usePendingApproval } from "./usePendingApproval";
 
 const MAX_VISIBLE_SPAN_ANNOTATIONS = 4;
 
@@ -57,9 +57,9 @@ export function BatchSpanAnnotateToolDetails({
 }: {
   part: ToolInvocationPart;
 }) {
-  const pendingAnnotation = useAgentContext(
-    (state) =>
-      state.pendingBatchSpanAnnotatesByToolCallId[part.toolCallId] ?? null
+  const pendingAnnotation = usePendingApproval(
+    part.toolCallId,
+    BATCH_SPAN_ANNOTATE_TOOL_NAME
   );
   const annotations = parseBatchSpanAnnotateInput(part.input) ?? [];
   const hasAnnotations = annotations.length > 0;

--- a/app/src/components/agent/EditCodeEvaluatorDraftToolDetails.tsx
+++ b/app/src/components/agent/EditCodeEvaluatorDraftToolDetails.tsx
@@ -4,11 +4,11 @@ import {
   parseEditCodeEvaluatorDraftInput,
   type PendingCodeEvaluatorEdit,
 } from "@phoenix/agent/tools/codeEvaluatorDraft";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import { LazyDiffAcceptRejectToolDetails } from "./LazyDiffAcceptRejectToolDetails";
 import type { ToolInvocationPart } from "./toolPartTypes";
 import { formatToolState } from "./toolPartTypes";
+import { usePendingApproval } from "./usePendingApproval";
 
 export function getEditCodeEvaluatorDraftToolPreview(
   part: ToolInvocationPart
@@ -39,9 +39,10 @@ export function EditCodeEvaluatorDraftToolDetails({
 }: {
   part: ToolInvocationPart;
 }) {
-  const pending = useAgentContext((state) => {
-    return state.pendingCodeEvaluatorEditsByToolCallId[part.toolCallId] ?? null;
-  });
+  const pending = usePendingApproval(
+    part.toolCallId,
+    EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME
+  );
 
   return (
     <LazyDiffAcceptRejectToolDetails<

--- a/app/src/components/agent/EditLLMEvaluatorDraftToolDetails.tsx
+++ b/app/src/components/agent/EditLLMEvaluatorDraftToolDetails.tsx
@@ -4,11 +4,11 @@ import {
   parseEditLlmEvaluatorDraftInput,
   type PendingLlmEvaluatorEdit,
 } from "@phoenix/agent/tools/llmEvaluatorDraft";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import { LazyDiffAcceptRejectToolDetails } from "./LazyDiffAcceptRejectToolDetails";
 import type { ToolInvocationPart } from "./toolPartTypes";
 import { formatToolState } from "./toolPartTypes";
+import { usePendingApproval } from "./usePendingApproval";
 
 export function getEditLlmEvaluatorDraftToolPreview(
   part: ToolInvocationPart
@@ -39,9 +39,10 @@ export function EditLLMEvaluatorDraftToolDetails({
 }: {
   part: ToolInvocationPart;
 }) {
-  const pending = useAgentContext((state) => {
-    return state.pendingLlmEvaluatorEditsByToolCallId[part.toolCallId] ?? null;
-  });
+  const pending = usePendingApproval(
+    part.toolCallId,
+    EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME
+  );
 
   return (
     <LazyDiffAcceptRejectToolDetails<

--- a/app/src/components/agent/EditPromptToolDetails.tsx
+++ b/app/src/components/agent/EditPromptToolDetails.tsx
@@ -6,9 +6,9 @@ import {
   promptSnapshotToText,
 } from "@phoenix/agent/tools/playgroundPrompt";
 import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import { LazyDiffAcceptRejectToolDetails } from "./LazyDiffAcceptRejectToolDetails";
+import { usePendingApproval } from "./usePendingApproval";
 import type { ToolInvocationPart } from "./toolPartTypes";
 import { formatToolState } from "./toolPartTypes";
 
@@ -33,9 +33,7 @@ export function formatEditPromptState(part: ToolInvocationPart): string {
 }
 
 export function EditPromptToolDetails({ part }: { part: ToolInvocationPart }) {
-  const pending = useAgentContext(
-    (state) => state.pendingPromptEditsByToolCallId[part.toolCallId] ?? null
-  );
+  const pending = usePendingApproval(part.toolCallId, EDIT_PROMPT_TOOL_NAME);
   const input = parseEditPromptInput(part.input);
 
   return (

--- a/app/src/components/agent/LoadDatasetToolDetails.tsx
+++ b/app/src/components/agent/LoadDatasetToolDetails.tsx
@@ -3,12 +3,12 @@ import type { ReactNode } from "react";
 import { z } from "zod";
 
 import {
+  LOAD_DATASET_TOOL_NAME,
   parseLoadDatasetInput,
   type DatasetSelectionSnapshot,
   type PendingLoadDataset,
 } from "@phoenix/agent/tools/playgroundLoadDataset";
 import { Flex } from "@phoenix/components";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import {
   ToolPartApprovalActions,
@@ -17,6 +17,7 @@ import {
 } from "./ToolPartPrimitives";
 import type { ToolInvocationPart } from "./toolPartTypes";
 import { formatToolState, stringifyToolValue } from "./toolPartTypes";
+import { usePendingApproval } from "./usePendingApproval";
 
 const loadDatasetToolDetailsCSS = css`
   && {
@@ -96,8 +97,9 @@ export function formatLoadDatasetState(part: ToolInvocationPart): string {
 }
 
 export function LoadDatasetToolDetails({ part }: { part: ToolInvocationPart }) {
-  const pendingLoad = useAgentContext(
-    (state) => state.pendingLoadDatasetsByToolCallId[part.toolCallId] ?? null
+  const pendingLoad = usePendingApproval(
+    part.toolCallId,
+    LOAD_DATASET_TOOL_NAME
   );
   const input = parseLoadDatasetInput(part.input);
   const isResolved = part.state === "output-available";

--- a/app/src/components/agent/RemovePromptInstanceToolDetails.tsx
+++ b/app/src/components/agent/RemovePromptInstanceToolDetails.tsx
@@ -2,15 +2,16 @@ import {
   parseRemovePromptInstanceInput,
   parseRemovePromptInstanceOutput,
   type PendingPromptInstanceRemoval,
+  REMOVE_PROMPT_INSTANCE_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundPrompt";
 import { Flex } from "@phoenix/components";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import {
   ToolPartApprovalActions,
   ToolPartCodeBlock,
   ToolPartLabel,
 } from "./ToolPartPrimitives";
+import { usePendingApproval } from "./usePendingApproval";
 import type { ToolInvocationPart } from "./toolPartTypes";
 import { formatToolState, stringifyToolValue } from "./toolPartTypes";
 
@@ -61,9 +62,9 @@ export function RemovePromptInstanceToolDetails({
 }: {
   part: ToolInvocationPart;
 }) {
-  const pendingRemoval = useAgentContext(
-    (state) =>
-      state.pendingPromptInstanceRemovalsByToolCallId[part.toolCallId] ?? null
+  const pendingRemoval = usePendingApproval(
+    part.toolCallId,
+    REMOVE_PROMPT_INSTANCE_TOOL_NAME
   );
   const input = parseRemovePromptInstanceInput(part.input);
   const result = parseRemovePromptInstanceOutput(part.output);

--- a/app/src/components/agent/SavePromptToolDetails.tsx
+++ b/app/src/components/agent/SavePromptToolDetails.tsx
@@ -12,7 +12,6 @@ import {
 } from "@phoenix/agent/tools/playgroundSavePrompt";
 import { Flex, Link, Token } from "@phoenix/components";
 import { getPromptVersionTagColor } from "@phoenix/constants/promptConstants";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import {
   ToolPartApprovalActions,
@@ -21,6 +20,7 @@ import {
 } from "./ToolPartPrimitives";
 import type { ToolInvocationPart } from "./toolPartTypes";
 import { formatToolState, stringifyToolValue } from "./toolPartTypes";
+import { usePendingApproval } from "./usePendingApproval";
 
 const savePromptToolDetailsCSS = css`
   && {
@@ -114,9 +114,7 @@ export function formatSavePromptState(part: ToolInvocationPart): string {
 }
 
 export function SavePromptToolDetails({ part }: { part: ToolInvocationPart }) {
-  const pendingSave = useAgentContext(
-    (state) => state.pendingSavePromptsByToolCallId[part.toolCallId] ?? null
-  );
+  const pendingSave = usePendingApproval(part.toolCallId, SAVE_PROMPT_TOOL_NAME);
   const input = parseSavePromptInput(part.input);
   const isResolved = part.state === "output-available";
   const isRejected = isResolved && getOutputStatus(part.output) === "rejected";

--- a/app/src/components/agent/WritePromptToolsToolDetails.tsx
+++ b/app/src/components/agent/WritePromptToolsToolDetails.tsx
@@ -7,11 +7,11 @@ import {
   WRITE_PROMPT_TOOLS_TOOL_NAME,
 } from "@phoenix/agent/tools/playgroundPromptTools";
 import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
-import { useAgentContext } from "@phoenix/contexts/AgentContext";
 
 import { LazyDiffAcceptRejectToolDetails } from "./LazyDiffAcceptRejectToolDetails";
 import type { ToolInvocationPart } from "./toolPartTypes";
 import { formatToolState } from "./toolPartTypes";
+import { usePendingApproval } from "./usePendingApproval";
 
 /** One-line collapsed preview of the proposed batch (counts of writes/deletes). */
 export function getWritePromptToolsToolPreview(
@@ -45,9 +45,9 @@ export function WritePromptToolsToolDetails({
 }: {
   part: ToolInvocationPart;
 }) {
-  const pending = useAgentContext(
-    (state) =>
-      state.pendingPromptToolWritesByToolCallId[part.toolCallId] ?? null
+  const pending = usePendingApproval(
+    part.toolCallId,
+    WRITE_PROMPT_TOOLS_TOOL_NAME
   );
   const input = parseWritePromptToolsInput(part.input);
 

--- a/app/src/components/agent/__tests__/BatchSpanAnnotateToolDetails.test.tsx
+++ b/app/src/components/agent/__tests__/BatchSpanAnnotateToolDetails.test.tsx
@@ -53,8 +53,9 @@ function createBatchSpanAnnotatePart(): ToolInvocationPart {
 
 function renderPendingAnnotations(annotations: PendingAnnotation[]) {
   const agentStore = createAgentStore();
-  agentStore.getState().setPendingBatchSpanAnnotate("tool-call-1", {
+  agentStore.getState().setPendingApproval("tool-call-1", {
     toolCallId: "tool-call-1",
+    toolName: BATCH_SPAN_ANNOTATE_TOOL_NAME,
     sessionId: "session-1",
     annotations,
     accept: async () => undefined,

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -1,6 +1,6 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
-import { DefaultChatTransport, getToolName, isToolUIPart } from "ai";
+import { DefaultChatTransport, isToolUIPart } from "ai";
 import { useCallback, useEffect, useRef } from "react";
 
 import {
@@ -17,20 +17,10 @@ import {
 } from "@phoenix/agent/chat/shouldSendAutomatically";
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { selectActiveContexts } from "@phoenix/agent/context/selectors";
-import { BATCH_SPAN_ANNOTATE_TOOL_NAME } from "@phoenix/agent/tools/batchSpanAnnotate";
-import { EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME } from "@phoenix/agent/tools/codeEvaluatorDraft";
 import type {
   ElicitToolOutput,
   PendingElicitation,
 } from "@phoenix/agent/tools/elicit";
-import { EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME } from "@phoenix/agent/tools/llmEvaluatorDraft";
-import { LOAD_DATASET_TOOL_NAME } from "@phoenix/agent/tools/playgroundLoadDataset";
-import {
-  EDIT_PROMPT_TOOL_NAME,
-  REMOVE_PROMPT_INSTANCE_TOOL_NAME,
-} from "@phoenix/agent/tools/playgroundPrompt";
-import { WRITE_PROMPT_TOOLS_TOOL_NAME } from "@phoenix/agent/tools/playgroundPromptTools";
-import { SAVE_PROMPT_TOOL_NAME } from "@phoenix/agent/tools/playgroundSavePrompt";
 import { authFetch } from "@phoenix/authFetch";
 import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
@@ -195,33 +185,11 @@ export function useAgentChat({
   }) => {
     const unresolvedToolCalls = getUnresolvedToolCalls(messages);
 
+    // Clear any staged approval for a call we're about to error out. The
+    // unified slice is keyed by toolCallId, so this is a no-op for tool calls
+    // that never staged an approval.
     unresolvedToolCalls.forEach((toolCall) => {
-      if (toolCall.tool === EDIT_PROMPT_TOOL_NAME) {
-        store.getState().setPendingPromptEdit(toolCall.toolCallId, null);
-      }
-      if (toolCall.tool === REMOVE_PROMPT_INSTANCE_TOOL_NAME) {
-        store
-          .getState()
-          .setPendingPromptInstanceRemoval(toolCall.toolCallId, null);
-      }
-      if (toolCall.tool === BATCH_SPAN_ANNOTATE_TOOL_NAME) {
-        store.getState().setPendingBatchSpanAnnotate(toolCall.toolCallId, null);
-      }
-      if (toolCall.tool === WRITE_PROMPT_TOOLS_TOOL_NAME) {
-        store.getState().setPendingPromptToolWrite(toolCall.toolCallId, null);
-      }
-      if (toolCall.tool === SAVE_PROMPT_TOOL_NAME) {
-        store.getState().setPendingSavePrompt(toolCall.toolCallId, null);
-      }
-      if (toolCall.tool === EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME) {
-        store.getState().setPendingCodeEvaluatorEdit(toolCall.toolCallId, null);
-      }
-      if (toolCall.tool === EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME) {
-        store.getState().setPendingLlmEvaluatorEdit(toolCall.toolCallId, null);
-      }
-      if (toolCall.tool === LOAD_DATASET_TOOL_NAME) {
-        store.getState().setPendingLoadDataset(toolCall.toolCallId, null);
-      }
+      store.getState().clearPendingApproval(toolCall.toolCallId);
     });
 
     await Promise.all(
@@ -329,17 +297,12 @@ export function useAgentChat({
           if (!isToolUIPart(part) || retained.has(part.toolCallId)) {
             continue;
           }
-          const toolName = getToolName(part);
-          if (toolName === EDIT_PROMPT_TOOL_NAME) {
-            state.setPendingPromptEdit(part.toolCallId, null);
-          } else if (toolName === REMOVE_PROMPT_INSTANCE_TOOL_NAME) {
-            state.setPendingPromptInstanceRemoval(part.toolCallId, null);
-          } else if (toolName === BATCH_SPAN_ANNOTATE_TOOL_NAME) {
-            state.setPendingBatchSpanAnnotate(part.toolCallId, null);
-          } else if (toolName === WRITE_PROMPT_TOOLS_TOOL_NAME) {
-            state.setPendingPromptToolWrite(part.toolCallId, null);
-          } else if (pendingElicitation?.toolCallId === part.toolCallId) {
+          if (pendingElicitation?.toolCallId === part.toolCallId) {
             state.setPendingElicitation(sessionId, null);
+          } else {
+            // Release any staged approval for a dropped tool part; keyed by
+            // toolCallId, so it is a no-op when nothing was staged.
+            state.clearPendingApproval(part.toolCallId);
           }
         }
       }

--- a/app/src/components/agent/usePendingApproval.ts
+++ b/app/src/components/agent/usePendingApproval.ts
@@ -1,0 +1,26 @@
+import {
+  type PendingApproval,
+  selectPendingApproval,
+} from "@phoenix/agent/shared/pendingApproval";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
+
+/**
+ * Subscribes to the pending approval staged for `toolCallId`, narrowed to the
+ * caller's own tool.
+ *
+ * The single state-read seam every approval `*ToolDetails` component uses: it
+ * reads the unified `pendingApprovalsByToolCallId` slice via
+ * {@link selectPendingApproval} and narrows the discriminated union to the
+ * member matching `toolName`, returning `null` for any other (or absent) entry.
+ */
+export function usePendingApproval<TName extends PendingApproval["toolName"]>(
+  toolCallId: string,
+  toolName: TName
+): Extract<PendingApproval, { toolName: TName }> | null {
+  return useAgentContext((state) => {
+    const approval = selectPendingApproval(state, toolCallId);
+    return approval?.toolName === toolName
+      ? (approval as Extract<PendingApproval, { toolName: TName }>)
+      : null;
+  });
+}

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -14,6 +14,7 @@ import {
 import { Group, Panel, Separator } from "react-resizable-panels";
 
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
+import { cancelPendingApprovalsForTools } from "@phoenix/agent/shared/pendingApproval";
 import { createEvaluatorHostSubmit } from "@phoenix/agent/tools/approval";
 import {
   applyDraftOperations,
@@ -385,7 +386,8 @@ export const EditCodeEvaluatorDialogContent = ({
     const {
       registerClientAction,
       unregisterClientAction,
-      setPendingCodeEvaluatorEdit,
+      setPendingApproval,
+      clearPendingApproval,
     } = agentStore.getState();
     const getDraftHost = () => draftHostRef.current;
     registerClientAction(
@@ -396,7 +398,8 @@ export const EditCodeEvaluatorDialogContent = ({
       EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
       createEditCodeEvaluatorDraftClientAction({
         getDraftHost,
-        setPendingCodeEvaluatorEdit,
+        setPendingApproval,
+        clearPendingApproval,
         shouldAutoAccept: () =>
           agentStore.getState().permissions.edits === "bypass",
       })
@@ -415,13 +418,11 @@ export const EditCodeEvaluatorDialogContent = ({
       unregisterClientAction(READ_CODE_EVALUATOR_DRAFT_TOOL_NAME);
       unregisterClientAction(EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME);
       unregisterClientAction(SUBMIT_CODE_EVALUATOR_DRAFT_TOOL_NAME);
-      for (const pendingEdit of Object.values(
-        agentStore.getState().pendingCodeEvaluatorEditsByToolCallId
-      )) {
-        if (pendingEdit) {
-          void pendingEdit.cancel?.();
-        }
-      }
+      cancelPendingApprovalsForTools({
+        pendingApprovalsByToolCallId:
+          agentStore.getState().pendingApprovalsByToolCallId,
+        toolNames: [EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME],
+      });
     };
   }, [agentStore, store, mode, evaluatorNodeId]);
 

--- a/app/src/components/evaluators/useLlmEvaluatorDraftRegistration.ts
+++ b/app/src/components/evaluators/useLlmEvaluatorDraftRegistration.ts
@@ -1,5 +1,6 @@
 import { type RefObject, useEffect, useRef } from "react";
 
+import { cancelPendingApprovalsForTools } from "@phoenix/agent/shared/pendingApproval";
 import { createEvaluatorHostSubmit } from "@phoenix/agent/tools/approval";
 import {
   fromOutputConfigDraft,
@@ -158,7 +159,8 @@ export const useLlmEvaluatorDraftRegistration = ({
     const {
       registerClientAction,
       unregisterClientAction,
-      setPendingLlmEvaluatorEdit,
+      setPendingApproval,
+      clearPendingApproval,
     } = agentStore.getState();
     const getDraftHost = () => draftHostRef.current;
     registerClientAction(
@@ -169,7 +171,8 @@ export const useLlmEvaluatorDraftRegistration = ({
       EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME,
       createEditLlmEvaluatorDraftClientAction({
         getDraftHost,
-        setPendingLlmEvaluatorEdit,
+        setPendingApproval,
+        clearPendingApproval,
         shouldAutoAccept: () =>
           agentStore.getState().permissions.edits === "bypass",
       })
@@ -187,13 +190,11 @@ export const useLlmEvaluatorDraftRegistration = ({
       unregisterClientAction(READ_LLM_EVALUATOR_DRAFT_TOOL_NAME);
       unregisterClientAction(EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME);
       unregisterClientAction(SUBMIT_LLM_EVALUATOR_DRAFT_TOOL_NAME);
-      for (const pendingEdit of Object.values(
-        agentStore.getState().pendingLlmEvaluatorEditsByToolCallId
-      )) {
-        if (pendingEdit) {
-          void pendingEdit.cancel?.();
-        }
-      }
+      cancelPendingApprovalsForTools({
+        pendingApprovalsByToolCallId:
+          agentStore.getState().pendingApprovalsByToolCallId,
+        toolNames: [EDIT_LLM_EVALUATOR_DRAFT_TOOL_NAME],
+      });
     };
   }, [
     agentStore,

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -19,6 +19,7 @@ import type { BlockerFunction } from "react-router";
 import { useBlocker, useSearchParams } from "react-router";
 
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
+import { cancelPendingApprovalsForTools } from "@phoenix/agent/shared/pendingApproval";
 import {
   EDIT_CODE_EVALUATOR_DRAFT_TOOL_NAME,
   OPEN_CODE_EVALUATOR_FORM_TOOL_NAME,
@@ -423,11 +424,8 @@ function PlaygroundContent() {
     const {
       registerClientAction,
       unregisterClientAction,
-      setPendingPromptEdit,
-      setPendingPromptInstanceRemoval,
-      setPendingSavePrompt,
-      setPendingLoadDataset,
-      setPendingPromptToolWrite,
+      setPendingApproval,
+      clearPendingApproval,
     } = agentStore.getState();
     registerClientAction(
       READ_PROMPT_TOOL_NAME,
@@ -445,7 +443,8 @@ function PlaygroundContent() {
       REMOVE_PROMPT_INSTANCE_TOOL_NAME,
       createRemovePromptInstanceClientAction({
         playgroundStore,
-        setPendingPromptInstanceRemoval,
+        setPendingApproval,
+        clearPendingApproval,
         shouldAutoAccept: () =>
           agentStore.getState().permissions.edits === "bypass",
       })
@@ -454,7 +453,8 @@ function PlaygroundContent() {
       EDIT_PROMPT_TOOL_NAME,
       createEditPromptClientAction({
         playgroundStore,
-        setPendingPromptEdit,
+        setPendingApproval,
+        clearPendingApproval,
         shouldAutoAccept: () =>
           agentStore.getState().permissions.edits === "bypass",
       })
@@ -463,7 +463,8 @@ function PlaygroundContent() {
       SAVE_PROMPT_TOOL_NAME,
       createSavePromptClientAction({
         playgroundStore,
-        setPendingSavePrompt,
+        setPendingApproval,
+        clearPendingApproval,
         shouldAutoAccept: () =>
           agentStore.getState().permissions.edits === "bypass",
       })
@@ -501,7 +502,8 @@ function PlaygroundContent() {
         playgroundStore,
         setSearchParams,
         getSearchParams: () => searchParamsRef.current,
-        setPendingLoadDataset,
+        setPendingApproval,
+        clearPendingApproval,
         shouldAutoAccept: () =>
           agentStore.getState().permissions.edits === "bypass",
       })
@@ -514,7 +516,8 @@ function PlaygroundContent() {
       WRITE_PROMPT_TOOLS_TOOL_NAME,
       createWritePromptToolsClientAction({
         playgroundStore,
-        setPendingPromptToolWrite,
+        setPendingApproval,
+        clearPendingApproval,
         shouldAutoAccept: () =>
           agentStore.getState().permissions.edits === "bypass",
       })
@@ -543,41 +546,19 @@ function PlaygroundContent() {
       unregisterClientAction(READ_PROMPT_TOOLS_TOOL_NAME);
       unregisterClientAction(WRITE_PROMPT_TOOLS_TOOL_NAME);
       unregisterClientAction(SET_APPENDED_MESSAGES_PATH_TOOL_NAME);
-      for (const pendingEdit of Object.values(
-        agentStore.getState().pendingPromptEditsByToolCallId
-      )) {
-        if (pendingEdit) {
-          void pendingEdit.cancel?.();
-        }
-      }
-      for (const pendingRemoval of Object.values(
-        agentStore.getState().pendingPromptInstanceRemovalsByToolCallId
-      )) {
-        if (pendingRemoval) {
-          void pendingRemoval.cancel?.();
-        }
-      }
-      for (const pendingSave of Object.values(
-        agentStore.getState().pendingSavePromptsByToolCallId
-      )) {
-        if (pendingSave) {
-          void pendingSave.cancel?.();
-        }
-      }
-      for (const pendingLoad of Object.values(
-        agentStore.getState().pendingLoadDatasetsByToolCallId
-      )) {
-        if (pendingLoad) {
-          void pendingLoad.cancel?.();
-        }
-      }
-      for (const pendingWrite of Object.values(
-        agentStore.getState().pendingPromptToolWritesByToolCallId
-      )) {
-        if (pendingWrite) {
-          void pendingWrite.cancel?.();
-        }
-      }
+      // Discard any approval proposals owned by the playground surface that were
+      // never resolved before it unmounted.
+      cancelPendingApprovalsForTools({
+        pendingApprovalsByToolCallId:
+          agentStore.getState().pendingApprovalsByToolCallId,
+        toolNames: [
+          EDIT_PROMPT_TOOL_NAME,
+          REMOVE_PROMPT_INSTANCE_TOOL_NAME,
+          SAVE_PROMPT_TOOL_NAME,
+          LOAD_DATASET_TOOL_NAME,
+          WRITE_PROMPT_TOOLS_TOOL_NAME,
+        ],
+      });
     };
   }, [agentStore, playgroundStore, setSearchParams]);
 

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -13,19 +13,13 @@ import {
   type AgentCapabilities,
   type AgentCapabilityKey,
 } from "@phoenix/agent/extensions/capabilities";
-import type { PendingDatasetWrite } from "@phoenix/agent/shared/pendingDatasetWrite";
-import type { PendingBatchSpanAnnotate } from "@phoenix/agent/tools/batchSpanAnnotate";
-import type { PendingCodeEvaluatorEdit } from "@phoenix/agent/tools/codeEvaluatorDraft";
-import type { PendingElicitation } from "@phoenix/agent/tools/elicit";
-import type { PendingLlmEvaluatorEdit } from "@phoenix/agent/tools/llmEvaluatorDraft";
-import type { PendingPatchExperiment } from "@phoenix/agent/tools/patchExperiment";
-import type { PendingLoadDataset } from "@phoenix/agent/tools/playgroundLoadDataset";
 import type {
-  PendingPromptEdit,
-  PendingPromptInstanceRemoval,
-} from "@phoenix/agent/tools/playgroundPrompt";
-import type { PendingPromptToolWrite } from "@phoenix/agent/tools/playgroundPromptTools";
-import type { PendingSavePrompt } from "@phoenix/agent/tools/playgroundSavePrompt";
+  PendingApproval,
+  PendingApprovalsByToolCallId,
+} from "@phoenix/agent/shared/pendingApproval";
+import type { PendingDatasetWrite } from "@phoenix/agent/shared/pendingDatasetWrite";
+import type { PendingElicitation } from "@phoenix/agent/tools/elicit";
+import type { PendingPatchExperiment } from "@phoenix/agent/tools/patchExperiment";
 import { getDefaultInvocationConfig } from "@phoenix/pages/playground/providerAdapters";
 import { generateUUID } from "@phoenix/utils/uuidUtils";
 
@@ -397,28 +391,23 @@ export interface AgentState extends AgentProps {
   unregisterClientAction: (name: string) => void;
 
   // -- Approval-gated tool proposals advertised by agent tool calls --
-  // TODO(pending-tool-rehydration): Replace these tool-specific slices with a
-  // generic pending tool state map keyed by toolCallId. The tool registry
-  // should own each tool's serializer and runtime rebinder.
-  pendingPromptEditsByToolCallId: Partial<Record<string, PendingPromptEdit>>;
-  setPendingPromptEdit: (
-    toolCallId: string,
-    edit: PendingPromptEdit | null
-  ) => void;
-  pendingPromptInstanceRemovalsByToolCallId: Partial<
-    Record<string, PendingPromptInstanceRemoval>
-  >;
-  setPendingPromptInstanceRemoval: (
-    toolCallId: string,
-    removal: PendingPromptInstanceRemoval | null
-  ) => void;
-  pendingBatchSpanAnnotatesByToolCallId: Partial<
-    Record<string, PendingBatchSpanAnnotate>
-  >;
-  setPendingBatchSpanAnnotate: (
-    toolCallId: string,
-    annotation: PendingBatchSpanAnnotate | null
-  ) => void;
+  //
+  // A single toolCallId-keyed map holds every approval-gated pending write
+  // (edit_prompt_instance, remove_prompt_instance, batch_span_annotate,
+  // write_prompt_tools, save_prompt, edit_code_evaluator_draft,
+  // edit_llm_evaluator_draft, load_dataset). Entries are a `PendingApproval`
+  // discriminated union keyed by `toolName`; each carries plain preview data
+  // plus the accept/reject/cancel callbacks rebound at dispatch/mount time (the
+  // callbacks capture non-serializable runtime deps, so the slice is ephemeral).
+  // Read through `selectPendingApproval`; navigation-cancel through
+  // `cancelPendingApprovalsForTools`.
+  pendingApprovalsByToolCallId: PendingApprovalsByToolCallId;
+  setPendingApproval: (toolCallId: string, pending: PendingApproval) => void;
+  clearPendingApproval: (toolCallId: string) => void;
+
+  // Dataset write proposals (create/patch/split writes) keep their own slice:
+  // they run their staging via `bindPendingDatasetWrite`, not the shared
+  // approval lifecycle above.
   pendingDatasetWritesByToolCallId: Partial<
     Record<string, PendingDatasetWrite>
   >;
@@ -426,47 +415,14 @@ export interface AgentState extends AgentProps {
     toolCallId: string,
     pending: PendingDatasetWrite | null
   ) => void;
+  // patch_experiment keeps its own slice: it is session-keyed and pruned with
+  // its session (see buildSessionRetentionPatch / deleteSession).
   pendingPatchExperimentsByToolCallId: Partial<
     Record<string, PendingPatchExperiment>
   >;
   setPendingPatchExperiment: (
     toolCallId: string,
     patch: PendingPatchExperiment | null
-  ) => void;
-  pendingPromptToolWritesByToolCallId: Partial<
-    Record<string, PendingPromptToolWrite>
-  >;
-  setPendingPromptToolWrite: (
-    toolCallId: string,
-    write: PendingPromptToolWrite | null
-  ) => void;
-  pendingSavePromptsByToolCallId: Partial<Record<string, PendingSavePrompt>>;
-  setPendingSavePrompt: (
-    toolCallId: string,
-    pendingSave: PendingSavePrompt | null
-  ) => void;
-
-  // -- Code-evaluator draft edit approvals advertised by edit_code_evaluator_draft tool calls --
-  pendingCodeEvaluatorEditsByToolCallId: Partial<
-    Record<string, PendingCodeEvaluatorEdit>
-  >;
-  setPendingCodeEvaluatorEdit: (
-    toolCallId: string,
-    edit: PendingCodeEvaluatorEdit | null
-  ) => void;
-
-  // -- LLM-evaluator draft edit approvals advertised by edit_llm_evaluator_draft tool calls --
-  pendingLlmEvaluatorEditsByToolCallId: Partial<
-    Record<string, PendingLlmEvaluatorEdit>
-  >;
-  setPendingLlmEvaluatorEdit: (
-    toolCallId: string,
-    edit: PendingLlmEvaluatorEdit | null
-  ) => void;
-  pendingLoadDatasetsByToolCallId: Partial<Record<string, PendingLoadDataset>>;
-  setPendingLoadDataset: (
-    toolCallId: string,
-    pendingLoad: PendingLoadDataset | null
   ) => void;
 }
 
@@ -684,16 +640,9 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
     capabilities: createDefaultAgentCapabilities(),
     routeContexts: [],
     mountedContexts: {},
-    pendingPromptEditsByToolCallId: {},
-    pendingPromptInstanceRemovalsByToolCallId: {},
-    pendingBatchSpanAnnotatesByToolCallId: {},
+    pendingApprovalsByToolCallId: {},
     pendingDatasetWritesByToolCallId: {},
     pendingPatchExperimentsByToolCallId: {},
-    pendingPromptToolWritesByToolCallId: {},
-    pendingSavePromptsByToolCallId: {},
-    pendingCodeEvaluatorEditsByToolCallId: {},
-    pendingLlmEvaluatorEditsByToolCallId: {},
-    pendingLoadDatasetsByToolCallId: {},
     setIsOpen: (isOpen) => {
       set({ isOpen }, false, { type: "setIsOpen" });
     },
@@ -1210,35 +1159,30 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
       );
     },
 
-    setPendingPromptEdit: (toolCallId, edit) => {
+    setPendingApproval: (toolCallId, pending) => {
       set(
-        (state) => {
-          const next = { ...state.pendingPromptEditsByToolCallId };
-          if (edit) {
-            next[toolCallId] = edit;
-          } else {
-            delete next[toolCallId];
-          }
-          return { pendingPromptEditsByToolCallId: next };
-        },
+        (state) => ({
+          pendingApprovalsByToolCallId: {
+            ...state.pendingApprovalsByToolCallId,
+            [toolCallId]: pending,
+          },
+        }),
         false,
-        { type: "setPendingPromptEdit" }
+        { type: "setPendingApproval" }
       );
     },
-
-    setPendingPromptInstanceRemoval: (toolCallId, removal) => {
+    clearPendingApproval: (toolCallId) => {
       set(
         (state) => {
-          const next = { ...state.pendingPromptInstanceRemovalsByToolCallId };
-          if (removal) {
-            next[toolCallId] = removal;
-          } else {
-            delete next[toolCallId];
+          if (!(toolCallId in state.pendingApprovalsByToolCallId)) {
+            return state;
           }
-          return { pendingPromptInstanceRemovalsByToolCallId: next };
+          const next = { ...state.pendingApprovalsByToolCallId };
+          delete next[toolCallId];
+          return { pendingApprovalsByToolCallId: next };
         },
         false,
-        { type: "setPendingPromptInstanceRemoval" }
+        { type: "clearPendingApproval" }
       );
     },
 
@@ -1257,21 +1201,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         { type: "setPendingDatasetWrite" }
       );
     },
-    setPendingBatchSpanAnnotate: (toolCallId, annotation) => {
-      set(
-        (state) => {
-          const next = { ...state.pendingBatchSpanAnnotatesByToolCallId };
-          if (annotation) {
-            next[toolCallId] = annotation;
-          } else {
-            delete next[toolCallId];
-          }
-          return { pendingBatchSpanAnnotatesByToolCallId: next };
-        },
-        false,
-        { type: "setPendingBatchSpanAnnotate" }
-      );
-    },
 
     setPendingPatchExperiment: (toolCallId, patch) => {
       set(
@@ -1286,85 +1215,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         },
         false,
         { type: "setPendingPatchExperiment" }
-      );
-    },
-
-    setPendingPromptToolWrite: (toolCallId, write) => {
-      set(
-        (state) => {
-          const next = { ...state.pendingPromptToolWritesByToolCallId };
-          if (write) {
-            next[toolCallId] = write;
-          } else {
-            delete next[toolCallId];
-          }
-          return { pendingPromptToolWritesByToolCallId: next };
-        },
-        false,
-        { type: "setPendingPromptToolWrite" }
-      );
-    },
-
-    setPendingSavePrompt: (toolCallId, pendingSave) => {
-      set(
-        (state) => {
-          const next = { ...state.pendingSavePromptsByToolCallId };
-          if (pendingSave) {
-            next[toolCallId] = pendingSave;
-          } else {
-            delete next[toolCallId];
-          }
-          return { pendingSavePromptsByToolCallId: next };
-        },
-        false,
-        { type: "setPendingSavePrompt" }
-      );
-    },
-
-    setPendingCodeEvaluatorEdit: (toolCallId, edit) => {
-      set(
-        (state) => {
-          const next = { ...state.pendingCodeEvaluatorEditsByToolCallId };
-          if (edit) {
-            next[toolCallId] = edit;
-          } else {
-            delete next[toolCallId];
-          }
-          return { pendingCodeEvaluatorEditsByToolCallId: next };
-        },
-        false,
-        { type: "setPendingCodeEvaluatorEdit" }
-      );
-    },
-
-    setPendingLlmEvaluatorEdit: (toolCallId, edit) => {
-      set(
-        (state) => {
-          const next = { ...state.pendingLlmEvaluatorEditsByToolCallId };
-          if (edit) {
-            next[toolCallId] = edit;
-          } else {
-            delete next[toolCallId];
-          }
-          return { pendingLlmEvaluatorEditsByToolCallId: next };
-        },
-        false,
-        { type: "setPendingLlmEvaluatorEdit" }
-      );
-    },
-    setPendingLoadDataset: (toolCallId, pendingLoad) => {
-      set(
-        (state) => {
-          const next = { ...state.pendingLoadDatasetsByToolCallId };
-          if (pendingLoad) {
-            next[toolCallId] = pendingLoad;
-          } else {
-            delete next[toolCallId];
-          }
-          return { pendingLoadDatasetsByToolCallId: next };
-        },
-        false,
-        { type: "setPendingLoadDataset" }
       );
     },
 


### PR DESCRIPTION
# Consolidate pending-approval PXI tool-call state behind the `AgentToolDefinition` seam

Closes #13639. Follows #13574, which established `AgentToolDefinition` as the
dispatch seam and left a `// TODO(pending-tool-rehydration)` note where the
approval descriptor should plug in. This PR fills that seam.

## What changed

Every approval-gated PXI tool used to carry a near-identical "pending approval"
structure duplicated four ways. There were **8** such tools
(`edit_prompt_instance`, `remove_prompt_instance`, `batch_span_annotate`,
`write_prompt_tools`, `save_prompt`, `edit_code_evaluator_draft`,
`edit_llm_evaluator_draft`, `load_dataset`), each with:

- its own `pending*ByToolCallId` slice + `setPending*` setter + init in `agentStore.ts`;
- a bespoke `bindPending*Actions` factory re-implementing accept/reject/cancel;
- a `*_NAVIGATION_CANCEL_ERROR` constant;
- a `*ToolDetails.tsx` reading `state.pending*ByToolCallId[toolCallId]`.

This PR collapses those four parallel artifacts into one shared seam.

### 1. One store slice (Goal 1)

The 8 slices/setters/inits collapse into a single ephemeral map plus two setters:

```ts
pendingApprovalsByToolCallId: Partial<Record<string, PendingApproval>>;
setPendingApproval(toolCallId, pending): void;
clearPendingApproval(toolCallId): void;
```

`PendingApproval` (in `agent/shared/pendingApproval/registry.ts`) is a
discriminated union by `toolName` — each member carries its own preview data
plus the bound `accept`/`reject`/`cancel` callbacks.

The out-of-scope `pendingDatasetWritesByToolCallId` (dataset writes, which stage
through the separate `bindPendingDatasetWrite`) and
`pendingPatchExperimentsByToolCallId` (session-keyed and pruned with its
session) keep their own slices, matching the issue's 8-tool scope.

### 2. One generic accept/reject/cancel lifecycle (Goal 2)

The shared `bindPendingApproval` (`agent/shared/pendingApproval`) owns the
generic lifecycle: clear-on-resolve, output emission, and the navigation-cancel.
Each tool now only declares the three things that are genuinely tool-specific:

- `commit(approvalSource)` — applies the approved write and returns its full,
  model-facing output object (so each tool's existing output shape is preserved
  verbatim, not flattened);
- `buildRejectedOutput()` — the rejected output payload;
- `navigationCancelError` — the message surfaced when the owning editor unmounts.

The 8 `bindPending*Actions` factories shrink to thin adapters over this core, and
the per-tool navigation-cancel loops in `Playground.tsx` and the evaluator
dialogs collapse into one generic helper, `cancelPendingApprovalsForTools`,
which cancels only the approvals a given surface owns.

### 3. One state-read seam (Goal 3)

The 8 `*ToolDetails.tsx` reads now go through a single `usePendingApproval`
hook (built on the `selectPendingApproval` selector) that narrows the union to
the caller's tool. Per-tool *rendering* (diff preview vs annotation preview vs
save preview) stays distinct — only the state-read seam unifies.

## Design note: where the descriptor lives

The issue flagged as an open question *where* the approval descriptor should
live on `AgentToolDefinition`. It does **not** live on the static registry
entry: `accept`/`reject`/`cancel` capture non-serializable runtime dependencies
(Relay mutations, store setters, the AI SDK `addToolOutput`) that cannot be held
on a static definition. Instead the descriptor is the config passed to
`bindPendingApproval` at dispatch/mount time, exactly preserving the
"**data lives in the store, behavior is rebound at dispatch/mount time**" split
the issue calls the design crux. The `TODO(pending-tool-rehydration)` comment in
`defineTool.ts` is updated to record this resolution.

`pendingElicitation` (`ask_user`) is intentionally left as-is: it is the only
*persisted*, session-keyed pending state and does not fit the toolCallId-keyed
union.

## Files touched

- `agent/shared/pendingApproval/*` — the generic core: `bindPendingApproval`
  (now driven by a per-tool `commit`/`buildRejectedOutput`/optional
  `navigationCancelError` descriptor), the `PendingApproval` union registry,
  `selectPendingApproval`, `cancelPendingApprovalsForTools`.
- `agent/shared/pendingDatasetWrite/*` — dataset writes already rode the generic
  `bindPendingApproval`; its thin wrapper is re-adapted to the new
  `commit`-based core (no behavior change — it has no navigation-cancel path and
  its accepted/rejected output shapes are preserved). Dataset writes keep their
  own `pendingDatasetWritesByToolCallId` slice; only the 8 toolCallId-keyed
  slices are consolidated.
- `store/agentStore.ts` — 8 slices/setters/inits → 1 slice + 2 setters.
- 8 tool modules — `Pending*` types gain a `toolName` discriminant, `bindPending*`
  adapters delegate to the shared core, cancel constants feed the descriptor.
- 8 `*ToolDetails.tsx` — read through the new `usePendingApproval` hook.
- `Playground.tsx`, `useLlmEvaluatorDraftRegistration.ts`,
  `EditCodeEvaluatorDialogContent.tsx` — register with the unified setters and
  navigation-cancel via the shared helper.
- `useAgentChat.ts` — the interrupt/rewind cleanup calls `clearPendingApproval`
  generically instead of eight per-tool setters.

## How to verify

- **Unit:** `make test-frontend`. Updated per-tool pending tests plus new tests
  for `bindPendingApproval`, `selectPendingApproval`, and
  `cancelPendingApprovalsForTools`.
- **Types/lint/format:** `make typecheck-frontend`, `make lint-frontend`,
  `make format-frontend`.
- **E2E (correctness-sensitive — regressions here are silent wrong/lost
  approvals):** exercise each approval flow end to end in the PXI panel — propose
  → Accept, propose → Reject, propose → close the owning editor (navigation
  cancel), and bypass-mode auto-accept — for prompt edit/removal, prompt-tools
  write, save prompt, batch span annotate, load dataset, and the code/LLM
  evaluator draft edits.

## Notes

- No changeset: this PR modifies only `app/` (the frontend app), not a published
  package under `js/`, which is where the changeset workflow is scoped.
- No user-facing docs or `skills/` reference this internal PXI state plumbing, so
  none needed updating.
