### PR TITLE
fix: preserve combobox tab navigation

### DIFF
--- a/app/src/components/core/combobox/ComboBox.tsx
+++ b/app/src/components/core/combobox/ComboBox.tsx
@@ -50,9 +50,10 @@ export interface ComboBoxProps<T extends object>
 /**
  * Prevents the event from propagating to the parent element.
  */
-const stopPropagationHandler = (e: React.MouseEvent | React.KeyboardEvent) => {
-  e.preventDefault();
-  e.stopPropagation();
+const stopPropagationHandler = (
+  event: React.MouseEvent | React.KeyboardEvent
+) => {
+  event.stopPropagation();
 };
 
 export function ComboBox<T extends object>({

--- a/app/src/components/core/combobox/__tests__/ComboBox.test.tsx
+++ b/app/src/components/core/combobox/__tests__/ComboBox.test.tsx
@@ -1,0 +1,71 @@
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { userEvent } from "storybook/test";
+
+import { ComboBox, ComboBoxItem } from "../ComboBox";
+
+describe("ComboBox", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("preserves native Tab navigation while stopping keyboard propagation", async () => {
+    const onParentKeyDown = vi.fn();
+    const onParentKeyUp = vi.fn();
+    act(() => {
+      root.render(
+        <div onKeyDown={onParentKeyDown} onKeyUp={onParentKeyUp}>
+          <ComboBox label="Prompt" stopPropagation>
+            <ComboBoxItem id="support" textValue="Customer support">
+              Customer support
+            </ComboBoxItem>
+          </ComboBox>
+          <label>
+            Description
+            <input aria-label="Description" />
+          </label>
+        </div>
+      );
+    });
+
+    const promptInput = container.querySelector<HTMLInputElement>(
+      'input[role="combobox"]'
+    );
+    const descriptionInput = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Description"]'
+    );
+    expect(promptInput).not.toBeNull();
+    expect(descriptionInput).not.toBeNull();
+
+    act(() => promptInput?.focus());
+    onParentKeyDown.mockClear();
+    const user = userEvent.setup();
+
+    await act(async () => user.tab());
+
+    expect(document.activeElement).toBe(descriptionInput);
+    expect(onParentKeyDown).not.toHaveBeenCalled();
+
+    await act(async () => user.tab({ shift: true }));
+
+    expect(document.activeElement).toBe(promptInput);
+    onParentKeyDown.mockClear();
+    onParentKeyUp.mockClear();
+
+    await act(async () => user.keyboard("{ArrowDown}"));
+
+    expect(onParentKeyDown).not.toHaveBeenCalled();
+    expect(onParentKeyUp).not.toHaveBeenCalled();
+  });
+});

--- a/app/stories/ComboBox.stories.tsx
+++ b/app/stories/ComboBox.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react";
 
-import { Flex, View } from "@phoenix/components";
+import { Flex, Input, Label, TextField, View } from "@phoenix/components";
 import type { ComboBoxProps } from "@phoenix/components/core/combobox/ComboBox";
 import {
   ComboBox,
@@ -81,6 +81,27 @@ export const Default = {
   args: {
     label: "Ice cream flavor",
   },
+};
+
+export const KeyboardNavigation = {
+  render: () => (
+    <View width="300px">
+      <Flex direction="column" gap="size-100">
+        <ComboBox label="Prompt" stopPropagation>
+          <ComboBoxItem textValue="Customer support" key="customer-support">
+            Customer support
+          </ComboBoxItem>
+          <ComboBoxItem textValue="Product summary" key="product-summary">
+            Product summary
+          </ComboBoxItem>
+        </ComboBox>
+        <TextField>
+          <Label>Description</Label>
+          <Input />
+        </TextField>
+      </Flex>
+    </View>
+  ),
 };
 
 export function Gallery() {


### PR DESCRIPTION
👾 AUTOMATED REPORT:

resolves #14282

## Summary

- preserve native browser defaults while stopping combobox events from bubbling to parent handlers
- add focused regression coverage for Tab, Shift+Tab, and isolated ArrowDown handling
- add a representative Storybook keyboard-navigation scenario

## Testing

- Real app: verified the Playground Save Prompt dialog without submitting or modifying application data; Tab moves from Prompt to Prompt Description and Shift+Tab returns to Prompt
- Demonstration: matched 1280x720 H.264 before/after app videos plus the Storybook keyboard-navigation story in combined light/dark mode
- Adversarial QA: challenged forward/reverse focus transitions, parent event isolation, native ArrowDown behavior, validation content, and state leakage after closing/reopening the dialog
- Manual verification: the AFTER artifact covers the direct Tab case; a separate agent-browser pass covers Shift+Tab, ArrowDown, and close/reopen repetition; Storybook capture covers both themes
- Checks: `make test-frontend` (1,866 passed, 12 skipped), `make typecheck-frontend`, `make lint-frontend`, pre-commit hooks, and pre-push hooks

## Usability evidence

### Playground Save Prompt

The same keystrokes type `← TAB marker` after pressing Tab. Before, it remains in the Prompt title; after, it lands in Prompt Description.

| Before | After |
| --- | --- |
| [![Play before](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14294-163a222844c3-7f6f2dc28fa6-before-contact-sheet.png)](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14294-163a222844c3-203fb4bf2bc9-before.mp4) | [![Play after](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14294-163a222844c3-e54eb0beabee-after-contact-sheet.png)](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14294-163a222844c3-3aafe31a48fa-after.mp4) |

### Storybook: Keyboard Navigation

![Keyboard navigation story after, light and dark themes](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14294-163a222844c3-0a17546acf29-core-forms-combo-box--keyboard-navigation-after__both.png)
