### PR TITLE
ci: fix CLA allowlist to match Copilot's login (case-sensitive)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,4 +30,4 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/Arize-ai/phoenix/blob/main/CLA.md"
           branch: "cla"
-          allowlist: gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot], claude, copilot-swe-agent[bot], copilot
+          allowlist: gitbook-bot, github-actions, dependabot[bot], cursoragent, mintlify[bot], claude, Copilot


### PR DESCRIPTION
## What

Fixes the CLA allowlist so PRs authored by the GitHub Copilot coding agent
actually pass. Replaces the two non-matching `copilot*` entries with the
correctly-cased login `Copilot`.

## Why

`contributor-assistant/github-action` compares allowlist entries against the
contributor's **GitHub login, case-sensitively**. Copilot's real login is
capital-C **`Copilot`** (confirmed by the commit author noreply email
`198982749+Copilot@users.noreply.github.com`, which encodes the login).

The previous entries could never match:
- `copilot` (added in #14123) — correct account, **wrong case** → `copilot` ≠ `Copilot`.
- `copilot-swe-agent[bot]` — the git author *display name*, not the API-resolved login, so it's never compared against.

This is a value bug, not a stale-deploy issue: `pull_request_target` runs the
workflow from the base branch (`main`), and the lowercase entry was already live
on `main` when the CLA recheck still failed.

## After merge

Once this is on `main`, commenting `recheck` on an affected PR (e.g. #14118)
re-evaluates against the updated base-branch workflow, and Copilot-authored
commits will pass.
