### PR TITLE
feat(pxi): pin assistant button to the top nav

### DIFF
--- a/app/src/components/agent/AgentChatTopNavButton.tsx
+++ b/app/src/components/agent/AgentChatTopNavButton.tsx
@@ -25,8 +25,10 @@ import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
 // Keep these in sync with topNavCSS in components/nav/Navbar.tsx: the nav has
 // `padding: static-size-100` (8px) and `padding-right: static-size-200`
 // (16px), so the detached pill rendered at these fixed offsets appears to
-// stay exactly where the in-flow pill was.
-const NAV_PILL_TOP_PX = 4;
+// stay exactly where the in-flow pill was. The detached wrapper contains the
+// same fixed-height pill wrapper as the in-flow pill, so aligning it with the
+// nav's top padding reproduces the in-flow position exactly.
+const NAV_PILL_TOP_PX = 8;
 const NAV_PILL_RIGHT_PX = 16;
 // Gap between the pill and an open drawer's left edge.
 const DRAWER_EDGE_GAP_PX = 12;
@@ -34,23 +36,26 @@ const DRAWER_EDGE_GAP_PX = 12;
 // drawer cannot push the pill off screen.
 const MIN_VIEWPORT_RIGHT_GAP_PX = 96;
 
-// Height of the resting pill (see FAB_RESTING_SIZE in agentFabPositioning.ts).
-// The streaming state grows to FAB_STREAMING_SIZE.height (40px); pinning the
-// wrapper to the resting height with visible overflow lets the taller
-// streaming state bleed out without reflowing the nav row.
-const RESTING_PILL_HEIGHT_PX = 36;
+// Height of the nav's natural content row (a size-S control is 30px), NOT the
+// pill's rendered height. The resting pill (36px, see FAB_RESTING_SIZE in
+// agentFabPositioning.ts) and the streaming state (40px,
+// FAB_STREAMING_SIZE.height) are both taller; pinning the wrapper to the
+// nav's natural content height with visible overflow lets the pill bleed
+// into the nav's 8px vertical padding without inflating the nav row —
+// toggling the pill in and out of the nav must not shift the layout.
+const NAV_PILL_WRAPPER_HEIGHT_PX = 30;
 
-// Fixed-height, centered wrapper so the button's height animation (resting
-// 36px <-> streaming 40px) does not change the wrapper's box and reflow the
-// surrounding layout. The wrapper keeps its intrinsic size when the nav gets
-// tight; the breadcrumb is the nav's designated shrinking region (see
-// topNavCSS in Navbar.tsx).
+// Fixed-height, centered wrapper so neither the pill's resting size nor its
+// height animation (resting 36px <-> streaming 40px) changes the wrapper's
+// box and reflows the surrounding layout. The wrapper keeps its intrinsic
+// size when the nav gets tight; the breadcrumb is the nav's designated
+// shrinking region (see topNavCSS in Navbar.tsx).
 const pillWrapperCSS = css`
   flex: none;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: ${RESTING_PILL_HEIGHT_PX}px;
+  height: ${NAV_PILL_WRAPPER_HEIGHT_PX}px;
   overflow: visible;
 `;
 

--- a/app/src/components/agent/AgentChatTopNavButton.tsx
+++ b/app/src/components/agent/AgentChatTopNavButton.tsx
@@ -26,7 +26,7 @@ import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
 // `padding: static-size-100` (8px) and `padding-right: static-size-200`
 // (16px), so the detached pill rendered at these fixed offsets appears to
 // stay exactly where the in-flow pill was.
-const NAV_PILL_TOP_PX = 8;
+const NAV_PILL_TOP_PX = 4;
 const NAV_PILL_RIGHT_PX = 16;
 // Gap between the pill and an open drawer's left edge.
 const DRAWER_EDGE_GAP_PX = 12;
@@ -34,10 +34,24 @@ const DRAWER_EDGE_GAP_PX = 12;
 // drawer cannot push the pill off screen.
 const MIN_VIEWPORT_RIGHT_GAP_PX = 96;
 
-// The pill keeps its intrinsic size when the nav gets tight; the breadcrumb
-// is the nav's designated shrinking region (see topNavCSS in Navbar.tsx).
-const inlineNavPillCSS = css`
+// Height of the resting pill (see FAB_RESTING_SIZE in agentFabPositioning.ts).
+// The streaming state grows to FAB_STREAMING_SIZE.height (40px); pinning the
+// wrapper to the resting height with visible overflow lets the taller
+// streaming state bleed out without reflowing the nav row.
+const RESTING_PILL_HEIGHT_PX = 36;
+
+// Fixed-height, centered wrapper so the button's height animation (resting
+// 36px <-> streaming 40px) does not change the wrapper's box and reflow the
+// surrounding layout. The wrapper keeps its intrinsic size when the nav gets
+// tight; the breadcrumb is the nav's designated shrinking region (see
+// topNavCSS in Navbar.tsx).
+const pillWrapperCSS = css`
   flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: ${RESTING_PILL_HEIGHT_PX}px;
+  overflow: visible;
 `;
 
 const detachedPillCSS = css`
@@ -156,16 +170,17 @@ export function AgentChatTopNavButton() {
   }
 
   const button = (
-    <TooltipTrigger delay={1000} closeDelay={0}>
-      <AgentChatWidgetButton
-        ariaLabel="Open assistant"
-        aria-expanded={isOpen}
-        isStreaming={isStreaming}
-        onPress={() => toggleOpen()}
-        css={inlineNavPillCSS}
-      />
-      <AgentChatWidgetTooltip />
-    </TooltipTrigger>
+    <div css={pillWrapperCSS}>
+      <TooltipTrigger delay={1000} closeDelay={0}>
+        <AgentChatWidgetButton
+          ariaLabel="Open assistant"
+          aria-expanded={isOpen}
+          isStreaming={isStreaming}
+          onPress={() => toggleOpen()}
+        />
+        <AgentChatWidgetTooltip />
+      </TooltipTrigger>
+    </div>
   );
 
   // Modals cover the whole viewport with a backdrop; portal into the modal

--- a/app/src/components/agent/AgentChatTopNavButton.tsx
+++ b/app/src/components/agent/AgentChatTopNavButton.tsx
@@ -1,0 +1,191 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useHotkeys } from "react-hotkeys-hook";
+
+import { TooltipTrigger } from "@phoenix/components";
+import {
+  MODAL_FLOATING_UI_Z_INDEX,
+  NON_MODAL_FLOATING_Z_INDEX,
+} from "@phoenix/components/core/zIndex";
+import { useAgentContext } from "@phoenix/contexts/AgentContext";
+import {
+  useActiveDrawerElement,
+  useActiveModalPortalContainerElement,
+} from "@phoenix/hooks/useHasOpenModal";
+
+import {
+  AgentChatWidgetButton,
+  AgentChatWidgetTooltip,
+  OPEN_AGENT_HOTKEY,
+} from "./AgentChatWidget";
+import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
+
+// Keep these in sync with topNavCSS in components/nav/Navbar.tsx: the nav has
+// `padding: static-size-100` (8px) and `padding-right: static-size-200`
+// (16px), so the detached pill rendered at these fixed offsets appears to
+// stay exactly where the in-flow pill was.
+const NAV_PILL_TOP_PX = 8;
+const NAV_PILL_RIGHT_PX = 16;
+// Gap between the pill and an open drawer's left edge.
+const DRAWER_EDGE_GAP_PX = 12;
+// Keep at least this much room at the left viewport edge so an extremely wide
+// drawer cannot push the pill off screen.
+const MIN_VIEWPORT_RIGHT_GAP_PX = 96;
+
+// The pill keeps its intrinsic size when the nav gets tight; the breadcrumb
+// is the nav's designated shrinking region (see topNavCSS in Navbar.tsx).
+const inlineNavPillCSS = css`
+  flex: none;
+`;
+
+const detachedPillCSS = css`
+  position: fixed;
+  top: ${NAV_PILL_TOP_PX}px;
+  z-index: ${NON_MODAL_FLOATING_Z_INDEX};
+  &[data-layer="modal"] {
+    z-index: ${MODAL_FLOATING_UI_Z_INDEX};
+  }
+  &[data-animate="true"] {
+    transition: right 300ms cubic-bezier(0.2, 0.9, 0.2, 1);
+  }
+`;
+
+type DrawerPillPosition = {
+  rightPx: number;
+  /**
+   * Animate only the initial travel to the drawer's edge. Subsequent updates
+   * come from the user dragging the drawer's resize handle and must track the
+   * pointer without a trailing transition.
+   */
+  animate: boolean;
+};
+
+/**
+ * Fixed-position wrapper that keeps its children just outside an open
+ * drawer's left edge, tracking drawer resizes. Mount only while a drawer is
+ * open; position state resets when it unmounts.
+ */
+function DrawerAnchoredPill({
+  drawer,
+  children,
+}: {
+  drawer: HTMLElement;
+  children: ReactNode;
+}) {
+  const [position, setPosition] = useState<DrawerPillPosition | null>(null);
+
+  useEffect(() => {
+    let isFirstUpdate = true;
+    const update = (animate: boolean) => {
+      // offsetWidth ignores the drawer's slide-in transform, so the first
+      // update resolves directly to the drawer's resting edge and the CSS
+      // transition covers the travel.
+      const rightPx = Math.min(
+        drawer.offsetWidth + DRAWER_EDGE_GAP_PX,
+        window.innerWidth - MIN_VIEWPORT_RIGHT_GAP_PX
+      );
+      setPosition({ rightPx, animate });
+    };
+    // The observer fires once on observe, which handles initial positioning.
+    const observer = new ResizeObserver(() => {
+      update(isFirstUpdate);
+      isFirstUpdate = false;
+    });
+    observer.observe(drawer);
+    const handleViewportResize = () => update(false);
+    window.addEventListener("resize", handleViewportResize);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", handleViewportResize);
+    };
+  }, [drawer]);
+
+  return createPortal(
+    <div
+      css={detachedPillCSS}
+      style={{ right: position?.rightPx ?? NAV_PILL_RIGHT_PX }}
+      data-animate={(position?.animate ?? true) ? "true" : "false"}
+    >
+      {children}
+    </div>,
+    document.body
+  );
+}
+
+/**
+ * The PXI assistant button pinned to the far right of the top nav.
+ *
+ * Renders inline in the nav flow so it never overlaps page content. Because
+ * drawers (slideovers) are fixed to the right viewport edge and cover the top
+ * nav's right side, the pill detaches while one is open and slides left to
+ * rest just outside the drawer's edge, tracking drawer resizes. While a modal
+ * is open it portals into the modal layer so it stays interactive above the
+ * backdrop.
+ */
+export function AgentChatTopNavButton() {
+  const isAssistantAgentEnabled = useAssistantAgentEnabled();
+  const isOpen = useAgentContext((state) => state.isOpen);
+  const toggleOpen = useAgentContext((state) => state.toggleOpen);
+  const activeSessionId = useAgentContext((state) => state.activeSessionId);
+  const isStreaming = useAgentContext((state) =>
+    activeSessionId
+      ? state.chatStatusBySessionId[activeSessionId] === "streaming"
+      : false
+  );
+  const drawer = useActiveDrawerElement();
+  const modalContainer = useActiveModalPortalContainerElement();
+
+  useHotkeys(
+    OPEN_AGENT_HOTKEY,
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      toggleOpen();
+    },
+    {
+      enabled: isAssistantAgentEnabled,
+      preventDefault: true,
+    },
+    [isAssistantAgentEnabled, toggleOpen]
+  );
+
+  if (!isAssistantAgentEnabled) {
+    return null;
+  }
+
+  const button = (
+    <TooltipTrigger delay={1000} closeDelay={0}>
+      <AgentChatWidgetButton
+        ariaLabel="Open assistant"
+        aria-expanded={isOpen}
+        isStreaming={isStreaming}
+        onPress={() => toggleOpen()}
+        css={inlineNavPillCSS}
+      />
+      <AgentChatWidgetTooltip />
+    </TooltipTrigger>
+  );
+
+  // Modals cover the whole viewport with a backdrop; portal into the modal
+  // layer (like the floating FAB does) so the pill stays interactive.
+  if (modalContainer) {
+    return createPortal(
+      <div
+        css={detachedPillCSS}
+        style={{ right: NAV_PILL_RIGHT_PX }}
+        data-layer="modal"
+      >
+        {button}
+      </div>,
+      modalContainer
+    );
+  }
+
+  if (drawer) {
+    return <DrawerAnchoredPill drawer={drawer}>{button}</DrawerAnchoredPill>;
+  }
+
+  return button;
+}

--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -24,7 +24,7 @@ import { FAB_RESTING_SIZE, FAB_STREAMING_SIZE } from "./agentFabPositioning";
 import { PxiGlyph, type PxiGlyphAnimation } from "./PxiGlyph";
 import { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
 
-const OPEN_AGENT_HOTKEY = "mod+i";
+export const OPEN_AGENT_HOTKEY = "mod+i";
 
 const thinkingBorderWipe = keyframes`
   0% {
@@ -538,7 +538,7 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
   );
 }
 
-function AgentChatWidgetTooltip() {
+export function AgentChatWidgetTooltip() {
   const modifierKey = useModifierKey();
   const modifierGlyph = modifierKey === "Cmd" ? "⌘" : "Ctrl";
 

--- a/app/src/components/agent/index.tsx
+++ b/app/src/components/agent/index.tsx
@@ -7,6 +7,7 @@ export {
 } from "./AgentExperimentalSettings";
 export { SystemSettingsWarning } from "./SystemSettingsWarning";
 export { AgentChatPanel, FloatingAgentChatPanel } from "./AgentChatPanel";
+export { AgentChatTopNavButton } from "./AgentChatTopNavButton";
 export { AgentChatWidget } from "./AgentChatWidget";
 export { useAssistantAgentEnabled } from "./useAssistantAgentEnabled";
 export { Chat } from "./Chat";

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -25,6 +25,14 @@ const topNavCSS = css`
   align-items: center;
   gap: var(--global-dimension-static-size-100);
 
+  /* The PXI pill's decorative glow (.agent-chat-widget__hover-shimmer,
+     inset: -28px) extends past the nav's right padding. Clip horizontal
+     paint overflow — without creating a scroll container — so it does not
+     add scrollable overflow (a horizontal scrollbar) to the surrounding
+     layout panel. Vertical overflow stays visible for the pill's streaming
+     height bleed (see pillWrapperCSS in agent/AgentChatTopNavButton.tsx). */
+  overflow-x: clip;
+
   /* The breadcrumb trail (an <ol> from the Breadcrumbs component) is the
      nav's designated shrinking region: give the whole chain a min-width so
      crumb links can compress to their ellipsis and right-aligned controls

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -25,6 +25,21 @@ const topNavCSS = css`
   align-items: center;
   gap: var(--global-dimension-static-size-100);
 
+  /* The breadcrumb trail (an <ol> from the Breadcrumbs component) is the
+     nav's designated shrinking region: give the whole chain a min-width so
+     crumb links can compress to their ellipsis and right-aligned controls
+     (page actions, the PXI button) stay visible when the nav narrows —
+     e.g. while the docked assistant panel is open. */
+  & > ol {
+    flex: 0 1 auto;
+    min-width: 0;
+
+    .breadcrumb,
+    .breadcrumb > div {
+      min-width: 0;
+    }
+  }
+
   .copy-action-menu__button {
     opacity: 0;
     transition: none;

--- a/app/src/hooks/useHasOpenModal.ts
+++ b/app/src/hooks/useHasOpenModal.ts
@@ -151,6 +151,18 @@ export function useHasOpenDrawer() {
 }
 
 /**
+ * Returns the topmost open Phoenix drawer element, or `null` when none is
+ * mounted.
+ *
+ * Useful for UI that needs to reposition itself relative to a drawer's edge
+ * (drawers are fixed to the right viewport edge and cover content beneath
+ * them).
+ */
+export function useActiveDrawerElement() {
+  return useSyncExternalStore(subscribe, getActiveDrawerElement, () => null);
+}
+
+/**
  * Returns the portal container for the topmost open modal.
  *
  * Consumers that need to remain interactive while a modal is open should portal

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -6,7 +6,7 @@ import { Outlet, useLoaderData } from "react-router";
 import { Counter, Flex, Icon, Icons, Loading } from "@phoenix/components";
 import {
   AgentChatPanel,
-  AgentChatWidget,
+  AgentChatTopNavButton,
   FloatingAgentChatPanel,
   useAssistantAgentEnabled,
 } from "@phoenix/components/agent";
@@ -128,9 +128,9 @@ export function Layout() {
                 <SideNavToggleButton />
                 <NavBreadcrumb />
                 <TopNavActionsSlot />
+                <AgentChatTopNavButton />
               </TopNavbar>
               <div data-testid="content" css={contentCSS} ref={contentRef}>
-                <AgentChatWidget boundaryRef={contentRef} />
                 {shouldShowFloatingAgentPanel ? (
                   <FloatingAgentChatPanel
                     boundaryRef={contentRef}

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -7,6 +7,7 @@ import { Counter, Flex, Icon, Icons, Loading } from "@phoenix/components";
 import {
   AgentChatPanel,
   AgentChatTopNavButton,
+  AgentChatWidget,
   FloatingAgentChatPanel,
   useAssistantAgentEnabled,
 } from "@phoenix/components/agent";
@@ -90,6 +91,9 @@ export function Layout() {
   const isAgentAssistantEnabled = useAssistantAgentEnabled();
   const isAgentPanelOpen = useAgentContext((state) => state.isOpen);
   const agentPosition = useAgentContext((state) => state.position);
+  const isAgentFabFloating = useAgentContext(
+    (state) => state.fabMode === "floating"
+  );
   const hasOpenModal = useHasOpenModal();
   const hasOpenDrawer = useHasOpenDrawer();
   const shouldForceFloatingAgentPanel = hasOpenModal || hasOpenDrawer;
@@ -128,9 +132,12 @@ export function Layout() {
                 <SideNavToggleButton />
                 <NavBreadcrumb />
                 <TopNavActionsSlot />
-                <AgentChatTopNavButton />
+                {isAgentFabFloating ? null : <AgentChatTopNavButton />}
               </TopNavbar>
               <div data-testid="content" css={contentCSS} ref={contentRef}>
+                {isAgentFabFloating ? (
+                  <AgentChatWidget boundaryRef={contentRef} />
+                ) : null}
                 {shouldShowFloatingAgentPanel ? (
                   <FloatingAgentChatPanel
                     boundaryRef={contentRef}

--- a/app/src/pages/settings/SettingsAgentsPage.tsx
+++ b/app/src/pages/settings/SettingsAgentsPage.tsx
@@ -92,24 +92,63 @@ function AssistantAgentEnabledSetting() {
     (state) => state.setIsAssistantAgentEnabled
   );
   return (
+    <li css={settingRowCSS}>
+      <Switch
+        labelPlacement="start"
+        isSelected={adminAssistantEnabled && isAssistantAgentEnabled}
+        isDisabled={!adminAssistantEnabled}
+        onChange={setIsAssistantAgentEnabled}
+        css={settingSwitchCSS}
+      >
+        <span className="assistant-personal-settings__label">
+          <Text weight="heavy">Use assistant</Text>
+          <Text color="text-500" size="S">
+            Shows the assistant in this browser.
+          </Text>
+        </span>
+      </Switch>
+      {!adminAssistantEnabled ? <SystemSettingsWarning /> : null}
+    </li>
+  );
+}
+
+function AssistantFabModeSetting() {
+  const adminAssistantEnabled = useAgentContext(
+    (state) => state.agentsConfig.assistantEnabled
+  );
+  const isAssistantAgentEnabled = usePreferencesContext(
+    (state) => state.isAssistantAgentEnabled
+  );
+  const fabMode = useAgentContext((state) => state.fabMode);
+  const setFabMode = useAgentContext((state) => state.setFabMode);
+  return (
+    <li css={settingRowCSS}>
+      <Switch
+        labelPlacement="start"
+        isSelected={fabMode === "floating"}
+        isDisabled={!adminAssistantEnabled || !isAssistantAgentEnabled}
+        onChange={(isFloating) =>
+          setFabMode(isFloating ? "floating" : "pinned")
+        }
+        css={settingSwitchCSS}
+      >
+        <span className="assistant-personal-settings__label">
+          <Text weight="heavy">Floating assistant button</Text>
+          <Text color="text-500" size="S">
+            Shows the assistant as a draggable floating button instead of
+            pinning it to the top navigation bar.
+          </Text>
+        </span>
+      </Switch>
+    </li>
+  );
+}
+
+function AssistantDisplaySettings() {
+  return (
     <ul css={settingsListCSS}>
-      <li css={settingRowCSS}>
-        <Switch
-          labelPlacement="start"
-          isSelected={adminAssistantEnabled && isAssistantAgentEnabled}
-          isDisabled={!adminAssistantEnabled}
-          onChange={setIsAssistantAgentEnabled}
-          css={settingSwitchCSS}
-        >
-          <span className="assistant-personal-settings__label">
-            <Text weight="heavy">Use assistant</Text>
-            <Text color="text-500" size="S">
-              Shows the assistant in this browser.
-            </Text>
-          </span>
-        </Switch>
-        {!adminAssistantEnabled ? <SystemSettingsWarning /> : null}
-      </li>
+      <AssistantAgentEnabledSetting />
+      <AssistantFabModeSetting />
     </ul>
   );
 }
@@ -140,7 +179,7 @@ function PersonalSettingsSection() {
         These settings apply only to this browser. System settings control which
         options are available.
       </Text>
-      <AssistantAgentEnabledSetting />
+      <AssistantDisplaySettings />
       <AgentSettingsForm>
         <AgentWebAccessSettings />
         {shouldShowSubagentsSetting(window.Config.agentBashDisabled) ? (

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -508,6 +508,22 @@ describe("agentStore", () => {
     });
   });
 
+  describe("setFabMode", () => {
+    it("defaults to the pinned top-nav button", () => {
+      const store = createAgentStore();
+
+      expect(store.getState().fabMode).toBe("pinned");
+    });
+
+    it("switches the assistant button to floating", () => {
+      const store = createAgentStore();
+
+      store.getState().setFabMode("floating");
+
+      expect(store.getState().fabMode).toBe("floating");
+    });
+  });
+
   describe("setFabPlacement", () => {
     it("updates the pinned FAB corner", () => {
       const store = createAgentStore();

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -45,6 +45,14 @@ export type AgentFabPlacement =
   | "bottom-start"
   | "bottom-end";
 
+/**
+ * How the PXI assistant button is presented.
+ * - "pinned": rendered inline at the right edge of the top nav
+ * - "floating": a draggable floating action button snapped to a viewport
+ *   corner (see {@link AgentFabPlacement})
+ */
+export type AgentFabMode = "pinned" | "floating";
+
 /** Server-provided PXI configuration exposed to the frontend. */
 export type AgentServerConfig = {
   /** Remote collector used for optional agent trace export. */
@@ -257,6 +265,8 @@ export interface AgentProps {
   isOpen: boolean;
   /** Current layout position of the agent panel. */
   position: AgentPosition;
+  /** Whether the assistant button is pinned to the top nav or floating. */
+  fabMode: AgentFabMode;
   /** Pinned corner for the global PXI floating action button. */
   fabPlacement: AgentFabPlacement;
   /** Ordered list of session IDs. */
@@ -285,6 +295,7 @@ export interface AgentState extends AgentProps {
   setIsOpen: (isOpen: boolean) => void;
   toggleOpen: () => void;
   setPosition: (position: AgentPosition) => void;
+  setFabMode: (mode: AgentFabMode) => void;
   setFabPlacement: (placement: AgentFabPlacement) => void;
   createSession: () => string;
   deleteSession: (sessionId: string) => void;
@@ -673,6 +684,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
   > = (set, get) => ({
     isOpen: false,
     position: "pinned",
+    fabMode: "pinned",
     fabPlacement: "bottom-end",
     sessions: [],
     activeSessionId: null,
@@ -704,6 +716,9 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
     },
     setPosition: (position) => {
       set({ position }, false, { type: "setPosition" });
+    },
+    setFabMode: (fabMode) => {
+      set({ fabMode }, false, { type: "setFabMode" });
     },
     setFabPlacement: (fabPlacement) => {
       set({ fabPlacement }, false, { type: "setFabPlacement" });
@@ -1378,6 +1393,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
       partialize: (state) => ({
         isOpen: state.isOpen,
         position: state.position,
+        fabMode: state.fabMode,
         fabPlacement: state.fabPlacement,
         sessions: state.sessions,
         activeSessionId: state.activeSessionId,


### PR DESCRIPTION
Replace the free-floating, draggable PXI FAB with a pill pinned to the far right of the top nav (Chrome "Ask Gemini" style) so it no longer overlaps page content. The button stays mounted while the chat is open and toggles the panel; aria-expanded conveys the open state.

Overlay handling:
- While a drawer (slideover) is open, the pill detaches and slides left to rest just outside the drawer's edge, tracking resize drags per-frame via ResizeObserver (only the initial travel animates).
- While a modal is open, it portals into the modal layer so it stays interactive above the backdrop, matching the old FAB behavior.

The top nav breadcrumb is now the designated shrinking region (min-width: 0 down the chain) so crumbs ellipsize instead of pushing right-aligned controls out of view when the docked panel narrows the nav.

## Pinned/floating toggle

A new **Floating assistant button** switch in Settings → Assistant → Personal settings lets users opt back into the draggable floating FAB. The preference (`fabMode: "pinned" | "floating"`) is persisted in the agent store per browser; pinned (top nav) is the default. Only one entry point mounts at a time, so the `mod+i` hotkey registers exactly once.

Pinned-pill layout fixes that came out of dogfooding the toggle:
- The nav clips horizontal paint overflow (`overflow-x: clip`) so the pill's decorative glow (`inset: -28px`) no longer creates a horizontal scrollbar in the layout panel's scroll container.
- The pill wrapper is pinned to the nav's natural 30px content height so the 36px pill bleeds into the nav's vertical padding instead of inflating the nav from 46px to 52px — toggling the pill in and out of the nav no longer shifts the layout. The detached (drawer/modal) pill offset matches the in-flow position exactly.

## Screenshots

Pinned (default) — the PXI pill sits inline at the right edge of the top nav:

![Pinned assistant pill in the top nav](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14105-pinned-mode.png)

The new setting, toggled on — the pill leaves the nav and the FAB appears in the bottom-right corner:

![Floating assistant button setting toggled on](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14105-settings-toggle.png)

Floating mode — the draggable corner-snapping FAB, with a clean top nav:

![Floating FAB in the bottom-right corner](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14105-floating-mode.png)

resolves #13974
