### PR TITLE
fix: make span status code filters case insensitive

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -301,8 +301,8 @@ def _is_string_constant(node: typing.Any) -> TypeGuard[ast.Constant]:
     return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
-def _is_span_kind(node: typing.Any) -> TypeGuard[ast.Name]:
-    return isinstance(node, ast.Name) and node.id == "span_kind"
+def _is_uppercase_enum(node: typing.Any) -> TypeGuard[ast.Name]:
+    return isinstance(node, ast.Name) and node.id in ("span_kind", "status_code")
 
 
 def _convert_to_uppercase(node: ast.expr) -> ast.expr:
@@ -521,9 +521,9 @@ class _FilterTranslator(_ProjectionTranslator):
                 left = comparator
             return ast.Call(func=ast.Name(id="and_", ctx=ast.Load()), args=args, keywords=[])
         left, op, right = self.visit(node.left), node.ops[0], self.visit(node.comparators[0])
-        if _is_span_kind(left):
+        if _is_uppercase_enum(left):
             right = _convert_to_uppercase(right)
-        elif _is_span_kind(right):
+        elif _is_uppercase_enum(right):
             left = _convert_to_uppercase(left)
         if _is_subscript(left, "attributes"):
             left = (

--- a/tests/unit/server/api/types/test_Trace_span_aggregates.py
+++ b/tests/unit/server/api/types/test_Trace_span_aggregates.py
@@ -208,7 +208,7 @@ async def test_spans_filter_condition_on_status_code(
         variables={
             "traceId": trace_gid,
             "first": 10,
-            "filter": "status_code == 'ERROR'",
+            "filter": "status_code == 'error'",
         },
     )
     assert not response.errors

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -196,6 +196,22 @@ def test_get_attribute_keys_list(expression: str, expected: Optional[list[str]])
             "'cha' in span_kind",
             "TextContains(span_kind, 'CHA')",
         ),
+        (
+            "status_code == 'error'",
+            "status_code == 'ERROR'",
+        ),
+        (
+            "'Error' == status_code",
+            "'ERROR' == status_code",
+        ),
+        (
+            "status_code in ('ok', 'Error')",
+            "status_code.in_(('OK', 'ERROR'))",
+        ),
+        (
+            "'err' in status_code",
+            "TextContains(status_code, 'ERR')",
+        ),
     ],
 )
 async def test_filter_translated(


### PR DESCRIPTION
## What changed

- Normalize span filter DSL literals for `status_code` to uppercase, matching the existing `span_kind` behavior.
- Cover equality, reversed equality, membership, and substring comparisons.
- Exercise the GraphQL span filter with a lowercase `error` value.

## Why

Span status codes are stored as uppercase values, so users previously had to type `ERROR` exactly. Lowercase or mixed-case values did not match, making the filter unnecessarily difficult to enter.

## Impact

Status-code filter values are now case-insensitive. Existing uppercase filters continue to work unchanged.

## Validation

- `uv run pytest tests/unit/trace/dsl/test_filter.py tests/unit/server/api/types/test_Trace_span_aggregates.py -n auto`
- `uv run ruff check src/phoenix/trace/dsl/filter.py tests/unit/trace/dsl/test_filter.py tests/unit/server/api/types/test_Trace_span_aggregates.py`
- `uv run ruff format --check src/phoenix/trace/dsl/filter.py tests/unit/trace/dsl/test_filter.py tests/unit/server/api/types/test_Trace_span_aggregates.py`
- `git diff --check`
