### PR TITLE
feat(sessions): sweep orphaned sessions after a one-hour grace period

### DIFF
--- a/src/phoenix/server/retention.py
+++ b/src/phoenix/server/retention.py
@@ -118,6 +118,14 @@ class TraceDataSweeper(DaemonTask):
           or a trace INSERT's KEY SHARE on the parent) is skipped this sweep
           and reconsidered next hour. SQLite serializes writers, so the race
           cannot occur there.
+
+        A narrower race remains if the sweeper commits after ingestion selects
+        an old orphaned session but before ingestion flushes its trace. In that
+        case the single span insert fails inside the bulk inserter's per-span
+        savepoint, is logged and metered, and the batch continues. We accept
+        that tradeoff here because it is the same pre-existing race carried by
+        explicit session/project deletes; a retry in the ingestion path would
+        address all such deletes together.
         """
         cutoff = self._now() - _ORPHAN_SESSION_GRACE_PERIOD
         total_deleted = 0

--- a/src/phoenix/server/retention.py
+++ b/src/phoenix/server/retention.py
@@ -9,7 +9,8 @@ import sqlalchemy as sa
 from sqlalchemy.orm import selectinload
 
 from phoenix.db.constants import DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID
-from phoenix.db.models import Project, ProjectTraceRetentionPolicy
+from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.db.models import Project, ProjectSession, ProjectTraceRetentionPolicy, Trace
 from phoenix.server.dml_event import SpanDeleteEvent
 from phoenix.server.dml_event_handler import DmlEventHandler
 from phoenix.server.prometheus import (
@@ -21,6 +22,9 @@ from phoenix.utilities import hour_of_week
 
 logger = logging.getLogger(__name__)
 
+_ORPHAN_SESSION_DELETE_BATCH_SIZE = 1000
+_ORPHAN_SESSION_GRACE_PERIOD = timedelta(hours=1)
+
 
 class TraceDataSweeper(DaemonTask):
     def __init__(self, db: DbSessionFactory, dml_event_handler: DmlEventHandler):
@@ -29,22 +33,25 @@ class TraceDataSweeper(DaemonTask):
         self._dml_event_handler = dml_event_handler
 
     async def _run(self) -> None:
-        """Check hourly and apply policies."""
+        """Check hourly, apply policies, then clean up orphaned sessions."""
         while self._running:
             await self._sleep_until_next_hour()
             RETENTION_SWEEPER_LAST_RUN.set(time())
             try:
-                if not (policies := await self._get_policies()):
-                    continue
-                current_hour = self._current_hour()
-                if tasks := [
-                    create_task(self._apply(policy))
-                    for policy in policies
-                    if self._should_apply(policy, current_hour)
-                ]:
-                    await gather(*tasks, return_exceptions=True)
+                if policies := await self._get_policies():
+                    current_hour = self._current_hour()
+                    if tasks := [
+                        create_task(self._apply(policy))
+                        for policy in policies
+                        if self._should_apply(policy, current_hour)
+                    ]:
+                        await gather(*tasks, return_exceptions=True)
             except Exception:
                 logger.exception("Unexpected error in retention sweeper main loop")
+            try:
+                await self._delete_orphan_sessions()
+            except Exception:
+                logger.exception("Failed to delete orphaned project sessions")
 
     async def _get_policies(self) -> list[ProjectTraceRetentionPolicy]:
         stmt = sa.select(ProjectTraceRetentionPolicy).options(
@@ -83,6 +90,66 @@ class TraceDataSweeper(DaemonTask):
         except Exception:
             logger.exception(f"Failed to apply retention policy '{policy.name}' (id={policy.id})")
             RETENTION_POLICY_EXECUTIONS.labels(status="error").inc()
+
+    async def _delete_orphan_sessions(self) -> None:
+        """Delete session rows whose traces are all gone and whose last activity is old.
+
+        Trace deletion (retention rules, bulk deletes) does not cascade upward to
+        ``project_sessions``, so sessions whose traces have all been deleted
+        linger as ghosts in the sessions UI. Only sessions quiet for the grace
+        period are deleted: ``end_time`` advances with each new trace, so an
+        active session never qualifies, and the grace period keeps the sweep
+        clear of in-flight ingestion (a session row is created just before its
+        first trace commits). Deleting a session cascades to its session
+        annotations, consistent with trace deletion cascading to span/trace
+        annotations. Deletes run in batches to bound transaction time.
+
+        Two guards close a race with a session resuming mid-sweep (ingestion
+        get-or-creates session rows without locking, and the traces FK cascades
+        on session delete, so an unguarded delete could cascade away a
+        just-committed trace):
+
+        - ``end_time < cutoff`` is repeated as a direct qual on the DELETE.
+          Under READ COMMITTED, if the DELETE blocks on a concurrent ingestion
+          transaction that advanced the row's ``end_time``, the recheck against
+          the new row version excludes it (the subquery's snapshot would not).
+        - On PostgreSQL, candidates are locked with FOR UPDATE SKIP LOCKED, so
+          any session row currently locked by in-flight ingestion (its UPDATE,
+          or a trace INSERT's KEY SHARE on the parent) is skipped this sweep
+          and reconsidered next hour. SQLite serializes writers, so the race
+          cannot occur there.
+        """
+        cutoff = self._now() - _ORPHAN_SESSION_GRACE_PERIOD
+        total_deleted = 0
+        while self._running:
+            candidate_ids = (
+                sa.select(ProjectSession.id)
+                .where(ProjectSession.end_time < cutoff)
+                .where(
+                    ~sa.select(sa.literal(1))
+                    .where(Trace.project_session_rowid == ProjectSession.id)
+                    .exists()
+                )
+                .limit(_ORPHAN_SESSION_DELETE_BATCH_SIZE)
+            )
+            if self._db.dialect is SupportedSQLDialect.POSTGRESQL:
+                candidate_ids = candidate_ids.with_for_update(skip_locked=True)
+            stmt = (
+                sa.delete(ProjectSession)
+                .where(ProjectSession.id.in_(candidate_ids))
+                .where(ProjectSession.end_time < cutoff)
+                .returning(ProjectSession.id)
+            )
+            async with self._db() as session:
+                deleted = len((await session.scalars(stmt)).all())
+            total_deleted += deleted
+            if deleted < _ORPHAN_SESSION_DELETE_BATCH_SIZE:
+                break
+        if total_deleted:
+            logger.info(
+                f"Deleted {total_deleted} orphaned project session(s) with no remaining "
+                f"traces and no activity since {cutoff.isoformat()}"
+            )
 
     async def _sleep_until_next_hour(self) -> None:
         next_hour = self._now().replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)

--- a/tests/unit/server/test_retention.py
+++ b/tests/unit/server/test_retention.py
@@ -2,7 +2,7 @@ from asyncio import Event, sleep
 from datetime import datetime, timedelta, timezone
 from secrets import token_hex
 from typing import Any, AsyncIterator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import sqlalchemy as sa
@@ -448,3 +448,109 @@ async def sweeper_trigger() -> AsyncIterator[Event]:
 
     with patch.object(TraceDataSweeper, "_sleep_until_next_hour", wait_for_event):
         yield event
+
+
+class TestOrphanSessionSweep:
+    """_delete_orphan_sessions removes sessions with no remaining traces once
+    their last activity (end_time) is older than the grace period.
+    """
+
+    @staticmethod
+    def _sweeper(db: DbSessionFactory) -> TraceDataSweeper:
+        sweeper = TraceDataSweeper(db=db, dml_event_handler=MagicMock())
+        # The batch loop checks self._running; start() is deliberately not called
+        # so the sweep can be driven synchronously.
+        sweeper._running = True
+        return sweeper
+
+    @staticmethod
+    async def _add_session(
+        session: Any,
+        project_id: int,
+        end_time: datetime,
+        with_trace: bool,
+    ) -> int:
+        project_session = models.ProjectSession(
+            session_id=token_hex(8),
+            project_id=project_id,
+            start_time=end_time - timedelta(minutes=5),
+            end_time=end_time,
+        )
+        session.add(project_session)
+        await session.flush()
+        if with_trace:
+            session.add(
+                models.Trace(
+                    trace_id=token_hex(16),
+                    project_rowid=project_id,
+                    project_session_rowid=project_session.id,
+                    start_time=end_time - timedelta(minutes=5),
+                    end_time=end_time,
+                )
+            )
+            await session.flush()
+        return int(project_session.id)
+
+    async def test_deletes_only_old_orphans(
+        self,
+        db: DbSessionFactory,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        old, recent = now - timedelta(hours=2), now - timedelta(minutes=10)
+        async with db() as session:
+            project = models.Project(name=token_hex(8))
+            session.add(project)
+            await session.flush()
+            old_orphan = await self._add_session(session, project.id, old, with_trace=False)
+            recent_orphan = await self._add_session(session, project.id, recent, with_trace=False)
+            old_with_trace = await self._add_session(session, project.id, old, with_trace=True)
+            recent_with_trace = await self._add_session(
+                session, project.id, recent, with_trace=True
+            )
+            # An annotation on the old orphan must cascade away with the session.
+            session.add(
+                models.ProjectSessionAnnotation(
+                    project_session_id=old_orphan,
+                    name=token_hex(4),
+                    metadata_={},
+                    annotator_kind="HUMAN",
+                    source="APP",
+                )
+            )
+
+        await self._sweeper(db)._delete_orphan_sessions()
+
+        async with db() as session:
+            remaining = set((await session.scalars(sa.select(models.ProjectSession.id))).all())
+            num_annotations = await session.scalar(
+                sa.select(func.count(models.ProjectSessionAnnotation.id))
+            )
+        assert old_orphan not in remaining, "old orphan should be deleted"
+        assert {recent_orphan, old_with_trace, recent_with_trace} <= remaining, (
+            "recent orphans and sessions with traces should be kept"
+        )
+        assert num_annotations == 0, "the deleted session's annotation should cascade away"
+
+    async def test_deletes_in_batches(
+        self,
+        db: DbSessionFactory,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        num_orphans = 3
+        async with db() as session:
+            project = models.Project(name=token_hex(8))
+            session.add(project)
+            await session.flush()
+            orphan_ids = {
+                await self._add_session(
+                    session, project.id, now - timedelta(hours=2), with_trace=False
+                )
+                for _ in range(num_orphans)
+            }
+
+        with patch("phoenix.server.retention._ORPHAN_SESSION_DELETE_BATCH_SIZE", 1):
+            await self._sweeper(db)._delete_orphan_sessions()
+
+        async with db() as session:
+            remaining = set((await session.scalars(sa.select(models.ProjectSession.id))).all())
+        assert not (orphan_ids & remaining), "all orphans should be deleted across batches"


### PR DESCRIPTION
## Problem

Trace deletion does not cascade upward to `project_sessions`. When trace retention (or a bulk delete) removes all of a session's traces, the session row lingers as a ghost: it still appears in the sessions UI — the connection queries `project_sessions` directly — with zero traces behind it, empty metrics, and timestamps for content Phoenix no longer has. The GraphQL `deleteTraces` mutation cleans up after itself (anti-join delete in the same transaction), but the retention sweeper never did, and nothing sweeps the backlog accumulated on deployments that have run retention for months.

## Solution

`TraceDataSweeper` now deletes orphaned sessions on its hourly tick: a session qualifies only when it has **no remaining traces** and its **`end_time` is more than one hour old**.

Gating on `end_time` — which advances with every ingested trace — is what makes this safe:

- Active sessions never qualify, regardless of grace duration.
- In-flight ingestion (session row committed just before its first trace) is far outside the window.
- Late-arriving spans have ample margin.

Deletes run in batches of 1000 to bound transaction time; the anti-join probe is served by the existing `ix_traces_project_session_rowid` index. Deleting a session cascades to its session annotations — a deliberate decision, consistent with trace deletion cascading to span/trace annotations (by the time a session is sweepable, Phoenix has already discarded all of its traces).

## Race hardening

Ingestion (`insert_span`) get-or-creates session rows without locking, and `traces.project_session_rowid` is `ON DELETE CASCADE` — so an unguarded sweep racing a *resuming* session could, in one interleaving, cascade-delete a just-committed trace with no error anywhere. Two guards close that interleaving:

1. The `end_time < cutoff` predicate is repeated as a **direct qual on the DELETE**. Under READ COMMITTED, if the DELETE blocks on a concurrent ingestion transaction that advanced the row's `end_time`, EvalPlanQual rechecks the new row version and excludes it (the subquery-only form would not).
2. On PostgreSQL the candidate subquery uses **`FOR UPDATE SKIP LOCKED`**: session rows locked by in-flight ingestion (the `end_time` UPDATE, or a trace INSERT's KEY SHARE on the parent) are skipped this sweep and reconsidered next hour. SQLite serializes writers, so the race cannot occur there.

The residual interleaving — sweeper commits inside ingestion's unlocked SELECT→flush gap — fails exactly one span inside its per-span savepoint (logged + `BULK_LOADER_SPAN_EXCEPTIONS`), leaves the batch intact, and self-heals on the session's next span. This is the same pre-existing race class carried by the `deleteTraces` mutation and project deletion; an ingestion-side retry would fix all producers at once and is deliberately left as a follow-up.

## Testing

- Grace-period boundary: 2-hour-old orphan deleted; 10-minute-old orphan and sessions with traces kept.
- Session annotations cascade away with the deleted session.
- Batch looping (batch size patched to 1, multiple orphans, all deleted).

The race guards above are liveness/interleaving properties not exercised by unit tests: the EvalPlanQual qual requires a mid-DELETE concurrent commit, and `SKIP LOCKED` only affects whether the sweep waits, not what it deletes.