### PR TITLE
feat(client): add name_contains filter to Python client projects.list()

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
@@ -113,8 +113,14 @@ class Projects:
 
     def list(
         self,
+        *,
+        name_contains: Optional[str] = None,
     ) -> list[v1.Project]:
         """List all projects.
+
+        Args:
+            name_contains (Optional[str]): If provided, only return projects whose
+                name contains this substring (case-insensitive).
 
         Returns:
             A list of all projects.
@@ -131,12 +137,19 @@ class Projects:
             projects = client.projects.list()
             for project in projects:
                 print(f"Project name: {project['name']}")
+
+            # Filter by a substring of the project name
+            projects = client.projects.list(name_contains="agent")
         """  # noqa: E501
         all_projects: list[v1.Project] = []
         next_cursor: Optional[str] = None
         while True:
             url = "v1/projects"
-            params = {"cursor": next_cursor} if next_cursor else {}
+            params: dict[str, str] = {}
+            if next_cursor:
+                params["cursor"] = next_cursor
+            if name_contains:
+                params["name_contains"] = name_contains
             response = self._client.get(url, params=params)
             response.raise_for_status()
             data = cast(v1.GetProjectsResponseBody, response.json())
@@ -382,8 +395,14 @@ class AsyncProjects:
 
     async def list(
         self,
+        *,
+        name_contains: Optional[str] = None,
     ) -> list[v1.Project]:
         """List all projects.
+
+        Args:
+            name_contains (Optional[str]): If provided, only return projects whose
+                name contains this substring (case-insensitive).
 
         Returns:
             A list of all projects.
@@ -400,12 +419,19 @@ class AsyncProjects:
             projects = await async_client.projects.list()
             for project in projects:
                 print(f"Project name: {project['name']}")
+
+            # Filter by a substring of the project name
+            projects = await async_client.projects.list(name_contains="agent")
         """  # noqa: E501
         all_projects: list[v1.Project] = []
         next_cursor: Optional[str] = None
         while True:
             url = "v1/projects"
-            params = {"cursor": next_cursor} if next_cursor else {}
+            params: dict[str, str] = {}
+            if next_cursor:
+                params["cursor"] = next_cursor
+            if name_contains:
+                params["name_contains"] = name_contains
             response = await self._client.get(url, params=params)
             response.raise_for_status()
             data = cast(v1.GetProjectsResponseBody, response.json())

--- a/packages/phoenix-client/tests/client/resources/projects/test_projects.py
+++ b/packages/phoenix-client/tests/client/resources/projects/test_projects.py
@@ -1,0 +1,113 @@
+import httpx
+import pytest
+
+from phoenix.client.__generated__ import v1
+from phoenix.client.resources.projects import AsyncProjects, Projects
+
+
+def _make_project(*, id: str = "id1", name: str = "proj-1") -> v1.Project:
+    return v1.Project(id=id, name=name)
+
+
+class TestProjectsList:
+    def test_list_single_page(self) -> None:
+        projects = [_make_project(id=f"id{i}", name=f"p{i}") for i in range(3)]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/projects"
+            assert "name_contains" not in request.url.params
+            return httpx.Response(200, json={"data": projects, "next_cursor": None})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = Projects(client).list()
+        assert len(result) == 3
+
+    def test_list_forwards_name_contains(self) -> None:
+        projects = [_make_project(id="id1", name="my-agent")]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.params.get("name_contains") == "agent"
+            return httpx.Response(200, json={"data": projects, "next_cursor": None})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = Projects(client).list(name_contains="agent")
+        assert len(result) == 1
+        assert result[0]["name"] == "my-agent"
+
+    def test_list_forwards_name_contains_on_every_page(self) -> None:
+        page1 = [_make_project(id="id1", name="agent-1")]
+        page2 = [_make_project(id="id2", name="agent-2")]
+
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            assert request.url.params.get("name_contains") == "agent"
+            if call_count == 1:
+                assert "cursor" not in request.url.params
+                return httpx.Response(200, json={"data": page1, "next_cursor": "cursor-abc"})
+            else:
+                assert request.url.params.get("cursor") == "cursor-abc"
+                return httpx.Response(200, json={"data": page2, "next_cursor": None})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = Projects(client).list(name_contains="agent")
+        assert len(result) == 2
+        assert call_count == 2
+
+    def test_list_without_name_contains_does_not_send_param(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "name_contains" not in request.url.params
+            return httpx.Response(200, json={"data": [], "next_cursor": None})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = Projects(client).list()
+        assert result == []
+
+
+class TestAsyncProjectsList:
+    @pytest.mark.anyio
+    async def test_list_forwards_name_contains(self) -> None:
+        projects = [_make_project(id="id1", name="my-agent")]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.params.get("name_contains") == "agent"
+            return httpx.Response(200, json={"data": projects, "next_cursor": None})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = await AsyncProjects(client).list(name_contains="agent")
+        assert len(result) == 1
+        assert result[0]["name"] == "my-agent"
+
+    @pytest.mark.anyio
+    async def test_list_forwards_name_contains_on_every_page(self) -> None:
+        page1 = [_make_project(id="id1", name="agent-1")]
+        page2 = [_make_project(id="id2", name="agent-2")]
+
+        call_count = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            assert request.url.params.get("name_contains") == "agent"
+            if call_count == 1:
+                return httpx.Response(200, json={"data": page1, "next_cursor": "cursor-abc"})
+            else:
+                assert request.url.params.get("cursor") == "cursor-abc"
+                return httpx.Response(200, json={"data": page2, "next_cursor": None})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = await AsyncProjects(client).list(name_contains="agent")
+        assert len(result) == 2
+        assert call_count == 2
+
+    @pytest.mark.anyio
+    async def test_list_without_name_contains_does_not_send_param(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert "name_contains" not in request.url.params
+            return httpx.Response(200, json={"data": [], "next_cursor": None})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+        result = await AsyncProjects(client).list()
+        assert result == []


### PR DESCRIPTION
fixes #14034

Server-side `name_contains` filtering landed on `GET /v1/projects` in #14029, but the Python client's `Projects.list()` / `AsyncProjects.list()` never exposed it, so callers had to page through every project and filter client-side.

This adds an optional `name_contains` keyword argument to both the sync and async `list()` methods. It's forwarded as a query param on every page of the existing cursor-pagination loop, matching the server's case-insensitive substring semantics from #14029 exactly (no new client-side matching logic).

Issue context: #14034 was filed by @mikeldking, who authored the server-side #14029 this completes — treating it as a maintainer-requested follow-up; happy to adjust if you'd rather it wait.

## Code snippet

    from phoenix.client import Client
    client = Client()

    projects = client.projects.list(name_contains="agent")

## Testing

Added `packages/phoenix-client/tests/client/resources/projects/test_projects.py` covering:
- default `list()` behavior unchanged (no `name_contains` param sent)
- `name_contains` forwarded correctly on a single-page response
- `name_contains` forwarded on *every* page of a multi-page (cursor) response
- same three cases for the async client

Ran locally: `ruff format --check` / `ruff check` clean; `mypy --strict` (package + new test module) clean; `pytest tests/client/resources/projects` 7/7; full sibling suite 168/169 (the 1 failure is pre-existing in `experiments/test_log_methods.py`, untouched by this change).
