### PR TITLE
feat: automatically add items when creating a dataset from a selection

### DIFF
--- a/app/src/components/dataset/CreateDatasetForm.tsx
+++ b/app/src/components/dataset/CreateDatasetForm.tsx
@@ -16,12 +16,14 @@ export type CreateDatasetFormProps = {
   ) => void;
   onDatasetCreateError?: (error: Error) => void;
   onCancel?: () => void;
+  submitButtonText?: string;
 };
 
 export function CreateDatasetForm({
   onDatasetCreated,
   onDatasetCreateError,
   onCancel,
+  submitButtonText = "Create Dataset",
 }: CreateDatasetFormProps) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [commit, isCommitting] = useMutation<CreateDatasetFormMutation>(graphql`
@@ -81,7 +83,7 @@ export function CreateDatasetForm({
     <DatasetForm
       isSubmitting={isCommitting}
       onSubmit={onSubmit}
-      submitButtonText={isCommitting ? "Creating..." : "Create Dataset"}
+      submitButtonText={isCommitting ? "Creating..." : submitButtonText}
       formMode="create"
       errorMessage={errorMessage}
       onCancel={onCancel}

--- a/app/src/pages/project/SpanSelectionToolbar.tsx
+++ b/app/src/pages/project/SpanSelectionToolbar.tsx
@@ -247,6 +247,7 @@ export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
                       </DialogTitleExtra>
                     </DialogHeader>
                     <CreateDatasetForm
+                      submitButtonText="Create and add"
                       onDatasetCreateError={(error) => {
                         const formattedError =
                           getErrorMessagesFromRelayMutationError(error);
@@ -256,11 +257,7 @@ export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
                       }}
                       onDatasetCreated={(dataset) => {
                         setIsCreatingDataset(false);
-                        notifySuccess({
-                          title: "Dataset created",
-                          message: `${dataset.name} has been successfully created.`,
-                        });
-                        setIsDatasetPopoverOpen(true);
+                        onAddSpansToDataset(dataset.id);
                       }}
                     />
                   </DialogContent>


### PR DESCRIPTION
resolves #14265

To test: select trace or span rows within a project, use the action bar to `add to dataset`, use the + button to create a new dataset. Save button will say `save and add`. The items will appear in the new dataset.

Tested and working.
