### PR TITLE
feat(app): support batch annotation config management

### DIFF
--- a/app/src/pages/settings/AnnotationConfigSelectionToolbar.tsx
+++ b/app/src/pages/settings/AnnotationConfigSelectionToolbar.tsx
@@ -1,162 +1,179 @@
-import { css } from "@emotion/react";
 import { useState } from "react";
 
 import {
+  Alert,
   Button,
-  Card,
   Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
   DialogTrigger,
   Flex,
   Icon,
+  IconButton,
   Icons,
   Modal,
   ModalOverlay,
   Text,
+  Toolbar,
+  Tooltip,
+  TooltipTrigger,
   View,
 } from "@phoenix/components";
 import { AnnotationConfigDialog } from "@phoenix/components/annotation/AnnotationConfigDialog";
+import { FloatingToolbarContainer } from "@phoenix/components/core/toolbar/FloatingToolbarContainer";
+import { useNotifySuccess } from "@phoenix/contexts";
 import type { AnnotationConfig } from "@phoenix/pages/settings/types";
 
+type PersistedAnnotationConfig = AnnotationConfig & { id: string };
+
 interface AnnotationConfigSelectionToolbarProps {
-  selectedConfig: AnnotationConfig;
+  selectedConfigs: PersistedAnnotationConfig[];
   onClearSelection: () => void;
   onEditAnnotationConfig: (config: AnnotationConfig) => void;
   onDeleteAnnotationConfig: (
-    configId: string,
-    args?: { onCompleted?: () => void; onError?: () => void }
+    configIds: string[],
+    args?: {
+      onCompleted?: () => void;
+      onError?: (error: string) => void;
+    }
   ) => void;
 }
 
 export const AnnotationConfigSelectionToolbar = ({
-  selectedConfig,
+  selectedConfigs,
   onClearSelection,
   onEditAnnotationConfig,
   onDeleteAnnotationConfig,
 }: AnnotationConfigSelectionToolbarProps) => {
-  const [isEditing, setIsEditing] = useState(false);
-  if (!selectedConfig) {
-    return null;
-  }
-  const id = selectedConfig?.id;
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const notifySuccess = useNotifySuccess();
+  const isPlural = selectedConfigs.length !== 1;
+  const selectedConfig =
+    selectedConfigs.length === 1 ? selectedConfigs[0] : null;
+
+  const handleDelete = () => {
+    setIsDeleting(true);
+    onDeleteAnnotationConfig(
+      selectedConfigs.map((config) => config.id),
+      {
+        onCompleted: () => {
+          notifySuccess({
+            title: `Annotation Config${isPlural ? "s" : ""} Deleted`,
+            message: `${selectedConfigs.length} annotation config${isPlural ? "s" : ""} ${isPlural ? "have" : "has"} been deleted.`,
+          });
+          setIsDeleting(false);
+          setIsDeleteDialogOpen(false);
+          onClearSelection();
+        },
+        onError: (error) => {
+          setDeleteError(error);
+          setIsDeleting(false);
+        },
+      }
+    );
+  };
+
   return (
-    <div
-      data-editing={isEditing}
-      css={css`
-        position: fixed;
-        bottom: var(--global-dimension-size-600);
-        left: 50%;
-        transform: translateX(-50%);
-        z-index: 1000;
-        box-shadow: 8px 8px 20px 0 rgba(0, 0, 0, 0.4);
-        border-radius: var(--global-rounding-medium);
-        &[data-editing="true"] {
-          display: none;
-        }
-      `}
-    >
-      <View
-        padding="size-200"
-        borderColor="default"
-        borderWidth="thin"
-        borderRadius="medium"
-        minWidth="size-6000"
-      >
-        <Flex
-          direction="row"
-          gap="size-400"
-          alignItems="center"
-          justifyContent="space-between"
-        >
-          <Text>Config: &quot;{selectedConfig?.name}&quot;</Text>
+    <FloatingToolbarContainer>
+      <Toolbar aria-label="Annotation config selection">
+        <View paddingEnd="size-100">
           <Flex direction="row" gap="size-100" alignItems="center">
-            <Button variant="quiet" onPress={onClearSelection}>
-              Clear Selection
-            </Button>
-            <DialogTrigger
-              onOpenChange={(open) => {
-                setIsEditing(open);
-                if (!open) {
-                  onClearSelection();
-                }
-              }}
-            >
-              <Button variant="danger" size="S">
-                <Icon svg={<Icons.Trash />} />
-                Delete
-              </Button>
-              <ModalOverlay>
-                <Modal>
-                  <Dialog
-                    css={css`
-                      border: none;
-                    `}
-                  >
-                    {({ close }) => (
-                      <Card title="Delete Annotation Config">
-                        <View padding="size-200">
-                          <Text>
-                            Are you sure you want to delete this annotation
-                            config? Annotations made with this config will not
-                            be impacted.
-                          </Text>
-                        </View>
-                        <View
-                          paddingX="size-200"
-                          paddingY="size-100"
-                          borderTopColor="default"
-                          borderTopWidth="thin"
-                        >
-                          <Flex gap="size-100" justifyContent="end">
-                            <Button variant="quiet" onPress={close}>
-                              Cancel
-                            </Button>
-                            <Button
-                              size="S"
-                              variant="danger"
-                              onPress={() => {
-                                if (id) {
-                                  onDeleteAnnotationConfig(id, {
-                                    onCompleted: () => {
-                                      close();
-                                    },
-                                  });
-                                }
-                              }}
-                            >
-                              Delete
-                            </Button>
-                          </Flex>
-                        </View>
-                      </Card>
-                    )}
-                  </Dialog>
-                </Modal>
-              </ModalOverlay>
-            </DialogTrigger>
-            <DialogTrigger
-              onOpenChange={(open) => {
-                setIsEditing(open);
-                if (!open) {
-                  onClearSelection();
-                }
-              }}
-            >
-              <Button size="S" variant="primary">
-                <Icon svg={<Icons.Edit />} />
-                Edit
-              </Button>
-              <ModalOverlay>
-                <Modal>
-                  <AnnotationConfigDialog
-                    initialAnnotationConfig={selectedConfig}
-                    onAddAnnotationConfig={onEditAnnotationConfig}
-                  />
-                </Modal>
-              </ModalOverlay>
-            </DialogTrigger>
+            <TooltipTrigger>
+              <IconButton
+                size="M"
+                onPress={onClearSelection}
+                aria-label="Clear selection"
+              >
+                <Icon svg={<Icons.Close />} />
+              </IconButton>
+              <Tooltip>Clear selection</Tooltip>
+            </TooltipTrigger>
+            <Text>{`${selectedConfigs.length} config${isPlural ? "s" : ""} selected`}</Text>
           </Flex>
-        </Flex>
-      </View>
-    </div>
+        </View>
+        {selectedConfig ? (
+          <DialogTrigger onOpenChange={(open) => !open && onClearSelection()}>
+            <Button size="M" leadingVisual={<Icon svg={<Icons.Edit />} />}>
+              Edit
+            </Button>
+            <ModalOverlay>
+              <Modal>
+                <AnnotationConfigDialog
+                  initialAnnotationConfig={selectedConfig}
+                  onAddAnnotationConfig={onEditAnnotationConfig}
+                />
+              </Modal>
+            </ModalOverlay>
+          </DialogTrigger>
+        ) : null}
+        <Button
+          variant="danger"
+          size="M"
+          leadingVisual={
+            <Icon svg={isDeleting ? <Icons.Loading /> : <Icons.Trash />} />
+          }
+          isDisabled={isDeleting}
+          onPress={() => setIsDeleteDialogOpen(true)}
+          aria-label="Delete annotation configs"
+        >
+          {isDeleting ? "Deleting..." : "Delete"}
+        </Button>
+      </Toolbar>
+      <ModalOverlay
+        isOpen={isDeleteDialogOpen}
+        onOpenChange={(isOpen) => {
+          if (isOpen) setDeleteError(null);
+          setIsDeleteDialogOpen(isOpen);
+        }}
+        isDismissable
+      >
+        <Modal>
+          <Dialog>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>{`Delete Annotation Config${isPlural ? "s" : ""}`}</DialogTitle>
+                <DialogTitleExtra>
+                  <DialogCloseButton />
+                </DialogTitleExtra>
+              </DialogHeader>
+              <View padding="size-200">
+                <Text color="danger">
+                  {`Are you sure you want to delete ${selectedConfigs.length} annotation config${isPlural ? "s" : ""}? Annotations made with ${isPlural ? "these configs" : "this config"} will not be impacted.`}
+                </Text>
+                {deleteError ? (
+                  <Alert variant="danger">{deleteError}</Alert>
+                ) : null}
+              </View>
+              <View
+                paddingEnd="size-200"
+                paddingTop="size-100"
+                paddingBottom="size-100"
+                borderTopColor="default"
+                borderTopWidth="thin"
+              >
+                <Flex direction="row" justifyContent="end" gap="size-100">
+                  <Button size="S" onPress={() => setIsDeleteDialogOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="S"
+                    onPress={handleDelete}
+                    isDisabled={isDeleting}
+                  >
+                    {isDeleting ? "Deleting..." : "Delete"}
+                  </Button>
+                </Flex>
+              </View>
+            </DialogContent>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </FloatingToolbarContainer>
   );
 };

--- a/app/src/pages/settings/AnnotationConfigTable.tsx
+++ b/app/src/pages/settings/AnnotationConfigTable.tsx
@@ -41,18 +41,19 @@ import type { AnnotationConfigTableFragment$key } from "@phoenix/pages/settings/
 import { AnnotationConfigSelectionToolbar } from "@phoenix/pages/settings/AnnotationConfigSelectionToolbar";
 import type { AnnotationConfig } from "@phoenix/pages/settings/types";
 
+type PersistedAnnotationConfig = AnnotationConfig & { id: string };
+
 const columns = [
-  createRowSelectionColumn<AnnotationConfig>({
-    showSelectAllHeader: false,
-    size: 24,
-    minSize: 24,
-    maxSize: 24,
+  createRowSelectionColumn<PersistedAnnotationConfig>({
+    size: 30,
+    minSize: 30,
+    maxSize: 30,
   }),
   {
     id: "name",
     header: "Name",
     accessorKey: "name",
-    cell: ({ row }: CellContext<AnnotationConfig, unknown>) => {
+    cell: ({ row }: CellContext<PersistedAnnotationConfig, unknown>) => {
       return (
         <AnnotationLabel
           key={row.original.id}
@@ -70,9 +71,10 @@ const columns = [
     header: "Description",
     accessorKey: "description",
     sortUndefined: "last",
-    accessorFn: (row: AnnotationConfig) => row.description ?? undefined,
+    accessorFn: (row: PersistedAnnotationConfig) =>
+      row.description ?? undefined,
     maxSize: 150,
-    cell: ({ row }: CellContext<AnnotationConfig, unknown>) => {
+    cell: ({ row }: CellContext<PersistedAnnotationConfig, unknown>) => {
       return (
         <Truncate maxWidth="100%">
           <Text>{row.original.description}</Text>
@@ -85,7 +87,7 @@ const columns = [
     header: "Type",
     accessorKey: "annotationType",
     minSize: 10,
-    cell: ({ row }: CellContext<AnnotationConfig, unknown>) => {
+    cell: ({ row }: CellContext<PersistedAnnotationConfig, unknown>) => {
       return (
         <Text>
           {row.original.annotationType.charAt(0).toUpperCase() +
@@ -98,7 +100,7 @@ const columns = [
     id: "values",
     header: "Values",
     enableSorting: false,
-    accessorFn: (row: AnnotationConfig) => {
+    accessorFn: (row: PersistedAnnotationConfig) => {
       switch (row.annotationType) {
         case "CATEGORICAL": {
           if (!row.values) {
@@ -144,12 +146,12 @@ const columns = [
           return "";
       }
     },
-    cell: ({ getValue }: CellContext<AnnotationConfig, unknown>) => {
+    cell: ({ getValue }: CellContext<PersistedAnnotationConfig, unknown>) => {
       const value = getValue() as React.ReactNode;
       return <Flex gap="size-100">{value}</Flex>;
     },
   },
-] satisfies ColumnDef<AnnotationConfig>[];
+] satisfies ColumnDef<PersistedAnnotationConfig>[];
 
 export const AnnotationConfigTable = ({
   annotationConfigs,
@@ -158,11 +160,11 @@ export const AnnotationConfigTable = ({
 }: {
   annotationConfigs: AnnotationConfigTableFragment$key;
   onDeleteAnnotationConfig: (
-    id: string,
+    ids: string[],
     {
       onCompleted,
       onError,
-    }?: { onCompleted?: () => void; onError?: () => void }
+    }?: { onCompleted?: () => void; onError?: (error: string) => void }
   ) => void;
   onEditAnnotationConfig: (
     annotationConfig: AnnotationConfig,
@@ -218,7 +220,7 @@ export const AnnotationConfigTable = ({
   const configs = useMemo(
     () => data.annotationConfigs.edges.map((edge) => edge.annotationConfig),
     [data.annotationConfigs.edges]
-  ) as AnnotationConfig[]; // cast to AnnotationConfig[] because otherwise 'name' and 'annotationType' are optional
+  ) as PersistedAnnotationConfig[]; // fields are guaranteed by the concrete config fragments
   // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable({
     data: configs,
@@ -227,7 +229,7 @@ export const AnnotationConfigTable = ({
     getSortedRowModel: getSortedRowModel(),
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
-    enableMultiRowSelection: false,
+    getRowId: (row) => row.id,
     state: {
       rowSelection,
       columnPinning: CHECKBOX_COLUMN_PINNING,
@@ -309,14 +311,7 @@ export const AnnotationConfigTable = ({
         ) : (
           <tbody>
             {rows.map((row) => (
-              <tr
-                key={row.id}
-                onClick={() => {
-                  setRowSelection({
-                    [row.id]: !rowSelection?.[row.id],
-                  });
-                }}
-              >
+              <tr key={row.id}>
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}
@@ -338,14 +333,14 @@ export const AnnotationConfigTable = ({
           </tbody>
         )}
       </table>
-      {selectedRows.length > 0 && (
+      {selectedRows.length > 0 ? (
         <AnnotationConfigSelectionToolbar
-          selectedConfig={selectedConfigs[0]}
+          selectedConfigs={selectedConfigs}
           onClearSelection={clearSelection}
           onEditAnnotationConfig={onEditAnnotationConfig}
           onDeleteAnnotationConfig={onDeleteAnnotationConfig}
         />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/app/src/pages/settings/SettingsAnnotationsPage.tsx
+++ b/app/src/pages/settings/SettingsAnnotationsPage.tsx
@@ -76,10 +76,12 @@ const SettingsAnnotations = ({
     }
   `);
 
-  const parseError = (callback?: (error: string) => void) => (error: Error) => {
-    const formattedError = getErrorMessagesFromRelayMutationError(error);
-    callback?.(formattedError?.[0] ?? "Failed to create annotation config");
-  };
+  const parseError =
+    (fallback: string, callback?: (error: string) => void) =>
+    (error: Error) => {
+      const formattedError = getErrorMessagesFromRelayMutationError(error);
+      callback?.(formattedError?.[0] ?? fallback);
+    };
 
   const handleAddAnnotationConfig = (
     _config: AnnotationConfig,
@@ -96,7 +98,7 @@ const SettingsAnnotations = ({
         onCompleted?.();
         refetch();
       },
-      onError: parseError(onError),
+      onError: parseError("Failed to create annotation config", onError),
     });
   };
 
@@ -134,24 +136,24 @@ const SettingsAnnotations = ({
         onCompleted?.();
         refetch();
       },
-      onError: parseError(onError),
+      onError: parseError("Failed to update annotation config", onError),
     });
   };
 
   const handleDeleteAnnotationConfig = (
-    id: string,
+    ids: string[],
     {
       onCompleted,
       onError,
     }: { onCompleted?: () => void; onError?: (error: string) => void } = {}
   ) => {
     deleteAnnotationConfigs({
-      variables: { input: { ids: [id] } },
+      variables: { input: { ids } },
       onCompleted: () => {
         onCompleted?.();
         refetch();
       },
-      onError: parseError(onError),
+      onError: parseError("Failed to delete annotation configs", onError),
     });
   };
 


### PR DESCRIPTION
## Summary
- align annotation config selection with dataset examples
- support select-all and batch deletion with the shared floating toolbar
- retain editing for single selections

## Screenshots
![Multiple annotation configs selected](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14198-annotation-config-multi-select.png)

![Batch delete confirmation](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14198-annotation-config-delete-dialog.png)

## Test plan
- `make lint-frontend`
- `make typecheck-frontend`
- `make build-frontend`