### PR TITLE
fix(ui): make traces kind column resizable

### DIFF
--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -678,7 +678,7 @@ export function TracesTable(props: TracesTableProps) {
         },
         enableSorting: false,
         accessorKey: "spanKind",
-        maxSize: 100,
+        size: 100,
         cell: (props) => {
           if (props.row.original.__additionalRow) {
             return (


### PR DESCRIPTION
## Summary

- preserve the traces kind column's existing 100 px initial width
- remove the 100 px maximum so nested trace rows can be viewed by resizing the column

## Screenshots

### Before

The kind column is capped at 100 px, clipping deeply indented span kinds.

![Before: kind column capped at 100 px](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14201-traces-kind-column-before.png)

### After

The column still starts at 100 px and can be resized to reveal the supported nested tree.

![After: kind column resized to 400 px](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14201-traces-kind-column-after.png)

## Test plan

- `pnpm run fmt:check -- src/pages/project/TracesTable.tsx`
- `pnpm run typecheck`
- `pnpm run build:relay`
- verified the 100 px initial width and 400 px resized state against a seeded nested trace with agent-browser

Related GitHub issue: none; this was requested directly.