### PR TITLE
feat(playground): show output error count

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -43,7 +43,6 @@ import {
   Text,
   View,
 } from "@phoenix/components";
-import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
 import type { AnnotationConfig } from "@phoenix/components/annotation";
 import {
   Tooltip,
@@ -115,7 +114,7 @@ import {
   usePlaygroundDatasetExamplesTableContext,
 } from "./PlaygroundDatasetExamplesTableContext";
 import { PlaygroundErrorWrap } from "./PlaygroundErrorWrap";
-import { PlaygroundInstanceProgressIndicator } from "./PlaygroundInstanceProgressIndicator";
+import { PlaygroundOutputHeader } from "./PlaygroundOutputHeader";
 import { PlaygroundRunTraceDetailsDialog } from "./PlaygroundRunTraceDialog";
 import type { PartialOutputToolCall } from "./PlaygroundToolCall";
 import { PlaygroundToolCall } from "./PlaygroundToolCall";
@@ -748,19 +747,7 @@ function PlaygroundInstanceOutputColumnHeader({
 
   return (
     <Flex direction="column" gap="size-50" width="100%">
-      <Flex
-        direction="row"
-        gap="size-100"
-        alignItems="center"
-        justifyContent="space-between"
-        width="100%"
-      >
-        <Flex direction="row" gap="size-100" alignItems="center">
-          <AlphabeticIndexIcon index={index} size="XS" />
-          <span>Output</span>
-        </Flex>
-        <PlaygroundInstanceProgressIndicator instanceId={instanceId} />
-      </Flex>
+      <PlaygroundOutputHeader instanceId={instanceId} index={index} />
       <ExperimentCostAndLatencySummary
         executionState={costExecutionState}
         experiment={costSummary}

--- a/app/src/pages/playground/PlaygroundOutputHeader.tsx
+++ b/app/src/pages/playground/PlaygroundOutputHeader.tsx
@@ -1,0 +1,41 @@
+import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
+import { Counter } from "@phoenix/components/core/counter";
+import { Flex } from "@phoenix/components/core/layout";
+import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+
+import { PlaygroundInstanceProgressIndicator } from "./PlaygroundInstanceProgressIndicator";
+
+export type PlaygroundOutputHeaderProps = {
+  instanceId: number;
+  index: number;
+};
+
+export function PlaygroundOutputHeader({
+  instanceId,
+  index,
+}: PlaygroundOutputHeaderProps) {
+  const errorCount = usePlaygroundContext(
+    (state) =>
+      state.instances.find((instance) => instance.id === instanceId)
+        ?.experimentRunProgress?.runsFailed ?? 0
+  );
+
+  return (
+    <Flex
+      direction="row"
+      gap="size-100"
+      alignItems="center"
+      justifyContent="space-between"
+      width="100%"
+    >
+      <Flex direction="row" gap="size-100" alignItems="center">
+        <AlphabeticIndexIcon index={index} size="XS" />
+        <span>Output</span>
+        {errorCount > 0 ? (
+          <Counter variant="danger">{errorCount}</Counter>
+        ) : null}
+      </Flex>
+      <PlaygroundInstanceProgressIndicator instanceId={instanceId} />
+    </Flex>
+  );
+}

--- a/app/src/pages/playground/__tests__/PlaygroundOutputHeader.test.tsx
+++ b/app/src/pages/playground/__tests__/PlaygroundOutputHeader.test.tsx
@@ -1,0 +1,87 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { PlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import { createPlaygroundStore } from "@phoenix/store";
+
+import { PlaygroundOutputHeader } from "../PlaygroundOutputHeader";
+
+describe("PlaygroundOutputHeader", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("shows completed run errors after the experiment finishes", () => {
+    const playgroundStore = createPlaygroundStore({
+      modelConfigByProvider: {},
+    });
+    const instance = playgroundStore.getState().instances[0];
+    expect(instance).toBeDefined();
+    if (instance == null) {
+      return;
+    }
+    playgroundStore.setState({
+      instances: [
+        {
+          ...instance,
+          activeRunId: null,
+          experimentRunProgress: {
+            totalRuns: 10,
+            runsCompleted: 7,
+            runsFailed: 3,
+            totalEvals: 0,
+            evalsCompleted: 0,
+            evalsFailed: 0,
+          },
+        },
+      ],
+    });
+
+    act(() => {
+      root.render(
+        <PlaygroundContext.Provider value={playgroundStore}>
+          <PlaygroundOutputHeader instanceId={instance.id} index={0} />
+        </PlaygroundContext.Provider>
+      );
+    });
+
+    const errorCounter = container.querySelector(
+      '.counter[data-variant="danger"]'
+    );
+    expect(errorCounter?.textContent).toBe("3");
+  });
+
+  it("does not show an error counter when every run succeeds", () => {
+    const playgroundStore = createPlaygroundStore({
+      modelConfigByProvider: {},
+    });
+    const instance = playgroundStore.getState().instances[0];
+    expect(instance).toBeDefined();
+    if (instance == null) {
+      return;
+    }
+
+    act(() => {
+      root.render(
+        <PlaygroundContext.Provider value={playgroundStore}>
+          <PlaygroundOutputHeader instanceId={instance.id} index={0} />
+        </PlaygroundContext.Provider>
+      );
+    });
+
+    expect(container.querySelector(".counter")).toBeNull();
+  });
+});

--- a/app/stories/PlaygroundOutputHeader.stories.tsx
+++ b/app/stories/PlaygroundOutputHeader.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { PropsWithChildren } from "react";
+import { useEffect } from "react";
+
+import { PlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import { PlaygroundOutputHeader } from "@phoenix/pages/playground/PlaygroundOutputHeader";
+import { createPlaygroundStore, type PlaygroundStore } from "@phoenix/store";
+
+const TOTAL_RUNS = 10;
+const STORY_PROGRESS_INTERVAL_MS = 800;
+
+function createStoryPlayground({
+  errorCount,
+  isRunning = false,
+}: {
+  errorCount: number;
+  isRunning?: boolean;
+}) {
+  const playgroundStore = createPlaygroundStore({ modelConfigByProvider: {} });
+  const instance = playgroundStore.getState().instances[0];
+  if (instance == null) {
+    throw new Error("Expected the playground store to create an instance");
+  }
+  playgroundStore.setState({
+    instances: [
+      {
+        ...instance,
+        activeRunId: isRunning ? 1 : null,
+        experimentRunProgress: {
+          totalRuns: TOTAL_RUNS,
+          runsCompleted: isRunning ? 3 : TOTAL_RUNS - errorCount,
+          runsFailed: errorCount,
+          totalEvals: 0,
+          evalsCompleted: 0,
+          evalsFailed: 0,
+        },
+      },
+    ],
+  });
+  return { instanceId: instance.id, playgroundStore };
+}
+
+function RunningPlaygroundProvider({
+  children,
+  errorCount,
+  instanceId,
+  playgroundStore,
+}: PropsWithChildren<{
+  errorCount: number;
+  instanceId: number;
+  playgroundStore: PlaygroundStore;
+}>) {
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      playgroundStore.setState((state) => ({
+        instances: state.instances.map((instance) => {
+          if (instance.id !== instanceId) {
+            return instance;
+          }
+          const progress = instance.experimentRunProgress;
+          if (progress == null) {
+            return instance;
+          }
+          const lastRunningCompletedCount = TOTAL_RUNS - errorCount - 1;
+          const runsCompleted =
+            progress.runsCompleted >= lastRunningCompletedCount
+              ? 0
+              : progress.runsCompleted + 1;
+          return {
+            ...instance,
+            experimentRunProgress: {
+              ...progress,
+              runsCompleted,
+            },
+          };
+        }),
+      }));
+    }, STORY_PROGRESS_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [errorCount, instanceId, playgroundStore]);
+
+  return (
+    <PlaygroundContext.Provider value={playgroundStore}>
+      {children}
+    </PlaygroundContext.Provider>
+  );
+}
+
+const idlePlayground = createStoryPlayground({ errorCount: 0 });
+const completedWithErrorsPlayground = createStoryPlayground({ errorCount: 3 });
+const runningWithoutErrorsPlayground = createStoryPlayground({
+  errorCount: 0,
+  isRunning: true,
+});
+const runningWithErrorsPlayground = createStoryPlayground({
+  errorCount: 2,
+  isRunning: true,
+});
+
+const meta = {
+  title: "Playground/Output Header",
+  component: PlaygroundOutputHeader,
+  parameters: {
+    width: 560,
+  },
+} satisfies Meta<typeof PlaygroundOutputHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    instanceId: idlePlayground.instanceId,
+    index: 0,
+  },
+  decorators: [
+    (Story) => (
+      <PlaygroundContext.Provider value={idlePlayground.playgroundStore}>
+        <Story />
+      </PlaygroundContext.Provider>
+    ),
+  ],
+};
+
+export const CompletedWithErrors: Story = {
+  args: {
+    instanceId: completedWithErrorsPlayground.instanceId,
+    index: 0,
+  },
+  decorators: [
+    (Story) => (
+      <PlaygroundContext.Provider
+        value={completedWithErrorsPlayground.playgroundStore}
+      >
+        <Story />
+      </PlaygroundContext.Provider>
+    ),
+  ],
+};
+
+export const RunningWithoutErrors: Story = {
+  args: {
+    instanceId: runningWithoutErrorsPlayground.instanceId,
+    index: 0,
+  },
+  decorators: [
+    (Story) => (
+      <RunningPlaygroundProvider
+        errorCount={0}
+        instanceId={runningWithoutErrorsPlayground.instanceId}
+        playgroundStore={runningWithoutErrorsPlayground.playgroundStore}
+      >
+        <Story />
+      </RunningPlaygroundProvider>
+    ),
+  ],
+};
+
+export const RunningWithErrors: Story = {
+  args: {
+    instanceId: runningWithErrorsPlayground.instanceId,
+    index: 0,
+  },
+  decorators: [
+    (Story) => (
+      <RunningPlaygroundProvider
+        errorCount={2}
+        instanceId={runningWithErrorsPlayground.instanceId}
+        playgroundStore={runningWithErrorsPlayground.playgroundStore}
+      >
+        <Story />
+      </RunningPlaygroundProvider>
+    ),
+  ],
+};


### PR DESCRIPTION
Add error count to the playground output table header.

Extract the table header into a component with a story.

👾 AUTOMATED REPORT:

resolves #14266

## Summary

- show the failed-run count in each playground output header after an experiment run
- render the production header directly in Storybook across idle, completed-error, running-success, and running-error states
- cover error and no-error output headers with focused regression tests

## Testing

- Demonstration: `Playground/Output Header` Storybook stories in idle, completed-error, running-success, and running-error states across light and dark themes
- Manual verification: artifact-backed Storybook pass confirmed the production-composed header, zero-error state, danger error count, and advancing progress indicator in both themes
- Checks: `make test-frontend`, `make typecheck-frontend`, `make lint-frontend`, and `make format-frontend`

## Usability evidence

All screenshots are After-only because `Playground/Output Header` is a newly added production-composed story.

### Default

| After — Light | After — Dark |
| --- | --- |
| ![Default output header in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14277-c35bee8ae87a-3a638c91b7f2-playground-output-header-default-after__light.png) | ![Default output header in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14277-c35bee8ae87a-a8a723e45ca9-playground-output-header-default-after__dark.png) |

### Completed with errors

| After — Light | After — Dark |
| --- | --- |
| ![Completed output header with errors in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14277-c35bee8ae87a-c01ade881523-playground-output-header-completed-with-errors-after__light.png) | ![Completed output header with errors in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14277-c35bee8ae87a-7eeffd05dd25-playground-output-header-completed-with-errors-after__dark.png) |

### Running without errors

| After — Light | After — Dark |
| --- | --- |
| ![Running output header without errors in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14277-c35bee8ae87a-6e5d73da32dd-playground-output-header-running-without-errors-after__light.png) | ![Running output header without errors in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14277-c35bee8ae87a-382e3fba5e1d-playground-output-header-running-without-errors-after__dark.png) |

### Running with errors

| After — Light | After — Dark |
| --- | --- |
| ![Running output header with errors in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14277-c35bee8ae87a-042545a75847-playground-output-header-running-with-errors-after__light.png) | ![Running output header with errors in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14277-c35bee8ae87a-6529815a22a2-playground-output-header-running-with-errors-after__dark.png) |
