### PR TITLE
fix(ui): bound menu popover dimensions

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -61,6 +61,7 @@ export const mediumRootCSS = css`
     --global-dimension-size-4000: 320px;
     --global-dimension-size-4600: 368px;
     --global-dimension-size-5000: 400px;
+    --global-dimension-size-5250: 420px;
     --global-dimension-size-6000: 480px;
     --global-dimension-size-8000: 640px;
     --global-dimension-size-8500: 680px;
@@ -1004,6 +1005,9 @@ const menuCSS = (theme: Theme) => css`
     --global-menu-min-height: var(--global-dimension-size-3600);
     --global-menu-max-height-small: var(--global-dimension-size-6000);
     --global-menu-max-height-large: var(--global-dimension-size-8000);
+    --global-menu-width-xs: var(--global-dimension-size-2500);
+    --global-menu-width-sm: var(--global-dimension-size-4000);
+    --global-menu-width-md: var(--global-dimension-size-5250);
 
     /* Menu colors and spacing */
     --global-menu-border-color: var(--global-border-color-default);

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1000,6 +1000,12 @@ const inputFieldCSS = (theme: Theme) => css`
 const menuCSS = (theme: Theme) => css`
   :root,
   .theme--${theme} {
+    /* Menu sizing */
+    --global-menu-min-height: var(--global-dimension-size-3600);
+    --global-menu-max-height-small: var(--global-dimension-size-6000);
+    --global-menu-max-height-large: var(--global-dimension-size-8000);
+
+    /* Menu colors and spacing */
     --global-menu-border-color: var(--global-border-color-default);
     --global-menu-background-color: var(--global-color-gray-50);
     --global-menu-item-background-color-hover: var(--hover-background);

--- a/app/src/components/core/copy/CopyActionMenu.tsx
+++ b/app/src/components/core/copy/CopyActionMenu.tsx
@@ -1,11 +1,9 @@
-import { css } from "@emotion/react";
 import copy from "copy-to-clipboard";
 import { useCallback, useRef, useState } from "react";
 
 import { Button } from "../button";
 import { Icon } from "../icon";
-import { Menu, MenuItem, MenuTrigger } from "../menu";
-import { Popover } from "../overlay";
+import { Menu, MenuContainer, MenuItem, MenuTrigger } from "../menu";
 import type { CopyActionMenuItem } from "./types";
 
 const SHOW_COPIED_TIMEOUT_MS = 2000;
@@ -60,13 +58,14 @@ export function CopyActionMenu({ items }: CopyActionMenuProps) {
       >
         {copiedItemId != null ? "Copied" : undefined}
       </Button>
-      <Popover placement="bottom end" offset={3}>
-        <Menu
-          onAction={onAction}
-          css={css`
-            --menu-min-width: auto;
-          `}
-        >
+      <MenuContainer
+        size="xs"
+        minHeight={0}
+        placement="bottom end"
+        offset={3}
+        shouldFlip
+      >
+        <Menu onAction={onAction}>
           {items.map((item) => (
             <MenuItem
               key={item.name}
@@ -78,7 +77,7 @@ export function CopyActionMenu({ items }: CopyActionMenuProps) {
             </MenuItem>
           ))}
         </Menu>
-      </Popover>
+      </MenuContainer>
     </MenuTrigger>
   );
 }

--- a/app/src/components/core/menu/Menu.tsx
+++ b/app/src/components/core/menu/Menu.tsx
@@ -259,8 +259,8 @@ const menuContainerCss = css`
 export const MenuContainer = ({
   children,
   placement = "bottom end",
-  minHeight = 300,
-  maxHeight = 650,
+  minHeight = "var(--global-menu-min-height)",
+  maxHeight = "var(--global-menu-max-height-large)",
   maxWidth = 450,
   ...popoverProps
 }: PropsWithChildren &

--- a/app/src/components/core/menu/Menu.tsx
+++ b/app/src/components/core/menu/Menu.tsx
@@ -18,7 +18,7 @@ import { Flex } from "../layout";
 import { Popover } from "../overlay";
 
 const menuCSS = css`
-  --menu-min-width: 250px;
+  --menu-min-width: var(--global-menu-width-xs);
   min-width: var(--menu-min-width);
   display: flex;
   flex-direction: column;
@@ -239,6 +239,8 @@ const menuContainerCss = css`
   flex-direction: column;
 `;
 
+export type MenuContainerSize = "xs" | "sm" | "md";
+
 /**
  * A menu container is a container for a menu.
  * This is the container for the menu items, and should be used in conjunction with MenuTrigger and Menu.
@@ -261,13 +263,15 @@ export const MenuContainer = ({
   placement = "bottom end",
   minHeight = "var(--global-menu-min-height)",
   maxHeight = "var(--global-menu-max-height-large)",
-  maxWidth = 450,
+  size = "md",
+  maxWidth = `var(--global-menu-width-${size})`,
   ...popoverProps
 }: PropsWithChildren &
   Omit<PopoverProps, "maxHeight" | "maxWidth"> & {
     minHeight?: React.CSSProperties["minHeight"];
     maxHeight?: React.CSSProperties["maxHeight"];
     maxWidth?: React.CSSProperties["maxWidth"];
+    size?: MenuContainerSize;
   }) => {
   return (
     <Popover
@@ -282,7 +286,7 @@ export const MenuContainer = ({
           display: flex;
           flex-direction: column;
           height: 100%;
-          min-width: 300px;
+          min-width: var(--global-menu-width-xs);
         `}
       >
         {children}

--- a/app/src/components/dataset/DatasetLabelConfigButton.tsx
+++ b/app/src/components/dataset/DatasetLabelConfigButton.tsx
@@ -21,12 +21,11 @@ import {
   LinkButton,
   Loading,
   Menu,
+  MenuContainer,
   MenuFooter,
   MenuHeader,
   MenuHeaderTitle,
   MenuItem,
-  Popover,
-  PopoverArrow,
   SearchField,
   type Selection,
   useFilter,
@@ -62,17 +61,19 @@ export function DatasetLabelConfigButton(props: DatasetLabelConfigButtonProps) {
       >
         Label
       </Button>
-      <Popover
+      <MenuContainer
+        size="sm"
+        minHeight={0}
         placement="bottom start"
+        shouldFlip
         shouldCloseOnInteractOutside={() => true}
       >
-        <PopoverArrow />
         <Dialog>
           <Suspense fallback={<Loading />}>
             <DatasetLabelSelectionContent datasetId={datasetId} />
           </Suspense>
         </Dialog>
-      </Popover>
+      </MenuContainer>
     </DialogTrigger>
   );
 }

--- a/app/src/components/dataset/DatasetLabelFilterButton.tsx
+++ b/app/src/components/dataset/DatasetLabelFilterButton.tsx
@@ -11,11 +11,11 @@ import {
   Input,
   Loading,
   Menu,
+  MenuContainer,
   MenuFooter,
   MenuHeader,
   MenuItem,
   MenuTrigger,
-  Popover,
   SearchField,
   type Selection,
   useFilter,
@@ -47,14 +47,14 @@ export function DatasetLabelFilterButton(props: DatasetLabelFilterButtonProps) {
       >
         Labels
       </Button>
-      <Popover placement="bottom end">
+      <MenuContainer size="sm" minHeight={0} placement="bottom end" shouldFlip>
         <Suspense fallback={<Loading />}>
           <DatasetLabelFilterContent
             selectedLabelIds={selectedLabelIds}
             onSelectionChange={onSelectionChange}
           />
         </Suspense>
-      </Popover>
+      </MenuContainer>
     </MenuTrigger>
   );
 }

--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -875,7 +875,7 @@ const CodeEditor = ({
             >
               Templates
             </Button>
-            <MenuContainer placement="bottom end" maxWidth={360}>
+            <MenuContainer size="sm" placement="bottom end">
               <Menu
                 onAction={(key) => {
                   const template = CODE_EVALUATOR_TEMPLATES.find(

--- a/app/src/components/experiment/ExperimentActionMenu.tsx
+++ b/app/src/components/experiment/ExperimentActionMenu.tsx
@@ -12,11 +12,11 @@ import {
   Icon,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
   Modal,
   ModalOverlay,
-  Popover,
   Text,
   View,
 } from "@phoenix/components";
@@ -304,7 +304,7 @@ export function ExperimentActionMenu(props: ExperimentActionMenuProps) {
           aria-label="Experiment action menu"
           leadingVisual={<Icon svg={<Icons.MoreHorizontal />} />}
         />
-        <Popover>
+        <MenuContainer size="sm" minHeight={0} shouldFlip>
           <Menu
             disabledKeys={
               projectId ? [] : [ExperimentAction.GO_TO_EXPERIMENT_RUN_TRACES]
@@ -407,7 +407,7 @@ export function ExperimentActionMenu(props: ExperimentActionMenuProps) {
           >
             {menuItems}
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
       <ModalOverlay
         isDismissable

--- a/app/src/components/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/components/experiment/ExperimentCompareDetails.tsx
@@ -22,6 +22,7 @@ import {
   IconButton,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
   MenuTriggerPlaceholder,
@@ -596,7 +597,7 @@ function ExperimentRunOutputsSidebar() {
                   )}
                   <SelectChevronUpDownIcon />
                 </Button>
-                <Popover>
+                <MenuContainer size="sm" minHeight={0} shouldFlip>
                   <Menu
                     items={annotationSummaries}
                     selectionMode="single"
@@ -624,7 +625,7 @@ function ExperimentRunOutputsSidebar() {
                       </MenuItem>
                     )}
                   </Menu>
-                </Popover>
+                </MenuContainer>
               </MenuTrigger>
               {selectedAnnotation && (
                 <IconButton

--- a/app/src/components/trace/SpanAnnotationsEditor.tsx
+++ b/app/src/components/trace/SpanAnnotationsEditor.tsx
@@ -25,10 +25,9 @@ import {
   Icon,
   Icons,
   Loading,
+  MenuContainer,
   Modal,
   ModalOverlay,
-  Popover,
-  PopoverArrow,
   useFilter,
   useNullableTimeRangeContext,
   View,
@@ -245,8 +244,12 @@ function NewAnnotationButton(props: NewAnnotationButtonProps) {
         >
           Annotation
         </Button>
-        <Popover placement="bottom end">
-          <PopoverArrow />
+        <MenuContainer
+          size="md"
+          minHeight={0}
+          placement="bottom end"
+          shouldFlip
+        >
           <Dialog>
             <Suspense fallback={<Loading />}>
               <AnnotationList
@@ -263,7 +266,7 @@ function NewAnnotationButton(props: NewAnnotationButtonProps) {
               />
             </Suspense>
           </Dialog>
-        </Popover>
+        </MenuContainer>
       </DialogTrigger>
       {showEditConfigDialog ? (
         <ModalOverlay

--- a/app/src/pages/dataset/AddDatasetExampleButton.tsx
+++ b/app/src/pages/dataset/AddDatasetExampleButton.tsx
@@ -14,11 +14,11 @@ import {
   Icon,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
   Modal,
   ModalOverlay,
-  Popover,
   Text,
 } from "@phoenix/components";
 import { useNotifySuccess } from "@phoenix/contexts";
@@ -116,7 +116,12 @@ export function AddDatasetExampleButton(props: AddDatasetExampleButtonProps) {
         >
           Examples
         </Button>
-        <Popover placement="bottom end">
+        <MenuContainer
+          size="sm"
+          minHeight={0}
+          placement="bottom end"
+          shouldFlip
+        >
           <Menu
             onAction={(action) => {
               switch (action) {
@@ -142,7 +147,7 @@ export function AddDatasetExampleButton(props: AddDatasetExampleButtonProps) {
               </Flex>
             </MenuItem>
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
       <DialogTrigger isOpen={isFromFileOpen} onOpenChange={setIsFromFileOpen}>
         <ModalOverlay isOpen={isFromFileOpen} onOpenChange={setIsFromFileOpen}>

--- a/app/src/pages/dataset/DatasetDownloadMenu.tsx
+++ b/app/src/pages/dataset/DatasetDownloadMenu.tsx
@@ -3,9 +3,9 @@ import {
   Icon,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
-  Popover,
 } from "@phoenix/components";
 import { prependBasename } from "@phoenix/utils/routingUtils";
 
@@ -13,7 +13,7 @@ export function DatasetDownloadMenu({ datasetId }: { datasetId: string }) {
   return (
     <MenuTrigger>
       <Button size="M" leadingVisual={<Icon svg={<Icons.Download />} />} />
-      <Popover>
+      <MenuContainer size="xs" minHeight={0} shouldFlip>
         <Menu
           aria-label="Dataset download"
           onAction={(action) => {
@@ -52,7 +52,7 @@ export function DatasetDownloadMenu({ datasetId }: { datasetId: string }) {
           <MenuItem id="openai-ft">Download OpenAI Fine-Tuning JSONL</MenuItem>
           <MenuItem id="openai-evals">Download OpenAI Evals JSONL</MenuItem>
         </Menu>
-      </Popover>
+      </MenuContainer>
     </MenuTrigger>
   );
 }

--- a/app/src/pages/dataset/RunDatasetExperimentButton.tsx
+++ b/app/src/pages/dataset/RunDatasetExperimentButton.tsx
@@ -9,9 +9,9 @@ import {
   Icon,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
-  Popover,
   Text,
 } from "@phoenix/components";
 import { ExperimentCodeModal } from "@phoenix/components/experiment";
@@ -54,7 +54,12 @@ export function RunDatasetExperimentButton(
         >
           Experiment
         </Button>
-        <Popover placement="bottom end">
+        <MenuContainer
+          size="sm"
+          minHeight={0}
+          placement="bottom end"
+          shouldFlip
+        >
           <Menu
             disabledKeys={
               hasExamples ? [] : [ExperimentAction.RUN_IN_PLAYGROUND]
@@ -89,7 +94,7 @@ export function RunDatasetExperimentButton(
               </Flex>
             </MenuItem>
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
       <DialogTrigger
         isOpen={isCodeDialogOpen}

--- a/app/src/pages/dataset/evaluators/DatasetEvaluatorActionMenu.tsx
+++ b/app/src/pages/dataset/evaluators/DatasetEvaluatorActionMenu.tsx
@@ -6,9 +6,9 @@ import {
   Icon,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
-  Popover,
   Text,
 } from "@phoenix/components";
 import { EditBuiltInDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditBuiltInDatasetEvaluatorSlideover";
@@ -47,7 +47,12 @@ export function DatasetEvaluatorActionMenu({
           aria-label="Evaluator actions"
           leadingVisual={<Icon svg={<Icons.MoreHorizontal />} />}
         />
-        <Popover placement="bottom right">
+        <MenuContainer
+          size="xs"
+          minHeight={0}
+          placement="bottom right"
+          shouldFlip
+        >
           <Menu
             onAction={(action) => {
               switch (action) {
@@ -83,7 +88,7 @@ export function DatasetEvaluatorActionMenu({
               </Flex>
             </MenuItem>
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
       {evaluatorKind === "BUILTIN" ? (
         <EditBuiltInDatasetEvaluatorSlideover

--- a/app/src/pages/datasets/DatasetActionMenu.tsx
+++ b/app/src/pages/datasets/DatasetActionMenu.tsx
@@ -9,10 +9,9 @@ import {
   Icons,
   Loading,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
-  Popover,
-  PopoverArrow,
   Text,
 } from "@phoenix/components";
 import { DatasetLabelSelectionContent } from "@phoenix/components/dataset/DatasetLabelConfigButton";
@@ -55,7 +54,7 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
           aria-label="Dataset actions"
           leadingVisual={<Icon svg={<Icons.MoreHorizontal />} />}
         />
-        <Popover>
+        <MenuContainer size="xs" minHeight={0} shouldFlip>
           <Menu
             onAction={(action) => {
               switch (action) {
@@ -91,19 +90,17 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
                   <Text>Label</Text>
                 </Flex>
               </MenuItem>
-              <Popover
+              <MenuContainer
+                size="sm"
+                minHeight={0}
                 placement="start top"
-                css={css`
-                  min-width: 300px;
-                  width: 300px;
-                `}
+                shouldFlip
               >
-                <PopoverArrow />
                 <Suspense
                   fallback={
                     <Loading
                       css={css`
-                        min-width: 300px;
+                        min-width: var(--global-menu-width-xs);
                         min-height: 100px;
                       `}
                     />
@@ -111,7 +108,7 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
                 >
                   <DatasetLabelSelectionContent datasetId={datasetId} />
                 </Suspense>
-              </Popover>
+              </MenuContainer>
             </SubmenuTrigger>
             <MenuItem id={DatasetAction.DELETE}>
               <Flex
@@ -125,7 +122,7 @@ export function DatasetActionMenu(props: DatasetActionMenuProps) {
               </Flex>
             </MenuItem>
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
 
       {/* Delete Dataset Dialog */}

--- a/app/src/pages/experiments/DownloadExperimentActionMenu.tsx
+++ b/app/src/pages/experiments/DownloadExperimentActionMenu.tsx
@@ -3,9 +3,9 @@ import {
   Icon,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
-  Popover,
 } from "@phoenix/components";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
 import { prependBasename } from "@phoenix/utils/routingUtils";
@@ -20,7 +20,7 @@ export function DownloadExperimentActionMenu({
     <StopPropagation>
       <MenuTrigger>
         <Button size="S" leadingVisual={<Icon svg={<Icons.Download />} />} />
-        <Popover>
+        <MenuContainer size="xs" minHeight={0} shouldFlip>
           <Menu
             onAction={(action) => {
               if (action === "csv") {
@@ -40,7 +40,7 @@ export function DownloadExperimentActionMenu({
             <MenuItem id="csv">Download CSV</MenuItem>
             <MenuItem id="json">Download JSON</MenuItem>
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
     </StopPropagation>
   );

--- a/app/src/pages/project/DatasetSelectorPopoverContent.tsx
+++ b/app/src/pages/project/DatasetSelectorPopoverContent.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import { startTransition, useMemo } from "react";
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
 
@@ -20,6 +21,10 @@ import { SearchIcon } from "@phoenix/components/core/field";
 import type { DatasetSelectorPopoverContent_datasets$key } from "./__generated__/DatasetSelectorPopoverContent_datasets.graphql";
 import type { DatasetSelectorPopoverContentDatasetsQuery } from "./__generated__/DatasetSelectorPopoverContentDatasetsQuery.graphql";
 import type { DatasetSelectorPopoverContentQuery } from "./__generated__/DatasetSelectorPopoverContentQuery.graphql";
+
+const datasetMenuCSS = css`
+  max-height: var(--global-menu-max-height-small);
+`;
 
 export type DatasetSelectorPopoverContentProps = {
   onCreateNewDataset: () => void;
@@ -109,6 +114,7 @@ function DatasetsList(props: {
         </SearchField>
       </MenuHeader>
       <Menu
+        css={datasetMenuCSS}
         aria-label="datasets"
         items={items}
         selectionMode="single"

--- a/app/src/pages/project/SpanSelectionToolbar.tsx
+++ b/app/src/pages/project/SpanSelectionToolbar.tsx
@@ -12,10 +12,9 @@ import {
   Icon,
   IconButton,
   Icons,
+  MenuContainer,
   Modal,
   ModalOverlay,
-  Popover,
-  PopoverArrow,
   Text,
   Toolbar,
   View,
@@ -191,9 +190,13 @@ export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
             >
               {isAddingSpansToDataset ? "Adding..." : "Add to Dataset"}
             </Button>
-            <Popover placement="top end">
+            <MenuContainer
+              size="md"
+              minHeight={0}
+              placement="top end"
+              shouldFlip
+            >
               <Suspense>
-                <PopoverArrow />
                 <Dialog>
                   <DatasetSelectorPopoverContent
                     onDatasetSelected={(datasetId) => {
@@ -207,7 +210,7 @@ export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
                   />
                 </Dialog>
               </Suspense>
-            </Popover>
+            </MenuContainer>
           </DialogTrigger>
           <TransferTracesButton
             traceIds={traceIds}

--- a/app/src/pages/project/TransferTracesButton.tsx
+++ b/app/src/pages/project/TransferTracesButton.tsx
@@ -16,11 +16,10 @@ import {
   Input,
   Loading,
   Menu,
+  MenuContainer,
   MenuHeader,
   MenuHeaderTitle,
   MenuItem,
-  Popover,
-  PopoverArrow,
   SearchField,
   useFilter,
 } from "@phoenix/components";
@@ -83,8 +82,7 @@ export function TransferTracesButton({
       >
         {isTransferring ? "Transferring" : "Transfer"}
       </Button>
-      <Popover>
-        <PopoverArrow />
+      <MenuContainer size="md" minHeight={0} placement="top end" shouldFlip>
         <Dialog>
           {({ close }) => (
             <Suspense fallback={<Loading />}>
@@ -98,7 +96,7 @@ export function TransferTracesButton({
             </Suspense>
           )}
         </Dialog>
-      </Popover>
+      </MenuContainer>
     </DialogTrigger>
   );
 }

--- a/app/src/pages/projects/ProjectActionMenu.tsx
+++ b/app/src/pages/projects/ProjectActionMenu.tsx
@@ -8,11 +8,11 @@ import {
   Icon,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
   Modal,
   ModalOverlay,
-  Popover,
   Text,
   View,
 } from "@phoenix/components";
@@ -119,7 +119,12 @@ export function ProjectActionMenu({
           size="S"
           leadingVisual={<Icon svg={<Icons.MoreHorizontal />} />}
         />
-        <Popover placement="bottom end">
+        <MenuContainer
+          size="sm"
+          minHeight={0}
+          placement="bottom end"
+          shouldFlip
+        >
           <Menu
             aria-label="Project Actions Menu"
             onAction={(action) => {
@@ -191,7 +196,7 @@ export function ProjectActionMenu({
               </MenuItem>
             ) : null}
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
       <ModalOverlay
         isOpen={showDeleteDialog}

--- a/app/src/pages/prompt/PromptLabelConfigButton.tsx
+++ b/app/src/pages/prompt/PromptLabelConfigButton.tsx
@@ -19,12 +19,11 @@ import {
   LinkButton,
   Loading,
   Menu,
+  MenuContainer,
   MenuFooter,
   MenuHeader,
   MenuHeaderTitle,
   MenuItem,
-  Popover,
-  PopoverArrow,
   SearchField,
   type Selection,
   useFilter,
@@ -55,17 +54,19 @@ export function PromptLabelConfigButton(props: PromptLabelConfigButtonProps) {
         leadingVisual={<Icon svg={<Icons.Settings />} />}
         aria-label="Edit prompt labels"
       />
-      <Popover
+      <MenuContainer
+        size="sm"
+        minHeight={0}
         placement="bottom start"
+        shouldFlip
         shouldCloseOnInteractOutside={() => true}
       >
-        <PopoverArrow />
         <Dialog>
           <Suspense fallback={<Loading />}>
             <PromptLabelSelectionContent promptId={promptId} />
           </Suspense>
         </Dialog>
-      </Popover>
+      </MenuContainer>
     </DialogTrigger>
   );
 }

--- a/app/src/pages/prompts/PromptActionMenu.tsx
+++ b/app/src/pages/prompts/PromptActionMenu.tsx
@@ -10,11 +10,10 @@ import {
   Icons,
   Loading,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
   Modal,
-  Popover,
-  PopoverArrow,
   Text,
 } from "@phoenix/components";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
@@ -48,7 +47,7 @@ export function PromptActionMenu({
           aria-label="Prompt actions"
           leadingVisual={<Icon svg={<Icons.MoreHorizontal />} />}
         />
-        <Popover>
+        <MenuContainer size="xs" minHeight={0} shouldFlip>
           <Menu
             aria-label="Prompt action menu"
             onAction={(action) => {
@@ -71,19 +70,17 @@ export function PromptActionMenu({
                   <Text>Label</Text>
                 </Flex>
               </MenuItem>
-              <Popover
+              <MenuContainer
+                size="sm"
+                minHeight={0}
                 placement="start top"
-                css={css`
-                  min-width: 300px;
-                  width: 300px;
-                `}
+                shouldFlip
               >
-                <PopoverArrow />
                 <Suspense
                   fallback={
                     <Loading
                       css={css`
-                        min-width: 300px;
+                        min-width: var(--global-menu-width-xs);
                         min-height: 100px;
                       `}
                     />
@@ -91,7 +88,7 @@ export function PromptActionMenu({
                 >
                   <PromptLabelSelectionContent promptId={promptId} />
                 </Suspense>
-              </Popover>
+              </MenuContainer>
             </SubmenuTrigger>
             <MenuItem id={PromptAction.DELETE}>
               <Flex
@@ -105,7 +102,7 @@ export function PromptActionMenu({
               </Flex>
             </MenuItem>
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
       <DialogTrigger
         isOpen={showDeleteDialog}

--- a/app/src/pages/prompts/PromptsLabelMenu.tsx
+++ b/app/src/pages/prompts/PromptsLabelMenu.tsx
@@ -12,11 +12,11 @@ import {
   Input,
   Loading,
   Menu,
+  MenuContainer,
   MenuFooter,
   MenuHeader,
   MenuItem,
   MenuTrigger,
-  Popover,
   SearchField,
   type Selection,
   useFilter,
@@ -53,12 +53,12 @@ export const PromptsLabelMenu = ({
       >
         Labels
       </Button>
-      <Popover placement="bottom end">
+      <MenuContainer size="sm" minHeight={0} placement="bottom end" shouldFlip>
         <Suspense
           fallback={
             <Loading
               css={css`
-                min-width: 300px;
+                min-width: var(--global-menu-width-xs);
                 min-height: 200px;
               `}
             />
@@ -69,7 +69,7 @@ export const PromptsLabelMenu = ({
             onSelectionChange={onSelectionChange}
           />
         </Suspense>
-      </Popover>
+      </MenuContainer>
     </MenuTrigger>
   );
 };

--- a/app/src/pages/settings/RetentionPolicyActionMenu.tsx
+++ b/app/src/pages/settings/RetentionPolicyActionMenu.tsx
@@ -15,11 +15,11 @@ import {
   Icons,
   Loading,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
   Modal,
   ModalOverlay,
-  Popover,
   Text,
   View,
 } from "@phoenix/components";
@@ -82,7 +82,7 @@ export const RetentionPolicyActionMenu = ({
           size="S"
           leadingVisual={<Icon svg={<Icons.MoreHorizontal />} />}
         />
-        <Popover>
+        <MenuContainer size="xs" minHeight={0} shouldFlip>
           <Menu
             disabledKeys={canDelete ? [] : [RetentionPolicyAction.DELETE]}
             onAction={(action) => {
@@ -122,7 +122,7 @@ export const RetentionPolicyActionMenu = ({
               </Flex>
             </MenuItem>
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
       {/* Edit Dialog */}
       <DialogTrigger isOpen={showEditDialog} onOpenChange={setShowEditDialog}>

--- a/app/src/pages/settings/UserActionMenu.tsx
+++ b/app/src/pages/settings/UserActionMenu.tsx
@@ -8,11 +8,11 @@ import {
   Icon,
   Icons,
   Menu,
+  MenuContainer,
   MenuItem,
   MenuTrigger,
   Modal,
   ModalOverlay,
-  Popover,
 } from "@phoenix/components";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
 
@@ -83,7 +83,7 @@ export function UserActionMenu(props: UserActionMenuProps) {
           size="S"
           leadingVisual={<Icon svg={<Icons.MoreHorizontal />} />}
         />
-        <Popover>
+        <MenuContainer size="xs" minHeight={0} shouldFlip>
           <Menu
             aria-label="User Actions"
             onAction={(action) => {
@@ -99,7 +99,7 @@ export function UserActionMenu(props: UserActionMenuProps) {
           >
             {actionMenuItems}
           </Menu>
-        </Popover>
+        </MenuContainer>
       </MenuTrigger>
       <DialogTrigger
         isOpen={showDeleteDialog}

--- a/app/stories/Menu.stories.tsx
+++ b/app/stories/Menu.stories.tsx
@@ -278,6 +278,72 @@ const FILTER_OPTIONS = [
   { id: "23", name: "Category W", color: "#6B7280" },
 ];
 
+type MenuMaxHeightToken =
+  | "--global-menu-max-height-small"
+  | "--global-menu-max-height-large";
+
+function MenuMaxHeightTokenStory({
+  label,
+  token,
+}: {
+  label: string;
+  token: MenuMaxHeightToken;
+}) {
+  return (
+    <MenuTrigger defaultOpen>
+      <Button>{label}</Button>
+      <MenuContainer
+        placement="bottom start"
+        minHeight={0}
+        maxHeight={`var(${token})`}
+      >
+        <MenuHeader>
+          <MenuHeaderTitle>{token}</MenuHeaderTitle>
+        </MenuHeader>
+        <Menu aria-label={label} items={FILTER_OPTIONS}>
+          {({ id, name }) => <MenuItem id={id}>{name}</MenuItem>}
+        </Menu>
+      </MenuContainer>
+    </MenuTrigger>
+  );
+}
+
+export const SmallMaxHeightToken = {
+  render: () => (
+    <MenuMaxHeightTokenStory
+      label="Small max-height menu"
+      token="--global-menu-max-height-small"
+    />
+  ),
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        story:
+          "The small semantic menu cutoff resolves to 480px and keeps longer menus scrollable.",
+      },
+    },
+  },
+};
+
+export const LargeMaxHeightToken = {
+  render: () => (
+    <MenuMaxHeightTokenStory
+      label="Large max-height menu"
+      token="--global-menu-max-height-large"
+    />
+  ),
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        story:
+          "The large semantic menu cutoff resolves to 640px and is the default maximum height for MenuContainer.",
+      },
+    },
+  },
+};
+
 export const FilterMenu = () => {
   const { contains } = useFilter({ sensitivity: "base" });
   const [selectedIds, setSelectedIds] = useState<string[]>([]);


### PR DESCRIPTION
👾 AUTOMATED REPORT:

resolves #14285

## Summary

- add semantic menu height tokens and token-backed `MenuContainer` widths: `xs` (200px), `sm` (320px), and `md` (420px)
- constrain the dataset picker height and migrate searchable, action, label, and annotation menus from raw popovers to intentionally sized `MenuContainer` instances
- preserve compact empty states, long-label wrapping, nested submenu bounds, and viewport-aware placement

## Testing

- Real app: verified Add to Dataset, Transfer, dataset/prompt label filters and editors, annotation config picker, Account menu, dataset action menu, and nested label submenu with synthetic local data
- Demonstration: matched app screenshots in light and dark themes, plus a 390x844 narrow-viewport Add to Dataset capture
- Adversarial QA: long content, populated → filtered-empty → restored transitions, clear/reopen repetition, Escape focus return, nested submenu geometry, and near-viewport-edge flipping
- Manual verification: artifact-backed geometry assertions confirmed the `md` menu is bounded at 420px, `sm` menus remain within 320px, `xs` action menus remain within 200px, and no captured state clips or overflows
- Checks: `make format-frontend`, `make typecheck-frontend`, `make lint-frontend`, `make test-frontend` (1,864 passed, 12 skipped)

## Usability evidence

### Add to Dataset — populated long content

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, populated Add to Dataset in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-bdeeaf2eef04-add-to-dataset-populated__dark.png) | ![After, populated Add to Dataset in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-738e6073ecd5-add-to-dataset-populated__dark.png) |
| Light | ![Before, populated Add to Dataset in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-25116396040d-add-to-dataset-populated__light.png) | ![After, populated Add to Dataset in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-0930f3848127-add-to-dataset-populated__light.png) |

### Add to Dataset — filtered empty

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, filtered-empty Add to Dataset in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-ae3e31c01045-add-to-dataset-filtered-empty__dark.png) | ![After, filtered-empty Add to Dataset in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-e5b7fcca9a1e-add-to-dataset-filtered-empty__dark.png) |
| Light | ![Before, filtered-empty Add to Dataset in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-6bd0a4246962-add-to-dataset-filtered-empty__light.png) | ![After, filtered-empty Add to Dataset in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-33f8a663dae1-add-to-dataset-filtered-empty__light.png) |

### Add to Dataset — 390×844 viewport

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, narrow Add to Dataset in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-3dfc838a56c6-add-to-dataset-narrow__dark.png) | ![After, narrow Add to Dataset in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-574ced193fff-add-to-dataset-narrow__dark.png) |
| Light | ![Before, narrow Add to Dataset in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-caf25946eb34-add-to-dataset-narrow__light.png) | ![After, narrow Add to Dataset in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-48eecb1e6400-add-to-dataset-narrow__light.png) |

<details>
<summary>Additional migrated menu surfaces</summary>

#### Transfer to Project

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, Transfer menu in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-d6a1d6a0ee2b-transfer-populated__dark.png) | ![After, Transfer menu in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-2936a568d343-transfer-populated__dark.png) |
| Light | ![Before, Transfer menu in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-cd274dd598a8-transfer-populated__light.png) | ![After, Transfer menu in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-57e0a3d6ed67-transfer-populated__light.png) |

#### Dataset label filter

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, dataset label filter in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-7734db23c002-dataset-label-filter-populated__dark.png) | ![After, dataset label filter in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-9711d4362663-dataset-label-filter-populated__dark.png) |
| Light | ![Before, dataset label filter in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-c13cbcb83f79-dataset-label-filter-populated__light.png) | ![After, dataset label filter in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-18189f3546ca-dataset-label-filter-populated__light.png) |

#### Dataset label editor

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, dataset label editor in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-dca06e4facf1-dataset-label-editor__dark.png) | ![After, dataset label editor in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-ce5f0ab15ea8-dataset-label-editor__dark.png) |
| Light | ![Before, dataset label editor in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-fa65cb7a88d6-dataset-label-editor__light.png) | ![After, dataset label editor in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-37358f7a284c-dataset-label-editor__light.png) |

#### Prompt label filter

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, prompt label filter in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-57c4a9740238-prompt-label-filter__dark.png) | ![After, prompt label filter in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-2da7b9d0da20-prompt-label-filter__dark.png) |
| Light | ![Before, prompt label filter in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-2ff3acee2424-prompt-label-filter__light.png) | ![After, prompt label filter in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-5f10e51a7ede-prompt-label-filter__light.png) |

#### Prompt label editor

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, prompt label editor in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-8a4ecf6675b2-prompt-label-editor__dark.png) | ![After, prompt label editor in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-624f306ff632-prompt-label-editor__dark.png) |
| Light | ![Before, prompt label editor in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-87d31142a040-prompt-label-editor__light.png) | ![After, prompt label editor in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-2e7641f59fd5-prompt-label-editor__light.png) |

#### Annotation config picker

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, annotation config picker in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-fc02004520d9-annotation-config-picker__dark.png) | ![After, annotation config picker in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-b36ac7104962-annotation-config-picker__dark.png) |
| Light | ![Before, annotation config picker in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-9f309f30afdd-annotation-config-picker__light.png) | ![After, annotation config picker in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-3d2eec41ccda-annotation-config-picker__light.png) |

#### Dataset action menu

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, dataset action menu in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-2430c745be6d-dataset-action-menu__dark.png) | ![After, dataset action menu in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-0b622227878f-dataset-action-menu__dark.png) |
| Light | ![Before, dataset action menu in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-3ccebe3c3fd0-dataset-action-menu__light.png) | ![After, dataset action menu in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-20b461a651fc-dataset-action-menu__light.png) |

#### Existing Account MenuContainer consumer

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, Account menu in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-570d0c48db0e-account-menu__dark.png) | ![After, Account menu in dark theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-ab4d54008001-account-menu__dark.png) |
| Light | ![Before, Account menu in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-201aa21735ba-account-menu__light.png) | ![After, Account menu in light theme](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-2a0c31d7de57-account-menu__light.png) |

#### Additional after-state probes

- [Restored after filter/clear/reopen](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-2dc589221d95-add-to-dataset-restored__dark.png)
- [Bounded nested dataset-label submenu](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14288-6efbb214c575-816480041764-dataset-action-label-submenu__light.png)

</details>
