### PR TITLE
feat(online-eval): consumer + env-var config (stacked on producer-only)

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 from importlib.metadata import version
+from math import isfinite
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -3228,21 +3229,42 @@ def get_env_online_eval_frontier_lag_seconds() -> float:
     """
     Gets the value of the PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS environment variable.
     """
-    return _float_val(ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS, 60.0)
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS, 60.0)
+    if not isfinite(seconds) or seconds < 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS}: "
+            f"{seconds}. Value must be a finite non-negative number."
+        )
+    return seconds
 
 
 def get_env_online_eval_backstop_interval_seconds() -> float:
     """
     Gets the value of the PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS environment variable.
     """
-    return _float_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS, 3600.0)
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS, 3600.0)
+    if not isfinite(seconds) or seconds <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS}: "
+            f"{seconds}. Value must be a finite positive number."
+        )
+    return seconds
 
 
 def get_env_online_eval_backstop_lookback_span_ids() -> int:
     """
     Gets the value of the PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS environment variable.
     """
-    return _int_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS, 100_000)
+    span_ids = _int_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS, 100_000)
+    if span_ids < 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS}: "
+            f"{span_ids}. Value must be a non-negative integer."
+        )
+    return span_ids
 
 
 def get_env_online_eval_max_span_ids_per_tick() -> int:
@@ -3273,14 +3295,28 @@ def get_env_online_eval_pending_ttl_seconds() -> float:
     evaluated or re-materialized, so only set this if dropping evals on old
     spans under sustained backlog is acceptable.
     """
-    return _float_val(ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS, 0.0)
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS, 0.0)
+    if not isfinite(seconds) or seconds < 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS}: "
+            f"{seconds}. Value must be a finite non-negative number."
+        )
+    return seconds
 
 
 def get_env_online_eval_retention_seconds() -> float:
     """
     Gets the value of the PHOENIX_ONLINE_EVAL_RETENTION_SECONDS environment variable.
     """
-    return _float_val(ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS, 604_800.0)
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS, 604_800.0)
+    if not isfinite(seconds) or seconds <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS}: "
+            f"{seconds}. Value must be a finite positive number."
+        )
+    return seconds
 
 
 def get_env_online_eval_max_outstanding() -> int:
@@ -3289,7 +3325,13 @@ def get_env_online_eval_max_outstanding() -> int:
 
     Counts PENDING + RUNNING + retryable ERROR (non-terminal work).
     """
-    return _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING, 10_000)
+    max_outstanding = _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING, 10_000)
+    if max_outstanding <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable {ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING}: "
+            f"{max_outstanding}. Value must be a positive integer."
+        )
+    return max_outstanding
 
 
 def get_env_client_headers() -> dict[str, str]:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -317,6 +317,11 @@ ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS = "PHOENIX_ONLINE_EVAL_BACKSTO
 """
 How often the online-eval producer re-sweeps recent spans for work units missed by the
 frontier scan. Defaults to 3600.
+
+Configure this together with PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS: gap-free
+re-coverage requires the lookback span ids to be at least the instance-wide ingest rate
+multiplied by this interval. Spans share one id sequence, so the relevant rate is the sum
+across all projects and tenants.
 """
 ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS = (
     "PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS"
@@ -324,6 +329,12 @@ ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS = (
 """
 How far behind the producer watermark, measured in span ids, the backstop sweep looks.
 Defaults to 100000.
+
+With the default 3600-second interval, 100000 ids provides gap-free re-coverage only below
+about 28 spans per second instance-wide. Above that rate, rows can leave the lookback between
+sweeps, so the backstop no longer bounds exceptional loss from late-visible spans or skipped
+criteria. The reaper floor is aligned to this lookback; changes to the lookback and interval
+must preserve the coverage relationship and move the reaper floor with them.
 """
 ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS = "PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS"
 """

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -306,7 +306,39 @@ Defaults to 20000.
 """
 ENV_PHOENIX_ONLINE_EVAL_ENABLED = "PHOENIX_ONLINE_EVAL_ENABLED"
 """
-Whether to run the online-eval producer daemon. Defaults to false.
+Whether to run the online-eval producer and consumer daemons. Defaults to false.
+"""
+ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS = "PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS"
+"""
+How long an observed span high-water id must age before the online-eval producer scans up
+to it. Defaults to 60.
+"""
+ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS = "PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS"
+"""
+How often the online-eval producer re-sweeps recent spans for work units missed by the
+frontier scan. Defaults to 3600.
+"""
+ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS = (
+    "PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS"
+)
+"""
+How far behind the producer watermark, measured in span ids, the backstop sweep looks.
+Defaults to 100000.
+"""
+ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS = "PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS"
+"""
+How long a PENDING online-eval work unit may wait before the reaper marks it EXPIRED.
+Defaults to 0 (disabled).
+"""
+ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS = "PHOENIX_ONLINE_EVAL_RETENTION_SECONDS"
+"""
+How long terminal online-eval work units are kept before the reaper deletes them.
+Defaults to 604800 (7 days).
+"""
+ENV_PHOENIX_ONLINE_EVAL_MAX_PENDING = "PHOENIX_ONLINE_EVAL_MAX_PENDING"
+"""
+The pending work-unit count above which the online-eval producer stops materializing new
+work units. Defaults to 10000.
 """
 ENV_LOGGING_MODE = "PHOENIX_LOGGING_MODE"
 """
@@ -3171,6 +3203,55 @@ def get_env_online_eval_enabled() -> bool:
     Gets the value of the PHOENIX_ONLINE_EVAL_ENABLED environment variable.
     """
     return _bool_val(ENV_PHOENIX_ONLINE_EVAL_ENABLED, False)
+
+
+def get_env_online_eval_frontier_lag_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS environment variable.
+    """
+    return _float_val(ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS, 60.0)
+
+
+def get_env_online_eval_backstop_interval_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS environment variable.
+    """
+    return _float_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS, 3600.0)
+
+
+def get_env_online_eval_backstop_lookback_span_ids() -> int:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS environment variable.
+    """
+    return _int_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS, 100_000)
+
+
+def get_env_online_eval_pending_ttl_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS environment variable.
+
+    Defaults to 0, which disables TTL-based shedding: pending work units wait
+    until a consumer claims them, however long that takes (the admission gate
+    bounds queue growth). Setting a positive TTL opts into load shedding —
+    pending units older than the TTL are expired terminally and are NEVER
+    evaluated or re-materialized, so only set this if dropping evals on old
+    spans under sustained backlog is acceptable.
+    """
+    return _float_val(ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS, 0.0)
+
+
+def get_env_online_eval_retention_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_RETENTION_SECONDS environment variable.
+    """
+    return _float_val(ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS, 604_800.0)
+
+
+def get_env_online_eval_max_pending() -> int:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_MAX_PENDING environment variable.
+    """
+    return _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_PENDING, 10_000)
 
 
 def get_env_client_headers() -> dict[str, str]:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -336,6 +336,14 @@ sweeps, so the backstop no longer bounds exceptional loss from late-visible span
 criteria. The reaper floor is aligned to this lookback; changes to the lookback and interval
 must preserve the coverage relationship and move the reaper floor with them.
 """
+ENV_PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK = "PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK"
+"""
+The maximum span-id range the online-eval producer advances through in one tick.
+Defaults to 10000.
+
+Higher values increase catch-up throughput at the cost of larger per-tick transactions;
+lower values reduce transaction size but take longer to catch up to the observed frontier.
+"""
 ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS = "PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS"
 """
 How long a PENDING online-eval work unit may wait before the reaper marks it EXPIRED.
@@ -346,10 +354,10 @@ ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS = "PHOENIX_ONLINE_EVAL_RETENTION_SECON
 How long terminal online-eval work units are kept before the reaper deletes them.
 Defaults to 604800 (7 days).
 """
-ENV_PHOENIX_ONLINE_EVAL_MAX_PENDING = "PHOENIX_ONLINE_EVAL_MAX_PENDING"
+ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING = "PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING"
 """
-The pending work-unit count above which the online-eval producer stops materializing new
-work units. Defaults to 10000.
+The outstanding work-unit count above which the online-eval producer stops materializing
+new work units: PENDING + RUNNING + retryable ERROR (non-terminal work). Defaults to 10000.
 """
 ENV_LOGGING_MODE = "PHOENIX_LOGGING_MODE"
 """
@@ -3237,6 +3245,23 @@ def get_env_online_eval_backstop_lookback_span_ids() -> int:
     return _int_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS, 100_000)
 
 
+def get_env_online_eval_max_span_ids_per_tick() -> int:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK environment variable.
+
+    Raises:
+        ValueError: If the value is not a positive integer.
+    """
+    max_span_ids = _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK, 10_000)
+    if max_span_ids <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK}: "
+            f"{max_span_ids}. Value must be a positive integer."
+        )
+    return max_span_ids
+
+
 def get_env_online_eval_pending_ttl_seconds() -> float:
     """
     Gets the value of the PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS environment variable.
@@ -3258,11 +3283,13 @@ def get_env_online_eval_retention_seconds() -> float:
     return _float_val(ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS, 604_800.0)
 
 
-def get_env_online_eval_max_pending() -> int:
+def get_env_online_eval_max_outstanding() -> int:
     """
-    Gets the value of the PHOENIX_ONLINE_EVAL_MAX_PENDING environment variable.
+    Gets the value of the PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING environment variable.
+
+    Counts PENDING + RUNNING + retryable ERROR (non-terminal work).
     """
-    return _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_PENDING, 10_000)
+    return _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING, 10_000)
 
 
 def get_env_client_headers() -> dict[str, str]:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -642,13 +642,12 @@ def _lifespan(
             # shutdown snapshot would leak a provider session past the daemon.
             await stack.enter_async_context(sandbox_session_manager)
             await stack.enter_async_context(experiment_runner)
-            # Entered after sandbox_session_manager for the same teardown-order
-            # reason as experiment_runner: the consumer runs code evals through
-            # sandbox sessions, so it must stop before the manager does.
-            if online_eval_producer is not None:
-                await stack.enter_async_context(online_eval_producer)
+            # Enter the consumer before the producer so teardown stops admission
+            # before draining work; both stop before sandbox_session_manager.
             if online_eval_consumer is not None:
                 await stack.enter_async_context(online_eval_consumer)
+            if online_eval_producer is not None:
+                await stack.enter_async_context(online_eval_producer)
             if docs_mcp_server is not None:
                 # The docs MCP server connects to an external host during
                 # startup. Never let its initialization (which can hang until a
@@ -967,7 +966,7 @@ def create_app(
     )
     online_eval_producer: Optional[OnlineEvalProducer] = None
     online_eval_consumer: Optional[OnlineEvalConsumer] = None
-    if get_env_online_eval_enabled():
+    if get_env_online_eval_enabled() and not read_only:
         online_eval_producer = OnlineEvalProducer(db)
         online_eval_consumer = OnlineEvalConsumer(
             db,

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -112,6 +112,7 @@ from phoenix.server.grpc_server import GrpcServer
 from phoenix.server.jwt_store import JwtStore
 from phoenix.server.middleware.gzip import GZipMiddleware
 from phoenix.server.oauth2 import OAuth2Clients
+from phoenix.server.online_eval.consumer import OnlineEvalConsumer
 from phoenix.server.online_eval.producer import OnlineEvalProducer
 from phoenix.server.prometheus import SPAN_QUEUE_REJECTIONS
 from phoenix.server.redaction import Redactor, current_redactor
@@ -581,6 +582,7 @@ def _lifespan(
     experiment_runner: ExperimentRunner,
     sandbox_session_manager: SandboxSessionManager,
     online_eval_producer: Optional[OnlineEvalProducer] = None,
+    online_eval_consumer: Optional[OnlineEvalConsumer] = None,
     token_store: Optional[TokenStore] = None,
     tracer_provider: Optional["TracerProvider"] = None,
     enable_prometheus: bool = False,
@@ -640,12 +642,13 @@ def _lifespan(
             # shutdown snapshot would leak a provider session past the daemon.
             await stack.enter_async_context(sandbox_session_manager)
             await stack.enter_async_context(experiment_runner)
-            # Entered after sandbox_session_manager so the stacked consumer PR
-            # can enter its consumer next to the producer with the teardown
-            # ordering it needs (code evals run through sandbox sessions, so
-            # the consumer must stop before the manager does).
+            # Entered after sandbox_session_manager for the same teardown-order
+            # reason as experiment_runner: the consumer runs code evals through
+            # sandbox sessions, so it must stop before the manager does.
             if online_eval_producer is not None:
                 await stack.enter_async_context(online_eval_producer)
+            if online_eval_consumer is not None:
+                await stack.enter_async_context(online_eval_consumer)
             if docs_mcp_server is not None:
                 # The docs MCP server connects to an external host during
                 # startup. Never let its initialization (which can hang until a
@@ -963,8 +966,15 @@ def create_app(
         sandbox_session_manager=sandbox_session_manager,
     )
     online_eval_producer: Optional[OnlineEvalProducer] = None
+    online_eval_consumer: Optional[OnlineEvalConsumer] = None
     if get_env_online_eval_enabled():
         online_eval_producer = OnlineEvalProducer(db)
+        online_eval_consumer = OnlineEvalConsumer(
+            db,
+            decrypt=encryption_service.decrypt,
+            sandbox_session_manager=sandbox_session_manager,
+            event_queue=dml_event_handler,
+        )
     graphql_schema = build_graphql_schema(graphql_schema_extensions)
     graphql_router = create_graphql_router(
         db=db,
@@ -1014,6 +1024,7 @@ def create_app(
             experiment_runner=experiment_runner,
             sandbox_session_manager=sandbox_session_manager,
             online_eval_producer=online_eval_producer,
+            online_eval_consumer=online_eval_consumer,
             grpc_interceptors=grpc_interceptors,
             token_store=token_store,
             tracer_provider=tracer_provider,
@@ -1142,6 +1153,7 @@ def create_app(
     app.state.docs_mcp_server = docs_mcp_server
     app.state.sandbox_session_manager = sandbox_session_manager
     app.state.online_eval_producer = online_eval_producer
+    app.state.online_eval_consumer = online_eval_consumer
     app.state.graphql_schema = graphql_schema
     app.state.build_graphql_context = _get_build_graphql_context_function(
         db=db,

--- a/src/phoenix/server/online_eval/consumer.py
+++ b/src/phoenix/server/online_eval/consumer.py
@@ -30,10 +30,12 @@ from phoenix.server.online_eval.coordinator import (
 from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
 from phoenix.server.online_eval.executor import HydratedWorkUnit, OnlineEvalExecutor
 from phoenix.server.prometheus import (
+    ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS,
     ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS,
     ONLINE_EVAL_INGEST_SPANS_PER_SECOND,
     ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS,
     ONLINE_EVAL_PENDING_WORK_UNITS,
+    ONLINE_EVAL_RETRYABLE_ERROR_WORK_UNITS,
     ONLINE_EVAL_RUNNING_WORK_UNITS,
 )
 from phoenix.server.sandbox.session_manager import SandboxSessionManager
@@ -45,6 +47,7 @@ TICK_INTERVAL_SECONDS = 5.0
 CLAIM_BATCH_SIZE = 10
 ERROR_COOLDOWN_SECONDS = 60.0
 DRAIN_TIMEOUT_SECONDS = 10.0
+_CONSUMER_GROUP = "default"
 
 _TRANSIENT_HTTP_STATUS_CODES = frozenset({408, 429})
 
@@ -92,16 +95,14 @@ class OnlineEvalConsumer(DaemonTask):
         sandbox_session_manager: Optional[SandboxSessionManager] = None,
         event_queue: Optional[CanPutItem[DmlEvent]] = None,
         coordinator: Optional[EvalWorkCoordinator] = None,
-        consumer_group: str = "default",
         tick_interval_seconds: float = TICK_INTERVAL_SECONDS,
         claim_batch_size: int = CLAIM_BATCH_SIZE,
     ) -> None:
         super().__init__()
         self._db = db
         self._grain: models.EvalWorkGrain = "SPAN"
-        self._consumer_group = consumer_group
         self._coordinator: EvalWorkCoordinator = coordinator or DbEvalWorkCoordinator(
-            db, grain=self._grain, consumer_group=self._consumer_group
+            db, grain=self._grain
         )
         self._executor = OnlineEvalExecutor(
             db,
@@ -133,6 +134,8 @@ class OnlineEvalConsumer(DaemonTask):
         lag = await self._coordinator.lag()
         ONLINE_EVAL_PENDING_WORK_UNITS.set(lag.pending_count)
         ONLINE_EVAL_RUNNING_WORK_UNITS.set(lag.running_count)
+        ONLINE_EVAL_RETRYABLE_ERROR_WORK_UNITS.set(lag.retryable_error_count)
+        ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS.set(lag.exhausted_error_count)
         ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS.set(lag.frontier_gap)
         ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS.set(lag.oldest_pending_age_seconds or 0.0)
         async with self._db.read() as session:
@@ -143,7 +146,7 @@ class OnlineEvalConsumer(DaemonTask):
                         models.EvalWorkCursor.observed_at,
                     ).where(
                         models.EvalWorkCursor.grain == self._grain,
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     )
                 )
             ).first()
@@ -190,10 +193,15 @@ class OnlineEvalConsumer(DaemonTask):
         try:
             hydrated = await self._executor.hydrate(unit)
             if hydrated is None:
-                await self._coordinator.expire(
+                expired = await self._coordinator.expire(
                     work_unit_id=unit.work_unit_id,
                     claimed_by=self._consumer_id,
                 )
+                if not expired:
+                    logger.warning(
+                        f"Online-eval work unit {unit.work_unit_id} could not expire after its "
+                        "claim was lost"
+                    )
                 return
             await self._evaluate_with_heartbeat(unit, hydrated)
         except Exception as exc:
@@ -210,13 +218,18 @@ class OnlineEvalConsumer(DaemonTask):
             )
             cooldown_until = datetime.now(timezone.utc) + timedelta(seconds=cooldown_seconds)
             try:
-                await self._coordinator.fail(
+                failed = await self._coordinator.fail(
                     work_unit_id=unit.work_unit_id,
                     claimed_by=self._consumer_id,
                     error=str(exc),
                     cooldown_until=cooldown_until,
                     count_attempt=not transient,
                 )
+                if not failed:
+                    logger.warning(
+                        f"Online-eval work unit {unit.work_unit_id} failure was not recorded "
+                        "after its claim was lost"
+                    )
             except Exception:
                 logger.exception(
                     f"Failed to record failure for online-eval work unit {unit.work_unit_id}"
@@ -238,6 +251,7 @@ class OnlineEvalConsumer(DaemonTask):
         hydrated: HydratedWorkUnit,
     ) -> None:
         eval_task = asyncio.create_task(self._executor.evaluate_and_annotate(unit, hydrated))
+        heartbeat_enabled = True
         try:
             while True:
                 done, _ = await asyncio.wait({eval_task}, timeout=HEARTBEAT_INTERVAL_SECONDS)
@@ -246,11 +260,19 @@ class OnlineEvalConsumer(DaemonTask):
                 # A lost claim does not cancel the eval: the result is still
                 # valid under this unit's identifier and the write dedupes
                 # against whichever consumer got there first.
+                if not heartbeat_enabled:
+                    continue
                 try:
-                    await self._coordinator.heartbeat(
+                    heartbeat_succeeded = await self._coordinator.heartbeat(
                         work_unit_id=unit.work_unit_id,
                         claimed_by=self._consumer_id,
                     )
+                    if not heartbeat_succeeded:
+                        logger.warning(
+                            f"Online-eval work unit {unit.work_unit_id} heartbeat stopped after "
+                            "its claim was lost"
+                        )
+                        heartbeat_enabled = False
                 except Exception:
                     logger.exception(
                         f"Heartbeat failed for online-eval work unit {unit.work_unit_id}"

--- a/src/phoenix/server/online_eval/consumer.py
+++ b/src/phoenix/server/online_eval/consumer.py
@@ -185,7 +185,6 @@ class OnlineEvalConsumer(DaemonTask):
     async def stop(self) -> None:
         self._running = False
         if self._pending_tasks:
-            # Gracefully drain in-flight evals, then cancel and await stragglers.
             _, pending = await asyncio.wait(set(self._pending_tasks), timeout=DRAIN_TIMEOUT_SECONDS)
             for task in pending:
                 task.cancel()

--- a/src/phoenix/server/online_eval/consumer.py
+++ b/src/phoenix/server/online_eval/consumer.py
@@ -4,8 +4,8 @@ Runs on every replica; instances compete for work through coordinator claims.
 Each cycle claims a batch of work units and processes them concurrently:
 hydrate behind the staleness guard (stale units are expired, never executed),
 evaluate with lease heartbeats, write annotations, then complete — or fail
-with a cooldown. Shutdown drains in-flight evals instead of cancelling them,
-so LLM spend already paid gets committed.
+with a cooldown. Shutdown gives in-flight evals a grace period, then cancels
+stragglers before sandbox teardown.
 """
 
 from __future__ import annotations
@@ -14,7 +14,7 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from secrets import token_hex
-from typing import Callable, Optional
+from typing import Awaitable, Callable, Optional
 
 import httpx
 from sqlalchemy import select
@@ -47,9 +47,23 @@ TICK_INTERVAL_SECONDS = 5.0
 CLAIM_BATCH_SIZE = 10
 ERROR_COOLDOWN_SECONDS = 60.0
 DRAIN_TIMEOUT_SECONDS = 10.0
+EXECUTION_DEADLINE_SECONDS = 600.0
 _CONSUMER_GROUP = "default"
 
 _TRANSIENT_HTTP_STATUS_CODES = frozenset({408, 429})
+_TRANSITION_RETRY_DELAYS_SECONDS = (1.0, 2.0, 4.0)
+
+
+class EvalExecutionTimeout(Exception):
+    """An online evaluation exceeded its per-unit execution deadline."""
+
+
+async def _cancel_and_await(task: asyncio.Task[None]) -> None:
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 def is_transient_error(exc: BaseException) -> bool:
@@ -80,7 +94,12 @@ def is_transient_error(exc: BaseException) -> bool:
             status_code >= 500 or status_code in _TRANSIENT_HTTP_STATUS_CODES
         ):
             return True
-        node = node.__cause__ if node.__cause__ is not None else node.__context__
+        if node.__cause__ is not None:
+            node = node.__cause__
+        elif node.__suppress_context__:
+            node = None
+        else:
+            node = node.__context__
     return False
 
 
@@ -97,6 +116,7 @@ class OnlineEvalConsumer(DaemonTask):
         coordinator: Optional[EvalWorkCoordinator] = None,
         tick_interval_seconds: float = TICK_INTERVAL_SECONDS,
         claim_batch_size: int = CLAIM_BATCH_SIZE,
+        execution_deadline_seconds: float = EXECUTION_DEADLINE_SECONDS,
     ) -> None:
         super().__init__()
         self._db = db
@@ -113,6 +133,7 @@ class OnlineEvalConsumer(DaemonTask):
         self._consumer_id = f"consumer-{token_hex(8)}"
         self._tick_interval_seconds = tick_interval_seconds
         self._claim_batch_size = claim_batch_size
+        self._execution_deadline_seconds = execution_deadline_seconds
         self._pending_tasks: set[asyncio.Task[None]] = set()
         self._publish_metrics = get_env_enable_prometheus()
         self._last_ingest_sample: Optional[tuple[int, datetime]] = None
@@ -164,11 +185,12 @@ class OnlineEvalConsumer(DaemonTask):
     async def stop(self) -> None:
         self._running = False
         if self._pending_tasks:
-            # Wait for in-flight evals without cancelling them: asyncio.wait
-            # leaves timed-out tasks running rather than killing them mid-write,
-            # and any unit that outlives the grace window is reclaimed through
-            # its lapsed lease.
-            await asyncio.wait(set(self._pending_tasks), timeout=DRAIN_TIMEOUT_SECONDS)
+            # Gracefully drain in-flight evals, then cancel and await stragglers.
+            _, pending = await asyncio.wait(set(self._pending_tasks), timeout=DRAIN_TIMEOUT_SECONDS)
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
         await super().stop()
 
     async def _cycle(self) -> None:
@@ -217,33 +239,63 @@ class OnlineEvalConsumer(DaemonTask):
                 ERROR_COOLDOWN_SECONDS if transient else ERROR_COOLDOWN_SECONDS * (2**unit.attempts)
             )
             cooldown_until = datetime.now(timezone.utc) + timedelta(seconds=cooldown_seconds)
-            try:
-                failed = await self._coordinator.fail(
+            error = str(exc)
+            failed = await self._retry_transition(
+                action="record failure",
+                work_unit_id=unit.work_unit_id,
+                transition=lambda: self._coordinator.fail(
                     work_unit_id=unit.work_unit_id,
                     claimed_by=self._consumer_id,
-                    error=str(exc),
+                    error=error,
                     cooldown_until=cooldown_until,
                     count_attempt=not transient,
-                )
-                if not failed:
-                    logger.warning(
-                        f"Online-eval work unit {unit.work_unit_id} failure was not recorded "
-                        "after its claim was lost"
-                    )
-            except Exception:
-                logger.exception(
-                    f"Failed to record failure for online-eval work unit {unit.work_unit_id}"
+                ),
+            )
+            if failed is False:
+                logger.warning(
+                    f"Online-eval work unit {unit.work_unit_id} failure was not recorded "
+                    "after its claim was lost"
                 )
         else:
-            completed = await self._coordinator.complete(
+            completed = await self._retry_transition(
+                action="complete",
                 work_unit_id=unit.work_unit_id,
-                claimed_by=self._consumer_id,
+                transition=lambda: self._coordinator.complete(
+                    work_unit_id=unit.work_unit_id,
+                    claimed_by=self._consumer_id,
+                ),
             )
-            if not completed:
+            if completed is False:
                 logger.warning(
                     f"Online-eval work unit {unit.work_unit_id} finished after its claim "
                     "was lost; the annotation write is idempotent"
                 )
+
+    async def _retry_transition(
+        self,
+        *,
+        action: str,
+        work_unit_id: int,
+        transition: Callable[[], Awaitable[bool]],
+    ) -> Optional[bool]:
+        for delay_seconds in _TRANSITION_RETRY_DELAYS_SECONDS:
+            try:
+                return await transition()
+            except Exception:
+                logger.warning(
+                    f"Failed to {action} for online-eval work unit {work_unit_id}; "
+                    f"retrying in {delay_seconds:g}s",
+                    exc_info=True,
+                )
+                await asyncio.sleep(delay_seconds)
+        try:
+            return await transition()
+        except Exception:
+            logger.exception(
+                f"Failed to {action} for online-eval work unit {work_unit_id} after "
+                "3 retries; leaving the row for lease-lapse reclaim"
+            )
+            return None
 
     async def _evaluate_with_heartbeat(
         self,
@@ -252,11 +304,26 @@ class OnlineEvalConsumer(DaemonTask):
     ) -> None:
         eval_task = asyncio.create_task(self._executor.evaluate_and_annotate(unit, hydrated))
         heartbeat_enabled = True
+        deadline_at = asyncio.get_running_loop().time() + self._execution_deadline_seconds
         try:
             while True:
-                done, _ = await asyncio.wait({eval_task}, timeout=HEARTBEAT_INTERVAL_SECONDS)
+                remaining_seconds = deadline_at - asyncio.get_running_loop().time()
+                if remaining_seconds <= 0:
+                    await _cancel_and_await(eval_task)
+                    raise EvalExecutionTimeout(
+                        f"evaluation exceeded {self._execution_deadline_seconds:g}s deadline"
+                    ) from None
+                done, _ = await asyncio.wait(
+                    {eval_task},
+                    timeout=min(HEARTBEAT_INTERVAL_SECONDS, remaining_seconds),
+                )
                 if done:
                     break
+                if asyncio.get_running_loop().time() >= deadline_at:
+                    await _cancel_and_await(eval_task)
+                    raise EvalExecutionTimeout(
+                        f"evaluation exceeded {self._execution_deadline_seconds:g}s deadline"
+                    ) from None
                 # A lost claim does not cancel the eval: the result is still
                 # valid under this unit's identifier and the write dedupes
                 # against whichever consumer got there first.
@@ -279,5 +346,5 @@ class OnlineEvalConsumer(DaemonTask):
                     )
         finally:
             if not eval_task.done():
-                eval_task.cancel()
+                await _cancel_and_await(eval_task)
         await eval_task

--- a/src/phoenix/server/online_eval/consumer.py
+++ b/src/phoenix/server/online_eval/consumer.py
@@ -1,0 +1,261 @@
+"""Online-eval consumer daemon.
+
+Runs on every replica; instances compete for work through coordinator claims.
+Each cycle claims a batch of work units and processes them concurrently:
+hydrate behind the staleness guard (stale units are expired, never executed),
+evaluate with lease heartbeats, write annotations, then complete — or fail
+with a cooldown. Shutdown drains in-flight evals instead of cancelling them,
+so LLM spend already paid gets committed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+from typing import Callable, Optional
+
+import httpx
+from sqlalchemy import select
+
+from phoenix.config import get_env_enable_prometheus
+from phoenix.db import models
+from phoenix.server.dml_event import DmlEvent
+from phoenix.server.online_eval.coordinator import (
+    HEARTBEAT_INTERVAL_SECONDS,
+    ClaimedWorkUnit,
+    EvalWorkCoordinator,
+)
+from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
+from phoenix.server.online_eval.executor import HydratedWorkUnit, OnlineEvalExecutor
+from phoenix.server.prometheus import (
+    ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS,
+    ONLINE_EVAL_INGEST_SPANS_PER_SECOND,
+    ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS,
+    ONLINE_EVAL_PENDING_WORK_UNITS,
+    ONLINE_EVAL_RUNNING_WORK_UNITS,
+)
+from phoenix.server.sandbox.session_manager import SandboxSessionManager
+from phoenix.server.types import CanPutItem, DaemonTask, DbSessionFactory
+
+logger = logging.getLogger(__name__)
+
+TICK_INTERVAL_SECONDS = 5.0
+CLAIM_BATCH_SIZE = 10
+ERROR_COOLDOWN_SECONDS = 60.0
+DRAIN_TIMEOUT_SECONDS = 10.0
+
+_TRANSIENT_HTTP_STATUS_CODES = frozenset({408, 429})
+
+
+def is_transient_error(exc: BaseException) -> bool:
+    """Best-effort classification of failures that heal on their own —
+    provider outages, rate limits, network partitions. Transient failures
+    retry after a flat cooldown WITHOUT counting toward MAX_ATTEMPTS, so an
+    outage longer than the retry budget cannot permanently exhaust queued
+    work. Anything unrecognized counts attempts as usual, which keeps poison
+    units bounded (fail-safe default). Walks the exception chain so wrapped
+    errors (e.g. ``EvalExecutionError`` raised from an httpx timeout)
+    classify by their root cause."""
+    seen: set[int] = set()
+    node: Optional[BaseException] = exc
+    while node is not None and id(node) not in seen:
+        seen.add(id(node))
+        # asyncio.TimeoutError is an alias of TimeoutError on 3.11+ but a
+        # distinct class on 3.10.
+        if isinstance(node, (ConnectionError, TimeoutError, asyncio.TimeoutError)):
+            return True
+        if isinstance(node, httpx.TransportError):
+            return True
+        # Provider SDK errors (openai, anthropic, ...) expose status_code
+        # directly; httpx.HTTPStatusError exposes it via .response.
+        status_code = getattr(node, "status_code", None)
+        if status_code is None:
+            status_code = getattr(getattr(node, "response", None), "status_code", None)
+        if isinstance(status_code, int) and (
+            status_code >= 500 or status_code in _TRANSIENT_HTTP_STATUS_CODES
+        ):
+            return True
+        node = node.__cause__ if node.__cause__ is not None else node.__context__
+    return False
+
+
+class OnlineEvalConsumer(DaemonTask):
+    """Per-replica daemon claiming and executing online-eval work units."""
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        decrypt: Callable[[bytes], bytes],
+        sandbox_session_manager: Optional[SandboxSessionManager] = None,
+        event_queue: Optional[CanPutItem[DmlEvent]] = None,
+        coordinator: Optional[EvalWorkCoordinator] = None,
+        consumer_group: str = "default",
+        tick_interval_seconds: float = TICK_INTERVAL_SECONDS,
+        claim_batch_size: int = CLAIM_BATCH_SIZE,
+    ) -> None:
+        super().__init__()
+        self._db = db
+        self._grain: models.EvalWorkGrain = "SPAN"
+        self._consumer_group = consumer_group
+        self._coordinator: EvalWorkCoordinator = coordinator or DbEvalWorkCoordinator(
+            db, grain=self._grain, consumer_group=self._consumer_group
+        )
+        self._executor = OnlineEvalExecutor(
+            db,
+            decrypt=decrypt,
+            sandbox_session_manager=sandbox_session_manager,
+            event_queue=event_queue,
+        )
+        self._consumer_id = f"consumer-{token_hex(8)}"
+        self._tick_interval_seconds = tick_interval_seconds
+        self._claim_batch_size = claim_batch_size
+        self._pending_tasks: set[asyncio.Task[None]] = set()
+        self._publish_metrics = get_env_enable_prometheus()
+        self._last_ingest_sample: Optional[tuple[int, datetime]] = None
+
+    async def _run(self) -> None:
+        while self._running:
+            try:
+                await self._cycle()
+            except Exception:
+                logger.exception("Online-eval consumer cycle failed")
+            if self._publish_metrics:
+                try:
+                    await self._publish_queue_metrics()
+                except Exception:
+                    logger.exception("Online-eval queue metrics publish failed")
+            await asyncio.sleep(self._tick_interval_seconds)
+
+    async def _publish_queue_metrics(self) -> None:
+        lag = await self._coordinator.lag()
+        ONLINE_EVAL_PENDING_WORK_UNITS.set(lag.pending_count)
+        ONLINE_EVAL_RUNNING_WORK_UNITS.set(lag.running_count)
+        ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS.set(lag.frontier_gap)
+        ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS.set(lag.oldest_pending_age_seconds or 0.0)
+        async with self._db.read() as session:
+            sample = (
+                await session.execute(
+                    select(
+                        models.EvalWorkCursor.observed_high_water_id,
+                        models.EvalWorkCursor.observed_at,
+                    ).where(
+                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    )
+                )
+            ).first()
+        if sample is None or sample.observed_high_water_id is None or sample.observed_at is None:
+            return
+        if self._last_ingest_sample is not None:
+            last_high_water, last_observed_at = self._last_ingest_sample
+            elapsed = (sample.observed_at - last_observed_at).total_seconds()
+            if elapsed > 0:
+                ONLINE_EVAL_INGEST_SPANS_PER_SECOND.set(
+                    max(sample.observed_high_water_id - last_high_water, 0) / elapsed
+                )
+        self._last_ingest_sample = (sample.observed_high_water_id, sample.observed_at)
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._pending_tasks:
+            # Wait for in-flight evals without cancelling them: asyncio.wait
+            # leaves timed-out tasks running rather than killing them mid-write,
+            # and any unit that outlives the grace window is reclaimed through
+            # its lapsed lease.
+            await asyncio.wait(set(self._pending_tasks), timeout=DRAIN_TIMEOUT_SECONDS)
+        await super().stop()
+
+    async def _cycle(self) -> None:
+        units = await self._coordinator.claim(
+            claimed_by=self._consumer_id,
+            limit=self._claim_batch_size,
+        )
+        if not units:
+            return
+        tasks = [asyncio.create_task(self._process_unit(unit)) for unit in units]
+        for task in tasks:
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._pending_tasks.discard)
+        # asyncio.wait does not propagate this task's cancellation to the unit
+        # tasks; a shutdown mid-cycle leaves them to the stop() drain.
+        done, _ = await asyncio.wait(tasks)
+        for task in done:
+            if not task.cancelled() and (exc := task.exception()) is not None:
+                logger.error("Online-eval work unit task failed", exc_info=exc)
+
+    async def _process_unit(self, unit: ClaimedWorkUnit) -> None:
+        try:
+            hydrated = await self._executor.hydrate(unit)
+            if hydrated is None:
+                await self._coordinator.expire(
+                    work_unit_id=unit.work_unit_id,
+                    claimed_by=self._consumer_id,
+                )
+                return
+            await self._evaluate_with_heartbeat(unit, hydrated)
+        except Exception as exc:
+            transient = is_transient_error(exc)
+            logger.exception(
+                f"Online-eval work unit {unit.work_unit_id} failed "
+                f"({'transient — will retry without counting an attempt' if transient else 'counting an attempt'})"  # noqa: E501
+            )
+            # Transient failures cool down flat and don't count attempts (an
+            # outage retries until it heals); everything else backs off
+            # exponentially on the attempt count and exhausts at MAX_ATTEMPTS.
+            cooldown_seconds = (
+                ERROR_COOLDOWN_SECONDS if transient else ERROR_COOLDOWN_SECONDS * (2**unit.attempts)
+            )
+            cooldown_until = datetime.now(timezone.utc) + timedelta(seconds=cooldown_seconds)
+            try:
+                await self._coordinator.fail(
+                    work_unit_id=unit.work_unit_id,
+                    claimed_by=self._consumer_id,
+                    error=str(exc),
+                    cooldown_until=cooldown_until,
+                    count_attempt=not transient,
+                )
+            except Exception:
+                logger.exception(
+                    f"Failed to record failure for online-eval work unit {unit.work_unit_id}"
+                )
+        else:
+            completed = await self._coordinator.complete(
+                work_unit_id=unit.work_unit_id,
+                claimed_by=self._consumer_id,
+            )
+            if not completed:
+                logger.warning(
+                    f"Online-eval work unit {unit.work_unit_id} finished after its claim "
+                    "was lost; the annotation write is idempotent"
+                )
+
+    async def _evaluate_with_heartbeat(
+        self,
+        unit: ClaimedWorkUnit,
+        hydrated: HydratedWorkUnit,
+    ) -> None:
+        eval_task = asyncio.create_task(self._executor.evaluate_and_annotate(unit, hydrated))
+        try:
+            while True:
+                done, _ = await asyncio.wait({eval_task}, timeout=HEARTBEAT_INTERVAL_SECONDS)
+                if done:
+                    break
+                # A lost claim does not cancel the eval: the result is still
+                # valid under this unit's identifier and the write dedupes
+                # against whichever consumer got there first.
+                try:
+                    await self._coordinator.heartbeat(
+                        work_unit_id=unit.work_unit_id,
+                        claimed_by=self._consumer_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        f"Heartbeat failed for online-eval work unit {unit.work_unit_id}"
+                    )
+        finally:
+            if not eval_task.done():
+                eval_task.cancel()
+        await eval_task

--- a/src/phoenix/server/online_eval/coordinator.py
+++ b/src/phoenix/server/online_eval/coordinator.py
@@ -86,7 +86,9 @@ class EvalWorkCoordinator(Protocol):
         work_unit_id: int,
         claimed_by: str,
     ) -> bool:
-        """Transition a claimed unit RUNNING -> DONE. Returns False if the claim was lost."""
+        """Transition a claimed unit RUNNING -> DONE. Returns True when the unit is
+        already DONE so callers can safely retry an ambiguous commit. Returns False for
+        any other lost claim."""
         ...
 
     async def fail(

--- a/src/phoenix/server/online_eval/coordinator.py
+++ b/src/phoenix/server/online_eval/coordinator.py
@@ -1,0 +1,119 @@
+"""Consumer-side coordination seam for online-eval work distribution over the
+``eval_work_units`` table: claim/heartbeat/complete/fail transitions plus queue-lag
+observability. Producer-side operations (cursor lease, watermark advance, work-row
+materialization) are not part of this interface.
+
+Work-unit lifecycle:
+
+    PENDING --claim--> RUNNING --complete--> DONE
+                       RUNNING --fail-----> ERROR
+                       RUNNING --expire---> EXPIRED
+    RUNNING (lease lapsed) --> reclaimable
+    ERROR (cooldown elapsed, attempts remain) --> retried
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Protocol
+
+LEASE_TTL_SECONDS = 90
+HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class ClaimedWorkUnit:
+    """A leased work unit. ``identifier`` keys the annotation write so re-runs of the
+    same (span, evaluator, config) collide on the annotation unique constraint;
+    ``lease_expires_at`` is the claim time plus ``LEASE_TTL_SECONDS``."""
+
+    work_unit_id: int
+    span_rowid: int
+    evaluator_id: int
+    criteria_id: int
+    config_fingerprint: str
+    identifier: str
+    attempts: int
+    claimed_by: str
+    lease_expires_at: datetime
+
+
+@dataclass(frozen=True)
+class QueueLag:
+    """Observable backlog; all fields are zero when no cursor or work rows exist.
+    ``frontier_gap`` is the spans.id distance between the producer's eligible frontier
+    and its watermark; ``oldest_pending_age_seconds`` is None when the queue is empty."""
+
+    pending_count: int
+    running_count: int
+    frontier_gap: int
+    oldest_pending_age_seconds: Optional[float]
+
+
+class EvalWorkCoordinator(Protocol):
+    """Coordinates online-eval work across replicas behind a swappable backend."""
+
+    async def claim(
+        self,
+        *,
+        claimed_by: str,
+        limit: int,
+    ) -> Sequence[ClaimedWorkUnit]:
+        """Lease up to ``limit`` claimable work units for ``claimed_by``. A unit is
+        claimable when it is PENDING, or RUNNING with a lapsed lease, or ERROR past
+        its cooldown with attempts remaining. Returns an empty sequence when no
+        claimable work exists."""
+        ...
+
+    async def heartbeat(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        """Renew the lease on a claimed unit. Returns False if the claim was lost —
+        never silent success."""
+        ...
+
+    async def complete(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        """Transition a claimed unit RUNNING -> DONE. Returns False if the claim was lost."""
+        ...
+
+    async def fail(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+        error: str,
+        cooldown_until: Optional[datetime] = None,
+        count_attempt: bool = True,
+    ) -> bool:
+        """Transition a claimed unit RUNNING -> ERROR, recording the error and setting an
+        optional retry cooldown. ``count_attempt=True`` (the default) increments attempts,
+        walking the unit toward the max-attempts claimability bar; pass False for transient
+        infrastructure failures (provider outage, network timeout) so the unit retries after
+        its cooldown without ever being exhausted by an outage. Returns False if the claim
+        was lost."""
+        ...
+
+    async def expire(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        """Transition a claimed unit RUNNING -> EXPIRED. Terminal: for work that must
+        never run (stale config fingerprint, missing or disabled criteria), unlike the
+        retryable ERROR from ``fail``. Returns False if the claim was lost."""
+        ...
+
+    async def lag(self) -> QueueLag:
+        """Report current queue backlog. Returns zeroed metrics when the queue is empty."""
+        ...

--- a/src/phoenix/server/online_eval/coordinator.py
+++ b/src/phoenix/server/online_eval/coordinator.py
@@ -44,10 +44,13 @@ class ClaimedWorkUnit:
 class QueueLag:
     """Observable backlog; all fields are zero when no cursor or work rows exist.
     ``frontier_gap`` is the spans.id distance between the producer's eligible frontier
-    and its watermark; ``oldest_pending_age_seconds`` is None when the queue is empty."""
+    and its watermark; ``oldest_pending_age_seconds`` covers PENDING and retryable ERROR
+    work and is None when that backlog is empty."""
 
     pending_count: int
     running_count: int
+    retryable_error_count: int
+    exhausted_error_count: int
     frontier_gap: int
     oldest_pending_age_seconds: Optional[float]
 

--- a/src/phoenix/server/online_eval/db_coordinator.py
+++ b/src/phoenix/server/online_eval/db_coordinator.py
@@ -27,6 +27,8 @@ from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, annotation_ident
 from phoenix.server.types import DbSessionFactory
 
 _CONSUMER_GROUP = "default"
+TRANSIENT_RETRY_MAX_AGE_SECONDS = 86_400.0
+STALE_FINGERPRINT_ERROR = "stale config fingerprint"
 
 
 def work_unit_lease_lapsed(now: datetime) -> ColumnElement[bool]:
@@ -162,9 +164,11 @@ class DbEvalWorkCoordinator:
         work_unit_id: int,
         claimed_by: str,
     ) -> bool:
+        """Complete a claimed unit, treating an already-DONE row as success."""
         return await self._fenced_transition(
             work_unit_id=work_unit_id,
             claimed_by=claimed_by,
+            already_status="DONE",
             status="DONE",
         )
 
@@ -183,6 +187,14 @@ class DbEvalWorkCoordinator:
         }
         if count_attempt:
             values["attempts"] = models.EvalWorkUnit.attempts + 1
+        else:
+            retry_age_cutoff = datetime.now(timezone.utc) - timedelta(
+                seconds=TRANSIENT_RETRY_MAX_AGE_SECONDS
+            )
+            values["attempts"] = case(
+                (models.EvalWorkUnit.created_at < retry_age_cutoff, self._max_attempts),
+                else_=models.EvalWorkUnit.attempts,
+            )
         return await self._fenced_transition(
             work_unit_id=work_unit_id,
             claimed_by=claimed_by,
@@ -200,6 +212,7 @@ class DbEvalWorkCoordinator:
             work_unit_id=work_unit_id,
             claimed_by=claimed_by,
             status="EXPIRED",
+            error=STALE_FINGERPRINT_ERROR,
         )
 
     async def _fenced_transition(
@@ -207,6 +220,7 @@ class DbEvalWorkCoordinator:
         *,
         work_unit_id: int,
         claimed_by: str,
+        already_status: Optional[str] = None,
         **values: Any,
     ) -> bool:
         async with self._db() as session:
@@ -219,9 +233,15 @@ class DbEvalWorkCoordinator:
                 )
                 .values(**values)
             )
-            await session.commit()
             rowcount = result.rowcount  # type: ignore[attr-defined]
-            return bool(rowcount == 1)
+            transitioned = bool(rowcount == 1)
+            if not transitioned and already_status is not None:
+                status = await session.scalar(
+                    select(models.EvalWorkUnit.status).where(models.EvalWorkUnit.id == work_unit_id)
+                )
+                transitioned = status == already_status
+            await session.commit()
+            return transitioned
 
     async def lag(self) -> QueueLag:
         now = datetime.now(timezone.utc)

--- a/src/phoenix/server/online_eval/db_coordinator.py
+++ b/src/phoenix/server/online_eval/db_coordinator.py
@@ -14,7 +14,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
-from sqlalchemy import and_, func, or_, select, update
+from sqlalchemy import and_, case, func, or_, select, update
 from sqlalchemy.sql.elements import ColumnElement
 
 from phoenix.db import models
@@ -26,6 +26,10 @@ from phoenix.server.online_eval.coordinator import (
 )
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, annotation_identifier
 from phoenix.server.types import DbSessionFactory
+
+
+def work_unit_lease_lapsed(now: datetime) -> ColumnElement[bool]:
+    return models.EvalWorkUnit.claimed_at < now - timedelta(seconds=LEASE_TTL_SECONDS)
 
 
 class DbEvalWorkCoordinator:
@@ -45,12 +49,12 @@ class DbEvalWorkCoordinator:
         self._max_attempts = max_attempts
 
     def _claimable(self, now: datetime) -> ColumnElement[bool]:
-        lease_lapsed_before = now - timedelta(seconds=LEASE_TTL_SECONDS)
         return or_(
             models.EvalWorkUnit.status == "PENDING",
             and_(
                 models.EvalWorkUnit.status == "RUNNING",
-                models.EvalWorkUnit.claimed_at < lease_lapsed_before,
+                models.EvalWorkUnit.attempts < self._max_attempts,
+                work_unit_lease_lapsed(now),
             ),
             and_(
                 models.EvalWorkUnit.status == "ERROR",
@@ -72,6 +76,19 @@ class DbEvalWorkCoordinator:
         async with self._db() as session:
             candidates = select(models.EvalWorkUnit.id).where(self._claimable(now))
             candidates = candidates.order_by(models.EvalWorkUnit.id).limit(limit)
+            claim_values = {
+                "status": "RUNNING",
+                "claimed_at": now,
+                "claimed_by": claimed_by,
+                # A straggler outliving the stop() drain is counted.
+                "attempts": case(
+                    (
+                        models.EvalWorkUnit.status == "RUNNING",
+                        models.EvalWorkUnit.attempts + 1,
+                    ),
+                    else_=models.EvalWorkUnit.attempts,
+                ),
+            }
             claimed_ids: list[int] = []
             if self._db.dialect is SupportedSQLDialect.POSTGRESQL:
                 locked_ids = (
@@ -81,7 +98,7 @@ class DbEvalWorkCoordinator:
                     await session.execute(
                         update(models.EvalWorkUnit)
                         .where(models.EvalWorkUnit.id.in_(locked_ids))
-                        .values(status="RUNNING", claimed_at=now, claimed_by=claimed_by)
+                        .values(**claim_values)
                     )
                     claimed_ids = list(locked_ids)
             else:
@@ -89,7 +106,7 @@ class DbEvalWorkCoordinator:
                     cas = await session.execute(
                         update(models.EvalWorkUnit)
                         .where(models.EvalWorkUnit.id == unit_id, self._claimable(now))
-                        .values(status="RUNNING", claimed_at=now, claimed_by=claimed_by)
+                        .values(**claim_values)
                     )
                     if cas.rowcount == 1:  # type: ignore[attr-defined]
                         claimed_ids.append(unit_id)

--- a/src/phoenix/server/online_eval/db_coordinator.py
+++ b/src/phoenix/server/online_eval/db_coordinator.py
@@ -10,9 +10,8 @@ claim as False via the update rowcount.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from sqlalchemy import and_, case, func, or_, select, update
 from sqlalchemy.sql.elements import ColumnElement
@@ -27,6 +26,8 @@ from phoenix.server.online_eval.coordinator import (
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, annotation_identifier
 from phoenix.server.types import DbSessionFactory
 
+_CONSUMER_GROUP = "default"
+
 
 def work_unit_lease_lapsed(now: datetime) -> ColumnElement[bool]:
     return models.EvalWorkUnit.claimed_at < now - timedelta(seconds=LEASE_TTL_SECONDS)
@@ -40,12 +41,10 @@ class DbEvalWorkCoordinator:
         db: DbSessionFactory,
         *,
         grain: models.EvalWorkGrain = "SPAN",
-        consumer_group: str = "default",
         max_attempts: int = MAX_ATTEMPTS,
     ) -> None:
         self._db = db
         self._grain = grain
-        self._consumer_group = consumer_group
         self._max_attempts = max_attempts
 
     def _claimable(self, now: datetime) -> ColumnElement[bool]:
@@ -53,7 +52,7 @@ class DbEvalWorkCoordinator:
             models.EvalWorkUnit.status == "PENDING",
             and_(
                 models.EvalWorkUnit.status == "RUNNING",
-                models.EvalWorkUnit.attempts < self._max_attempts,
+                models.EvalWorkUnit.attempts < self._max_attempts - 1,
                 work_unit_lease_lapsed(now),
             ),
             and_(
@@ -227,19 +226,37 @@ class DbEvalWorkCoordinator:
     async def lag(self) -> QueueLag:
         now = datetime.now(timezone.utc)
         async with self._db.read() as session:
-            counts: dict[str, int] = {
-                status: count
-                for status, count in (
+            error_exhausted = case(
+                (
+                    and_(
+                        models.EvalWorkUnit.status == "ERROR",
+                        models.EvalWorkUnit.attempts >= self._max_attempts,
+                    ),
+                    True,
+                ),
+                else_=False,
+            ).label("error_exhausted")
+            counts: dict[tuple[str, bool], int] = {
+                (status, exhausted): count
+                for status, exhausted, count in (
                     await session.execute(
-                        select(models.EvalWorkUnit.status, func.count())
-                        .where(models.EvalWorkUnit.status.in_(["PENDING", "RUNNING"]))
-                        .group_by(models.EvalWorkUnit.status)
+                        select(models.EvalWorkUnit.status, error_exhausted, func.count())
+                        .where(models.EvalWorkUnit.status.in_(["PENDING", "RUNNING", "ERROR"]))
+                        .group_by(models.EvalWorkUnit.status, error_exhausted)
                     )
                 ).all()
             }
-            oldest_pending_created_at = await session.scalar(
+            oldest_work_created_at = await session.scalar(
                 select(models.EvalWorkUnit.created_at)
-                .where(models.EvalWorkUnit.status == "PENDING")
+                .where(
+                    or_(
+                        models.EvalWorkUnit.status == "PENDING",
+                        and_(
+                            models.EvalWorkUnit.status == "ERROR",
+                            models.EvalWorkUnit.attempts < self._max_attempts,
+                        ),
+                    )
+                )
                 .order_by(models.EvalWorkUnit.created_at)
                 .limit(1)
             )
@@ -250,7 +267,7 @@ class DbEvalWorkCoordinator:
                         models.EvalWorkCursor.observed_high_water_id,
                     ).where(
                         models.EvalWorkCursor.grain == self._grain,
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     )
                 )
             ).first()
@@ -258,13 +275,15 @@ class DbEvalWorkCoordinator:
         if cursor is not None and cursor.observed_high_water_id is not None:
             frontier_gap = max(cursor.observed_high_water_id - cursor.produced_through_id, 0)
         oldest_pending_age_seconds = (
-            max((now - oldest_pending_created_at).total_seconds(), 0.0)
-            if oldest_pending_created_at is not None
+            max((now - oldest_work_created_at).total_seconds(), 0.0)
+            if oldest_work_created_at is not None
             else None
         )
         return QueueLag(
-            pending_count=counts.get("PENDING", 0),
-            running_count=counts.get("RUNNING", 0),
+            pending_count=counts.get(("PENDING", False), 0),
+            running_count=counts.get(("RUNNING", False), 0),
+            retryable_error_count=counts.get(("ERROR", False), 0),
+            exhausted_error_count=counts.get(("ERROR", True), 0),
             frontier_gap=frontier_gap,
             oldest_pending_age_seconds=oldest_pending_age_seconds,
         )

--- a/src/phoenix/server/online_eval/db_coordinator.py
+++ b/src/phoenix/server/online_eval/db_coordinator.py
@@ -1,0 +1,253 @@
+"""Database-backed ``EvalWorkCoordinator`` over the ``eval_work_units`` table.
+
+Claiming is dialect-split: PostgreSQL locks candidate rows with ``FOR UPDATE SKIP
+LOCKED`` so competing consumers never block on each other's claims; SQLite (no row
+locks) claims each candidate with a per-id compare-and-swap and keeps only the rows
+whose update landed. Every post-claim transition (heartbeat / complete / fail /
+expire) is fenced by ``claimed_by == me AND status == 'RUNNING'`` and reports a lost
+claim as False via the update rowcount.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from sqlalchemy import and_, func, or_, select, update
+from sqlalchemy.sql.elements import ColumnElement
+
+from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.server.online_eval.coordinator import (
+    LEASE_TTL_SECONDS,
+    ClaimedWorkUnit,
+    QueueLag,
+)
+from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, annotation_identifier
+from phoenix.server.types import DbSessionFactory
+
+
+class DbEvalWorkCoordinator:
+    """Coordinates online-eval consumers through ``eval_work_units`` row state."""
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        grain: models.EvalWorkGrain = "SPAN",
+        consumer_group: str = "default",
+        max_attempts: int = MAX_ATTEMPTS,
+    ) -> None:
+        self._db = db
+        self._grain = grain
+        self._consumer_group = consumer_group
+        self._max_attempts = max_attempts
+
+    def _claimable(self, now: datetime) -> ColumnElement[bool]:
+        lease_lapsed_before = now - timedelta(seconds=LEASE_TTL_SECONDS)
+        return or_(
+            models.EvalWorkUnit.status == "PENDING",
+            and_(
+                models.EvalWorkUnit.status == "RUNNING",
+                models.EvalWorkUnit.claimed_at < lease_lapsed_before,
+            ),
+            and_(
+                models.EvalWorkUnit.status == "ERROR",
+                models.EvalWorkUnit.attempts < self._max_attempts,
+                or_(
+                    models.EvalWorkUnit.cooldown_until.is_(None),
+                    models.EvalWorkUnit.cooldown_until <= now,
+                ),
+            ),
+        )
+
+    async def claim(
+        self,
+        *,
+        claimed_by: str,
+        limit: int,
+    ) -> Sequence[ClaimedWorkUnit]:
+        now = datetime.now(timezone.utc)
+        async with self._db() as session:
+            candidates = select(models.EvalWorkUnit.id).where(self._claimable(now))
+            candidates = candidates.order_by(models.EvalWorkUnit.id).limit(limit)
+            claimed_ids: list[int] = []
+            if self._db.dialect is SupportedSQLDialect.POSTGRESQL:
+                locked_ids = (
+                    await session.scalars(candidates.with_for_update(skip_locked=True))
+                ).all()
+                if locked_ids:
+                    await session.execute(
+                        update(models.EvalWorkUnit)
+                        .where(models.EvalWorkUnit.id.in_(locked_ids))
+                        .values(status="RUNNING", claimed_at=now, claimed_by=claimed_by)
+                    )
+                    claimed_ids = list(locked_ids)
+            else:
+                for unit_id in (await session.scalars(candidates)).all():
+                    cas = await session.execute(
+                        update(models.EvalWorkUnit)
+                        .where(models.EvalWorkUnit.id == unit_id, self._claimable(now))
+                        .values(status="RUNNING", claimed_at=now, claimed_by=claimed_by)
+                    )
+                    if cas.rowcount == 1:  # type: ignore[attr-defined]
+                        claimed_ids.append(unit_id)
+            rows = (
+                (
+                    await session.execute(
+                        select(
+                            models.EvalWorkUnit.id,
+                            models.EvalWorkUnit.span_rowid,
+                            models.EvalWorkUnit.evaluator_id,
+                            models.EvalWorkUnit.criteria_id,
+                            models.EvalWorkUnit.config_fingerprint,
+                            models.EvalWorkUnit.attempts,
+                        )
+                        .where(models.EvalWorkUnit.id.in_(claimed_ids))
+                        .order_by(models.EvalWorkUnit.id)
+                    )
+                ).all()
+                if claimed_ids
+                else []
+            )
+            await session.commit()
+        lease_expires_at = now + timedelta(seconds=LEASE_TTL_SECONDS)
+        return [
+            ClaimedWorkUnit(
+                work_unit_id=row.id,
+                span_rowid=row.span_rowid,
+                evaluator_id=row.evaluator_id,
+                criteria_id=row.criteria_id,
+                config_fingerprint=row.config_fingerprint,
+                identifier=annotation_identifier(row.config_fingerprint),
+                attempts=row.attempts,
+                claimed_by=claimed_by,
+                lease_expires_at=lease_expires_at,
+            )
+            for row in rows
+        ]
+
+    async def heartbeat(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        return await self._fenced_transition(
+            work_unit_id=work_unit_id,
+            claimed_by=claimed_by,
+            claimed_at=datetime.now(timezone.utc),
+        )
+
+    async def complete(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        return await self._fenced_transition(
+            work_unit_id=work_unit_id,
+            claimed_by=claimed_by,
+            status="DONE",
+        )
+
+    async def fail(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+        error: str,
+        cooldown_until: Optional[datetime] = None,
+        count_attempt: bool = True,
+    ) -> bool:
+        values: dict[str, Any] = {
+            "error": error,
+            "cooldown_until": cooldown_until,
+        }
+        if count_attempt:
+            values["attempts"] = models.EvalWorkUnit.attempts + 1
+        return await self._fenced_transition(
+            work_unit_id=work_unit_id,
+            claimed_by=claimed_by,
+            status="ERROR",
+            **values,
+        )
+
+    async def expire(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        return await self._fenced_transition(
+            work_unit_id=work_unit_id,
+            claimed_by=claimed_by,
+            status="EXPIRED",
+        )
+
+    async def _fenced_transition(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+        **values: Any,
+    ) -> bool:
+        async with self._db() as session:
+            result = await session.execute(
+                update(models.EvalWorkUnit)
+                .where(
+                    models.EvalWorkUnit.id == work_unit_id,
+                    models.EvalWorkUnit.claimed_by == claimed_by,
+                    models.EvalWorkUnit.status == "RUNNING",
+                )
+                .values(**values)
+            )
+            await session.commit()
+            rowcount = result.rowcount  # type: ignore[attr-defined]
+            return bool(rowcount == 1)
+
+    async def lag(self) -> QueueLag:
+        now = datetime.now(timezone.utc)
+        async with self._db.read() as session:
+            counts: dict[str, int] = {
+                status: count
+                for status, count in (
+                    await session.execute(
+                        select(models.EvalWorkUnit.status, func.count())
+                        .where(models.EvalWorkUnit.status.in_(["PENDING", "RUNNING"]))
+                        .group_by(models.EvalWorkUnit.status)
+                    )
+                ).all()
+            }
+            oldest_pending_created_at = await session.scalar(
+                select(models.EvalWorkUnit.created_at)
+                .where(models.EvalWorkUnit.status == "PENDING")
+                .order_by(models.EvalWorkUnit.created_at)
+                .limit(1)
+            )
+            cursor = (
+                await session.execute(
+                    select(
+                        models.EvalWorkCursor.produced_through_id,
+                        models.EvalWorkCursor.observed_high_water_id,
+                    ).where(
+                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    )
+                )
+            ).first()
+        frontier_gap = 0
+        if cursor is not None and cursor.observed_high_water_id is not None:
+            frontier_gap = max(cursor.observed_high_water_id - cursor.produced_through_id, 0)
+        oldest_pending_age_seconds = (
+            max((now - oldest_pending_created_at).total_seconds(), 0.0)
+            if oldest_pending_created_at is not None
+            else None
+        )
+        return QueueLag(
+            pending_count=counts.get("PENDING", 0),
+            running_count=counts.get("RUNNING", 0),
+            frontier_gap=frontier_gap,
+            oldest_pending_age_seconds=oldest_pending_age_seconds,
+        )

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -127,14 +127,14 @@ class OnlineEvalExecutor:
             context = span_eval_context(span)
             if isinstance(evaluator_orm, models.LLMEvaluator):
                 return await self._hydrate_llm(
-                    session, evaluator_orm, resolved.annotation_name, resolved.version_ref, context
+                    session, evaluator_orm, resolved.name, resolved.version_ref, context
                 )
             if isinstance(evaluator_orm, models.CodeEvaluator):
                 return await self._hydrate_code(
-                    session, evaluator_orm, resolved.annotation_name, resolved.version_ref, context
+                    session, evaluator_orm, resolved.name, resolved.version_ref, context
                 )
             if isinstance(evaluator_orm, models.BuiltinEvaluator):
-                return self._hydrate_builtin(evaluator_orm, resolved.annotation_name, context)
+                return self._hydrate_builtin(evaluator_orm, resolved.name, context)
             return None
 
     async def _hydrate_llm(

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -1,0 +1,334 @@
+"""Execution glue for claimed online-eval work units: criteria-first hydration
+behind the staleness guard, span-grain context assembly, ``BaseEvaluator.evaluate()``
+invocation, and the idempotent EvaluationResult -> SpanAnnotation write. Work-unit
+lifecycle transitions (complete/fail/expire) stay with the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import with_polymorphic
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.db.types.annotation_configs import (
+    CategoricalOutputConfig,
+    ContinuousOutputConfig,
+    FreeformOutputConfig,
+    OutputConfigType,
+)
+from phoenix.db.types.evaluators import InputMapping
+from phoenix.db.types.prompts import PromptChatTemplate
+from phoenix.server.api.evaluators import (
+    BaseEvaluator,
+    CodeEvaluatorRunner,
+    LLMEvaluator,
+    get_builtin_evaluator_by_key,
+)
+from phoenix.server.api.helpers.playground_clients import get_playground_client
+from phoenix.server.dml_event import DmlEvent, SpanAnnotationInsertEvent
+from phoenix.server.online_eval.coordinator import ClaimedWorkUnit
+from phoenix.server.online_eval.derivation import config_fingerprint
+from phoenix.server.online_eval.producer import resolve_criteria
+from phoenix.server.sandbox import SecretsContext, build_sandbox_backend
+from phoenix.server.sandbox.session_manager import SandboxSessionManager
+from phoenix.server.types import CanPutItem, DbSessionFactory
+
+logger = logging.getLogger(__name__)
+
+_EMPTY_INPUT_MAPPING = InputMapping(literal_mapping={}, path_mapping={})
+
+AnnotatorKind = Literal["LLM", "CODE"]
+
+
+class EvalExecutionError(Exception):
+    """The evaluator ran but produced no writable result."""
+
+
+@dataclass(frozen=True)
+class HydratedWorkUnit:
+    """Everything one eval needs, copied out of the mutable criteria/evaluator
+    rows while the staleness guard held. The executor never re-reads those rows
+    after hydration, so the eval runs under snapshot semantics."""
+
+    annotation_name: str
+    annotator_kind: AnnotatorKind
+    evaluator: BaseEvaluator
+    input_mapping: InputMapping
+    output_configs: Sequence[OutputConfigType]
+    context: dict[str, Any]
+
+
+def span_eval_context(span: models.Span) -> dict[str, Any]:
+    """Span-grain evaluation context. ``input`` / ``output`` surface the span's
+    IO values for direct template-variable binding; ``attributes`` exposes the
+    full attribute tree to ``path_mapping`` expressions."""
+    return {
+        "input": span.input_value,
+        "output": span.output_value,
+        "metadata": span.metadata_,
+        "attributes": span.attributes,
+        "name": span.name,
+        "span_kind": span.span_kind,
+        "status_code": span.status_code,
+        "status_message": span.status_message,
+    }
+
+
+class OnlineEvalExecutor:
+    """Hydrates and executes claimed work units against the eval runtime."""
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        decrypt: Callable[[bytes], bytes],
+        sandbox_session_manager: Optional[SandboxSessionManager] = None,
+        event_queue: Optional[CanPutItem[DmlEvent]] = None,
+    ) -> None:
+        self._db = db
+        self._decrypt = decrypt
+        self._sandbox_session_manager = sandbox_session_manager
+        self._event_queue = event_queue
+
+    async def hydrate(self, unit: ClaimedWorkUnit) -> Optional[HydratedWorkUnit]:
+        """Load and snapshot everything the eval needs, returning None when the
+        unit is stale: the criteria row is gone or disabled, the referenced span
+        is gone, or the fingerprint recomputed from current criteria/evaluator/
+        version state no longer matches the one materialized on the unit. Stale
+        units must be expired, never executed. The session closes before any
+        LLM call happens; hydration failures that are not staleness raise and
+        take the retryable failure path."""
+        async with self._db() as session:
+            criteria = await session.get(models.ProjectEvaluatorCriteria, unit.criteria_id)
+            if criteria is None or not criteria.enabled:
+                return None
+            polymorphic = with_polymorphic(
+                models.Evaluator,
+                [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+            )
+            evaluator_orm = await session.scalar(
+                select(polymorphic).where(polymorphic.id == criteria.evaluator_id)
+            )
+            if evaluator_orm is None:
+                return None
+            resolved = await resolve_criteria(session, criteria, evaluator_orm)
+            if resolved is None or config_fingerprint(resolved) != unit.config_fingerprint:
+                return None
+            span = await session.get(models.Span, unit.span_rowid)
+            if span is None:
+                return None
+            context = span_eval_context(span)
+            if isinstance(evaluator_orm, models.LLMEvaluator):
+                return await self._hydrate_llm(
+                    session, evaluator_orm, resolved.annotation_name, resolved.version_ref, context
+                )
+            if isinstance(evaluator_orm, models.CodeEvaluator):
+                return await self._hydrate_code(
+                    session, evaluator_orm, resolved.annotation_name, resolved.version_ref, context
+                )
+            if isinstance(evaluator_orm, models.BuiltinEvaluator):
+                return self._hydrate_builtin(evaluator_orm, resolved.annotation_name, context)
+            return None
+
+    async def _hydrate_llm(
+        self,
+        session: AsyncSession,
+        evaluator_orm: models.LLMEvaluator,
+        annotation_name: str,
+        prompt_version_id: int,
+        context: dict[str, Any],
+    ) -> Optional[HydratedWorkUnit]:
+        prompt_version = await session.get(models.PromptVersion, prompt_version_id)
+        if prompt_version is None:
+            return None
+        prompt = await session.get(models.Prompt, evaluator_orm.prompt_id)
+        if prompt is None:
+            return None
+        template = prompt_version.template
+        if not isinstance(template, PromptChatTemplate):
+            raise ValueError(
+                f"LLM evaluator {evaluator_orm.id}: prompt version {prompt_version.id} "
+                "does not carry a chat template"
+            )
+        tools = prompt_version.tools
+        if tools is None:
+            raise ValueError(
+                f"LLM evaluator {evaluator_orm.id}: prompt version {prompt_version.id} has no tools"
+            )
+        llm_client = await get_playground_client(
+            model_provider=prompt_version.model_provider,
+            model_name=prompt_version.model_name,
+            session=session,
+            decrypt=self._decrypt,
+            connection=prompt_version.custom_provider_id,
+        )
+        evaluator = LLMEvaluator(
+            name=evaluator_orm.name.root,
+            description=evaluator_orm.description,
+            template=template,
+            template_format=prompt_version.template_format,
+            tools=tools,
+            invocation_parameters=prompt_version.invocation_parameters,
+            model_provider=prompt_version.model_provider,
+            llm_client=llm_client,
+            output_configs=evaluator_orm.output_configs,
+            prompt_name=prompt.name.root,
+        )
+        return HydratedWorkUnit(
+            annotation_name=annotation_name,
+            annotator_kind="LLM",
+            evaluator=evaluator,
+            input_mapping=_EMPTY_INPUT_MAPPING,
+            output_configs=evaluator_orm.output_configs,
+            context=context,
+        )
+
+    async def _hydrate_code(
+        self,
+        session: AsyncSession,
+        evaluator_orm: models.CodeEvaluator,
+        annotation_name: str,
+        code_version_id: int,
+        context: dict[str, Any],
+    ) -> Optional[HydratedWorkUnit]:
+        if self._sandbox_session_manager is None:
+            raise ValueError(
+                f"Code evaluator {evaluator_orm.id}: no sandbox session manager available"
+            )
+        code_version = await session.get(models.CodeEvaluatorVersion, code_version_id)
+        if code_version is None:
+            return None
+        if evaluator_orm.sandbox_config_id is None:
+            raise ValueError(f"Code evaluator {evaluator_orm.id} has no sandbox config")
+        sandbox_config = await session.get(models.SandboxConfig, evaluator_orm.sandbox_config_id)
+        if sandbox_config is None or not sandbox_config.enabled:
+            raise ValueError(
+                f"Code evaluator {evaluator_orm.id}: sandbox config "
+                f"{evaluator_orm.sandbox_config_id} is missing or disabled"
+            )
+        provider = await session.get(models.SandboxProvider, sandbox_config.backend_type)
+        if provider is None or not provider.enabled:
+            raise ValueError(
+                f"Code evaluator {evaluator_orm.id}: sandbox provider "
+                f"{sandbox_config.backend_type!r} is missing or disabled"
+            )
+        backend = await build_sandbox_backend(
+            sandbox_config,
+            secrets=SecretsContext(session=session, decrypt=self._decrypt),
+        )
+        if backend is None:
+            raise ValueError(
+                f"Code evaluator {evaluator_orm.id}: no sandbox backend available for "
+                f"config {sandbox_config.id}"
+            )
+        output_configs: list[OutputConfigType] = [
+            config
+            for config in evaluator_orm.output_configs
+            if isinstance(
+                config, (CategoricalOutputConfig, ContinuousOutputConfig, FreeformOutputConfig)
+            )
+        ]
+        evaluator = CodeEvaluatorRunner(
+            name=evaluator_orm.name.root,
+            description=evaluator_orm.description,
+            source_code=code_version.source_code,
+            stored_output_configs=output_configs,
+            sandbox_backend=backend,
+            language=evaluator_orm.language,
+            sandbox_session_manager=self._sandbox_session_manager,
+            timeout=sandbox_config.timeout,
+            evaluator_version_id=str(GlobalID("CodeEvaluatorVersion", str(code_version.id))),
+            session_key=(
+                f"online-eval:{evaluator_orm.id}:{self._sandbox_session_manager.replica_id}"
+            ),
+        )
+        return HydratedWorkUnit(
+            annotation_name=annotation_name,
+            annotator_kind="CODE",
+            evaluator=evaluator,
+            input_mapping=evaluator_orm.input_mapping,
+            output_configs=output_configs,
+            context=context,
+        )
+
+    def _hydrate_builtin(
+        self,
+        evaluator_orm: models.BuiltinEvaluator,
+        annotation_name: str,
+        context: dict[str, Any],
+    ) -> HydratedWorkUnit:
+        evaluator_cls = get_builtin_evaluator_by_key(evaluator_orm.key)
+        if evaluator_cls is None:
+            raise ValueError(f"Built-in evaluator key {evaluator_orm.key!r} is not in the registry")
+        return HydratedWorkUnit(
+            annotation_name=annotation_name,
+            annotator_kind="CODE",
+            evaluator=evaluator_cls(),
+            input_mapping=_EMPTY_INPUT_MAPPING,
+            output_configs=evaluator_orm.output_configs,
+            context=context,
+        )
+
+    async def evaluate_and_annotate(
+        self, unit: ClaimedWorkUnit, hydrated: HydratedWorkUnit
+    ) -> None:
+        """Run the eval and write successful results as span annotations under
+        the unit's identifier. DO_NOTHING makes the write first-write-wins, so
+        re-runs of the same unit are no-ops. Raises when any result errored so
+        the caller retries; successes already written dedupe on the retry. No
+        DB session is open while the evaluator runs."""
+        results = await hydrated.evaluator.evaluate(
+            context=hydrated.context,
+            input_mapping=hydrated.input_mapping,
+            name=hydrated.annotation_name,
+            output_configs=hydrated.output_configs,
+        )
+        records = [
+            {
+                "span_rowid": unit.span_rowid,
+                "name": result["name"],
+                "label": result["label"],
+                "score": result["score"],
+                "explanation": result["explanation"],
+                "metadata_": result["metadata"],
+                "annotator_kind": hydrated.annotator_kind,
+                "identifier": unit.identifier,
+                "source": "API",
+                "user_id": None,
+            }
+            for result in results
+            if result["error"] is None
+        ]
+        if records:
+            async with self._db() as session:
+                inserted_ids = (
+                    await session.scalars(
+                        insert_on_conflict(
+                            *records,
+                            table=models.SpanAnnotation,
+                            dialect=self._db.dialect,
+                            unique_by=("name", "span_rowid", "identifier"),
+                            on_conflict=OnConflict.DO_NOTHING,
+                        ).returning(models.SpanAnnotation.id)
+                    )
+                ).all()
+            # DO_NOTHING returns only rows actually inserted, so a deduped
+            # re-run emits no event and dataloader caches aren't re-invalidated.
+            if self._event_queue is not None and inserted_ids:
+                self._event_queue.put(SpanAnnotationInsertEvent(tuple(inserted_ids)))
+        errored = [result for result in results if result["error"] is not None]
+        if errored:
+            # Chain the original exception (when the evaluator captured one) so
+            # the consumer can classify transient infrastructure failures —
+            # provider outages, network timeouts — and retry them without
+            # burning attempts.
+            raise EvalExecutionError(errored[0]["error"]) from errored[0].get("error_exc")
+        if not records:
+            raise EvalExecutionError("evaluator returned no results")

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -21,6 +21,7 @@ from phoenix.db.types.annotation_configs import (
     CategoricalOutputConfig,
     ContinuousOutputConfig,
     FreeformOutputConfig,
+    OutputConfig,
     OutputConfigType,
 )
 from phoenix.db.types.evaluators import InputMapping
@@ -45,6 +46,7 @@ logger = logging.getLogger(__name__)
 _EMPTY_INPUT_MAPPING = InputMapping(literal_mapping={}, path_mapping={})
 
 AnnotatorKind = Literal["LLM", "CODE"]
+EvaluatorKind = Literal["LLM", "CODE", "BUILTIN"]
 
 
 class EvalExecutionError(Exception):
@@ -59,6 +61,7 @@ class HydratedWorkUnit:
 
     annotation_name: str
     annotator_kind: AnnotatorKind
+    evaluator_kind: EvaluatorKind
     evaluator: BaseEvaluator
     input_mapping: InputMapping
     output_configs: Sequence[OutputConfigType]
@@ -125,16 +128,31 @@ class OnlineEvalExecutor:
             if span is None:
                 return None
             context = span_eval_context(span)
+            input_mapping = (
+                InputMapping.model_validate(resolved.input_mapping)
+                if resolved.input_mapping is not None
+                else _EMPTY_INPUT_MAPPING
+            )
             if isinstance(evaluator_orm, models.LLMEvaluator):
                 return await self._hydrate_llm(
-                    session, evaluator_orm, resolved.name, resolved.version_ref, context
+                    session,
+                    evaluator_orm,
+                    resolved.name,
+                    resolved.version_ref,
+                    input_mapping,
+                    context,
                 )
             if isinstance(evaluator_orm, models.CodeEvaluator):
                 return await self._hydrate_code(
-                    session, evaluator_orm, resolved.name, resolved.version_ref, context
+                    session,
+                    evaluator_orm,
+                    resolved.name,
+                    resolved.version_ref,
+                    input_mapping,
+                    context,
                 )
             if isinstance(evaluator_orm, models.BuiltinEvaluator):
-                return self._hydrate_builtin(evaluator_orm, resolved.name, context)
+                return self._hydrate_builtin(evaluator_orm, resolved.name, input_mapping, context)
             return None
 
     async def _hydrate_llm(
@@ -143,6 +161,7 @@ class OnlineEvalExecutor:
         evaluator_orm: models.LLMEvaluator,
         annotation_name: str,
         prompt_version_id: int,
+        input_mapping: InputMapping,
         context: dict[str, Any],
     ) -> Optional[HydratedWorkUnit]:
         prompt_version = await session.get(models.PromptVersion, prompt_version_id)
@@ -184,8 +203,9 @@ class OnlineEvalExecutor:
         return HydratedWorkUnit(
             annotation_name=annotation_name,
             annotator_kind="LLM",
+            evaluator_kind="LLM",
             evaluator=evaluator,
-            input_mapping=_EMPTY_INPUT_MAPPING,
+            input_mapping=input_mapping,
             output_configs=evaluator_orm.output_configs,
             context=context,
         )
@@ -196,6 +216,7 @@ class OnlineEvalExecutor:
         evaluator_orm: models.CodeEvaluator,
         annotation_name: str,
         code_version_id: int,
+        input_mapping: InputMapping,
         context: dict[str, Any],
     ) -> Optional[HydratedWorkUnit]:
         if self._sandbox_session_manager is None:
@@ -228,13 +249,16 @@ class OnlineEvalExecutor:
                 f"Code evaluator {evaluator_orm.id}: no sandbox backend available for "
                 f"config {sandbox_config.id}"
             )
-        output_configs: list[OutputConfigType] = [
-            config
-            for config in evaluator_orm.output_configs
+        output_configs: list[OutputConfigType] = []
+        for config in evaluator_orm.output_configs:
+            if config.name is None:
+                continue
+            output_config = OutputConfig.model_validate(config.model_dump()).root
             if isinstance(
-                config, (CategoricalOutputConfig, ContinuousOutputConfig, FreeformOutputConfig)
-            )
-        ]
+                output_config,
+                (CategoricalOutputConfig, ContinuousOutputConfig, FreeformOutputConfig),
+            ):
+                output_configs.append(output_config)
         evaluator = CodeEvaluatorRunner(
             name=evaluator_orm.name.root,
             description=evaluator_orm.description,
@@ -252,8 +276,9 @@ class OnlineEvalExecutor:
         return HydratedWorkUnit(
             annotation_name=annotation_name,
             annotator_kind="CODE",
+            evaluator_kind="CODE",
             evaluator=evaluator,
-            input_mapping=evaluator_orm.input_mapping,
+            input_mapping=input_mapping,
             output_configs=output_configs,
             context=context,
         )
@@ -262,6 +287,7 @@ class OnlineEvalExecutor:
         self,
         evaluator_orm: models.BuiltinEvaluator,
         annotation_name: str,
+        input_mapping: InputMapping,
         context: dict[str, Any],
     ) -> HydratedWorkUnit:
         evaluator_cls = get_builtin_evaluator_by_key(evaluator_orm.key)
@@ -270,8 +296,9 @@ class OnlineEvalExecutor:
         return HydratedWorkUnit(
             annotation_name=annotation_name,
             annotator_kind="CODE",
+            evaluator_kind="BUILTIN",
             evaluator=evaluator_cls(),
-            input_mapping=_EMPTY_INPUT_MAPPING,
+            input_mapping=input_mapping,
             output_configs=evaluator_orm.output_configs,
             context=context,
         )
@@ -281,15 +308,37 @@ class OnlineEvalExecutor:
     ) -> None:
         """Run the eval and write successful results as span annotations under
         the unit's identifier. DO_NOTHING makes the write first-write-wins, so
-        re-runs of the same unit are no-ops. Raises when any result errored so
-        the caller retries; successes already written dedupe on the retry. No
-        DB session is open while the evaluator runs."""
+        re-runs of the same unit are no-ops. Raises before writing unless the
+        evaluator returns one complete, error-free result set. No DB session is
+        open while the evaluator runs."""
         results = await hydrated.evaluator.evaluate(
             context=hydrated.context,
             input_mapping=hydrated.input_mapping,
             name=hydrated.annotation_name,
             output_configs=hydrated.output_configs,
         )
+        errored = [result for result in results if result["error"] is not None]
+        if errored:
+            raise EvalExecutionError(errored[0]["error"]) from errored[0].get("error_exc")
+        if hydrated.evaluator_kind != "BUILTIN":
+            # Built-ins retain their evaluator-defined result-name contract.
+            multi_output = len(hydrated.output_configs) > 1
+            expected_names = {
+                (
+                    f"{hydrated.annotation_name}.{config.name}"
+                    if multi_output
+                    else hydrated.annotation_name
+                )
+                for config in hydrated.output_configs
+            }
+            returned_names = {result["name"] for result in results}
+            if returned_names != expected_names:
+                missing = sorted(expected_names - returned_names)
+                unexpected = sorted(returned_names - expected_names)
+                raise EvalExecutionError(
+                    "evaluator returned an incomplete result set: "
+                    f"missing={missing}, unexpected={unexpected}"
+                )
         records = [
             {
                 "span_rowid": unit.span_rowid,
@@ -304,7 +353,6 @@ class OnlineEvalExecutor:
                 "user_id": None,
             }
             for result in results
-            if result["error"] is None
         ]
         if records:
             async with self._db() as session:
@@ -323,12 +371,5 @@ class OnlineEvalExecutor:
             # re-run emits no event and dataloader caches aren't re-invalidated.
             if self._event_queue is not None and inserted_ids:
                 self._event_queue.put(SpanAnnotationInsertEvent(tuple(inserted_ids)))
-        errored = [result for result in results if result["error"] is not None]
-        if errored:
-            # Chain the original exception (when the evaluator captured one) so
-            # the consumer can classify transient infrastructure failures —
-            # provider outages, network timeouts — and retry them without
-            # burning attempts.
-            raise EvalExecutionError(errored[0]["error"]) from errored[0].get("error_exc")
         if not records:
             raise EvalExecutionError("evaluator returned no results")

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -2,7 +2,7 @@
 
 Materializes span-grain eval work units from enabled project evaluator criteria.
 The producer runs on every replica but self-elects each tick via the
-``eval_work_cursors`` CAS lease, so exactly one replica per (grain, consumer_group)
+``eval_work_cursors`` CAS lease, so exactly one replica per grain
 scans spans and writes work rows at a time. Each tick: renew the lease, reap
 expired/aged work rows, scan the lag-gated span id window per criteria, and
 idempotently insert surviving (span, evaluator, config) work units. A slow-cadence
@@ -53,6 +53,7 @@ TICK_INTERVAL_SECONDS = 10.0
 
 _INSERT_BATCH_SIZE = 1000
 _WORK_UNIT_UNIQUE_BY = ("span_rowid", "evaluator_id", "config_fingerprint")
+_CONSUMER_GROUP = "default"
 
 
 async def resolve_criteria(
@@ -154,13 +155,11 @@ class OnlineEvalProducer(DaemonTask):
         self,
         db: DbSessionFactory,
         *,
-        consumer_group: str = "default",
         tick_interval_seconds: float = TICK_INTERVAL_SECONDS,
     ) -> None:
         super().__init__()
         self._db = db
         self._grain: models.EvalWorkGrain = "SPAN"
-        self._consumer_group = consumer_group
         self._tick_interval_seconds = tick_interval_seconds
         self._producer_id = f"producer-{token_hex(8)}"
         self._frontier_lag_seconds = get_env_online_eval_frontier_lag_seconds()
@@ -231,8 +230,8 @@ class OnlineEvalProducer(DaemonTask):
         if gate_open and time.monotonic() - self._last_backstop_at >= (
             self._backstop_interval_seconds
         ):
-            self._last_backstop_at = time.monotonic()
             await self._backstop_sweep(active, produced_through_id)
+            self._last_backstop_at = time.monotonic()
 
     async def _acquire_cursor(self, now: datetime) -> Optional[models.EvalWorkCursor]:
         stale = now - timedelta(seconds=CURSOR_LEASE_TTL_SECONDS)
@@ -242,7 +241,7 @@ class OnlineEvalProducer(DaemonTask):
                     update(models.EvalWorkCursor)
                     .where(
                         models.EvalWorkCursor.grain == self._grain,
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                         or_(
                             models.EvalWorkCursor.claimed_by.is_(None),
                             models.EvalWorkCursor.claimed_by == self._producer_id,
@@ -259,7 +258,7 @@ class OnlineEvalProducer(DaemonTask):
                 row_exists = await session.scalar(
                     select(models.EvalWorkCursor.id).where(
                         models.EvalWorkCursor.grain == self._grain,
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     )
                 )
                 if row_exists is not None:
@@ -269,7 +268,7 @@ class OnlineEvalProducer(DaemonTask):
                     insert_on_conflict(
                         {
                             "grain": self._grain,
-                            "consumer_group": self._consumer_group,
+                            "consumer_group": _CONSUMER_GROUP,
                             "produced_through_id": produced_through_id,
                         },
                         table=models.EvalWorkCursor,
@@ -314,7 +313,7 @@ class OnlineEvalProducer(DaemonTask):
                     update(models.EvalWorkCursor)
                     .where(
                         models.EvalWorkCursor.grain == self._grain,
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                         models.EvalWorkCursor.claimed_by == self._producer_id,
                     )
                     .values(claimed_by=None, claimed_at=None)
@@ -332,10 +331,17 @@ class OnlineEvalProducer(DaemonTask):
                 update(models.EvalWorkUnit)
                 .where(
                     models.EvalWorkUnit.status == "RUNNING",
-                    models.EvalWorkUnit.attempts >= MAX_ATTEMPTS,
+                    models.EvalWorkUnit.attempts >= MAX_ATTEMPTS - 1,
                     work_unit_lease_lapsed(now),
                 )
-                .values(status="ERROR")
+                .values(
+                    status="ERROR",
+                    attempts=MAX_ATTEMPTS,
+                    error=func.coalesce(
+                        models.EvalWorkUnit.error,
+                        "lease lapsed with attempts exhausted",
+                    ),
+                )
             )
             if self._pending_ttl_seconds > 0:
                 pending_cutoff = now - timedelta(seconds=self._pending_ttl_seconds)
@@ -479,7 +485,7 @@ class OnlineEvalProducer(DaemonTask):
                 update(models.EvalWorkCursor)
                 .where(
                     models.EvalWorkCursor.grain == self._grain,
-                    models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     models.EvalWorkCursor.claimed_by == self._producer_id,
                 )
                 .values(produced_through_id=frontier)
@@ -507,7 +513,7 @@ class OnlineEvalProducer(DaemonTask):
                 update(models.EvalWorkCursor)
                 .where(
                     models.EvalWorkCursor.grain == self._grain,
-                    models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     models.EvalWorkCursor.claimed_by == self._producer_id,
                 )
                 .values(observed_high_water_id=high_water, observed_at=observed_at)

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -24,6 +24,14 @@ from sqlalchemy import Select, and_, delete, exists, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_polymorphic
 
+from phoenix.config import (
+    get_env_online_eval_backstop_interval_seconds,
+    get_env_online_eval_backstop_lookback_span_ids,
+    get_env_online_eval_frontier_lag_seconds,
+    get_env_online_eval_max_pending,
+    get_env_online_eval_pending_ttl_seconds,
+    get_env_online_eval_retention_seconds,
+)
 from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.online_eval.derivation import (
@@ -153,24 +161,14 @@ class OnlineEvalProducer(DaemonTask):
         self._consumer_group = consumer_group
         self._tick_interval_seconds = tick_interval_seconds
         self._producer_id = f"producer-{token_hex(8)}"
-        # Config knobs are hardcoded to their defaults until the online-eval env-var surface lands.
-        self._frontier_lag_seconds = 60.0
-        # The backstop's coverage guarantee is rate-dependent: gap-free re-coverage
-        # requires lookback_span_ids >= instance_wide_ingest_rate * interval_seconds.
-        # Spans draw from a single id sequence, so the rate that matters is the sum
-        # across all projects and tenants — 100k ids per 3600s sweep only protects
-        # deployments ingesting under ~28 spans/sec instance-wide. Above that, rows
-        # can age out of the lookback between sweeps and the backstop stops bounding
-        # the exceptional loss modes it exists to catch (late-visible spans, skipped
-        # criteria). The reaper's floor (``_reap``) is aligned to this lookback, so
-        # any change here must move both together.
-        self._backstop_interval_seconds = 3600.0
-        self._backstop_lookback_span_ids = 100_000
+        self._frontier_lag_seconds = get_env_online_eval_frontier_lag_seconds()
+        self._backstop_interval_seconds = get_env_online_eval_backstop_interval_seconds()
+        self._backstop_lookback_span_ids = get_env_online_eval_backstop_lookback_span_ids()
         self._max_span_ids_per_tick = 10_000
-        # Disabled because expiry is terminal and blocks backstop re-materialization.
-        self._pending_ttl_seconds = 0.0
-        self._retention_seconds = 604_800.0
-        self._max_pending = 10_000
+        # Disabled by default because expiry is terminal and blocks backstop re-materialization.
+        self._pending_ttl_seconds = get_env_online_eval_pending_ttl_seconds()
+        self._retention_seconds = get_env_online_eval_retention_seconds()
+        self._max_pending = get_env_online_eval_max_pending()
         self._last_backstop_at = time.monotonic()
         self._lease_held = False
 

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -28,12 +28,14 @@ from phoenix.config import (
     get_env_online_eval_backstop_interval_seconds,
     get_env_online_eval_backstop_lookback_span_ids,
     get_env_online_eval_frontier_lag_seconds,
-    get_env_online_eval_max_pending,
+    get_env_online_eval_max_outstanding,
+    get_env_online_eval_max_span_ids_per_tick,
     get_env_online_eval_pending_ttl_seconds,
     get_env_online_eval_retention_seconds,
 )
 from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.server.online_eval.db_coordinator import work_unit_lease_lapsed
 from phoenix.server.online_eval.derivation import (
     MAX_ATTEMPTS,
     ResolvedCriteria,
@@ -164,11 +166,11 @@ class OnlineEvalProducer(DaemonTask):
         self._frontier_lag_seconds = get_env_online_eval_frontier_lag_seconds()
         self._backstop_interval_seconds = get_env_online_eval_backstop_interval_seconds()
         self._backstop_lookback_span_ids = get_env_online_eval_backstop_lookback_span_ids()
-        self._max_span_ids_per_tick = 10_000
+        self._max_span_ids_per_tick = get_env_online_eval_max_span_ids_per_tick()
         # Disabled by default because expiry is terminal and blocks backstop re-materialization.
         self._pending_ttl_seconds = get_env_online_eval_pending_ttl_seconds()
         self._retention_seconds = get_env_online_eval_retention_seconds()
-        self._max_pending = get_env_online_eval_max_pending()
+        self._max_outstanding = get_env_online_eval_max_outstanding()
         self._last_backstop_at = time.monotonic()
         self._lease_held = False
 
@@ -326,6 +328,15 @@ class OnlineEvalProducer(DaemonTask):
         # regardless of age — they must remain to block backstop resurrection.
         reap_floor = produced_through_id - self._backstop_lookback_span_ids
         async with self._db() as session:
+            await session.execute(
+                update(models.EvalWorkUnit)
+                .where(
+                    models.EvalWorkUnit.status == "RUNNING",
+                    models.EvalWorkUnit.attempts >= MAX_ATTEMPTS,
+                    work_unit_lease_lapsed(now),
+                )
+                .values(status="ERROR")
+            )
             if self._pending_ttl_seconds > 0:
                 pending_cutoff = now - timedelta(seconds=self._pending_ttl_seconds)
                 await session.execute(
@@ -377,10 +388,10 @@ class OnlineEvalProducer(DaemonTask):
                 )
                 or 0
             )
-        if outstanding_count > self._max_pending:
+        if outstanding_count > self._max_outstanding:
             logger.warning(
                 f"Online-eval producer admission gate closed: "
-                f"{outstanding_count} outstanding work units exceeds {self._max_pending}"
+                f"{outstanding_count} outstanding work units exceeds {self._max_outstanding}"
             )
             return False
         return True

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -35,7 +35,10 @@ from phoenix.config import (
 )
 from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
-from phoenix.server.online_eval.db_coordinator import work_unit_lease_lapsed
+from phoenix.server.online_eval.db_coordinator import (
+    STALE_FINGERPRINT_ERROR,
+    work_unit_lease_lapsed,
+)
 from phoenix.server.online_eval.derivation import (
     MAX_ATTEMPTS,
     ResolvedCriteria,
@@ -54,6 +57,11 @@ TICK_INTERVAL_SECONDS = 10.0
 _INSERT_BATCH_SIZE = 1000
 _WORK_UNIT_UNIQUE_BY = ("span_rowid", "evaluator_id", "config_fingerprint")
 _CONSUMER_GROUP = "default"
+_PENDING_TTL_EXCEEDED_ERROR = "pending ttl exceeded"
+
+
+class _CursorLeaseLost(Exception):
+    pass
 
 
 async def resolve_criteria(
@@ -185,53 +193,61 @@ class OnlineEvalProducer(DaemonTask):
             await self._release_lease()
 
     async def _tick(self) -> None:
-        now = datetime.now(timezone.utc)
-        cursor = await self._acquire_cursor(now)
-        if cursor is None:
-            return
-        cursor = await self._clamp_cursor(cursor)
-        if cursor is None:
-            return
-        produced_through_id = cursor.produced_through_id
+        try:
+            now = datetime.now(timezone.utc)
+            cursor = await self._acquire_cursor(now)
+            if cursor is None:
+                return
+            cursor = await self._clamp_cursor(cursor)
+            if cursor is None:
+                return
+            produced_through_id = cursor.produced_through_id
 
-        await self._reap(now, produced_through_id)
+            await self._reap(now, produced_through_id)
+            await self._renew_lease(datetime.now(timezone.utc))
 
-        observed_high_water_id = cursor.observed_high_water_id
-        pending_observation = (
-            observed_high_water_id is not None
-            and cursor.observed_at is not None
-            and observed_high_water_id > produced_through_id
-        )
-        frontier: Optional[int] = None
-        if (
-            pending_observation
-            and observed_high_water_id is not None
-            and cursor.observed_at is not None
-            and (now - cursor.observed_at).total_seconds() >= self._frontier_lag_seconds
-        ):
-            frontier = min(
-                observed_high_water_id,
-                produced_through_id + self._max_span_ids_per_tick,
+            observed_high_water_id = cursor.observed_high_water_id
+            pending_observation = (
+                observed_high_water_id is not None
+                and cursor.observed_at is not None
+                and observed_high_water_id > produced_through_id
             )
+            frontier: Optional[int] = None
+            if (
+                pending_observation
+                and observed_high_water_id is not None
+                and cursor.observed_at is not None
+                and (now - cursor.observed_at).total_seconds() >= self._frontier_lag_seconds
+            ):
+                frontier = min(
+                    observed_high_water_id,
+                    produced_through_id + self._max_span_ids_per_tick,
+                )
 
-        gate_open = await self._admission_gate_open()
-        active = await self._load_active_criteria() if gate_open else []
+            budget = await self._admission_budget()
+            active = await self._load_active_criteria() if budget > 0 else []
 
-        advanced = False
-        if gate_open and frontier is not None:
-            advanced = await self._materialize_and_advance(active, produced_through_id, frontier)
-            if advanced:
-                produced_through_id = frontier
+            advanced = False
+            if budget > 0 and frontier is not None:
+                await self._renew_lease(datetime.now(timezone.utc))
+                advanced, budget = await self._materialize_and_advance(
+                    active, produced_through_id, frontier, budget
+                )
+                if advanced:
+                    produced_through_id = frontier
 
-        observation_consumed = advanced and frontier == observed_high_water_id
-        if not pending_observation or observation_consumed:
-            await self._record_observation(produced_through_id)
+            observation_consumed = advanced and frontier == observed_high_water_id
+            if not pending_observation or observation_consumed:
+                await self._record_observation(produced_through_id)
 
-        if gate_open and time.monotonic() - self._last_backstop_at >= (
-            self._backstop_interval_seconds
-        ):
-            await self._backstop_sweep(active, produced_through_id)
-            self._last_backstop_at = time.monotonic()
+            if budget > 0 and time.monotonic() - self._last_backstop_at >= (
+                self._backstop_interval_seconds
+            ):
+                await self._renew_lease(datetime.now(timezone.utc))
+                await self._backstop_sweep(active, produced_through_id, budget)
+                self._last_backstop_at = time.monotonic()
+        except _CursorLeaseLost:
+            logger.warning("Online-eval producer tick aborted after losing its lease")
 
     async def _acquire_cursor(self, now: datetime) -> Optional[models.EvalWorkCursor]:
         stale = now - timedelta(seconds=CURSOR_LEASE_TTL_SECONDS)
@@ -321,6 +337,22 @@ class OnlineEvalProducer(DaemonTask):
         except Exception:
             logger.exception("Failed to release online-eval producer lease")
 
+    async def _renew_lease(self, now: datetime) -> None:
+        async with self._db() as session:
+            renewed = await session.scalar(
+                update(models.EvalWorkCursor)
+                .where(
+                    models.EvalWorkCursor.grain == self._grain,
+                    models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
+                    models.EvalWorkCursor.claimed_by == self._producer_id,
+                )
+                .values(claimed_at=now)
+                .returning(models.EvalWorkCursor.id)
+            )
+        if renewed is None:
+            self._lease_held = False
+            raise _CursorLeaseLost
+
     async def _reap(self, now: datetime, produced_through_id: int) -> None:
         retention_cutoff = now - timedelta(seconds=self._retention_seconds)
         # Terminal rows inside the backstop lookback window are never deleted,
@@ -351,7 +383,13 @@ class OnlineEvalProducer(DaemonTask):
                         models.EvalWorkUnit.status == "PENDING",
                         models.EvalWorkUnit.created_at < pending_cutoff,
                     )
-                    .values(status="EXPIRED")
+                    .values(
+                        status="EXPIRED",
+                        error=func.coalesce(
+                            models.EvalWorkUnit.error,
+                            _PENDING_TTL_EXCEEDED_ERROR,
+                        ),
+                    )
                 )
             await session.execute(
                 delete(models.EvalWorkUnit).where(
@@ -369,7 +407,7 @@ class OnlineEvalProducer(DaemonTask):
                 )
             )
 
-    async def _admission_gate_open(self) -> bool:
+    async def _admission_budget(self) -> int:
         # The gate bounds the backlog that will eventually demand consumer
         # capacity — every non-terminal row, not just PENDING: RUNNING rows are
         # claimed but unfinished, and retryable ERROR rows return to the claim
@@ -394,13 +432,14 @@ class OnlineEvalProducer(DaemonTask):
                 )
                 or 0
             )
-        if outstanding_count > self._max_outstanding:
+        budget = max(0, self._max_outstanding - outstanding_count)
+        if budget == 0:
             logger.warning(
                 f"Online-eval producer admission gate closed: "
-                f"{outstanding_count} outstanding work units exceeds {self._max_outstanding}"
+                f"{outstanding_count} outstanding work units reached "
+                f"{self._max_outstanding}"
             )
-            return False
-        return True
+        return budget
 
     async def _load_active_criteria(self) -> list[_ActiveCriteria]:
         """Load and resolve enabled criteria into scan-ready form.
@@ -476,11 +515,23 @@ class OnlineEvalProducer(DaemonTask):
         active: list[_ActiveCriteria],
         low_exclusive: int,
         frontier: int,
-    ) -> bool:
+        budget: int,
+    ) -> tuple[bool, int]:
         async with self._db() as session:
-            for criteria in active:
+            for index, criteria in enumerate(active):
                 span_ids = list(await session.scalars(criteria.scan_stmt(low_exclusive, frontier)))
-                await self._insert_work_units(session, criteria, criteria.sampled(span_ids))
+                sampled_span_ids = criteria.sampled(span_ids)
+                admitted_span_ids = sampled_span_ids[:budget]
+                await self._insert_work_units(session, criteria, admitted_span_ids)
+                budget -= len(admitted_span_ids)
+                if len(admitted_span_ids) < len(sampled_span_ids) or (
+                    budget == 0 and index < len(active) - 1
+                ):
+                    logger.warning(
+                        f"Online-eval producer frontier truncated at insertion budget; "
+                        f"{budget} budget remaining"
+                    )
+                    return False, budget
             advanced = await session.scalar(
                 update(models.EvalWorkCursor)
                 .where(
@@ -491,10 +542,10 @@ class OnlineEvalProducer(DaemonTask):
                 .values(produced_through_id=frontier)
                 .returning(models.EvalWorkCursor.id)
             )
-        if advanced is None:
-            logger.warning("Online-eval producer lost its lease; watermark not advanced")
-            return False
-        return True
+            if advanced is None:
+                self._lease_held = False
+                raise _CursorLeaseLost
+        return True, budget
 
     async def _record_observation(self, produced_through_id: int) -> None:
         async with self._db() as session:
@@ -519,14 +570,19 @@ class OnlineEvalProducer(DaemonTask):
                 .values(observed_high_water_id=high_water, observed_at=observed_at)
             )
 
-    async def _backstop_sweep(self, active: list[_ActiveCriteria], watermark: int) -> None:
+    async def _backstop_sweep(
+        self,
+        active: list[_ActiveCriteria],
+        watermark: int,
+        budget: int,
+    ) -> int:
         if watermark <= 0:
-            return
+            return budget
         # Window is [watermark - lookback, watermark], matching the reaper's floor
         # exactly so every retained terminal row is inside the swept range.
         low_exclusive = max(watermark - self._backstop_lookback_span_ids - 1, 0)
         async with self._db() as session:
-            for criteria in active:
+            for index, criteria in enumerate(active):
                 stmt = criteria.scan_stmt(low_exclusive, watermark).where(
                     ~exists(
                         select(1).where(
@@ -535,16 +591,39 @@ class OnlineEvalProducer(DaemonTask):
                             models.SpanAnnotation.identifier == criteria.identifier,
                         )
                     ),
-                    ~exists(
-                        select(1).where(
-                            models.EvalWorkUnit.span_rowid == models.Span.id,
-                            models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
-                            models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
-                        )
+                    or_(
+                        ~exists(
+                            select(1).where(
+                                models.EvalWorkUnit.span_rowid == models.Span.id,
+                                models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
+                                models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
+                            )
+                        ),
+                        exists(
+                            select(1).where(
+                                models.EvalWorkUnit.span_rowid == models.Span.id,
+                                models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
+                                models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
+                                models.EvalWorkUnit.status == "EXPIRED",
+                                models.EvalWorkUnit.error == STALE_FINGERPRINT_ERROR,
+                            )
+                        ),
                     ),
                 )
                 span_ids = list(await session.scalars(stmt))
-                await self._insert_work_units(session, criteria, criteria.sampled(span_ids))
+                sampled_span_ids = criteria.sampled(span_ids)
+                admitted_span_ids = sampled_span_ids[:budget]
+                await self._insert_work_units(session, criteria, admitted_span_ids)
+                budget -= len(admitted_span_ids)
+                if len(admitted_span_ids) < len(sampled_span_ids) or (
+                    budget == 0 and index < len(active) - 1
+                ):
+                    logger.warning(
+                        f"Online-eval producer backstop truncated at insertion budget; "
+                        f"{budget} budget remaining"
+                    )
+                    break
+        return budget
 
     async def _insert_work_units(
         self,
@@ -562,9 +641,36 @@ class OnlineEvalProducer(DaemonTask):
             for span_rowid in span_ids
         ]
         for start in range(0, len(records), _INSERT_BATCH_SIZE):
+            batch = records[start : start + _INSERT_BATCH_SIZE]
+            batch_span_ids = [record["span_rowid"] for record in batch]
+            await session.execute(
+                update(models.EvalWorkUnit)
+                .where(
+                    models.EvalWorkUnit.span_rowid.in_(batch_span_ids),
+                    models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
+                    models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
+                    models.EvalWorkUnit.status == "EXPIRED",
+                    models.EvalWorkUnit.error == STALE_FINGERPRINT_ERROR,
+                    ~exists(
+                        select(1).where(
+                            models.SpanAnnotation.span_rowid == models.EvalWorkUnit.span_rowid,
+                            models.SpanAnnotation.name == criteria.name,
+                            models.SpanAnnotation.identifier == criteria.identifier,
+                        )
+                    ),
+                )
+                .values(
+                    status="PENDING",
+                    attempts=0,
+                    error=None,
+                    claimed_by=None,
+                    claimed_at=None,
+                    cooldown_until=None,
+                )
+            )
             await session.execute(
                 insert_on_conflict(
-                    *records[start : start + _INSERT_BATCH_SIZE],
+                    *batch,
                     table=models.EvalWorkUnit,
                     dialect=self._db.dialect,
                     unique_by=_WORK_UNIT_UNIQUE_BY,

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -147,6 +147,37 @@ class _ActiveCriteria:
         )
         return self.span_filter(stmt)
 
+    def materializable_scan_stmt(
+        self, low_exclusive: int, high_inclusive: int
+    ) -> Select[tuple[int]]:
+        return self.scan_stmt(low_exclusive, high_inclusive).where(
+            ~exists(
+                select(1).where(
+                    models.SpanAnnotation.span_rowid == models.Span.id,
+                    models.SpanAnnotation.name == self.name,
+                    models.SpanAnnotation.identifier == self.identifier,
+                )
+            ),
+            or_(
+                ~exists(
+                    select(1).where(
+                        models.EvalWorkUnit.span_rowid == models.Span.id,
+                        models.EvalWorkUnit.evaluator_id == self.evaluator_id,
+                        models.EvalWorkUnit.config_fingerprint == self.fingerprint,
+                    )
+                ),
+                exists(
+                    select(1).where(
+                        models.EvalWorkUnit.span_rowid == models.Span.id,
+                        models.EvalWorkUnit.evaluator_id == self.evaluator_id,
+                        models.EvalWorkUnit.config_fingerprint == self.fingerprint,
+                        models.EvalWorkUnit.status == "EXPIRED",
+                        models.EvalWorkUnit.error == STALE_FINGERPRINT_ERROR,
+                    )
+                ),
+            ),
+        )
+
     def sampled(self, span_ids: list[int]) -> list[int]:
         return [sid for sid in span_ids if sample_key(sid) < self.sampling_rate]
 
@@ -519,7 +550,11 @@ class OnlineEvalProducer(DaemonTask):
     ) -> tuple[bool, int]:
         async with self._db() as session:
             for index, criteria in enumerate(active):
-                span_ids = list(await session.scalars(criteria.scan_stmt(low_exclusive, frontier)))
+                span_ids = list(
+                    await session.scalars(
+                        criteria.materializable_scan_stmt(low_exclusive, frontier)
+                    )
+                )
                 sampled_span_ids = criteria.sampled(span_ids)
                 admitted_span_ids = sampled_span_ids[:budget]
                 await self._insert_work_units(session, criteria, admitted_span_ids)
@@ -531,6 +566,7 @@ class OnlineEvalProducer(DaemonTask):
                         f"Online-eval producer frontier truncated at insertion budget; "
                         f"{budget} budget remaining"
                     )
+                    await self._fence_mutating_session(session)
                     return False, budget
             advanced = await session.scalar(
                 update(models.EvalWorkCursor)
@@ -583,33 +619,7 @@ class OnlineEvalProducer(DaemonTask):
         low_exclusive = max(watermark - self._backstop_lookback_span_ids - 1, 0)
         async with self._db() as session:
             for index, criteria in enumerate(active):
-                stmt = criteria.scan_stmt(low_exclusive, watermark).where(
-                    ~exists(
-                        select(1).where(
-                            models.SpanAnnotation.span_rowid == models.Span.id,
-                            models.SpanAnnotation.name == criteria.name,
-                            models.SpanAnnotation.identifier == criteria.identifier,
-                        )
-                    ),
-                    or_(
-                        ~exists(
-                            select(1).where(
-                                models.EvalWorkUnit.span_rowid == models.Span.id,
-                                models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
-                                models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
-                            )
-                        ),
-                        exists(
-                            select(1).where(
-                                models.EvalWorkUnit.span_rowid == models.Span.id,
-                                models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
-                                models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
-                                models.EvalWorkUnit.status == "EXPIRED",
-                                models.EvalWorkUnit.error == STALE_FINGERPRINT_ERROR,
-                            )
-                        ),
-                    ),
-                )
+                stmt = criteria.materializable_scan_stmt(low_exclusive, watermark)
                 span_ids = list(await session.scalars(stmt))
                 sampled_span_ids = criteria.sampled(span_ids)
                 admitted_span_ids = sampled_span_ids[:budget]
@@ -623,7 +633,23 @@ class OnlineEvalProducer(DaemonTask):
                         f"{budget} budget remaining"
                     )
                     break
+            await self._fence_mutating_session(session)
         return budget
+
+    async def _fence_mutating_session(self, session: AsyncSession) -> None:
+        renewed = await session.scalar(
+            update(models.EvalWorkCursor)
+            .where(
+                models.EvalWorkCursor.grain == self._grain,
+                models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
+                models.EvalWorkCursor.claimed_by == self._producer_id,
+            )
+            .values(claimed_at=datetime.now(timezone.utc))
+            .returning(models.EvalWorkCursor.id)
+        )
+        if renewed is None:
+            self._lease_held = False
+            raise _CursorLeaseLost
 
     async def _insert_work_units(
         self,

--- a/src/phoenix/server/prometheus.py
+++ b/src/phoenix/server/prometheus.py
@@ -145,6 +145,16 @@ ONLINE_EVAL_RUNNING_WORK_UNITS = Gauge(
     name="online_eval_running_work_units",
     documentation="Current number of online-eval work units in RUNNING status",
 )
+ONLINE_EVAL_RETRYABLE_ERROR_WORK_UNITS = Gauge(
+    namespace="phoenix",
+    name="online_eval_retryable_error_work_units",
+    documentation="Current number of retryable online-eval work units in ERROR status",
+)
+ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS = Gauge(
+    namespace="phoenix",
+    name="online_eval_exhausted_error_work_units",
+    documentation="Current number of exhausted online-eval work units in ERROR status",
+)
 ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS = Gauge(
     namespace="phoenix",
     name="online_eval_frontier_gap_span_ids",
@@ -154,8 +164,8 @@ ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS = Gauge(
 ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS = Gauge(
     namespace="phoenix",
     name="online_eval_oldest_pending_age_seconds",
-    documentation="Age in seconds of the oldest PENDING online-eval work unit "
-    "(0 when the queue is empty)",
+    documentation="Age in seconds of the oldest PENDING or retryable ERROR online-eval work unit "
+    "(0 when the backlog is empty)",
 )
 ONLINE_EVAL_INGEST_SPANS_PER_SECOND = Gauge(
     namespace="phoenix",

--- a/tests/unit/server/online_eval/test_app_wiring.py
+++ b/tests/unit/server/online_eval/test_app_wiring.py
@@ -1,10 +1,10 @@
-"""End-to-end wiring test for the online-eval producer daemon behind
-``PHOENIX_ONLINE_EVAL_ENABLED``: the enabled app starts and stops the producer
+"""End-to-end wiring test for the online-eval daemons behind
+``PHOENIX_ONLINE_EVAL_ENABLED``: the enabled app starts and stops both daemons
 through the lifespan, and a seeded criteria + span flows producer tick →
-PENDING work unit. (The consumer daemon and its wiring land in the stacked
-follow-up PR; until then materialized units rest as PENDING.)
+consumer cycle → span annotation with the work unit DONE.
 """
 
+import asyncio
 from contextlib import AsyncExitStack
 from datetime import datetime, timedelta, timezone
 
@@ -16,6 +16,7 @@ from phoenix.config import ENV_PHOENIX_ONLINE_EVAL_ENABLED
 from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.app import create_app
+from phoenix.server.online_eval.consumer import OnlineEvalConsumer
 from phoenix.server.online_eval.producer import OnlineEvalProducer
 from phoenix.server.types import DbSessionFactory
 from tests.unit.conftest import (
@@ -25,7 +26,7 @@ from tests.unit.conftest import (
 )
 
 from ..._helpers import _add_project, _add_span, _add_trace
-from .test_producer import _seed_criteria
+from .test_consumer import _patch_playground_client, _seed_llm_criteria, _StubLLMClient
 
 
 def _create_app(db: DbSessionFactory):  # type: ignore[no-untyped-def]
@@ -37,22 +38,26 @@ def _create_app(db: DbSessionFactory):  # type: ignore[no-untyped-def]
     )
 
 
-async def test_online_eval_producer_absent_by_default(db: DbSessionFactory) -> None:
+async def test_online_eval_daemons_absent_by_default(db: DbSessionFactory) -> None:
     app = _create_app(db)
     assert app.state.online_eval_producer is None
+    assert app.state.online_eval_consumer is None
 
 
-async def test_enabled_app_materializes_seeded_criteria(
+async def test_enabled_app_runs_seeded_criteria_end_to_end(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_ENABLED, "true")
+    _patch_playground_client(monkeypatch, _StubLLMClient())
 
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(patch_batched_caller())
         await stack.enter_async_context(patch_grpc_server())
         app = _create_app(db)
         producer = app.state.online_eval_producer
+        consumer = app.state.online_eval_consumer
         assert isinstance(producer, OnlineEvalProducer)
+        assert isinstance(consumer, OnlineEvalConsumer)
         await stack.enter_async_context(LifespanManager(app))
 
         async with db() as session:
@@ -63,7 +68,7 @@ async def test_enabled_app_materializes_seeded_criteria(
                 trace,
                 attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
             )
-        _, criteria_id = await _seed_criteria(db, project.id)
+        _, criteria_id = await _seed_llm_criteria(db, project.id)
 
         # Age the cursor's high-water observation past the frontier lag so the
         # next tick's scan window covers the seeded span. The daemon's own
@@ -98,4 +103,26 @@ async def test_enabled_app_materializes_seeded_criteria(
             )
         assert unit is not None
         assert unit.criteria_id == criteria_id
-        assert unit.status == "PENDING"
+
+        await consumer._cycle()
+
+        # The daemon's own background cycle may have claimed the unit ahead of
+        # the explicit cycle above; either path lands on DONE within moments.
+        deadline = asyncio.get_running_loop().time() + 10
+        while True:
+            async with db() as session:
+                refreshed = await session.get(models.EvalWorkUnit, unit.id)
+                assert refreshed is not None
+                status = refreshed.status
+            if status == "DONE" or asyncio.get_running_loop().time() > deadline:
+                break
+            await asyncio.sleep(0.05)
+        assert status == "DONE"
+
+        async with db() as session:
+            annotation = await session.scalar(
+                select(models.SpanAnnotation).where(models.SpanAnnotation.span_rowid == span.id)
+            )
+        assert annotation is not None
+        assert annotation.label == "good"
+        assert annotation.source == "API"

--- a/tests/unit/server/online_eval/test_app_wiring.py
+++ b/tests/unit/server/online_eval/test_app_wiring.py
@@ -29,17 +29,28 @@ from ..._helpers import _add_project, _add_span, _add_trace
 from .test_consumer import _patch_playground_client, _seed_llm_criteria, _StubLLMClient
 
 
-def _create_app(db: DbSessionFactory):  # type: ignore[no-untyped-def]
+def _create_app(db: DbSessionFactory, *, read_only: bool = False):  # type: ignore[no-untyped-def]
     return create_app(
         db=db,
         authentication_enabled=False,
         serve_ui=False,
         bulk_inserter_factory=TestBulkInserter,
+        read_only=read_only,
     )
 
 
 async def test_online_eval_daemons_absent_by_default(db: DbSessionFactory) -> None:
     app = _create_app(db)
+    assert app.state.online_eval_producer is None
+    assert app.state.online_eval_consumer is None
+
+
+async def test_online_eval_daemons_absent_in_read_only_mode(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_ENABLED, "true")
+
+    app = _create_app(db, read_only=True)
     assert app.state.online_eval_producer is None
     assert app.state.online_eval_consumer is None
 

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -150,9 +150,10 @@ async def _seed_llm_criteria(db: DbSessionFactory, project_id: int) -> tuple[int
         criteria = models.ProjectEvaluatorCriteria(
             project_id=project_id,
             evaluator_id=evaluator.id,
-            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
             filter_condition="",
             sampling_rate=1.0,
+            evaluation_target="SPAN",
         )
         session.add(criteria)
         await session.flush()
@@ -173,9 +174,10 @@ async def _seed_builtin_criteria(db: DbSessionFactory, project_id: int) -> tuple
         criteria = models.ProjectEvaluatorCriteria(
             project_id=project_id,
             evaluator_id=evaluator.id,
-            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
             filter_condition="",
             sampling_rate=1.0,
+            evaluation_target="SPAN",
         )
         session.add(criteria)
         await session.flush()
@@ -248,7 +250,7 @@ async def test_happy_path_claims_evaluates_annotates_and_completes(
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
-        assert annotation.name == criteria.annotation_name.root
+        assert annotation.name == criteria.name.root
     assert annotation.span_rowid == span.id
     assert annotation.label == "good"
     assert annotation.score == 1.0

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -1,0 +1,433 @@
+import asyncio
+from datetime import datetime, timezone
+from secrets import token_hex
+from typing import Any, AsyncIterator, Optional
+
+import httpx
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.orm import with_polymorphic
+
+from phoenix.db import models
+from phoenix.db.types.annotation_configs import (
+    CategoricalAnnotationValue,
+    CategoricalOutputConfig,
+    OptimizationDirection,
+)
+from phoenix.db.types.identifier import Identifier
+from phoenix.db.types.model_provider import ModelProvider
+from phoenix.db.types.prompts import (
+    PromptChatTemplate,
+    PromptMessage,
+    PromptOpenAIInvocationParameters,
+    PromptOpenAIInvocationParametersContent,
+    PromptTemplateFormat,
+    PromptTemplateType,
+    PromptToolChoiceOneOrMore,
+    PromptToolFunction,
+    PromptToolFunctionDefinition,
+    PromptTools,
+)
+from phoenix.server.api.types.ChatCompletionSubscriptionPayload import (
+    FunctionCallChunk,
+    ToolCallChunk,
+)
+from phoenix.server.online_eval.consumer import OnlineEvalConsumer, is_transient_error
+from phoenix.server.online_eval.derivation import annotation_identifier, config_fingerprint
+from phoenix.server.online_eval.executor import EvalExecutionError
+from phoenix.server.online_eval.producer import resolve_criteria
+from phoenix.server.types import DbSessionFactory
+
+from ..._helpers import _add_project, _add_span, _add_trace
+
+
+class _StubLLMClient:
+    """Streams a single canned tool call, or raises to simulate a provider error."""
+
+    def __init__(
+        self,
+        tool_name: str = "quality",
+        arguments: str = '{"label": "good", "explanation": "looks good"}',
+        error: Optional[Exception] = None,
+    ) -> None:
+        self._tool_name = tool_name
+        self._arguments = arguments
+        self._error = error
+
+    async def chat_completion_create(self, **_: Any) -> AsyncIterator[Any]:
+        if self._error is not None:
+            raise self._error
+        yield ToolCallChunk(
+            id="call-1",
+            function=FunctionCallChunk(name=self._tool_name, arguments=self._arguments),
+        )
+
+
+def _patch_playground_client(monkeypatch: pytest.MonkeyPatch, client: _StubLLMClient) -> None:
+    async def _get_client(**_: Any) -> _StubLLMClient:
+        return client
+
+    monkeypatch.setattr("phoenix.server.online_eval.executor.get_playground_client", _get_client)
+
+
+async def _seed_llm_criteria(db: DbSessionFactory, project_id: int) -> tuple[int, int]:
+    """Create an LLM evaluator (prompt + version + tools) and an enabled criteria
+    row, returning (evaluator_id, criteria_id)."""
+    async with db() as session:
+        prompt = models.Prompt(
+            name=Identifier(root=f"prompt-{token_hex(4)}"),
+            description=None,
+            prompt_versions=[
+                models.PromptVersion(
+                    template_type=PromptTemplateType.CHAT,
+                    template_format=PromptTemplateFormat.MUSTACHE,
+                    template=PromptChatTemplate(
+                        type="chat",
+                        messages=[
+                            PromptMessage(
+                                role="user",
+                                content="Input: {{input}}\n\nOutput: {{output}}\n\nGood?",
+                            ),
+                        ],
+                    ),
+                    invocation_parameters=PromptOpenAIInvocationParameters(
+                        type="openai", openai=PromptOpenAIInvocationParametersContent()
+                    ),
+                    tools=PromptTools(
+                        type="tools",
+                        tools=[
+                            PromptToolFunction(
+                                type="function",
+                                function=PromptToolFunctionDefinition(
+                                    name="quality",
+                                    description="rates output quality",
+                                    parameters={
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {
+                                                "type": "string",
+                                                "enum": ["good", "bad"],
+                                            },
+                                        },
+                                        "required": ["label"],
+                                    },
+                                ),
+                            )
+                        ],
+                        tool_choice=PromptToolChoiceOneOrMore(type="one_or_more"),
+                    ),
+                    response_format=None,
+                    model_provider=ModelProvider.OPENAI,
+                    model_name="gpt-4",
+                    metadata_={},
+                )
+            ],
+        )
+        evaluator = models.LLMEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            description=None,
+            kind="LLM",
+            output_configs=[
+                CategoricalOutputConfig(
+                    type="CATEGORICAL",
+                    name="quality",
+                    optimization_direction=OptimizationDirection.MAXIMIZE,
+                    description=None,
+                    values=[
+                        CategoricalAnnotationValue(label="good", score=1.0),
+                        CategoricalAnnotationValue(label="bad", score=0.0),
+                    ],
+                )
+            ],
+            prompt=prompt,
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project_id,
+            evaluator_id=evaluator.id,
+            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+        )
+        session.add(criteria)
+        await session.flush()
+        return evaluator.id, criteria.id
+
+
+async def _seed_builtin_criteria(db: DbSessionFactory, project_id: int) -> tuple[int, int]:
+    async with db() as session:
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project_id,
+            evaluator_id=evaluator.id,
+            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+        )
+        session.add(criteria)
+        await session.flush()
+        return evaluator.id, criteria.id
+
+
+async def _materialize_unit(
+    db: DbSessionFactory, span_rowid: int, evaluator_id: int, criteria_id: int
+) -> tuple[int, str]:
+    """Materialize one PENDING work unit exactly as the producer would, returning
+    (work_unit_id, config_fingerprint)."""
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        polymorphic = with_polymorphic(
+            models.Evaluator,
+            [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+        )
+        evaluator = await session.scalar(select(polymorphic).where(polymorphic.id == evaluator_id))
+        assert evaluator is not None
+        resolved = await resolve_criteria(session, criteria, evaluator)
+        assert resolved is not None
+        fingerprint = config_fingerprint(resolved)
+        unit = models.EvalWorkUnit(
+            span_rowid=span_rowid,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=fingerprint,
+        )
+        session.add(unit)
+        await session.flush()
+        return unit.id, fingerprint
+
+
+async def _get_unit(db: DbSessionFactory, unit_id: int) -> models.EvalWorkUnit:
+    async with db() as session:
+        unit = await session.get(models.EvalWorkUnit, unit_id)
+        assert unit is not None
+        return unit
+
+
+async def _annotations(db: DbSessionFactory) -> list[models.SpanAnnotation]:
+    async with db() as session:
+        return list(await session.scalars(select(models.SpanAnnotation)))
+
+
+async def test_happy_path_claims_evaluates_annotates_and_completes(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(db, project.id)
+    unit_id, fingerprint = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    _patch_playground_client(monkeypatch, _StubLLMClient())
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "DONE"
+    annotations = await _annotations(db)
+    assert len(annotations) == 1
+    annotation = annotations[0]
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert annotation.name == criteria.annotation_name.root
+    assert annotation.span_rowid == span.id
+    assert annotation.label == "good"
+    assert annotation.score == 1.0
+    assert annotation.explanation == "looks good"
+    assert annotation.annotator_kind == "LLM"
+    assert annotation.source == "API"
+    assert annotation.identifier == annotation_identifier(fingerprint)
+
+    # Nothing is claimable afterwards; a repeat cycle writes nothing new.
+    await consumer._cycle()
+    assert len(await _annotations(db)) == 1
+
+
+async def test_evaluator_error_fails_unit_with_cooldown_and_no_annotation(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    _patch_playground_client(monkeypatch, _StubLLMClient(error=RuntimeError("provider is down")))
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    before = datetime.now(timezone.utc)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "ERROR"
+    assert unit.attempts == 1
+    assert unit.error is not None
+    assert "provider is down" in unit.error
+    assert unit.cooldown_until is not None
+    assert unit.cooldown_until > before
+    assert await _annotations(db) == []
+
+
+async def test_transient_provider_error_retries_without_burning_attempts(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider outage (network/timeout/5xx) must not walk a unit toward
+    MAX_ATTEMPTS: an outage longer than the retry budget would otherwise turn
+    every claimed unit terminally ERROR — permanent silent eval loss. Transient
+    failures cool down without counting an attempt, then complete once the
+    provider heals."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    _patch_playground_client(
+        monkeypatch, _StubLLMClient(error=httpx.ConnectError("provider unreachable"))
+    )
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "ERROR"
+    assert unit.attempts == 0  # the outage did not consume a retry
+    assert unit.error is not None
+    assert "provider unreachable" in unit.error
+    assert unit.cooldown_until is not None
+    assert await _annotations(db) == []
+
+    # Once the cooldown lapses and the provider heals, the unit completes.
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(cooldown_until=datetime.now(timezone.utc))
+        )
+    _patch_playground_client(monkeypatch, _StubLLMClient())
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "DONE"
+    assert unit.attempts == 0
+    assert len(await _annotations(db)) == 1
+
+
+def test_is_transient_error_classification() -> None:
+    request = httpx.Request("POST", "http://provider.test")
+    assert is_transient_error(TimeoutError("llm timed out"))
+    assert is_transient_error(asyncio.TimeoutError())
+    assert is_transient_error(ConnectionError("reset"))
+    assert is_transient_error(httpx.ConnectTimeout("t", request=request))
+    assert is_transient_error(
+        httpx.HTTPStatusError("503", request=request, response=httpx.Response(503, request=request))
+    )
+    # Wrapped errors classify by their root cause through the exception chain.
+    try:
+        try:
+            raise TimeoutError("llm timed out")
+        except TimeoutError as inner:
+            raise EvalExecutionError("wrapped") from inner
+    except EvalExecutionError as wrapped:
+        assert is_transient_error(wrapped)
+    # Fail-safe default: anything unrecognized counts attempts as usual.
+    assert not is_transient_error(RuntimeError("provider is down"))
+    assert not is_transient_error(ValueError("bad config"))
+    assert not is_transient_error(EvalExecutionError("evaluator returned no results"))
+    assert not is_transient_error(
+        httpx.HTTPStatusError("400", request=request, response=httpx.Response(400, request=request))
+    )
+
+
+async def test_staleness_guard_expires_unit_without_annotating(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+
+    # A criteria edit between materialization and consumption changes the
+    # recomputed fingerprint, so the unit must be dropped, not executed.
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(sampling_rate=0.5)
+        )
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "EXPIRED"
+    assert await _annotations(db) == []
+
+
+async def test_stop_drains_in_flight_work_instead_of_cancelling(
+    db: DbSessionFactory,
+) -> None:
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    finished = asyncio.Event()
+
+    async def _in_flight() -> None:
+        await asyncio.sleep(0.05)
+        finished.set()
+
+    await consumer.start()
+    task = asyncio.create_task(_in_flight())
+    consumer._pending_tasks.add(task)
+    task.add_done_callback(consumer._pending_tasks.discard)
+
+    await consumer.stop()
+
+    assert finished.is_set()
+    assert not task.cancelled()
+
+
+async def test_disabled_criteria_expires_unit(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(enabled=False)
+        )
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "EXPIRED"
+    assert await _annotations(db) == []

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -1,5 +1,6 @@
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from queue import SimpleQueue
 from secrets import token_hex
 from typing import Any, AsyncIterator, Optional
 
@@ -32,9 +33,12 @@ from phoenix.server.api.types.ChatCompletionSubscriptionPayload import (
     FunctionCallChunk,
     ToolCallChunk,
 )
+from phoenix.server.dml_event import DmlEvent, SpanAnnotationInsertEvent
 from phoenix.server.online_eval.consumer import OnlineEvalConsumer, is_transient_error
+from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
+from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
 from phoenix.server.online_eval.derivation import annotation_identifier, config_fingerprint
-from phoenix.server.online_eval.executor import EvalExecutionError
+from phoenix.server.online_eval.executor import EvalExecutionError, OnlineEvalExecutor
 from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.types import DbSessionFactory
 
@@ -256,6 +260,50 @@ async def test_happy_path_claims_evaluates_annotates_and_completes(
     # Nothing is claimable afterwards; a repeat cycle writes nothing new.
     await consumer._cycle()
     assert len(await _annotations(db)) == 1
+
+
+async def test_reclaimed_execution_writes_one_annotation_and_one_insert_event(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    _patch_playground_client(monkeypatch, _StubLLMClient())
+    coordinator = DbEvalWorkCoordinator(db)
+
+    (first_claim,) = await coordinator.claim(claimed_by="consumer-1", limit=1)
+    lapsed = datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(claimed_at=lapsed)
+        )
+    (reclaimed,) = await coordinator.claim(claimed_by="consumer-2", limit=1)
+    assert reclaimed.work_unit_id == first_claim.work_unit_id
+    assert reclaimed.identifier == first_claim.identifier
+
+    events: SimpleQueue[DmlEvent] = SimpleQueue()
+    executor = OnlineEvalExecutor(db, decrypt=lambda b: b, event_queue=events)
+    first_hydrated = await executor.hydrate(first_claim)
+    reclaimed_hydrated = await executor.hydrate(reclaimed)
+    assert first_hydrated is not None
+    assert reclaimed_hydrated is not None
+
+    await executor.evaluate_and_annotate(first_claim, first_hydrated)
+    await executor.evaluate_and_annotate(reclaimed, reclaimed_hydrated)
+
+    annotations = await _annotations(db)
+    assert len(annotations) == 1
+    assert events.get_nowait() == SpanAnnotationInsertEvent((annotations[0].id,))
+    assert events.empty()
 
 
 async def test_evaluator_error_fails_unit_with_cooldown_and_no_annotation(

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -112,9 +112,11 @@ class _StubSandboxSessionManager:
 
     def __init__(self) -> None:
         self.session = _StubSandboxSession()
+        self.session_keys: list[str] = []
 
     @asynccontextmanager
-    async def acquire(self, _backend: Any, _session_key: str) -> AsyncIterator[_StubSandboxSession]:
+    async def acquire(self, _backend: Any, session_key: str) -> AsyncIterator[_StubSandboxSession]:
+        self.session_keys.append(session_key)
         yield self.session
 
 
@@ -496,6 +498,48 @@ async def test_llm_criteria_input_mapping_override_is_used_during_execution(
     assert len(await _annotations(db)) == 1
 
 
+async def test_builtin_criteria_input_mapping_override_is_used_during_execution(
+    db: DbSessionFactory,
+    synced_builtin_evaluators: None,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"remapped": {"text": "the mapped value is present"}},
+        )
+        evaluator_id = await session.scalar(
+            select(models.BuiltinEvaluator.id).where(models.BuiltinEvaluator.key == "contains")
+        )
+        assert evaluator_id is not None
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator_id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SPAN",
+            input_mapping=InputMapping(
+                path_mapping={"text": "attributes.remapped.text"},
+                literal_mapping={"words": "mapped value"},
+            ),
+        )
+        session.add(criteria)
+        await session.flush()
+        criteria_id = criteria.id
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    await consumer._cycle()
+
+    assert (await _get_unit(db, unit_id)).status == "DONE"
+    (annotation,) = await _annotations(db)
+    assert annotation.label == "true"
+    assert annotation.score == 1.0
+
+
 async def test_code_criteria_input_mapping_override_is_used_during_execution(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -538,8 +582,63 @@ async def test_code_criteria_input_mapping_override_is_used_during_execution(
     assert "mapped context" in executed_code
     assert "criteria literal" in executed_code
     assert "evaluator default" not in executed_code
+    assert manager.session_keys == [f"online-eval:{evaluator_id}:test-replica"]
     annotation = (await _annotations(db))[0]
     assert annotation.score == 0.75
+
+
+@pytest.mark.parametrize(
+    ("configuration_state", "error_message"),
+    [
+        ("missing", "has no sandbox config"),
+        ("disabled", "is missing or disabled"),
+        ("provider_disabled", "sandbox provider 'WASM' is missing or disabled"),
+    ],
+)
+async def test_code_hydration_configuration_failure_counts_attempt(
+    db: DbSessionFactory,
+    configuration_state: str,
+    error_message: str,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_code_criteria(
+        db,
+        project.id,
+        criteria_input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+    )
+    async with db() as session:
+        evaluator = await session.get(models.CodeEvaluator, evaluator_id)
+        assert evaluator is not None
+        if configuration_state == "missing":
+            evaluator.sandbox_config_id = None
+        else:
+            assert evaluator.sandbox_config_id is not None
+            sandbox_config = await session.get(models.SandboxConfig, evaluator.sandbox_config_id)
+            assert sandbox_config is not None
+            if configuration_state == "disabled":
+                sandbox_config.enabled = False
+            else:
+                provider = await session.get(models.SandboxProvider, sandbox_config.backend_type)
+                assert provider is not None
+                provider.enabled = False
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+
+    consumer = OnlineEvalConsumer(
+        db,
+        decrypt=lambda value: value,
+        sandbox_session_manager=cast(Any, _StubSandboxSessionManager()),
+    )
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "ERROR"
+    assert unit.attempts == 1
+    assert unit.error is not None
+    assert error_message in unit.error
+    assert await _annotations(db) == []
 
 
 async def test_reclaimed_execution_writes_one_annotation_and_one_insert_event(
@@ -900,6 +999,51 @@ async def test_failure_transition_retries_raised_exceptions(
     await consumer._process_unit(unit)
 
     assert fail_calls == 4
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.attempts == 1
+
+
+async def test_failure_transition_retries_after_ambiguous_commit(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    (unit,) = await consumer._coordinator.claim(
+        claimed_by=consumer._consumer_id,
+        limit=1,
+    )
+
+    async def _hydrate(_: ClaimedWorkUnit) -> HydratedWorkUnit:
+        return _hydrated_stub(results=[], evaluator_kind="BUILTIN", output_configs=[])
+
+    async def _evaluate(*_: Any, **__: Any) -> None:
+        raise ValueError("bad evaluator")
+
+    original_fail = consumer._coordinator.fail
+    fail_calls = 0
+
+    async def _ambiguous_fail(**kwargs: Any) -> bool:
+        nonlocal fail_calls
+        fail_calls += 1
+        failed = await original_fail(**kwargs)
+        if fail_calls == 1:
+            raise ConnectionError("commit acknowledgement lost")
+        return failed
+
+    monkeypatch.setattr(consumer_module, "_TRANSITION_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
+    monkeypatch.setattr(consumer._executor, "hydrate", _hydrate)
+    monkeypatch.setattr(consumer._executor, "evaluate_and_annotate", _evaluate)
+    monkeypatch.setattr(consumer._coordinator, "fail", _ambiguous_fail)
+
+    await consumer._process_unit(unit)
+
+    assert fail_calls == 2
     row = await _get_unit(db, unit_id)
     assert row.status == "ERROR"
     assert row.attempts == 1

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -1,8 +1,9 @@
 import asyncio
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from queue import SimpleQueue
 from secrets import token_hex
-from typing import Any, AsyncIterator, Optional
+from typing import Any, AsyncIterator, Optional, Sequence, cast
 
 import httpx
 import pytest
@@ -13,8 +14,11 @@ from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
     CategoricalAnnotationValue,
     CategoricalOutputConfig,
+    ContinuousOutputConfig,
     OptimizationDirection,
+    OutputConfigType,
 )
+from phoenix.db.types.evaluators import InputMapping
 from phoenix.db.types.identifier import Identifier
 from phoenix.db.types.model_provider import ModelProvider
 from phoenix.db.types.prompts import (
@@ -34,12 +38,23 @@ from phoenix.server.api.types.ChatCompletionSubscriptionPayload import (
     ToolCallChunk,
 )
 from phoenix.server.dml_event import DmlEvent, SpanAnnotationInsertEvent
-from phoenix.server.online_eval.consumer import OnlineEvalConsumer, is_transient_error
-from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
+from phoenix.server.online_eval import consumer as consumer_module
+from phoenix.server.online_eval import executor as executor_module
+from phoenix.server.online_eval.consumer import (
+    EvalExecutionTimeout,
+    OnlineEvalConsumer,
+    is_transient_error,
+)
+from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS, ClaimedWorkUnit
 from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
 from phoenix.server.online_eval.derivation import annotation_identifier, config_fingerprint
-from phoenix.server.online_eval.executor import EvalExecutionError, OnlineEvalExecutor
+from phoenix.server.online_eval.executor import (
+    EvalExecutionError,
+    HydratedWorkUnit,
+    OnlineEvalExecutor,
+)
 from phoenix.server.online_eval.producer import resolve_criteria
+from phoenix.server.sandbox.types import ExecutionResult
 from phoenix.server.types import DbSessionFactory
 
 from ..._helpers import _add_project, _add_span, _add_trace
@@ -57,8 +72,10 @@ class _StubLLMClient:
         self._tool_name = tool_name
         self._arguments = arguments
         self._error = error
+        self.requests: list[dict[str, Any]] = []
 
-    async def chat_completion_create(self, **_: Any) -> AsyncIterator[Any]:
+    async def chat_completion_create(self, **kwargs: Any) -> AsyncIterator[Any]:
+        self.requests.append(kwargs)
         if self._error is not None:
             raise self._error
         yield ToolCallChunk(
@@ -74,7 +91,113 @@ def _patch_playground_client(monkeypatch: pytest.MonkeyPatch, client: _StubLLMCl
     monkeypatch.setattr("phoenix.server.online_eval.executor.get_playground_client", _get_client)
 
 
-async def _seed_llm_criteria(db: DbSessionFactory, project_id: int) -> tuple[int, int]:
+class _StubSandboxBackend:
+    secret_values: tuple[str, ...] = ()
+
+
+class _StubSandboxSession:
+    def __init__(self) -> None:
+        self.executed_code: list[str] = []
+
+    async def execute(self, code: str, *, timeout: Optional[int] = None) -> ExecutionResult:
+        self.executed_code.append(code)
+        return ExecutionResult(
+            stdout="===PHOENIX_RESULT_BEGIN===\n0.75\n===PHOENIX_RESULT_END===\n",
+            stderr="",
+        )
+
+
+class _StubSandboxSessionManager:
+    replica_id = "test-replica"
+
+    def __init__(self) -> None:
+        self.session = _StubSandboxSession()
+
+    @asynccontextmanager
+    async def acquire(self, _backend: Any, _session_key: str) -> AsyncIterator[_StubSandboxSession]:
+        yield self.session
+
+
+class _StubEvaluator:
+    def __init__(self, results: list[dict[str, Any]]) -> None:
+        self._results = results
+
+    async def evaluate(self, **_: Any) -> list[dict[str, Any]]:
+        return self._results
+
+
+def _output_config(name: str) -> CategoricalOutputConfig:
+    return CategoricalOutputConfig(
+        type="CATEGORICAL",
+        name=name,
+        optimization_direction=OptimizationDirection.MAXIMIZE,
+        description=None,
+        values=[
+            CategoricalAnnotationValue(label="good", score=1.0),
+            CategoricalAnnotationValue(label="bad", score=0.0),
+        ],
+    )
+
+
+def _evaluation_result(
+    name: str,
+    *,
+    error: Optional[str] = None,
+    error_exc: Optional[Exception] = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "name": name,
+        "label": None if error else "good",
+        "score": None if error else 1.0,
+        "explanation": None,
+        "metadata": {},
+        "error": error,
+    }
+    if error_exc is not None:
+        result["error_exc"] = error_exc
+    return result
+
+
+def _hydrated_stub(
+    *,
+    results: list[dict[str, Any]],
+    evaluator_kind: str,
+    output_configs: Sequence[OutputConfigType],
+    annotation_name: str = "criterion",
+) -> HydratedWorkUnit:
+    return HydratedWorkUnit(
+        annotation_name=annotation_name,
+        annotator_kind="LLM" if evaluator_kind == "LLM" else "CODE",
+        evaluator_kind=cast(Any, evaluator_kind),
+        evaluator=cast(Any, _StubEvaluator(results)),
+        input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+        output_configs=output_configs,
+        context={},
+    )
+
+
+def _claimed_unit(span_rowid: int, *, work_unit_id: int = 1) -> ClaimedWorkUnit:
+    now = datetime.now(timezone.utc)
+    return ClaimedWorkUnit(
+        work_unit_id=work_unit_id,
+        span_rowid=span_rowid,
+        evaluator_id=1,
+        criteria_id=1,
+        config_fingerprint="fingerprint",
+        identifier="online:fingerprint",
+        attempts=0,
+        claimed_by="consumer",
+        lease_expires_at=now + timedelta(seconds=LEASE_TTL_SECONDS),
+    )
+
+
+async def _seed_llm_criteria(
+    db: DbSessionFactory,
+    project_id: int,
+    *,
+    template_content: str = "Input: {{input}}\n\nOutput: {{output}}\n\nGood?",
+    criteria_input_mapping: Optional[InputMapping] = None,
+) -> tuple[int, int]:
     """Create an LLM evaluator (prompt + version + tools) and an enabled criteria
     row, returning (evaluator_id, criteria_id)."""
     async with db() as session:
@@ -90,7 +213,7 @@ async def _seed_llm_criteria(db: DbSessionFactory, project_id: int) -> tuple[int
                         messages=[
                             PromptMessage(
                                 role="user",
-                                content="Input: {{input}}\n\nOutput: {{output}}\n\nGood?",
+                                content=template_content,
                             ),
                         ],
                     ),
@@ -154,6 +277,82 @@ async def _seed_llm_criteria(db: DbSessionFactory, project_id: int) -> tuple[int
             filter_condition="",
             sampling_rate=1.0,
             evaluation_target="SPAN",
+            input_mapping=criteria_input_mapping,
+        )
+        session.add(criteria)
+        await session.flush()
+        return evaluator.id, criteria.id
+
+
+async def _seed_code_criteria(
+    db: DbSessionFactory,
+    project_id: int,
+    *,
+    criteria_input_mapping: InputMapping,
+) -> tuple[int, int]:
+    async with db() as session:
+        language = await session.get(models.Language, "PYTHON")
+        if language is None:
+            session.add(models.Language(name="PYTHON"))
+        provider = await session.get(models.SandboxProvider, "WASM")
+        if provider is None:
+            session.add(
+                models.SandboxProvider(
+                    backend_type="WASM",
+                    enabled=True,
+                    config={},
+                )
+            )
+        await session.flush()
+        sandbox_config = models.SandboxConfig(
+            backend_type="WASM",
+            language="PYTHON",
+            name=Identifier(root=f"sandbox-{token_hex(4)}"),
+            description=None,
+            config={},
+            timeout=30,
+        )
+        session.add(sandbox_config)
+        await session.flush()
+        evaluator = models.CodeEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            description=None,
+            kind="CODE",
+            language="PYTHON",
+            sandbox_config_id=sandbox_config.id,
+            input_mapping=InputMapping(
+                literal_mapping={
+                    "output": "evaluator default",
+                    "metadata": "evaluator default",
+                },
+                path_mapping={},
+            ),
+            output_configs=[
+                ContinuousOutputConfig(
+                    type="CONTINUOUS",
+                    name="score",
+                    optimization_direction=OptimizationDirection.MAXIMIZE,
+                    description=None,
+                    lower_bound=0.0,
+                    upper_bound=1.0,
+                )
+            ],
+            versions=[
+                models.CodeEvaluatorVersion(
+                    source_code="def evaluate(output, metadata): return 0.75"
+                )
+            ],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project_id,
+            evaluator_id=evaluator.id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SPAN",
+            input_mapping=criteria_input_mapping,
         )
         session.add(criteria)
         await session.flush()
@@ -264,6 +463,85 @@ async def test_happy_path_claims_evaluates_annotates_and_completes(
     assert len(await _annotations(db)) == 1
 
 
+async def test_llm_criteria_input_mapping_override_is_used_during_execution(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"remapped": {"question": "mapped question"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(
+        db,
+        project.id,
+        template_content="Question: {{question}}\nAnswer: {{answer}}",
+        criteria_input_mapping=InputMapping(
+            path_mapping={"question": "attributes.remapped.question"},
+            literal_mapping={"answer": "literal answer"},
+        ),
+    )
+    await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    client = _StubLLMClient()
+    _patch_playground_client(monkeypatch, client)
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    await consumer._cycle()
+
+    assert len(client.requests) == 1
+    messages = client.requests[0]["messages"]
+    assert messages[0]["content"] == "Question: mapped question\nAnswer: literal answer"
+    assert len(await _annotations(db)) == 1
+
+
+async def test_code_criteria_input_mapping_override_is_used_during_execution(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"remapped": {"value": "mapped context"}},
+        )
+    evaluator_id, criteria_id = await _seed_code_criteria(
+        db,
+        project.id,
+        criteria_input_mapping=InputMapping(
+            path_mapping={"output": "attributes.remapped.value"},
+            literal_mapping={"metadata": "criteria literal"},
+        ),
+    )
+    await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    coordinator = DbEvalWorkCoordinator(db)
+    (unit,) = await coordinator.claim(claimed_by="consumer", limit=1)
+    manager = _StubSandboxSessionManager()
+
+    async def _build_backend(*_: Any, **__: Any) -> _StubSandboxBackend:
+        return _StubSandboxBackend()
+
+    monkeypatch.setattr(executor_module, "build_sandbox_backend", _build_backend)
+    executor = OnlineEvalExecutor(
+        db,
+        decrypt=lambda value: value,
+        sandbox_session_manager=cast(Any, manager),
+    )
+    hydrated = await executor.hydrate(unit)
+    assert hydrated is not None
+
+    await executor.evaluate_and_annotate(unit, hydrated)
+
+    (executed_code,) = manager.session.executed_code
+    assert "mapped context" in executed_code
+    assert "criteria literal" in executed_code
+    assert "evaluator default" not in executed_code
+    annotation = (await _annotations(db))[0]
+    assert annotation.score == 0.75
+
+
 async def test_reclaimed_execution_writes_one_annotation_and_one_insert_event(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -306,6 +584,78 @@ async def test_reclaimed_execution_writes_one_annotation_and_one_insert_event(
     assert len(annotations) == 1
     assert events.get_nowait() == SpanAnnotationInsertEvent((annotations[0].id,))
     assert events.empty()
+
+
+async def test_llm_incomplete_result_set_writes_nothing(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    output_configs = [_output_config("quality"), _output_config("relevance")]
+    hydrated = _hydrated_stub(
+        results=[_evaluation_result("criterion.quality")],
+        evaluator_kind="LLM",
+        output_configs=output_configs,
+    )
+    executor = OnlineEvalExecutor(db, decrypt=lambda value: value)
+
+    with pytest.raises(EvalExecutionError, match="incomplete result set"):
+        await executor.evaluate_and_annotate(_claimed_unit(span.id), hydrated)
+
+    assert await _annotations(db) == []
+
+
+async def test_code_mixed_result_set_writes_nothing(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    output_configs = [_output_config("quality"), _output_config("relevance")]
+    original_error = RuntimeError("second output failed")
+    hydrated = _hydrated_stub(
+        results=[
+            _evaluation_result("criterion.quality"),
+            _evaluation_result(
+                "criterion.relevance",
+                error="second output failed",
+                error_exc=original_error,
+            ),
+        ],
+        evaluator_kind="CODE",
+        output_configs=output_configs,
+    )
+    executor = OnlineEvalExecutor(db, decrypt=lambda value: value)
+
+    with pytest.raises(EvalExecutionError, match="second output failed") as exc_info:
+        await executor.evaluate_and_annotate(_claimed_unit(span.id), hydrated)
+
+    assert exc_info.value.__cause__ is original_error
+    assert await _annotations(db) == []
+
+
+async def test_complete_result_set_is_written_atomically(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    output_configs = [_output_config("quality"), _output_config("relevance")]
+    hydrated = _hydrated_stub(
+        results=[
+            _evaluation_result("criterion.quality"),
+            _evaluation_result("criterion.relevance"),
+        ],
+        evaluator_kind="CODE",
+        output_configs=output_configs,
+    )
+    executor = OnlineEvalExecutor(db, decrypt=lambda value: value)
+
+    await executor.evaluate_and_annotate(_claimed_unit(span.id), hydrated)
+
+    annotations = await _annotations(db)
+    assert {annotation.name for annotation in annotations} == {
+        "criterion.quality",
+        "criterion.relevance",
+    }
 
 
 async def test_evaluator_error_fails_unit_with_cooldown_and_no_annotation(
@@ -412,6 +762,149 @@ def test_is_transient_error_classification() -> None:
     )
 
 
+async def test_execution_deadline_cancels_eval_and_counts_attempt(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    consumer = OnlineEvalConsumer(
+        db,
+        decrypt=lambda value: value,
+        execution_deadline_seconds=0.01,
+    )
+    (unit,) = await consumer._coordinator.claim(
+        claimed_by=consumer._consumer_id,
+        limit=1,
+    )
+    hydrated = _hydrated_stub(results=[], evaluator_kind="BUILTIN", output_configs=[])
+    cancelled = asyncio.Event()
+
+    async def _hydrate(_: ClaimedWorkUnit) -> HydratedWorkUnit:
+        return hydrated
+
+    async def _never_resolves(*_: Any, **__: Any) -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    classified: list[BaseException] = []
+
+    def _classify(exc: BaseException) -> bool:
+        classified.append(exc)
+        return is_transient_error(exc)
+
+    monkeypatch.setattr(consumer._executor, "hydrate", _hydrate)
+    monkeypatch.setattr(consumer._executor, "evaluate_and_annotate", _never_resolves)
+    monkeypatch.setattr(consumer_module, "is_transient_error", _classify)
+
+    await consumer._process_unit(unit)
+
+    assert cancelled.is_set()
+    assert len(classified) == 1
+    timeout = classified[0]
+    assert isinstance(timeout, EvalExecutionTimeout)
+    assert timeout.__cause__ is None
+    assert timeout.__suppress_context__
+    assert not is_transient_error(timeout)
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.attempts == 1
+
+
+async def test_complete_retries_after_ambiguous_commit(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    (unit,) = await consumer._coordinator.claim(
+        claimed_by=consumer._consumer_id,
+        limit=1,
+    )
+    hydrated = _hydrated_stub(results=[], evaluator_kind="BUILTIN", output_configs=[])
+
+    async def _hydrate(_: ClaimedWorkUnit) -> HydratedWorkUnit:
+        return hydrated
+
+    async def _evaluate(*_: Any, **__: Any) -> None:
+        return None
+
+    original_complete = consumer._coordinator.complete
+    complete_calls = 0
+
+    async def _ambiguous_complete(**kwargs: Any) -> bool:
+        nonlocal complete_calls
+        complete_calls += 1
+        completed = await original_complete(**kwargs)
+        if complete_calls == 1:
+            raise ConnectionError("commit acknowledgement lost")
+        return completed
+
+    monkeypatch.setattr(consumer_module, "_TRANSITION_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
+    monkeypatch.setattr(consumer._executor, "hydrate", _hydrate)
+    monkeypatch.setattr(consumer._executor, "evaluate_and_annotate", _evaluate)
+    monkeypatch.setattr(consumer._coordinator, "complete", _ambiguous_complete)
+
+    await consumer._process_unit(unit)
+
+    assert complete_calls == 2
+    assert (await _get_unit(db, unit_id)).status == "DONE"
+
+
+async def test_failure_transition_retries_raised_exceptions(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    (unit,) = await consumer._coordinator.claim(
+        claimed_by=consumer._consumer_id,
+        limit=1,
+    )
+    hydrated = _hydrated_stub(results=[], evaluator_kind="BUILTIN", output_configs=[])
+
+    async def _hydrate(_: ClaimedWorkUnit) -> HydratedWorkUnit:
+        return hydrated
+
+    async def _evaluate(*_: Any, **__: Any) -> None:
+        raise ValueError("bad evaluator")
+
+    original_fail = consumer._coordinator.fail
+    fail_calls = 0
+
+    async def _flaky_fail(**kwargs: Any) -> bool:
+        nonlocal fail_calls
+        fail_calls += 1
+        if fail_calls <= 3:
+            raise ConnectionError("database unavailable")
+        return await original_fail(**kwargs)
+
+    monkeypatch.setattr(consumer_module, "_TRANSITION_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
+    monkeypatch.setattr(consumer._executor, "hydrate", _hydrate)
+    monkeypatch.setattr(consumer._executor, "evaluate_and_annotate", _evaluate)
+    monkeypatch.setattr(consumer._coordinator, "fail", _flaky_fail)
+
+    await consumer._process_unit(unit)
+
+    assert fail_calls == 4
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.attempts == 1
+
+
 async def test_staleness_guard_expires_unit_without_annotating(
     db: DbSessionFactory,
 ) -> None:
@@ -458,6 +951,33 @@ async def test_stop_drains_in_flight_work_instead_of_cancelling(
 
     assert finished.is_set()
     assert not task.cancelled()
+
+
+async def test_stop_cancels_and_awaits_work_past_drain_timeout(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(consumer_module, "DRAIN_TIMEOUT_SECONDS", 0.01)
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    started = asyncio.Event()
+    cancellation_finished = asyncio.Event()
+
+    async def _in_flight() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(0)
+            cancellation_finished.set()
+
+    task = asyncio.create_task(_in_flight())
+    consumer._pending_tasks.add(task)
+    task.add_done_callback(consumer._pending_tasks.discard)
+    await started.wait()
+
+    await consumer.stop()
+
+    assert task.cancelled()
+    assert cancellation_finished.is_set()
 
 
 async def test_disabled_criteria_expires_unit(db: DbSessionFactory) -> None:

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -87,6 +87,26 @@ async def test_claim_and_complete_happy_path(db: DbSessionFactory) -> None:
     assert not await coordinator.complete(work_unit_id=unit_ids[0], claimed_by="consumer-1")
 
 
+async def test_heartbeat_keeps_lapsed_unit_unavailable_to_competing_consumer(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    owner = DbEvalWorkCoordinator(db)
+    competitor = DbEvalWorkCoordinator(db)
+
+    await owner.claim(claimed_by="consumer-1", limit=1)
+    lapsed = datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(claimed_at=lapsed)
+        )
+
+    assert await owner.heartbeat(work_unit_id=unit_id, claimed_by="consumer-1")
+    assert await competitor.claim(claimed_by="consumer-2", limit=1) == []
+
+
 async def test_fail_sets_cooldown_and_unit_is_reclaimable_after_it(db: DbSessionFactory) -> None:
     (unit_id,) = await _seed_work_units(db, 1)
     coordinator = DbEvalWorkCoordinator(db)
@@ -151,6 +171,7 @@ async def test_transitions_return_false_after_lapsed_lease_is_reclaimed(
 
     reclaimed = await coordinator.claim(claimed_by="consumer-2", limit=1)
     assert [unit.work_unit_id for unit in reclaimed] == [unit_id]
+    assert reclaimed[0].attempts == 1
 
     assert not await coordinator.heartbeat(work_unit_id=unit_id, claimed_by="consumer-1")
     assert not await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-1")
@@ -160,7 +181,33 @@ async def test_transitions_return_false_after_lapsed_lease_is_reclaimed(
     row = await _get_unit(db, unit_id)
     assert row.status == "RUNNING"
     assert row.claimed_by == "consumer-2"
+    assert row.attempts == 1
     assert await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-2")
+
+
+async def test_lapsed_lease_with_exhausted_attempts_is_not_claimable(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db, max_attempts=1)
+    lapsed = datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(
+                status="RUNNING",
+                claimed_at=lapsed,
+                claimed_by="consumer-1",
+                attempts=1,
+            )
+        )
+
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+    row = await _get_unit(db, unit_id)
+    assert row.status == "RUNNING"
+    assert row.claimed_by == "consumer-1"
+    assert row.attempts == 1
 
 
 async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -9,7 +9,11 @@ from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.app import _db
 from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
-from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
+from phoenix.server.online_eval.db_coordinator import (
+    STALE_FINGERPRINT_ERROR,
+    TRANSIENT_RETRY_MAX_AGE_SECONDS,
+    DbEvalWorkCoordinator,
+)
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS
 from phoenix.server.types import DbSessionFactory
 
@@ -86,7 +90,7 @@ async def test_claim_and_complete_happy_path(db: DbSessionFactory) -> None:
     for unit_id in unit_ids:
         assert await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-1")
         assert (await _get_unit(db, unit_id)).status == "DONE"
-    assert not await coordinator.complete(work_unit_id=unit_ids[0], claimed_by="consumer-1")
+    assert await coordinator.complete(work_unit_id=unit_ids[0], claimed_by="consumer-1")
 
 
 async def test_heartbeat_keeps_lapsed_unit_unavailable_to_competing_consumer(
@@ -145,13 +149,78 @@ async def test_failed_unit_with_exhausted_attempts_is_not_claimable(db: DbSessio
     assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
 
 
+async def test_aged_transient_failure_is_parked_as_exhausted_error(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(
+                created_at=datetime.now(timezone.utc)
+                - timedelta(seconds=TRANSIENT_RETRY_MAX_AGE_SECONDS + 1)
+            )
+        )
+
+    assert await coordinator.fail(
+        work_unit_id=unit_id,
+        claimed_by="consumer-1",
+        error="provider unavailable",
+        cooldown_until=datetime.now(timezone.utc) - timedelta(seconds=1),
+        count_attempt=False,
+    )
+
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.attempts == MAX_ATTEMPTS
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+    lag = await coordinator.lag()
+    assert lag.retryable_error_count == 0
+    assert lag.exhausted_error_count == 1
+
+
+async def test_fresh_transient_failure_remains_retryable_after_cooldown(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    cooldown_until = datetime.now(timezone.utc) + timedelta(seconds=60)
+
+    assert await coordinator.fail(
+        work_unit_id=unit_id,
+        claimed_by="consumer-1",
+        error="provider unavailable",
+        cooldown_until=cooldown_until,
+        count_attempt=False,
+    )
+    row = await _get_unit(db, unit_id)
+    assert row.attempts == 0
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(cooldown_until=datetime.now(timezone.utc) - timedelta(seconds=1))
+        )
+    claimed = await coordinator.claim(claimed_by="consumer-2", limit=1)
+    assert [unit.work_unit_id for unit in claimed] == [unit_id]
+    assert claimed[0].attempts == 0
+
+
 async def test_expire_is_terminal(db: DbSessionFactory) -> None:
     (unit_id,) = await _seed_work_units(db, 1)
     coordinator = DbEvalWorkCoordinator(db)
 
     await coordinator.claim(claimed_by="consumer-1", limit=1)
     assert await coordinator.expire(work_unit_id=unit_id, claimed_by="consumer-1")
-    assert (await _get_unit(db, unit_id)).status == "EXPIRED"
+    row = await _get_unit(db, unit_id)
+    assert row.status == "EXPIRED"
+    assert row.error == STALE_FINGERPRINT_ERROR
     assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
     assert not await coordinator.expire(work_unit_id=unit_id, claimed_by="consumer-1")
 

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -10,6 +10,7 @@ from phoenix.db.types.identifier import Identifier
 from phoenix.server.app import _db
 from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
 from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
+from phoenix.server.online_eval.derivation import MAX_ATTEMPTS
 from phoenix.server.types import DbSessionFactory
 
 from ..._helpers import _add_project, _add_span, _add_trace
@@ -211,6 +212,27 @@ async def test_lapsed_lease_with_exhausted_attempts_is_not_claimable(
     assert row.attempts == 1
 
 
+async def test_lapsed_unit_is_claimed_exactly_max_attempts_times(db: DbSessionFactory) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+    execution_count = 0
+
+    for execution_count in range(1, MAX_ATTEMPTS + 1):
+        claimed = await coordinator.claim(claimed_by=f"consumer-{execution_count}", limit=1)
+        assert [unit.work_unit_id for unit in claimed] == [unit_id]
+        async with db() as session:
+            await session.execute(
+                update(models.EvalWorkUnit)
+                .where(models.EvalWorkUnit.id == unit_id)
+                .values(
+                    claimed_at=datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+                )
+            )
+
+    assert execution_count == 3
+    assert await coordinator.claim(claimed_by="consumer-4", limit=1) == []
+
+
 async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
     db: DbSessionFactory,
 ) -> None:
@@ -219,10 +241,13 @@ async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
     empty = await coordinator.lag()
     assert empty.pending_count == 0
     assert empty.running_count == 0
+    assert empty.retryable_error_count == 0
+    assert empty.exhausted_error_count == 0
     assert empty.frontier_gap == 0
     assert empty.oldest_pending_age_seconds is None
 
-    unit_ids = await _seed_work_units(db, 4)
+    unit_ids = await _seed_work_units(db, 6)
+    now = datetime.now(timezone.utc)
     async with db() as session:
         await session.execute(
             update(models.EvalWorkUnit)
@@ -233,6 +258,24 @@ async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
             update(models.EvalWorkUnit)
             .where(models.EvalWorkUnit.id == unit_ids[1])
             .values(status="DONE")
+        )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[2])
+            .values(
+                status="ERROR",
+                attempts=MAX_ATTEMPTS - 1,
+                created_at=now - timedelta(seconds=120),
+            )
+        )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[3])
+            .values(
+                status="ERROR",
+                attempts=MAX_ATTEMPTS,
+                created_at=now - timedelta(seconds=3600),
+            )
         )
         session.add(
             models.EvalWorkCursor(
@@ -246,9 +289,11 @@ async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
     lag = await coordinator.lag()
     assert lag.pending_count == 2
     assert lag.running_count == 1
+    assert lag.retryable_error_count == 1
+    assert lag.exhausted_error_count == 1
     assert lag.frontier_gap == 7
     assert lag.oldest_pending_age_seconds is not None
-    assert lag.oldest_pending_age_seconds >= 0.0
+    assert 100.0 <= lag.oldest_pending_age_seconds < 300.0
 
 
 @pytest.mark.postgres_only

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -34,9 +34,10 @@ async def _seed_work_units(db: DbSessionFactory, n: int) -> list[int]:
         criteria = models.ProjectEvaluatorCriteria(
             project_id=project.id,
             evaluator_id=evaluator.id,
-            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
             filter_condition="",
             sampling_rate=1.0,
+            evaluation_target="SPAN",
         )
         session.add(criteria)
         await session.flush()

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -1,0 +1,225 @@
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
+from phoenix.server.app import _db
+from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
+from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
+from phoenix.server.types import DbSessionFactory
+
+from ..._helpers import _add_project, _add_span, _add_trace
+
+
+async def _seed_work_units(db: DbSessionFactory, n: int) -> list[int]:
+    """Create a span, evaluator, and criteria, plus ``n`` PENDING work units
+    (distinct fingerprints), returning the work unit ids in id order."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator.id,
+            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+        )
+        session.add(criteria)
+        await session.flush()
+        units = [
+            models.EvalWorkUnit(
+                span_rowid=span.id,
+                evaluator_id=evaluator.id,
+                criteria_id=criteria.id,
+                config_fingerprint=f"fp-{i}-{token_hex(8)}",
+            )
+            for i in range(n)
+        ]
+        session.add_all(units)
+        await session.flush()
+        return sorted(unit.id for unit in units)
+
+
+async def _get_unit(db: DbSessionFactory, unit_id: int) -> models.EvalWorkUnit:
+    async with db() as session:
+        unit = await session.get(models.EvalWorkUnit, unit_id)
+        assert unit is not None
+        return unit
+
+
+async def test_claim_and_complete_happy_path(db: DbSessionFactory) -> None:
+    unit_ids = await _seed_work_units(db, 2)
+    coordinator = DbEvalWorkCoordinator(db)
+    before = datetime.now(timezone.utc)
+
+    claimed = await coordinator.claim(claimed_by="consumer-1", limit=10)
+    assert [unit.work_unit_id for unit in claimed] == unit_ids
+    for claimed_unit in claimed:
+        assert claimed_unit.criteria_id > 0
+        assert claimed_unit.identifier == "online:" + claimed_unit.config_fingerprint[:16]
+        assert claimed_unit.attempts == 0
+        assert claimed_unit.claimed_by == "consumer-1"
+        assert claimed_unit.lease_expires_at >= before + timedelta(seconds=LEASE_TTL_SECONDS)
+        row = await _get_unit(db, claimed_unit.work_unit_id)
+        assert row.status == "RUNNING"
+        assert row.claimed_by == "consumer-1"
+
+    assert await coordinator.claim(claimed_by="consumer-2", limit=10) == []
+    assert await coordinator.heartbeat(work_unit_id=unit_ids[0], claimed_by="consumer-1")
+
+    for unit_id in unit_ids:
+        assert await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-1")
+        assert (await _get_unit(db, unit_id)).status == "DONE"
+    assert not await coordinator.complete(work_unit_id=unit_ids[0], claimed_by="consumer-1")
+
+
+async def test_fail_sets_cooldown_and_unit_is_reclaimable_after_it(db: DbSessionFactory) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    future = datetime.now(timezone.utc) + timedelta(seconds=60)
+    assert await coordinator.fail(
+        work_unit_id=unit_id, claimed_by="consumer-1", error="boom", cooldown_until=future
+    )
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.error == "boom"
+    assert row.attempts == 1
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+
+    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(cooldown_until=past)
+        )
+    reclaimed = await coordinator.claim(claimed_by="consumer-2", limit=1)
+    assert [unit.work_unit_id for unit in reclaimed] == [unit_id]
+    assert reclaimed[0].attempts == 1
+
+
+async def test_failed_unit_with_exhausted_attempts_is_not_claimable(db: DbSessionFactory) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db, max_attempts=1)
+
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    assert await coordinator.fail(work_unit_id=unit_id, claimed_by="consumer-1", error="boom")
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+
+
+async def test_expire_is_terminal(db: DbSessionFactory) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    assert await coordinator.expire(work_unit_id=unit_id, claimed_by="consumer-1")
+    assert (await _get_unit(db, unit_id)).status == "EXPIRED"
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+    assert not await coordinator.expire(work_unit_id=unit_id, claimed_by="consumer-1")
+
+
+async def test_transitions_return_false_after_lapsed_lease_is_reclaimed(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    lapsed = datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(claimed_at=lapsed)
+        )
+
+    reclaimed = await coordinator.claim(claimed_by="consumer-2", limit=1)
+    assert [unit.work_unit_id for unit in reclaimed] == [unit_id]
+
+    assert not await coordinator.heartbeat(work_unit_id=unit_id, claimed_by="consumer-1")
+    assert not await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-1")
+    assert not await coordinator.fail(work_unit_id=unit_id, claimed_by="consumer-1", error="late")
+    assert not await coordinator.expire(work_unit_id=unit_id, claimed_by="consumer-1")
+
+    row = await _get_unit(db, unit_id)
+    assert row.status == "RUNNING"
+    assert row.claimed_by == "consumer-2"
+    assert await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-2")
+
+
+async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
+    db: DbSessionFactory,
+) -> None:
+    coordinator = DbEvalWorkCoordinator(db)
+
+    empty = await coordinator.lag()
+    assert empty.pending_count == 0
+    assert empty.running_count == 0
+    assert empty.frontier_gap == 0
+    assert empty.oldest_pending_age_seconds is None
+
+    unit_ids = await _seed_work_units(db, 4)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[0])
+            .values(status="RUNNING", claimed_at=datetime.now(timezone.utc), claimed_by="c")
+        )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[1])
+            .values(status="DONE")
+        )
+        session.add(
+            models.EvalWorkCursor(
+                grain="SPAN",
+                consumer_group="default",
+                produced_through_id=5,
+                observed_high_water_id=12,
+            )
+        )
+
+    lag = await coordinator.lag()
+    assert lag.pending_count == 2
+    assert lag.running_count == 1
+    assert lag.frontier_gap == 7
+    assert lag.oldest_pending_age_seconds is not None
+    assert lag.oldest_pending_age_seconds >= 0.0
+
+
+@pytest.mark.postgres_only
+async def test_claim_skips_rows_locked_by_a_concurrent_transaction(
+    postgresql_engine: AsyncEngine,
+) -> None:
+    db = DbSessionFactory(db=_db(postgresql_engine), dialect="postgresql")
+    unit_ids = await _seed_work_units(db, 2)
+    coordinator = DbEvalWorkCoordinator(db)
+
+    async with db() as session:
+        locked = await session.scalar(
+            select(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[0])
+            .with_for_update()
+        )
+        assert locked is not None
+        claimed = await coordinator.claim(claimed_by="consumer-1", limit=10)
+        assert [unit.work_unit_id for unit in claimed] == [unit_ids[1]]
+
+    claimed = await coordinator.claim(claimed_by="consumer-1", limit=10)
+    assert [unit.work_unit_id for unit in claimed] == [unit_ids[0]]

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -8,6 +8,8 @@ from sqlalchemy import func, select, update
 from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.online_eval import producer as producer_module
+from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
+from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerprint
 from phoenix.server.online_eval.producer import (
     OnlineEvalProducer,
@@ -194,7 +196,10 @@ async def test_future_targets_are_not_loaded_by_span_producer(
     assert await producer._load_active_criteria() == []
 
 
-async def test_tick_advances_at_most_one_id_chunk(db: DbSessionFactory) -> None:
+async def test_tick_advances_at_most_one_id_chunk(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK", "2")
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -210,7 +215,6 @@ async def test_tick_advances_at_most_one_id_chunk(db: DbSessionFactory) -> None:
     )
 
     producer = OnlineEvalProducer(db)
-    producer._max_span_ids_per_tick = 2
     await producer._tick()
 
     cursor = await _get_cursor(db, cursor_id)
@@ -224,6 +228,16 @@ async def test_tick_advances_at_most_one_id_chunk(db: DbSessionFactory) -> None:
     cursor = await _get_cursor(db, cursor_id)
     assert cursor.produced_through_id == low_exclusive + 4
     assert sorted(await _work_unit_span_rowids(db)) == [span.id for span in spans[:4]]
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+async def test_max_span_ids_per_tick_must_be_positive(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK", value)
+
+    with pytest.raises(ValueError, match="Value must be a positive integer"):
+        OnlineEvalProducer(db)
 
 
 async def test_cursor_regresses_to_live_span_high_water(db: DbSessionFactory) -> None:
@@ -435,10 +449,60 @@ async def test_reaper_default_keeps_old_pending_work(
     assert unit.status == "PENDING"
 
 
+async def test_reaper_terminalizes_only_lapsed_exhausted_running_work(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+    now = _now()
+    lapsed = now - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+
+    async with db() as session:
+        lapsed_unit = models.EvalWorkUnit(
+            span_rowid=span.id,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            status="RUNNING",
+            attempts=MAX_ATTEMPTS,
+            claimed_at=lapsed,
+            claimed_by="consumer-1",
+        )
+        fresh_unit = models.EvalWorkUnit(
+            span_rowid=span.id,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            status="RUNNING",
+            attempts=MAX_ATTEMPTS,
+            claimed_at=now,
+            claimed_by="consumer-1",
+        )
+        session.add_all([lapsed_unit, fresh_unit])
+        await session.flush()
+        lapsed_id, fresh_id = lapsed_unit.id, fresh_unit.id
+
+    producer = OnlineEvalProducer(db)
+    await producer._reap(now, span.id)
+
+    async with db() as session:
+        lapsed_row = await session.get(models.EvalWorkUnit, lapsed_id)
+        fresh_row = await session.get(models.EvalWorkUnit, fresh_id)
+    assert lapsed_row is not None
+    assert lapsed_row.status == "ERROR"
+    assert fresh_row is not None
+    assert fresh_row.status == "RUNNING"
+    competitor = DbEvalWorkCoordinator(db)
+    assert await competitor.claim(claimed_by="consumer-2", limit=2) == []
+
+
 async def test_admission_gate_skips_materialization(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_PENDING", "0")
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING", "0")
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -492,7 +556,7 @@ async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -
         )
 
     producer = OnlineEvalProducer(db)
-    producer._max_pending = 0
+    producer._max_outstanding = 0
     assert await producer._admission_gate_open()
 
     async with db() as session:

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -265,6 +265,24 @@ async def test_materialization_budget_truncates_without_advancing(
     assert cursor.produced_through_id == low_exclusive
     assert await producer._admission_budget() == 0
 
+    coordinator = DbEvalWorkCoordinator(db)
+    admitted = await coordinator.claim(claimed_by="consumer", limit=3)
+    assert len(admitted) == 3
+    for unit in admitted:
+        assert await coordinator.complete(
+            work_unit_id=unit.work_unit_id,
+            claimed_by="consumer",
+        )
+
+    await producer._tick()
+
+    async with db() as session:
+        units = list(await session.scalars(select(models.EvalWorkUnit)))
+    assert len(units) == 4
+    assert sum(unit.status == "DONE" for unit in units) == 3
+    assert sum(unit.status == "PENDING" for unit in units) == 1
+    assert (await _get_cursor(db, cursor_id)).produced_through_id == spans[-1].id
+
 
 @pytest.mark.parametrize("value", ["0", "-1"])
 async def test_max_span_ids_per_tick_must_be_positive(
@@ -329,9 +347,13 @@ async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
         expired_span = await _add_span(session, trace)
     evaluator_id, criteria_id = await _seed_criteria(db, project.id)
     watermark = expired_span.id
-    await _seed_cursor(db, produced_through_id=watermark)
-
     producer = OnlineEvalProducer(db)
+    await _seed_cursor(
+        db,
+        produced_through_id=watermark,
+        claimed_by=producer._producer_id,
+        claimed_at=_now(),
+    )
     active = await producer._load_active_criteria()
     assert len(active) == 1
     criteria = active[0]
@@ -380,6 +402,12 @@ async def test_backstop_stops_at_insertion_budget(db: DbSessionFactory) -> None:
     await _seed_criteria(db, project.id)
 
     producer = OnlineEvalProducer(db)
+    await _seed_cursor(
+        db,
+        produced_through_id=spans[-1].id,
+        claimed_by=producer._producer_id,
+        claimed_at=_now(),
+    )
     active = await producer._load_active_criteria()
     remaining = await producer._backstop_sweep(active, spans[-1].id, 2)
 
@@ -416,6 +444,11 @@ async def test_stale_fingerprint_rows_are_resurrected_when_config_reverts(
         assert resolved is not None
         original_fingerprint = config_fingerprint(resolved)
         evaluator.key = f"{original_key}-changed"
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.span_rowid == spans[0].id)
+            .values(attempts=2)
+        )
 
     coordinator = DbEvalWorkCoordinator(db)
     claimed = await coordinator.claim(claimed_by="consumer", limit=3)
@@ -433,19 +466,33 @@ async def test_stale_fingerprint_rows_are_resurrected_when_config_reverts(
         assert criteria is not None
         evaluator.key = original_key
         evaluator.synced_at = original_synced_at
-        session.add(
-            models.SpanAnnotation(
-                span_rowid=spans[1].id,
-                name=criteria.name.root,
-                label="done",
-                score=1.0,
-                explanation=None,
-                metadata_={},
-                annotator_kind="LLM",
-                identifier=annotation_identifier(original_fingerprint),
-                source="API",
-                user_id=None,
-            )
+        session.add_all(
+            [
+                models.SpanAnnotation(
+                    span_rowid=spans[0].id,
+                    name=criteria.name.root,
+                    label="old",
+                    score=0.0,
+                    explanation=None,
+                    metadata_={},
+                    annotator_kind="LLM",
+                    identifier=annotation_identifier("different-fingerprint"),
+                    source="API",
+                    user_id=None,
+                ),
+                models.SpanAnnotation(
+                    span_rowid=spans[1].id,
+                    name=criteria.name.root,
+                    label="done",
+                    score=1.0,
+                    explanation=None,
+                    metadata_={},
+                    annotator_kind="LLM",
+                    identifier=annotation_identifier(original_fingerprint),
+                    source="API",
+                    user_id=None,
+                ),
+            ]
         )
         await session.execute(
             update(models.EvalWorkUnit)
@@ -925,6 +972,89 @@ async def test_lost_lease_rolls_back_materialization_and_aborts_tick(
         sum("tick aborted after losing its lease" in record.message for record in caplog.records)
         == 1
     )
+
+
+async def test_separate_lease_steal_rolls_back_truncated_frontier(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING", "1")
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(2)]
+    await _seed_criteria(db, project.id)
+    cursor_id = await _seed_cursor(
+        db,
+        produced_through_id=spans[0].id - 1,
+        observed_high_water_id=spans[-1].id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    insert_work_units = producer._insert_work_units
+
+    async def _steal_then_insert(
+        session: Any,
+        criteria: Any,
+        span_ids: list[int],
+    ) -> None:
+        async with db() as rival_session:
+            await rival_session.execute(
+                update(models.EvalWorkCursor)
+                .where(models.EvalWorkCursor.id == cursor_id)
+                .values(claimed_by="rival-producer")
+            )
+        await insert_work_units(session, criteria, span_ids)
+
+    monkeypatch.setattr(producer, "_insert_work_units", _steal_then_insert)
+
+    with caplog.at_level("WARNING"):
+        await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    assert not producer._lease_held
+    assert any("tick aborted after losing its lease" in record.message for record in caplog.records)
+
+
+async def test_separate_lease_steal_rolls_back_backstop(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    cursor_id = await _seed_cursor(db, produced_through_id=span.id)
+
+    producer = OnlineEvalProducer(db)
+    producer._backstop_interval_seconds = 0
+    insert_work_units = producer._insert_work_units
+
+    async def _steal_then_insert(
+        session: Any,
+        criteria: Any,
+        span_ids: list[int],
+    ) -> None:
+        async with db() as rival_session:
+            await rival_session.execute(
+                update(models.EvalWorkCursor)
+                .where(models.EvalWorkCursor.id == cursor_id)
+                .values(claimed_by="rival-producer")
+            )
+        await insert_work_units(session, criteria, span_ids)
+
+    monkeypatch.setattr(producer, "_insert_work_units", _steal_then_insert)
+
+    with caplog.at_level("WARNING"):
+        await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    assert not producer._lease_held
+    assert any("tick aborted after losing its lease" in record.message for record in caplog.records)
 
 
 async def test_renew_lease_refreshes_claimed_at(db: DbSessionFactory) -> None:

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -9,8 +9,15 @@ from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.online_eval import producer as producer_module
 from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
-from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
-from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerprint
+from phoenix.server.online_eval.db_coordinator import (
+    STALE_FINGERPRINT_ERROR,
+    DbEvalWorkCoordinator,
+)
+from phoenix.server.online_eval.derivation import (
+    MAX_ATTEMPTS,
+    annotation_identifier,
+    config_fingerprint,
+)
 from phoenix.server.online_eval.producer import (
     OnlineEvalProducer,
     resolve_criteria,
@@ -230,6 +237,35 @@ async def test_tick_advances_at_most_one_id_chunk(
     assert sorted(await _work_unit_span_rowids(db)) == [span.id for span in spans[:4]]
 
 
+async def test_materialization_budget_truncates_without_advancing(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING", "3")
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(2)]
+    await _seed_criteria(db, project.id)
+    await _seed_criteria(db, project.id)
+    low_exclusive = spans[0].id - 1
+    cursor_id = await _seed_cursor(
+        db,
+        produced_through_id=low_exclusive,
+        observed_high_water_id=spans[-1].id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    async with db() as session:
+        unit_count = await session.scalar(select(func.count()).select_from(models.EvalWorkUnit))
+    assert unit_count == 3
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == low_exclusive
+    assert await producer._admission_budget() == 0
+
+
 @pytest.mark.parametrize("value", ["0", "-1"])
 async def test_max_span_ids_per_tick_must_be_positive(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch, value: str
@@ -325,7 +361,7 @@ async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
             )
         )
 
-    await producer._backstop_sweep(active, watermark)
+    await producer._backstop_sweep(active, watermark, 10)
 
     async with db() as session:
         units = list(await session.scalars(select(models.EvalWorkUnit)))
@@ -334,6 +370,141 @@ async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
     assert by_span[late_span.id].status == "PENDING"
     assert annotated_span.id not in by_span
     assert by_span[expired_span.id].status == "EXPIRED"
+
+
+async def test_backstop_stops_at_insertion_budget(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(3)]
+    await _seed_criteria(db, project.id)
+
+    producer = OnlineEvalProducer(db)
+    active = await producer._load_active_criteria()
+    remaining = await producer._backstop_sweep(active, spans[-1].id, 2)
+
+    assert remaining == 0
+    assert len(await _work_unit_span_rowids(db)) == 2
+
+
+async def test_stale_fingerprint_rows_are_resurrected_when_config_reverts(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(3)]
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+    await _seed_cursor(
+        db,
+        produced_through_id=spans[0].id - 1,
+        observed_high_water_id=spans[-1].id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    async with db() as session:
+        evaluator = await session.get(models.BuiltinEvaluator, evaluator_id)
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert evaluator is not None
+        assert criteria is not None
+        original_key = evaluator.key
+        original_synced_at = evaluator.synced_at
+        resolved = await resolve_criteria(session, criteria, evaluator)
+        assert resolved is not None
+        original_fingerprint = config_fingerprint(resolved)
+        evaluator.key = f"{original_key}-changed"
+
+    coordinator = DbEvalWorkCoordinator(db)
+    claimed = await coordinator.claim(claimed_by="consumer", limit=3)
+    assert len(claimed) == 3
+    for unit in claimed:
+        assert await coordinator.expire(
+            work_unit_id=unit.work_unit_id,
+            claimed_by="consumer",
+        )
+
+    async with db() as session:
+        evaluator = await session.get(models.BuiltinEvaluator, evaluator_id)
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert evaluator is not None
+        assert criteria is not None
+        evaluator.key = original_key
+        evaluator.synced_at = original_synced_at
+        session.add(
+            models.SpanAnnotation(
+                span_rowid=spans[1].id,
+                name=criteria.name.root,
+                label="done",
+                score=1.0,
+                explanation=None,
+                metadata_={},
+                annotator_kind="LLM",
+                identifier=annotation_identifier(original_fingerprint),
+                source="API",
+                user_id=None,
+            )
+        )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.span_rowid == spans[2].id)
+            .values(status="DONE")
+        )
+
+    producer._backstop_interval_seconds = 0
+    await producer._tick()
+
+    async with db() as session:
+        units = list(
+            await session.scalars(
+                select(models.EvalWorkUnit).order_by(models.EvalWorkUnit.span_rowid)
+            )
+        )
+    assert [unit.config_fingerprint for unit in units] == [original_fingerprint] * 3
+    assert units[0].status == "PENDING"
+    assert units[0].attempts == 0
+    assert units[0].error is None
+    assert units[0].claimed_by is None
+    assert units[0].claimed_at is None
+    assert units[0].cooldown_until is None
+    assert units[1].status == "EXPIRED"
+    assert units[1].error == STALE_FINGERPRINT_ERROR
+    assert units[2].status == "DONE"
+
+
+async def test_ttl_expired_row_is_not_resurrected(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS", "1")
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    await _seed_cursor(
+        db,
+        produced_through_id=span.id - 1,
+        observed_high_water_id=span.id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit).values(created_at=_now() - timedelta(seconds=10))
+        )
+
+    await producer._reap(_now(), span.id)
+    active = await producer._load_active_criteria()
+    await producer._backstop_sweep(active, span.id, 10)
+
+    async with db() as session:
+        unit = (await session.scalars(select(models.EvalWorkUnit))).one()
+    assert unit.status == "EXPIRED"
+    assert unit.error == "pending ttl exceeded"
 
 
 async def test_reaper_transitions_and_deletes(
@@ -401,14 +572,15 @@ async def test_reaper_transitions_and_deletes(
 
     async with db() as session:
         remaining = {
-            unit.id: unit.status for unit in await session.scalars(select(models.EvalWorkUnit))
+            unit.id: (unit.status, unit.error)
+            for unit in await session.scalars(select(models.EvalWorkUnit))
         }
-    assert remaining.get(ids["stale_pending"]) == "EXPIRED"
-    assert remaining.get(ids["fresh_pending"]) == "PENDING"
+    assert remaining.get(ids["stale_pending"]) == ("EXPIRED", "pending ttl exceeded")
+    assert remaining.get(ids["fresh_pending"]) == ("PENDING", None)
     assert ids["done_outside"] not in remaining
-    assert remaining.get(ids["done_inside"]) == "DONE"
+    assert remaining.get(ids["done_inside"]) == ("DONE", None)
     assert ids["exhausted_error_outside"] not in remaining
-    assert remaining.get(ids["retryable_error_outside"]) == "ERROR"
+    assert remaining.get(ids["retryable_error_outside"]) == ("ERROR", None)
 
 
 async def test_reaper_default_keeps_old_pending_work(
@@ -559,7 +731,7 @@ async def test_admission_gate_skips_materialization(
     assert cursor.produced_through_id == 0
 
 
-async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -> None:
+async def test_admission_budget_counts_nonterminal_backlog(db: DbSessionFactory) -> None:
     """The gate bounds all backlog that will eventually demand consumer
     capacity: RUNNING and retryable-ERROR rows count alongside PENDING (under
     a provider outage the pending population migrates into retryable ERROR),
@@ -581,12 +753,12 @@ async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -
         )
 
     producer = OnlineEvalProducer(db)
-    producer._max_outstanding = 0
-    assert await producer._admission_gate_open()
+    producer._max_outstanding = 1
+    assert await producer._admission_budget() == 1
 
     async with db() as session:
         session.add(_unit("ERROR", attempts=MAX_ATTEMPTS))
-    assert await producer._admission_gate_open()  # exhausted ERROR is terminal
+    assert await producer._admission_budget() == 1
 
     async with db() as session:
         session.add(_unit("RUNNING", claimed_by="consumer-1", claimed_at=_now()))
@@ -596,7 +768,7 @@ async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -
                 select(models.EvalWorkUnit.id).order_by(models.EvalWorkUnit.id.desc()).limit(1)
             )
         ).one()
-    assert not await producer._admission_gate_open()  # RUNNING counts
+    assert await producer._admission_budget() == 0
 
     async with db() as session:
         await session.execute(
@@ -604,11 +776,11 @@ async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -
             .where(models.EvalWorkUnit.id == running_id)
             .values(status="DONE")
         )
-    assert await producer._admission_gate_open()
+    assert await producer._admission_budget() == 1
 
     async with db() as session:
         session.add(_unit("ERROR", attempts=1))
-    assert not await producer._admission_gate_open()  # retryable ERROR counts
+    assert await producer._admission_budget() == 0
 
 
 async def test_unexpected_criteria_load_error_fails_closed(
@@ -706,3 +878,66 @@ async def test_lease_stand_down_and_stale_reclaim(db: DbSessionFactory) -> None:
     assert cursor.claimed_by == producer._producer_id
     assert cursor.produced_through_id == span.id
     assert sorted(await _work_unit_span_rowids(db)) == [span.id]
+
+
+async def test_lost_lease_rolls_back_materialization_and_aborts_tick(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    cursor_id = await _seed_cursor(
+        db,
+        produced_through_id=span.id - 1,
+        observed_high_water_id=span.id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    insert_work_units = producer._insert_work_units
+
+    async def _insert_then_lose_lease(
+        session: Any,
+        criteria: Any,
+        span_ids: list[int],
+    ) -> None:
+        await insert_work_units(session, criteria, span_ids)
+        await session.execute(
+            update(models.EvalWorkCursor)
+            .where(models.EvalWorkCursor.id == cursor_id)
+            .values(claimed_by="rival-producer")
+        )
+
+    monkeypatch.setattr(producer, "_insert_work_units", _insert_then_lose_lease)
+
+    with caplog.at_level("WARNING"):
+        await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == span.id - 1
+    assert cursor.claimed_by == producer._producer_id
+    assert (
+        sum("tick aborted after losing its lease" in record.message for record in caplog.records)
+        == 1
+    )
+
+
+async def test_renew_lease_refreshes_claimed_at(db: DbSessionFactory) -> None:
+    producer = OnlineEvalProducer(db)
+    old = _now() - timedelta(seconds=60)
+    cursor_id = await _seed_cursor(
+        db,
+        claimed_by=producer._producer_id,
+        claimed_at=old,
+    )
+    renewed_at = _now()
+
+    await producer._renew_lease(renewed_at)
+
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.claimed_at == renewed_at

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -467,7 +467,18 @@ async def test_reaper_terminalizes_only_lapsed_exhausted_running_work(
             criteria_id=criteria_id,
             config_fingerprint=f"fp-{token_hex(8)}",
             status="RUNNING",
-            attempts=MAX_ATTEMPTS,
+            attempts=MAX_ATTEMPTS - 1,
+            claimed_at=lapsed,
+            claimed_by="consumer-1",
+        )
+        failed_lapsed_unit = models.EvalWorkUnit(
+            span_rowid=span.id,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            status="RUNNING",
+            attempts=MAX_ATTEMPTS - 1,
+            error="provider failed",
             claimed_at=lapsed,
             claimed_by="consumer-1",
         )
@@ -477,22 +488,33 @@ async def test_reaper_terminalizes_only_lapsed_exhausted_running_work(
             criteria_id=criteria_id,
             config_fingerprint=f"fp-{token_hex(8)}",
             status="RUNNING",
-            attempts=MAX_ATTEMPTS,
+            attempts=MAX_ATTEMPTS - 1,
             claimed_at=now,
             claimed_by="consumer-1",
         )
-        session.add_all([lapsed_unit, fresh_unit])
+        session.add_all([lapsed_unit, failed_lapsed_unit, fresh_unit])
         await session.flush()
-        lapsed_id, fresh_id = lapsed_unit.id, fresh_unit.id
+        lapsed_id, failed_lapsed_id, fresh_id = (
+            lapsed_unit.id,
+            failed_lapsed_unit.id,
+            fresh_unit.id,
+        )
 
     producer = OnlineEvalProducer(db)
     await producer._reap(now, span.id)
 
     async with db() as session:
         lapsed_row = await session.get(models.EvalWorkUnit, lapsed_id)
+        failed_lapsed_row = await session.get(models.EvalWorkUnit, failed_lapsed_id)
         fresh_row = await session.get(models.EvalWorkUnit, fresh_id)
     assert lapsed_row is not None
     assert lapsed_row.status == "ERROR"
+    assert lapsed_row.attempts == MAX_ATTEMPTS
+    assert lapsed_row.error == "lease lapsed with attempts exhausted"
+    assert failed_lapsed_row is not None
+    assert failed_lapsed_row.status == "ERROR"
+    assert failed_lapsed_row.attempts == MAX_ATTEMPTS
+    assert failed_lapsed_row.error == "provider failed"
     assert fresh_row is not None
     assert fresh_row.status == "RUNNING"
     competitor = DbEvalWorkCoordinator(db)
@@ -502,7 +524,7 @@ async def test_reaper_terminalizes_only_lapsed_exhausted_running_work(
 async def test_admission_gate_skips_materialization(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING", "0")
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING", "1")
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -510,13 +532,16 @@ async def test_admission_gate_skips_materialization(
         backlog_span = await _add_span(session, trace)
     evaluator_id, criteria_id = await _seed_criteria(db, project.id)
     async with db() as session:
-        session.add(
-            models.EvalWorkUnit(
-                span_rowid=backlog_span.id,
-                evaluator_id=evaluator_id,
-                criteria_id=criteria_id,
-                config_fingerprint=f"fp-{token_hex(8)}",
-            )
+        session.add_all(
+            [
+                models.EvalWorkUnit(
+                    span_rowid=backlog_span.id,
+                    evaluator_id=evaluator_id,
+                    criteria_id=criteria_id,
+                    config_fingerprint=f"fp-{token_hex(8)}",
+                )
+                for _ in range(2)
+            ]
         )
     cursor_id = await _seed_cursor(
         db,
@@ -529,7 +554,7 @@ async def test_admission_gate_skips_materialization(
 
     async with db() as session:
         unit_count = await session.scalar(select(func.count()).select_from(models.EvalWorkUnit))
-    assert unit_count == 1
+    assert unit_count == 2
     cursor = await _get_cursor(db, cursor_id)
     assert cursor.produced_through_id == 0
 

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -322,7 +322,12 @@ async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
     assert by_span[expired_span.id].status == "EXPIRED"
 
 
-async def test_reaper_transitions_and_deletes(db: DbSessionFactory) -> None:
+async def test_reaper_transitions_and_deletes(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS", "2")
+    # TTL shedding is opt-in (default off); this test exercises the opted-in path.
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS", "3600")
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -378,9 +383,6 @@ async def test_reaper_transitions_and_deletes(db: DbSessionFactory) -> None:
         }
 
     producer = OnlineEvalProducer(db)
-    producer._backstop_lookback_span_ids = 2
-    # TTL shedding is opt-in (default off); this test exercises the opted-in path.
-    producer._pending_ttl_seconds = 3600.0
     await producer._reap(now, produced_through)
 
     async with db() as session:
@@ -395,11 +397,15 @@ async def test_reaper_transitions_and_deletes(db: DbSessionFactory) -> None:
     assert remaining.get(ids["retryable_error_outside"]) == "ERROR"
 
 
-async def test_reaper_default_keeps_old_pending_work(db: DbSessionFactory) -> None:
+async def test_reaper_default_keeps_old_pending_work(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """With the pending TTL unset (the default), backlog never expires: a
     PENDING unit older than any drain window stays claimable instead of being
     shed. TTL expiry is terminal and blocks backstop re-materialization of the
     same fingerprint, so shedding must be an explicit operator opt-in."""
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS", "2")
+    monkeypatch.delenv("PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS", raising=False)
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -421,7 +427,6 @@ async def test_reaper_default_keeps_old_pending_work(db: DbSessionFactory) -> No
         unit_id = old_pending.id
 
     producer = OnlineEvalProducer(db)
-    producer._backstop_lookback_span_ids = 2
     await producer._reap(now, span.id)
 
     async with db() as session:
@@ -430,7 +435,10 @@ async def test_reaper_default_keeps_old_pending_work(db: DbSessionFactory) -> No
     assert unit.status == "PENDING"
 
 
-async def test_admission_gate_skips_materialization(db: DbSessionFactory) -> None:
+async def test_admission_gate_skips_materialization(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_PENDING", "0")
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -453,7 +461,6 @@ async def test_admission_gate_skips_materialization(db: DbSessionFactory) -> Non
     )
 
     producer = OnlineEvalProducer(db)
-    producer._max_pending = 0
     await producer._tick()
 
     async with db() as session:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Optional, get_args
+from typing import Any, Callable, Optional, get_args
 from unittest.mock import MagicMock
 from urllib.parse import quote, unquote, urlparse
 
@@ -8,6 +8,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from starlette.datastructures import URL
 
+import phoenix.config as phoenix_config
 from phoenix.config import (
     AssignableUserRoleName,
     OAuth2ClientConfig,
@@ -24,6 +25,186 @@ from phoenix.config import (
     get_env_tls_enabled_for_http,
 )
 from phoenix.db.models import UserRoleName
+
+
+class TestGetEnvOnlineEval:
+    @pytest.mark.parametrize(
+        ("env_name", "getter", "value", "expected"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS,
+                phoenix_config.get_env_online_eval_frontier_lag_seconds,
+                "0",
+                0.0,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_backstop_interval_seconds,
+                "0.001",
+                0.001,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS,
+                phoenix_config.get_env_online_eval_pending_ttl_seconds,
+                "0",
+                0.0,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS,
+                phoenix_config.get_env_online_eval_retention_seconds,
+                "0.001",
+                0.001,
+            ),
+        ],
+    )
+    def test_float_boundaries(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], float],
+        value: str,
+        expected: float,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        assert getter() == expected
+
+    @pytest.mark.parametrize(
+        ("env_name", "getter", "value"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS,
+                phoenix_config.get_env_online_eval_frontier_lag_seconds,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_backstop_interval_seconds,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_backstop_interval_seconds,
+                "0",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS,
+                phoenix_config.get_env_online_eval_pending_ttl_seconds,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS,
+                phoenix_config.get_env_online_eval_retention_seconds,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS,
+                phoenix_config.get_env_online_eval_retention_seconds,
+                "0",
+            ),
+        ],
+    )
+    def test_float_domains(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], float],
+        value: str,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        with pytest.raises(ValueError, match=env_name):
+            getter()
+
+    @pytest.mark.parametrize(
+        ("env_name", "getter"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS,
+                phoenix_config.get_env_online_eval_frontier_lag_seconds,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_backstop_interval_seconds,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS,
+                phoenix_config.get_env_online_eval_pending_ttl_seconds,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS,
+                phoenix_config.get_env_online_eval_retention_seconds,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+    def test_float_domains_reject_non_finite_values(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], float],
+        value: str,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        with pytest.raises(ValueError, match=env_name):
+            getter()
+
+    @pytest.mark.parametrize(
+        ("env_name", "getter", "value", "expected"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS,
+                phoenix_config.get_env_online_eval_backstop_lookback_span_ids,
+                "0",
+                0,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_outstanding,
+                "1",
+                1,
+            ),
+        ],
+    )
+    def test_integer_boundaries(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], int],
+        value: str,
+        expected: int,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        assert getter() == expected
+
+    @pytest.mark.parametrize(
+        ("env_name", "getter", "value"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS,
+                phoenix_config.get_env_online_eval_backstop_lookback_span_ids,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_outstanding,
+                "0",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_outstanding,
+                "-1",
+            ),
+        ],
+    )
+    def test_integer_domains(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], int],
+        value: str,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        with pytest.raises(ValueError, match=env_name):
+            getter()
 
 
 class TestPostgresConnectionString:


### PR DESCRIPTION
Stacked follow-up to #14011 (producer-only, merged as `77fd41a0dd`), split per review feedback (Roger Yang) to keep the base PR reviewable. This is the **consumer runtime + public env surface** slice of the multi-replica online-evals design described in #14011.

**Base:** `version-online-evals` (#14011 is already merged into it).

## What this restores (deferred out of #14011)

- `online_eval/consumer.py` (`OnlineEvalConsumer`) + `online_eval/executor.py` (`OnlineEvalExecutor`), consumer-only: every replica claims work units (PG `FOR UPDATE SKIP LOCKED` / SQLite CAS), runs the eval, writes idempotent span annotations. Transient provider failures (network/timeout/429/5xx) cool down flat without burning attempts; unrecognized errors keep bounded exponential backoff.
- The online-eval app integration in `app.py`: producer/consumer construction, lifespan wiring, and `app.state`, gated by `PHOENIX_ONLINE_EVAL_ENABLED` (the gate itself landed in #14011, default **off**).
- The 7 public `PHOENIX_ONLINE_EVAL_*` tuning knobs in `config.py`. All are producer-side — the consumer reads none of them; the producer, which ran on hardcoded defaults in #14011, reads them from config here. One knob is new to the env surface: `PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK` (default `10_000`) — the per-tick scan bound was born in #14011's review hardening after the env surface was designed, so its public knob lands here with the rest.
- Consumer unit tests + the end-to-end producer→consumer app-wiring test.

## Additional hardening

**Lapsed-lease reclaims now count attempts** (`db_coordinator.py`, both dialect paths). Previously `attempts` incremented only via `fail()`, so a consumer that hard-crashes (OOM/SIGKILL) never fails its unit — the lapsed RUNNING lease was reclaimed forever without approaching `MAX_ATTEMPTS`, the exact unbounded crash loop that bound exists to prevent. Now:

- Claiming a RUNNING row with a lapsed lease increments `attempts` (conditional `CASE` on prior status, shared by the PG batch-update and SQLite CAS paths).
- The claimable predicate excludes RUNNING-lapsed rows approaching the ceiling, and the crash path now gets exactly the same execution budget as the failure path (three runs) — the reaper terminalizes the excluded rows with a recorded reason so they stop occupying admission capacity.
- ERROR-cooldown reclaims are unchanged — their attempt was already counted at `fail()` time (no double-count) — and transient failures still don't burn attempts.
- Accepted edge (documented in code): a shutdown straggler that outlives the `stop()` drain also pays +1 on reclaim — rare and bounded.

**Execution correctness** (review round, 2026-07-16):

- Criteria-level input-mapping overrides now reach execution for every evaluator kind. They were already part of the config fingerprint but hydration installed an empty (or evaluator-default) mapping, so a remapped criterion could evaluate the wrong context keys and still complete.
- Annotation writes are all-or-nothing: a work unit commits only a complete, error-free result set whose names match the configured outputs (built-ins keep their evaluator-defined single-result contract). Partial sets no longer mix outputs from different invocations under one identifier.
- Every evaluation has a hard 10-minute deadline: the eval task is cancelled and the unit fails with a counted attempt, so a hung evaluator can neither wedge the replica nor renew its lease forever. Shutdown keeps the 10-second grace drain and then cancels stragglers, so no evaluation outlives the sandbox manager it runs on.
- Transient failures still retry without burning attempts, but no longer forever: a unit older than 24 hours parks terminally instead of retrying, so a persistent transport failure cannot accumulate immortal work that closes admission instance-wide.
- Completion/failure transitions retry with bounded backoff, and completion treats an already-DONE row as success, so a transient DB failure at acknowledgement time no longer forces a paid re-execution.
- Lost claims are respected everywhere: expire/fail results are checked and a consumer that loses its claim stops heartbeating instead of renewing a dead lease every 30 seconds.

**Producer lifecycle** (same round):

- The outstanding-work limit is enforced as an insertion budget during materialization (including the exact boundary), not a once-per-tick boolean. When the budget truncates a window, the watermark does not advance and the idempotent inserts make the rescan cheap.
- The producer renews its cursor lease between tick phases and aborts the tick — rolling back any uncommitted inserts — the moment a fenced update shows the lease was lost, instead of committing work as a deposed leader.
- Work expired for a stale config fingerprint is resurrected to PENDING if the criterion reverts to that exact configuration before the span is annotated (the A→B→A case). TTL-shed work stays terminal, and the two expiry causes are now recorded distinctly.
- Queue gauges expose the retryable/exhausted error backlog — the population the admission gate actually counts — so an outage reads as a blocked queue rather than an empty one.

**Wiring and configuration** (same round):

- Read-only deployments no longer start the online-eval daemons.
- Lifespan teardown stops the producer before draining the consumer, so shutdown stops admission first.
- All tuning knobs validate their domains at startup (finiteness, sign, zero semantics); the unsupported `consumer_group` constructor option is removed.

## Test plan

- [x] Unit tests on both dialects (`--db all`, 121 online-eval tests): consumer happy path / evaluator-error cooldown / transient retry without burning attempts / transient age-bound parking / staleness guard / `stop()` grace drain + straggler cancellation / execution deadline (counted, non-transient) / atomic result sets (missing tool call, partial code results) / criteria input-mapping overrides; coordinator claim + fenced transitions; exact three-execution budget on both crash and failure paths; heartbeat stops after a lost claim; idempotent completion; A→B→A resurrection incl. TTL and annotated exclusions; insertion-budget truncation without watermark advance; lost-lease tick abort with rollback
- [x] App-wiring tests: flag on → seeded criteria + spans → producer materializes → consumer annotates; flag on + read-only → no daemons
- [x] Config getter domain validation tests (222 config tests)
- [x] ruff + mypy clean; full CI green, incl. SQLite/PostgreSQL unit + integration and e2e
