### PR TITLE
fix(ui): remove permanent scrollbar on trace tree panel

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1073,8 +1073,8 @@ const cardCSS = (theme: Theme) => css`
       ? "var(--global-color-gray-100)"
       : "var(--global-color-gray-75)"};
     --global-card-header-background-color-hover: ${theme === "light"
-      ? "var(--global-color-gray-200)"
-      : "var(--global-color-gray-100)"};
+      ? "rgba(0, 0, 0, 0.04)"
+      : "rgba(255, 255, 255, 0.07)"};
   }
 `;
 

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -58,7 +58,8 @@ export function TraceTree(props: TraceTreeProps) {
         display: flex;
         flex-direction: column;
         overflow: hidden;
-        height: 100%;
+        flex: 1 1 auto;
+        min-height: 0;
         align-items: stretch;
         container-type: inline-size;
       `}

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -45,7 +45,7 @@ export function TraceTreeToolbar() {
         flex: none;
         align-items: center;
         padding: var(--global-dimension-size-100);
-        border-bottom: 1px solid var(--global-color-gray-300);
+        border-bottom: 1px solid var(--global-border-color-default);
         height: var(--global-dimension-size-600);
         @container (width < ${COMPACT_BREAKPOINT}) {
           button {

--- a/app/src/components/trace/TraceTreeToolbar.tsx
+++ b/app/src/components/trace/TraceTreeToolbar.tsx
@@ -42,6 +42,7 @@ export function TraceTreeToolbar() {
         justify-content: space-between;
         box-sizing: border-box;
         width: 100%;
+        flex: none;
         align-items: center;
         padding: var(--global-dimension-size-100);
         border-bottom: 1px solid var(--global-color-gray-300);

--- a/app/src/pages/trace/ConnectedTraceTree.tsx
+++ b/app/src/pages/trace/ConnectedTraceTree.tsx
@@ -70,7 +70,7 @@ export function ConnectedTraceTree(props: ConnectedTraceTreeProps) {
   const totalSpans = data?.numSpans;
   const totalSpansViewing = spansList.length;
   return (
-    <Flex direction="column" flex="1 1 auto" height="100%">
+    <Flex direction="column" flex="1 1 auto" minHeight={0}>
       {hasNext ? (
         <Alert
           variant="warning"

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -357,7 +357,9 @@ function ScrollingPanelContent({ children }: PropsWithChildren) {
       data-testid="scrolling-panel-content"
       css={css`
         height: 100%;
-        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
       `}
     >
       {children}


### PR DESCRIPTION
The trace tree panel showed a vertical scrollbar even when the tree had no overflow.

**Root cause:** `ScrollingPanelContent` (`height: 100%; overflow-y: auto`) contains the trace tree toolbar plus a tree wrapper sized to `height: 100%` of the panel — so the panel's content was always exactly one toolbar-height (48px) taller than the container, producing a permanent scrollbar regardless of tree size.

**Fix:**
- `ScrollingPanelContent` is now a flex column with `overflow: hidden`, so the toolbar and tree partition the panel height instead of stacking past it.
- The tree wrapper (`ConnectedTraceTree`) and `TraceTree` root use `flex: 1 1 auto; min-height: 0` instead of `height: 100%`.
- The toolbar is `flex: none` so it can't be squeezed.
- The tree's inner `<ul>` (`overflow: auto`) remains the sole scroll container, so a scrollbar appears only when spans actually overflow.

Verified in headless Chromium with a reduced reproduction of the before/after DOM/CSS: before, the panel overflows by exactly 48px with only 3 spans (permanent scrollbar); after, no overflow with few spans, and with many spans the inner list scrolls while the panel does not. The session-details usage of `TraceTree` (inside a `max-height` auto-height container) is unaffected since the flex properties resolve the same as the previous no-op `height: 100%` there.

## Additional UI fixes

- **Card header hover is now opacity-based.** The hover overlay on collapsible card headers (`GlobalStyles.tsx`) was a flat gray fill, which washed out color-filled cards like chat role messages (system/user/assistant). It's now a translucent black/white overlay so the underlying color shows through on hover.
- **Trace tree search border now matches the panel.** `TraceTreeToolbar`'s bottom border was hardcoded to `--global-color-gray-300` instead of the shared `--global-border-color-default` token used by the rest of the panel, so it visually mismatched the other borders.

### Screenshots

Card header hover, opacity-based, on an indigo-filled system message card in Playground:

![card header hover](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14168-card-header-hover.png)

Trace tree search toolbar border now matches the surrounding panel borders:

![trace search border](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14168-trace-search-border.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnLAxYCU9mcd53Zsvhf9AQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnLAxYCU9mcd53Zsvhf9AQ)_