### PR TITLE
docs(integrations): add OrcaRouter LLM provider integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -562,6 +562,13 @@
                 ]
               },
               {
+                "group": "OrcaRouter",
+                "pages": [
+                  "docs/phoenix/integrations/llm-providers/orcarouter",
+                  "docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing"
+                ]
+              },
+              {
                 "group": "VertexAI",
                 "pages": [
                   "docs/phoenix/integrations/llm-providers/vertexai",

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -130,6 +130,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="VertexAI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/9a7aa063-image.avif" href="/docs/phoenix/integrations/llm-providers/vertexai" />
   <Card title="LiteLLM" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/a22c16d3-image.avif" href="/docs/phoenix/integrations/llm-providers/litellm" />
   <Card title="OpenRouter" img="https://storage.googleapis.com/arize-assets/gitbook_openrouter.png" href="/docs/phoenix/integrations/llm-providers/openrouter" />
+  <Card title="OrcaRouter" img="https://www.orcarouter.ai/orca-logo-classic.png" href="/docs/phoenix/integrations/llm-providers/orcarouter" />
 </CardGroup>
 
 ### Platforms

--- a/docs/phoenix/integrations/llm-providers/orcarouter.mdx
+++ b/docs/phoenix/integrations/llm-providers/orcarouter.mdx
@@ -1,0 +1,16 @@
+---
+title: "OrcaRouter"
+description: "OrcaRouter is an OpenAI-compatible AI gateway that routes requests across 200+ models. Use Phoenix tracing to observe which upstream model served each request."
+sidebarTitle: "Overview"
+---
+
+<img noZoom width="400px" style={{margin: "0 auto", borderRadius: "10px"}} src="https://www.orcarouter.ai/orca-logo-classic.png" className="hidden dark:block"/>
+<img noZoom width="400px" style={{margin: "0 auto", borderRadius: "10px"}} src="https://www.orcarouter.ai/orca-logo-classic.png" className="block dark:hidden"/>
+
+<Card title="OrcaRouter" href="https://www.orcarouter.ai/" icon="globe" horizontal>
+**Website**: [](https://www.orcarouter.ai/)
+</Card>
+
+<Columns cols={2}>
+  <Card img="https://www.orcarouter.ai/orca-logo-classic.png" title="OrcaRouter Tracing" href="/docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing"/>
+</Columns>

--- a/docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing.mdx
+++ b/docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing.mdx
@@ -1,0 +1,77 @@
+---
+title: "OrcaRouter Tracing"
+description: "Phoenix provides auto-instrumentation for OrcaRouter through the OpenAI Python Library since OrcaRouter provides a fully OpenAI-compatible API endpoint."
+---
+
+## Install
+
+```bash
+pip install openinference-instrumentation-openai openai
+```
+
+## Setup
+
+Add your OrcaRouter API key as an environment variable:
+
+```bash
+export ORCAROUTER_API_KEY='your_orcarouter_api_key'
+```
+
+Use the register function to connect your application to Phoenix:
+
+```python
+from phoenix.otel import register
+
+# configure the Phoenix tracer
+tracer_provider = register(
+  project_name="my-llm-app", # Default is 'default'
+  auto_instrument=True # Auto-instrument your app based on installed dependencies
+)
+```
+
+## Run OrcaRouter
+
+```python
+import os
+import openai
+
+client = openai.OpenAI(
+    base_url="https://api.orcarouter.ai/v1",
+    api_key=os.environ["ORCAROUTER_API_KEY"]
+)
+
+response = client.chat.completions.create(
+    model="orcarouter/auto",
+    messages=[{"role": "user", "content": "Write a haiku about observability."}],
+)
+print(response.choices[0].message.content)
+```
+
+`orcarouter/auto` selects an upstream provider per request. You can also target a specific provider model using `<provider>/<model>` format (e.g. `openai/gpt-4.1-mini`, `anthropic/claude-haiku-4-5`). To test without a funded account, use a free model such as `deepseek/deepseek-v4-flash-free`.
+
+## Observe
+
+Now that you have tracing set up, all invocations of the OpenAI client pointed at OrcaRouter will be streamed to your running Phoenix for observability and evaluation.
+
+## What Gets Traced
+
+All OrcaRouter model calls are automatically traced and include:
+
+* Request/response data and timing
+* Model name — the resolved upstream model name (e.g. `deepseek-v4-flash-202505`), not the virtual `orcarouter/auto` identifier
+* Token usage and cost data
+* Error handling and debugging information
+
+## Common Issues
+
+* **API Key**: Use your OrcaRouter API key (`sk-orca-...`), not an OpenAI key
+* **Model Names**: Use `orcarouter/auto` for adaptive routing, or `<provider>/<model>` for a specific upstream. See [OrcaRouter's documentation](https://docs.orcarouter.ai/introduction) for available models
+* **Insufficient balance**: `orcarouter/auto` routes to paid upstream models and requires a funded OrcaRouter wallet. Use `deepseek/deepseek-v4-flash-free` to test without balance
+* **Base URL**: Ensure you're using `https://api.orcarouter.ai/v1` as the base URL
+
+## Resources
+
+<Columns cols={2}>
+  <Card title="OrcaRouter Documentation" href="https://docs.orcarouter.ai/introduction" icon="book" horizontal description="OrcaRouter setup docs"/>
+  <Card title="OpenInference OpenAI Instrumentation" href="https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai" icon="puzzle-piece" horizontal description="OpenAI instrumentation package"/>
+</Columns>


### PR DESCRIPTION
## Summary

Adds OrcaRouter as an LLM provider integration in Phoenix docs, mirroring the existing OpenRouter integration.

- New overview page: `docs/phoenix/integrations/llm-providers/orcarouter.mdx`
- New tracing page: `docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing.mdx`
- OrcaRouter card added to LLM Providers section in `integrations.mdx`
- Nav group added to `docs.json` after OpenRouter

## How it works

OrcaRouter is OpenAI-compatible (`https://api.orcarouter.ai/v1`), so it uses `openinference-instrumentation-openai` — the same instrumentor as OpenRouter. The tracing page notes:
- `orcarouter/auto` virtual model (selects upstream per request)
- Resolved upstream model name appears on spans (not `orcarouter/auto`)
- Free model option (`deepseek/deepseek-v4-flash-free`) for testing without a funded account

No evals page needed — users can point the OpenAI eval provider at OrcaRouter's endpoint.
