### PR TITLE
feat(app): global search command palette (⌘K)

### DIFF
--- a/.agents/skills/phoenix-design/references/empty-states.md
+++ b/.agents/skills/phoenix-design/references/empty-states.md
@@ -50,24 +50,11 @@ so a search in an empty list wrongly stays on the topical state.
 
 ## Never render a bare `Text` as an empty state
 
-Any `renderEmptyState` — menus, comboboxes, and command palettes (`⌘K`) — must
+Any `renderEmptyState` — menus, comboboxes, and command palettes must
 render `CompactEmptyState`, never a lone `<Text>No results</Text>`. Bare text
 skips the topical/search icon, the subtle theme-aware color, the centering, and
 the faint glow, so it reads as a stray label rather than a considered empty
 state and drifts from every other empty surface.
-
-For a command palette the state is always a search, so let the shared default do
-the work — pass no `renderEmptyState` and `CommandPalette` renders the search
-icon + "No results" for you. Only override when the surface needs a genuinely
-different message, and even then reach for `CompactEmptyState`, not `Text`.
-
-```tsx
-// ✗ drifts from the system — no icon, no glow, wrong color
-renderEmptyState={() => <Text color="text-500">No results for “{query}”</Text>}
-
-// ✓ omit it entirely; the palette's default CompactEmptyState covers it
-<CommandPalette /* … */ >{items}</CommandPalette>
-```
 
 # Empty-State Graphics
 

--- a/.agents/skills/phoenix-design/references/empty-states.md
+++ b/.agents/skills/phoenix-design/references/empty-states.md
@@ -48,6 +48,27 @@ e.g. a server-filtered table that tracks its own filter string:
 Do not gate `isFiltered` on `items.length` — with zero items that never flips,
 so a search in an empty list wrongly stays on the topical state.
 
+## Never render a bare `Text` as an empty state
+
+Any `renderEmptyState` — menus, comboboxes, and command palettes (`⌘K`) — must
+render `CompactEmptyState`, never a lone `<Text>No results</Text>`. Bare text
+skips the topical/search icon, the subtle theme-aware color, the centering, and
+the faint glow, so it reads as a stray label rather than a considered empty
+state and drifts from every other empty surface.
+
+For a command palette the state is always a search, so let the shared default do
+the work — pass no `renderEmptyState` and `CommandPalette` renders the search
+icon + "No results" for you. Only override when the surface needs a genuinely
+different message, and even then reach for `CompactEmptyState`, not `Text`.
+
+```tsx
+// ✗ drifts from the system — no icon, no glow, wrong color
+renderEmptyState={() => <Text color="text-500">No results for “{query}”</Text>}
+
+// ✓ omit it entirely; the palette's default CompactEmptyState covers it
+<CommandPalette /* … */ >{items}</CommandPalette>
+```
+
 # Empty-State Graphics
 
 `EmptyStateGraphic` renders the illustration shown above an `EmptyState`.

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3711,6 +3711,9 @@ type SandboxProviderCredentialSpec {
   isRequired: Boolean!
 }
 
+"""
+An entity returned by global search. One of the searchable resource types: Project, Dataset, Experiment, or Prompt.
+"""
 union SearchResult = Project | Dataset | Experiment | Prompt
 
 type Secret implements Node {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3498,6 +3498,11 @@ type Query {
   node(id: ID!): Node!
   viewer: User
   prompts(first: Int = 50, last: Int, after: String, before: String, filter: PromptFilter, labelIds: [ID!]): PromptConnection!
+
+  """
+  Search top-level resources (projects, datasets, experiments, and prompts) by name or description.
+  """
+  searchResources(query: String!, limitPerType: Int! = 5): [SearchResult!]!
   promptLabels(first: Int = 50, last: Int, after: String, before: String): PromptLabelConnection!
   datasetLabels(
     first: Int = 50
@@ -3705,6 +3710,8 @@ type SandboxProviderCredentialSpec {
   description: String!
   isRequired: Boolean!
 }
+
+union SearchResult = Project | Dataset | Experiment | Prompt
 
 type Secret implements Node {
   """The Globally Unique ID of this object"""

--- a/app/src/components/core/KeyboardToken.tsx
+++ b/app/src/components/core/KeyboardToken.tsx
@@ -18,17 +18,41 @@ const keyboardTokenCSS = css`
   text-transform: uppercase;
 `;
 
+// A subdued variant that drops the raised-key chrome (border, shadow, fill) in
+// favor of a faint outline, so the token recedes into dense surfaces like the
+// side navigation instead of competing with adjacent labels.
+const quietKeyboardTokenCSS = css`
+  background-color: transparent;
+  color: var(--ac-global-text-color-500);
+  padding: 0 var(--global-dimension-static-size-75);
+  font-size: var(--global-dimension-static-font-size-50);
+  border-radius: var(--global-rounding-small);
+  border: 1px solid var(--ac-global-border-color-default);
+  text-transform: uppercase;
+`;
+
 /**
  * Keyboard Token represents text that specifies a keyboard command,
  * and is styled to look like a keyboard key.
+ *
+ * Use the `quiet` variant when the token sits inside busy chrome (e.g. the
+ * side navigation) and the raised-key styling would be too loud.
  */
 export function KeyboardToken({
   ref,
   children,
+  variant = "default",
   ...props
-}: KeyboardProps & { ref?: Ref<HTMLElement> }) {
+}: KeyboardProps & {
+  ref?: Ref<HTMLElement>;
+  variant?: "default" | "quiet";
+}) {
   return (
-    <Keyboard ref={ref} css={keyboardTokenCSS} {...props}>
+    <Keyboard
+      ref={ref}
+      css={variant === "quiet" ? quietKeyboardTokenCSS : keyboardTokenCSS}
+      {...props}
+    >
       {children}
     </Keyboard>
   );

--- a/app/src/components/core/commandpalette/CommandPalette.tsx
+++ b/app/src/components/core/commandpalette/CommandPalette.tsx
@@ -59,6 +59,16 @@ const commandPaletteCSS = css`
   .command-palette__menu {
     max-height: 50vh;
     overflow-y: auto;
+    /* Fade results in/out as they settle so a new search transition reads as a
+       smooth update rather than a hard swap. */
+    transition: opacity 0.15s ease;
+  }
+
+  &[data-pending="true"] .command-palette__menu {
+    /* While a search transition is in flight React keeps the prior results
+       mounted (see startTransition in GlobalSearchPalette); dim them slightly
+       to signal the refresh without unmounting anything. */
+    opacity: 0.5;
   }
 
   .command-palette__section:not(:first-child) {
@@ -149,6 +159,11 @@ export interface CommandPaletteProps {
    * Footer content. Defaults to keyboard navigation hints.
    */
   footer?: ReactNode;
+  /**
+   * Whether a search/results refresh is in flight. When true the results are
+   * dimmed to signal the pending update while the prior results stay mounted.
+   */
+  isPending?: boolean;
 }
 
 /**
@@ -169,6 +184,7 @@ export function CommandPalette({
   children,
   renderEmptyState,
   footer,
+  isPending,
 }: CommandPaletteProps) {
   return (
     <ModalOverlay isOpen={isOpen} onOpenChange={onOpenChange} isDismissable>
@@ -177,6 +193,7 @@ export function CommandPalette({
           aria-label={ariaLabel}
           className="command-palette"
           css={commandPaletteCSS}
+          data-pending={isPending ? "true" : undefined}
         >
           <Autocomplete
             inputValue={inputValue}

--- a/app/src/components/core/commandpalette/CommandPalette.tsx
+++ b/app/src/components/core/commandpalette/CommandPalette.tsx
@@ -13,7 +13,9 @@ import {
 
 import { Text } from "@phoenix/components/core/content";
 import { Dialog } from "@phoenix/components/core/dialog";
+import { CompactEmptyState } from "@phoenix/components/core/empty";
 import { SearchField, SearchIcon } from "@phoenix/components/core/field";
+import { Icon, Icons } from "@phoenix/components/core/icon";
 import { KeyboardToken } from "@phoenix/components/core/KeyboardToken";
 import { Menu } from "@phoenix/components/core/menu";
 import { Modal, ModalOverlay } from "@phoenix/components/core/overlay";
@@ -79,9 +81,15 @@ const commandPaletteCSS = css`
     align-items: center;
     flex: none;
     gap: var(--global-dimension-static-size-200);
-    padding: var(--global-dimension-static-size-100)
+    padding: var(--global-dimension-static-size-150)
       var(--global-dimension-static-size-200);
     border-top: 1px solid var(--global-border-color-default);
+  }
+
+  .command-palette__hint {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--global-dimension-static-size-100);
   }
 
   .command-palette__empty-state {
@@ -185,21 +193,26 @@ export function CommandPalette({
                 <SearchIcon />
                 <Input placeholder={placeholder} />
               </SearchField>
-              <KeyboardToken aria-hidden="true">Esc</KeyboardToken>
             </div>
             <Menu
               className="command-palette__menu"
               aria-label={ariaLabel}
               onAction={onAction}
-              renderEmptyState={() => (
-                <div className="command-palette__empty-state">
-                  {renderEmptyState ? (
-                    renderEmptyState()
-                  ) : (
-                    <Text color="text-500">No results</Text>
-                  )}
-                </div>
-              )}
+              renderEmptyState={() =>
+                renderEmptyState ? (
+                  <div className="command-palette__empty-state">
+                    {renderEmptyState()}
+                  </div>
+                ) : (
+                  // CompactEmptyState reads the Autocomplete's live query from
+                  // context, so a non-empty search renders the search icon +
+                  // "No results" automatically.
+                  <CompactEmptyState
+                    icon={<Icon svg={<Icons.Search />} />}
+                    description="No results"
+                  />
+                )
+              }
             >
               {children}
             </Menu>
@@ -216,18 +229,24 @@ export function CommandPalette({
 function CommandPaletteHints() {
   return (
     <>
-      <Text size="XS" color="text-500">
+      <span className="command-palette__hint">
         <KeyboardToken>↑↓</KeyboardToken>
-        &nbsp;to navigate
-      </Text>
-      <Text size="XS" color="text-500">
+        <Text size="XS" color="text-500">
+          to navigate
+        </Text>
+      </span>
+      <span className="command-palette__hint">
         <KeyboardToken>↵</KeyboardToken>
-        &nbsp;to select
-      </Text>
-      <Text size="XS" color="text-500">
+        <Text size="XS" color="text-500">
+          to select
+        </Text>
+      </span>
+      <span className="command-palette__hint">
         <KeyboardToken>esc</KeyboardToken>
-        &nbsp;to close
-      </Text>
+        <Text size="XS" color="text-500">
+          to close
+        </Text>
+      </span>
     </>
   );
 }

--- a/app/src/components/core/commandpalette/CommandPalette.tsx
+++ b/app/src/components/core/commandpalette/CommandPalette.tsx
@@ -1,0 +1,257 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
+import type {
+  AutocompleteProps as AriaAutocompleteProps,
+  Key,
+} from "react-aria-components";
+import {
+  Autocomplete,
+  Header,
+  Input,
+  MenuSection,
+} from "react-aria-components";
+
+import { Text } from "@phoenix/components/core/content";
+import { Dialog } from "@phoenix/components/core/dialog";
+import { SearchField, SearchIcon } from "@phoenix/components/core/field";
+import { KeyboardToken } from "@phoenix/components/core/KeyboardToken";
+import { Menu } from "@phoenix/components/core/menu";
+import { Modal, ModalOverlay } from "@phoenix/components/core/overlay";
+
+const commandPaletteModalCSS = css`
+  /* Pin the palette near the top of the viewport instead of centering it so
+     the list can grow and shrink without the dialog jumping around */
+  &&[data-variant="default"] .react-aria-Dialog {
+    top: 15vh;
+    transform: translate(-50%, 0);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+`;
+
+const commandPaletteCSS = css`
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+
+  .command-palette__field {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex: none;
+    gap: var(--global-dimension-static-size-100);
+    padding-right: var(--global-dimension-static-size-100);
+    border-bottom: 1px solid var(--global-border-color-default);
+
+    .search-field {
+      flex: 1 1 auto;
+    }
+
+    .react-aria-Input {
+      font-size: var(--global-font-size-m);
+      height: var(--global-dimension-size-550);
+    }
+  }
+
+  .command-palette__menu {
+    max-height: 50vh;
+    overflow-y: auto;
+  }
+
+  .command-palette__section:not(:first-child) {
+    margin-top: var(--global-dimension-static-size-100);
+  }
+
+  .command-palette__section-header {
+    padding: var(--global-dimension-static-size-50)
+      var(--global-dimension-static-size-100);
+    color: var(--global-text-color-500);
+    font-size: var(--global-font-size-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .command-palette__footer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex: none;
+    gap: var(--global-dimension-static-size-200);
+    padding: var(--global-dimension-static-size-100)
+      var(--global-dimension-static-size-200);
+    border-top: 1px solid var(--global-border-color-default);
+  }
+
+  .command-palette__empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--global-dimension-static-size-300);
+  }
+`;
+
+export interface CommandPaletteProps {
+  /**
+   * Whether the command palette is open
+   */
+  isOpen: boolean;
+  /**
+   * Handler called when the open state changes (e.g. Escape, backdrop click)
+   */
+  onOpenChange: (isOpen: boolean) => void;
+  /**
+   * The search input value (controlled)
+   */
+  inputValue?: string;
+  /**
+   * Handler called when the search input value changes
+   */
+  onInputChange?: (value: string) => void;
+  /**
+   * An optional filter applied to the menu items based on the input value.
+   * Omit when the items are already filtered (e.g. server-side search).
+   */
+  filter?: AriaAutocompleteProps<object>["filter"];
+  /**
+   * Placeholder text for the search input
+   * @default "Search…"
+   */
+  placeholder?: string;
+  /**
+   * Accessible label for the palette
+   * @default "Command palette"
+   */
+  "aria-label"?: string;
+  /**
+   * Handler called when a menu item without its own handler is actioned
+   */
+  onAction?: (key: Key) => void;
+  /**
+   * Menu contents: CommandPaletteSection / CommandPaletteItem elements
+   */
+  children: ReactNode;
+  /**
+   * Content rendered when no items match. Receives no arguments; close over
+   * the input value for a contextual message.
+   */
+  renderEmptyState?: () => ReactNode;
+  /**
+   * Footer content. Defaults to keyboard navigation hints.
+   */
+  footer?: ReactNode;
+}
+
+/**
+ * A command palette (⌘K style) dialog: a search input wired to a menu of
+ * commands or search results via React Aria's Autocomplete, giving virtual
+ * focus — arrow keys move through results while focus stays in the input —
+ * along with Enter to select and Escape to dismiss.
+ */
+export function CommandPalette({
+  isOpen,
+  onOpenChange,
+  inputValue,
+  onInputChange,
+  filter,
+  placeholder = "Search…",
+  "aria-label": ariaLabel = "Command palette",
+  onAction,
+  children,
+  renderEmptyState,
+  footer,
+}: CommandPaletteProps) {
+  return (
+    <ModalOverlay isOpen={isOpen} onOpenChange={onOpenChange} isDismissable>
+      <Modal size="M" css={commandPaletteModalCSS}>
+        <Dialog
+          aria-label={ariaLabel}
+          className="command-palette"
+          css={commandPaletteCSS}
+        >
+          <Autocomplete
+            inputValue={inputValue}
+            onInputChange={onInputChange}
+            filter={filter}
+          >
+            <div className="command-palette__field">
+              <SearchField
+                aria-label={ariaLabel}
+                variant="quiet"
+                size="L"
+                autoFocus
+              >
+                <SearchIcon />
+                <Input placeholder={placeholder} />
+              </SearchField>
+              <KeyboardToken aria-hidden="true">Esc</KeyboardToken>
+            </div>
+            <Menu
+              className="command-palette__menu"
+              aria-label={ariaLabel}
+              onAction={onAction}
+              renderEmptyState={() => (
+                <div className="command-palette__empty-state">
+                  {renderEmptyState ? (
+                    renderEmptyState()
+                  ) : (
+                    <Text color="text-500">No results</Text>
+                  )}
+                </div>
+              )}
+            >
+              {children}
+            </Menu>
+            <div className="command-palette__footer">
+              {footer ?? <CommandPaletteHints />}
+            </div>
+          </Autocomplete>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}
+
+function CommandPaletteHints() {
+  return (
+    <>
+      <Text size="XS" color="text-500">
+        <KeyboardToken>↑↓</KeyboardToken>
+        &nbsp;to navigate
+      </Text>
+      <Text size="XS" color="text-500">
+        <KeyboardToken>↵</KeyboardToken>
+        &nbsp;to select
+      </Text>
+      <Text size="XS" color="text-500">
+        <KeyboardToken>esc</KeyboardToken>
+        &nbsp;to close
+      </Text>
+    </>
+  );
+}
+
+export interface CommandPaletteSectionProps {
+  /**
+   * The section heading, e.g. "Recently viewed"
+   */
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * A titled group of command palette items. Sections whose items are all
+ * filtered out are hidden automatically.
+ */
+export function CommandPaletteSection({
+  title,
+  children,
+}: CommandPaletteSectionProps) {
+  return (
+    <MenuSection className="command-palette__section">
+      <Header className="command-palette__section-header">{title}</Header>
+      {children}
+    </MenuSection>
+  );
+}

--- a/app/src/components/core/commandpalette/CommandPalette.tsx
+++ b/app/src/components/core/commandpalette/CommandPalette.tsx
@@ -117,7 +117,6 @@ const commandPaletteCSS = css`
     width: 100%;
     min-height: var(--global-dimension-size-1600);
     box-sizing: border-box;
-    padding: var(--global-dimension-static-size-300);
   }
 `;
 

--- a/app/src/components/core/commandpalette/CommandPalette.tsx
+++ b/app/src/components/core/commandpalette/CommandPalette.tsx
@@ -64,6 +64,14 @@ const commandPaletteCSS = css`
     transition: opacity 0.15s ease;
   }
 
+  .command-palette__menu[data-empty] {
+    /* When the menu is empty React Aria collapses it around the empty state;
+       stretch it so the empty state can fill the available width instead of
+       centering a collapsed box that gets clipped at the top and bottom. */
+    align-items: stretch;
+    padding: 0;
+  }
+
   &[data-pending="true"] .command-palette__menu {
     /* While a search transition is in flight React keeps the prior results
        mounted (see startTransition in GlobalSearchPalette); dim them slightly
@@ -106,6 +114,9 @@ const commandPaletteCSS = css`
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 100%;
+    min-height: var(--global-dimension-size-1600);
+    box-sizing: border-box;
     padding: var(--global-dimension-static-size-300);
   }
 `;
@@ -215,21 +226,21 @@ export function CommandPalette({
               className="command-palette__menu"
               aria-label={ariaLabel}
               onAction={onAction}
-              renderEmptyState={() =>
-                renderEmptyState ? (
-                  <div className="command-palette__empty-state">
-                    {renderEmptyState()}
-                  </div>
-                ) : (
-                  // CompactEmptyState reads the Autocomplete's live query from
-                  // context, so a non-empty search renders the search icon +
-                  // "No results" automatically.
-                  <CompactEmptyState
-                    icon={<Icon svg={<Icons.Search />} />}
-                    description="No results"
-                  />
-                )
-              }
+              renderEmptyState={() => (
+                <div className="command-palette__empty-state">
+                  {renderEmptyState ? (
+                    renderEmptyState()
+                  ) : (
+                    // CompactEmptyState reads the Autocomplete's live query
+                    // from context, so a non-empty search renders the search
+                    // icon + "No results" automatically.
+                    <CompactEmptyState
+                      icon={<Icon svg={<Icons.Search />} />}
+                      description="No results"
+                    />
+                  )}
+                </div>
+              )}
             >
               {children}
             </Menu>

--- a/app/src/components/core/commandpalette/CommandPaletteItem.tsx
+++ b/app/src/components/core/commandpalette/CommandPaletteItem.tsx
@@ -1,0 +1,95 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
+import type { MenuItemProps as AriaMenuItemProps } from "react-aria-components";
+
+import { MenuItem } from "@phoenix/components/core/menu";
+
+const commandPaletteItemCSS = css`
+  .command-palette-item__layout {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--global-dimension-static-size-100);
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
+  .command-palette-item__icon {
+    display: flex;
+    align-items: center;
+    flex: none;
+    color: var(--global-text-color-700);
+    font-size: var(--global-font-size-m);
+  }
+
+  .command-palette-item__label {
+    flex: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 60%;
+  }
+
+  .command-palette-item__description {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--global-text-color-500);
+    font-size: var(--global-font-size-s);
+  }
+`;
+
+export interface CommandPaletteItemProps extends Omit<
+  AriaMenuItemProps,
+  "children" | "className" | "style"
+> {
+  /**
+   * A leading visual, e.g. an <Icon />
+   */
+  icon?: ReactNode;
+  /**
+   * Secondary text shown dimmed after the label, truncated to one line
+   */
+  description?: ReactNode;
+  /**
+   * The primary label content
+   */
+  children: ReactNode;
+  /**
+   * Plain-text equivalent of the label, used for typeahead, filtering, and
+   * assistive technology. Required because the label may contain markup
+   * (e.g. match highlighting).
+   */
+  textValue: string;
+}
+
+/**
+ * A single result or command inside a CommandPalette, with an optional icon
+ * and dimmed one-line description.
+ */
+export function CommandPaletteItem({
+  icon,
+  description,
+  children,
+  ...props
+}: CommandPaletteItemProps) {
+  return (
+    <MenuItem
+      {...props}
+      className="command-palette-item"
+      css={commandPaletteItemCSS}
+    >
+      <div className="command-palette-item__layout">
+        {icon && <span className="command-palette-item__icon">{icon}</span>}
+        <span className="command-palette-item__label">{children}</span>
+        {description && (
+          <span className="command-palette-item__description">
+            {description}
+          </span>
+        )}
+      </div>
+    </MenuItem>
+  );
+}

--- a/app/src/components/core/commandpalette/MatchText.tsx
+++ b/app/src/components/core/commandpalette/MatchText.tsx
@@ -1,0 +1,44 @@
+import { css } from "@emotion/react";
+
+const matchTextCSS = css`
+  background-color: rgba(var(--global-color-blue-500-rgb), 0.4);
+  color: inherit;
+  border-radius: var(--global-rounding-xsmall);
+`;
+
+export interface MatchTextProps {
+  /**
+   * The full text to render
+   */
+  text: string;
+  /**
+   * The substring to highlight (case-insensitive, first occurrence)
+   */
+  match?: string;
+}
+
+/**
+ * Renders text with the first case-insensitive occurrence of `match`
+ * highlighted via a `<mark>` element so users can see why a search result
+ * matched their query.
+ */
+export function MatchText({ text, match }: MatchTextProps) {
+  const matchLength = match?.trim().length ?? 0;
+  if (!match || matchLength === 0) {
+    return <>{text}</>;
+  }
+  const matchStart = text.toLowerCase().indexOf(match.trim().toLowerCase());
+  if (matchStart === -1) {
+    return <>{text}</>;
+  }
+  const matchEnd = matchStart + matchLength;
+  return (
+    <>
+      {text.slice(0, matchStart)}
+      <mark className="match-text" css={matchTextCSS}>
+        {text.slice(matchStart, matchEnd)}
+      </mark>
+      {text.slice(matchEnd)}
+    </>
+  );
+}

--- a/app/src/components/core/commandpalette/index.tsx
+++ b/app/src/components/core/commandpalette/index.tsx
@@ -1,0 +1,3 @@
+export * from "./CommandPalette";
+export * from "./CommandPaletteItem";
+export * from "./MatchText";

--- a/app/src/components/core/empty/CompactEmptyState.tsx
+++ b/app/src/components/core/empty/CompactEmptyState.tsx
@@ -21,9 +21,10 @@ const compactEmptyStateCSS = css`
   // border-box so the 100% width includes the padding below; otherwise padding
   // is added outside the full width and overflows the popover → horizontal scroll.
   box-sizing: border-box;
-  // No min-height: the container drives size (a sized View, TableEmptyWrap, or a
-  // popover that wraps to content). The glow clips harmlessly in tight spots —
-  // it's ~0 alpha by its edge — and has all the room it needs in tall ones.
+  // Inherit the container's min-height so the glow fills sized regions (a sized
+  // View, TableEmptyWrap, or command palette menu) while still wrapping to
+  // content in compact popovers.
+  min-height: inherit;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/app/src/components/core/index.tsx
+++ b/app/src/components/core/index.tsx
@@ -12,6 +12,7 @@ export * from "./alert";
 export * from "./badge";
 export * from "./disclosure";
 export * from "./combobox";
+export * from "./commandpalette";
 export * from "./button";
 export * from "./icon";
 export * from "./view";

--- a/app/src/components/search/GlobalSearch.tsx
+++ b/app/src/components/search/GlobalSearch.tsx
@@ -1,0 +1,98 @@
+import { css } from "@emotion/react";
+import { Suspense, useState } from "react";
+import { Pressable, VisuallyHidden } from "react-aria-components";
+import { useHotkeys } from "react-hotkeys-hook";
+
+import {
+  ErrorBoundary,
+  Icon,
+  Icons,
+  KeyboardToken,
+  Text,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
+import { navLinkCSS } from "@phoenix/components/nav/Navbar";
+import { useModifierKey } from "@phoenix/hooks/useModifierKey";
+
+import { GlobalSearchPalette } from "./GlobalSearchPalette";
+import { RecentlyViewedTracker } from "./RecentlyViewedTracker";
+
+const SEARCH_HOTKEY = "mod+k";
+const SEARCH_SHORTHAND_HOTKEY = "f";
+
+const searchButtonCSS = css`
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: inherit;
+
+  .keyboard-token {
+    margin-inline-end: var(--global-dimension-size-100);
+  }
+`;
+
+/**
+ * The global search affordance: a search entry in the side navigation plus
+ * the ⌘K / F keyboard shortcuts, opening a command palette that searches
+ * projects, datasets, experiments, prompts, pages, and recently viewed
+ * resources.
+ */
+export function GlobalSearch({ isExpanded }: { isExpanded: boolean }) {
+  const [isOpen, setOpen] = useState(false);
+  const modifierKey = useModifierKey();
+  const modifierGlyph = modifierKey === "Cmd" ? "⌘" : "Ctrl";
+
+  useHotkeys(
+    SEARCH_HOTKEY,
+    (event) => {
+      event.preventDefault();
+      setOpen((isCurrentlyOpen) => !isCurrentlyOpen);
+    },
+    { preventDefault: true, enableOnFormTags: true },
+    [setOpen]
+  );
+  useHotkeys(
+    SEARCH_SHORTHAND_HOTKEY,
+    (event) => {
+      event.preventDefault();
+      setOpen(true);
+    },
+    [setOpen]
+  );
+
+  return (
+    <>
+      <RecentlyViewedTracker />
+      <TooltipTrigger delay={0} isDisabled={isExpanded}>
+        <Pressable>
+          <button
+            css={css(navLinkCSS, searchButtonCSS)}
+            onClick={() => setOpen(true)}
+            data-testid="global-search-trigger"
+          >
+            <Icon svg={<Icons.Search />} />
+            <Text>Search</Text>
+            <KeyboardToken className="keyboard-token">
+              <VisuallyHidden>{modifierKey}</VisuallyHidden>
+              <span aria-hidden="true">{modifierGlyph}</span>K
+            </KeyboardToken>
+          </button>
+        </Pressable>
+        <Tooltip placement="right" offset={10}>
+          Search
+        </Tooltip>
+      </TooltipTrigger>
+      {isOpen && (
+        // The ErrorBoundary remounts each time the palette opens (keyed on
+        // isOpen), so a failed search resets on the next open. A null fallback
+        // simply closes the palette rather than crashing the surrounding app.
+        <ErrorBoundary fallback={() => null}>
+          <Suspense fallback={null}>
+            <GlobalSearchPalette isOpen={isOpen} onOpenChange={setOpen} />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </>
+  );
+}

--- a/app/src/components/search/GlobalSearch.tsx
+++ b/app/src/components/search/GlobalSearch.tsx
@@ -19,7 +19,6 @@ import { GlobalSearchPalette } from "./GlobalSearchPalette";
 import { RecentlyViewedTracker } from "./RecentlyViewedTracker";
 
 const SEARCH_HOTKEY = "mod+k";
-const SEARCH_SHORTHAND_HOTKEY = "f";
 
 const searchButtonCSS = css`
   border: none;
@@ -38,7 +37,7 @@ const searchButtonCSS = css`
 
 /**
  * The global search affordance: a search entry in the side navigation plus
- * the ⌘K / F keyboard shortcuts, opening a command palette that searches
+ * the ⌘K keyboard shortcut, opening a command palette that searches
  * projects, datasets, experiments, prompts, pages, and recently viewed
  * resources.
  */
@@ -54,14 +53,6 @@ export function GlobalSearch({ isExpanded }: { isExpanded: boolean }) {
       setOpen((isCurrentlyOpen) => !isCurrentlyOpen);
     },
     { preventDefault: true, enableOnFormTags: true },
-    [setOpen]
-  );
-  useHotkeys(
-    SEARCH_SHORTHAND_HOTKEY,
-    (event) => {
-      event.preventDefault();
-      setOpen(true);
-    },
     [setOpen]
   );
 

--- a/app/src/components/search/GlobalSearch.tsx
+++ b/app/src/components/search/GlobalSearch.tsx
@@ -28,7 +28,11 @@ const searchButtonCSS = css`
   font-size: inherit;
 
   .keyboard-token {
+    // Match the trailing counter geometry (Navbar's .counter) so the ⌘K
+    // hint right-aligns with the numeric counts on sibling nav items: same
+    // trailing margin and same horizontal padding.
     margin-inline-end: var(--global-dimension-size-100);
+    padding-inline: var(--global-dimension-size-50);
   }
 `;
 
@@ -73,7 +77,7 @@ export function GlobalSearch({ isExpanded }: { isExpanded: boolean }) {
           >
             <Icon svg={<Icons.Search />} />
             <Text>Search</Text>
-            <KeyboardToken className="keyboard-token">
+            <KeyboardToken variant="quiet" className="keyboard-token">
               <VisuallyHidden>{modifierKey}</VisuallyHidden>
               <span aria-hidden="true">{modifierGlyph}</span>K
             </KeyboardToken>

--- a/app/src/components/search/GlobalSearchPalette.tsx
+++ b/app/src/components/search/GlobalSearchPalette.tsx
@@ -98,6 +98,18 @@ const RESOURCE_ICONS: Record<RecentlyViewedResourceType, React.ReactNode> = {
   prompt: <Icon svg={<Icons.MessageSquare />} />,
 };
 
+/**
+ * Search result sections, in the order they render. Results are collected into
+ * a map keyed by resource type and flattened against this list at render time,
+ * so no code depends on a section's position in an array.
+ */
+const RESULT_SECTIONS: { title: string; type: RecentlyViewedResourceType }[] = [
+  { title: "Projects", type: "project" },
+  { title: "Datasets", type: "dataset" },
+  { title: "Experiments", type: "experiment" },
+  { title: "Prompts", type: "prompt" },
+];
+
 export function GlobalSearchPalette({
   isOpen,
   onOpenChange,
@@ -141,7 +153,7 @@ export function GlobalSearchPalette({
 
   return (
     <SearchResultsLoader searchQuery={searchQuery.trim()}>
-      {(resultSections) => (
+      {(resultsByType) => (
         <CommandPalette
           isOpen={isOpen}
           onOpenChange={onOpenChange}
@@ -187,11 +199,14 @@ export function GlobalSearchPalette({
               ))}
             </CommandPaletteSection>
           )}
-          {resultSections
-            .filter((section) => section.resources.length > 0)
-            .map((section) => (
-              <CommandPaletteSection key={section.title} title={section.title}>
-                {section.resources.map(({ resource, description }) => (
+          {RESULT_SECTIONS.map((section) => {
+            const entries = resultsByType.get(section.type) ?? [];
+            if (entries.length === 0) {
+              return null;
+            }
+            return (
+              <CommandPaletteSection key={section.type} title={section.title}>
+                {entries.map(({ resource, description }) => (
                   <CommandPaletteItem
                     key={`result:${resource.id}`}
                     id={`result:${resource.id}`}
@@ -208,20 +223,26 @@ export function GlobalSearchPalette({
                   </CommandPaletteItem>
                 ))}
               </CommandPaletteSection>
-            ))}
+            );
+          })}
         </CommandPalette>
       )}
     </SearchResultsLoader>
   );
 }
 
-type ResultSection = {
-  title: string;
-  type: RecentlyViewedResourceType;
-  resources: { resource: RecentlyViewedResource; description?: string }[];
+type ResultEntry = {
+  resource: RecentlyViewedResource;
+  description?: string;
 };
 
-type SearchResultsChildren = (resultSections: ResultSection[]) => ReactNode;
+/**
+ * Search results grouped by resource type. Consumers flatten this against
+ * {@link RESULT_SECTIONS} to render sections in a stable order.
+ */
+type SearchResultsByType = Map<RecentlyViewedResourceType, ResultEntry[]>;
+
+type SearchResultsChildren = (results: SearchResultsByType) => ReactNode;
 
 /**
  * Loads server search results and hands them to `children` as plain data.
@@ -239,7 +260,7 @@ function SearchResultsLoader({
   children: SearchResultsChildren;
 }) {
   if (!searchQuery) {
-    return children([]);
+    return children(new Map());
   }
   return (
     <SearchResultsData searchQuery={searchQuery}>{children}</SearchResultsData>
@@ -290,16 +311,19 @@ function SearchResultsData({
     { fetchPolicy: "store-and-network" }
   );
 
-  const resultSections: ResultSection[] = [
-    { title: "Projects", type: "project", resources: [] },
-    { title: "Datasets", type: "dataset", resources: [] },
-    { title: "Experiments", type: "experiment", resources: [] },
-    { title: "Prompts", type: "prompt", resources: [] },
-  ];
+  const resultsByType: SearchResultsByType = new Map();
+  const addEntry = (entry: ResultEntry) => {
+    const entries = resultsByType.get(entry.resource.type);
+    if (entries) {
+      entries.push(entry);
+    } else {
+      resultsByType.set(entry.resource.type, [entry]);
+    }
+  };
   for (const result of data.searchResources) {
     switch (result.__typename) {
       case "Project":
-        resultSections[0].resources.push({
+        addEntry({
           resource: {
             id: result.id,
             type: "project",
@@ -310,7 +334,7 @@ function SearchResultsData({
         });
         break;
       case "Dataset":
-        resultSections[1].resources.push({
+        addEntry({
           resource: {
             id: result.id,
             type: "dataset",
@@ -321,7 +345,7 @@ function SearchResultsData({
         });
         break;
       case "Experiment":
-        resultSections[2].resources.push({
+        addEntry({
           resource: {
             id: result.id,
             type: "experiment",
@@ -332,7 +356,7 @@ function SearchResultsData({
         });
         break;
       case "Prompt":
-        resultSections[3].resources.push({
+        addEntry({
           resource: {
             id: result.id,
             type: "prompt",
@@ -345,5 +369,5 @@ function SearchResultsData({
     }
   }
 
-  return children(resultSections);
+  return children(resultsByType);
 }

--- a/app/src/components/search/GlobalSearchPalette.tsx
+++ b/app/src/components/search/GlobalSearchPalette.tsx
@@ -11,7 +11,6 @@ import {
   Icon,
   Icons,
   MatchText,
-  Text,
   useFilter,
 } from "@phoenix/components";
 import type {
@@ -93,7 +92,7 @@ const DESTINATIONS: SearchDestination[] = [
 ];
 
 const RESOURCE_ICONS: Record<RecentlyViewedResourceType, React.ReactNode> = {
-  project: <Icon svg={<Icons.Grid />} />,
+  project: <Icon svg={<Icons.Trace />} />,
   dataset: <Icon svg={<Icons.Database />} />,
   experiment: <Icon svg={<Icons.Experiment />} />,
   prompt: <Icon svg={<Icons.MessageSquare />} />,
@@ -153,9 +152,6 @@ export function GlobalSearchPalette({
             setInputValue(value);
             debouncedSetSearchQuery(value);
           }}
-          renderEmptyState={() => (
-            <Text color="text-500">No results for “{inputValue}”</Text>
-          )}
         >
           {matchingRecentlyViewed.length > 0 && (
             <CommandPaletteSection title="Recently viewed">

--- a/app/src/components/search/GlobalSearchPalette.tsx
+++ b/app/src/components/search/GlobalSearchPalette.tsx
@@ -179,6 +179,7 @@ export function GlobalSearchPalette({
                   id={`recent:${resource.id}`}
                   textValue={resource.name}
                   icon={RESOURCE_ICONS[resource.type]}
+                  description={resource.description}
                   onAction={() => onSelectResource(resource)}
                 >
                   <MatchText text={resource.name} match={inputValue} />
@@ -212,15 +213,18 @@ export function GlobalSearchPalette({
             }
             return (
               <CommandPaletteSection key={section.type} title={section.title}>
-                {entries.map(({ resource, description }) => (
+                {entries.map((resource) => (
                   <CommandPaletteItem
                     key={`result:${resource.id}`}
                     id={`result:${resource.id}`}
                     textValue={resource.name}
                     icon={RESOURCE_ICONS[resource.type]}
                     description={
-                      description ? (
-                        <MatchText text={description} match={inputValue} />
+                      resource.description ? (
+                        <MatchText
+                          text={resource.description}
+                          match={inputValue}
+                        />
                       ) : undefined
                     }
                     onAction={() => onSelectResource(resource)}
@@ -237,16 +241,16 @@ export function GlobalSearchPalette({
   );
 }
 
-type ResultEntry = {
-  resource: RecentlyViewedResource;
-  description?: string;
-};
-
 /**
  * Search results grouped by resource type. Consumers flatten this against
- * {@link RESULT_SECTIONS} to render sections in a stable order.
+ * {@link RESULT_SECTIONS} to render sections in a stable order. Entries are
+ * full {@link RecentlyViewedResource}s (description included) so selecting one
+ * records it into the recently viewed store losslessly.
  */
-type SearchResultsByType = Map<RecentlyViewedResourceType, ResultEntry[]>;
+type SearchResultsByType = Map<
+  RecentlyViewedResourceType,
+  RecentlyViewedResource[]
+>;
 
 type SearchResultsChildren = (results: SearchResultsByType) => ReactNode;
 
@@ -318,58 +322,50 @@ function SearchResultsLoader({
   if (!hasQuery) {
     return children(resultsByType);
   }
-  const addEntry = (entry: ResultEntry) => {
-    const entries = resultsByType.get(entry.resource.type);
+  const addEntry = (resource: RecentlyViewedResource) => {
+    const entries = resultsByType.get(resource.type);
     if (entries) {
-      entries.push(entry);
+      entries.push(resource);
     } else {
-      resultsByType.set(entry.resource.type, [entry]);
+      resultsByType.set(resource.type, [resource]);
     }
   };
   for (const result of data.searchResources) {
     switch (result.__typename) {
       case "Project":
         addEntry({
-          resource: {
-            id: result.id,
-            type: "project",
-            name: result.name,
-            path: `/projects/${result.id}`,
-          },
+          id: result.id,
+          type: "project",
+          name: result.name,
           description: result.description ?? undefined,
+          path: `/projects/${result.id}`,
         });
         break;
       case "Dataset":
         addEntry({
-          resource: {
-            id: result.id,
-            type: "dataset",
-            name: result.name,
-            path: `/datasets/${result.id}`,
-          },
+          id: result.id,
+          type: "dataset",
+          name: result.name,
           description: result.description ?? undefined,
+          path: `/datasets/${result.id}`,
         });
         break;
       case "Experiment":
         addEntry({
-          resource: {
-            id: result.id,
-            type: "experiment",
-            name: result.name,
-            path: `/datasets/${result.dataset.id}/compare?experimentId=${result.id}`,
-          },
+          id: result.id,
+          type: "experiment",
+          name: result.name,
           description: result.description ?? undefined,
+          path: `/datasets/${result.dataset.id}/compare?experimentId=${result.id}`,
         });
         break;
       case "Prompt":
         addEntry({
-          resource: {
-            id: result.id,
-            type: "prompt",
-            name: result.promptName as string,
-            path: `/prompts/${result.id}`,
-          },
+          id: result.id,
+          type: "prompt",
+          name: result.promptName as string,
           description: result.description ?? undefined,
+          path: `/prompts/${result.id}`,
         });
         break;
     }

--- a/app/src/components/search/GlobalSearchPalette.tsx
+++ b/app/src/components/search/GlobalSearchPalette.tsx
@@ -1,6 +1,6 @@
 import debounce from "lodash/debounce";
 import type { ReactNode } from "react";
-import { startTransition, useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { useNavigate } from "react-router";
 
@@ -121,6 +121,11 @@ export function GlobalSearchPalette({
   const { contains } = useFilter({ sensitivity: "base" });
   const [inputValue, setInputValue] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
+  // The results query suspends, so drive it through a transition: React keeps
+  // the prior results mounted while the next batch loads instead of throwing to
+  // the Suspense fallback (which would blank the palette). isPending dims the
+  // results while that refresh is in flight.
+  const [isPending, startTransition] = useTransition();
   const recentlyViewed = useRecentlyViewedStore((state) => state.resources);
   const recordResourceView = useRecentlyViewedStore(
     (state) => state.recordResourceView
@@ -135,7 +140,7 @@ export function GlobalSearchPalette({
           setSearchQuery(value);
         });
       }, SEARCH_DEBOUNCE_MS),
-    []
+    [startTransition]
   );
 
   const onSelectResource = (resource: RecentlyViewedResource) => {
@@ -160,6 +165,7 @@ export function GlobalSearchPalette({
           aria-label="Search Phoenix"
           placeholder="Search projects, datasets, experiments, prompts…"
           inputValue={inputValue}
+          isPending={isPending}
           onInputChange={(value) => {
             setInputValue(value);
             debouncedSetSearchQuery(value);
@@ -246,11 +252,19 @@ type SearchResultsChildren = (results: SearchResultsByType) => ReactNode;
 
 /**
  * Loads server search results and hands them to `children` as plain data.
- * When the query is empty it skips the network round-trip entirely. The query
- * (which suspends and throws on error) runs here — above CommandPalette rather
- * than inside its menu collection — so React Aria's detached collection render
- * cannot swallow a failure and the ErrorBoundary wrapping the palette catches
- * it, degrading gracefully instead of crashing the app.
+ *
+ * The query (which suspends and throws on error) runs here — above
+ * CommandPalette rather than inside its menu collection — so React Aria's
+ * detached collection render cannot swallow a failure and the ErrorBoundary
+ * wrapping the palette catches it, degrading gracefully instead of crashing.
+ *
+ * Crucially this component is rendered unconditionally regardless of whether
+ * there is a query: it always calls the same hook at the same tree position and
+ * always renders `children` at the same depth. That stability is what keeps the
+ * CommandPalette (and its modal overlay) mounted across the empty↔non-empty
+ * boundary — swapping element types there would remount the modal and flash the
+ * backdrop. When the query is empty we read `store-only` so no network request
+ * is made and the hook never suspends.
  */
 function SearchResultsLoader({
   searchQuery,
@@ -259,21 +273,7 @@ function SearchResultsLoader({
   searchQuery: string;
   children: SearchResultsChildren;
 }) {
-  if (!searchQuery) {
-    return children(new Map());
-  }
-  return (
-    <SearchResultsData searchQuery={searchQuery}>{children}</SearchResultsData>
-  );
-}
-
-function SearchResultsData({
-  searchQuery,
-  children,
-}: {
-  searchQuery: string;
-  children: SearchResultsChildren;
-}) {
+  const hasQuery = searchQuery.length > 0;
   const data = useLazyLoadQuery<GlobalSearchPaletteQuery>(
     graphql`
       query GlobalSearchPaletteQuery($searchQuery: String!) {
@@ -306,12 +306,18 @@ function SearchResultsData({
       }
     `,
     { searchQuery },
-    // Always revalidate: cached results render instantly while fresh results
-    // are fetched, so reopening the palette never shows stale entities
-    { fetchPolicy: "store-and-network" }
+    // With a query: always revalidate so cached results render instantly while
+    // fresh results are fetched, and reopening never shows stale entities.
+    // Without a query: `store-only` reads whatever is cached without a network
+    // request, so the hook resolves synchronously and never suspends — keeping
+    // the palette mounted and responsive before the user types anything.
+    { fetchPolicy: hasQuery ? "store-and-network" : "store-only" }
   );
 
   const resultsByType: SearchResultsByType = new Map();
+  if (!hasQuery) {
+    return children(resultsByType);
+  }
   const addEntry = (entry: ResultEntry) => {
     const entries = resultsByType.get(entry.resource.type);
     if (entries) {

--- a/app/src/components/search/GlobalSearchPalette.tsx
+++ b/app/src/components/search/GlobalSearchPalette.tsx
@@ -1,0 +1,353 @@
+import debounce from "lodash/debounce";
+import type { ReactNode } from "react";
+import { startTransition, useMemo, useState } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { useNavigate } from "react-router";
+
+import {
+  CommandPalette,
+  CommandPaletteItem,
+  CommandPaletteSection,
+  Icon,
+  Icons,
+  MatchText,
+  Text,
+  useFilter,
+} from "@phoenix/components";
+import type {
+  RecentlyViewedResource,
+  RecentlyViewedResourceType,
+} from "@phoenix/store/recentlyViewedStore";
+import { useRecentlyViewedStore } from "@phoenix/store/recentlyViewedStore";
+
+import type { GlobalSearchPaletteQuery } from "./__generated__/GlobalSearchPaletteQuery.graphql";
+
+const SEARCH_DEBOUNCE_MS = 200;
+const MAX_RECENTLY_VIEWED_SHOWN = 5;
+
+type SearchDestination = {
+  path: string;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+};
+
+/**
+ * Top-level pages reachable from the palette. Mirrors the side navigation.
+ */
+const DESTINATIONS: SearchDestination[] = [
+  {
+    path: "/projects",
+    label: "Tracing",
+    description: "Projects, traces, and spans",
+    icon: <Icon svg={<Icons.Trace />} />,
+  },
+  {
+    path: "/dashboards",
+    label: "Dashboards",
+    description: "Monitor projects and metrics",
+    icon: <Icon svg={<Icons.Grid />} />,
+  },
+  {
+    path: "/datasets",
+    label: "Datasets & Experiments",
+    description: "Curate data and run experiments",
+    icon: <Icon svg={<Icons.Database />} />,
+  },
+  {
+    path: "/playground",
+    label: "Playground",
+    description: "Experiment with prompts and models",
+    icon: <Icon svg={<Icons.PlayCircle />} />,
+  },
+  {
+    path: "/evaluators",
+    label: "Evaluators",
+    description: "Evaluate application output",
+    icon: <Icon svg={<Icons.Scale />} />,
+  },
+  {
+    path: "/prompts",
+    label: "Prompts",
+    description: "Manage and version prompts",
+    icon: <Icon svg={<Icons.MessageSquare />} />,
+  },
+  {
+    path: "/apis/rest",
+    label: "REST API",
+    description: "REST API reference",
+    icon: <Icon svg={<Icons.Code />} />,
+  },
+  {
+    path: "/apis/graphql",
+    label: "GraphQL",
+    description: "GraphQL API explorer",
+    icon: <Icon svg={<Icons.GraphQL />} />,
+  },
+  {
+    path: "/settings/general",
+    label: "Settings",
+    description: "Platform configuration",
+    icon: <Icon svg={<Icons.Options />} />,
+  },
+];
+
+const RESOURCE_ICONS: Record<RecentlyViewedResourceType, React.ReactNode> = {
+  project: <Icon svg={<Icons.Grid />} />,
+  dataset: <Icon svg={<Icons.Database />} />,
+  experiment: <Icon svg={<Icons.Experiment />} />,
+  prompt: <Icon svg={<Icons.MessageSquare />} />,
+};
+
+export function GlobalSearchPalette({
+  isOpen,
+  onOpenChange,
+}: {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  const navigate = useNavigate();
+  const { contains } = useFilter({ sensitivity: "base" });
+  const [inputValue, setInputValue] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const recentlyViewed = useRecentlyViewedStore((state) => state.resources);
+  const recordResourceView = useRecentlyViewedStore(
+    (state) => state.recordResourceView
+  );
+  // Stabilize the debounced setter across renders. A fresh debounce() per render
+  // would never cancel the prior timer, defeating debouncing and firing one
+  // request per keystroke. Matches the shared DebouncedSearch field's approach.
+  const debouncedSetSearchQuery = useMemo(
+    () =>
+      debounce((value: string) => {
+        startTransition(() => {
+          setSearchQuery(value);
+        });
+      }, SEARCH_DEBOUNCE_MS),
+    []
+  );
+
+  const onSelectResource = (resource: RecentlyViewedResource) => {
+    recordResourceView(resource);
+    onOpenChange(false);
+    navigate(resource.path);
+  };
+
+  const matchingRecentlyViewed = recentlyViewed
+    .filter((resource) => !inputValue || contains(resource.name, inputValue))
+    .slice(0, MAX_RECENTLY_VIEWED_SHOWN);
+  const matchingDestinations = DESTINATIONS.filter(
+    (destination) => !inputValue || contains(destination.label, inputValue)
+  );
+
+  return (
+    <SearchResultsLoader searchQuery={searchQuery.trim()}>
+      {(resultSections) => (
+        <CommandPalette
+          isOpen={isOpen}
+          onOpenChange={onOpenChange}
+          aria-label="Search Phoenix"
+          placeholder="Search projects, datasets, experiments, prompts…"
+          inputValue={inputValue}
+          onInputChange={(value) => {
+            setInputValue(value);
+            debouncedSetSearchQuery(value);
+          }}
+          renderEmptyState={() => (
+            <Text color="text-500">No results for “{inputValue}”</Text>
+          )}
+        >
+          {matchingRecentlyViewed.length > 0 && (
+            <CommandPaletteSection title="Recently viewed">
+              {matchingRecentlyViewed.map((resource) => (
+                <CommandPaletteItem
+                  key={`recent:${resource.id}`}
+                  id={`recent:${resource.id}`}
+                  textValue={resource.name}
+                  icon={RESOURCE_ICONS[resource.type]}
+                  onAction={() => onSelectResource(resource)}
+                >
+                  <MatchText text={resource.name} match={inputValue} />
+                </CommandPaletteItem>
+              ))}
+            </CommandPaletteSection>
+          )}
+          {matchingDestinations.length > 0 && (
+            <CommandPaletteSection title="Pages">
+              {matchingDestinations.map((destination) => (
+                <CommandPaletteItem
+                  key={`page:${destination.path}`}
+                  id={`page:${destination.path}`}
+                  textValue={destination.label}
+                  icon={destination.icon}
+                  description={destination.description}
+                  onAction={() => {
+                    onOpenChange(false);
+                    navigate(destination.path);
+                  }}
+                >
+                  <MatchText text={destination.label} match={inputValue} />
+                </CommandPaletteItem>
+              ))}
+            </CommandPaletteSection>
+          )}
+          {resultSections
+            .filter((section) => section.resources.length > 0)
+            .map((section) => (
+              <CommandPaletteSection key={section.title} title={section.title}>
+                {section.resources.map(({ resource, description }) => (
+                  <CommandPaletteItem
+                    key={`result:${resource.id}`}
+                    id={`result:${resource.id}`}
+                    textValue={resource.name}
+                    icon={RESOURCE_ICONS[resource.type]}
+                    description={
+                      description ? (
+                        <MatchText text={description} match={inputValue} />
+                      ) : undefined
+                    }
+                    onAction={() => onSelectResource(resource)}
+                  >
+                    <MatchText text={resource.name} match={inputValue} />
+                  </CommandPaletteItem>
+                ))}
+              </CommandPaletteSection>
+            ))}
+        </CommandPalette>
+      )}
+    </SearchResultsLoader>
+  );
+}
+
+type ResultSection = {
+  title: string;
+  type: RecentlyViewedResourceType;
+  resources: { resource: RecentlyViewedResource; description?: string }[];
+};
+
+type SearchResultsChildren = (resultSections: ResultSection[]) => ReactNode;
+
+/**
+ * Loads server search results and hands them to `children` as plain data.
+ * When the query is empty it skips the network round-trip entirely. The query
+ * (which suspends and throws on error) runs here — above CommandPalette rather
+ * than inside its menu collection — so React Aria's detached collection render
+ * cannot swallow a failure and the ErrorBoundary wrapping the palette catches
+ * it, degrading gracefully instead of crashing the app.
+ */
+function SearchResultsLoader({
+  searchQuery,
+  children,
+}: {
+  searchQuery: string;
+  children: SearchResultsChildren;
+}) {
+  if (!searchQuery) {
+    return children([]);
+  }
+  return (
+    <SearchResultsData searchQuery={searchQuery}>{children}</SearchResultsData>
+  );
+}
+
+function SearchResultsData({
+  searchQuery,
+  children,
+}: {
+  searchQuery: string;
+  children: SearchResultsChildren;
+}) {
+  const data = useLazyLoadQuery<GlobalSearchPaletteQuery>(
+    graphql`
+      query GlobalSearchPaletteQuery($searchQuery: String!) {
+        searchResources(query: $searchQuery) {
+          __typename
+          ... on Project {
+            id
+            name
+            description
+          }
+          ... on Dataset {
+            id
+            name
+            description
+          }
+          ... on Experiment {
+            id
+            name
+            description
+            dataset {
+              id
+            }
+          }
+          ... on Prompt {
+            id
+            promptName: name
+            description
+          }
+        }
+      }
+    `,
+    { searchQuery },
+    // Always revalidate: cached results render instantly while fresh results
+    // are fetched, so reopening the palette never shows stale entities
+    { fetchPolicy: "store-and-network" }
+  );
+
+  const resultSections: ResultSection[] = [
+    { title: "Projects", type: "project", resources: [] },
+    { title: "Datasets", type: "dataset", resources: [] },
+    { title: "Experiments", type: "experiment", resources: [] },
+    { title: "Prompts", type: "prompt", resources: [] },
+  ];
+  for (const result of data.searchResources) {
+    switch (result.__typename) {
+      case "Project":
+        resultSections[0].resources.push({
+          resource: {
+            id: result.id,
+            type: "project",
+            name: result.name,
+            path: `/projects/${result.id}`,
+          },
+          description: result.description ?? undefined,
+        });
+        break;
+      case "Dataset":
+        resultSections[1].resources.push({
+          resource: {
+            id: result.id,
+            type: "dataset",
+            name: result.name,
+            path: `/datasets/${result.id}`,
+          },
+          description: result.description ?? undefined,
+        });
+        break;
+      case "Experiment":
+        resultSections[2].resources.push({
+          resource: {
+            id: result.id,
+            type: "experiment",
+            name: result.name,
+            path: `/datasets/${result.dataset.id}/compare?experimentId=${result.id}`,
+          },
+          description: result.description ?? undefined,
+        });
+        break;
+      case "Prompt":
+        resultSections[3].resources.push({
+          resource: {
+            id: result.id,
+            type: "prompt",
+            name: result.promptName as string,
+            path: `/prompts/${result.id}`,
+          },
+          description: result.description ?? undefined,
+        });
+        break;
+    }
+  }
+
+  return children(resultSections);
+}

--- a/app/src/components/search/RecentlyViewedTracker.tsx
+++ b/app/src/components/search/RecentlyViewedTracker.tsx
@@ -1,0 +1,174 @@
+import { useEffect } from "react";
+import { fetchQuery, graphql, useRelayEnvironment } from "react-relay";
+import { matchPath, useLocation } from "react-router";
+
+import type { RecentlyViewedResource } from "@phoenix/store/recentlyViewedStore";
+import { useRecentlyViewedStore } from "@phoenix/store/recentlyViewedStore";
+
+import type { RecentlyViewedTrackerNodeQuery } from "./__generated__/RecentlyViewedTrackerNodeQuery.graphql";
+
+const nodeQuery = graphql`
+  query RecentlyViewedTrackerNodeQuery($id: ID!) {
+    node(id: $id) {
+      __typename
+      id
+      ... on Project {
+        name
+      }
+      ... on Dataset {
+        name
+      }
+      ... on Experiment {
+        name
+      }
+      ... on Prompt {
+        promptName: name
+      }
+    }
+  }
+`;
+
+type EntityRouteMatch = {
+  id: string;
+  toResource: (node: { name: string }) => RecentlyViewedResource;
+};
+
+function experimentResource(
+  datasetId: string,
+  experimentId: string
+): EntityRouteMatch {
+  return {
+    id: experimentId,
+    toResource: ({ name }) => ({
+      id: experimentId,
+      type: "experiment",
+      name,
+      path: `/datasets/${datasetId}/compare?experimentId=${experimentId}`,
+    }),
+  };
+}
+
+/**
+ * Extracts the most specific entity (project, dataset, experiment, or prompt)
+ * from the current location, if any.
+ */
+function matchEntityRoute(
+  pathname: string,
+  search: string
+): EntityRouteMatch | null {
+  const experimentMatch = matchPath(
+    { path: "/datasets/:datasetId/experiments/:experimentId", end: false },
+    pathname
+  );
+  if (experimentMatch?.params.experimentId) {
+    const { datasetId, experimentId } = experimentMatch.params;
+    return experimentResource(datasetId as string, experimentId);
+  }
+  // The experiment compare route carries the experiment(s) in the query string,
+  // e.g. /datasets/:datasetId/compare?experimentId=Y — record the experiment,
+  // not the parent dataset (which the /datasets/:datasetId match below would
+  // otherwise capture).
+  const compareMatch = matchPath(
+    { path: "/datasets/:datasetId/compare", end: false },
+    pathname
+  );
+  if (compareMatch?.params.datasetId) {
+    const experimentId = new URLSearchParams(search).get("experimentId");
+    return experimentId
+      ? experimentResource(compareMatch.params.datasetId, experimentId)
+      : null;
+  }
+  const datasetMatch = matchPath(
+    { path: "/datasets/:datasetId", end: false },
+    pathname
+  );
+  if (datasetMatch?.params.datasetId) {
+    const { datasetId } = datasetMatch.params;
+    return {
+      id: datasetId,
+      toResource: ({ name }) => ({
+        id: datasetId,
+        type: "dataset",
+        name,
+        path: `/datasets/${datasetId}`,
+      }),
+    };
+  }
+  const projectMatch = matchPath(
+    { path: "/projects/:projectId", end: false },
+    pathname
+  );
+  if (projectMatch?.params.projectId) {
+    const { projectId } = projectMatch.params;
+    return {
+      id: projectId,
+      toResource: ({ name }) => ({
+        id: projectId,
+        type: "project",
+        name,
+        path: `/projects/${projectId}`,
+      }),
+    };
+  }
+  const promptMatch = matchPath(
+    { path: "/prompts/:promptId", end: false },
+    pathname
+  );
+  if (promptMatch?.params.promptId) {
+    const { promptId } = promptMatch.params;
+    return {
+      id: promptId,
+      toResource: ({ name }) => ({
+        id: promptId,
+        type: "prompt",
+        name,
+        path: `/prompts/${promptId}`,
+      }),
+    };
+  }
+  return null;
+}
+
+/**
+ * Watches the current location and records visits to entity pages (projects,
+ * datasets, experiments, prompts) in the recently viewed store so they can be
+ * surfaced in the search palette. Renders nothing.
+ */
+export function RecentlyViewedTracker() {
+  const { pathname, search } = useLocation();
+  const environment = useRelayEnvironment();
+  const recordResourceView = useRecentlyViewedStore(
+    (state) => state.recordResourceView
+  );
+
+  useEffect(() => {
+    const match = matchEntityRoute(pathname, search);
+    if (!match) {
+      return;
+    }
+    const subscription = fetchQuery<RecentlyViewedTrackerNodeQuery>(
+      environment,
+      nodeQuery,
+      { id: match.id },
+      { fetchPolicy: "store-or-network" }
+    ).subscribe({
+      next: (data) => {
+        const node = data.node;
+        const name =
+          "name" in node && typeof node.name === "string"
+            ? node.name
+            : "promptName" in node && typeof node.promptName === "string"
+              ? node.promptName
+              : null;
+        if (name) {
+          recordResourceView(match.toResource({ name }));
+        }
+      },
+      // A dangling URL (e.g. a deleted entity) is not worth surfacing
+      error: () => {},
+    });
+    return () => subscription.unsubscribe();
+  }, [pathname, search, environment, recordResourceView]);
+
+  return null;
+}

--- a/app/src/components/search/RecentlyViewedTracker.tsx
+++ b/app/src/components/search/RecentlyViewedTracker.tsx
@@ -14,23 +14,32 @@ const nodeQuery = graphql`
       id
       ... on Project {
         name
+        description
       }
       ... on Dataset {
         name
+        description
       }
       ... on Experiment {
         name
+        description
       }
       ... on Prompt {
         promptName: name
+        description
       }
     }
   }
 `;
 
+type EntityNodeFields = {
+  name: string;
+  description?: string;
+};
+
 type EntityRouteMatch = {
   id: string;
-  toResource: (node: { name: string }) => RecentlyViewedResource;
+  toResource: (node: EntityNodeFields) => RecentlyViewedResource;
 };
 
 function experimentResource(
@@ -39,10 +48,11 @@ function experimentResource(
 ): EntityRouteMatch {
   return {
     id: experimentId,
-    toResource: ({ name }) => ({
+    toResource: ({ name, description }) => ({
       id: experimentId,
       type: "experiment",
       name,
+      description,
       path: `/datasets/${datasetId}/compare?experimentId=${experimentId}`,
     }),
   };
@@ -86,10 +96,11 @@ function matchEntityRoute(
     const { datasetId } = datasetMatch.params;
     return {
       id: datasetId,
-      toResource: ({ name }) => ({
+      toResource: ({ name, description }) => ({
         id: datasetId,
         type: "dataset",
         name,
+        description,
         path: `/datasets/${datasetId}`,
       }),
     };
@@ -102,10 +113,11 @@ function matchEntityRoute(
     const { projectId } = projectMatch.params;
     return {
       id: projectId,
-      toResource: ({ name }) => ({
+      toResource: ({ name, description }) => ({
         id: projectId,
         type: "project",
         name,
+        description,
         path: `/projects/${projectId}`,
       }),
     };
@@ -118,10 +130,11 @@ function matchEntityRoute(
     const { promptId } = promptMatch.params;
     return {
       id: promptId,
-      toResource: ({ name }) => ({
+      toResource: ({ name, description }) => ({
         id: promptId,
         type: "prompt",
         name,
+        description,
         path: `/prompts/${promptId}`,
       }),
     };
@@ -160,8 +173,12 @@ export function RecentlyViewedTracker() {
             : "promptName" in node && typeof node.promptName === "string"
               ? node.promptName
               : null;
+        const description =
+          "description" in node && typeof node.description === "string"
+            ? node.description
+            : undefined;
         if (name) {
-          recordResourceView(match.toResource({ name }));
+          recordResourceView(match.toResource({ name, description }));
         }
       },
       // A dangling URL (e.g. a deleted entity) is not worth surfacing

--- a/app/src/components/search/__generated__/GlobalSearchPaletteQuery.graphql.ts
+++ b/app/src/components/search/__generated__/GlobalSearchPaletteQuery.graphql.ts
@@ -1,0 +1,219 @@
+/**
+ * @generated SignedSource<<668b09e7744cc2ced436f0897de841b0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type GlobalSearchPaletteQuery$variables = {
+  searchQuery: string;
+};
+export type GlobalSearchPaletteQuery$data = {
+  readonly searchResources: ReadonlyArray<{
+    readonly __typename: "Dataset";
+    readonly description: string | null;
+    readonly id: string;
+    readonly name: string;
+  } | {
+    readonly __typename: "Experiment";
+    readonly dataset: {
+      readonly id: string;
+    };
+    readonly description: string | null;
+    readonly id: string;
+    readonly name: string;
+  } | {
+    readonly __typename: "Project";
+    readonly description: string | null;
+    readonly id: string;
+    readonly name: string;
+  } | {
+    readonly __typename: "Prompt";
+    readonly description: string | null;
+    readonly id: string;
+    readonly promptName: string;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  }>;
+};
+export type GlobalSearchPaletteQuery = {
+  response: GlobalSearchPaletteQuery$data;
+  variables: GlobalSearchPaletteQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "searchQuery"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "query",
+    "variableName": "searchQuery"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v6 = [
+  (v3/*: any*/),
+  (v4/*: any*/),
+  (v5/*: any*/)
+],
+v7 = {
+  "kind": "InlineFragment",
+  "selections": (v6/*: any*/),
+  "type": "Project",
+  "abstractKey": null
+},
+v8 = {
+  "kind": "InlineFragment",
+  "selections": (v6/*: any*/),
+  "type": "Dataset",
+  "abstractKey": null
+},
+v9 = [
+  (v3/*: any*/)
+],
+v10 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v3/*: any*/),
+    (v4/*: any*/),
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Dataset",
+      "kind": "LinkedField",
+      "name": "dataset",
+      "plural": false,
+      "selections": (v9/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "type": "Experiment",
+  "abstractKey": null
+},
+v11 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v3/*: any*/),
+    {
+      "alias": "promptName",
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    (v5/*: any*/)
+  ],
+  "type": "Prompt",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "GlobalSearchPaletteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "searchResources",
+        "plural": true,
+        "selections": [
+          (v2/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
+          (v10/*: any*/),
+          (v11/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "GlobalSearchPaletteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "searchResources",
+        "plural": true,
+        "selections": [
+          (v2/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
+          (v10/*: any*/),
+          (v11/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": (v9/*: any*/),
+            "type": "Node",
+            "abstractKey": "__isNode"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "abd60605b97fd8dd0e627174759332db",
+    "id": null,
+    "metadata": {},
+    "name": "GlobalSearchPaletteQuery",
+    "operationKind": "query",
+    "text": "query GlobalSearchPaletteQuery(\n  $searchQuery: String!\n) {\n  searchResources(query: $searchQuery) {\n    __typename\n    ... on Project {\n      id\n      name\n      description\n    }\n    ... on Dataset {\n      id\n      name\n      description\n    }\n    ... on Experiment {\n      id\n      name\n      description\n      dataset {\n        id\n      }\n    }\n    ... on Prompt {\n      id\n      promptName: name\n      description\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "141d8d75beb1ae54ec45c3d0369d99d9";
+
+export default node;

--- a/app/src/components/search/__generated__/RecentlyViewedTrackerNodeQuery.graphql.ts
+++ b/app/src/components/search/__generated__/RecentlyViewedTrackerNodeQuery.graphql.ts
@@ -1,0 +1,140 @@
+/**
+ * @generated SignedSource<<423a3c17f3b7eda625d8a732b4f5b6b9>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type RecentlyViewedTrackerNodeQuery$variables = {
+  id: string;
+};
+export type RecentlyViewedTrackerNodeQuery$data = {
+  readonly node: {
+    readonly __typename: string;
+    readonly id: string;
+    readonly name?: string;
+    readonly promptName?: string;
+  };
+};
+export type RecentlyViewedTrackerNodeQuery = {
+  response: RecentlyViewedTrackerNodeQuery$data;
+  variables: RecentlyViewedTrackerNodeQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  }
+],
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      }
+    ],
+    "concreteType": null,
+    "kind": "LinkedField",
+    "name": "node",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": (v1/*: any*/),
+        "type": "Project",
+        "abstractKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": (v1/*: any*/),
+        "type": "Dataset",
+        "abstractKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": (v1/*: any*/),
+        "type": "Experiment",
+        "abstractKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "alias": "promptName",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          }
+        ],
+        "type": "Prompt",
+        "abstractKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RecentlyViewedTrackerNodeQuery",
+    "selections": (v2/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RecentlyViewedTrackerNodeQuery",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "cd6df96fb9f51e7036fae0fcc51d1988",
+    "id": null,
+    "metadata": {},
+    "name": "RecentlyViewedTrackerNodeQuery",
+    "operationKind": "query",
+    "text": "query RecentlyViewedTrackerNodeQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    id\n    ... on Project {\n      name\n    }\n    ... on Dataset {\n      name\n    }\n    ... on Experiment {\n      name\n    }\n    ... on Prompt {\n      promptName: name\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "6f303d77a3726864c26bfe9f8a981d7b";
+
+export default node;

--- a/app/src/components/search/__generated__/RecentlyViewedTrackerNodeQuery.graphql.ts
+++ b/app/src/components/search/__generated__/RecentlyViewedTrackerNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<423a3c17f3b7eda625d8a732b4f5b6b9>>
+ * @generated SignedSource<<eeaab7cab687d23e307c65ed3c0bde8d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type RecentlyViewedTrackerNodeQuery$variables = {
 export type RecentlyViewedTrackerNodeQuery$data = {
   readonly node: {
     readonly __typename: string;
+    readonly description?: string | null;
     readonly id: string;
     readonly name?: string;
     readonly promptName?: string;
@@ -33,16 +34,24 @@ var v0 = [
     "name": "id"
   }
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v2 = [
   {
     "alias": null,
     "args": null,
     "kind": "ScalarField",
     "name": "name",
     "storageKey": null
-  }
+  },
+  (v1/*: any*/)
 ],
-v2 = [
+v3 = [
   {
     "alias": null,
     "args": [
@@ -73,19 +82,19 @@ v2 = [
       },
       {
         "kind": "InlineFragment",
-        "selections": (v1/*: any*/),
+        "selections": (v2/*: any*/),
         "type": "Project",
         "abstractKey": null
       },
       {
         "kind": "InlineFragment",
-        "selections": (v1/*: any*/),
+        "selections": (v2/*: any*/),
         "type": "Dataset",
         "abstractKey": null
       },
       {
         "kind": "InlineFragment",
-        "selections": (v1/*: any*/),
+        "selections": (v2/*: any*/),
         "type": "Experiment",
         "abstractKey": null
       },
@@ -98,7 +107,8 @@ v2 = [
             "kind": "ScalarField",
             "name": "name",
             "storageKey": null
-          }
+          },
+          (v1/*: any*/)
         ],
         "type": "Prompt",
         "abstractKey": null
@@ -113,7 +123,7 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "RecentlyViewedTrackerNodeQuery",
-    "selections": (v2/*: any*/),
+    "selections": (v3/*: any*/),
     "type": "Query",
     "abstractKey": null
   },
@@ -122,19 +132,19 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "RecentlyViewedTrackerNodeQuery",
-    "selections": (v2/*: any*/)
+    "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "cd6df96fb9f51e7036fae0fcc51d1988",
+    "cacheID": "ba52f1cdbfb96c516dadf1e2710d1d90",
     "id": null,
     "metadata": {},
     "name": "RecentlyViewedTrackerNodeQuery",
     "operationKind": "query",
-    "text": "query RecentlyViewedTrackerNodeQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    id\n    ... on Project {\n      name\n    }\n    ... on Dataset {\n      name\n    }\n    ... on Experiment {\n      name\n    }\n    ... on Prompt {\n      promptName: name\n    }\n  }\n}\n"
+    "text": "query RecentlyViewedTrackerNodeQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    id\n    ... on Project {\n      name\n      description\n    }\n    ... on Dataset {\n      name\n      description\n    }\n    ... on Experiment {\n      name\n      description\n    }\n    ... on Prompt {\n      promptName: name\n      description\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6f303d77a3726864c26bfe9f8a981d7b";
+(node as any).hash = "0467eab28982d171751e239c16de6ef6";
 
 export default node;

--- a/app/src/components/search/index.tsx
+++ b/app/src/components/search/index.tsx
@@ -1,0 +1,3 @@
+export * from "./GlobalSearch";
+export * from "./GlobalSearchPalette";
+export * from "./RecentlyViewedTracker";

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -24,6 +24,7 @@ import {
   TopNavbar,
   VersionUpdateNotice,
 } from "@phoenix/components/nav";
+import { GlobalSearch } from "@phoenix/components/search";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import {
@@ -161,6 +162,9 @@ function SideNav() {
       <Brand />
       <Flex direction="column" justifyContent="space-between" flex="1 1 auto">
         <ul css={sideLinksCSS}>
+          <li key="search">
+            <GlobalSearch isExpanded={isSideNavExpanded} />
+          </li>
           <li>
             <NavLink
               to="/projects"

--- a/app/src/store/recentlyViewedStore.tsx
+++ b/app/src/store/recentlyViewedStore.tsx
@@ -15,6 +15,11 @@ export interface RecentlyViewedResource {
   type: RecentlyViewedResourceType;
   name: string;
   /**
+   * The resource's user-authored description, when it has one. Persisted so
+   * the search palette can show what a recently viewed resource is.
+   */
+  description?: string;
+  /**
    * The app path that shows the resource
    */
   path: string;
@@ -41,7 +46,8 @@ export const useRecentlyViewedStore = create<RecentlyViewedState>()(
               const mostRecent = state.resources[0];
               if (
                 mostRecent?.id === resource.id &&
-                mostRecent.name === resource.name
+                mostRecent.name === resource.name &&
+                mostRecent.description === resource.description
               ) {
                 return state;
               }

--- a/app/src/store/recentlyViewedStore.tsx
+++ b/app/src/store/recentlyViewedStore.tsx
@@ -1,0 +1,66 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+export type RecentlyViewedResourceType =
+  | "project"
+  | "dataset"
+  | "experiment"
+  | "prompt";
+
+export interface RecentlyViewedResource {
+  /**
+   * The GraphQL GlobalID of the resource
+   */
+  id: string;
+  type: RecentlyViewedResourceType;
+  name: string;
+  /**
+   * The app path that shows the resource
+   */
+  path: string;
+}
+
+export interface RecentlyViewedState {
+  /**
+   * Most recently viewed first
+   */
+  resources: RecentlyViewedResource[];
+  recordResourceView: (resource: RecentlyViewedResource) => void;
+}
+
+const MAX_RECENTLY_VIEWED = 10;
+
+export const useRecentlyViewedStore = create<RecentlyViewedState>()(
+  persist(
+    devtools(
+      (set) => ({
+        resources: [],
+        recordResourceView: (resource) => {
+          set(
+            (state) => {
+              const mostRecent = state.resources[0];
+              if (
+                mostRecent?.id === resource.id &&
+                mostRecent.name === resource.name
+              ) {
+                return state;
+              }
+              return {
+                resources: [
+                  resource,
+                  ...state.resources.filter(
+                    (existing) => existing.id !== resource.id
+                  ),
+                ].slice(0, MAX_RECENTLY_VIEWED),
+              };
+            },
+            false,
+            { type: "recordResourceView" }
+          );
+        },
+      }),
+      { name: "recentlyViewedStore" }
+    ),
+    { name: "arize-phoenix-recently-viewed" }
+  )
+);

--- a/app/stories/CommandPalette.stories.tsx
+++ b/app/stories/CommandPalette.stories.tsx
@@ -1,0 +1,142 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useState } from "react";
+
+import {
+  Button,
+  CommandPalette,
+  CommandPaletteItem,
+  CommandPaletteSection,
+  Icon,
+  Icons,
+  KeyboardToken,
+  MatchText,
+  Text,
+  useFilter,
+} from "@phoenix/components";
+
+export default {
+  title: "Core/Collections/Command Palette",
+  component: CommandPalette,
+  parameters: {
+    layout: "centered",
+  },
+} as Meta<typeof CommandPalette>;
+
+/**
+ * Static commands filtered client-side via useFilter's contains matcher.
+ */
+const Template: StoryFn<typeof CommandPalette> = () => {
+  const [isOpen, setOpen] = useState(false);
+  const { contains } = useFilter({ sensitivity: "base" });
+  return (
+    <>
+      <Button onPress={() => setOpen(true)}>
+        Open Command Palette&nbsp;<KeyboardToken>⌘K</KeyboardToken>
+      </Button>
+      <CommandPalette
+        isOpen={isOpen}
+        onOpenChange={setOpen}
+        placeholder="Type a command…"
+        filter={(textValue, inputValue) => contains(textValue, inputValue)}
+        onAction={() => setOpen(false)}
+      >
+        <CommandPaletteSection title="Navigation">
+          <CommandPaletteItem
+            textValue="Go to projects"
+            icon={<Icon svg={<Icons.Grid />} />}
+            description="View all tracing projects"
+          >
+            Go to projects
+          </CommandPaletteItem>
+          <CommandPaletteItem
+            textValue="Go to datasets"
+            icon={<Icon svg={<Icons.Database />} />}
+            description="Datasets and experiments"
+          >
+            Go to datasets
+          </CommandPaletteItem>
+          <CommandPaletteItem
+            textValue="Go to prompts"
+            icon={<Icon svg={<Icons.MessageSquare />} />}
+            description="Prompt management"
+          >
+            Go to prompts
+          </CommandPaletteItem>
+        </CommandPaletteSection>
+        <CommandPaletteSection title="Actions">
+          <CommandPaletteItem
+            textValue="Create a new project"
+            icon={<Icon svg={<Icons.PlusCircle />} />}
+          >
+            Create a new project
+          </CommandPaletteItem>
+          <CommandPaletteItem
+            textValue="Open the playground"
+            icon={<Icon svg={<Icons.PlayCircle />} />}
+            description="Prompt playground"
+          >
+            Open the playground
+          </CommandPaletteItem>
+        </CommandPaletteSection>
+      </CommandPalette>
+    </>
+  );
+};
+
+export const Default = {
+  render: Template,
+};
+
+/**
+ * Server-side style search: the consumer owns the input value, pre-filters
+ * the items itself (no filter prop), and highlights the matching substring.
+ */
+const SearchTemplate: StoryFn<typeof CommandPalette> = () => {
+  const [isOpen, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const { contains } = useFilter({ sensitivity: "base" });
+  const datasets = [
+    { name: "eval datasets", description: "Golden questions for evals" },
+    { name: "Evaluator: ambiguity", description: "Reference examples" },
+    { name: "chatbot transcripts", description: "Production conversations" },
+  ];
+  const matches = datasets.filter(
+    (dataset) =>
+      contains(dataset.name, search) || contains(dataset.description, search)
+  );
+  return (
+    <>
+      <Button onPress={() => setOpen(true)}>Search datasets</Button>
+      <CommandPalette
+        isOpen={isOpen}
+        onOpenChange={setOpen}
+        inputValue={search}
+        onInputChange={setSearch}
+        placeholder="Search datasets…"
+        onAction={() => setOpen(false)}
+        renderEmptyState={() => (
+          <Text color="text-500">No results for “{search}”</Text>
+        )}
+      >
+        <CommandPaletteSection title="Datasets">
+          {matches.map((dataset) => (
+            <CommandPaletteItem
+              key={dataset.name}
+              textValue={dataset.name}
+              icon={<Icon svg={<Icons.Database />} />}
+              description={
+                <MatchText text={dataset.description} match={search} />
+              }
+            >
+              <MatchText text={dataset.name} match={search} />
+            </CommandPaletteItem>
+          ))}
+        </CommandPaletteSection>
+      </CommandPalette>
+    </>
+  );
+};
+
+export const WithMatchHighlighting = {
+  render: SearchTemplate,
+};

--- a/app/stories/CommandPalette.stories.tsx
+++ b/app/stories/CommandPalette.stories.tsx
@@ -6,6 +6,7 @@ import {
   CommandPalette,
   CommandPaletteItem,
   CommandPaletteSection,
+  CompactEmptyState,
   Icon,
   Icons,
   KeyboardToken,
@@ -115,7 +116,10 @@ const SearchTemplate: StoryFn<typeof CommandPalette> = () => {
         placeholder="Search datasets…"
         onAction={() => setOpen(false)}
         renderEmptyState={() => (
-          <Text color="text-500">No results for “{search}”</Text>
+          <CompactEmptyState
+            icon={<Icon svg={<Icons.Database />} />}
+            description="No datasets"
+          />
         )}
       >
         <CommandPaletteSection title="Datasets">
@@ -139,4 +143,110 @@ const SearchTemplate: StoryFn<typeof CommandPalette> = () => {
 
 export const WithMatchHighlighting = {
   render: SearchTemplate,
+};
+
+/**
+ * When the query matches nothing and no `renderEmptyState` is provided, the
+ * palette falls back to a `CompactEmptyState`. Because it lives inside the
+ * Autocomplete, the non-empty query flips it to the search icon + "No results"
+ * automatically. Opens pre-seeded with a query that matches none of the items.
+ */
+const EmptyStateTemplate: StoryFn<typeof CommandPalette> = () => {
+  const [isOpen, setOpen] = useState(true);
+  const { contains } = useFilter({ sensitivity: "base" });
+  return (
+    <>
+      <Button onPress={() => setOpen(true)}>Open Command Palette</Button>
+      <CommandPalette
+        isOpen={isOpen}
+        onOpenChange={setOpen}
+        inputValue="nothing matches this"
+        placeholder="Type a command…"
+        filter={(textValue, inputValue) => contains(textValue, inputValue)}
+        onAction={() => setOpen(false)}
+      >
+        <CommandPaletteSection title="Navigation">
+          <CommandPaletteItem
+            textValue="Go to projects"
+            icon={<Icon svg={<Icons.Grid />} />}
+            description="View all tracing projects"
+          >
+            Go to projects
+          </CommandPaletteItem>
+          <CommandPaletteItem
+            textValue="Go to datasets"
+            icon={<Icon svg={<Icons.Database />} />}
+            description="Datasets and experiments"
+          >
+            Go to datasets
+          </CommandPaletteItem>
+        </CommandPaletteSection>
+      </CommandPalette>
+    </>
+  );
+};
+
+export const EmptyState = {
+  render: EmptyStateTemplate,
+};
+
+/**
+ * The `footer` prop replaces the default navigation hints — here with a single
+ * action hint alongside the standard "select" affordance.
+ */
+const CustomFooterTemplate: StoryFn<typeof CommandPalette> = () => {
+  const [isOpen, setOpen] = useState(false);
+  const { contains } = useFilter({ sensitivity: "base" });
+  return (
+    <>
+      <Button onPress={() => setOpen(true)}>
+        Open Command Palette&nbsp;<KeyboardToken>⌘K</KeyboardToken>
+      </Button>
+      <CommandPalette
+        isOpen={isOpen}
+        onOpenChange={setOpen}
+        placeholder="Type a command…"
+        filter={(textValue, inputValue) => contains(textValue, inputValue)}
+        onAction={() => setOpen(false)}
+        footer={
+          <>
+            <span className="command-palette__hint">
+              <KeyboardToken>↵</KeyboardToken>
+              <Text size="XS" color="text-500">
+                to open
+              </Text>
+            </span>
+            <span className="command-palette__hint">
+              <KeyboardToken>⌘</KeyboardToken>
+              <KeyboardToken>↵</KeyboardToken>
+              <Text size="XS" color="text-500">
+                to open in a new tab
+              </Text>
+            </span>
+          </>
+        }
+      >
+        <CommandPaletteSection title="Recently viewed">
+          <CommandPaletteItem
+            textValue="chatbot-eval"
+            icon={<Icon svg={<Icons.Grid />} />}
+            description="Project"
+          >
+            chatbot-eval
+          </CommandPaletteItem>
+          <CommandPaletteItem
+            textValue="golden-questions"
+            icon={<Icon svg={<Icons.Database />} />}
+            description="Dataset"
+          >
+            golden-questions
+          </CommandPaletteItem>
+        </CommandPaletteSection>
+      </CommandPalette>
+    </>
+  );
+};
+
+export const WithCustomFooter = {
+  render: CustomFooterTemplate,
 };

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -134,6 +134,7 @@ from phoenix.server.api.types.SandboxConfig import (
     SandboxProvider,
     get_sandbox_backend_info,
 )
+from phoenix.server.api.types.SearchResult import SearchResult
 from phoenix.server.api.types.Secret import Secret
 from phoenix.server.api.types.ServerStatus import ServerStatus
 from phoenix.server.api.types.SortDir import SortDir
@@ -1148,6 +1149,108 @@ class Query:
                 data=data,
                 args=args,
             )
+
+    @strawberry.field(  # type: ignore[untyped-decorator]
+        description=(
+            "Search top-level resources (projects, datasets, experiments, and prompts) "
+            "by name or description."
+        )
+    )
+    async def search_resources(
+        self,
+        info: Info[Context, None],
+        query: str,
+        limit_per_type: int = 5,
+    ) -> list[SearchResult]:
+        search_term = query.strip()
+        if not search_term:
+            return []
+        if limit_per_type < 1:
+            raise BadRequest("limitPerType must be a positive integer")
+        limit_per_type = min(limit_per_type, 25)
+
+        # icontains(autoescape=True) matches a case-insensitive substring while
+        # escaping LIKE metacharacters (% and _) so they match literally rather
+        # than acting as wildcards.
+        projects_stmt = (
+            exclude_dataset_evaluator_projects(
+                exclude_experiment_projects(
+                    select(models.Project).where(
+                        or_(
+                            models.Project.name.icontains(search_term, autoescape=True),
+                            models.Project.description.icontains(search_term, autoescape=True),
+                        )
+                    )
+                )
+            )
+            .order_by(
+                case((models.Project.name.icontains(search_term, autoescape=True), 0), else_=1),
+                models.Project.updated_at.desc(),
+            )
+            .limit(limit_per_type)
+        )
+        datasets_stmt = (
+            select(models.Dataset)
+            .where(
+                or_(
+                    models.Dataset.name.icontains(search_term, autoescape=True),
+                    models.Dataset.description.icontains(search_term, autoescape=True),
+                )
+            )
+            .order_by(
+                case((models.Dataset.name.icontains(search_term, autoescape=True), 0), else_=1),
+                models.Dataset.updated_at.desc(),
+            )
+            .limit(limit_per_type)
+        )
+        experiments_stmt = (
+            select(models.Experiment)
+            .where(models.Experiment.is_ephemeral.is_(False))
+            .where(
+                or_(
+                    models.Experiment.name.icontains(search_term, autoescape=True),
+                    models.Experiment.description.icontains(search_term, autoescape=True),
+                )
+            )
+            .order_by(
+                case(
+                    (models.Experiment.name.icontains(search_term, autoescape=True), 0),
+                    else_=1,
+                ),
+                models.Experiment.updated_at.desc(),
+            )
+            .limit(limit_per_type)
+        )
+        # Prompt.name is an Identifier column and must be cast to String for matching
+        prompt_name = cast(models.Prompt.name, String)
+        prompts_stmt = (
+            select(models.Prompt)
+            .where(
+                or_(
+                    prompt_name.icontains(search_term, autoescape=True),
+                    models.Prompt.description.icontains(search_term, autoescape=True),
+                )
+            )
+            .order_by(
+                case((prompt_name.icontains(search_term, autoescape=True), 0), else_=1),
+                models.Prompt.updated_at.desc(),
+            )
+            .limit(limit_per_type)
+        )
+
+        results: list[SearchResult] = []
+        async with info.context.db.read() as session:
+            projects = await session.scalars(projects_stmt)
+            results.extend(Project(id=project.id, db_record=project) for project in projects)
+            datasets = await session.scalars(datasets_stmt)
+            results.extend(Dataset(id=dataset.id, db_record=dataset) for dataset in datasets)
+            experiments = await session.scalars(experiments_stmt)
+            results.extend(
+                Experiment(id=experiment.id, db_record=experiment) for experiment in experiments
+            )
+            prompts = await session.scalars(prompts_stmt)
+            results.extend(Prompt(id=prompt.id, db_record=prompt) for prompt in prompts)
+        return results
 
     @strawberry.field
     async def prompt_labels(

--- a/src/phoenix/server/api/types/SearchResult.py
+++ b/src/phoenix/server/api/types/SearchResult.py
@@ -10,5 +10,11 @@ from phoenix.server.api.types.Prompt import Prompt
 
 SearchResult: TypeAlias = Annotated[
     Union[Project, Dataset, Experiment, Prompt],
-    strawberry.union("SearchResult"),
+    strawberry.union(
+        "SearchResult",
+        description=(
+            "An entity returned by global search. One of the searchable "
+            "resource types: Project, Dataset, Experiment, or Prompt."
+        ),
+    ),
 ]

--- a/src/phoenix/server/api/types/SearchResult.py
+++ b/src/phoenix/server/api/types/SearchResult.py
@@ -1,0 +1,14 @@
+from typing import Annotated, Union
+
+import strawberry
+from typing_extensions import TypeAlias
+
+from phoenix.server.api.types.Dataset import Dataset
+from phoenix.server.api.types.Experiment import Experiment
+from phoenix.server.api.types.Project import Project
+from phoenix.server.api.types.Prompt import Prompt
+
+SearchResult: TypeAlias = Annotated[
+    Union[Project, Dataset, Experiment, Prompt],
+    strawberry.union("SearchResult"),
+]

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -2879,3 +2879,160 @@ async def test_node_with_noninteger_payload_returns_bad_request(
     assert response.data is None
     assert response.errors
     assert f"Invalid node id: {bad_id}" in response.errors[0].message
+
+
+@pytest.fixture
+async def resources_for_search(
+    db: DbSessionFactory,
+) -> None:
+    """
+    Seed projects, datasets, experiments, and prompts where some match the
+    term "chatbot" by name, some by description, and some not at all.
+    """
+    async with db() as session:
+        session.add(models.Project(name="chatbot-project"))
+        session.add(models.Project(name="other-project", description="A chatbot playground"))
+        session.add(models.Project(name="unrelated-project", description="nothing to see"))
+
+        dataset_matching_by_name = models.Dataset(name="chatbot-dataset", metadata_={})
+        dataset_matching_by_description = models.Dataset(
+            name="golden-questions",
+            description="Examples for the CHATBOT",
+            metadata_={},
+        )
+        unmatched_dataset = models.Dataset(name="other-dataset", metadata_={})
+        session.add(dataset_matching_by_name)
+        session.add(dataset_matching_by_description)
+        session.add(unmatched_dataset)
+        await session.flush()
+
+        dataset_version = models.DatasetVersion(
+            dataset_id=dataset_matching_by_name.id, metadata_={}
+        )
+        session.add(dataset_version)
+        await session.flush()
+
+        session.add(
+            models.Experiment(
+                dataset_id=dataset_matching_by_name.id,
+                dataset_version_id=dataset_version.id,
+                name="chatbot-experiment",
+                repetitions=1,
+                metadata_={},
+            )
+        )
+        session.add(
+            models.Experiment(
+                dataset_id=dataset_matching_by_name.id,
+                dataset_version_id=dataset_version.id,
+                name="chatbot-ephemeral-experiment",
+                repetitions=1,
+                is_ephemeral=True,
+                metadata_={},
+            )
+        )
+
+        session.add(models.Prompt(name=Identifier(root="chatbot_prompt"), metadata_={}))
+        session.add(
+            models.Prompt(
+                name=Identifier(root="agent_prompt"),
+                description="Prompt for the chatbot",
+                metadata_={},
+            )
+        )
+        session.add(models.Prompt(name=Identifier(root="unrelated_prompt"), metadata_={}))
+
+
+class TestSearchResources:
+    _QUERY = """
+      query ($query: String!, $limitPerType: Int! = 5) {
+        searchResources(query: $query, limitPerType: $limitPerType) {
+          __typename
+          ... on Project { name }
+          ... on Dataset { name }
+          ... on Experiment { name }
+          ... on Prompt { promptName: name }
+        }
+      }
+    """
+
+    async def test_matches_name_and_description_across_types(
+        self,
+        gql_client: AsyncGraphQLClient,
+        resources_for_search: None,
+    ) -> None:
+        response = await gql_client.execute(query=self._QUERY, variables={"query": "chatbot"})
+        assert response.data and not response.errors
+        results = response.data["searchResources"]
+        by_type: dict[str, list[str]] = {}
+        for result in results:
+            name = result.get("name") or result["promptName"]
+            by_type.setdefault(result["__typename"], []).append(name)
+        # Name matches rank before description-only matches within each type
+        assert by_type["Project"] == ["chatbot-project", "other-project"]
+        assert by_type["Dataset"] == ["chatbot-dataset", "golden-questions"]
+        # Ephemeral (playground) experiments are excluded
+        assert by_type["Experiment"] == ["chatbot-experiment"]
+        assert by_type["Prompt"] == ["chatbot_prompt", "agent_prompt"]
+
+    async def test_search_is_case_insensitive(
+        self,
+        gql_client: AsyncGraphQLClient,
+        resources_for_search: None,
+    ) -> None:
+        response = await gql_client.execute(query=self._QUERY, variables={"query": "CHATBOT"})
+        assert response.data and not response.errors
+        assert len(response.data["searchResources"]) == 7
+
+    async def test_blank_query_returns_no_results(
+        self,
+        gql_client: AsyncGraphQLClient,
+        resources_for_search: None,
+    ) -> None:
+        response = await gql_client.execute(query=self._QUERY, variables={"query": "   "})
+        assert response.data and not response.errors
+        assert response.data["searchResources"] == []
+
+    async def test_limit_per_type_caps_each_type(
+        self,
+        gql_client: AsyncGraphQLClient,
+        resources_for_search: None,
+    ) -> None:
+        response = await gql_client.execute(
+            query=self._QUERY, variables={"query": "chatbot", "limitPerType": 1}
+        )
+        assert response.data and not response.errors
+        names = [
+            result.get("name") or result["promptName"]
+            for result in response.data["searchResources"]
+        ]
+        # One result per type, and the name match wins over the description match
+        assert names == [
+            "chatbot-project",
+            "chatbot-dataset",
+            "chatbot-experiment",
+            "chatbot_prompt",
+        ]
+
+    async def test_like_wildcards_are_matched_literally(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+    ) -> None:
+        async with db() as session:
+            session.add(models.Project(name="a_b metrics"))
+            session.add(models.Project(name="axb metrics"))
+            session.add(models.Project(name="100% coverage"))
+            session.add(models.Project(name="fifty coverage"))
+
+        # "_" must not act as a single-character wildcard
+        response = await gql_client.execute(query=self._QUERY, variables={"query": "a_b"})
+        assert response.data and not response.errors
+        names = [result["name"] for result in response.data["searchResources"]]
+        assert names == ["a_b metrics"]
+
+        # "%" must not act as a multi-character wildcard
+        response = await gql_client.execute(query=self._QUERY, variables={"query": "100%"})
+        assert response.data and not response.errors
+        names = [result["name"] for result in response.data["searchResources"]]
+        assert names == ["100% coverage"]


### PR DESCRIPTION
## Summary

Adds a global search command palette opened with **⌘K** (Ctrl+K on Windows/Linux), plus a "Search" button in the side navigation. The palette searches across projects, datasets, experiments, and prompts, surfaces recently-viewed resources, and offers quick-jump destinations to top-level pages.