### PR TITLE
feat: session turn divider with copy

### DIFF
--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -715,6 +715,13 @@ export function SessionDetailsTraceList({
     }
   }, [selectedTraceId, sessionRootSpans]);
 
+  const selectedIndex =
+    selectedTraceId == null
+      ? -1
+      : sessionRootSpans.findIndex(
+          ({ traceId }) => traceId === selectedTraceId
+        );
+
   const turnListPanel = (
     <div
       css={css`
@@ -764,10 +771,12 @@ export function SessionDetailsTraceList({
           }
         >
           {sessionRootSpans.map(({ traceId, rootSpan }, index) => {
-            const isSelected = traceId === selectedTraceId;
+            const isSelected = index === selectedIndex;
+            // Hide this row's top divider when the row directly above it is
+            // the selected one, since the selected row draws its own
+            // border-bottom and a divider here would double up.
             const isAfterSelected =
-              index > 0 &&
-              sessionRootSpans[index - 1]?.traceId === selectedTraceId;
+              selectedIndex >= 0 && index === selectedIndex + 1;
             return (
               <div
                 key={rootSpan.spanId}

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -21,6 +21,7 @@ import {
   ExpandableContent,
   Icon,
   Icons,
+  IDBadge,
   LinkButton,
   ListBox,
   ListBoxItem,
@@ -316,16 +317,9 @@ function SessionTurnDivider({
       css={sessionTurnDividerCSS}
     >
       <Text fontFamily="mono" color="text-500">
-        {paddedIndex}
+        Turn {paddedIndex}
       </Text>
       <div className="session-turn-divider__rule" />
-      <CopyToClipboardButton
-        text={traceId}
-        size="S"
-        variant="quiet"
-        tooltipText="Copy trace ID"
-        aria-label="Copy trace ID"
-      />
       <LinkButton
         size="S"
         variant="quiet"
@@ -337,6 +331,16 @@ function SessionTurnDivider({
           traceId,
           spanNodeId: rootSpan.id,
         })}
+      >
+        Trace
+      </LinkButton>
+      <IDBadge id={traceId} />
+      <CopyToClipboardButton
+        text={traceId}
+        size="S"
+        variant="quiet"
+        tooltipText="Copy trace ID"
+        aria-label="Copy trace ID"
       />
     </Flex>
   );
@@ -543,6 +547,13 @@ function SessionTurnList({
 }
 
 const turnDetailRowCSS = css`
+  &[data-selected],
+  &[data-after-selected] {
+    .session-turn-divider__rule {
+      visibility: hidden;
+    }
+  }
+
   &[data-selected] {
     background-color: var(--global-list-detail-selected-background-color);
     border-bottom: var(--global-border-size-thin) solid
@@ -752,34 +763,41 @@ export function SessionDetailsTraceList({
             debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
           }
         >
-          {sessionRootSpans.map(({ traceId, rootSpan }, index) => (
-            <div
-              key={rootSpan.spanId}
-              css={turnDetailRowCSS}
-              data-selected={traceId === selectedTraceId || undefined}
-              ref={(el) => {
-                if (el) {
-                  rowRefs.current.set(traceId, el);
-                } else {
-                  rowRefs.current.delete(traceId);
-                }
-              }}
-            >
-              <View
-                paddingTop="size-100"
-                paddingBottom="size-200"
-                paddingX="size-200"
+          {sessionRootSpans.map(({ traceId, rootSpan }, index) => {
+            const isSelected = traceId === selectedTraceId;
+            const isAfterSelected =
+              index > 0 &&
+              sessionRootSpans[index - 1]?.traceId === selectedTraceId;
+            return (
+              <div
+                key={rootSpan.spanId}
+                css={turnDetailRowCSS}
+                data-selected={isSelected || undefined}
+                data-after-selected={isAfterSelected || undefined}
+                ref={(el) => {
+                  if (el) {
+                    rowRefs.current.set(traceId, el);
+                  } else {
+                    rowRefs.current.delete(traceId);
+                  }
+                }}
               >
-                <View width="100%" maxWidth="size-8500" marginX="auto">
-                  <SessionTurnDetail
-                    index={index}
-                    traceId={traceId}
-                    rootSpan={rootSpan}
-                  />
+                <View
+                  paddingTop="size-100"
+                  paddingBottom="size-200"
+                  paddingX="size-200"
+                >
+                  <View width="100%" maxWidth="size-8500" marginX="auto">
+                    <SessionTurnDetail
+                      index={index}
+                      traceId={traceId}
+                      rootSpan={rootSpan}
+                    />
+                  </View>
                 </View>
-              </View>
-            </div>
-          ))}
+              </div>
+            );
+          })}
           {isLoadingNext && (
             <View
               borderBottomColor="default"

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -4,7 +4,6 @@ import {
 } from "@arizeai/openinference-semantic-conventions";
 import { css } from "@emotion/react";
 import { isNumber, isString, throttle } from "lodash";
-import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PreloadedQuery } from "react-relay";
 import { graphql, usePaginationFragment, usePreloadedQuery } from "react-relay";
@@ -34,6 +33,7 @@ import {
 } from "@phoenix/components";
 import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/AnnotationSummaryGroup";
 import { TraceAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/TraceAnnotationSummaryGroup";
+import { CopyToClipboardButton } from "@phoenix/components/core/copy";
 import { DynamicContent } from "@phoenix/components/DynamicContent";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { EditSpanAnnotationsDialog } from "@phoenix/components/trace/EditSpanAnnotationsDialog";
@@ -131,17 +131,12 @@ const SESSION_TURN_MESSAGE_MAX_HEIGHT = 280;
 type RootSpanMessageRole = "INPUT" | "OUTPUT";
 
 type RootSpanMessageProps = {
-  /**
-   * Optional content rendered opposite the message label in the header,
-   * typically a small action like the trace link.
-   */
-  extra?: ReactNode;
   label?: string;
   role: RootSpanMessageRole;
   value: unknown;
 };
 
-function RootSpanMessage({ extra, label, role, value }: RootSpanMessageProps) {
+function RootSpanMessage({ label, role, value }: RootSpanMessageProps) {
   const isInput = role === "INPUT";
   const styles = useChatMessageStyles(isInput ? "user" : "assistant");
   const defaultLabel = isInput ? "INPUT" : "OUTPUT";
@@ -162,7 +157,6 @@ function RootSpanMessage({ extra, label, role, value }: RootSpanMessageProps) {
         width="100%"
       >
         <Text color="text-700">{label ?? defaultLabel}</Text>
-        {extra}
       </Flex>
       <View
         borderRadius={"medium"}
@@ -216,29 +210,6 @@ function RootSpanEndTime({ rootSpan }: RootSpanProps) {
     <Text color="text-700" size="XS">
       {fullTimeFormatter(endDate)}
     </Text>
-  );
-}
-
-function RootSpanTraceLink({
-  traceId,
-  rootSpan,
-}: RootSpanProps & { traceId: string }) {
-  const location = useLocation();
-
-  return (
-    <LinkButton
-      size="S"
-      variant="quiet"
-      leadingVisual={<Icon svg={<Icons.Trace />} />}
-      to={getSessionTraceUrl({
-        pathname: location.pathname,
-        search: location.search,
-        traceId,
-        spanNodeId: rootSpan.id,
-      })}
-    >
-      Trace
-    </LinkButton>
   );
 }
 
@@ -317,15 +288,71 @@ function RootSpanOutputMetadata({ rootSpan }: RootSpanProps) {
   );
 }
 
-function SessionTurnDetail({
+const sessionTurnDividerCSS = css`
+  .session-turn-divider__rule {
+    flex: 1;
+    height: 0;
+    border-top: 1px solid var(--global-color-gray-300);
+  }
+`;
+
+/**
+ * A divider that labels a turn ("Turn 01") and exposes the turn-level actions:
+ * copy the trace ID and view the trace. The whole turn is one trace, so these
+ * controls belong here rather than inside the OUTPUT bubble.
+ */
+function SessionTurnDivider({
+  index,
   traceId,
   rootSpan,
-}: RootSpanProps & { traceId: string }) {
+}: RootSpanProps & { traceId: string; index: number }) {
+  const location = useLocation();
+  const paddedIndex = String(index + 1).padStart(2, "0");
+  return (
+    <Flex
+      direction="row"
+      alignItems="center"
+      gap="size-100"
+      css={sessionTurnDividerCSS}
+    >
+      <Text fontFamily="mono" color="text-500">
+        {paddedIndex}
+      </Text>
+      <div className="session-turn-divider__rule" />
+      <CopyToClipboardButton
+        text={traceId}
+        size="S"
+        variant="quiet"
+        tooltipText="Copy trace ID"
+        aria-label="Copy trace ID"
+      />
+      <LinkButton
+        size="S"
+        variant="quiet"
+        aria-label="View trace"
+        leadingVisual={<Icon svg={<Icons.Trace />} />}
+        to={getSessionTraceUrl({
+          pathname: location.pathname,
+          search: location.search,
+          traceId,
+          spanNodeId: rootSpan.id,
+        })}
+      />
+    </Flex>
+  );
+}
+
+function SessionTurnDetail({
+  index,
+  traceId,
+  rootSpan,
+}: RootSpanProps & { traceId: string; index: number }) {
   const user = getUserFromRootSpanAttributes(rootSpan.attributes);
   const inputLabel = user != null ? `USER: ${user}` : "INPUT";
 
   return (
     <Flex direction="column" gap="size-200">
+      <SessionTurnDivider index={index} traceId={traceId} rootSpan={rootSpan} />
       <Flex
         direction="column"
         gap="size-100"
@@ -347,11 +374,7 @@ function SessionTurnDetail({
         alignItems="end"
         css={messageWrapCSS}
       >
-        <RootSpanMessage
-          extra={<RootSpanTraceLink traceId={traceId} rootSpan={rootSpan} />}
-          role="OUTPUT"
-          value={rootSpan.output?.value}
-        />
+        <RootSpanMessage role="OUTPUT" value={rootSpan.output?.value} />
         <RootSpanOutputMetadata rootSpan={rootSpan} />
       </Flex>
     </Flex>
@@ -522,6 +545,8 @@ function SessionTurnList({
 const turnDetailRowCSS = css`
   &[data-selected] {
     background-color: var(--global-list-detail-selected-background-color);
+    border-bottom: var(--global-border-size-thin) solid
+      var(--global-border-color-default);
   }
 `;
 
@@ -727,7 +752,7 @@ export function SessionDetailsTraceList({
             debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
           }
         >
-          {sessionRootSpans.map(({ traceId, rootSpan }) => (
+          {sessionRootSpans.map(({ traceId, rootSpan }, index) => (
             <div
               key={rootSpan.spanId}
               css={turnDetailRowCSS}
@@ -741,12 +766,16 @@ export function SessionDetailsTraceList({
               }}
             >
               <View
-                borderBottomColor="default"
-                borderBottomWidth="thin"
-                padding="size-200"
+                paddingTop="size-100"
+                paddingBottom="size-200"
+                paddingX="size-200"
               >
                 <View width="100%" maxWidth="size-8500" marginX="auto">
-                  <SessionTurnDetail traceId={traceId} rootSpan={rootSpan} />
+                  <SessionTurnDetail
+                    index={index}
+                    traceId={traceId}
+                    rootSpan={rootSpan}
+                  />
                 </View>
               </View>
             </div>


### PR DESCRIPTION
* Moves trace link from above the turn output to a new divider between turn, better matching what the data is attached to
* adds ID display with copy

https://github.com/user-attachments/assets/20999e49-dde2-480a-acd7-b577b9c501c1

* divider line hidden within and directly after a selected turn, since those carry their own borders
<img width="1064" height="1920" alt="session-turn-hr-scenarios" src="https://github.com/user-attachments/assets/283f8ec4-6e4e-4ef6-b3a2-65d95898c4b7" />
