### PR TITLE
refactor: remove deprecated --ac- global style references

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1299,7 +1299,7 @@ const appGlobalStylesCSS = css`
   button,
   .theme // We scope it to the theme so we can mount two at the same time
   {
-    font-family: "Geist", sans-serif;
+    font-family: var(--global-font-family-sans);
     font-optical-sizing: auto;
     font-weight: 400;
     font-style: normal;
@@ -1374,6 +1374,9 @@ const appGlobalStylesCSS = css`
     --global-opacity-disabled: 0.4;
 
     /* Text */
+    --global-font-family-sans: "Geist", sans-serif;
+    --global-font-family-mono: "Geist Mono", monospace;
+
     --global-font-size-xxs: 10px;
     --global-font-size-xs: 12px;
     --global-font-size-s: 14px;
@@ -1468,12 +1471,12 @@ const chartCSS = css`
 
 const fontFamilyCSS = css`
   .font-default {
-    font-family: "Geist", sans-serif;
+    font-family: var(--global-font-family-sans);
     font-optical-sizing: auto;
   }
   .font-mono,
   pre {
-    font-family: "Geist Mono", monospace;
+    font-family: var(--global-font-family-mono);
     font-optical-sizing: auto;
   }
 `;

--- a/app/src/components/agent/BatchSpanAnnotateToolDetails.tsx
+++ b/app/src/components/agent/BatchSpanAnnotateToolDetails.tsx
@@ -161,7 +161,7 @@ const spanAnnotationTargetCSS = css`
 
 const spanAnnotationTargetLinkCSS = css`
   min-width: 0;
-  font-family: var(--ac-global-font-family-mono);
+  font-family: "Geist Mono", monospace;
   overflow-wrap: anywhere;
 `;
 

--- a/app/src/components/agent/BatchSpanAnnotateToolDetails.tsx
+++ b/app/src/components/agent/BatchSpanAnnotateToolDetails.tsx
@@ -161,7 +161,7 @@ const spanAnnotationTargetCSS = css`
 
 const spanAnnotationTargetLinkCSS = css`
   min-width: 0;
-  font-family: "Geist Mono", monospace;
+  font-family: var(--global-font-family-mono);
   overflow-wrap: anywhere;
 `;
 

--- a/app/src/components/agent/DiffAcceptRejectToolDetails.tsx
+++ b/app/src/components/agent/DiffAcceptRejectToolDetails.tsx
@@ -38,7 +38,7 @@ const diffAcceptRejectToolDetailsCSS = css`
   }
 
   .diff-accept-reject__diff {
-    font-family: "Geist", sans-serif;
+    font-family: var(--global-font-family-sans);
     white-space: normal;
   }
 `;

--- a/app/src/components/agent/DiffAcceptRejectToolDetails.tsx
+++ b/app/src/components/agent/DiffAcceptRejectToolDetails.tsx
@@ -38,7 +38,7 @@ const diffAcceptRejectToolDetailsCSS = css`
   }
 
   .diff-accept-reject__diff {
-    font-family: var(--ac-global-font-family-sans);
+    font-family: "Geist", sans-serif;
     white-space: normal;
   }
 `;

--- a/app/src/components/agent/LoadDatasetToolDetails.tsx
+++ b/app/src/components/agent/LoadDatasetToolDetails.tsx
@@ -30,7 +30,7 @@ const loadDatasetToolDetailsCSS = css`
       var(--global-dimension-size-125);
     display: grid;
     gap: var(--global-dimension-size-75);
-    font-family: "Geist", sans-serif;
+    font-family: var(--global-font-family-sans);
     white-space: normal;
   }
 

--- a/app/src/components/agent/LoadDatasetToolDetails.tsx
+++ b/app/src/components/agent/LoadDatasetToolDetails.tsx
@@ -30,7 +30,7 @@ const loadDatasetToolDetailsCSS = css`
       var(--global-dimension-size-125);
     display: grid;
     gap: var(--global-dimension-size-75);
-    font-family: var(--ac-global-font-family-sans);
+    font-family: "Geist", sans-serif;
     white-space: normal;
   }
 

--- a/app/src/components/agent/SavePromptToolDetails.tsx
+++ b/app/src/components/agent/SavePromptToolDetails.tsx
@@ -34,7 +34,7 @@ const savePromptToolDetailsCSS = css`
       var(--global-dimension-size-125);
     display: grid;
     gap: var(--global-dimension-size-75);
-    font-family: var(--ac-global-font-family-sans);
+    font-family: "Geist", sans-serif;
     white-space: normal;
   }
 

--- a/app/src/components/agent/SavePromptToolDetails.tsx
+++ b/app/src/components/agent/SavePromptToolDetails.tsx
@@ -34,7 +34,7 @@ const savePromptToolDetailsCSS = css`
       var(--global-dimension-size-125);
     display: grid;
     gap: var(--global-dimension-size-75);
-    font-family: "Geist", sans-serif;
+    font-family: var(--global-font-family-sans);
     white-space: normal;
   }
 

--- a/app/src/components/agent/SlashCommandMenu.tsx
+++ b/app/src/components/agent/SlashCommandMenu.tsx
@@ -58,7 +58,7 @@ const slashCommandMenuItemCSS = css`
 `;
 
 const slashCommandMenuNameCSS = css`
-  font-family: "Geist Mono", monospace;
+  font-family: var(--global-font-family-mono);
   font-size: var(--global-font-size-s);
 `;
 

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -199,7 +199,7 @@ export const toolPartCSS = css`
 
   .tool-part__body {
     background: var(--tool-call-body-background-color);
-    font-family: var(--ac-global-font-family-code);
+    font-family: "Geist Mono", monospace;
     font-size: var(--global-font-size-xs);
     line-height: var(--global-line-height-xs);
     white-space: pre-wrap;
@@ -210,7 +210,7 @@ export const toolPartCSS = css`
   }
 
   .tool-part__subagent-message {
-    font-family: var(--ac-global-font-family-sans);
+    font-family: "Geist", sans-serif;
     font-size: var(--global-font-size-s);
     line-height: var(--global-line-height-s);
     padding: 0 var(--global-dimension-size-250) var(--global-dimension-size-125);
@@ -291,7 +291,7 @@ export const toolPartCSS = css`
   .tool-part__preview {
     flex: ${TOOL_CALL_SUMMARY_LANE_RULES.middleFlex};
     font-weight: 400;
-    font-family: var(--ac-global-font-family-code);
+    font-family: "Geist Mono", monospace;
     color: var(--tool-call-secondary-color);
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -199,7 +199,7 @@ export const toolPartCSS = css`
 
   .tool-part__body {
     background: var(--tool-call-body-background-color);
-    font-family: "Geist Mono", monospace;
+    font-family: var(--global-font-family-mono);
     font-size: var(--global-font-size-xs);
     line-height: var(--global-line-height-xs);
     white-space: pre-wrap;
@@ -210,7 +210,7 @@ export const toolPartCSS = css`
   }
 
   .tool-part__subagent-message {
-    font-family: "Geist", sans-serif;
+    font-family: var(--global-font-family-sans);
     font-size: var(--global-font-size-s);
     line-height: var(--global-line-height-s);
     padding: 0 var(--global-dimension-size-250) var(--global-dimension-size-125);
@@ -291,7 +291,7 @@ export const toolPartCSS = css`
   .tool-part__preview {
     flex: ${TOOL_CALL_SUMMARY_LANE_RULES.middleFlex};
     font-weight: 400;
-    font-family: "Geist Mono", monospace;
+    font-family: var(--global-font-family-mono);
     color: var(--tool-call-secondary-color);
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/src/components/core/counter/Counter.tsx
+++ b/app/src/components/core/counter/Counter.tsx
@@ -20,7 +20,7 @@ const counterCSS = css`
   line-height: var(--global-line-height-xs);
   text-align: center;
   color: var(--global-text-color-900);
-  font-family: "Geist Mono", monospace;
+  font-family: var(--global-font-family-mono);
   &[data-variant="danger"] {
     background-color: var(--global-color-danger-700);
   }

--- a/app/src/components/core/timer/Timer.tsx
+++ b/app/src/components/core/timer/Timer.tsx
@@ -25,7 +25,7 @@ export type TimerProps = {
 };
 
 const timerCSS = css`
-  font-family: "Geist Mono", monospace;
+  font-family: var(--global-font-family-mono);
   font-variant-numeric: tabular-nums;
   ${textSizeCSS};
 `;

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -1374,11 +1374,11 @@ const typeFooterCSS = css`
 
   & .cm-editor {
     height: 100% !important;
-    background-color: var(--ac-global-color-grey-100);
+    background-color: var(--global-color-gray-100);
   }
 
   & .cm-gutters {
-    background-color: var(--ac-global-color-grey-100);
+    background-color: var(--global-color-gray-100);
   }
 
   & .cm-scroller {

--- a/app/src/components/exception/TextErrorBoundaryFallback.tsx
+++ b/app/src/components/exception/TextErrorBoundaryFallback.tsx
@@ -51,7 +51,7 @@ export function TextErrorBoundaryFallback({
               white-space: pre-wrap;
               overflow-wrap: break-word;
               margin: 0;
-              font-size: var(--ac-global-font-size-xs, 12px);
+              font-size: var(--global-font-size-xs, 12px);
             `}
           >
             {error}

--- a/app/src/components/filter/styles.ts
+++ b/app/src/components/filter/styles.ts
@@ -43,7 +43,7 @@ export const dslFilterCodeMirrorCSS = css`
       transform: translateY(calc(-1 * var(--global-dimension-static-size-200)));
     }
     & > ul {
-      font-family: "Geist", sans-serif;
+      font-family: var(--global-font-family-sans);
       font-size: var(--global-font-size-s);
       line-height: var(--global-line-height-s);
       max-height: 400px;
@@ -81,7 +81,7 @@ export const dslFilterCodeMirrorCSS = css`
       }
     }
     .cm-completionLabel {
-      font-family: "Geist Mono", monospace;
+      font-family: var(--global-font-family-mono);
       /* An option label can be an arbitrarily long expression (e.g. a
          recent search) — truncate rather than wrap or overflow so every
          row stays one line */
@@ -91,7 +91,7 @@ export const dslFilterCodeMirrorCSS = css`
       white-space: nowrap;
     }
     li.dsl-filter-suggestion .cm-completionLabel {
-      font-family: "Geist", sans-serif;
+      font-family: var(--global-font-family-sans);
     }
     .cm-completionMatchedText {
       text-decoration: none;
@@ -101,7 +101,7 @@ export const dslFilterCodeMirrorCSS = css`
     .cm-completionDetail {
       margin-left: auto;
       font-style: normal;
-      font-family: "Geist Mono", monospace;
+      font-family: var(--global-font-family-mono);
       font-size: var(--global-font-size-xs);
       color: var(--global-text-color-500);
       overflow: hidden;
@@ -114,7 +114,7 @@ export const dslFilterCodeMirrorCSS = css`
   /* The info panel shown beside the highlighted completion */
   .cm-tooltip.cm-completionInfo {
     ${popoverSurfaceCSS}
-    font-family: "Geist", sans-serif;
+    font-family: var(--global-font-family-sans);
     font-size: var(--global-font-size-s);
     padding: var(--global-dimension-static-size-100);
     color: var(--global-text-color-700);

--- a/app/src/components/markdown/streamdownComponents.tsx
+++ b/app/src/components/markdown/streamdownComponents.tsx
@@ -199,7 +199,7 @@ const inlineCodeCSS = css`
   border-radius: var(--global-rounding-small);
   background: var(--global-inline-code-background-color);
   color: var(--global-inline-code-text-color);
-  font-family: var(--ac-global-font-family-code);
+  font-family: "Geist Mono", monospace;
   font-size: 0.9em;
   line-height: 1.4;
 `;

--- a/app/src/components/markdown/streamdownComponents.tsx
+++ b/app/src/components/markdown/streamdownComponents.tsx
@@ -199,7 +199,7 @@ const inlineCodeCSS = css`
   border-radius: var(--global-rounding-small);
   background: var(--global-inline-code-background-color);
   color: var(--global-inline-code-text-color);
-  font-family: "Geist Mono", monospace;
+  font-family: var(--global-font-family-mono);
   font-size: 0.9em;
   line-height: 1.4;
 `;

--- a/app/src/components/markdown/styles.ts
+++ b/app/src/components/markdown/styles.ts
@@ -64,7 +64,7 @@ export const markdownCSS = css`
     border-bottom: 1px solid var(--global-code-block-border-color);
     background: var(--global-code-block-header-background-color);
     color: var(--global-code-block-header-text-color);
-    font-family: var(--ac-global-font-family-code);
+    font-family: "Geist Mono", monospace;
     font-size: var(--global-font-size-xs);
     line-height: var(--global-line-height-xs);
     letter-spacing: 0.03em;
@@ -145,7 +145,7 @@ export const markdownCSS = css`
     margin: 0;
     padding: var(--global-dimension-size-150);
     background: transparent;
-    font-family: var(--ac-global-font-family-code);
+    font-family: "Geist Mono", monospace;
     font-size: var(--global-font-size-sm);
     line-height: var(--global-line-height-s);
     white-space: pre;
@@ -153,7 +153,7 @@ export const markdownCSS = css`
   }
 
   [data-streamdown="code-block-body"] code {
-    font-family: var(--ac-global-font-family-code);
+    font-family: "Geist Mono", monospace;
     white-space: pre;
   }
 

--- a/app/src/components/markdown/styles.ts
+++ b/app/src/components/markdown/styles.ts
@@ -64,7 +64,7 @@ export const markdownCSS = css`
     border-bottom: 1px solid var(--global-code-block-border-color);
     background: var(--global-code-block-header-background-color);
     color: var(--global-code-block-header-text-color);
-    font-family: "Geist Mono", monospace;
+    font-family: var(--global-font-family-mono);
     font-size: var(--global-font-size-xs);
     line-height: var(--global-line-height-xs);
     letter-spacing: 0.03em;
@@ -145,7 +145,7 @@ export const markdownCSS = css`
     margin: 0;
     padding: var(--global-dimension-size-150);
     background: transparent;
-    font-family: "Geist Mono", monospace;
+    font-family: var(--global-font-family-mono);
     font-size: var(--global-font-size-sm);
     line-height: var(--global-line-height-s);
     white-space: pre;
@@ -153,7 +153,7 @@ export const markdownCSS = css`
   }
 
   [data-streamdown="code-block-body"] code {
-    font-family: "Geist Mono", monospace;
+    font-family: var(--global-font-family-mono);
     white-space: pre;
   }
 

--- a/app/src/pages/experiments/ExperimentDetailsDialog.tsx
+++ b/app/src/pages/experiments/ExperimentDetailsDialog.tsx
@@ -101,7 +101,7 @@ const detailRowCSS = css`
   flex-direction: row;
   justify-content: space-between;
   align-items: baseline;
-  padding: var(--ac-global-dimension-size-50) 0;
+  padding: var(--global-dimension-size-50) 0;
 `;
 
 function DetailRow({

--- a/app/src/pages/project/ProjectAnnotationCountsCards.tsx
+++ b/app/src/pages/project/ProjectAnnotationCountsCards.tsx
@@ -319,7 +319,7 @@ const ProjectAnnotationCountsCardsContent = (
 };
 
 const totalCountCSS = css`
-  color: var(--ac-global-text-color-700);
+  color: var(--global-text-color-700);
 `;
 
 const countCellCSS = css`

--- a/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
@@ -56,15 +56,15 @@ const credentialFieldFooterCSS = css`
 
 const credentialDescriptionCSS = css`
   flex: 1 1 auto;
-  color: var(--ac-global-text-color-700);
-  font-size: var(--ac-global-font-size-xs);
+  color: var(--global-text-color-700);
+  font-size: var(--global-font-size-xs);
 `;
 
 const credentialEnvVarCSS = css`
   flex: 0 0 auto;
   font-family: "Geist Mono", monospace;
-  font-size: var(--ac-global-font-size-xs);
-  color: var(--ac-global-text-color-500);
+  font-size: var(--global-font-size-xs);
+  color: var(--global-text-color-500);
   white-space: nowrap;
 `;
 

--- a/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProviderCredentialsDialog.tsx
@@ -62,7 +62,7 @@ const credentialDescriptionCSS = css`
 
 const credentialEnvVarCSS = css`
   flex: 0 0 auto;
-  font-family: "Geist Mono", monospace;
+  font-family: var(--global-font-family-mono);
   font-size: var(--global-font-size-xs);
   color: var(--global-text-color-500);
   white-space: nowrap;

--- a/app/src/pages/trace/SessionDetailsTracesView.tsx
+++ b/app/src/pages/trace/SessionDetailsTracesView.tsx
@@ -724,7 +724,7 @@ const traceTreeContainerCSS = css`
   max-height: 500px;
   overflow: auto;
   border-top: 1px solid var(--global-border-color-default);
-  background: var(--ac-global-color-grey-75);
+  background: var(--global-color-gray-75);
 `;
 
 const spanDetailsContainerCSS = css`

--- a/app/stories/AgentChatWidgetButton.stories.tsx
+++ b/app/stories/AgentChatWidgetButton.stories.tsx
@@ -55,8 +55,8 @@ const interactiveCanvasCSS = css`
     ),
     linear-gradient(
       180deg,
-      var(--ac-global-background-color-dark-300),
-      var(--ac-global-background-color-dark-200)
+      var(--global-color-gray-300),
+      var(--global-color-gray-200)
     );
   overflow: hidden;
 `;

--- a/app/stories/FileDropZone.stories.tsx
+++ b/app/stories/FileDropZone.stories.tsx
@@ -20,9 +20,9 @@ const fileChipCSS = css`
   align-items: center;
   gap: 4px;
   padding: 2px 10px;
-  background: var(--ac-global-color-grey-300);
+  background: var(--global-color-gray-300);
   border-radius: 12px;
-  font-size: var(--ac-global-dimension-font-size-75);
+  font-size: var(--global-dimension-font-size-75);
   list-style: none;
 `;
 
@@ -32,7 +32,7 @@ const fileChipRemoveButtonCSS = css`
   cursor: pointer;
   padding: 0 2px;
   line-height: 1;
-  color: var(--ac-global-text-color-700);
+  color: var(--global-text-color-700);
 `;
 
 const meta: Meta<typeof FileDropZone> = {

--- a/app/stories/ToolPart.stories.tsx
+++ b/app/stories/ToolPart.stories.tsx
@@ -27,18 +27,18 @@ const containerCSS = css`
 `;
 
 const storyNoteCSS = css`
-  margin-bottom: var(--ac-global-dimension-size-200);
-  padding: var(--ac-global-dimension-size-150);
-  border: 1px solid var(--ac-global-color-grey-300);
-  border-radius: var(--ac-global-rounding-small);
-  background: var(--ac-global-color-grey-100);
-  color: var(--ac-global-text-color-900);
+  margin-bottom: var(--global-dimension-size-200);
+  padding: var(--global-dimension-size-150);
+  border: 1px solid var(--global-color-gray-300);
+  border-radius: var(--global-rounding-small);
+  background: var(--global-color-gray-100);
+  color: var(--global-text-color-900);
   font-size: 12px;
   line-height: 1.5;
 
   strong {
     display: block;
-    margin-bottom: var(--ac-global-dimension-size-50);
+    margin-bottom: var(--global-dimension-size-50);
     font-weight: 600;
   }
 `;

--- a/app/stories/TraceTreeSkeleton.stories.tsx
+++ b/app/stories/TraceTreeSkeleton.stories.tsx
@@ -20,7 +20,7 @@ const frameCSS = {
   width: 640,
   height: 480,
   border: "1px solid var(--global-border-color-default)",
-  background: "var(--ac-global-color-grey-75)",
+  background: "var(--global-color-gray-75)",
   overflow: "auto" as const,
 };
 


### PR DESCRIPTION
## Summary

Removes all `--ac-global-*` CSS custom property references from the frontend. These `--ac-` tokens are **not defined anywhere** in the codebase — they're a deprecated naming scheme that was silently resolving to nothing (or falling back to browser defaults). All references now point at the real, theme-aware `--global-*` tokens defined in `app/src/GlobalStyles.tsx`.

Also adds first-class `--global-font-family-sans` / `--global-font-family-mono` design tokens and wires every hardcoded `"Geist"` / `"Geist Mono"` font stack (both the ones formerly under `--ac-` and pre-existing literals) through them, so font families now have a single source of truth.

## Mapping

| Deprecated | Replacement |
|---|---|
| `--ac-global-color-grey-*` | `--global-color-gray-*` |
| `--ac-global-text-color-*` | `--global-text-color-*` |
| `--ac-global-font-size-xs` | `--global-font-size-xs` |
| `--ac-global-dimension-size-*` | `--global-dimension-size-*` |
| `--ac-global-dimension-font-size-75` | `--global-dimension-font-size-75` |
| `--ac-global-rounding-small` | `--global-rounding-small` |
| `--ac-global-background-color-dark-{200,300}` | `--global-color-gray-{200,300}` (theme-aware) |
| `--ac-global-font-family-{code,mono}` | `--global-font-family-mono` (new token) |
| `--ac-global-font-family-sans` | `--global-font-family-sans` (new token) |

## Screenshots

Captured via Storybook (which mounts `GlobalStyles`, so tokens resolve exactly as in the app) for the most affected surfaces. No regressions — fonts, colors, and gradients all render correctly.

**Agent tool part** — exercises both `--global-font-family-mono` (tool output, note the aligned monospace columns) and `--global-font-family-sans`:

![tool part](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14128-toolpart-fonts.png)

**File drop zone** — renamed color / size tokens (`--global-color-gray-300`, `--global-text-color-700`, `--global-dimension-font-size-75`):

![file drop zone](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14128-filedropzone.png)

**Agent chat widget button** — `--global-color-gray-{200,300}` gradient (previously an invalid `--ac-` gradient that resolved to transparent):

![agent widget](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14128-agent-widget-gradient.png)

**Trace tree skeleton** — `--global-color-gray-75` background + default border:

![trace tree skeleton](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14128-trace-tree-skeleton.png)

## Verification

- `grep -rn "\-\-ac-" app/` returns nothing
- `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)