### PR TITLE
ci: allowlist Copilot coding agent in CLA workflow with correct case

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,4 +30,4 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/Arize-ai/phoenix/blob/main/CLA.md"
           branch: "cla"
-          allowlist: gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot], claude, copilot-swe-agent[bot], copilot
+          allowlist: gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot], claude, Copilot


### PR DESCRIPTION
## Summary

The `contributor-assistant/github-action` matches contributor GitHub logins **case-sensitively**. The Copilot coding agent's real login is `Copilot`, so the lowercase `copilot` and `copilot-swe-agent[bot]` entries in the CLA allowlist never matched — the agent was effectively not allowlisted.

This replaces both stale entries with `Copilot` so the Copilot coding agent is correctly allowlisted.

## Changes

- `.github/workflows/cla.yml` (line 33): replaced `copilot-swe-agent[bot], copilot` with `Copilot` in the CLA `allowlist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AowkoKAokawt8gopSkTdh

---
_Generated by [Claude Code](https://claude.ai/code/session_019AowkoKAokawt8gopSkTdh)_