### PR TITLE
docs: remove stale metrics image TODO

### DIFF
--- a/docs/phoenix/tracing/llm-traces/metrics.mdx
+++ b/docs/phoenix/tracing/llm-traces/metrics.mdx
@@ -5,7 +5,6 @@ description: Each Phoenix project comes with a pre-defined metrics dashboard
 
 To access the dashboard in a space, navigate to "Dashboards" in the sidebar, then choose your project from the dropdown at the top of the page.
 
-{/* TODO: replace the placeholder URL below with the uploaded image URL (upload to the arize-phoenix-assets GCS bucket under assets/images/) */}
 <Frame caption="The pre-defined metrics dashboard for a Phoenix project">
   ![Phoenix metrics dashboard showing traces over time and trace latency percentiles](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/ui/phoenix_dashboard.jpg)
 </Frame>


### PR DESCRIPTION
## Summary
Small focused improvement for metrics dashboard documentation.

## Changes
- Remove a stale TODO comment that still referred to the dashboard image as a placeholder.

## Validation
- Docs-only change; reviewed the one-line diff.

## Notes
Kept intentionally small to make review easy.