### PR TITLE
docs(ci): document Node 20 deprecation for archived CLA Assistant action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,16 @@ jobs:
       statuses: write # set the CLA commit status
     steps:
       # Existing CLA integration; replacing the service requires a separate CLA migration.
+      #
+      # Node 20 deprecation: this action's manifest declares `using: node20`, so GitHub
+      # emits a Node 20 deprecation warning and now runs it on the Node 24 runtime by
+      # default (per https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
+      # The action is functional on Node 24; the warning is informational only. Upstream
+      # (contributor-assistant/github-action) is archived and read-only as of March 2026,
+      # with v2.6.1 as its final release, so there is no Node 24 release to bump the pin to.
+      # We intentionally keep this vetted, SHA-pinned release rather than repoint to an
+      # unvetted community fork on this pull_request_target workflow (which holds write
+      # scopes). Revisit if/when a trusted Node 24 successor exists.
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # zizmor: ignore[archived-uses] v2.6.1


### PR DESCRIPTION
## Summary

The CLA Assistant workflow surfaces a Node 20 deprecation warning:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable.

This comes from `contributor-assistant/github-action@v2.6.1`, whose `action.yml` declares `using: node20`. Findings:

- **GitHub already runs this action on Node 24** ("running with Node 24 by default") — the warning is informational, and the action is functional. The `Error: Committers of PR #14118 have to sign the CLA` line in the same log is the action working as intended (a contributor hasn't signed), not a runtime failure.
- **Upstream is archived and read-only** (since March 2026), with **v2.6.1 as the final release**. There is no Node 24 release to bump the pinned SHA to. This is why the workflow already carries `zizmor: ignore[archived-uses]`.
- The only way to silence the manifest-level `node20` warning would be to repoint at a **community fork** that declares `node24`. On this `pull_request_target` workflow — which holds `contents: write`, `pull-requests: write`, `actions: write`, `statuses: write` — that trades a benign warning for real supply-chain risk, and the existing comment notes that replacing the action requires a separate CLA migration.

## Change

No functional/version change. Adds a comment to `.github/workflows/cla.yml` explaining why the pinned, vetted v2.6.1 release is intentionally retained despite the Node 20 deprecation warning, and the condition under which to revisit (a trusted Node 24 successor).

resolves #<issue-number>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ufTEWizUpygBH6E757eZE)_