### PR TITLE
fix(ui): constrain action-bar dataset picker height

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1000,6 +1000,12 @@ const inputFieldCSS = (theme: Theme) => css`
 const menuCSS = (theme: Theme) => css`
   :root,
   .theme--${theme} {
+    /* Menu sizing */
+    --global-menu-min-height: var(--global-dimension-size-3600);
+    --global-menu-max-height-small: var(--global-dimension-size-6000);
+    --global-menu-max-height-large: var(--global-dimension-size-8000);
+
+    /* Menu colors and spacing */
     --global-menu-border-color: var(--global-border-color-default);
     --global-menu-background-color: var(--global-color-gray-50);
     --global-menu-item-background-color-hover: var(--hover-background);

--- a/app/src/components/core/menu/Menu.tsx
+++ b/app/src/components/core/menu/Menu.tsx
@@ -259,8 +259,8 @@ const menuContainerCss = css`
 export const MenuContainer = ({
   children,
   placement = "bottom end",
-  minHeight = 300,
-  maxHeight = 650,
+  minHeight = "var(--global-menu-min-height)",
+  maxHeight = "var(--global-menu-max-height-large)",
   maxWidth = 450,
   ...popoverProps
 }: PropsWithChildren &

--- a/app/src/pages/project/DatasetSelectorPopoverContent.tsx
+++ b/app/src/pages/project/DatasetSelectorPopoverContent.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import { startTransition, useMemo } from "react";
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
 
@@ -20,6 +21,10 @@ import { SearchIcon } from "@phoenix/components/core/field";
 import type { DatasetSelectorPopoverContent_datasets$key } from "./__generated__/DatasetSelectorPopoverContent_datasets.graphql";
 import type { DatasetSelectorPopoverContentDatasetsQuery } from "./__generated__/DatasetSelectorPopoverContentDatasetsQuery.graphql";
 import type { DatasetSelectorPopoverContentQuery } from "./__generated__/DatasetSelectorPopoverContentQuery.graphql";
+
+const datasetMenuCSS = css`
+  max-height: var(--global-menu-max-height-small);
+`;
 
 export type DatasetSelectorPopoverContentProps = {
   onCreateNewDataset: () => void;
@@ -109,6 +114,7 @@ function DatasetsList(props: {
         </SearchField>
       </MenuHeader>
       <Menu
+        css={datasetMenuCSS}
         aria-label="datasets"
         items={items}
         selectionMode="single"

--- a/app/stories/Menu.stories.tsx
+++ b/app/stories/Menu.stories.tsx
@@ -278,6 +278,72 @@ const FILTER_OPTIONS = [
   { id: "23", name: "Category W", color: "#6B7280" },
 ];
 
+type MenuMaxHeightToken =
+  | "--global-menu-max-height-small"
+  | "--global-menu-max-height-large";
+
+function MenuMaxHeightTokenStory({
+  label,
+  token,
+}: {
+  label: string;
+  token: MenuMaxHeightToken;
+}) {
+  return (
+    <MenuTrigger defaultOpen>
+      <Button>{label}</Button>
+      <MenuContainer
+        placement="bottom start"
+        minHeight={0}
+        maxHeight={`var(${token})`}
+      >
+        <MenuHeader>
+          <MenuHeaderTitle>{token}</MenuHeaderTitle>
+        </MenuHeader>
+        <Menu aria-label={label} items={FILTER_OPTIONS}>
+          {({ id, name }) => <MenuItem id={id}>{name}</MenuItem>}
+        </Menu>
+      </MenuContainer>
+    </MenuTrigger>
+  );
+}
+
+export const SmallMaxHeightToken = {
+  render: () => (
+    <MenuMaxHeightTokenStory
+      label="Small max-height menu"
+      token="--global-menu-max-height-small"
+    />
+  ),
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        story:
+          "The small semantic menu cutoff resolves to 480px and keeps longer menus scrollable.",
+      },
+    },
+  },
+};
+
+export const LargeMaxHeightToken = {
+  render: () => (
+    <MenuMaxHeightTokenStory
+      label="Large max-height menu"
+      token="--global-menu-max-height-large"
+    />
+  ),
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        story:
+          "The large semantic menu cutoff resolves to 640px and is the default maximum height for MenuContainer.",
+      },
+    },
+  },
+};
+
 export const FilterMenu = () => {
   const { contains } = useFilter({ sensitivity: "base" });
   const [selectedIds, setSelectedIds] = useState<string[]>([]);


### PR DESCRIPTION
Adds a max height for the add to dataset menu, and reusable tokens for menu height limits in general.

This does NOT fix another issue discovered in this process: the menu width is unbounded and shrinks to hug the empty state, and can stretch the entire width of the screen for long datasets. I'm filing and fixing that separately.

👾 AUTOMATED REPORT:

resolves #14248

## Summary

- cap the action-bar dataset picker list at the small semantic menu height
- add reusable small and large menu height tokens backed by the existing dimension scale
- migrate shared MenuContainer height defaults from hardcoded pixels to semantic tokens
- add dedicated, open-by-default Storybook stories for both max-height tokens

## Testing

- Real app: created 60 datasets, selected a real span, opened Add to Dataset, and verified the capped list scrolls to the final fetched dataset
- Demonstration: replayed one unchanged 1280x720 app scenario against the base SHA and implementation; captured affected existing Menu stories before/after plus the new token stories after in light and dark themes
- Manual verification: the asserted after walkthrough verified the 480px capped menu and scrolling; Storybook captures verified both themes for affected and new menu stories
- Checks: make format-frontend, make lint-frontend, make typecheck-frontend, make test-frontend (1,864 passed, 12 skipped), and make build-frontend

## Usability evidence

### App walkthrough

The same 1280x720 scenario opens **Add to Dataset** with 60 datasets. Select a poster to play the H.264 walkthrough.

| Before | After |
| --- | --- |
| [![Play before walkthrough](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14280-80d3f0ee601f-8c1186f67d31-before-contact-sheet.png)](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14280-80d3f0ee601f-87f5ee87cf34-before.mp4) | [![Play after walkthrough](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14280-80d3f0ee601f-a4577a0d62c9-after-contact-sheet.png)](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14280-80d3f0ee601f-159708042130-after.mp4) |