### PR TITLE
docs(mcp): fix shell comment in README

### DIFF
--- a/js/packages/phoenix-mcp/README.md
+++ b/js/packages/phoenix-mcp/README.md
@@ -68,7 +68,7 @@ This MCP server can be used with `npx` and can be directly integrated with clien
 This package is managed via a pnpm workspace.
 
 ```sh
-// From the /js/ directory
+# From the /js/ directory
 pnpm install
 pnpm build
 ```


### PR DESCRIPTION
## Summary
Small focused improvement for the Phoenix MCP README.

## Changes
- Fix an incorrect shell comment in the README example.

## Validation
- Docs-only change; reviewed the README diff.

## Notes
Kept intentionally small to make review easy.