### PR TITLE
chore: update phoenix version to 17.22.0 in kustomize and helm

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -42,13 +42,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 9.0.16
+version: 9.0.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "17.21.0"
+appVersion: "17.22.0"
 icon: https://phoenix.arize.com/wp-content/uploads/2025/04/logo-with-arize.svg
 maintainers:
   - name: arize

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # phoenix-helm
 
-![Version: 9.0.16](https://img.shields.io/badge/Version-9.0.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 17.21.0](https://img.shields.io/badge/AppVersion-17.21.0-informational?style=flat-square)
+![Version: 9.0.17](https://img.shields.io/badge/Version-9.0.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 17.22.0](https://img.shields.io/badge/AppVersion-17.22.0-informational?style=flat-square)
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8e8e8b34-7900-43fa-a38f-1f070bd48c64&page=helm/README.md" />
 
@@ -126,7 +126,7 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for Phoenix container (Always, IfNotPresent, or Never) |
 | image.registry | string | `"docker.io"` | Docker image registry for Phoenix |
 | image.repository | string | `"arizephoenix/phoenix"` | Docker image repository for Phoenix |
-| image.tag | string | `"version-17.21.0-nonroot"` | Docker image tag/version to deploy |
+| image.tag | string | `"version-17.22.0-nonroot"` | Docker image tag/version to deploy |
 | ingress.annotations | object | `{}` | Annotations to add to the ingress resource |
 | ingress.apiPath | string | `"/"` | Path prefix for the Phoenix API |
 | ingress.enabled | bool | `true` | Enable ingress controller for external access |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -703,7 +703,7 @@ image:
   repository: "arizephoenix/phoenix"
 
   # -- Docker image tag/version to deploy
-  tag: version-17.21.0-nonroot
+  tag: version-17.22.0-nonroot
 
 # -- Resource configuration
 resources:

--- a/kustomize/base/phoenix.yaml
+++ b/kustomize/base/phoenix.yaml
@@ -30,7 +30,7 @@ spec:
                         value: "6006"
                       - name: PHOENIX_SQL_DATABASE_URL
                         value: "postgresql://postgres:postgres123@postgres:5432/postgres"
-                  image: arizephoenix/phoenix:version-17.21.0
+                  image: arizephoenix/phoenix:version-17.22.0
                   name: phoenix
                   ports:
                       - containerPort: 6006


### PR DESCRIPTION
This PR updates the phoenix version in the kustomize template to version 17.22.0.

This change was automatically generated by the docker-build-release workflow.