### PR TITLE
fix(agent): make Command+I toggle the assistant popover closed

### DIFF
--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -496,6 +496,11 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
     },
     {
       enabled: isAssistantAgentEnabled,
+      // Keep the hotkey live while focus is inside the agent chat's textarea
+      // (or any form field) so pressing the shortcut again toggles the popover
+      // closed rather than being swallowed by the focused input.
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
       preventDefault: true,
     },
     [isAssistantAgentEnabled, toggleOpen]

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -44,6 +44,20 @@ function dispatchCommandI() {
   });
 }
 
+function dispatchCommandIFromElement(target: Element) {
+  act(() => {
+    target.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        code: "KeyI",
+        key: "i",
+        metaKey: true,
+      })
+    );
+  });
+}
+
 function appendModalOverlay() {
   const overlay = document.createElement("div");
   const modalRoot = document.createElement("div");
@@ -165,6 +179,30 @@ describe("AgentChatWidget", () => {
     expect(
       container.querySelector('[data-testid="agent-open"]')?.textContent
     ).toBe("false");
+  });
+
+  it("toggles PXI closed with Command+I while a form field is focused", () => {
+    renderWidget();
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    dispatchCommandIFromElement(textarea);
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("true");
+
+    // With the popover open, focus lives inside the chat's textarea. The
+    // shortcut must still fire from a form field so it can toggle closed.
+    dispatchCommandIFromElement(textarea);
+
+    expect(
+      container.querySelector('[data-testid="agent-open"]')?.textContent
+    ).toBe("false");
+
+    textarea.remove();
   });
 
   it("hides the mounted FAB while PXI is open", () => {


### PR DESCRIPTION
## Summary

Pressing `⌘I` / `Ctrl+I` opens the assistant popover but a second press didn't close it. The `mod+i` hotkey already calls `toggleOpen()`, but once the popover is open focus moves into the chat textarea, and `react-hotkeys-hook` suppresses hotkeys fired from form fields by default. The second keypress was swallowed by the focused textarea, so the toggle never ran.

## Changes

- `AgentChatWidget.tsx`: enable `enableOnFormTags` and `enableOnContentEditable` on the `mod+i` hotkey so it fires even when focus is inside the chat input, letting the shortcut consistently toggle the popover's visibility (mirrors the existing `ctrl+t` hotkey in `Chat.tsx`).
- `AgentChatWidget.test.tsx`: add a regression test that dispatches the shortcut from a focused `<textarea>` and asserts it toggles the popover both open and closed. The test fails without the fix.

## Testing

- `pnpm vitest run src/components/agent/__tests__/AgentChatWidget.test.tsx` — 12 passed.
- Verified the new test fails when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdmQbeMR5HL8HFY3Z193X5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdmQbeMR5HL8HFY3Z193X5)_