### PR TITLE
fix(server): resolve PostgreSQL schema for database usage stats

### DIFF
--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     Insert,
     Select,
     SQLColumnExpression,
+    TextClause,
     Values,
     and_,
     case,
@@ -20,6 +21,7 @@ from sqlalchemy import (
     literal_column,
     or_,
     select,
+    text,
     util,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,7 +29,7 @@ from sqlalchemy.orm import QueryableAttribute, aliased
 from sqlalchemy.sql.roles import InElementRole
 from typing_extensions import assert_never
 
-from phoenix.config import PLAYGROUND_PROJECT_NAME
+from phoenix.config import PLAYGROUND_PROJECT_NAME, get_env_database_schema
 from phoenix.db import models
 
 
@@ -1278,3 +1280,31 @@ def token_counts_by_trace(keys: Collection[int]) -> Select[Any]:
         .where(models.Span.trace_rowid.in_(keys))
         .group_by(models.Span.trace_rowid)
     )
+
+
+# Ordinary tables in the schema Phoenix's ORM actually reads and writes:
+# `models.Base.metadata.schema` comes from the same env var (read at import
+# time), and when it's unset table names are unqualified, so they resolve
+# through the connection's search_path — i.e. current_schema().
+_PG_TABLES_IN_PHOENIX_SCHEMA = """\
+FROM pg_class AS c
+JOIN pg_namespace AS n ON n.oid = c.relnamespace
+WHERE c.relkind = 'r'
+AND n.nspname = coalesce(cast(:nspname AS text), current_schema())
+"""
+
+
+def pg_table_sizes_stmt() -> TextClause:
+    """Rows of (table_name, total_bytes) for each ordinary table in Phoenix's
+    PostgreSQL schema, including indexes and TOAST data."""
+    return text(
+        f"SELECT c.relname, pg_total_relation_size(c.oid)\n{_PG_TABLES_IN_PHOENIX_SCHEMA}"
+    ).bindparams(nspname=get_env_database_schema())
+
+
+def pg_total_table_size_stmt() -> TextClause:
+    """Total bytes across all ordinary tables in Phoenix's PostgreSQL schema,
+    including indexes and TOAST data. Returns 0 (not NULL) when no tables match."""
+    return text(
+        f"SELECT coalesce(sum(pg_total_relation_size(c.oid)), 0)\n{_PG_TABLES_IN_PHOENIX_SCHEMA}"
+    ).bindparams(nspname=get_env_database_schema())

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -1283,16 +1283,19 @@ def token_counts_by_trace(keys: Collection[int]) -> Select[Any]:
 
 
 # Ordinary tables in the schema Phoenix's ORM actually reads and writes.
-# Resolution chain:
+# Resolution:
 #   1. The schema env var (`models.Base.metadata.schema` is set from the same
 #      var at import time, so when set it is authoritative).
 #   2. The schema an unqualified reference to the `projects` table resolves
 #      from on this connection (`to_regclass` follows search_path the same way
-#      the ORM's unqualified queries do). This is NOT always current_schema():
-#      CREATE targets the first *existing* schema in search_path, but reads
-#      resolve from the first schema *containing* the table, e.g. when
-#      search_path gained a leading entry after the tables were created.
-#   3. current_schema(), for a fresh database where no tables exist yet.
+#      the ORM's unqualified queries do). This is NOT current_schema(): CREATE
+#      targets the first *existing* schema in search_path, but reads resolve
+#      from the first schema *containing* the table, e.g. when search_path
+#      gained a leading entry after the tables were created.
+# If neither resolves (pre-migration database), the filter matches nothing and
+# usage reports zero: when the ORM can't see the tables, there is no Phoenix
+# usage to report — deliberately not current_schema(), which could count an
+# unrelated application's tables in a shared schema.
 _PG_TABLES_IN_PHOENIX_SCHEMA = f"""\
 FROM pg_class AS c
 JOIN pg_namespace AS n ON n.oid = c.relnamespace
@@ -1302,8 +1305,7 @@ AND n.nspname = coalesce(
     (SELECT pn.nspname
      FROM pg_class AS pc
      JOIN pg_namespace AS pn ON pn.oid = pc.relnamespace
-     WHERE pc.oid = to_regclass('{models.Project.__tablename__}')),
-    current_schema()
+     WHERE pc.oid = to_regclass('{models.Project.__tablename__}'))
 )
 """
 

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -1282,15 +1282,29 @@ def token_counts_by_trace(keys: Collection[int]) -> Select[Any]:
     )
 
 
-# Ordinary tables in the schema Phoenix's ORM actually reads and writes:
-# `models.Base.metadata.schema` comes from the same env var (read at import
-# time), and when it's unset table names are unqualified, so they resolve
-# through the connection's search_path — i.e. current_schema().
-_PG_TABLES_IN_PHOENIX_SCHEMA = """\
+# Ordinary tables in the schema Phoenix's ORM actually reads and writes.
+# Resolution chain:
+#   1. The schema env var (`models.Base.metadata.schema` is set from the same
+#      var at import time, so when set it is authoritative).
+#   2. The schema an unqualified reference to the `projects` table resolves
+#      from on this connection (`to_regclass` follows search_path the same way
+#      the ORM's unqualified queries do). This is NOT always current_schema():
+#      CREATE targets the first *existing* schema in search_path, but reads
+#      resolve from the first schema *containing* the table, e.g. when
+#      search_path gained a leading entry after the tables were created.
+#   3. current_schema(), for a fresh database where no tables exist yet.
+_PG_TABLES_IN_PHOENIX_SCHEMA = f"""\
 FROM pg_class AS c
 JOIN pg_namespace AS n ON n.oid = c.relnamespace
 WHERE c.relkind = 'r'
-AND n.nspname = coalesce(cast(:nspname AS text), current_schema())
+AND n.nspname = coalesce(
+    cast(:nspname AS text),
+    (SELECT pn.nspname
+     FROM pg_class AS pc
+     JOIN pg_namespace AS pn ON pn.oid = pc.relnamespace
+     WHERE pc.oid = to_regclass('{models.Project.__tablename__}')),
+    current_schema()
+)
 """
 
 

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from collections import defaultdict
 from datetime import datetime
@@ -17,7 +18,6 @@ from typing_extensions import TypeAlias, assert_never
 
 from phoenix.config import (
     get_env_database_allocated_storage_capacity_gibibytes,
-    get_env_database_schema,
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_collector_endpoint,
     get_env_phoenix_agents_web_access_enabled,
@@ -28,6 +28,7 @@ from phoenix.db.helpers import (
     SupportedSQLDialect,
     exclude_dataset_evaluator_projects,
     exclude_experiment_projects,
+    pg_table_sizes_stmt,
 )
 from phoenix.db.models import LatencyMs
 from phoenix.db.types.annotation_configs import OptimizationDirection
@@ -148,6 +149,8 @@ from phoenix.server.api.types.UserRole import UserRole
 from phoenix.server.api.types.ValidationResult import ValidationResult
 from phoenix.server.sandbox.types import SANDBOX_BACKEND_TYPES
 from phoenix.utilities.template_formatters import TemplateFormatterError
+
+logger = logging.getLogger(__name__)
 
 initialize_playground_clients()
 
@@ -1585,24 +1588,15 @@ class Query:
             #     stats = cast(Iterable[tuple[str, int]], await session.execute(stmt))
             # stats = _consolidate_sqlite_db_table_stats(stats)
         elif info.context.db.dialect is SupportedSQLDialect.POSTGRESQL:
-            stmt = text("""\
-                SELECT c.relname, pg_total_relation_size(c.oid)
-                FROM pg_class as c
-                INNER JOIN pg_namespace as n ON n.oid = c.relnamespace
-                WHERE c.relkind = 'r'
-                AND n.nspname = :nspname;
-            """)
             try:
                 async with info.context.db.read() as session:
-                    nspname = get_env_database_schema() or await session.scalar(
-                        text("SELECT current_schema()")
-                    )
                     stats = type_cast(
                         Iterable[tuple[str, int]],
-                        await session.execute(stmt.bindparams(nspname=nspname)),
+                        await session.execute(pg_table_sizes_stmt()),
                     )
             except Exception:
                 # TODO: temporary workaround until we can reproduce the error
+                logger.exception("Failed to query PostgreSQL table sizes for db table stats")
                 return []
         else:
             assert_never(info.context.db.dialect)

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -16,12 +16,11 @@ from strawberry.types import Info
 from typing_extensions import TypeAlias, assert_never
 
 from phoenix.config import (
-    ENV_PHOENIX_SQL_DATABASE_SCHEMA,
     get_env_database_allocated_storage_capacity_gibibytes,
+    get_env_database_schema,
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_collector_endpoint,
     get_env_phoenix_agents_web_access_enabled,
-    getenv,
 )
 from phoenix.db import models
 from phoenix.db.constants import DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID
@@ -1586,17 +1585,22 @@ class Query:
             #     stats = cast(Iterable[tuple[str, int]], await session.execute(stmt))
             # stats = _consolidate_sqlite_db_table_stats(stats)
         elif info.context.db.dialect is SupportedSQLDialect.POSTGRESQL:
-            nspname = getenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA) or "public"
             stmt = text("""\
                 SELECT c.relname, pg_total_relation_size(c.oid)
                 FROM pg_class as c
                 INNER JOIN pg_namespace as n ON n.oid = c.relnamespace
                 WHERE c.relkind = 'r'
                 AND n.nspname = :nspname;
-            """).bindparams(nspname=nspname)
+            """)
             try:
                 async with info.context.db.read() as session:
-                    stats = type_cast(Iterable[tuple[str, int]], await session.execute(stmt))
+                    nspname = get_env_database_schema() or await session.scalar(
+                        text("SELECT current_schema()")
+                    )
+                    stats = type_cast(
+                        Iterable[tuple[str, int]],
+                        await session.execute(stmt.bindparams(nspname=nspname)),
+                    )
             except Exception:
                 # TODO: temporary workaround until we can reproduce the error
                 return []

--- a/src/phoenix/server/daemons/db_disk_usage_monitor.py
+++ b/src/phoenix/server/daemons/db_disk_usage_monitor.py
@@ -12,12 +12,11 @@ from typing_extensions import assert_never
 
 from phoenix.config import (
     get_env_database_allocated_storage_capacity_gibibytes,
-    get_env_database_schema,
     get_env_database_usage_email_warning_threshold_percentage,
     get_env_database_usage_insertion_blocking_threshold_percentage,
 )
 from phoenix.db import models
-from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.db.helpers import SupportedSQLDialect, pg_total_table_size_stmt
 from phoenix.server.email.types import DbUsageWarningEmailSender
 from phoenix.server.prometheus import (
     DB_DISK_USAGE_BYTES,
@@ -93,18 +92,8 @@ class DbDiskUsageMonitor(DaemonTask):
                 page_size = await session.scalar(text("PRAGMA page_size;"))
             current_usage_bytes = (page_count - freelist_count) * page_size
         elif self._db.dialect is SupportedSQLDialect.POSTGRESQL:
-            stmt = text("""\
-                SELECT sum(pg_total_relation_size(c.oid))
-                FROM pg_class as c
-                INNER JOIN pg_namespace as n ON n.oid = c.relnamespace
-                WHERE c.relkind = 'r'
-                AND n.nspname = :nspname;
-            """)
             async with self._db() as session:
-                nspname = get_env_database_schema() or await session.scalar(
-                    text("SELECT current_schema()")
-                )
-                current_usage_bytes = await session.scalar(stmt.bindparams(nspname=nspname))
+                current_usage_bytes = await session.scalar(pg_total_table_size_stmt())
         else:
             assert_never(self._db.dialect)
         return float(current_usage_bytes)

--- a/src/phoenix/server/daemons/db_disk_usage_monitor.py
+++ b/src/phoenix/server/daemons/db_disk_usage_monitor.py
@@ -11,11 +11,10 @@ from sqlalchemy import text
 from typing_extensions import assert_never
 
 from phoenix.config import (
-    ENV_PHOENIX_SQL_DATABASE_SCHEMA,
     get_env_database_allocated_storage_capacity_gibibytes,
+    get_env_database_schema,
     get_env_database_usage_email_warning_threshold_percentage,
     get_env_database_usage_insertion_blocking_threshold_percentage,
-    getenv,
 )
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
@@ -94,16 +93,18 @@ class DbDiskUsageMonitor(DaemonTask):
                 page_size = await session.scalar(text("PRAGMA page_size;"))
             current_usage_bytes = (page_count - freelist_count) * page_size
         elif self._db.dialect is SupportedSQLDialect.POSTGRESQL:
-            nspname = getenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA) or "public"
             stmt = text("""\
                 SELECT sum(pg_total_relation_size(c.oid))
                 FROM pg_class as c
                 INNER JOIN pg_namespace as n ON n.oid = c.relnamespace
                 WHERE c.relkind = 'r'
                 AND n.nspname = :nspname;
-            """).bindparams(nspname=nspname)
+            """)
             async with self._db() as session:
-                current_usage_bytes = await session.scalar(stmt)
+                nspname = get_env_database_schema() or await session.scalar(
+                    text("SELECT current_schema()")
+                )
+                current_usage_bytes = await session.scalar(stmt.bindparams(nspname=nspname))
         else:
             assert_never(self._db.dialect)
         return float(current_usage_bytes)

--- a/tests/unit/db/test_helpers.py
+++ b/tests/unit/db/test_helpers.py
@@ -8,6 +8,7 @@ import pytest
 import sqlalchemy as sa
 from faker import Faker
 from sqlalchemy import Select, func, literal, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.sql import CompoundSelect
 from typing_extensions import assert_never
 
@@ -18,6 +19,8 @@ from phoenix.db.helpers import (
     create_experiment_examples_snapshot_insert,
     date_trunc,
     get_dataset_example_revisions,
+    pg_table_sizes_stmt,
+    pg_total_table_size_stmt,
 )
 from phoenix.server.types import DbSessionFactory
 
@@ -1632,3 +1635,73 @@ class TestCreateExperimentExamplesSnapshotInsert:
             with pytest.raises(Exception):
                 await session.execute(insert_stmt2)
                 await session.flush()
+
+
+@pytest.mark.postgres_only
+class TestPgTableSizeStmts:
+    async def test_falls_back_to_current_schema_when_env_schema_unset(
+        self,
+        postgresql_engine: AsyncEngine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
+        async with AsyncSession(postgresql_engine) as session:
+            rows = (await session.execute(pg_table_sizes_stmt())).all()
+            total = await session.scalar(pg_total_table_size_stmt())
+        table_names = {name for name, _ in rows}
+        assert table_names >= {table.name for table in models.Base.metadata.tables.values()}
+        assert total is not None and float(total) > 0
+
+    async def test_follows_search_path_when_env_schema_unset(
+        self,
+        postgresql_engine: AsyncEngine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Regression test: tables live in a non-public schema by way of a
+        # role- or database-level search_path, with no schema env var set.
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
+        schema = f"schema_{token_hex(4)}"
+        async with AsyncSession(postgresql_engine) as session:
+            await session.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            await session.execute(sa.text(f'SET search_path TO "{schema}"'))
+            await session.execute(sa.text("CREATE TABLE widgets (id integer)"))
+            await session.execute(sa.text("INSERT INTO widgets VALUES (1)"))
+            rows = (await session.execute(pg_table_sizes_stmt())).all()
+            total = await session.scalar(pg_total_table_size_stmt())
+        assert {name for name, _ in rows} == {"widgets"}
+        assert total is not None and float(total) > 0
+
+    async def test_env_schema_takes_precedence_over_search_path(
+        self,
+        postgresql_engine: AsyncEngine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        schema_from_env = f"schema_{token_hex(4)}"
+        schema_from_search_path = f"schema_{token_hex(4)}"
+        # get_env_database_schema() ignores the schema env var unless the
+        # connection string is non-sqlite
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_URL", "postgresql://localhost/postgres")
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_SCHEMA", schema_from_env)
+        async with AsyncSession(postgresql_engine) as session:
+            for schema in (schema_from_env, schema_from_search_path):
+                await session.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            await session.execute(
+                sa.text(f'CREATE TABLE "{schema_from_env}".from_env (id integer)')
+            )
+            await session.execute(
+                sa.text(f'CREATE TABLE "{schema_from_search_path}".from_search_path (id integer)')
+            )
+            await session.execute(sa.text(f'SET search_path TO "{schema_from_search_path}"'))
+            rows = (await session.execute(pg_table_sizes_stmt())).all()
+        assert {name for name, _ in rows} == {"from_env"}
+
+    async def test_total_size_is_zero_not_null_when_no_tables_match(
+        self,
+        postgresql_engine: AsyncEngine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_URL", "postgresql://localhost/postgres")
+        monkeypatch.setenv("PHOENIX_SQL_DATABASE_SCHEMA", f"nonexistent_{token_hex(4)}")
+        async with AsyncSession(postgresql_engine) as session:
+            total = await session.scalar(pg_total_table_size_stmt())
+        assert total == 0

--- a/tests/unit/db/test_helpers.py
+++ b/tests/unit/db/test_helpers.py
@@ -1639,58 +1639,34 @@ class TestCreateExperimentExamplesSnapshotInsert:
 
 @pytest.mark.postgres_only
 class TestPgTableSizeStmts:
-    async def test_falls_back_to_current_schema_when_env_schema_unset(
+    async def test_resolves_tables_from_schema_containing_projects(
         self,
         postgresql_engine: AsyncEngine,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        # Regression test: with no env var, the schema must be resolved the
+        # way the ORM resolves unqualified table names — from the first
+        # search_path entry *containing* the tables. A hardcoded 'public'
+        # would count the template database's phoenix tables; current_schema()
+        # would count the empty leading schema.
         monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
+        leading_schema = f"schema_{token_hex(4)}"
+        phoenix_schema = f"schema_{token_hex(4)}"
         async with AsyncSession(postgresql_engine) as session:
+            for schema in (leading_schema, phoenix_schema):
+                await session.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            await session.execute(sa.text(f'CREATE TABLE "{phoenix_schema}".projects (id integer)'))
+            await session.execute(sa.text(f'INSERT INTO "{phoenix_schema}".projects VALUES (1)'))
+            await session.execute(
+                sa.text(f'CREATE TABLE "{phoenix_schema}".other_table (id integer)')
+            )
+            await session.execute(
+                sa.text(f'SET search_path TO "{leading_schema}", "{phoenix_schema}", public')
+            )
+            assert await session.scalar(sa.text("SELECT current_schema()")) == leading_schema
             rows = (await session.execute(pg_table_sizes_stmt())).all()
             total = await session.scalar(pg_total_table_size_stmt())
-        table_names = {name for name, _ in rows}
-        assert table_names >= {table.name for table in models.Base.metadata.tables.values()}
-        assert total is not None and float(total) > 0
-
-    async def test_follows_search_path_when_env_schema_unset(
-        self,
-        postgresql_engine: AsyncEngine,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        # Regression test: tables live in a non-public schema by way of a
-        # role- or database-level search_path, with no schema env var set.
-        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
-        schema = f"schema_{token_hex(4)}"
-        async with AsyncSession(postgresql_engine) as session:
-            await session.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
-            await session.execute(sa.text(f'SET search_path TO "{schema}"'))
-            await session.execute(sa.text("CREATE TABLE widgets (id integer)"))
-            await session.execute(sa.text("INSERT INTO widgets VALUES (1)"))
-            rows = (await session.execute(pg_table_sizes_stmt())).all()
-            total = await session.scalar(pg_total_table_size_stmt())
-        assert {name for name, _ in rows} == {"widgets"}
-        assert total is not None and float(total) > 0
-
-    async def test_resolves_tables_behind_leading_search_path_entry(
-        self,
-        postgresql_engine: AsyncEngine,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        # Regression test: current_schema() is where CREATE would target (the
-        # first existing entry in search_path), not where existing tables
-        # resolve from. Phoenix tables live in public, but search_path gained
-        # a leading empty schema after they were created — stats must still
-        # count the phoenix tables, not the empty schema.
-        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
-        schema = f"schema_{token_hex(4)}"
-        async with AsyncSession(postgresql_engine) as session:
-            await session.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
-            await session.execute(sa.text(f'SET search_path TO "{schema}", public'))
-            assert await session.scalar(sa.text("SELECT current_schema()")) == schema
-            rows = (await session.execute(pg_table_sizes_stmt())).all()
-            total = await session.scalar(pg_total_table_size_stmt())
-        table_names = {name for name, _ in rows}
-        assert table_names >= {table.name for table in models.Base.metadata.tables.values()}
+        assert {name for name, _ in rows} == {"projects", "other_table"}
         assert total == sum(size for _, size in rows) > 0
 
     async def test_env_schema_takes_precedence_over_search_path(
@@ -1722,8 +1698,20 @@ class TestPgTableSizeStmts:
         postgresql_engine: AsyncEngine,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        # env var pointing at a schema with no tables
         monkeypatch.setenv("PHOENIX_SQL_DATABASE_URL", "postgresql://localhost/postgres")
         monkeypatch.setenv("PHOENIX_SQL_DATABASE_SCHEMA", f"nonexistent_{token_hex(4)}")
         async with AsyncSession(postgresql_engine) as session:
-            total = await session.scalar(pg_total_table_size_stmt())
-        assert total == 0
+            assert await session.scalar(pg_total_table_size_stmt()) == 0
+        # no env var and no phoenix tables visible on search_path (the
+        # pre-migration state): the filter matches nothing rather than
+        # counting whatever lives in current_schema()
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA")
+        schema = f"schema_{token_hex(4)}"
+        async with AsyncSession(postgresql_engine) as session:
+            await session.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            await session.execute(sa.text(f'SET search_path TO "{schema}"'))
+            await session.execute(sa.text("CREATE TABLE not_phoenix (id integer)"))
+            await session.execute(sa.text("INSERT INTO not_phoenix VALUES (1)"))
+            assert await session.scalar(pg_total_table_size_stmt()) == 0
+            assert (await session.execute(pg_table_sizes_stmt())).all() == []

--- a/tests/unit/db/test_helpers.py
+++ b/tests/unit/db/test_helpers.py
@@ -1671,6 +1671,28 @@ class TestPgTableSizeStmts:
         assert {name for name, _ in rows} == {"widgets"}
         assert total is not None and float(total) > 0
 
+    async def test_resolves_tables_behind_leading_search_path_entry(
+        self,
+        postgresql_engine: AsyncEngine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Regression test: current_schema() is where CREATE would target (the
+        # first existing entry in search_path), not where existing tables
+        # resolve from. Phoenix tables live in public, but search_path gained
+        # a leading empty schema after they were created — stats must still
+        # count the phoenix tables, not the empty schema.
+        monkeypatch.delenv("PHOENIX_SQL_DATABASE_SCHEMA", raising=False)
+        schema = f"schema_{token_hex(4)}"
+        async with AsyncSession(postgresql_engine) as session:
+            await session.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            await session.execute(sa.text(f'SET search_path TO "{schema}", public'))
+            assert await session.scalar(sa.text("SELECT current_schema()")) == schema
+            rows = (await session.execute(pg_table_sizes_stmt())).all()
+            total = await session.scalar(pg_total_table_size_stmt())
+        table_names = {name for name, _ in rows}
+        assert table_names >= {table.name for table in models.Base.metadata.tables.values()}
+        assert total == sum(size for _, size in rows) > 0
+
     async def test_env_schema_takes_precedence_over_search_path(
         self,
         postgresql_engine: AsyncEngine,

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -459,8 +459,7 @@ async def test_compare_experiments_validation_errors(
     assert response.errors[0].message == expected_error
 
 
-@pytest.mark.skip(reason="TODO: re-enable this test after we figure out the issue with sqlite")
-async def test_db_table_stats(gql_client: AsyncGraphQLClient) -> None:
+async def test_db_table_stats(gql_client: AsyncGraphQLClient, dialect: str) -> None:
     query = """
       query {
         dbTableStats {
@@ -472,7 +471,15 @@ async def test_db_table_stats(gql_client: AsyncGraphQLClient) -> None:
     response = await gql_client.execute(query=query)
     assert not response.errors
     assert (data := response.data) is not None
-    assert set(s["tableName"] for s in data["dbTableStats"]) == set(models.Base.metadata.tables)
+    stats = data["dbTableStats"]
+    assert all(s["numBytes"] >= 0 for s in stats)
+    if dialect == "sqlite":
+        # the sqlite resolver reports a single aggregate row for the whole file
+        assert [s["tableName"] for s in stats] == ["SQLite"]
+    else:
+        assert {s["tableName"] for s in stats} >= {
+            table.name for table in models.Base.metadata.tables.values()
+        }
 
 
 async def test_agents_config_returns_env_values(


### PR DESCRIPTION
## Summary
- Resolve the PostgreSQL schema for database usage queries the same way the ORM resolves table names: `PHOENIX_SQL_DATABASE_SCHEMA` when set, otherwise the schema an unqualified `projects` reference resolves from on the active connection (`to_regclass`)
- Remove the hardcoded `public` fallback that caused Database Usage on `/settings/general` to show 0 for non-public PostgreSQL schemas
- Apply the same schema resolution in the disk usage monitor daemon

## Implementation
- Shared statements `pg_table_sizes_stmt()` / `pg_total_table_size_stmt()` in `phoenix.db.helpers` replace duplicated SQL in the GraphQL resolver and the disk usage monitor; the fallback happens in SQL via a `coalesce` chain, so there is no extra round trip
- `current_schema()` is not used: it reports where an unqualified `CREATE` would target (the first *existing* entry in `search_path`), while existing tables resolve from the first entry *containing* them. If `search_path` gains a leading entry after migration (e.g. `ALTER ROLE ... SET search_path`, or a schema named after the role appearing under the default `"$user", public` path), the ORM keeps working against `public` while `current_schema()` points elsewhere. `to_regclass('projects')` mirrors the ORM's resolution exactly
- When neither the env var nor `to_regclass` resolves a schema (pre-migration database), usage reports zero: if the ORM can't see the tables, there is no Phoenix usage to report — deliberately not `current_schema()`'s contents, which could be an unrelated application's tables in a shared schema
- The total-size statement coalesces `sum()` to 0, so a no-match schema can never raise `float(None)` in the daemon
- The `dbTableStats` resolver now logs the exception it swallows instead of silently returning `[]`

## Tests
- Re-enabled the previously skipped `test_db_table_stats` with dialect-aware assertions; its postgres run covers default-deployment schema resolution end-to-end
- Three focused postgres helper tests: multi-schema resolution (fails against both a hardcoded `public` and a `current_schema()` implementation), env var taking precedence over `search_path`, and zero total for both no-match paths (env schema with no tables; no phoenix tables visible on `search_path`)
