### PR TITLE
feat: clarify forced tool choice menus

### DIFF
--- a/app/src/components/generative/ToolChoiceSelector.tsx
+++ b/app/src/components/generative/ToolChoiceSelector.tsx
@@ -105,14 +105,14 @@ const idToCanonical = (id: string): CanonicalToolChoice => {
 };
 
 /**
- * Renders a labelled option row with a provider-specific API token badge.
+ * Renders a labelled option row with a descriptive token.
  */
 const OptionLabel = ({
   label,
-  apiToken,
+  tokenText,
 }: {
   label: string;
-  apiToken: string;
+  tokenText: string;
 }) => (
   <Flex
     gap="size-100"
@@ -122,7 +122,7 @@ const OptionLabel = ({
   >
     <span>{label}</span>
     <Token color="var(--global-color-gray-900)" size="S">
-      {apiToken}
+      {tokenText}
     </Token>
   </Flex>
 );
@@ -164,16 +164,16 @@ export function ToolChoiceSelector({
       <Popover>
         <ListBox>
           <SelectItem id="ZERO_OR_MORE" textValue="auto">
-            <OptionLabel label="Tools auto-selected by LLM" apiToken="auto" />
+            <OptionLabel label="Tools auto-selected by LLM" tokenText="auto" />
           </SelectItem>
           <SelectItem id="ONE_OR_MORE" textValue={config.oneOrMoreToken}>
             <OptionLabel
               label="Use at least one tool"
-              apiToken={config.oneOrMoreToken}
+              tokenText={config.oneOrMoreToken}
             />
           </SelectItem>
           <SelectItem id="NONE" textValue="none">
-            <OptionLabel label="Don't use any tools" apiToken="none" />
+            <OptionLabel label="Don't use any tools" tokenText="none" />
           </SelectItem>
           {toolNames.map((toolName) => (
             <SelectItem
@@ -181,7 +181,7 @@ export function ToolChoiceSelector({
               id={`${SPECIFIC_FUNCTION_PREFIX}${toolName}`}
               textValue={toolName}
             >
-              {toolName}
+              <OptionLabel label={toolName} tokenText="Always" />
             </SelectItem>
           ))}
         </ListBox>

--- a/app/src/components/generative/ToolChoiceSelector.tsx
+++ b/app/src/components/generative/ToolChoiceSelector.tsx
@@ -181,7 +181,7 @@ export function ToolChoiceSelector({
               id={`${SPECIFIC_FUNCTION_PREFIX}${toolName}`}
               textValue={toolName}
             >
-              <OptionLabel label={toolName} tokenText="Always" />
+              <OptionLabel label={`Use ${toolName}`} tokenText="always" />
             </SelectItem>
           ))}
         </ListBox>

--- a/app/src/components/generative/__tests__/ToolChoiceSelector.test.tsx
+++ b/app/src/components/generative/__tests__/ToolChoiceSelector.test.tsx
@@ -38,7 +38,7 @@ describe("ToolChoiceSelector", () => {
     });
   });
 
-  it("labels a forced tool choice as Always", async () => {
+  it("labels a forced tool choice with the action and always token", async () => {
     await act(async () => {
       root.render(
         <ThemeProvider themeMode="light" disableBodyTheme>
@@ -56,8 +56,8 @@ describe("ToolChoiceSelector", () => {
     });
 
     expect(container.querySelector("button")?.textContent).toContain(
-      "get_weather"
+      "Use get_weather"
     );
-    expect(container.querySelector(".token__text")?.textContent).toBe("Always");
+    expect(container.querySelector(".token__text")?.textContent).toBe("always");
   });
 });

--- a/app/src/components/generative/__tests__/ToolChoiceSelector.test.tsx
+++ b/app/src/components/generative/__tests__/ToolChoiceSelector.test.tsx
@@ -1,0 +1,63 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
+
+import { ToolChoiceSelector } from "../ToolChoiceSelector";
+
+describe("ToolChoiceSelector", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it("labels a forced tool choice as Always", async () => {
+    await act(async () => {
+      root.render(
+        <ThemeProvider themeMode="light" disableBodyTheme>
+          <ToolChoiceSelector
+            provider="OPENAI"
+            choice={{
+              type: "SPECIFIC_FUNCTION",
+              functionName: "get_weather",
+            }}
+            onChange={() => undefined}
+            toolNames={["get_weather"]}
+          />
+        </ThemeProvider>
+      );
+    });
+
+    expect(container.querySelector("button")?.textContent).toContain(
+      "get_weather"
+    );
+    expect(container.querySelector(".token__text")?.textContent).toBe("Always");
+  });
+});


### PR DESCRIPTION
resolves #14258

<img width="857" height="387" alt="image" src="https://github.com/user-attachments/assets/347806a6-2331-4919-bec0-f81f879285b3" />

- label specific-function choices as `Use <tool name>` with an `always` token
- preserve the action and token when the forced tool is selected
- add regression coverage for the selected forced-tool state