### PR TITLE
fix(app): scroll settings tab bar instead of wrapping on narrow widths

### DIFF
--- a/app/src/components/core/tabs/Tabs.tsx
+++ b/app/src/components/core/tabs/Tabs.tsx
@@ -72,10 +72,25 @@ const tabListCSS = css`
   }
 
   &[data-orientation="horizontal"] {
-    border-bottom: 1px solid var(--tab-border-color);
+    // Keep the bottom border spanning the full width even when the tabs
+    // overflow and the list becomes horizontally scrollable.
+    box-shadow: inset 0 -1px 0 0 var(--tab-border-color);
+    // When there are more tabs than horizontal space, scroll rather than
+    // wrapping tab labels or clipping tabs off the edge.
+    overflow-x: auto;
+    // Hide the scrollbar; the overflow is still scrollable via trackpad,
+    // shift-scroll, or keyboard navigation between tabs.
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
 
     .react-aria-Tab {
       border-bottom: 3px solid var(--tab-border-color);
+      // Prevent tabs from shrinking or wrapping their labels when the list
+      // runs out of room.
+      flex: 0 0 auto;
+      white-space: nowrap;
     }
   }
 `;

--- a/app/src/components/core/tabs/Tabs.tsx
+++ b/app/src/components/core/tabs/Tabs.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
+import { useEvent, useResizeObserver } from "@react-aria/utils";
 import type { ComponentProps } from "react";
 import React, { useEffect, useRef, useState } from "react";
-import { useEvent, useResizeObserver } from "@react-aria/utils";
 import {
   Tab as AriaTab,
   TabList as AriaTabList,

--- a/app/src/components/core/tabs/Tabs.tsx
+++ b/app/src/components/core/tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import type { ComponentProps } from "react";
-import React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Tab as AriaTab,
   TabList as AriaTabList,
@@ -14,6 +14,60 @@ import {
 
 import type { StylableProps } from "@phoenix/components/core/types";
 import { classNames } from "@phoenix/utils/classNames";
+
+/**
+ * Tracks whether a horizontally scrollable element has content hidden beyond
+ * its start and/or end edges. Used to render a directional fade affordance on
+ * the tab bar, since the scrollbar is hidden and macOS does not show one until
+ * the user actively scrolls.
+ *
+ * Returns a callback ref to attach to the scroll container plus booleans for
+ * whether content overflows past the start (left) and end (right) edges.
+ */
+function useHorizontalOverflow() {
+  const elementRef = useRef<HTMLElement | null>(null);
+  const [overflow, setOverflow] = useState({ start: false, end: false });
+
+  const update = useCallback(() => {
+    const el = elementRef.current;
+    if (!el) {
+      return;
+    }
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    // Account for sub-pixel rounding so the fade doesn't linger at the ends.
+    const maxScroll = scrollWidth - clientWidth;
+    const start = scrollLeft > 1;
+    const end = scrollLeft < maxScroll - 1;
+    setOverflow((prev) =>
+      prev.start === start && prev.end === end ? prev : { start, end }
+    );
+  }, []);
+
+  const ref = useCallback(
+    (node: HTMLElement | null) => {
+      elementRef.current = node;
+      update();
+    },
+    [update]
+  );
+
+  useEffect(() => {
+    const el = elementRef.current;
+    if (!el) {
+      return;
+    }
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(el);
+    return () => {
+      el.removeEventListener("scroll", update);
+      resizeObserver.disconnect();
+    };
+  }, [update]);
+
+  return { ref, overflow };
+}
 
 const tabsCSS = css`
   display: flex;
@@ -79,10 +133,41 @@ const tabListCSS = css`
     // wrapping tab labels or clipping tabs off the edge.
     overflow-x: auto;
     // Hide the scrollbar; the overflow is still scrollable via trackpad,
-    // shift-scroll, or keyboard navigation between tabs.
+    // shift-scroll, or keyboard navigation between tabs. A directional fade
+    // (below) signals that more tabs are available since macOS hides the
+    // scrollbar until the user scrolls.
     scrollbar-width: none;
     &::-webkit-scrollbar {
       display: none;
+    }
+
+    // Fade the edge(s) that have tabs hidden beyond them. The fade width is
+    // transparent-to-opaque so tabs appear to dissolve off the edge, hinting
+    // that the list can be scrolled. Only the overflowing side is faded, so
+    // there is no fade when everything fits or when scrolled to an end.
+    --tab-fade-size: var(--global-dimension-static-size-400);
+    &[data-overflow-start="true"][data-overflow-end="true"] {
+      mask-image: linear-gradient(
+        to right,
+        transparent,
+        black var(--tab-fade-size),
+        black calc(100% - var(--tab-fade-size)),
+        transparent
+      );
+    }
+    &[data-overflow-start="true"][data-overflow-end="false"] {
+      mask-image: linear-gradient(
+        to right,
+        transparent,
+        black var(--tab-fade-size)
+      );
+    }
+    &[data-overflow-start="false"][data-overflow-end="true"] {
+      mask-image: linear-gradient(
+        to right,
+        black calc(100% - var(--tab-fade-size)),
+        transparent
+      );
     }
 
     .react-aria-Tab {
@@ -101,10 +186,14 @@ export function TabList<T extends object>({
   className,
   ...props
 }: AriaTabListProps<T> & StylableProps) {
+  const { ref, overflow } = useHorizontalOverflow();
   return (
     <AriaTabList
+      ref={ref}
       css={css(tabListCSS, _css)}
       className={classNames("react-aria-TabList", className)}
+      data-overflow-start={overflow.start}
+      data-overflow-end={overflow.end}
       {...props}
     >
       {children}

--- a/app/src/components/core/tabs/Tabs.tsx
+++ b/app/src/components/core/tabs/Tabs.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import type { ComponentProps } from "react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { useEvent, useResizeObserver } from "@react-aria/utils";
 import {
   Tab as AriaTab,
   TabList as AriaTabList,
@@ -16,57 +17,44 @@ import type { StylableProps } from "@phoenix/components/core/types";
 import { classNames } from "@phoenix/utils/classNames";
 
 /**
- * Tracks whether a horizontally scrollable element has content hidden beyond
+ * Tracks whether a horizontally scrollable tab list has tabs hidden beyond
  * its start and/or end edges. Used to render a directional fade affordance on
  * the tab bar, since the scrollbar is hidden and macOS does not show one until
  * the user actively scrolls.
  *
- * Returns a callback ref to attach to the scroll container plus booleans for
- * whether content overflows past the start (left) and end (right) edges.
+ * Returns a ref to attach to the scroll container plus booleans for whether
+ * content overflows past the start (left) and end (right) edges.
  */
 function useHorizontalOverflow() {
-  const elementRef = useRef<HTMLElement | null>(null);
-  const [overflow, setOverflow] = useState({ start: false, end: false });
+  const elementRef = useRef<HTMLDivElement | null>(null);
+  const [hasOverflowAtStart, setHasOverflowAtStart] = useState(false);
+  const [hasOverflowAtEnd, setHasOverflowAtEnd] = useState(false);
 
-  const update = useCallback(() => {
+  const update = () => {
     const el = elementRef.current;
-    if (!el) {
+    // The fade affordance only applies to horizontal tab lists; skip
+    // measuring vertical ones so they never report horizontal overflow.
+    if (!el || el.getAttribute("data-orientation") !== "horizontal") {
       return;
     }
     const { scrollLeft, scrollWidth, clientWidth } = el;
     // Account for sub-pixel rounding so the fade doesn't linger at the ends.
     const maxScroll = scrollWidth - clientWidth;
-    const start = scrollLeft > 1;
-    const end = scrollLeft < maxScroll - 1;
-    setOverflow((prev) =>
-      prev.start === start && prev.end === end ? prev : { start, end }
-    );
-  }, []);
+    setHasOverflowAtStart(scrollLeft > 1);
+    setHasOverflowAtEnd(scrollLeft < maxScroll - 1);
+  };
 
-  const ref = useCallback(
-    (node: HTMLElement | null) => {
-      elementRef.current = node;
-      update();
-    },
-    [update]
-  );
-
+  useEvent(elementRef, "scroll", update);
+  useResizeObserver({ ref: elementRef, onResize: update });
+  // The resize observer only sees the container's own box, so content-width
+  // changes that don't resize it (tabs added or removed, count badges
+  // updating) would go unnoticed. Those changes all flow through a React
+  // render, so re-measure after every commit.
   useEffect(() => {
-    const el = elementRef.current;
-    if (!el) {
-      return;
-    }
     update();
-    el.addEventListener("scroll", update, { passive: true });
-    const resizeObserver = new ResizeObserver(update);
-    resizeObserver.observe(el);
-    return () => {
-      el.removeEventListener("scroll", update);
-      resizeObserver.disconnect();
-    };
-  }, [update]);
+  });
 
-  return { ref, overflow };
+  return { ref: elementRef, hasOverflowAtStart, hasOverflowAtEnd };
 }
 
 const tabsCSS = css`
@@ -126,12 +114,18 @@ const tabListCSS = css`
   }
 
   &[data-orientation="horizontal"] {
-    // Keep the bottom border spanning the full width even when the tabs
-    // overflow and the list becomes horizontally scrollable.
+    // Draw the bottom border as an inset shadow so it stays pinned to the
+    // visible width while tabs scroll beneath it. When the edge fade below is
+    // active the line fades along with the rest of that edge — the whole edge
+    // dissolves together.
     box-shadow: inset 0 -1px 0 0 var(--tab-border-color);
     // When there are more tabs than horizontal space, scroll rather than
     // wrapping tab labels or clipping tabs off the edge.
     overflow-x: auto;
+    // react-aria scrolls the focused tab just into view on keyboard
+    // navigation and honors scroll-padding, so inset the scroll port to keep
+    // the focused tab from parking underneath the edge fade.
+    scroll-padding-inline: var(--tab-fade-size);
     // Hide the scrollbar; the overflow is still scrollable via trackpad,
     // shift-scroll, or keyboard navigation between tabs. A directional fade
     // (below) signals that more tabs are available since macOS hides the
@@ -141,31 +135,26 @@ const tabListCSS = css`
       display: none;
     }
 
-    // Fade the edge(s) that have tabs hidden beyond them. The fade width is
+    // Fade the edge(s) that have tabs hidden beyond them. The fade is
     // transparent-to-opaque so tabs appear to dissolve off the edge, hinting
-    // that the list can be scrolled. Only the overflowing side is faded, so
-    // there is no fade when everything fits or when scrolled to an end.
+    // that the list can be scrolled. Each side's fade width collapses to 0
+    // when that side has no hidden tabs, and the mask is dropped entirely
+    // when everything fits.
     --tab-fade-size: var(--global-dimension-static-size-400);
-    &[data-overflow-start="true"][data-overflow-end="true"] {
+    --tab-fade-start: 0px;
+    --tab-fade-end: 0px;
+    &[data-overflow-start="true"] {
+      --tab-fade-start: var(--tab-fade-size);
+    }
+    &[data-overflow-end="true"] {
+      --tab-fade-end: var(--tab-fade-size);
+    }
+    &:is([data-overflow-start="true"], [data-overflow-end="true"]) {
       mask-image: linear-gradient(
         to right,
         transparent,
-        black var(--tab-fade-size),
-        black calc(100% - var(--tab-fade-size)),
-        transparent
-      );
-    }
-    &[data-overflow-start="true"][data-overflow-end="false"] {
-      mask-image: linear-gradient(
-        to right,
-        transparent,
-        black var(--tab-fade-size)
-      );
-    }
-    &[data-overflow-start="false"][data-overflow-end="true"] {
-      mask-image: linear-gradient(
-        to right,
-        black calc(100% - var(--tab-fade-size)),
+        black var(--tab-fade-start),
+        black calc(100% - var(--tab-fade-end)),
         transparent
       );
     }
@@ -186,14 +175,14 @@ export function TabList<T extends object>({
   className,
   ...props
 }: AriaTabListProps<T> & StylableProps) {
-  const { ref, overflow } = useHorizontalOverflow();
+  const { ref, hasOverflowAtStart, hasOverflowAtEnd } = useHorizontalOverflow();
   return (
     <AriaTabList
       ref={ref}
       css={css(tabListCSS, _css)}
       className={classNames("react-aria-TabList", className)}
-      data-overflow-start={overflow.start}
-      data-overflow-end={overflow.end}
+      data-overflow-start={hasOverflowAtStart}
+      data-overflow-end={hasOverflowAtEnd}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Problem

When the window is narrow enough, the settings header tab bar wraps and clips:

- Multi-word labels (e.g. **AI Providers**, **Data Retention**) break onto two lines.
- Trailing tabs (**Prompts**, **Data Retention**, **Assistant**) get clipped off the right edge with **no way to reach them**.

This affects any horizontal `TabList`, since the tab bar is a shared component.

## Fix

Updated the shared horizontal `TabList` styling in `app/src/components/core/tabs/Tabs.tsx`:

- **No wrapping**: tabs are now `flex: 0 0 auto` + `white-space: nowrap`, so labels stay on one line.
- **Scroll instead of clip**: the list becomes `overflow-x: auto` on overflow, so all tabs are reachable by scrolling (trackpad / shift-scroll / keyboard). The scrollbar is visually hidden.
- **Full-width underline**: moved the bottom border from `border-bottom` to an inset `box-shadow` so it spans the full width even while the list scrolls.
- **Overflow affordance (directional fade)**: since the scrollbar is hidden and macOS doesn't show one until the user scrolls, a small `useHorizontalOverflow` hook (`ResizeObserver` + `scroll` listener) toggles `data-overflow-start` / `data-overflow-end` on the `TabList`. A `mask-image` fades tabs off **only** the edge(s) with hidden content — no fade when everything fits or when scrolled to an end.

The change is scoped to `[data-orientation="horizontal"]`, and "never wrap / never clip" is a strictly-better default for all horizontal tab bars in the app.

## Verification (agent-browser @ multiple viewport widths)

- **950px**: "AI Providers" stays one line (previously wrapped).
- **Scroll**: horizontally scrolling reveals "Assistant" at the far right; underline spans full width; nothing clipped.
- **Fade**: right edge fades at scroll start, both edges fade mid-scroll, left edge fades at the end; no fade at 1600px where all tabs fit (verified via the `data-overflow-*` attributes).
- **1600px wide**: layout identical to before.
- `oxlint`, `tsc --noEmit`, and pre-commit hooks pass.

## Screenshots

### Before (950px)
Multi-word tab wraps to two lines; trailing tabs clipped and unreachable.

![settings tabs before fix — AI Providers wraps to two lines and tabs are clipped](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14164-settings-tabs-before.png)

### After (950px)
Single-line tabs; overflow scrolls horizontally to reveal all tabs.

![settings tabs after fix — single-line tabs, no wrapping](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14164-settings-tabs-after.png)

### After — scrolled (950px)
Horizontally scrolling the tab bar reveals the trailing tabs (Prompts, Data Retention, Assistant); the underline spans the full width.

![settings tabs after fix, scrolled to reveal trailing tabs](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14164-settings-tabs-after-scrolled.png)

## Overflow affordance (directional fade)

Only the edge with hidden tabs fades, hinting the list can be scrolled.

**Scroll start** — right edge fades ("Annotations" dissolving), no fade on the left:

![tab bar faded on the right edge at scroll start](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14164-tabs-fade-start.png)

**Mid-scroll** — both edges fade:

![tab bar faded on both edges mid-scroll](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14164-tabs-fade-both.png)

**Scroll end** — left edge fades ("Models" dissolving), "Assistant" fully visible, no fade on the right:

![tab bar faded on the left edge at scroll end](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14164-tabs-fade-end.png)