### PR TITLE
docs: add TokenLab tracing example

### DIFF
--- a/docs/phoenix/integrations/llm-providers/openai/openai-tracing.mdx
+++ b/docs/phoenix/integrations/llm-providers/openai/openai-tracing.mdx
@@ -4,7 +4,8 @@ description: "Phoenix provides auto-instrumentation for the [OpenAI Python Libra
 ---
 
 <Info>
-**Note***: This instrumentation also works with Azure OpenAI
+**Note***: This instrumentation also works with Azure OpenAI and
+OpenAI-compatible providers.
 
 </Info>
 
@@ -47,6 +48,24 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
+For an OpenAI-compatible provider such as TokenLab, configure the OpenAI client
+with the provider's base URL and API key. The same OpenInference
+instrumentation captures the request:
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="your-tokenlab-api-key",
+    base_url="https://api.tokenlab.sh/v1",
+)
+response = client.chat.completions.create(
+    model="claude-sonnet-5",
+    messages=[{"role": "user", "content": "Write a haiku."}],
+)
+print(response.choices[0].message.content)
+```
+
 ## Observe
 
 Now that you have tracing setup, all invocations of OpenAI (completions, chat completions, embeddings) will be streamed to your running Phoenix for observability and evaluation.
@@ -58,5 +77,4 @@ Now that you have tracing setup, all invocations of OpenAI (completions, chat co
 * [OpenInference package](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai)
 
 * [Working examples](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai/examples)
-
 


### PR DESCRIPTION
## Summary
- Document tracing TokenLab requests with Phoenix through the OpenAI-compatible SDK path.
- Use TokenLab's OpenAI-compatible base URL: https://api.tokenlab.sh/v1
- No runtime behavior changes; documentation only.

## Verification
- git diff --check


---

Supersedes #14156. The previous PR was closed while fixing contributor commit metadata; this replacement branch preserves the same scoped diff with commits authored by `hedging8563 <45883076+hedging8563@users.noreply.github.com>`.
