### PR TITLE
feat(api): add GET /spans/{span_identifier} endpoint to fetch a single span

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -837,7 +837,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Get a single span by span_identifier
+         * @description Fetch a single span by identifier. The identifier may be either a relay GlobalID or an OpenTelemetry span_id. Returns the span in the same shape as the elements of the list-spans endpoint.
+         */
+        get: operations["getSpan"];
         put?: never;
         post?: never;
         /**
@@ -3068,6 +3072,10 @@ export interface components {
             data: components["schemas"]["SessionData"][];
             /** Next Cursor */
             next_cursor: string | null;
+        };
+        /** GetSpanResponseBody */
+        GetSpanResponseBody: {
+            data: components["schemas"]["Span"];
         };
         /** GetTracesResponseBody */
         GetTracesResponseBody: {
@@ -8912,6 +8920,56 @@ export interface operations {
                 };
             };
             /** @description Span not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getSpan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The span identifier: either a relay GlobalID or OpenTelemetry span_id */
+                span_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetSpanResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -837,7 +837,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Get a single span by span_identifier
+         * @description Fetch a single span by identifier. The identifier may be either a relay GlobalID or an OpenTelemetry span_id. Returns the span in the same shape as the elements of the list-spans endpoint.
+         */
+        get: operations["getSpan"];
         put?: never;
         post?: never;
         /**
@@ -3068,6 +3072,10 @@ export interface components {
             data: components["schemas"]["SessionData"][];
             /** Next Cursor */
             next_cursor: string | null;
+        };
+        /** GetSpanResponseBody */
+        GetSpanResponseBody: {
+            data: components["schemas"]["Span"];
         };
         /** GetTracesResponseBody */
         GetTracesResponseBody: {
@@ -8912,6 +8920,56 @@ export interface operations {
                 };
             };
             /** @description Span not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getSpan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The span identifier: either a relay GlobalID or OpenTelemetry span_id */
+                span_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetSpanResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -837,7 +837,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Get a single span by span_identifier
+         * @description Fetch a single span by identifier. The identifier may be either a relay GlobalID or an OpenTelemetry span_id. Returns the span in the same shape as the elements of the list-spans endpoint.
+         */
+        get: operations["getSpan"];
         put?: never;
         post?: never;
         /**
@@ -3068,6 +3072,10 @@ export interface components {
             data: components["schemas"]["SessionData"][];
             /** Next Cursor */
             next_cursor: string | null;
+        };
+        /** GetSpanResponseBody */
+        GetSpanResponseBody: {
+            data: components["schemas"]["Span"];
         };
         /** GetTracesResponseBody */
         GetTracesResponseBody: {
@@ -8912,6 +8920,56 @@ export interface operations {
                 };
             };
             /** @description Span not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    getSpan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The span identifier: either a relay GlobalID or OpenTelemetry span_id */
+                span_identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetSpanResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1697,6 +1697,10 @@ class GetSessionsResponseBody(TypedDict):
     next_cursor: Optional[str]
 
 
+class GetSpanResponseBody(TypedDict):
+    data: Span
+
+
 class GetTracesResponseBody(TypedDict):
     data: Sequence[TraceData]
     next_cursor: Optional[str]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -5246,6 +5246,69 @@
       }
     },
     "/v1/spans/{span_identifier}": {
+      "get": {
+        "tags": [
+          "spans"
+        ],
+        "summary": "Get a single span by span_identifier",
+        "description": "Fetch a single span by identifier. The identifier may be either a relay GlobalID or an OpenTelemetry span_id. Returns the span in the same shape as the elements of the list-spans endpoint.",
+        "operationId": "getSpan",
+        "parameters": [
+          {
+            "name": "span_identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The span identifier: either a relay GlobalID or OpenTelemetry span_id",
+              "title": "Span Identifier"
+            },
+            "description": "The span identifier: either a relay GlobalID or OpenTelemetry span_id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSpanResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "spans"
@@ -11811,6 +11874,18 @@
           "next_cursor"
         ],
         "title": "GetSessionsResponseBody"
+      },
+      "GetSpanResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Span"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "GetSpanResponseBody"
       },
       "GetTracesResponseBody": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -583,6 +583,107 @@ class SpansResponseBody(PaginatedResponseBody[Span]):
     pass
 
 
+class GetSpanResponseBody(ResponseBody[Span]):
+    pass
+
+
+def _span_identifier_predicate(span_identifier: str) -> tuple[Any, str]:
+    """
+    Build the SQLAlchemy predicate used to resolve a span from a path identifier.
+
+    The identifier may be either a relay ``Span`` GlobalID (matched against
+    ``models.Span.id``) or a raw OpenTelemetry ``span_id`` (matched against
+    ``models.Span.span_id``). ``span_id`` has a global ``UniqueConstraint``, so a
+    raw-id match yields at most one row across all projects.
+
+    Returns:
+        A ``(predicate, error_detail)`` tuple, where ``error_detail`` is the
+        not-found message appropriate to the identifier type.
+    """
+    try:
+        span_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(span_identifier),
+            "Span",
+        )
+        predicate = models.Span.id == span_rowid
+        error_detail = f"Span with relay ID '{span_identifier}' not found"
+    except Exception:
+        predicate = models.Span.span_id == span_identifier
+        error_detail = f"Span with span_id '{span_identifier}' not found"
+    return predicate, error_detail
+
+
+def _span_orm_to_pydantic(span_orm: models.Span, trace_id: str) -> Span:
+    """
+    Convert a ``models.Span`` ORM row into the REST ``Span`` response model.
+
+    This is the single source of truth for the span serialization used by both
+    ``getSpans`` (list) and ``getSpan`` (single), keeping their payloads identical:
+    flatten attributes, pop ``openinference.span.kind`` into ``span_kind``, and
+    normalize event timestamps to timezone-aware UTC.
+    """
+    # Convert events to Phoenix Event list
+    events: list[SpanEvent] = []
+    for event in span_orm.events:
+        event_time = event.get("timestamp")
+        parsed_time = None
+
+        if event_time:
+            if isinstance(event_time, datetime):
+                parsed_time = normalize_datetime(event_time, timezone.utc)
+            elif isinstance(event_time, str):
+                try:
+                    naive_time = datetime.fromisoformat(event_time)
+                    parsed_time = normalize_datetime(naive_time, timezone.utc)
+                except ValueError:
+                    # If ISO format fails, try to parse as timestamp
+                    try:
+                        parsed_time = datetime.fromtimestamp(float(event_time), tz=timezone.utc)
+                    except (ValueError, TypeError):
+                        parsed_time = datetime.now(timezone.utc)  # fallback
+            elif isinstance(event_time, (int, float)):
+                try:
+                    # Assume nanoseconds if very large, otherwise seconds
+                    if event_time > 1e12:  # nanoseconds
+                        parsed_time = datetime.fromtimestamp(
+                            event_time / 1_000_000_000, tz=timezone.utc
+                        )
+                    else:  # seconds
+                        parsed_time = datetime.fromtimestamp(event_time, tz=timezone.utc)
+                except (ValueError, OSError):
+                    parsed_time = datetime.now(timezone.utc)  # fallback
+        else:
+            parsed_time = datetime.now(timezone.utc)  # fallback
+
+        events.append(
+            SpanEvent(
+                name=event.get("name", ""),
+                timestamp=parsed_time,
+                attributes=event.get("attributes", {}),
+            )
+        )
+
+    attributes = {k: v for k, v in flatten(span_orm.attributes or dict(), recurse_on_sequence=True)}
+    openinference_span_kind = attributes.pop("openinference.span.kind", "UNKNOWN")
+
+    return Span(
+        id=str(GlobalID("Span", str(span_orm.id))),
+        name=span_orm.name or "",
+        context=SpanContext(
+            trace_id=trace_id,
+            span_id=span_orm.span_id or "",
+        ),
+        span_kind=openinference_span_kind,
+        parent_id=span_orm.parent_id,
+        start_time=span_orm.start_time,
+        end_time=span_orm.end_time,
+        status_code=span_orm.status_code,
+        status_message=span_orm.status_message or "",
+        attributes=attributes,
+        events=events,
+    )
+
+
 # TODO: Add property details to SpanQuery schema
 @router.post(
     "/spans",
@@ -1012,72 +1113,9 @@ async def span_search(
         next_cursor = str(GlobalID("Span", str(span_extra.id)))
 
     # Convert ORM rows -> Phoenix spans
-    result_spans: list[Span] = []
-    for span_orm, span_trace_id in rows:
-        # Convert events to Phoenix Event list
-        events: list[SpanEvent] = []
-        for event in span_orm.events:
-            event_time = event.get("timestamp")
-            parsed_time = None
-
-            if event_time:
-                if isinstance(event_time, datetime):
-                    parsed_time = normalize_datetime(event_time, timezone.utc)
-                elif isinstance(event_time, str):
-                    try:
-                        naive_time = datetime.fromisoformat(event_time)
-                        parsed_time = normalize_datetime(naive_time, timezone.utc)
-                    except ValueError:
-                        # If ISO format fails, try to parse as timestamp
-                        try:
-                            parsed_time = datetime.fromtimestamp(float(event_time), tz=timezone.utc)
-                        except (ValueError, TypeError):
-                            parsed_time = datetime.now(timezone.utc)  # fallback
-                elif isinstance(event_time, (int, float)):
-                    try:
-                        # Assume nanoseconds if very large, otherwise seconds
-                        if event_time > 1e12:  # nanoseconds
-                            parsed_time = datetime.fromtimestamp(
-                                event_time / 1_000_000_000, tz=timezone.utc
-                            )
-                        else:  # seconds
-                            parsed_time = datetime.fromtimestamp(event_time, tz=timezone.utc)
-                    except (ValueError, OSError):
-                        parsed_time = datetime.now(timezone.utc)  # fallback
-            else:
-                parsed_time = datetime.now(timezone.utc)  # fallback
-
-            events.append(
-                SpanEvent(
-                    name=event.get("name", ""),
-                    timestamp=parsed_time,
-                    attributes=event.get("attributes", {}),
-                )
-            )
-
-        attributes = {
-            k: v for k, v in flatten(span_orm.attributes or dict(), recurse_on_sequence=True)
-        }
-        openinference_span_kind = attributes.pop("openinference.span.kind", "UNKNOWN")
-
-        result_spans.append(
-            Span(
-                id=str(GlobalID("Span", str(span_orm.id))),
-                name=span_orm.name or "",
-                context=SpanContext(
-                    trace_id=span_trace_id,
-                    span_id=span_orm.span_id or "",
-                ),
-                span_kind=openinference_span_kind,
-                parent_id=span_orm.parent_id,
-                start_time=span_orm.start_time,
-                end_time=span_orm.end_time,
-                status_code=span_orm.status_code,
-                status_message=span_orm.status_message or "",
-                attributes=attributes,
-                events=events,
-            )
-        )
+    result_spans: list[Span] = [
+        _span_orm_to_pydantic(span_orm, span_trace_id) for span_orm, span_trace_id in rows
+    ]
 
     return SpansResponseBody(next_cursor=next_cursor, data=result_spans)
 
@@ -1461,6 +1499,41 @@ async def create_spans(
     )
 
 
+@router.get(
+    "/spans/{span_identifier}",
+    operation_id="getSpan",
+    summary="Get a single span by span_identifier",
+    description=(
+        "Fetch a single span by identifier. The identifier may be either a relay "
+        "GlobalID or an OpenTelemetry span_id. Returns the span in the same shape as "
+        "the elements of the list-spans endpoint."
+    ),
+    responses=add_errors_to_responses([404]),
+)
+async def get_span(
+    request: Request,
+    span_identifier: str = Path(
+        description="The span identifier: either a relay GlobalID or OpenTelemetry span_id"
+    ),
+) -> GetSpanResponseBody:
+    predicate, error_detail = _span_identifier_predicate(span_identifier)
+
+    stmt = (
+        select(models.Span, models.Trace.trace_id)
+        .join(models.Trace, onclause=models.Trace.id == models.Span.trace_rowid)
+        .where(predicate)
+    )
+
+    async with request.app.state.db.read() as session:
+        row = (await session.execute(stmt)).first()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail=error_detail)
+
+    span_orm, span_trace_id = row
+    return GetSpanResponseBody(data=_span_orm_to_pydantic(span_orm, span_trace_id))
+
+
 @router.delete(
     "/spans/{span_identifier}",
     dependencies=[Depends(is_not_locked)],
@@ -1517,16 +1590,7 @@ async def delete_span(
     """
     async with request.app.state.db() as session:
         # Determine the predicate for deletion based on identifier type
-        try:
-            span_rowid = from_global_id_with_expected_type(
-                GlobalID.from_id(span_identifier),
-                "Span",
-            )
-            predicate = models.Span.id == span_rowid
-            error_detail = f"Span with relay ID '{span_identifier}' not found"
-        except Exception:
-            predicate = models.Span.span_id == span_identifier
-            error_detail = f"Span with span_id '{span_identifier}' not found"
+        predicate, error_detail = _span_identifier_predicate(span_identifier)
 
         # Delete the span and return its data in one operation
         target_span = await session.scalar(

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2222,6 +2222,7 @@ _COMMON_RESOURCE_ENDPOINTS = (
     (422, "GET", "v1/projects/fake-id-{}/session_annotations"),
     # Spans
     (422, "GET", "v1/spans"),
+    (404, "GET", "v1/spans/fake-id-{}"),
     # Sessions
     (404, "GET", "v1/projects/fake-id-{}/sessions"),
     (404, "GET", "v1/sessions/fake-id-{}"),

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -420,6 +420,69 @@ async def test_delete_span_with_global_id(
         assert remaining_grandchild is not None
 
 
+async def test_get_span_with_global_id(
+    httpx_client: httpx.AsyncClient,
+    span_hierarchy: dict[str, Any],
+) -> None:
+    """Test that a span can be fetched with a relay GlobalID identifier."""
+    hierarchy = span_hierarchy
+    child1_global_id = str(GlobalID("Span", str(hierarchy["child1"].id)))
+
+    response = await httpx_client.get(f"v1/spans/{child1_global_id}")
+    assert response.status_code == 200
+    span = Span.model_validate(response.json()["data"])
+
+    assert span.id == child1_global_id
+    # Response uses the nested context shape, not the flat example in the issue.
+    assert span.context.span_id == "child-1"
+    assert span.context.trace_id == hierarchy["trace"].trace_id
+    assert span.parent_id == "parent-span"
+
+
+async def test_get_span_with_otel_span_id(
+    httpx_client: httpx.AsyncClient,
+    span_hierarchy: dict[str, Any],
+) -> None:
+    """Test that a span can be fetched with a raw OpenTelemetry span_id."""
+    hierarchy = span_hierarchy
+
+    response = await httpx_client.get("v1/spans/parent-span")
+    assert response.status_code == 200
+    span = Span.model_validate(response.json()["data"])
+
+    assert span.id == str(GlobalID("Span", str(hierarchy["parent"].id)))
+    assert span.context.span_id == "parent-span"
+    assert span.context.trace_id == hierarchy["trace"].trace_id
+    assert span.parent_id is None
+
+
+async def test_get_span_not_found(
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: None,
+) -> None:
+    """Test that fetching an unknown identifier returns 404."""
+    response = await httpx_client.get("v1/spans/non-existent-span")
+    assert response.status_code == 404
+    assert "not found" in response.text.lower()
+
+
+async def test_get_span_matches_get_spans_element(
+    httpx_client: httpx.AsyncClient,
+    span_search_test_data: None,
+) -> None:
+    """The single-span payload must be byte-identical to the getSpans list element."""
+    list_resp = await httpx_client.get("v1/projects/search-test/spans")
+    assert list_resp.is_success
+    list_elements = list_resp.json()["data"]
+    assert list_elements
+
+    for element in list_elements:
+        span = Span.model_validate(element)
+        get_resp = await httpx_client.get(f"v1/spans/{span.context.span_id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["data"] == element
+
+
 @pytest.fixture
 async def span_hierarchy_with_metrics(
     db: DbSessionFactory,


### PR DESCRIPTION
resolves #14017

## Summary

Adds `GET /spans/{span_identifier}` to fetch a single span by ID, filling the gap next to the existing `DELETE /spans/{span_identifier}`. Until now a single span could only be read through the list/search endpoints, which require knowing the project and filtering down; this blocks simple "look up one span" flows and the CLI roadmap item #12024 (`px span <id>`).

## What it does

- **Endpoint**: `GET /v1/spans/{span_identifier}`, authenticated read.
- **Identifier**: accepts a relay `Span` GlobalID or a raw OpenTelemetry `span_id`, resolved exactly the way `DELETE /spans/{span_identifier}` already does. The global `UniqueConstraint` on `span_id` keeps a raw-id lookup unambiguous, so no project scope is needed.
- **Response**: `{"data": <span>}` using the same `Span` model the list endpoint (`getSpans`) returns, so a single-span payload is identical to a list element (nested `context.span_id` / `context.trace_id`). Token counts continue to surface inside `attributes` (`llm.token_count.*`), consistent with the list endpoint.
- **Not found**: an unknown or mismatched identifier returns a hard 404 with a message matching the identifier type, rather than an empty payload.

## Implementation notes

To keep list and detail in lockstep, two pieces that were previously inlined are now shared helpers used by both paths, with no behavior change to the existing endpoints:

- `_span_identifier_predicate` — the GlobalID-or-`span_id` resolution, previously inlined in `delete_span`.
- `_span_orm_to_pydantic` — the ORM to `Span` conversion, previously inlined in `span_search`.

A test asserts the single-span payload is byte-identical to the corresponding `getSpans` element, so the two can't drift. Scope is kept to spans: no dedicated top-level `token_count_*` fields (that would be its own change across spans/traces/sessions), and no changes to `DELETE` behavior.

## Test Plan

- New unit tests in `tests/unit/server/api/routers/v1/test_spans.py`: GlobalID lookup, raw OTel `span_id` lookup, 404 on unknown id, and byte-equality with the `getSpans` list element.
- `uv run pytest tests/unit/server/api/routers/v1/test_spans.py` -> 81 passed.
- `ruff format` + `ruff check` clean.
- Regenerated `schemas/openapi.json` and the generated clients (app + phoenix-client TS, Python client) via the repo's codegen; the schema diff is additive.
- Live smoke on a running server built from this branch: ingested an LLM span over OTLP, then `GET /v1/spans/{span_id}` and `GET /v1/spans/{GlobalID}` both returned it with nested `context` and the `llm.token_count.*` attributes intact; an unknown identifier returned a hard 404; and the single-span payload matched the `getSpans` list element exactly.
