### PR TITLE
feat: Add GPT 5.6 family

### DIFF
--- a/app/src/components/agent/__tests__/agentCuratedModels.test.ts
+++ b/app/src/components/agent/__tests__/agentCuratedModels.test.ts
@@ -12,7 +12,7 @@ describe("agent curated models", () => {
     expect(
       isAgentCuratedModelSelection({
         provider: "OPENAI",
-        modelName: "gpt-5.4",
+        modelName: "gpt-5.6-sol",
       })
     ).toBe(true);
   });
@@ -42,13 +42,13 @@ describe("agent curated models", () => {
   it("filters curated models against registered playground models", () => {
     expect(
       getCuratedBuiltInModels([
-        { providerKey: "OPENAI", name: "gpt-5.4" },
+        { providerKey: "OPENAI", name: "gpt-5.6-sol" },
         { providerKey: "OPENAI", name: "gpt-4o" },
         { providerKey: "ANTHROPIC", name: "claude-sonnet-4-6" },
       ])
     ).toEqual([
       { provider: "ANTHROPIC", modelName: "claude-sonnet-4-6" },
-      { provider: "OPENAI", modelName: "gpt-5.4" },
+      { provider: "OPENAI", modelName: "gpt-5.6-sol" },
     ]);
   });
 });

--- a/app/src/components/agent/agentCuratedModels.ts
+++ b/app/src/components/agent/agentCuratedModels.ts
@@ -17,6 +17,7 @@ export const AGENT_CURATED_BUILT_IN_MODELS: readonly AgentBuiltInModelSelection[
     { provider: "ANTHROPIC", modelName: "claude-opus-4-8" },
     { provider: "ANTHROPIC", modelName: "claude-opus-4-6" },
     { provider: "ANTHROPIC", modelName: "claude-sonnet-4-6" },
+    { provider: "OPENAI", modelName: "gpt-5.6-sol" },
     { provider: "OPENAI", modelName: "gpt-5.4" },
     { provider: "OPENAI", modelName: "gpt-5.4-mini" },
     { provider: "OPENAI", modelName: "gpt-5.5" },

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1902,6 +1902,9 @@ class OpenAIStreamingClient(OpenAIBaseStreamingClient):
 
 
 OPENAI_REASONING_MODELS = [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",


### PR DESCRIPTION
Adds GPT-5.6 model support across Phoenix.

- Adds GPT-5.6 Sol to the PXI curated model list
- Adds Sol, Terra, and Luna to the playground model list