### PR TITLE
docs(skills): weekly audit — 2026-07-08

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -39,6 +39,10 @@ px dataset get <name>
 px project list
 px project get <name>
 px annotation-config list
+px annotation-config get <identifier>
+px annotation-config create
+px annotation-config update <identifier>
+px annotation-config delete <id>
 px auth status
 px profile list
 px profile show [name]

--- a/.agents/skills/phoenix-tracing/SKILL.md
+++ b/.agents/skills/phoenix-tracing/SKILL.md
@@ -86,10 +86,6 @@ Reference these guidelines when:
 - [fundamentals-required-attributes](references/fundamentals-required-attributes.md) - Required fields per span type
 - [fundamentals-universal-attributes](references/fundamentals-universal-attributes.md) - Common attributes (user.id, session.id)
 - [fundamentals-flattening](references/fundamentals-flattening.md) - JSON flattening rules
-- [attributes-messages](references/attributes-messages.md) - Chat message format
-- [attributes-metadata](references/attributes-metadata.md) - Custom metadata schema
-- [attributes-graph](references/attributes-graph.md) - Agent workflow attributes
-- [attributes-exceptions](references/attributes-exceptions.md) - Error tracking
 
 ## Common Workflows
 
@@ -110,7 +106,6 @@ references/span-*               # Span type specifications
 references/sessions-*           # Session tracking
 references/production-*         # Production deployment
 references/fundamentals-*       # Core concepts
-references/attributes-*         # Attribute specifications
 
 # By language
 references/*-python.md          # Python implementations

--- a/.agents/skills/phoenix-tracing/references/instrumentation-manual-python.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-manual-python.md
@@ -175,6 +175,48 @@ def process_query(query: str):
         return result
 ```
 
+## Logging pre-built spans via the client (no OpenTelemetry)
+
+When you already have span data — reconstructing a trace from logs, or copying spans
+between projects — POST them directly with `Client.spans.log_spans` instead of running
+the OTel SDK. Spans use Phoenix's simplified structure (the same shape `get_spans`
+returns), so spans read from one project can be logged straight into another.
+
+```python
+from phoenix.client import Client
+from phoenix.client.exceptions import SpanCreationError
+
+client = Client()
+
+spans = [
+    {
+        "name": "answer_question",
+        "span_kind": "AGENT",
+        "context": {"trace_id": "abc123", "span_id": "root01"},
+        "start_time": "2024-01-01T00:00:00Z",
+        "end_time": "2024-01-01T00:00:01Z",
+        "status_code": "OK",
+        "attributes": {"input.value": "What is Phoenix?"},
+    },
+]
+
+try:
+    result = client.spans.log_spans(project_identifier="my-app", spans=spans)
+    print(f"Queued {result['total_queued']} of {result['total_received']} spans")
+except SpanCreationError as e:
+    # All-or-nothing: if any span is invalid or a duplicate, NONE are queued.
+    print(e.invalid_spans, e.duplicate_spans)
+```
+
+Signature: `log_spans(*, project_identifier: str, spans: Sequence[v1.Span], timeout:
+Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS)`, returning a `CreateSpansResponseBody`
+dict with `total_received` / `total_queued` (equal on success). On any invalid or
+duplicate span, no spans are queued and `SpanCreationError` is raised carrying
+`invalid_spans`, `duplicate_spans`, `total_invalid`, and `total_duplicates`. Use
+`client.spans.log_spans_dataframe(project_identifier=..., spans_dataframe=df)` to log
+from a pandas DataFrame. The TypeScript client exposes the same feature as `logSpans`
+(see `instrumentation-manual-typescript.md`).
+
 ## See Also
 
 - **Span attributes:** `span-chain.md`, `span-retriever.md`, `span-tool.md`, `span-llm.md`, `span-agent.md`, `span-embedding.md`, `span-reranker.md`, `span-guardrail.md`, `span-evaluator.md`

--- a/.agents/skills/phoenix-tracing/references/instrumentation-manual-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-manual-typescript.md
@@ -205,6 +205,51 @@ const processWithMetadata = withSpan(
 );
 ```
 
+## Logging pre-built spans via the client (no OpenTelemetry)
+
+When you already have span data — e.g. reconstructing a trace from logs, or copying
+spans from one project to another — you can POST them directly with `logSpans` from
+`@arizeai/phoenix-client/spans` instead of running the OTel SDK. Spans use Phoenix's
+simplified structure, the same shape `getSpans` returns, so spans read from one
+project can be logged straight into another.
+
+```typescript
+import { logSpans, SpanCreationError } from "@arizeai/phoenix-client/spans";
+import type { Span } from "@arizeai/phoenix-client/spans";
+
+const spans: Span[] = [
+  {
+    name: "answer_question",
+    span_kind: "AGENT",
+    context: { trace_id: "abc123", span_id: "root01" },
+    start_time: "2024-01-01T00:00:00Z",
+    end_time: "2024-01-01T00:00:01Z",
+    status_code: "OK",
+    attributes: { "input.value": "What is Phoenix?" },
+  },
+];
+
+try {
+  const result = await logSpans({
+    project: { projectName: "my-app" }, // or { projectId } or a plain project name string
+    spans,
+  });
+  console.log(`Queued ${result.totalQueued} of ${result.totalReceived} spans`);
+} catch (error) {
+  if (error instanceof SpanCreationError) {
+    // All-or-nothing: if any span is invalid or a duplicate, NONE are queued.
+    console.error(error.invalidSpans, error.duplicateSpans);
+  }
+}
+```
+
+`logSpans({ project, spans })` returns `{ totalReceived, totalQueued }` (equal on
+success). If any span is invalid or duplicates an existing span, no spans are queued
+and a `SpanCreationError` is thrown carrying `invalidSpans` (each `{ spanId, traceId,
+error }`), `duplicateSpans` (each `{ spanId, traceId }`), and `totalInvalid` /
+`totalDuplicates` counts. This function is marked `@experimental` and mirrors the
+Python client's `Client.spans.log_spans` (see `instrumentation-manual-python.md`).
+
 ## See Also
 
 - **Span attributes:** `span-chain.md`, `span-retriever.md`, `span-tool.md`, etc.

--- a/.agents/skills/phoenix-tracing/references/setup-python.md
+++ b/.agents/skills/phoenix-tracing/references/setup-python.md
@@ -57,6 +57,12 @@ tracer_provider = register(
 - `batch`: Use BatchSpanProcessor (default: True, production-recommended)
 - `protocol`: `"http/protobuf"` (default) or `"grpc"`
 
+**Endpoint path prefixes (HTTP):** `register` appends `/v1/traces` to the HTTP
+endpoint while preserving any existing path prefix, so a Phoenix served behind a
+reverse proxy works — `endpoint="http://host/prefix"` sends to
+`http://host/prefix/v1/traces`. An endpoint that already ends in `/v1/traces` (with or
+without a trailing slash) is used as-is rather than doubled.
+
 ## Auto-Instrumentation
 
 Install instrumentors for your frameworks:


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-07-01 → 2026-07-08

**Audited against:** `origin/main` at `27a4ecce01dace5f53c72358b584795a6e18cba0`
**Commits analyzed:** 79 (5 user-facing / audit candidates that produced or reconciled skill edits, remainder skipped)

## Edits applied

### phoenix-tracing
- `references/instrumentation-manual-typescript.md` — added a "Logging pre-built spans
  via the client (no OpenTelemetry)" section for the new `logSpans` API shipped in
  commit `794744059` (#13973). Grounded in
  `js/packages/phoenix-client/src/spans/logSpans.ts` (function signature, `Span` type,
  `SpanCreationError` with `invalidSpans`/`duplicateSpans`/`totalInvalid`/`totalDuplicates`,
  all-or-nothing semantics, `@experimental` marker) and the PR's own example
  `js/packages/phoenix-client/examples/log_spans.ts`. `ProjectIdentifier` union verified
  in `js/packages/phoenix-client/src/types/projects.ts:7`.
- `references/instrumentation-manual-python.md` — added the mirror section for
  `Client.spans.log_spans` (the Python method the TS `logSpans` mirrors). Grounded in
  `packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py:586`
  (verbatim signature `log_spans(*, project_identifier: str, spans: Sequence[v1.Span],
  timeout=DEFAULT_TIMEOUT_IN_SECONDS)`), the `Span`/`SpanContext` TypedDicts in
  `packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py:1491,755`,
  and `SpanCreationError` in
  `packages/phoenix-client/src/phoenix/client/exceptions/__init__.py:25`. Also documents
  `log_spans_dataframe` (same module, line 628). NOTE: the Python method pre-dates this
  window; it was added here to pair with the new TS API per the skill's Python/TS
  pairing rule — neither runtime's `log_spans`/`logSpans` was previously in any skill.
- `references/setup-python.md` — added a note under the `register` parameters describing
  HTTP endpoint path-prefix preservation (behavior change in commit `54575a7e7`, #13797).
  Grounded in `packages/phoenix-otel/src/phoenix/otel/otel.py:726` `_construct_http_endpoint`,
  which now preserves an existing path prefix and appends `/v1/traces` (previously the
  prefix was discarded), and no longer doubles an already-`/v1/traces` (or trailing-slash)
  endpoint.
- `SKILL.md` — removed four broken cross-links to reference files that never existed in
  git history (`attributes-messages.md`, `attributes-metadata.md`, `attributes-graph.md`,
  `attributes-exceptions.md`) plus the matching `references/attributes-*` navigation glob.
  Housekeeping, not tied to this window — flagged here for transparency; per the skill's
  decision table, broken cross-links waste agent tool calls and should be deleted.
  Confirmed the files never existed via `git log --all` and that no other skill file
  references them.

### phoenix-cli
- `SKILL.md` — added `annotation-config get / create / update / delete` to the top-level
  invocation quick-list (commit `94cd8f633`, #13968). The detailed "Annotation Configs"
  section was already self-patched by that same PR (verified accurate); only the
  invocation summary still listed `list` alone.

## Self-patched by the source PR (verified, no additional edit needed)

- **phoenix-evals** `references/evaluators-code-typescript.md` and
  `references/evaluators-pre-built.md` — the new TS classification-metric evaluators
  (`createPrecisionEvaluator`, `createRecallEvaluator`, `createF1Evaluator`,
  `createFBetaEvaluator`, `createPrecisionRecallFScoreEvaluators`) from commit
  `1f7d5f034` (#14004) were patched into the skill by that PR. Verified every documented
  symbol against `js/packages/phoenix-evals/src/code/` exports — all five resolve; no
  extra singular composed export exists. No edit required.

## Reconciled tagged candidates (read the diff, dropped with reason)

- `f96dbd9f6` (#14012) `fix(evals): gate 0/1 positive_label auto-detection on default
  macro average` — tagged `evals`. Read `packages/phoenix-evals/metrics/precision_recall.py`;
  it fixes an undocumented behavior detail of `PrecisionRecallFScore`. The skill never
  documented `positive_label` auto-detection, so nothing was stale; the TS reference's
  existing note already correctly states these evaluators mirror the gating behavior. No edit.
- `815bb2c24` (#14001) `refactor(js): migrate evals benchmarks to Phoenix vitest eval
  tests` — tagged `evals`. Confirmed test/config-only (no `src/` public surface). Skip.
- `9debbd50c` (#14029), `83d3cef5e` (#14028), `67f84ba8e` (#14024) — tagged `cli`. See
  Out-of-scope: REST-only, no CLI wrapping and no ergonomic client method (auto-generated
  bindings only). Dropped from `cli`.
- `80dda2385` (#14080) end-to-end PXI turn tracing — tagged `tracing`. See Out-of-scope:
  internal PXI agent + app frontend + server (`src/phoenix/server/agents/`,
  `src/phoenix/tracers.py`), not part of `phoenix-otel` or the public client. Dropped.

## Skipped commits

- Releases / version bumps / release-please: `e35aa00d1`, `1bad9cedb`, `aa1903e72`,
  `55988f2b5`, `16eece774`, `90d75e1f6`, `47a52487a` (client 2.12.0 — features are the
  two REST endpoints below; no new hand-written client methods), `8a855e492`, `053f9d545`,
  `0c18cf881`, `30701c3c8`, `43b2dfc24`, `8c3d52b7e`, `7635797af`.
- Deps: `b919bf6da`, `7f7bab420`, `e7653e519`.
- CI / build / storybook: `318053689`, `8367506ec`, `15137e6d0`.
- Docs / sitemap / llms.txt / skill-bookkeeping: `5386ab775`, `184811c43`, `73a4fbafd`,
  `337a62249`, `7957de5fd`, `04424ee85`, `2f1cc8efc`, `8b826fb8d`, `a4c8ca4ce`,
  `21419cb27`, `64d546125`, `7a1585c9b`, `0eb22c22c`, `9dc561189`, `b88f54c83`,
  `8aea845a8`.
- Cost data update: `7d19cfe66` (built-in model token prices — internal data).
- Frontend-only (belongs to phoenix-frontend/phoenix-design, not the three skills):
  `8d699e7ad`, `c4aa29323`, `81638b6de`, `63fcad265`, `546534a12`, `84d18bd3b`,
  `54f50e2e1`, `7a8830268`, `d4282c53e`, `c8bf70094`, `f251daeab`, `7775860c7`,
  `89d9a98e5`, `12d3eacdf`, `9024db5d4`, `1327bfa00`, `ef6c2940b`, `e78dc189d`,
  `082fe432e`, `a4b85ea96`, `4f82d5a91`, `2f7ea73a6`, `d95e4f30f`, `9bba6e0b0`,
  `8e6a169be`, `d9727dd89`, `ef59667be`, `cf16827f6`, `feacaa670`.

## Out-of-scope findings (real user-facing changes owned by other skills)

- **New REST endpoints, no CLI/SDK ergonomic surface** — `phoenix-rest-api`:
  - `9debbd50c` (#14029) `name_contains` filter on `GET /v1/projects`. The CLI's
    `px project list` does not yet expose a `--name-contains` flag; if/when it wraps this,
    it becomes a phoenix-cli edit.
  - `83d3cef5e` (#14028) assign/list/replace/unassign annotation configs on a project
    over REST.
  - `67f84ba8e` (#14024) dataset label REST endpoints.
  All three ship only as auto-generated OpenAPI bindings in the Python/TS clients
  (`__generated__/`), not hand-written resource methods, and are not wrapped by the CLI.
- `495d87933` (#13864) `auth.md` / `/.well-known/oauth-protected-resource` agent
  authentication discovery — server-side auth discovery (RFC 9728), not a CLI command or
  client method. Owner: `phoenix-server`.
- `67f61660e` (#13991) baseline tagging for experiments — GraphQL `setExperimentBaseline`
  mutation + frontend only; no Python/TS client or CLI surface. Owner: `phoenix-server` /
  `phoenix-frontend`.
- `27a4ecce0` (#14005) online-evals spec — `internal_docs/specs/online-evals.md` only;
  internal design doc, no shipped surface.
