### PR TITLE
fix(app): hide version upgrade notices on managed deployments

### DIFF
--- a/app/src/components/nav/VersionUpdateNotice.tsx
+++ b/app/src/components/nav/VersionUpdateNotice.tsx
@@ -27,6 +27,19 @@ const LOCAL_STORAGE_DISMISSED_UPDATE_VERSION_KEY =
  */
 const MINOR_VERSIONS_BEHIND_THRESHOLD = 2;
 
+/**
+ * Whether this Phoenix instance is a managed/hosted deployment (e.g. Phoenix
+ * Cloud). Managed deployments inject `window.Config.managementUrl` and upgrade
+ * on their own cadence, which users cannot control — so surfacing an upgrade
+ * notice there is misleading and actionable only by the operator, not the
+ * viewer. We reuse the `managementUrl` heuristic (the same deployment-mode
+ * signal used elsewhere, e.g. the sandbox trust warning) until a dedicated
+ * server flag exists.
+ */
+function isManagedDeployment(): boolean {
+  return Boolean(window.Config.managementUrl);
+}
+
 const versionUpdateNoticeIn = keyframes`
   from {
     opacity: 0;
@@ -174,7 +187,8 @@ export function VersionUpdateNoticeItem({
  * notice stays hidden until the latest release pulls the same threshold ahead
  * of the dismissed version. Renders as an `<li>` so it can sit directly
  * inside the nav link list, or nothing at all when there is no update to
- * show.
+ * show. Never shown on managed deployments (see {@link isManagedDeployment}),
+ * which upgrade on a cadence the viewer cannot control.
  */
 export function VersionUpdateNotice({ isExpanded }: { isExpanded: boolean }) {
   const canSeeVersionUpdates = useViewerCanSeeVersionUpdates();
@@ -199,6 +213,7 @@ export function VersionUpdateNotice({ isExpanded }: { isExpanded: boolean }) {
       minorVersions: MINOR_VERSIONS_BEHIND_THRESHOLD,
     });
   if (
+    isManagedDeployment() ||
     !canSeeVersionUpdates ||
     !isExpanded ||
     !hasSignificantUpdate ||
@@ -224,7 +239,9 @@ export function VersionUpdateNotice({ isExpanded }: { isExpanded: boolean }) {
  * pushing a banner for every minor release. Only admins see this status, for
  * the same reason the nav notice is admin-only: they are the ones who can
  * act on it by upgrading the server. Renders nothing while the latest
- * version is unknown or when the server is up to date.
+ * version is unknown, when the server is up to date, or on managed
+ * deployments (see {@link isManagedDeployment}), which upgrade on a cadence
+ * the viewer cannot control.
  */
 export function PlatformVersionStatus() {
   const canSeeVersionUpdates = useViewerCanSeeVersionUpdates();
@@ -232,7 +249,7 @@ export function PlatformVersionStatus() {
   const isLagging =
     latestVersion != null &&
     isVersionNewer({ current: VERSION, latest: latestVersion });
-  if (!canSeeVersionUpdates || !isLagging) {
+  if (isManagedDeployment() || !canSeeVersionUpdates || !isLagging) {
     return null;
   }
   return (


### PR DESCRIPTION
## Summary

Two upgrade banners were recently added to the Phoenix UI:

- The **Settings > General** platform card shows an `Alert` when a newer Phoenix release is available.
- The **expanded navbar** shows an "Update available" card above the GitHub link.

These are useful for self-hosted operators who control their own upgrade cadence, but they are misleading on **managed/hosted deployments** (e.g. Phoenix Cloud), which upgrade on a schedule the viewer cannot control. The notice is actionable only by the operator, not the end user.

## Change

Suppress both banners when `window.Config.managementUrl` is set. This reuses the same deployment-mode heuristic already used elsewhere in the app (e.g. the local-Deno sandbox trust warning in `sandboxes/utils.tsx`). `managementUrl` is backed by the `PHOENIX_MANAGEMENT_URL` env var, which managed deployments already inject.

- Added an `isManagedDeployment()` helper in `VersionUpdateNotice.tsx`.
- Added it to the early-return guard of both `VersionUpdateNotice` (navbar) and `PlatformVersionStatus` (settings).
- Self-hosted instances (no `managementUrl`) are unaffected.

## Screenshots

Both captures use a server reporting v15.0.0 (behind the latest PyPI release, v17.21.0), so the banners would normally appear. The only difference between the two is whether `PHOENIX_MANAGEMENT_URL` is set.

**Before — self-hosted (`PHOENIX_MANAGEMENT_URL` unset): both banners visible**

The settings platform card shows the "A newer version of Phoenix is available" warning, and the navbar shows the "Update available" card above "Star on GitHub".

![before: upgrade banners visible on self-hosted](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14176-before-banners-visible.png)

**After — managed deployment (`PHOENIX_MANAGEMENT_URL` set): both banners hidden**

Despite the server still being behind the latest release, both banners are suppressed.

![after: upgrade banners hidden on managed deployment](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14176-after-banners-hidden.png)

## Test plan

- `tsc --noEmit` passes.
- Verified manually with a local build (screenshots above):
  - **Self-hosted** (`PHOENIX_MANAGEMENT_URL` unset) → both banners visible.
  - **Managed** (`PHOENIX_MANAGEMENT_URL=https://app.phoenix.arize.com`) → both banners hidden, despite the version being behind.