### PR TITLE
refactor(app): show platform version update as danger text

### DIFF
--- a/app/src/components/nav/VersionUpdateNotice.tsx
+++ b/app/src/components/nav/VersionUpdateNotice.tsx
@@ -235,7 +235,7 @@ export function PlatformVersionStatus() {
     return null;
   }
   return (
-    <Text color="danger" size="XS" data-testid="platform-version-status">
+    <Text color="warning" size="XS" data-testid="platform-version-status">
       A newer version of Phoenix is available (v{latestVersion}).{" "}
       <ExternalLink href={getPhoenixReleaseNotesUrl(latestVersion)}>
         View release notes

--- a/app/src/components/nav/VersionUpdateNotice.tsx
+++ b/app/src/components/nav/VersionUpdateNotice.tsx
@@ -1,7 +1,6 @@
 import { css, keyframes } from "@emotion/react";
 
 import {
-  Alert,
   ExternalLink,
   Icon,
   IconButton,
@@ -236,16 +235,11 @@ export function PlatformVersionStatus() {
     return null;
   }
   return (
-    <Alert
-      variant="warning"
-      extra={
-        <ExternalLink href={getPhoenixReleaseNotesUrl(latestVersion)}>
-          View release notes
-        </ExternalLink>
-      }
-      data-testid="platform-version-status"
-    >
-      A newer version of Phoenix is available (v{latestVersion}).
-    </Alert>
+    <Text color="danger" size="XS" data-testid="platform-version-status">
+      A newer version of Phoenix is available (v{latestVersion}).{" "}
+      <ExternalLink href={getPhoenixReleaseNotesUrl(latestVersion)}>
+        View release notes
+      </ExternalLink>
+    </Text>
   );
 }


### PR DESCRIPTION
## Summary

The "A newer version of Phoenix is available" notice in **Settings > General** was rendered as a full warning `Alert` (icon + bordered box + background). That treatment is heavier than needed for a passive status readout, so this replaces it with plain danger-colored text plus the release-notes link.

- `PlatformVersionStatus` now renders a `Text color="danger" size="XS"` line instead of `<Alert variant="warning">`.
- Kept the "View release notes" `ExternalLink` inline after the message.
- Dropped the now-unused `Alert` import.

No behavioral changes to *when* the notice appears — same `isLagging` / admin-visibility gating. The nav-side `VersionUpdateNotice` card is untouched.

## Notes

- Typecheck (`tsc --noEmit`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6MzUCjKGtwbXRjQNZwR48)_