### PR TITLE
ci: add copilot to the CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,4 +30,4 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/Arize-ai/phoenix/blob/main/CLA.md"
           branch: "cla"
-          allowlist: gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot], claude, copilot-swe-agent[bot]
+          allowlist: gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot], claude, copilot-swe-agent[bot], copilot


### PR DESCRIPTION
## What

Adds `copilot` to the CLA Assistant allowlist in `.github/workflows/cla.yml`.

## Why

The already-allowlisted `copilot-swe-agent[bot]` is a different identity from
the `copilot` account that authors PRs when the GitHub Copilot coding agent is
invoked. Copilot-authored PRs are currently failing the CLA check as a result.

Allowlist changes to a workflow only take effect once they're on `main`, so
this has to land as its own standalone PR before it can help any in-flight
Copilot PR.

## Change

Appends `copilot` to the existing allowlist — no other changes.
