### PR TITLE
fix(agents): mirror complete PXI traces to Cloud

### DIFF
--- a/app/src/agent/chat/__tests__/agentTurnTracing.test.ts
+++ b/app/src/agent/chat/__tests__/agentTurnTracing.test.ts
@@ -101,6 +101,36 @@ describe("createAgentTurnTracer", () => {
     ).toBeNull();
   });
 
+  it("creates a complete browser trace for remote-only recording", async () => {
+    const fetch = createMockFetch();
+    const tracer = createAgentTurnTracer({
+      sessionId: "session-1",
+      fetch,
+      getAgentsConfig: () => ({
+        ...agentsConfig,
+        collectorEndpoint: "https://collector.example",
+        allowLocalTraces: false,
+        allowRemoteExport: true,
+      }),
+      getObservability: () => ({
+        ...observability,
+        storeLocalTraces: false,
+        exportRemoteTraces: true,
+      }),
+      forceFlushTimeoutMs: 0,
+    });
+
+    tracer.startTurn("submit-message");
+    await tracer.fetch("/agents/assistant/sessions/session-1/chat", {
+      method: "POST",
+    });
+
+    expect(readTraceparent(fetch.mock.calls[0]?.[1])).toMatch(
+      /^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/
+    );
+    await tracer.endTurn();
+  });
+
   it("mirrors the trace context into x-phoenix-* headers that survive traceparent rewrites", async () => {
     const fetch = createMockFetch();
     const tracer = createAgentTurnTracer({
@@ -311,16 +341,16 @@ describe("createAgentTurnTracer", () => {
     expect(secondToolSpan?.status.code).toBe(SpanStatusCode.OK);
   });
 
-  it("exports only PXI browser spans with registered projects by project", async () => {
-    const exportedSpansByProjectName = new Map<string, ReadableSpan[]>();
-    const projectNameByTraceId = new Map([
-      ["trace-local", "assistant_agent"],
-      ["trace-other", "other_agent"],
+  it("exports only registered PXI browser spans by destination", async () => {
+    const exportedSpansByDestination = new Map<string, ReadableSpan[]>();
+    const destinationByTraceId = new Map([
+      ["trace-local", { ingestTraces: true, exportRemoteTraces: false }],
+      ["trace-remote", { ingestTraces: false, exportRemoteTraces: true }],
     ]);
-    const createExporter = vi.fn((projectName: string): SpanExporter => {
+    const createExporter = vi.fn((destination): SpanExporter => {
       return {
         export(spans, resultCallback) {
-          exportedSpansByProjectName.set(projectName, spans);
+          exportedSpansByDestination.set(JSON.stringify(destination), spans);
           resultCallback({ code: ExportResultCode.SUCCESS });
         },
         shutdown: async () => undefined,
@@ -328,7 +358,7 @@ describe("createAgentTurnTracer", () => {
     });
     const exporter = new PxiRootSpanExporter(
       createExporter,
-      (span) => projectNameByTraceId.get(span.spanContext().traceId) ?? null
+      (span) => destinationByTraceId.get(span.spanContext().traceId) ?? null
     );
     const resultCallback = vi.fn();
 
@@ -347,9 +377,9 @@ describe("createAgentTurnTracer", () => {
         "openinference.span.kind": "TOOL",
       },
     });
-    const otherProjectSpan = createReadableSpan({
+    const remoteSpan = createReadableSpan({
       name: "pxi.turn",
-      traceId: "trace-other",
+      traceId: "trace-remote",
     });
     const unrelatedSpan = createReadableSpan({
       name: "click",
@@ -361,22 +391,31 @@ describe("createAgentTurnTracer", () => {
         localRootSpan,
         unregisteredRootSpan,
         localToolSpan,
-        otherProjectSpan,
+        remoteSpan,
         unrelatedSpan,
       ],
       resultCallback
     );
 
     expect(createExporter).toHaveBeenCalledTimes(2);
-    expect(createExporter).toHaveBeenCalledWith("assistant_agent");
-    expect(createExporter).toHaveBeenCalledWith("other_agent");
-    expect(exportedSpansByProjectName.get("assistant_agent")).toEqual([
-      localRootSpan,
-      localToolSpan,
-    ]);
-    expect(exportedSpansByProjectName.get("other_agent")).toEqual([
-      otherProjectSpan,
-    ]);
+    expect(createExporter).toHaveBeenCalledWith({
+      ingestTraces: true,
+      exportRemoteTraces: false,
+    });
+    expect(createExporter).toHaveBeenCalledWith({
+      ingestTraces: false,
+      exportRemoteTraces: true,
+    });
+    expect(
+      exportedSpansByDestination.get(
+        JSON.stringify({ ingestTraces: true, exportRemoteTraces: false })
+      )
+    ).toEqual([localRootSpan, localToolSpan]);
+    expect(
+      exportedSpansByDestination.get(
+        JSON.stringify({ ingestTraces: false, exportRemoteTraces: true })
+      )
+    ).toEqual([remoteSpan]);
     expect(resultCallback).toHaveBeenCalledWith({
       code: ExportResultCode.SUCCESS,
     });
@@ -390,7 +429,7 @@ describe("createAgentTurnTracer", () => {
         },
         shutdown: async () => undefined,
       }),
-      () => "assistant_agent"
+      () => ({ ingestTraces: true, exportRemoteTraces: false })
     );
     const resultCallback = vi.fn();
 

--- a/app/src/agent/chat/agentTurnTracing.ts
+++ b/app/src/agent/chat/agentTurnTracing.ts
@@ -139,7 +139,10 @@ export class PxiRootSpanExporter implements SpanExporter {
       if (!destination) {
         continue;
       }
-      const key = JSON.stringify(destination);
+      // PxiTraceDestination has exactly two boolean fields, so this key
+      // covers all reachable destinations without relying on JSON.stringify
+      // key-order stability.
+      const key = `${destination.ingestTraces}:${destination.exportRemoteTraces}`;
       const group = spansByDestination.get(key) ?? { destination, spans: [] };
       group.spans.push(span);
       spansByDestination.set(key, group);

--- a/app/src/agent/chat/agentTurnTracing.ts
+++ b/app/src/agent/chat/agentTurnTracing.ts
@@ -56,8 +56,12 @@ type ToolOutputTraceInput = {
   errorText?: string;
 };
 
-type CreateLocalTraceExporter = (projectName: string) => SpanExporter;
-type GetProjectNameForSpan = (span: ReadableSpan) => string | null;
+type PxiTraceDestination = {
+  ingestTraces: boolean;
+  exportRemoteTraces: boolean;
+};
+type CreateTraceExporter = (destination: PxiTraceDestination) => SpanExporter;
+type GetDestinationForSpan = (span: ReadableSpan) => PxiTraceDestination | null;
 
 type AgentTurnTracingOptions = {
   sessionId: string;
@@ -82,7 +86,7 @@ let webTracerProvider: WebTracerProvider | null = null;
 const DEFAULT_FORCE_FLUSH_TIMEOUT_MS = 5_000;
 
 const PXI_TRACER_NAME = "phoenix-ui.pxi";
-const pxiProjectNameByTraceId = new Map<string, string>();
+const pxiTraceDestinationByTraceId = new Map<string, PxiTraceDestination>();
 
 // PXI-specific carrier headers, sent alongside the standard W3C ones. Cloud
 // deployments may inject their own client tracing (e.g. Datadog RUM) whose
@@ -97,48 +101,55 @@ const PHOENIX_TRACESTATE_HEADER = "x-phoenix-tracestate";
 // instrumentation injected by the hosting deployment.
 const pxiPropagator = new W3CTraceContextPropagator();
 
-const createDefaultLocalTraceExporter: CreateLocalTraceExporter = (
-  projectName
-) =>
+const createDefaultTraceExporter: CreateTraceExporter = (destination) =>
   new OTLPTraceExporter({
-    url: prependBasename("/v1/traces"),
+    url: prependBasename("/agents/traces"),
     headers: {
-      "x-project-name": projectName,
+      "x-phoenix-pxi-ingest-traces": String(destination.ingestTraces),
+      "x-phoenix-pxi-export-remote-traces": String(
+        destination.exportRemoteTraces
+      ),
     },
   });
 
-function getPxiProjectNameForSpan(span: ReadableSpan): string | null {
-  return pxiProjectNameByTraceId.get(span.spanContext().traceId) ?? null;
+function getPxiDestinationForSpan(
+  span: ReadableSpan
+): PxiTraceDestination | null {
+  return pxiTraceDestinationByTraceId.get(span.spanContext().traceId) ?? null;
 }
 
 export class PxiRootSpanExporter implements SpanExporter {
-  private exportersByProjectName = new Map<string, SpanExporter>();
+  private exportersByDestination = new Map<string, SpanExporter>();
 
   constructor(
-    private createLocalTraceExporter: CreateLocalTraceExporter = createDefaultLocalTraceExporter,
-    private getProjectNameForSpan: GetProjectNameForSpan = getPxiProjectNameForSpan
+    private createTraceExporter: CreateTraceExporter = createDefaultTraceExporter,
+    private getDestinationForSpan: GetDestinationForSpan = getPxiDestinationForSpan
   ) {}
 
   export(
     spans: ReadableSpan[],
     resultCallback: (result: { code: ExportResultCode; error?: Error }) => void
   ): void {
-    const spansByProjectName = new Map<string, ReadableSpan[]>();
+    const spansByDestination = new Map<
+      string,
+      { destination: PxiTraceDestination; spans: ReadableSpan[] }
+    >();
     for (const span of spans) {
-      const projectName = this.getProjectNameForSpan(span);
-      if (!projectName) {
+      const destination = this.getDestinationForSpan(span);
+      if (!destination) {
         continue;
       }
-      const projectSpans = spansByProjectName.get(projectName) ?? [];
-      projectSpans.push(span);
-      spansByProjectName.set(projectName, projectSpans);
+      const key = JSON.stringify(destination);
+      const group = spansByDestination.get(key) ?? { destination, spans: [] };
+      group.spans.push(span);
+      spansByDestination.set(key, group);
     }
-    if (spansByProjectName.size === 0) {
+    if (spansByDestination.size === 0) {
       resultCallback({ code: ExportResultCode.SUCCESS });
       return;
     }
 
-    let pendingExports = spansByProjectName.size;
+    let pendingExports = spansByDestination.size;
     let hasExportError = false;
     let exportError: Error | undefined;
     const onExportComplete = (result: {
@@ -159,35 +170,38 @@ export class PxiRootSpanExporter implements SpanExporter {
       }
     };
 
-    for (const [projectName, projectSpans] of spansByProjectName) {
-      this.getExporter(projectName).export(projectSpans, onExportComplete);
+    for (const [key, { destination, spans }] of spansByDestination) {
+      this.getExporter(key, destination).export(spans, onExportComplete);
     }
   }
 
   async shutdown(): Promise<void> {
     await Promise.all(
-      Array.from(this.exportersByProjectName.values()).map((exporter) =>
+      Array.from(this.exportersByDestination.values()).map((exporter) =>
         exporter.shutdown()
       )
     );
-    this.exportersByProjectName.clear();
+    this.exportersByDestination.clear();
   }
 
   async forceFlush(): Promise<void> {
     await Promise.all(
-      Array.from(this.exportersByProjectName.values()).map((exporter) =>
+      Array.from(this.exportersByDestination.values()).map((exporter) =>
         exporter.forceFlush?.()
       )
     );
   }
 
-  private getExporter(projectName: string): SpanExporter {
-    const existingExporter = this.exportersByProjectName.get(projectName);
+  private getExporter(
+    key: string,
+    destination: PxiTraceDestination
+  ): SpanExporter {
+    const existingExporter = this.exportersByDestination.get(key);
     if (existingExporter) {
       return existingExporter;
     }
-    const exporter = this.createLocalTraceExporter(projectName);
-    this.exportersByProjectName.set(projectName, exporter);
+    const exporter = this.createTraceExporter(destination);
+    this.exportersByDestination.set(key, exporter);
     return exporter;
   }
 }
@@ -298,7 +312,7 @@ export function createAgentTurnTracer({
       agentsConfig,
       observability,
     });
-    if (!traceRecording.ingestTraces) {
+    if (!traceRecording.ingestTraces && !traceRecording.exportRemoteTraces) {
       return;
     }
 
@@ -312,7 +326,9 @@ export function createAgentTurnTracer({
       },
     });
     const traceId = span.spanContext().traceId;
-    pxiProjectNameByTraceId.set(traceId, agentsConfig.assistantProjectName);
+    pxiTraceDestinationByTraceId.set(traceId, {
+      ...traceRecording,
+    });
     activeTurnTrace = {
       span,
       context: trace.setSpan(context.active(), span),
@@ -350,7 +366,7 @@ export function createAgentTurnTracer({
     try {
       await forceFlushBrowserSpans(forceFlushTimeoutMs);
     } finally {
-      pxiProjectNameByTraceId.delete(traceId);
+      pxiTraceDestinationByTraceId.delete(traceId);
     }
   }
 

--- a/app/tests/pxi/fixtures.ts
+++ b/app/tests/pxi/fixtures.ts
@@ -44,8 +44,10 @@ function getAssistantProjectName() {
 async function installAgentDefaults({ page }: { page: Page }) {
   const assistantProvider = getAssistantProvider();
   const assistantModel = getAssistantModel();
+  const exportRemoteTraces =
+    process.env.PXI_E2E_EXPORT_REMOTE_TRACES === "true";
   await page.addInitScript(
-    ({ provider, modelName }) => {
+    ({ provider, modelName, exportRemoteTraces }) => {
       localStorage.clear();
       localStorage.setItem(
         "arize-phoenix-feature-flags",
@@ -75,7 +77,7 @@ async function installAgentDefaults({ page }: { page: Page }) {
             },
             observability: {
               storeLocalTraces: true,
-              exportRemoteTraces: false,
+              exportRemoteTraces,
               hasAcknowledgedConsent: false,
             },
             capabilities: {
@@ -92,6 +94,7 @@ async function installAgentDefaults({ page }: { page: Page }) {
     {
       provider: assistantProvider,
       modelName: assistantModel,
+      exportRemoteTraces,
     }
   );
 }

--- a/app/tests/pxi/ingest-traces-smoke.spec.ts
+++ b/app/tests/pxi/ingest-traces-smoke.spec.ts
@@ -182,9 +182,7 @@ test.describe("PXI ingest traces smoke", () => {
 
         if (process.env.PXI_E2E_EXPORT_REMOTE_TRACES === "true") {
           expect(relayRemoteExportHeaders).toContain("true");
-          await expect
-            .poll(() => relayResponseStatuses)
-            .toContain(200);
+          await expect.poll(() => relayResponseStatuses).toContain(200);
         }
 
         expect(chatTrace!.spans.length).toBeGreaterThanOrEqual(

--- a/app/tests/pxi/ingest-traces-smoke.spec.ts
+++ b/app/tests/pxi/ingest-traces-smoke.spec.ts
@@ -77,6 +77,29 @@ test.describe("PXI ingest traces smoke", () => {
     await pxi.open();
     await pxi.acknowledgeConsent();
 
+    if (process.env.PXI_E2E_EXPORT_REMOTE_TRACES === "true") {
+      const exportRemoteTraces = await page.evaluate(() => {
+        const stored = localStorage.getItem("arize-phoenix-assistant");
+        if (!stored) return null;
+        return JSON.parse(stored).state?.observability?.exportRemoteTraces;
+      });
+      expect(exportRemoteTraces).toBe(true);
+    }
+    const relayRemoteExportHeaders: string[] = [];
+    const relayResponseStatuses: number[] = [];
+    page.on("request", (request) => {
+      if (request.url().includes("/agents/traces")) {
+        relayRemoteExportHeaders.push(
+          request.headers()["x-phoenix-pxi-export-remote-traces"] ?? ""
+        );
+      }
+    });
+    page.on("response", (response) => {
+      if (response.url().includes("/agents/traces")) {
+        relayResponseStatuses.push(response.status());
+      }
+    });
+
     // Drive the chat turn directly without going through the harness's
     // askAndWait, which depends on assistant-message traceId metadata that
     // the new chat route does not yet emit. Wait for the assistant turn to
@@ -156,6 +179,11 @@ test.describe("PXI ingest traces smoke", () => {
 
         expect(chatTrace, "chat trace should be present").toBeDefined();
         expect(summaryTrace, "summary trace should be present").toBeDefined();
+
+        if (process.env.PXI_E2E_EXPORT_REMOTE_TRACES === "true") {
+          expect(relayRemoteExportHeaders).toContain("true");
+          expect(relayResponseStatuses).toContain(200);
+        }
 
         expect(chatTrace!.spans.length).toBeGreaterThanOrEqual(
           MIN_CHAT_SPAN_COUNT

--- a/app/tests/pxi/ingest-traces-smoke.spec.ts
+++ b/app/tests/pxi/ingest-traces-smoke.spec.ts
@@ -182,7 +182,9 @@ test.describe("PXI ingest traces smoke", () => {
 
         if (process.env.PXI_E2E_EXPORT_REMOTE_TRACES === "true") {
           expect(relayRemoteExportHeaders).toContain("true");
-          expect(relayResponseStatuses).toContain(200);
+          await expect
+            .poll(() => relayResponseStatuses)
+            .toContain(200);
         }
 
         expect(chatTrace!.spans.length).toBeGreaterThanOrEqual(

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1,5 +1,7 @@
 import asyncio
+import gzip
 import logging
+import zlib
 from collections.abc import (
     AsyncGenerator,
     AsyncIterator,
@@ -11,10 +13,16 @@ from contextlib import AbstractContextManager, aclosing, nullcontext
 from copy import deepcopy
 from typing import Annotated, Any, Literal, TypeVar
 
-from fastapi import APIRouter, Depends, HTTPException
+import httpx
+from fastapi import APIRouter, Depends, Header, HTTPException
+from google.protobuf.message import DecodeError
 from openinference.instrumentation import using_metadata, using_session, using_user
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry.context import Context
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
+)
 from opentelemetry.sdk.trace import Span as SDKSpan
 from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.trace import SpanContext, format_span_id, format_trace_id, get_current_span
@@ -40,6 +48,8 @@ from sqlalchemy import Insert, exists, func, select
 from sqlalchemy.dialects.postgresql import insert as insert_postgresql
 from sqlalchemy.dialects.sqlite import insert as insert_sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.concurrency import run_in_threadpool
+from starlette.datastructures import State
 from starlette.requests import Request
 from starlette.responses import Response
 from strawberry.relay import GlobalID
@@ -47,6 +57,8 @@ from typing_extensions import TypeIs, assert_never
 
 from phoenix.config import (
     get_env_phoenix_agents_assistant_project_name,
+    get_env_phoenix_agents_collector_api_key,
+    get_env_phoenix_agents_collector_endpoint,
     get_env_phoenix_agents_disable_bash,
     get_env_phoenix_agents_web_access_enabled,
 )
@@ -92,7 +104,9 @@ from phoenix.server.api.types.SandboxConfig import (
 from phoenix.server.bearer_auth import PhoenixUser, is_authenticated
 from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
 from phoenix.server.sandbox import SecretsContext
+from phoenix.server.telemetry import normalize_http_collector_endpoint
 from phoenix.server.types import CanPutItem, DbSessionFactory
+from phoenix.trace.otel import decode_otlp_span
 from phoenix.tracers import (
     Tracer,
     detached_otel_context,
@@ -101,6 +115,9 @@ from phoenix.tracers import (
 )
 
 _PHOENIX_PROVIDER_METADATA_KEY = "phoenix"
+
+_PXI_OTLP_CONTENT_TYPE = "application/x-protobuf"
+_PXI_REMOTE_EXPORT_TIMEOUT_SECONDS = 5.0
 
 ToolExecutionEnvironment = Literal["client", "server"]
 
@@ -772,9 +789,130 @@ async def _load_phoenix_user_email(
     )
 
 
+async def _decode_pxi_otlp_request(
+    *, body: bytes, content_encoding: str | None
+) -> ExportTraceServiceRequest:
+    if content_encoding == "gzip":
+        body = await run_in_threadpool(gzip.decompress, body)
+    elif content_encoding == "deflate":
+        body = await run_in_threadpool(zlib.decompress, body)
+    elif content_encoding:
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported content encoding: {content_encoding}",
+        )
+
+    otlp_request = ExportTraceServiceRequest()
+    try:
+        await run_in_threadpool(otlp_request.ParseFromString, body)
+    except DecodeError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="Request body is invalid ExportTraceServiceRequest",
+        ) from exc
+    return otlp_request
+
+
+async def _enqueue_pxi_spans(
+    *, otlp_request: ExportTraceServiceRequest, state: State, project_name: str
+) -> None:
+    for resource_spans in otlp_request.resource_spans:
+        for scope_spans in resource_spans.scope_spans:
+            for otlp_span in scope_spans.spans:
+                span = await run_in_threadpool(decode_otlp_span, otlp_span)
+                await state.enqueue_span(span, project_name)
+
+
+async def _export_pxi_otlp_request(
+    *,
+    body: bytes,
+    content_encoding: str | None,
+    collector_endpoint: str,
+    project_name: str,
+) -> None:
+    headers = {
+        "content-type": _PXI_OTLP_CONTENT_TYPE,
+        "x-project-name": project_name,
+    }
+    if content_encoding:
+        headers["content-encoding"] = content_encoding
+    if api_key := get_env_phoenix_agents_collector_api_key():
+        headers["authorization"] = f"Bearer {api_key}"
+
+    endpoint = normalize_http_collector_endpoint(collector_endpoint) + "/v1/traces"
+    try:
+        async with httpx.AsyncClient(timeout=_PXI_REMOTE_EXPORT_TIMEOUT_SECONDS) as client:
+            response = await client.post(endpoint, content=body, headers=headers)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("Failed to relay PXI browser spans to %s: %s", endpoint, exc)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to export PXI traces to the configured collector",
+        ) from exc
+
+
 def create_agents_router(authentication_enabled: bool) -> APIRouter:
     dependencies = [Depends(is_authenticated)] if authentication_enabled else []
     router = APIRouter(tags=["chat"], dependencies=dependencies)
+
+    @router.post("/agents/traces", include_in_schema=False)
+    async def relay_browser_traces(
+        request: Request,
+        content_type: str | None = Header(default=None),
+        content_encoding: str | None = Header(default=None),
+        x_phoenix_pxi_ingest_traces: bool = Header(default=False),
+        x_phoenix_pxi_export_remote_traces: bool = Header(default=False),
+    ) -> Response:
+        """Apply PXI trace policy and relay browser-owned OTLP spans."""
+        if content_type != _PXI_OTLP_CONTENT_TYPE:
+            raise HTTPException(
+                status_code=415,
+                detail=f"Unsupported content type: {content_type}",
+            )
+
+        recording = request.app.state.system_settings.agent_trace_recording
+        ingest_traces = bool(
+            x_phoenix_pxi_ingest_traces and recording.allow_local_traces
+        )
+        collector_endpoint = get_env_phoenix_agents_collector_endpoint()
+        export_remote_traces = bool(
+            x_phoenix_pxi_export_remote_traces
+            and recording.allow_remote_export
+            and collector_endpoint
+        )
+        if ingest_traces and request.app.state.span_queue_is_full():
+            raise HTTPException(
+                status_code=503,
+                detail="Server is at capacity and cannot process more requests",
+            )
+        body = await request.body()
+        otlp_request = await _decode_pxi_otlp_request(
+            body=body, content_encoding=content_encoding
+        )
+        project_name = get_env_phoenix_agents_assistant_project_name()
+
+        if ingest_traces:
+            await _enqueue_pxi_spans(
+                otlp_request=otlp_request,
+                state=request.state,
+                project_name=project_name,
+            )
+        if export_remote_traces:
+            assert collector_endpoint is not None
+            await _export_pxi_otlp_request(
+                body=body,
+                content_encoding=content_encoding,
+                collector_endpoint=collector_endpoint,
+                project_name=project_name,
+            )
+
+        response_message = ExportTraceServiceResponse()
+        return Response(
+            content=response_message.SerializeToString(),
+            media_type=_PXI_OTLP_CONTENT_TYPE,
+            status_code=200,
+        )
 
     @router.post("/agents/server/sessions/{session_id}/chat")
     async def run_server_agent(

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -101,8 +101,10 @@ from phoenix.server.api.types.SandboxConfig import (
     SandboxBackendStatus,
     get_sandbox_backend_info,
 )
+from phoenix.server.authorization import is_not_locked
 from phoenix.server.bearer_auth import PhoenixUser, is_authenticated
 from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
+from phoenix.server.prometheus import SPAN_QUEUE_REJECTIONS
 from phoenix.server.sandbox import SecretsContext
 from phoenix.server.telemetry import normalize_http_collector_endpoint
 from phoenix.server.types import CanPutItem, DbSessionFactory
@@ -793,9 +795,21 @@ async def _decode_pxi_otlp_request(
     *, body: bytes, content_encoding: str | None
 ) -> ExportTraceServiceRequest:
     if content_encoding == "gzip":
-        body = await run_in_threadpool(gzip.decompress, body)
+        try:
+            body = await run_in_threadpool(gzip.decompress, body)
+        except OSError as exc:
+            raise HTTPException(
+                status_code=415,
+                detail="Request body is not valid gzip-encoded data",
+            ) from exc
     elif content_encoding == "deflate":
-        body = await run_in_threadpool(zlib.decompress, body)
+        try:
+            body = await run_in_threadpool(zlib.decompress, body)
+        except zlib.error as exc:
+            raise HTTPException(
+                status_code=415,
+                detail="Request body is not valid deflate-encoded data",
+            ) from exc
     elif content_encoding:
         raise HTTPException(
             status_code=415,
@@ -823,6 +837,20 @@ async def _enqueue_pxi_spans(
                 await state.enqueue_span(span, project_name)
 
 
+_pxi_remote_export_client: httpx.AsyncClient | None = None
+
+
+def _get_pxi_remote_export_client() -> httpx.AsyncClient:
+    # Reused across calls rather than opened/closed per request: this fires
+    # once per browser trace flush, and a fresh client would pay a new
+    # TCP/TLS handshake to the Cloud collector on every flush instead of
+    # reusing a warm connection.
+    global _pxi_remote_export_client
+    if _pxi_remote_export_client is None:
+        _pxi_remote_export_client = httpx.AsyncClient(timeout=_PXI_REMOTE_EXPORT_TIMEOUT_SECONDS)
+    return _pxi_remote_export_client
+
+
 async def _export_pxi_otlp_request(
     *,
     body: bytes,
@@ -841,9 +869,9 @@ async def _export_pxi_otlp_request(
 
     endpoint = normalize_http_collector_endpoint(collector_endpoint) + "/v1/traces"
     try:
-        async with httpx.AsyncClient(timeout=_PXI_REMOTE_EXPORT_TIMEOUT_SECONDS) as client:
-            response = await client.post(endpoint, content=body, headers=headers)
-            response.raise_for_status()
+        client = _get_pxi_remote_export_client()
+        response = await client.post(endpoint, content=body, headers=headers)
+        response.raise_for_status()
     except httpx.HTTPError as exc:
         logger.warning("Failed to relay PXI browser spans to %s: %s", endpoint, exc)
         raise HTTPException(
@@ -879,16 +907,29 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             and recording.allow_remote_export
             and collector_endpoint
         )
-        if ingest_traces and request.app.state.span_queue_is_full():
-            raise HTTPException(
-                status_code=503,
-                detail="Server is at capacity and cannot process more requests",
-            )
         body = await request.body()
-        otlp_request = await _decode_pxi_otlp_request(body=body, content_encoding=content_encoding)
+        # PXI traces are always routed to the single configured assistant
+        # project rather than following the header/resource-attribute
+        # precedence generic OTLP ingestion uses: browser-side PXI spans
+        # never carry a project-name resource attribute of their own.
         project_name = get_env_phoenix_agents_assistant_project_name()
 
         if ingest_traces:
+            # Mirror the guards generic OTLP ingestion (`/v1/traces`) applies
+            # before writing spans: refuse local writes once storage is
+            # locked, and count/reject once the span queue is saturated.
+            # Both are scoped to `ingest_traces` since remote-only export
+            # never touches local storage or the local span queue.
+            is_not_locked(request)
+            if request.app.state.span_queue_is_full():
+                SPAN_QUEUE_REJECTIONS.inc()
+                raise HTTPException(
+                    status_code=503,
+                    detail="Server is at capacity and cannot process more requests",
+                )
+            otlp_request = await _decode_pxi_otlp_request(
+                body=body, content_encoding=content_encoding
+            )
             await _enqueue_pxi_spans(
                 otlp_request=otlp_request,
                 state=request.state,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -872,9 +872,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             )
 
         recording = request.app.state.system_settings.agent_trace_recording
-        ingest_traces = bool(
-            x_phoenix_pxi_ingest_traces and recording.allow_local_traces
-        )
+        ingest_traces = bool(x_phoenix_pxi_ingest_traces and recording.allow_local_traces)
         collector_endpoint = get_env_phoenix_agents_collector_endpoint()
         export_remote_traces = bool(
             x_phoenix_pxi_export_remote_traces
@@ -887,9 +885,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 detail="Server is at capacity and cannot process more requests",
             )
         body = await request.body()
-        otlp_request = await _decode_pxi_otlp_request(
-            body=body, content_encoding=content_encoding
-        )
+        otlp_request = await _decode_pxi_otlp_request(body=body, content_encoding=content_encoding)
         project_name = get_env_phoenix_agents_assistant_project_name()
 
         if ingest_traces:

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -246,9 +246,7 @@ class TestPxiBrowserTraceRelay:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         with respx.mock:
-            respx.post("https://collector.example/v1/traces").mock(
-                return_value=httpx.Response(503)
-            )
+            respx.post("https://collector.example/v1/traces").mock(return_value=httpx.Response(503))
             with pytest.raises(HTTPException) as exc_info:
                 await _export_pxi_otlp_request(
                     body=b"",

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import httpx
+import pytest
+import respx
+from asgi_lifespan import LifespanManager
+from fastapi import FastAPI, HTTPException
 from jinja2 import Template
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span
+from pydantic import SecretStr
 from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, ToolOutputAvailableChunk
 from sqlalchemy import func, select
+from starlette.datastructures import State
+from starlette.types import ASGIApp
 
 from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
@@ -18,6 +29,8 @@ from phoenix.server.agents.types import (
     SandboxAvailability,
 )
 from phoenix.server.api.routers.agents import (
+    _enqueue_pxi_spans,
+    _export_pxi_otlp_request,
     _interleave_agent_and_subagent_message_chunks,
     _load_phoenix_user_email,
     _load_sandbox_availability,
@@ -25,9 +38,40 @@ from phoenix.server.api.routers.agents import (
     _persist_db_traces_and_emit_event,
     _SubagentMessageChunksClosed,
 )
+from phoenix.server.app import create_app
 from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
+from phoenix.server.settings.registry import AgentTraceRecordingSetting
 from phoenix.server.types import DbSessionFactory, UserId
+from tests.unit.conftest import TestBulkInserter as _TestBulkInserter
+from tests.unit.conftest import patch_grpc_server
+
+
+@pytest.fixture
+async def pxi_app_with_auth(db: DbSessionFactory) -> AsyncIterator[FastAPI]:
+    async with contextlib.AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_grpc_server())
+        yield create_app(
+            db=db,
+            authentication_enabled=True,
+            serve_ui=False,
+            bulk_inserter_factory=_TestBulkInserter,
+            secret=SecretStr("test-secret-at-least-32-chars-long!!"),
+        )
+
+
+@pytest.fixture
+async def pxi_asgi_app_with_auth(pxi_app_with_auth: FastAPI) -> AsyncIterator[ASGIApp]:
+    async with LifespanManager(pxi_app_with_auth) as manager:
+        yield manager.app
+
+
+@pytest.fixture
+def pxi_client_with_auth(pxi_asgi_app_with_auth: ASGIApp) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=pxi_asgi_app_with_auth),
+        base_url="http://test",
+    )
 
 
 class _EventQueue:
@@ -36,6 +80,184 @@ class _EventQueue:
 
     def put(self, item: DmlEvent) -> None:
         self.events.append(item)
+
+
+class TestPxiBrowserTraceRelay:
+    async def test_local_enqueue_preserves_trace_and_parent_identity(self) -> None:
+        trace_id = bytes.fromhex("1234567890abcdef1234567890abcdef")
+        span_id = bytes.fromhex("1234567890abcdef")
+        parent_span_id = bytes.fromhex("fedcba0987654321")
+        otlp_request = ExportTraceServiceRequest(
+            resource_spans=[
+                ResourceSpans(
+                    scope_spans=[
+                        ScopeSpans(
+                            spans=[
+                                Span(
+                                    trace_id=trace_id,
+                                    span_id=span_id,
+                                    parent_span_id=parent_span_id,
+                                    name="client-tool",
+                                    start_time_unix_nano=1_000_000_000,
+                                    end_time_unix_nano=2_000_000_000,
+                                )
+                            ]
+                        )
+                    ]
+                )
+            ]
+        )
+        state = State()
+        state.enqueue_span = AsyncMock()
+
+        await _enqueue_pxi_spans(
+            otlp_request=otlp_request,
+            state=state,
+            project_name="pxi_test",
+        )
+
+        decoded_span, project_name = state.enqueue_span.await_args.args
+        assert decoded_span.context.trace_id == trace_id.hex()
+        assert decoded_span.context.span_id == span_id.hex()
+        assert decoded_span.parent_id == parent_span_id.hex()
+        assert decoded_span.name == "client-tool"
+        assert project_name == "pxi_test"
+
+    @pytest.mark.parametrize(
+        ("ingest_traces", "export_remote_traces", "expected_local", "expected_remote"),
+        [
+            (False, False, False, False),
+            (True, False, True, False),
+            (False, True, False, True),
+            (True, True, True, True),
+        ],
+    )
+    async def test_applies_all_destination_modes(
+        self,
+        app: FastAPI,
+        httpx_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        ingest_traces: bool,
+        export_remote_traces: bool,
+        expected_local: bool,
+        expected_remote: bool,
+    ) -> None:
+        await app.state.system_settings.update_agent_trace_recording(
+            AgentTraceRecordingSetting(
+                allow_local_traces=True,
+                allow_remote_export=True,
+            )
+        )
+        monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "https://collector.example")
+        monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", "pxi_test")
+        enqueue = AsyncMock()
+        export = AsyncMock()
+        monkeypatch.setattr("phoenix.server.api.routers.agents._enqueue_pxi_spans", enqueue)
+        monkeypatch.setattr("phoenix.server.api.routers.agents._export_pxi_otlp_request", export)
+
+        response = await httpx_client.post(
+            "/agents/traces",
+            content=ExportTraceServiceRequest().SerializeToString(),
+            headers={
+                "content-type": "application/x-protobuf",
+                "x-phoenix-pxi-ingest-traces": str(ingest_traces),
+                "x-phoenix-pxi-export-remote-traces": str(export_remote_traces),
+            },
+        )
+
+        assert response.status_code == 200
+        assert enqueue.await_count == int(expected_local)
+        assert export.await_count == int(expected_remote)
+        if expected_local:
+            enqueue_args = enqueue.await_args
+            assert enqueue_args is not None
+            assert enqueue_args.kwargs["project_name"] == "pxi_test"
+        if expected_remote:
+            export_args = export.await_args
+            assert export_args is not None
+            assert export_args.kwargs["project_name"] == "pxi_test"
+            assert export_args.kwargs["collector_endpoint"] == "https://collector.example"
+
+    async def test_server_policy_is_a_ceiling(
+        self,
+        app: FastAPI,
+        httpx_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        await app.state.system_settings.update_agent_trace_recording(
+            AgentTraceRecordingSetting(
+                allow_local_traces=False,
+                allow_remote_export=False,
+            )
+        )
+        monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "https://collector.example")
+        enqueue = AsyncMock()
+        export = AsyncMock()
+        monkeypatch.setattr("phoenix.server.api.routers.agents._enqueue_pxi_spans", enqueue)
+        monkeypatch.setattr("phoenix.server.api.routers.agents._export_pxi_otlp_request", export)
+
+        response = await httpx_client.post(
+            "/agents/traces",
+            content=b"",
+            headers={
+                "content-type": "application/x-protobuf",
+                "x-phoenix-pxi-ingest-traces": "true",
+                "x-phoenix-pxi-export-remote-traces": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        enqueue.assert_not_awaited()
+        export.assert_not_awaited()
+
+    async def test_requires_authentication_when_enabled(
+        self, pxi_client_with_auth: httpx.AsyncClient
+    ) -> None:
+        response = await pxi_client_with_auth.post(
+            "/agents/traces",
+            content=b"",
+            headers={"content-type": "application/x-protobuf"},
+        )
+
+        assert response.status_code == 401
+
+    async def test_remote_export_uses_server_credentials_and_project(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_API_KEY", "secret-api-key")
+        body = ExportTraceServiceRequest().SerializeToString()
+        with respx.mock:
+            route = respx.post("https://collector.example/v1/traces").mock(
+                return_value=httpx.Response(200)
+            )
+            await _export_pxi_otlp_request(
+                body=body,
+                content_encoding=None,
+                collector_endpoint="https://collector.example",
+                project_name="pxi_test",
+            )
+
+        request = route.calls.last.request
+        assert request.content == body
+        assert request.headers["authorization"] == "Bearer secret-api-key"
+        assert request.headers["x-project-name"] == "pxi_test"
+
+    async def test_remote_export_failure_is_retryable_by_the_browser(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with respx.mock:
+            respx.post("https://collector.example/v1/traces").mock(
+                return_value=httpx.Response(503)
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                await _export_pxi_otlp_request(
+                    body=b"",
+                    content_encoding=None,
+                    collector_endpoint="https://collector.example",
+                    project_name="pxi_test",
+                )
+
+        assert exc_info.value.status_code == 502
 
 
 class TestPersistDbTracesAndEmitEvent:

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -29,6 +29,7 @@ from phoenix.server.agents.types import (
     SandboxAvailability,
 )
 from phoenix.server.api.routers.agents import (
+    _decode_pxi_otlp_request,
     _enqueue_pxi_spans,
     _export_pxi_otlp_request,
     _interleave_agent_and_subagent_message_chunks,
@@ -41,6 +42,7 @@ from phoenix.server.api.routers.agents import (
 from phoenix.server.app import create_app
 from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
+from phoenix.server.prometheus import SPAN_QUEUE_REJECTIONS
 from phoenix.server.settings.registry import AgentTraceRecordingSetting
 from phoenix.server.types import DbSessionFactory, UserId
 from tests.unit.conftest import TestBulkInserter as _TestBulkInserter
@@ -210,6 +212,79 @@ class TestPxiBrowserTraceRelay:
         enqueue.assert_not_awaited()
         export.assert_not_awaited()
 
+    async def test_storage_lock_blocks_local_ingestion_but_not_remote_export(
+        self,
+        app: FastAPI,
+        httpx_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        await app.state.system_settings.update_agent_trace_recording(
+            AgentTraceRecordingSetting(
+                allow_local_traces=True,
+                allow_remote_export=True,
+            )
+        )
+        monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "https://collector.example")
+        monkeypatch.setattr(app.state.db, "should_not_insert_or_update", True)
+        enqueue = AsyncMock()
+        export = AsyncMock()
+        monkeypatch.setattr("phoenix.server.api.routers.agents._enqueue_pxi_spans", enqueue)
+        monkeypatch.setattr("phoenix.server.api.routers.agents._export_pxi_otlp_request", export)
+
+        response = await httpx_client.post(
+            "/agents/traces",
+            content=ExportTraceServiceRequest().SerializeToString(),
+            headers={
+                "content-type": "application/x-protobuf",
+                "x-phoenix-pxi-ingest-traces": "true",
+                "x-phoenix-pxi-export-remote-traces": "false",
+            },
+        )
+
+        assert response.status_code == 507
+        enqueue.assert_not_awaited()
+
+        # A remote-only request is unaffected by the local storage lock.
+        response = await httpx_client.post(
+            "/agents/traces",
+            content=ExportTraceServiceRequest().SerializeToString(),
+            headers={
+                "content-type": "application/x-protobuf",
+                "x-phoenix-pxi-ingest-traces": "false",
+                "x-phoenix-pxi-export-remote-traces": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        export.assert_awaited_once()
+
+    async def test_queue_full_increments_rejection_metric(
+        self,
+        app: FastAPI,
+        httpx_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        await app.state.system_settings.update_agent_trace_recording(
+            AgentTraceRecordingSetting(
+                allow_local_traces=True,
+                allow_remote_export=False,
+            )
+        )
+        monkeypatch.setattr(app.state, "span_queue_is_full", lambda: True)
+        rejections_before = SPAN_QUEUE_REJECTIONS._value.get()
+
+        response = await httpx_client.post(
+            "/agents/traces",
+            content=ExportTraceServiceRequest().SerializeToString(),
+            headers={
+                "content-type": "application/x-protobuf",
+                "x-phoenix-pxi-ingest-traces": "true",
+            },
+        )
+
+        assert response.status_code == 503
+        assert SPAN_QUEUE_REJECTIONS._value.get() == rejections_before + 1
+
     async def test_requires_authentication_when_enabled(
         self, pxi_client_with_auth: httpx.AsyncClient
     ) -> None:
@@ -241,6 +316,18 @@ class TestPxiBrowserTraceRelay:
         assert request.content == body
         assert request.headers["authorization"] == "Bearer secret-api-key"
         assert request.headers["x-project-name"] == "pxi_test"
+
+    @pytest.mark.parametrize("content_encoding", ["gzip", "deflate"])
+    async def test_decode_rejects_malformed_compressed_body_with_a_clean_error(
+        self, content_encoding: str
+    ) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await _decode_pxi_otlp_request(
+                body=b"not a valid compressed payload",
+                content_encoding=content_encoding,
+            )
+
+        assert exc_info.value.status_code == 415
 
     async def test_remote_export_failure_is_retryable_by_the_browser(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

PXI Cloud traces were incomplete because browser-created root and client-tool spans were recorded only locally, leaving exported backend spans with missing parents. The fix was prompted by live trace inspection showing Cloud consistently received backend spans but not the browser-owned portion of each trace

- start browser PXI turn tracing for remote-only as well as local recording
- send browser OTLP spans through an authenticated agents relay that re-applies server policy
- keep the collector credential and assistant project routing server-side while preserving trace/span identity
- retain local ingestion, propagate retryable remote failures, and cover all four destination modes

## Alternatives Considered 

1. Bulk export of completed turn spans (root + children) after turn completion, rather than simultaneous mirror. Has similar issues to the approach taken in this PR, but takes more work to exploit. 
2. Move to v1/traces endpoint rather than the bespoke endpoint in this PR. Avoids creation of a separate endpoint, though the one added here is not published in the schema and is intended as a stop-gap that will be removed down the line. 
3. Refactor to use web socket approach - more significant refactor and infrastructure considerations. 