### PR TITLE
feat(auth): refresh OAuth credentials across Phoenix clients

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -63,6 +63,8 @@ export PHOENIX_API_KEY=your-api-key  # if auth is enabled
 ```
 
 For interactive local use, `px auth login` stores an OAuth session in the selected profile; the session acts with the permissions of the user who logged in. API keys take precedence over OAuth tokens when both are configured.
+OAuth access tokens are refreshed automatically for REST, GraphQL, and PXI
+requests, and rotated tokens are persisted to the selected profile.
 
 Always use `--format raw --no-progress` when piping to `jq`.
 

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
@@ -90,6 +90,42 @@ const client = createClient({
 
 Use explicit options when you want configuration to live in code or when you need to override the environment for a specific client instance.
 
+### Refreshable Credentials
+
+When an access token can expire, use `createAuthenticatedFetch` to connect your
+credential provider to every Phoenix client API call. The provider owns secure
+token storage and refresh-token rotation; the fetch wrapper supplies the bearer
+token, shares refresh work across concurrent `401` responses, and retries each
+request once.
+
+```ts
+import {
+  createAuthenticatedFetch,
+  createClient,
+} from "@arizeai/phoenix-client";
+
+const authenticatedFetch = createAuthenticatedFetch({
+  getAccessToken: async ({ forceRefresh }) => {
+    if (forceRefresh) {
+      await refreshAndPersistTokens();
+    }
+    return loadTokens().accessToken;
+  },
+});
+
+const client = createClient({
+  options: {
+    baseUrl: "https://phoenix.example.com",
+    fetch: authenticatedFetch,
+  },
+});
+```
+
+The provider is called with `forceRefresh: false` before requests and with
+`forceRefresh: true` only when the token used by a request is rejected. If
+another request has already replaced that token, the newer token is reused
+without rotating the refresh token again.
+
 ### createClient Parameters
 
 | Field | Type | Description |
@@ -167,6 +203,7 @@ Prefer this layer when:
   <h2>Source Map</h2>
   <ul>
     <li><code>src/client.ts</code></li>
+    <li><code>src/authFetch.ts</code></li>
     <li><code>src/config.ts</code></li>
     <li><code>src/__generated__/api/v1.ts</code></li>
     <li><code>src/types/core.ts</code></li>

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
@@ -92,7 +92,7 @@ Use explicit options when you want configuration to live in code or when you nee
 
 ### Refreshable Credentials
 
-When an access token can expire, use `createAuthenticatedFetch` to connect your
+When an access token can expire, use `createAuthFetch` to connect your
 credential provider to every Phoenix client API call. The provider owns secure
 token storage and refresh-token rotation; the fetch wrapper supplies the bearer
 token, shares refresh work across concurrent `401` responses, and retries each
@@ -100,11 +100,11 @@ request once.
 
 ```ts
 import {
-  createAuthenticatedFetch,
+  createAuthFetch,
   createClient,
 } from "@arizeai/phoenix-client";
 
-const authenticatedFetch = createAuthenticatedFetch({
+const authFetch = createAuthFetch({
   getAccessToken: async ({ forceRefresh }) => {
     if (forceRefresh) {
       await refreshAndPersistTokens();
@@ -116,7 +116,7 @@ const authenticatedFetch = createAuthenticatedFetch({
 const client = createClient({
   options: {
     baseUrl: "https://phoenix.example.com",
-    fetch: authenticatedFetch,
+    fetch: authFetch,
   },
 });
 ```

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
@@ -90,42 +90,6 @@ const client = createClient({
 
 Use explicit options when you want configuration to live in code or when you need to override the environment for a specific client instance.
 
-### Refreshable Credentials
-
-When an access token can expire, use `createAuthFetch` to connect your
-credential provider to every Phoenix client API call. The provider owns secure
-token storage and refresh-token rotation; the fetch wrapper supplies the bearer
-token, shares refresh work across concurrent `401` responses, and retries each
-request once.
-
-```ts
-import {
-  createAuthFetch,
-  createClient,
-} from "@arizeai/phoenix-client";
-
-const authFetch = createAuthFetch({
-  getAccessToken: async ({ forceRefresh }) => {
-    if (forceRefresh) {
-      await refreshAndPersistTokens();
-    }
-    return loadTokens().accessToken;
-  },
-});
-
-const client = createClient({
-  options: {
-    baseUrl: "https://phoenix.example.com",
-    fetch: authFetch,
-  },
-});
-```
-
-The provider is called with `forceRefresh: false` before requests and with
-`forceRefresh: true` only when the token used by a request is rejected. If
-another request has already replaced that token, the newer token is reused
-without rotating the refresh token again.
-
 ### createClient Parameters
 
 | Field | Type | Description |

--- a/js/.changeset/fresh-horses-refresh.md
+++ b/js/.changeset/fresh-horses-refresh.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/phoenix-client": minor
+"@arizeai/phoenix-cli": patch
+---
+
+Add a reusable refreshable-credential fetch hook to the Phoenix TypeScript
+client, and use it for OAuth-authenticated CLI API and PXI requests.

--- a/js/.changeset/fresh-horses-refresh.md
+++ b/js/.changeset/fresh-horses-refresh.md
@@ -3,5 +3,5 @@
 "@arizeai/phoenix-cli": patch
 ---
 
-Add a reusable refreshable-credential fetch hook to the Phoenix TypeScript
+Add a reusable refreshable-credential fetch wrapper to the Phoenix TypeScript
 client, and use it for OAuth-authenticated CLI API and PXI requests.

--- a/js/.changeset/fresh-horses-refresh.md
+++ b/js/.changeset/fresh-horses-refresh.md
@@ -4,4 +4,5 @@
 ---
 
 Add a reusable refreshable-credential fetch wrapper to the Phoenix TypeScript
-client, and use it for OAuth-authenticated CLI API and PXI requests.
+client, use it for OAuth-authenticated CLI API and PXI requests, and keep each
+profile bound to the endpoint that issued its OAuth tokens.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -665,6 +665,10 @@ px annotation-config get response-quality --format raw --no-progress | jq -r '.i
 
 Log in with the browser-based OAuth flow and store tokens on the selected profile. The URL is always printed to stderr, so SSH and headless users can open it manually. OAuth CLI sessions act with the permissions of the user who logged in.
 
+The CLI refreshes expiring access tokens automatically for REST, GraphQL, and
+PXI requests. A request rejected with `401` triggers one refresh and retry;
+rotated tokens are persisted back to the selected profile.
+
 ```bash
 px auth login
 px auth login --no-browser

--- a/js/packages/phoenix-cli/src/authFetch.ts
+++ b/js/packages/phoenix-cli/src/authFetch.ts
@@ -1,0 +1,65 @@
+import { createAuthFetch } from "@arizeai/phoenix-client";
+
+import type { PhoenixConfig } from "./config";
+import { AuthRequiredError } from "./exitCodes";
+import { isOAuthTokenExpiring, refreshOAuthTokensForProfile } from "./oauth";
+import type { OAuthTokens } from "./settings";
+
+type OAuthConfig = PhoenixConfig & {
+  endpoint: string;
+  oauthTokens: OAuthTokens;
+  profileName: string;
+};
+
+export function hasOAuthCredentials(
+  config: PhoenixConfig
+): config is OAuthConfig {
+  return Boolean(config.endpoint && config.oauthTokens && config.profileName);
+}
+
+/**
+ * Create a fetch implementation backed by the OAuth session in a CLI profile.
+ * Refreshed tokens are persisted by the profile token provider.
+ *
+ * @param options - OAuth fetch configuration.
+ * @param options.config - Resolved CLI config containing an OAuth session.
+ * @param options.fetch - Fetch implementation used to send requests.
+ * @param options.settingsPath - Optional settings path override for tests.
+ */
+export function createOAuthFetch({
+  config,
+  fetch: fetchImpl = fetch,
+  settingsPath,
+}: {
+  config: OAuthConfig;
+  fetch?: typeof fetch;
+  settingsPath?: string;
+}): typeof fetch {
+  let tokens = config.oauthTokens;
+  const authFetch = createAuthFetch({
+    fetch: fetchImpl,
+    getAccessToken: async ({ forceRefresh }) => {
+      if (forceRefresh || isOAuthTokenExpiring({ tokens })) {
+        tokens = await refreshOAuthTokensForProfile({
+          endpoint: config.endpoint,
+          profileName: config.profileName,
+          currentTokens: tokens,
+          force: forceRefresh,
+          fetchImpl,
+          settingsPath,
+        });
+      }
+      return tokens.accessToken;
+    },
+    onUnauthorized: () => {
+      throw new AuthRequiredError("Session expired. Run: px auth login");
+    },
+  });
+
+  return function oauthFetch(input: RequestInfo | URL, init?: RequestInit) {
+    const request = new Request(input, init);
+    const headers = new Headers(config.headers);
+    request.headers.forEach((value, key) => headers.set(key, value));
+    return authFetch(new Request(request, { headers }));
+  };
+}

--- a/js/packages/phoenix-cli/src/client.ts
+++ b/js/packages/phoenix-cli/src/client.ts
@@ -1,13 +1,7 @@
-import {
-  createAuthenticatedFetch,
-  createClient,
-  type PhoenixClient,
-} from "@arizeai/phoenix-client";
+import { createClient, type PhoenixClient } from "@arizeai/phoenix-client";
 
+import { createOAuthFetch, hasOAuthCredentials } from "./authFetch";
 import type { PhoenixConfig } from "./config";
-import { AuthRequiredError } from "./exitCodes";
-import { isOAuthTokenExpiring, refreshOAuthTokensForProfile } from "./oauth";
-import type { OAuthTokens } from "./settings";
 
 export interface CreatePhoenixClientOptions {
   /**
@@ -42,62 +36,11 @@ export function createPhoenixClient({
     options: {
       baseUrl,
       headers,
-      ...(config.oauthTokens && config.profileName
-        ? {
-            fetch: createPhoenixAuthenticatedFetch({
-              endpoint: baseUrl,
-              headers,
-              profileName: config.profileName,
-              tokens: config.oauthTokens,
-            }),
-          }
+      ...(hasOAuthCredentials(config)
+        ? { fetch: createOAuthFetch({ config }) }
         : {}),
     },
   });
-}
-
-export function createPhoenixAuthenticatedFetch({
-  endpoint,
-  headers,
-  profileName,
-  tokens,
-  fetchImpl = fetch,
-}: {
-  endpoint: string;
-  headers: Record<string, string>;
-  profileName: string;
-  tokens: OAuthTokens;
-  fetchImpl?: typeof fetch;
-}): typeof fetch {
-  let currentTokens = tokens;
-  const authenticatedFetch = createAuthenticatedFetch({
-    fetch: fetchImpl,
-    getAccessToken: async ({ forceRefresh }) => {
-      if (forceRefresh || isOAuthTokenExpiring({ tokens: currentTokens })) {
-        currentTokens = await refreshOAuthTokensForProfile({
-          endpoint,
-          profileName,
-          currentTokens,
-          force: forceRefresh,
-          fetchImpl,
-        });
-      }
-      return currentTokens.accessToken;
-    },
-    onUnauthorized: () => {
-      throw new AuthRequiredError("Session expired. Run: px auth login");
-    },
-  });
-  return (input: RequestInfo | URL, init?: RequestInit) => {
-    const request = new Request(input, init);
-    const requestHeaders = new Headers(headers);
-    request.headers.forEach((value, key) => {
-      requestHeaders.set(key, value);
-    });
-    return authenticatedFetch(
-      new Request(request, { headers: requestHeaders })
-    );
-  };
 }
 
 export interface ResolveProjectIdOptions {

--- a/js/packages/phoenix-cli/src/client.ts
+++ b/js/packages/phoenix-cli/src/client.ts
@@ -1,4 +1,8 @@
-import { createClient, type PhoenixClient } from "@arizeai/phoenix-client";
+import {
+  createAuthenticatedFetch,
+  createClient,
+  type PhoenixClient,
+} from "@arizeai/phoenix-client";
 
 import type { PhoenixConfig } from "./config";
 import { AuthRequiredError } from "./exitCodes";
@@ -40,7 +44,7 @@ export function createPhoenixClient({
       headers,
       ...(config.oauthTokens && config.profileName
         ? {
-            fetch: createOAuthRefreshingFetch({
+            fetch: createPhoenixAuthenticatedFetch({
               endpoint: baseUrl,
               headers,
               profileName: config.profileName,
@@ -52,7 +56,7 @@ export function createPhoenixClient({
   });
 }
 
-export function createOAuthRefreshingFetch({
+export function createPhoenixAuthenticatedFetch({
   endpoint,
   headers,
   profileName,
@@ -66,59 +70,34 @@ export function createOAuthRefreshingFetch({
   fetchImpl?: typeof fetch;
 }): typeof fetch {
   let currentTokens = tokens;
-
-  return async (input: RequestInfo | URL, init?: RequestInit) => {
-    if (isOAuthTokenExpiring({ tokens: currentTokens })) {
-      currentTokens = await refreshOAuthTokensForProfile({
-        endpoint,
-        profileName,
-        currentTokens,
-        fetchImpl,
-      });
-    }
-
-    const firstResponse = await fetchImpl(
-      withBearerToken({ input, init, headers, tokens: currentTokens })
-    );
-    if (firstResponse.status !== 401) {
-      return firstResponse;
-    }
-
-    currentTokens = await refreshOAuthTokensForProfile({
-      endpoint,
-      profileName,
-      currentTokens,
-      force: true,
-      fetchImpl,
-    });
-    const retryResponse = await fetchImpl(
-      withBearerToken({ input, init, headers, tokens: currentTokens })
-    );
-    if (retryResponse.status === 401) {
+  const authenticatedFetch = createAuthenticatedFetch({
+    fetch: fetchImpl,
+    getAccessToken: async ({ forceRefresh }) => {
+      if (forceRefresh || isOAuthTokenExpiring({ tokens: currentTokens })) {
+        currentTokens = await refreshOAuthTokensForProfile({
+          endpoint,
+          profileName,
+          currentTokens,
+          force: forceRefresh,
+          fetchImpl,
+        });
+      }
+      return currentTokens.accessToken;
+    },
+    onUnauthorized: () => {
       throw new AuthRequiredError("Session expired. Run: px auth login");
-    }
-    return retryResponse;
-  };
-}
-
-function withBearerToken({
-  input,
-  init,
-  headers,
-  tokens,
-}: {
-  input: RequestInfo | URL;
-  init?: RequestInit;
-  headers: Record<string, string>;
-  tokens: OAuthTokens;
-}): Request {
-  const request = new Request(input, init);
-  const requestHeaders = new Headers(headers);
-  request.headers.forEach((value, key) => {
-    requestHeaders.set(key, value);
+    },
   });
-  requestHeaders.set("Authorization", `Bearer ${tokens.accessToken}`);
-  return new Request(request, { headers: requestHeaders });
+  return (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const requestHeaders = new Headers(headers);
+    request.headers.forEach((value, key) => {
+      requestHeaders.set(key, value);
+    });
+    return authenticatedFetch(
+      new Request(request, { headers: requestHeaders })
+    );
+  };
 }
 
 export interface ResolveProjectIdOptions {

--- a/js/packages/phoenix-cli/src/commands/api.ts
+++ b/js/packages/phoenix-cli/src/commands/api.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 
-import { createPhoenixAuthenticatedFetch } from "../client";
+import { createOAuthFetch, hasOAuthCredentials } from "../authFetch";
 import type { PhoenixConfig } from "../config";
 import { getConfigErrorMessage, resolveConfig } from "../config";
 import { renderCurlCommand } from "../curl";
@@ -115,16 +115,10 @@ async function apiGraphqlHandler(
     }
 
     // 4. POST using Node 22 built-in fetch
-    const fetchImpl =
-      config.oauthTokens && config.profileName
-        ? createPhoenixAuthenticatedFetch({
-            endpoint: config.endpoint,
-            headers: config.headers ?? {},
-            profileName: config.profileName,
-            tokens: config.oauthTokens,
-          })
-        : fetch;
-    const response = await fetchImpl(request.url, {
+    const apiFetch = hasOAuthCredentials(config)
+      ? createOAuthFetch({ config })
+      : fetch;
+    const response = await apiFetch(request.url, {
       method: request.method,
       headers: request.headers,
       body: request.body,

--- a/js/packages/phoenix-cli/src/commands/api.ts
+++ b/js/packages/phoenix-cli/src/commands/api.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 
+import { createPhoenixAuthenticatedFetch } from "../client";
 import type { PhoenixConfig } from "../config";
 import { getConfigErrorMessage, resolveConfig } from "../config";
 import { renderCurlCommand } from "../curl";
@@ -114,7 +115,16 @@ async function apiGraphqlHandler(
     }
 
     // 4. POST using Node 22 built-in fetch
-    const response = await fetch(request.url, {
+    const fetchImpl =
+      config.oauthTokens && config.profileName
+        ? createPhoenixAuthenticatedFetch({
+            endpoint: config.endpoint,
+            headers: config.headers ?? {},
+            profileName: config.profileName,
+            tokens: config.oauthTokens,
+          })
+        : fetch;
+    const response = await fetchImpl(request.url, {
       method: request.method,
       headers: request.headers,
       body: request.body,

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -589,7 +589,7 @@ function persistOAuthTokens({
       ...settingsFile.profiles,
       [profileName]: {
         ...existingProfile,
-        endpoint: existingProfile.endpoint ?? endpoint,
+        endpoint,
         oauthTokens,
       },
     },

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -346,13 +346,17 @@ async function authStatusHandler(options: AuthStatusOptions): Promise<void> {
       : getStoredActiveProfile(settingsFile)?.name;
 
   const result = await fetchViewer(config);
+  const oauthTokens = loadCurrentOAuthTokens({
+    config,
+    profileName: activeProfileName,
+  });
   const output = formatAuthStatus(
     config.endpoint,
     result,
     config.apiKey,
     activeProfileName,
     config.credentialSource,
-    config.oauthTokens,
+    oauthTokens,
     options.format
   );
   writeOutput({ message: output });
@@ -361,6 +365,19 @@ async function authStatusHandler(options: AuthStatusOptions): Promise<void> {
   if (code !== ExitCode.SUCCESS) {
     process.exit(code);
   }
+}
+
+function loadCurrentOAuthTokens({
+  config,
+  profileName,
+}: {
+  config: PhoenixConfig;
+  profileName?: string;
+}): OAuthTokens | undefined {
+  if (config.credentialSource !== "oauth" || !profileName) {
+    return config.oauthTokens;
+  }
+  return getProfileByName(loadSettings(), profileName)?.entry.oauthTokens;
 }
 
 async function authLoginHandler(options: AuthLoginOptions): Promise<void> {

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -12,6 +12,7 @@ import {
 import { writeError, writeOutput } from "../io";
 import {
   OAUTH_LOGIN_TIMEOUT_MS,
+  type PastedRedirectPrompt,
   buildAuthorizationUrl,
   exchangeAuthorizationCode,
   generatePkcePair,
@@ -22,6 +23,7 @@ import {
   startLoginCallbackServer,
   tokenResponseToOAuthTokens,
   waitForPastedRedirectUrl,
+  withSettingsLock,
   withTimeout,
 } from "../oauth";
 import {
@@ -29,6 +31,7 @@ import {
   type SettingsFile,
   ProfileResolutionError,
   getProfileByName,
+  getSettingsPath,
   getStoredActiveProfile,
   loadSettings,
   saveSettings,
@@ -397,15 +400,20 @@ async function authLoginHandler(options: AuthLoginOptions): Promise<void> {
       process.exit(ExitCode.INVALID_ARGUMENT);
     }
 
+    const settingsAtLogin = loadSettings({ strict: true });
     const targetProfileName = resolveTargetProfileName(
-      loadSettings({ strict: true }),
+      settingsAtLogin,
       options.profile
+    );
+    const profileHasApiKey = Boolean(
+      settingsAtLogin.profiles[targetProfileName]?.apiKey
     );
     const pkce = generatePkcePair();
     const state = generateState();
     const callbackServer = await startLoginCallbackServer({
       expectedState: state,
     });
+    let pastedRedirectPrompt: PastedRedirectPrompt | undefined;
     try {
       const authorizationUrl = buildAuthorizationUrl({
         endpoint,
@@ -429,14 +437,17 @@ async function authLoginHandler(options: AuthLoginOptions): Promise<void> {
         }
       }
 
-      const pastedRedirectPromise =
+      pastedRedirectPrompt =
         options.input !== false && (!browserOpened || options.browser === false)
           ? waitForPastedRedirectUrl({ expectedState: state })
           : undefined;
       const callbackPromise =
-        pastedRedirectPromise === undefined
+        pastedRedirectPrompt === undefined
           ? callbackServer.resultPromise
-          : Promise.race([callbackServer.resultPromise, pastedRedirectPromise]);
+          : Promise.race([
+              callbackServer.resultPromise,
+              pastedRedirectPrompt.resultPromise,
+            ]);
       const callbackResult = await withTimeout({
         promise: callbackPromise,
         timeoutMs: OAUTH_LOGIN_TIMEOUT_MS,
@@ -460,14 +471,18 @@ async function authLoginHandler(options: AuthLoginOptions): Promise<void> {
       const oauthTokens = tokenResponseToOAuthTokens({
         response: tokenResponse,
       });
-      saveSettings(
-        persistOAuthTokens({
-          settingsFile: loadSettings({ strict: true }),
-          profileName: targetProfileName,
-          endpoint,
-          oauthTokens,
-        })
-      );
+      // Re-read and write under the settings lock so a token rotation running
+      // in another px process cannot be clobbered by this stale snapshot.
+      await withSettingsLock(getSettingsPath(), async () => {
+        saveSettings(
+          persistOAuthTokens({
+            settingsFile: loadSettings({ strict: true }),
+            profileName: targetProfileName,
+            endpoint,
+            oauthTokens,
+          })
+        );
+      });
 
       const user = await verifyViewerOrExit({
         ...config,
@@ -477,6 +492,13 @@ async function authLoginHandler(options: AuthLoginOptions): Promise<void> {
         apiKey: undefined,
         credentialSource: "oauth",
       });
+      if (profileHasApiKey) {
+        writeError({
+          message:
+            `Note: profile "${targetProfileName}" also has an API key, which takes precedence over the OAuth session. ` +
+            "Remove the API key from the profile to use OAuth credentials.",
+        });
+      }
       writeOutput({
         message: formatAuthOutput(
           {
@@ -492,6 +514,9 @@ async function authLoginHandler(options: AuthLoginOptions): Promise<void> {
         ),
       });
     } finally {
+      // Release stdin when the loopback callback won the race — an open
+      // readline interface would keep the process alive after success.
+      pastedRedirectPrompt?.close();
       await callbackServer.close();
     }
   } catch (error) {
@@ -532,9 +557,13 @@ async function authLogoutHandler(options: AuthLogoutOptions): Promise<void> {
   );
   const profile = getProfileByName(settingsFile, targetProfileName);
   const refreshToken = profile?.entry.oauthTokens?.refreshToken;
-  if (refreshToken && config.endpoint) {
+  // Revoke against the endpoint stored on the profile — the server that
+  // issued the tokens — never a --endpoint/PHOENIX_HOST override, which would
+  // leak the refresh token to a host that never issued it.
+  const issuingEndpoint = profile?.entry.endpoint;
+  if (refreshToken && issuingEndpoint) {
     try {
-      await revokeOAuthToken({ endpoint: config.endpoint, refreshToken });
+      await revokeOAuthToken({ endpoint: issuingEndpoint, refreshToken });
     } catch (error) {
       writeError({
         message: `Warning: Could not revoke OAuth token: ${
@@ -545,13 +574,23 @@ async function authLogoutHandler(options: AuthLogoutOptions): Promise<void> {
   }
 
   if (profile) {
-    const { oauthTokens: _oauthTokens, ...entryWithoutOAuth } = profile.entry;
-    saveSettings({
-      ...settingsFile,
-      profiles: {
-        ...settingsFile.profiles,
-        [targetProfileName]: entryWithoutOAuth,
-      },
+    // Re-read and write under the settings lock so a token rotation running
+    // in another px process is not clobbered by the pre-revoke snapshot.
+    await withSettingsLock(getSettingsPath(), async () => {
+      const latestSettings = loadSettings({ strict: true });
+      const latestProfile = getProfileByName(latestSettings, targetProfileName);
+      if (!latestProfile) {
+        return;
+      }
+      const { oauthTokens: _oauthTokens, ...entryWithoutOAuth } =
+        latestProfile.entry;
+      saveSettings({
+        ...latestSettings,
+        profiles: {
+          ...latestSettings.profiles,
+          [targetProfileName]: entryWithoutOAuth,
+        },
+      });
     });
   }
 

--- a/js/packages/phoenix-cli/src/config.ts
+++ b/js/packages/phoenix-cli/src/config.ts
@@ -3,6 +3,7 @@ import {
   ENV_PHOENIX_CLIENT_HEADERS,
   ENV_PHOENIX_HOST,
   getHeadersFromEnvironment,
+  getProjectFromEnvironment,
   getStrFromEnvironment,
 } from "@arizeai/phoenix-config";
 
@@ -95,19 +96,12 @@ export function loadConfigFromEnvironment(): PhoenixConfig {
     config.headers = headers;
   }
 
-  const project = getProjectFromEnvironmentForCli();
+  const project = getProjectFromEnvironment();
   if (project) {
     config.project = project;
   }
 
   return config;
-}
-
-function getProjectFromEnvironmentForCli(): string | undefined {
-  return (
-    getStrFromEnvironment("PHOENIX_PROJECT") ??
-    getStrFromEnvironment("PHOENIX_PROJECT_NAME")
-  );
 }
 
 /**
@@ -205,14 +199,28 @@ export function resolveConfig({
     Object.entries(cliOptions).filter(([, value]) => value !== undefined)
   ) as Partial<PhoenixConfig>;
 
+  // OAuth tokens are only valid against the endpoint that issued them. When
+  // --endpoint or PHOENIX_HOST points the command at a different server, drop
+  // the tokens so they are never sent to — or refreshed against — a host that
+  // did not issue them.
+  const resolvedEndpoint =
+    definedCliOptions.endpoint ??
+    envConfig.endpoint ??
+    profileConfig.endpoint ??
+    builtInDefaults.endpoint;
+  const boundProfileConfig =
+    profileConfig.oauthTokens && profileConfig.endpoint !== resolvedEndpoint
+      ? { ...profileConfig, oauthTokens: undefined }
+      : profileConfig;
+
   const credentialSource = getCredentialSource({
     cliOptions: definedCliOptions,
     envConfig,
-    profileConfig,
+    profileConfig: boundProfileConfig,
   });
 
   const oauthTokens =
-    credentialSource === "oauth" ? profileConfig.oauthTokens : undefined;
+    credentialSource === "oauth" ? boundProfileConfig.oauthTokens : undefined;
 
   return {
     ...builtInDefaults,

--- a/js/packages/phoenix-cli/src/oauth.ts
+++ b/js/packages/phoenix-cli/src/oauth.ts
@@ -192,8 +192,17 @@ export async function startLoginCallbackServer({
   });
 
   const server = http.createServer((request, response) => {
-    const host = request.headers.host ?? "127.0.0.1";
-    const requestUrl = new URL(request.url ?? "/", `http://${host}`);
+    // Parse against a fixed loopback base: the Host header is untrusted input,
+    // and a malformed value would make the URL constructor throw inside the
+    // request handler, crashing the CLI mid-login.
+    let requestUrl: URL;
+    try {
+      requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+    } catch {
+      response.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+      response.end("Bad request");
+      return;
+    }
     if (requestUrl.pathname !== OAUTH_CALLBACK_PATH) {
       response.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
       response.end("Not found");
@@ -232,6 +241,16 @@ export async function startLoginCallbackServer({
   };
 }
 
+export interface PastedRedirectPrompt {
+  resultPromise: Promise<CallbackParseResult>;
+  /**
+   * Release stdin. Must be called when the prompt loses the race to the
+   * loopback callback — an open readline interface keeps the event loop
+   * alive and the process would hang after a successful login.
+   */
+  close: () => void;
+}
+
 export function waitForPastedRedirectUrl({
   expectedState,
   input = process.stdin,
@@ -240,10 +259,10 @@ export function waitForPastedRedirectUrl({
   expectedState: string;
   input?: NodeJS.ReadableStream;
   output?: NodeJS.WritableStream;
-}): Promise<CallbackParseResult> {
+}): PastedRedirectPrompt {
   output.write("Paste the full redirect URL and press Enter: ");
   const reader = readline.createInterface({ input, output });
-  return new Promise((resolve) => {
+  const resultPromise = new Promise<CallbackParseResult>((resolve) => {
     reader.once("line", (line) => {
       reader.close();
       resolve(
@@ -254,6 +273,7 @@ export function waitForPastedRedirectUrl({
       );
     });
   });
+  return { resultPromise, close: () => reader.close() };
 }
 
 export function withTimeout<T>({
@@ -454,7 +474,7 @@ export function resolveTargetProfileName(
   return getStoredActiveProfile(settings)?.name ?? "default";
 }
 
-async function withSettingsLock<T>(
+export async function withSettingsLock<T>(
   settingsPath: string,
   action: () => Promise<T>
 ): Promise<T> {
@@ -468,15 +488,29 @@ async function withSettingsLock<T>(
       descriptor = fs.openSync(lockPath, "wx", 0o600);
     } catch (error) {
       if (
-        typeof error === "object" &&
-        error !== null &&
-        (error as NodeJS.ErrnoException).code === "EEXIST" &&
-        Date.now() - startedAt < SETTINGS_LOCK_TIMEOUT_MS
+        typeof error !== "object" ||
+        error === null ||
+        (error as NodeJS.ErrnoException).code !== "EEXIST"
       ) {
-        await sleep(SETTINGS_LOCK_RETRY_MS);
+        throw error;
+      }
+      // A lock left behind by a killed process would otherwise block every
+      // future settings write; steal it once it is older than the timeout.
+      if (isLockStale(lockPath)) {
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {
+          // Another process stole it first; retry the open.
+        }
         continue;
       }
-      throw error;
+      if (Date.now() - startedAt >= SETTINGS_LOCK_TIMEOUT_MS) {
+        throw new Error(
+          `Timed out waiting for the settings lock at ${lockPath}. ` +
+            "If no other px process is running, delete the file and retry."
+        );
+      }
+      await sleep(SETTINGS_LOCK_RETRY_MS);
     }
   }
 
@@ -489,6 +523,17 @@ async function withSettingsLock<T>(
     } catch {
       // Another process may have cleaned up the lock after the refresh was persisted.
     }
+  }
+}
+
+function isLockStale(lockPath: string): boolean {
+  try {
+    return (
+      Date.now() - fs.statSync(lockPath).mtimeMs > SETTINGS_LOCK_TIMEOUT_MS
+    );
+  } catch {
+    // The lock disappeared; the next open attempt will settle it.
+    return false;
   }
 }
 

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -4,6 +4,7 @@ import {
   type UIMessageChunk,
 } from "ai";
 
+import { createPhoenixAuthenticatedFetch } from "../client";
 import type { PhoenixConfig } from "../config";
 import { formatPxiRuntimeError } from "./preflight";
 import type {
@@ -79,7 +80,11 @@ export function buildPxiHeaders({
 }): Record<string, string> {
   return {
     ...(config.headers ?? {}),
-    ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+    ...(config.apiKey
+      ? { Authorization: `Bearer ${config.apiKey}` }
+      : config.oauthTokens
+        ? { Authorization: `Bearer ${config.oauthTokens.accessToken}` }
+        : {}),
   };
 }
 
@@ -169,13 +174,24 @@ export function createServerAgentTransport({
     throw new Error("Phoenix endpoint not configured.");
   }
 
+  const transportFetch =
+    fetch ??
+    (options.config.oauthTokens && options.config.profileName
+      ? createPhoenixAuthenticatedFetch({
+          endpoint: options.config.endpoint,
+          headers: options.config.headers ?? {},
+          profileName: options.config.profileName,
+          tokens: options.config.oauthTokens,
+        })
+      : undefined);
+
   return new DefaultChatTransport<PxiMessage>({
     api: buildServerAgentChatUrl({
       endpoint: options.config.endpoint,
       sessionId: options.sessionId,
     }),
     headers: buildPxiHeaders({ config: options.config }),
-    fetch,
+    fetch: transportFetch,
     prepareSendMessagesRequest: ({ messages }) => ({
       body: buildPxiChatRequest({ messages, options }),
     }),

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -4,7 +4,7 @@ import {
   type UIMessageChunk,
 } from "ai";
 
-import { createPhoenixAuthenticatedFetch } from "../client";
+import { createOAuthFetch, hasOAuthCredentials } from "../authFetch";
 import type { PhoenixConfig } from "../config";
 import { formatPxiRuntimeError } from "./preflight";
 import type {
@@ -176,13 +176,8 @@ export function createServerAgentTransport({
 
   const transportFetch =
     fetch ??
-    (options.config.oauthTokens && options.config.profileName
-      ? createPhoenixAuthenticatedFetch({
-          endpoint: options.config.endpoint,
-          headers: options.config.headers ?? {},
-          profileName: options.config.profileName,
-          tokens: options.config.oauthTokens,
-        })
+    (hasOAuthCredentials(options.config)
+      ? createOAuthFetch({ config: options.config })
       : undefined);
 
   return new DefaultChatTransport<PxiMessage>({

--- a/js/packages/phoenix-cli/src/settings.ts
+++ b/js/packages/phoenix-cli/src/settings.ts
@@ -414,4 +414,7 @@ export function saveSettings(
     encoding: "utf-8",
     mode: 0o600,
   });
+  // writeFileSync only applies `mode` when it creates the file; the file holds
+  // secrets (API keys, OAuth tokens), so tighten a pre-existing permissive mode.
+  fs.chmodSync(filePath, 0o600);
 }

--- a/js/packages/phoenix-cli/test/auth.test.ts
+++ b/js/packages/phoenix-cli/test/auth.test.ts
@@ -455,6 +455,14 @@ describe("px auth login/logout", () => {
   it("logs in via pasted redirect URL against stubbed endpoints", async () => {
     let server: Awaited<ReturnType<typeof withServer>> | undefined;
     try {
+      writeTempSettings(tmpDir, {
+        activeProfile: "default",
+        profiles: {
+          default: {
+            endpoint: "http://old-phoenix.example.com",
+          },
+        },
+      });
       server = await withServer(async (request, response) => {
         if (request.url === "/oauth2/token" && request.method === "POST") {
           const body = new URLSearchParams(await readRequestBody(request));
@@ -535,6 +543,7 @@ describe("px auth login/logout", () => {
       expect(captured(stderrSpy)).toContain("/oauth2/authorize");
       const saved = readTempSettings(tmpDir);
       expect(saved.activeProfile).toBe("default");
+      expect(saved.profiles.default.endpoint).toBe(server.url);
       expect(saved.profiles.default.oauthTokens?.refreshToken).toBe(
         "refresh-token"
       );

--- a/js/packages/phoenix-cli/test/config.test.ts
+++ b/js/packages/phoenix-cli/test/config.test.ts
@@ -171,6 +171,45 @@ describe("Configuration", () => {
       expect(cliConfig.oauthTokens).toBeUndefined();
     });
 
+    it("drops profile OAuth tokens when the endpoint is overridden", () => {
+      const settings: SettingsFile = {
+        activeProfile: "prod",
+        profiles: {
+          prod: {
+            endpoint: "https://prod.example.com",
+            oauthTokens: {
+              accessToken: "oauth-access",
+              refreshToken: "oauth-refresh",
+              expiresAt: "2026-01-01T00:00:00.000Z",
+              scope: "read_only",
+            },
+          },
+        },
+      };
+      const settingsPath = path.join(tmpDir, "px", "settings.json");
+      fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+      saveSettings(settings, { settingsPath });
+
+      const flagConfig = resolveConfig({
+        cliOptions: { endpoint: "https://staging.example.com" },
+      });
+      expect(flagConfig.credentialSource).toBe("none");
+      expect(flagConfig.oauthTokens).toBeUndefined();
+
+      process.env.PHOENIX_HOST = "https://staging.example.com";
+      const envConfig = resolveConfig({ cliOptions: {} });
+      expect(envConfig.credentialSource).toBe("none");
+      expect(envConfig.oauthTokens).toBeUndefined();
+      delete process.env.PHOENIX_HOST;
+
+      // An override matching the issuing endpoint keeps the tokens.
+      const matchingConfig = resolveConfig({
+        cliOptions: { endpoint: "https://prod.example.com" },
+      });
+      expect(matchingConfig.credentialSource).toBe("oauth");
+      expect(matchingConfig.oauthTokens?.accessToken).toBe("oauth-access");
+    });
+
     it("prefers a profile API key over profile OAuth tokens", () => {
       const settings: SettingsFile = {
         activeProfile: "prod",

--- a/js/packages/phoenix-cli/test/oauth.test.ts
+++ b/js/packages/phoenix-cli/test/oauth.test.ts
@@ -4,7 +4,7 @@ import * as os from "os";
 import * as path from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createPhoenixAuthenticatedFetch } from "../src/client";
+import { createOAuthFetch } from "../src/authFetch";
 import {
   buildAuthorizationUrl,
   exchangeAuthorizationCode,
@@ -307,10 +307,8 @@ describe("OAuth fetch wrapper", () => {
       path.join(os.tmpdir(), "phoenix-oauth-test-")
     );
     const settingsPath = path.join(tmpDir, "px", "settings.json");
-    const oldXdgConfigHome = process.env.XDG_CONFIG_HOME;
     let server: Awaited<ReturnType<typeof withServer>> | undefined;
     try {
-      process.env.XDG_CONFIG_HOME = tmpDir;
       saveSettings(
         {
           activeProfile: "prod",
@@ -347,25 +345,22 @@ describe("OAuth fetch wrapper", () => {
         response.end("ok");
       });
 
-      const wrappedFetch = createPhoenixAuthenticatedFetch({
-        endpoint: server.url,
-        headers: {},
-        profileName: "prod",
-        tokens: {
-          accessToken: "old-access",
-          refreshToken: "old-refresh",
-          expiresAt: "2000-01-01T00:00:00.000Z",
-          scope: "read_only",
+      const oauthFetch = createOAuthFetch({
+        config: {
+          endpoint: server.url,
+          profileName: "prod",
+          oauthTokens: {
+            accessToken: "old-access",
+            refreshToken: "old-refresh",
+            expiresAt: "2000-01-01T00:00:00.000Z",
+            scope: "read_only",
+          },
         },
+        settingsPath,
       });
-      const response = await wrappedFetch(`${server.url}/v1/user`);
+      const response = await oauthFetch(`${server.url}/v1/user`);
       expect(response.status).toBe(200);
     } finally {
-      if (oldXdgConfigHome === undefined) {
-        delete process.env.XDG_CONFIG_HOME;
-      } else {
-        process.env.XDG_CONFIG_HOME = oldXdgConfigHome;
-      }
       await server?.close();
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -376,11 +371,9 @@ describe("OAuth fetch wrapper", () => {
       path.join(os.tmpdir(), "phoenix-oauth-test-")
     );
     const settingsPath = path.join(tmpDir, "px", "settings.json");
-    const oldXdgConfigHome = process.env.XDG_CONFIG_HOME;
     let server: Awaited<ReturnType<typeof withServer>> | undefined;
     let protectedRequestCount = 0;
     try {
-      process.env.XDG_CONFIG_HOME = tmpDir;
       saveSettings(
         {
           activeProfile: "prod",
@@ -416,48 +409,46 @@ describe("OAuth fetch wrapper", () => {
         response.writeHead(401);
         response.end();
       });
-      const wrappedFetch = createPhoenixAuthenticatedFetch({
-        endpoint: server.url,
-        headers: {},
-        profileName: "prod",
-        tokens: {
-          accessToken: "access",
-          refreshToken: "refresh",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          scope: "read_only",
+      const oauthFetch = createOAuthFetch({
+        config: {
+          endpoint: server.url,
+          profileName: "prod",
+          oauthTokens: {
+            accessToken: "access",
+            refreshToken: "refresh",
+            expiresAt: "2999-01-01T00:00:00.000Z",
+            scope: "read_only",
+          },
         },
+        settingsPath,
       });
-      await expect(wrappedFetch(`${server.url}/v1/user`)).rejects.toThrow(
+      await expect(oauthFetch(`${server.url}/v1/user`)).rejects.toThrow(
         "Session expired. Run: px auth login"
       );
       expect(protectedRequestCount).toBe(2);
     } finally {
-      if (oldXdgConfigHome === undefined) {
-        delete process.env.XDG_CONFIG_HOME;
-      } else {
-        process.env.XDG_CONFIG_HOME = oldXdgConfigHome;
-      }
       await server?.close();
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
   it("returns 403 responses to the caller", async () => {
-    const wrappedFetch = createPhoenixAuthenticatedFetch({
-      endpoint: "http://example.test",
-      headers: {},
-      profileName: "prod",
-      tokens: {
-        accessToken: "access",
-        refreshToken: "refresh",
-        expiresAt: "2999-01-01T00:00:00.000Z",
-        scope: "",
+    const oauthFetch = createOAuthFetch({
+      config: {
+        endpoint: "http://example.test",
+        profileName: "prod",
+        oauthTokens: {
+          accessToken: "access",
+          refreshToken: "refresh",
+          expiresAt: "2999-01-01T00:00:00.000Z",
+          scope: "",
+        },
       },
-      fetchImpl: vi
+      fetch: vi
         .fn<typeof fetch>()
         .mockResolvedValue(new Response(null, { status: 403 })),
     });
-    const response = await wrappedFetch("http://example.test/v1/projects");
+    const response = await oauthFetch("http://example.test/v1/projects");
     expect(response.status).toBe(403);
   });
 });

--- a/js/packages/phoenix-cli/test/oauth.test.ts
+++ b/js/packages/phoenix-cli/test/oauth.test.ts
@@ -4,7 +4,7 @@ import * as os from "os";
 import * as path from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createOAuthRefreshingFetch } from "../src/client";
+import { createPhoenixAuthenticatedFetch } from "../src/client";
 import {
   buildAuthorizationUrl,
   exchangeAuthorizationCode,
@@ -347,7 +347,7 @@ describe("OAuth fetch wrapper", () => {
         response.end("ok");
       });
 
-      const wrappedFetch = createOAuthRefreshingFetch({
+      const wrappedFetch = createPhoenixAuthenticatedFetch({
         endpoint: server.url,
         headers: {},
         profileName: "prod",
@@ -416,7 +416,7 @@ describe("OAuth fetch wrapper", () => {
         response.writeHead(401);
         response.end();
       });
-      const wrappedFetch = createOAuthRefreshingFetch({
+      const wrappedFetch = createPhoenixAuthenticatedFetch({
         endpoint: server.url,
         headers: {},
         profileName: "prod",
@@ -443,7 +443,7 @@ describe("OAuth fetch wrapper", () => {
   });
 
   it("returns 403 responses to the caller", async () => {
-    const wrappedFetch = createOAuthRefreshingFetch({
+    const wrappedFetch = createPhoenixAuthenticatedFetch({
       endpoint: "http://example.test",
       headers: {},
       profileName: "prod",

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -117,6 +117,22 @@ describe("PXI client", () => {
     });
   });
 
+  it("uses OAuth access tokens when no API key is configured", () => {
+    const headers = buildPxiHeaders({
+      config: {
+        endpoint: "http://localhost:6006",
+        oauthTokens: {
+          accessToken: "oauth-access",
+          refreshToken: "oauth-refresh",
+          expiresAt: "2999-01-01T00:00:00.000Z",
+          scope: "",
+        },
+      },
+    });
+
+    expect(headers.Authorization).toBe("Bearer oauth-access");
+  });
+
   it("builds the server-agent chat URL", () => {
     expect(
       buildServerAgentChatUrl({

--- a/js/packages/phoenix-cli/test/settings.test.ts
+++ b/js/packages/phoenix-cli/test/settings.test.ts
@@ -107,4 +107,13 @@ describe("loadSettings / saveSettings", () => {
     const stat = fs.statSync(settingsPath);
     expect(stat.mode & 0o777).toBe(0o600);
   });
+
+  it("tightens the mode of a pre-existing permissive settings file", () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, "{}", { mode: 0o644 });
+    fs.chmodSync(settingsPath, 0o644);
+    saveSettings({ activeProfile: null, profiles: {} }, { settingsPath });
+    const stat = fs.statSync(settingsPath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
 });

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -63,6 +63,34 @@ const phoenix = createClient({
 });
 ```
 
+For credentials that can expire, create an authenticated fetch implementation
+and pass it to the client. The token provider controls storage and refresh-token
+rotation. Requests that receive a `401` share one refresh operation and are
+retried once.
+
+```ts
+import {
+  createAuthenticatedFetch,
+  createClient,
+} from "@arizeai/phoenix-client";
+
+const authenticatedFetch = createAuthenticatedFetch({
+  getAccessToken: async ({ forceRefresh }) => {
+    if (forceRefresh) {
+      await refreshAndPersistTokens();
+    }
+    return loadTokens().accessToken;
+  },
+});
+
+const phoenix = createClient({
+  options: {
+    baseUrl: "http://localhost:6006",
+    fetch: authenticatedFetch,
+  },
+});
+```
+
 ## Prompts
 
 `@arizeai/phoenix-client` provides a `prompts` export that exposes utilities for working with prompts for LLMs.

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -69,12 +69,9 @@ rotation. Requests that receive a `401` share one refresh operation and are
 retried once.
 
 ```ts
-import {
-  createAuthenticatedFetch,
-  createClient,
-} from "@arizeai/phoenix-client";
+import { createAuthFetch, createClient } from "@arizeai/phoenix-client";
 
-const authenticatedFetch = createAuthenticatedFetch({
+const authFetch = createAuthFetch({
   getAccessToken: async ({ forceRefresh }) => {
     if (forceRefresh) {
       await refreshAndPersistTokens();
@@ -86,7 +83,7 @@ const authenticatedFetch = createAuthenticatedFetch({
 const phoenix = createClient({
   options: {
     baseUrl: "http://localhost:6006",
-    fetch: authenticatedFetch,
+    fetch: authFetch,
   },
 });
 ```

--- a/js/packages/phoenix-client/src/authFetch.ts
+++ b/js/packages/phoenix-client/src/authFetch.ts
@@ -1,0 +1,82 @@
+export interface AccessTokenProviderOptions {
+  /**
+   * Return an access token for a request.
+   *
+   * When `forceRefresh` is true, the previous token was rejected with a 401
+   * and the provider should refresh it before returning. Providers own token
+   * storage and refresh-token rotation.
+   */
+  getAccessToken: (options: {
+    forceRefresh: boolean;
+  }) => string | Promise<string>;
+}
+
+export interface CreateAuthenticatedFetchOptions extends AccessTokenProviderOptions {
+  /** Fetch implementation used to send requests. Defaults to global fetch. */
+  fetch?: typeof fetch;
+  /** Called when the request is still unauthorized after one refresh. */
+  onUnauthorized?: (response: Response) => void | Promise<void>;
+}
+
+/**
+ * Create a fetch implementation that supplies a bearer token and refreshes it
+ * after a 401 response.
+ *
+ * Refresh calls are coalesced so concurrent unauthorized requests rotate a
+ * refresh token only once. Each request is retried at most once.
+ */
+export function createAuthenticatedFetch({
+  getAccessToken,
+  fetch: fetchImpl = fetch,
+  onUnauthorized,
+}: CreateAuthenticatedFetchOptions): typeof fetch {
+  let refreshPromise: Promise<string> | undefined;
+
+  const getRefreshedAccessToken = (): Promise<string> => {
+    if (!refreshPromise) {
+      refreshPromise = Promise.resolve(
+        getAccessToken({ forceRefresh: true })
+      ).finally(() => {
+        refreshPromise = undefined;
+      });
+    }
+    return refreshPromise;
+  };
+
+  return async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const request = new Request(input, init);
+    const retryRequest = request.clone();
+    const accessToken = await getAccessToken({ forceRefresh: false });
+    const response = await fetchImpl(withBearerToken({ request, accessToken }));
+    if (response.status !== 401) {
+      return response;
+    }
+
+    // Another request may already have refreshed and persisted the token while
+    // this request was in flight. Reuse it instead of rotating again.
+    const currentAccessToken = await getAccessToken({ forceRefresh: false });
+    const retryAccessToken =
+      currentAccessToken === accessToken
+        ? await getRefreshedAccessToken()
+        : currentAccessToken;
+    const retryResponse = await fetchImpl(
+      withBearerToken({ request: retryRequest, accessToken: retryAccessToken })
+    );
+    if (retryResponse.status === 401) {
+      await onUnauthorized?.(retryResponse);
+    }
+    return retryResponse;
+  };
+}
+
+function withBearerToken({
+  request,
+  accessToken,
+}: {
+  request: Request;
+  accessToken: string;
+}): Request {
+  const headers = new Headers(request.headers);
+  headers.set("Authorization", `Bearer ${accessToken}`);
+  return new Request(request, { headers });
+}

--- a/js/packages/phoenix-client/src/authFetch.ts
+++ b/js/packages/phoenix-client/src/authFetch.ts
@@ -1,4 +1,4 @@
-export interface AccessTokenProviderOptions {
+export interface AuthFetchOptions {
   /**
    * Return an access token for a request.
    *
@@ -9,9 +9,6 @@ export interface AccessTokenProviderOptions {
   getAccessToken: (options: {
     forceRefresh: boolean;
   }) => string | Promise<string>;
-}
-
-export interface CreateAuthenticatedFetchOptions extends AccessTokenProviderOptions {
   /** Fetch implementation used to send requests. Defaults to global fetch. */
   fetch?: typeof fetch;
   /** Called when the request is still unauthorized after one refresh. */
@@ -24,15 +21,20 @@ export interface CreateAuthenticatedFetchOptions extends AccessTokenProviderOpti
  *
  * Refresh calls are coalesced so concurrent unauthorized requests rotate a
  * refresh token only once. Each request is retried at most once.
+ *
+ * @param options - Authentication behavior for the fetch implementation.
+ * @param options.getAccessToken - Returns the current token or refreshes it.
+ * @param options.fetch - Fetch implementation used to send requests.
+ * @param options.onUnauthorized - Handles a second unauthorized response.
  */
-export function createAuthenticatedFetch({
+export function createAuthFetch({
   getAccessToken,
   fetch: fetchImpl = fetch,
   onUnauthorized,
-}: CreateAuthenticatedFetchOptions): typeof fetch {
+}: AuthFetchOptions): typeof fetch {
   let refreshPromise: Promise<string> | undefined;
 
-  const getRefreshedAccessToken = (): Promise<string> => {
+  const refreshAccessToken = (): Promise<string> => {
     if (!refreshPromise) {
       refreshPromise = Promise.resolve(
         getAccessToken({ forceRefresh: true })
@@ -43,11 +45,14 @@ export function createAuthenticatedFetch({
     return refreshPromise;
   };
 
-  return async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+  return async function authFetch(
+    input: Parameters<typeof fetch>[0],
+    init?: RequestInit
+  ) {
     const request = new Request(input, init);
     const retryRequest = request.clone();
     const accessToken = await getAccessToken({ forceRefresh: false });
-    const response = await fetchImpl(withBearerToken({ request, accessToken }));
+    const response = await fetchImpl(addBearerToken({ request, accessToken }));
     if (response.status !== 401) {
       return response;
     }
@@ -57,10 +62,10 @@ export function createAuthenticatedFetch({
     const currentAccessToken = await getAccessToken({ forceRefresh: false });
     const retryAccessToken =
       currentAccessToken === accessToken
-        ? await getRefreshedAccessToken()
+        ? await refreshAccessToken()
         : currentAccessToken;
     const retryResponse = await fetchImpl(
-      withBearerToken({ request: retryRequest, accessToken: retryAccessToken })
+      addBearerToken({ request: retryRequest, accessToken: retryAccessToken })
     );
     if (retryResponse.status === 401) {
       await onUnauthorized?.(retryResponse);
@@ -69,7 +74,7 @@ export function createAuthenticatedFetch({
   };
 }
 
-function withBearerToken({
+function addBearerToken({
   request,
   accessToken,
 }: {

--- a/js/packages/phoenix-client/src/index.ts
+++ b/js/packages/phoenix-client/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./client";
+export * from "./authFetch";

--- a/js/packages/phoenix-client/test/authFetch.test.ts
+++ b/js/packages/phoenix-client/test/authFetch.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createAuthenticatedFetch } from "../src/authFetch";
+import { createAuthFetch } from "../src/authFetch";
 
-describe("createAuthenticatedFetch", () => {
+describe("createAuthFetch", () => {
   it("adds the current access token", async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
       .mockResolvedValue(new Response(null, { status: 200 }));
-    const authFetch = createAuthenticatedFetch({
+    const authFetch = createAuthFetch({
       getAccessToken: () => "access-token",
       fetch: fetchImpl,
     });
@@ -33,7 +33,7 @@ describe("createAuthenticatedFetch", () => {
       ({ forceRefresh }: { forceRefresh: boolean }) =>
         forceRefresh ? "refreshed-token" : "access-token"
     );
-    const authFetch = createAuthenticatedFetch({
+    const authFetch = createAuthFetch({
       getAccessToken,
       fetch: fetchImpl,
     });
@@ -68,7 +68,7 @@ describe("createAuthenticatedFetch", () => {
         status: token === "Bearer refreshed-token" ? 200 : 401,
       });
     });
-    const authFetch = createAuthenticatedFetch({
+    const authFetch = createAuthFetch({
       getAccessToken,
       fetch: fetchImpl,
     });
@@ -104,7 +104,7 @@ describe("createAuthenticatedFetch", () => {
         return new Response(null, { status: 401 });
       })
       .mockResolvedValueOnce(new Response(null, { status: 200 }));
-    const authFetch = createAuthenticatedFetch({
+    const authFetch = createAuthFetch({
       getAccessToken,
       fetch: fetchImpl,
     });
@@ -121,7 +121,7 @@ describe("createAuthenticatedFetch", () => {
 
   it("calls onUnauthorized after the retry is also rejected", async () => {
     const onUnauthorized = vi.fn();
-    const authFetch = createAuthenticatedFetch({
+    const authFetch = createAuthFetch({
       getAccessToken: ({ forceRefresh }) =>
         forceRefresh ? "refreshed-token" : "access-token",
       fetch: vi

--- a/js/packages/phoenix-client/test/authFetch.test.ts
+++ b/js/packages/phoenix-client/test/authFetch.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAuthenticatedFetch } from "../src/authFetch";
+
+describe("createAuthenticatedFetch", () => {
+  it("adds the current access token", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const authFetch = createAuthenticatedFetch({
+      getAccessToken: () => "access-token",
+      fetch: fetchImpl,
+    });
+
+    await authFetch("http://example.test/v1/projects", {
+      headers: { "X-Tenant": "tenant" },
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0];
+    expect(request).toBeInstanceOf(Request);
+    expect((request as Request).headers.get("Authorization")).toBe(
+      "Bearer access-token"
+    );
+    expect((request as Request).headers.get("X-Tenant")).toBe("tenant");
+  });
+
+  it("refreshes and retries once after a 401", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const getAccessToken = vi.fn(
+      ({ forceRefresh }: { forceRefresh: boolean }) =>
+        forceRefresh ? "refreshed-token" : "access-token"
+    );
+    const authFetch = createAuthenticatedFetch({
+      getAccessToken,
+      fetch: fetchImpl,
+    });
+
+    const response = await authFetch("http://example.test/v1/projects", {
+      method: "POST",
+      body: "replayable body",
+    });
+
+    expect(response.status).toBe(200);
+    expect(getAccessToken).toHaveBeenCalledTimes(3);
+    expect(getAccessToken).toHaveBeenCalledWith({ forceRefresh: true });
+    const retryRequest = fetchImpl.mock.calls[1]?.[0] as Request;
+    expect(retryRequest.headers.get("Authorization")).toBe(
+      "Bearer refreshed-token"
+    );
+    await expect(retryRequest.text()).resolves.toBe("replayable body");
+  });
+
+  it("coalesces refreshes for concurrent unauthorized requests", async () => {
+    let resolveRefresh: ((token: string) => void) | undefined;
+    const refresh = new Promise<string>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const getAccessToken = vi.fn(
+      ({ forceRefresh }: { forceRefresh: boolean }) =>
+        forceRefresh ? refresh : "access-token"
+    );
+    const fetchImpl = vi.fn<typeof fetch>(async (request) => {
+      const token = new Request(request).headers.get("Authorization");
+      return new Response(null, {
+        status: token === "Bearer refreshed-token" ? 200 : 401,
+      });
+    });
+    const authFetch = createAuthenticatedFetch({
+      getAccessToken,
+      fetch: fetchImpl,
+    });
+
+    const firstRequest = authFetch("http://example.test/v1/projects");
+    const secondRequest = authFetch("http://example.test/v1/datasets");
+    await vi.waitFor(() => {
+      expect(getAccessToken).toHaveBeenCalledWith({ forceRefresh: true });
+    });
+    resolveRefresh?.("refreshed-token");
+
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([
+      expect.objectContaining({ status: 200 }),
+      expect.objectContaining({ status: 200 }),
+    ]);
+    expect(
+      getAccessToken.mock.calls.filter(([options]) => options.forceRefresh)
+    ).toHaveLength(1);
+  });
+
+  it("reuses a token refreshed while the request was in flight", async () => {
+    let accessToken = "access-token";
+    const getAccessToken = vi.fn(
+      ({ forceRefresh }: { forceRefresh: boolean }) => {
+        if (forceRefresh) throw new Error("unexpected refresh");
+        return accessToken;
+      }
+    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(async () => {
+        accessToken = "already-refreshed-token";
+        return new Response(null, { status: 401 });
+      })
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const authFetch = createAuthenticatedFetch({
+      getAccessToken,
+      fetch: fetchImpl,
+    });
+
+    await expect(
+      authFetch("http://example.test/v1/projects")
+    ).resolves.toMatchObject({ status: 200 });
+    expect(getAccessToken).not.toHaveBeenCalledWith({ forceRefresh: true });
+    const retryRequest = fetchImpl.mock.calls[1]?.[0] as Request;
+    expect(retryRequest.headers.get("Authorization")).toBe(
+      "Bearer already-refreshed-token"
+    );
+  });
+
+  it("calls onUnauthorized after the retry is also rejected", async () => {
+    const onUnauthorized = vi.fn();
+    const authFetch = createAuthenticatedFetch({
+      getAccessToken: ({ forceRefresh }) =>
+        forceRefresh ? "refreshed-token" : "access-token",
+      fetch: vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 401 })),
+      onUnauthorized,
+    });
+
+    const response = await authFetch("http://example.test/v1/projects");
+
+    expect(response.status).toBe(401);
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+  });
+});

--- a/js/packages/phoenix-mcp/src/config.ts
+++ b/js/packages/phoenix-mcp/src/config.ts
@@ -4,6 +4,7 @@ import {
   ENV_PHOENIX_CLIENT_HEADERS,
   ENV_PHOENIX_HOST,
   getHeadersFromEnvironment,
+  getProjectFromEnvironment,
   getStrFromEnvironment,
   type Headers,
 } from "@arizeai/phoenix-config";
@@ -32,9 +33,7 @@ export function loadConfigFromEnvironment(): PhoenixMcpConfig {
   const baseUrl = getStrFromEnvironment(ENV_PHOENIX_HOST);
   const apiKey = getStrFromEnvironment(ENV_PHOENIX_API_KEY);
   const headers = getHeadersFromEnvironment(ENV_PHOENIX_CLIENT_HEADERS);
-  const project =
-    getStrFromEnvironment("PHOENIX_PROJECT") ??
-    getStrFromEnvironment("PHOENIX_PROJECT_NAME");
+  const project = getProjectFromEnvironment();
 
   return {
     baseUrl: baseUrl || DEFAULT_PHOENIX_ENDPOINT,

--- a/js/packages/phoenix-otel/src/config.ts
+++ b/js/packages/phoenix-otel/src/config.ts
@@ -1,6 +1,7 @@
 import {
   ENV_PHOENIX_API_KEY,
   ENV_PHOENIX_COLLECTOR_ENDPOINT,
+  getProjectFromEnvironment,
   getStrFromEnvironment,
 } from "@arizeai/phoenix-config";
 
@@ -25,14 +26,12 @@ export function getEnvApiKey(): string | undefined {
 /**
  * Reads the Phoenix project name from the environment.
  *
- * Resolves `PHOENIX_PROJECT` first, then falls back to the supported
- * `PHOENIX_PROJECT_NAME` alias.
+ * Delegates to `@arizeai/phoenix-config` so the `PHOENIX_PROJECT` (canonical) /
+ * `PHOENIX_PROJECT_NAME` (alias) resolution — including precedence and the
+ * one-time conflict warning — lives in a single shared implementation.
  *
  * @returns The resolved project name, or `undefined` if neither variable is set.
  */
 export function getEnvProjectName(): string | undefined {
-  return (
-    getStrFromEnvironment("PHOENIX_PROJECT") ??
-    getStrFromEnvironment("PHOENIX_PROJECT_NAME")
-  );
+  return getProjectFromEnvironment();
 }

--- a/src/phoenix/server/api/routers/oauth2_authorization_server.py
+++ b/src/phoenix/server/api/routers/oauth2_authorization_server.py
@@ -504,6 +504,9 @@ async def _exchange_refresh_token(request: Request, form: Any) -> JSONResponse:
         token_ids = [AccessTokenId(id_) for id_ in access_token_ids]
     refresh_token_expiry = _refresh_token_expiry(request, grant_expires_at=grant.expires_at)
     access_token_expiry = _access_token_expiry(request)
+    if not await token_store.consume_refresh_token(refresh_claims.token_id):
+        return _oauth_error("invalid_grant")
+    await token_store.revoke(*token_ids)
     access_token, refresh_token = await create_access_and_refresh_tokens(
         token_store=token_store,
         user=user,
@@ -512,7 +515,6 @@ async def _exchange_refresh_token(request: Request, form: Any) -> JSONResponse:
         grant_id=grant.id,
         scopes=tuple(refresh_claims.attributes.scopes),
     )
-    await token_store.revoke(refresh_claims.token_id, *token_ids)
     return _token_response(access_token, refresh_token, access_token_expiry)
 
 

--- a/src/phoenix/server/jwt_store.py
+++ b/src/phoenix/server/jwt_store.py
@@ -168,6 +168,10 @@ class JwtStore:
     ) -> tuple[RefreshToken, RefreshTokenId]:
         return await self._refresh_token_store.create(claim)
 
+    async def consume_refresh_token(self, token_id: RefreshTokenId) -> bool:
+        """Atomically delete a refresh token if it has not already been consumed."""
+        return await self._refresh_token_store.consume(token_id)
+
     async def create_api_key(
         self,
         claim: ApiKeyClaims,
@@ -294,6 +298,15 @@ class _Store(DaemonTask, Generic[_ClaimSetT, _TokenT, _TokenIdT, _RecordT], ABC)
         stmt = delete(self._table).where(self._table.id.in_(map(int, token_ids)))
         async with self._db() as session:
             await session.execute(stmt)
+
+    async def consume(self, token_id: _TokenIdT) -> bool:
+        stmt = delete(self._table).where(self._table.id == int(token_id)).returning(self._table.id)
+        async with self._db() as session:
+            deleted_id = await session.scalar(stmt)
+        if deleted_id is None:
+            return False
+        await self.evict(token_id)
+        return True
 
     @abstractmethod
     def _from_db(self, record: _RecordT, role: UserRoleName) -> tuple[_TokenIdT, _ClaimSetT]: ...

--- a/src/phoenix/server/types.py
+++ b/src/phoenix/server/types.py
@@ -301,6 +301,7 @@ class CanLogOutUser(Protocol):
 
 
 class TokenStore(CanReadToken, CanRevokeTokens, CanLogOutUser, Protocol):
+    async def consume_refresh_token(self, token_id: RefreshTokenId) -> bool: ...
     async def create_password_reset_token(
         self,
         claims: PasswordResetTokenClaims,

--- a/tests/integration/auth/test_oauth2.py
+++ b/tests/integration/auth/test_oauth2.py
@@ -373,6 +373,32 @@ class TestTokenLifecycle:
         )
         assert second_refresh.status_code == 200
 
+    def test_concurrent_refresh_token_rotation_has_one_winner(
+        self,
+        _app: _AppInfo,
+        _get_user: _GetUser,
+        _oauth_public_client: _OAuthPublicClient,
+    ) -> None:
+        user = _get_user(_app, _MEMBER).log_in(_app)
+        token_response = _oauth_public_client.complete_flow(user)
+        form = {
+            "grant_type": "refresh_token",
+            "refresh_token": token_response["refresh_token"],
+            "client_id": _oauth_public_client.client_id,
+        }
+        barrier = Barrier(2)
+
+        def rotate() -> httpx.Response:
+            barrier.wait()
+            return _httpx_client(_app).post("oauth2/token", data=form)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            responses = list(executor.map(lambda _: rotate(), range(2)))
+
+        assert sorted(response.status_code for response in responses) == [200, 400]
+        rejected = next(response for response in responses if response.status_code == 400)
+        assert rejected.json()["error"] == "invalid_grant"
+
     def test_rotated_refresh_token_reuse_is_invalid_grant(
         self,
         _app: _AppInfo,


### PR DESCRIPTION
## Summary

This follow-up polishes and hardens the OAuth CLI login work in #14175 by making refreshable credentials reusable, applying them consistently across CLI request paths, and enforcing single-use refresh-token rotation.

### Assessment

The authorization-code grant, token persistence, and refresh endpoint were present. The review found these correctness and security gaps:

- `@arizeai/phoenix-client` only supported static headers, so refresh behavior did not scale beyond the CLI.
- `px api graphql` bypassed refresh, while PXI only considered API keys.
- OAuth transport construction was mixed into the REST client and exposed endpoint, profile, header, and token details at each call site.
- Concurrent or late-arriving `401` responses could cause unnecessary client-side refresh-token rotations.
- `px auth status` displayed stale expiry metadata after a successful refresh.
- Logging into an existing profile with `--endpoint` preserved the old endpoint, binding new credentials to the wrong server.
- Server rotation used read → mint → revoke, so concurrent uses of one refresh token could both mint valid replacement pairs.

### Changes

- Add and export `createAuthFetch` from `@arizeai/phoenix-client`.
  - Injects bearer tokens through a provider hook.
  - Coalesces concurrent forced refreshes.
  - Reuses tokens refreshed while another request was in flight.
  - Retries once after `401` with an application-specific final unauthorized hook.
- Isolate CLI OAuth composition behind `hasOAuthCredentials` and `createOAuthFetch({ config })`.
- Use refreshing OAuth credentials for typed REST, GraphQL, and PXI requests.
- Reload rotated credentials before formatting `px auth status`.
- Persist the endpoint used by each OAuth login, replacing a stale endpoint on reused profiles.
- Atomically consume refresh tokens with `DELETE … RETURNING` before minting replacements; concurrent reuse now has exactly one winner.
- Remove process-wide settings mutation from OAuth transport tests.
- Preserve API-key precedence and CLI-specific recovery messaging.
- Update package docs, README guidance, the CLI skill, and release metadata.

### Code-review hardening (follow-up commit)

A multi-angle review of the CLI changes surfaced and fixed eight issues:

- **Endpoint binding at use time**: `resolveConfig` now drops profile OAuth tokens when `--endpoint`/`PHOENIX_HOST` differs from the profile's issuing endpoint, so bearer and refresh tokens are never sent to — or refreshed against — a host that did not issue them; `px auth logout` revokes against the profile's stored endpoint.
- **Callback-server robustness**: callback requests are parsed against a fixed loopback base, so a malformed `Host` header can no longer crash the CLI mid-login (previously an uncaught `TypeError` in the request handler).
- **`--no-browser` hang**: the pasted-redirect readline is closed when the loopback callback wins the race, so successful logins exit instead of holding stdin open indefinitely.
- **Stale settings lock**: locks older than the timeout are stolen by mtime, and a lock timeout now raises an actionable error naming the lock path instead of a raw `EEXIST`.
- **Locked login/logout writes**: login and logout persist settings under the settings lock, so they cannot clobber a single-use refresh-token rotation running in another process.
- **Secret file permissions**: `saveSettings` chmods `settings.json` to 0600 on every write (`writeFileSync`'s `mode` applies only at creation), matching the schema's documented guarantee.
- **Restored shared project-env resolution**: `getProjectFromEnvironment()` from `@arizeai/phoenix-config` is used again in the CLI, MCP, and OTel configs, recovering the both-vars-set conflict warning and empty-string alias fallthrough that the inline copies dropped.
- **Login UX**: `px auth login` warns when the target profile holds an API key that takes precedence over the new OAuth session, instead of reporting a success that later commands ignore.

Regression tests cover the endpoint binding and permission tightening.

## User impact

Users can log in once and use the selected profile across REST commands, GraphQL, and PXI without manually renewing access tokens. Reusing a profile against another server cannot retain the old routing target. Refresh-token rotation is single-use under concurrency, preventing multiple replacement sessions from one credential.

## Validation

- `pnpm fmt:check`
- `pnpm --filter @arizeai/phoenix-client test` — 459 passed, 1 skipped
- `pnpm --filter @arizeai/phoenix-client typecheck`
- isolated-config `pnpm --filter @arizeai/phoenix-cli test` — 581 passed
- post-review-fix: auth-related CLI suites (`auth`, `oauth`, `config`, `settings`, `oauthCallbackPage`, `pxiClient`, `cli`) — 96 passed incl. 2 new regression tests; phoenix-mcp 23 passed; phoenix-otel 19 passed; `pnpm build` and `oxlint`/`oxfmt` clean
- `pnpm --filter @arizeai/phoenix-cli typecheck`
- targeted `oxlint` on changed TypeScript files
- `uv run ruff format` and `uv run ruff check` on changed Python files
- `uv run pytest tests/integration/auth/test_oauth2.py -q` — 39 passed
- `make typecheck-python` — 950 source files checked
- `npm pack --dry-run --json` confirmed the client API and canonical package docs are included

### Live localhost smoke test

Against the authenticated Phoenix instance at `http://localhost:6006`:

- began with an expired OAuth access-token timestamp
- `px auth status --format raw` refreshed and persisted the session
- status reported the rotated expiry
- typed REST project listing succeeded
- GraphQL returned the authenticated viewer

## Review notes

This PR intentionally targets `feat/oauth2-authorization-server-cli-login` so its diff remains focused on the client, CLI, and rotation hardening for #14175.

