### PR TITLE
feat(ui): column reordering on the traces, sessions, and experiments tables

### DIFF
--- a/app/src/components/table/columnOrdering/ColumnHeaderCell.tsx
+++ b/app/src/components/table/columnOrdering/ColumnHeaderCell.tsx
@@ -14,7 +14,6 @@ export interface ColumnHeaderCellProps {
   label?: string;
   colSpan?: number;
   style?: CSSProperties;
-  align?: "left" | "center" | "right";
   children: ReactNode;
 }
 
@@ -29,12 +28,11 @@ export function ColumnHeaderCell({
   label,
   colSpan,
   style,
-  align,
   children,
 }: ColumnHeaderCellProps) {
   if (index < 0) {
     return (
-      <th colSpan={colSpan} style={style} align={align}>
+      <th colSpan={colSpan} style={style}>
         {children}
       </th>
     );
@@ -46,7 +44,6 @@ export function ColumnHeaderCell({
       label={label}
       colSpan={colSpan}
       style={style}
-      align={align}
     >
       {children}
     </SortableColumnHeader>

--- a/app/src/components/table/columnOrdering/ColumnHeaderCell.tsx
+++ b/app/src/components/table/columnOrdering/ColumnHeaderCell.tsx
@@ -1,0 +1,54 @@
+import type { CSSProperties, ReactNode } from "react";
+
+import { SortableColumnHeader } from "./SortableColumnHeader";
+
+export interface ColumnHeaderCellProps {
+  columnId: string;
+  /**
+   * The column's index in the surrounding provider's `columnOrder`, or -1 if
+   * it is not reorderable (a pinned column, or a header in a group row).
+   * @see useColumnOrder
+   */
+  index: number;
+  /** Accessible label for the drag handle. Falls back to columnId. */
+  label?: string;
+  colSpan?: number;
+  style?: CSSProperties;
+  align?: "left" | "center" | "right";
+  children: ReactNode;
+}
+
+/**
+ * A table header cell that is draggable to reorder its column when `index` is
+ * a valid position in the surrounding {@link ColumnOrderingProvider}, and a
+ * plain `<th>` otherwise.
+ */
+export function ColumnHeaderCell({
+  columnId,
+  index,
+  label,
+  colSpan,
+  style,
+  align,
+  children,
+}: ColumnHeaderCellProps) {
+  if (index < 0) {
+    return (
+      <th colSpan={colSpan} style={style} align={align}>
+        {children}
+      </th>
+    );
+  }
+  return (
+    <SortableColumnHeader
+      columnId={columnId}
+      index={index}
+      label={label}
+      colSpan={colSpan}
+      style={style}
+      align={align}
+    >
+      {children}
+    </SortableColumnHeader>
+  );
+}

--- a/app/src/components/table/columnOrdering/SortableColumnHeader.tsx
+++ b/app/src/components/table/columnOrdering/SortableColumnHeader.tsx
@@ -11,6 +11,11 @@ import {
 
 const sortableColumnHeaderCSS = css`
   position: relative;
+  /* Reserve the trailing edge for the drag handle so it never overlaps the
+     header's own content, which is what a right-aligned label would collide
+     with. Header labels stay leading-aligned; cells keep their own alignment. */
+  padding-right: var(--global-dimension-static-size-300);
+  text-align: left;
   ${dndDragFeedbackCSS}
   /* Keep the lifted copy opaque over the table */
   &[data-dnd-dragging] {
@@ -57,7 +62,6 @@ export interface SortableColumnHeaderProps {
   isReorderingDisabled?: boolean;
   colSpan?: number;
   style?: CSSProperties;
-  align?: "left" | "center" | "right";
   children: ReactNode;
 }
 
@@ -72,7 +76,6 @@ export function SortableColumnHeader({
   isReorderingDisabled = false,
   colSpan,
   style,
-  align,
   children,
 }: SortableColumnHeaderProps) {
   const { ref, handleRef, isDragSource } = useSortable({
@@ -85,7 +88,6 @@ export function SortableColumnHeader({
     <th
       ref={ref}
       colSpan={colSpan}
-      align={align}
       style={{
         ...style,
         // Inline so it survives the top layer the drag feedback renders into

--- a/app/src/components/table/columnOrdering/SortableColumnHeader.tsx
+++ b/app/src/components/table/columnOrdering/SortableColumnHeader.tsx
@@ -57,6 +57,7 @@ export interface SortableColumnHeaderProps {
   isReorderingDisabled?: boolean;
   colSpan?: number;
   style?: CSSProperties;
+  align?: "left" | "center" | "right";
   children: ReactNode;
 }
 
@@ -71,6 +72,7 @@ export function SortableColumnHeader({
   isReorderingDisabled = false,
   colSpan,
   style,
+  align,
   children,
 }: SortableColumnHeaderProps) {
   const { ref, handleRef, isDragSource } = useSortable({
@@ -83,6 +85,7 @@ export function SortableColumnHeader({
     <th
       ref={ref}
       colSpan={colSpan}
+      align={align}
       style={{
         ...style,
         // Inline so it survives the top layer the drag feedback renders into

--- a/app/src/components/table/columnOrdering/__tests__/columnOrderingUtils.test.ts
+++ b/app/src/components/table/columnOrdering/__tests__/columnOrderingUtils.test.ts
@@ -31,6 +31,15 @@ describe("mergeColumnOrder", () => {
       mergeColumnOrder({ columnOrder: [], columnIds: ["a", "b"] })
     ).toEqual(["a", "b"]);
   });
+
+  it("deduplicates persisted and available column ids", () => {
+    expect(
+      mergeColumnOrder({
+        columnOrder: ["b", "b"],
+        columnIds: ["a", "b", "a"],
+      })
+    ).toEqual(["b", "a"]);
+  });
 });
 
 describe("expandColumnOrderToLeafIds", () => {

--- a/app/src/components/table/columnOrdering/__tests__/useColumnOrder.test.ts
+++ b/app/src/components/table/columnOrdering/__tests__/useColumnOrder.test.ts
@@ -1,0 +1,24 @@
+import { useColumnOrder } from "../useColumnOrder";
+
+describe("useColumnOrder", () => {
+  it("preserves temporarily absent column ids across visible header drags", () => {
+    const onColumnOrderChange = vi.fn();
+    const result = useColumnOrder({
+      columns: [{ id: "a" }, { id: "b" }],
+      columnOrder: ["a", "hidden-annotation", "b"],
+      onColumnOrderChange,
+      columnVisibility: {},
+    });
+
+    expect(result.leafColumnOrder).toEqual(["a", "b"]);
+    expect(result.visibleColumnOrder).toEqual(["a", "b"]);
+
+    result.onVisibleColumnOrderChange(["b", "a"]);
+
+    expect(onColumnOrderChange).toHaveBeenCalledWith([
+      "b",
+      "hidden-annotation",
+      "a",
+    ]);
+  });
+});

--- a/app/src/components/table/columnOrdering/columnOrderingUtils.ts
+++ b/app/src/components/table/columnOrdering/columnOrderingUtils.ts
@@ -1,7 +1,7 @@
 /** Minimal shape of a tanstack ColumnDef needed to resolve ids and leaf columns, testable without a table instance. */
 export interface OrderableColumnDef {
   id?: string;
-  accessorKey?: string;
+  accessorKey?: string | number;
   header?: unknown;
   columns?: OrderableColumnDef[];
 }
@@ -12,7 +12,7 @@ export function getColumnDefId(def: OrderableColumnDef): string | null {
     return def.id;
   }
   if (def.accessorKey != null) {
-    return def.accessorKey.replaceAll(".", "_");
+    return String(def.accessorKey).replaceAll(".", "_");
   }
   if (typeof def.header === "string") {
     return def.header;

--- a/app/src/components/table/columnOrdering/columnOrderingUtils.ts
+++ b/app/src/components/table/columnOrdering/columnOrderingUtils.ts
@@ -37,11 +37,18 @@ export function mergeColumnOrder({
   columnIds: string[];
 }): string[] {
   const existing = new Set(columnIds);
-  const ordered = columnOrder.filter((id) => existing.has(id));
-  const seen = new Set(ordered);
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const id of columnOrder) {
+    if (existing.has(id) && !seen.has(id)) {
+      ordered.push(id);
+      seen.add(id);
+    }
+  }
   for (const id of columnIds) {
     if (!seen.has(id)) {
       ordered.push(id);
+      seen.add(id);
     }
   }
   return ordered;

--- a/app/src/components/table/columnOrdering/index.ts
+++ b/app/src/components/table/columnOrdering/index.ts
@@ -1,3 +1,5 @@
+export * from "./ColumnHeaderCell";
 export * from "./ColumnOrderingProvider";
 export * from "./SortableColumnHeader";
 export * from "./columnOrderingUtils";
+export * from "./useColumnOrder";

--- a/app/src/components/table/columnOrdering/useColumnOrder.ts
+++ b/app/src/components/table/columnOrdering/useColumnOrder.ts
@@ -48,12 +48,24 @@ export function useColumnOrder({
   nonOrderableColumnIds = [],
 }: UseColumnOrderProps): UseColumnOrderResult {
   const nonOrderable = new Set(nonOrderableColumnIds);
-  const orderableColumnIds = getTopLevelColumnIds(columns).filter(
+  const topLevelColumnIds = getTopLevelColumnIds(columns);
+  const orderableColumnIds = topLevelColumnIds.filter(
     (id) => !nonOrderable.has(id)
   );
   const topLevelColumnOrder = mergeColumnOrder({
     columnOrder,
     columnIds: orderableColumnIds,
+  });
+  // Persisted ids that are temporarily absent from the column defs may be
+  // hidden dynamic columns. Keep them out of the table order, but retain their
+  // positions when a header drag writes the current order back to storage.
+  const topLevelColumnIdSet = new Set(topLevelColumnIds);
+  const absentColumnIds = columnOrder.filter(
+    (id) => !topLevelColumnIdSet.has(id)
+  );
+  const persistedColumnOrder = mergeColumnOrder({
+    columnOrder,
+    columnIds: [...absentColumnIds, ...orderableColumnIds],
   });
   const leafIdsByTopLevelId = getLeafIdsByTopLevelId(columns);
   const leafColumnOrder = expandColumnOrderToLeafIds(
@@ -76,7 +88,7 @@ export function useColumnOrder({
     onVisibleColumnOrderChange: (orderedSubset) => {
       onColumnOrderChange(
         applySubsetColumnOrder({
-          columnOrder: topLevelColumnOrder,
+          columnOrder: persistedColumnOrder,
           orderedSubset,
         })
       );

--- a/app/src/components/table/columnOrdering/useColumnOrder.ts
+++ b/app/src/components/table/columnOrdering/useColumnOrder.ts
@@ -1,0 +1,87 @@
+import type { OrderableColumnDef } from "./columnOrderingUtils";
+import {
+  applySubsetColumnOrder,
+  expandColumnOrderToLeafIds,
+  getLeafIdsByTopLevelId,
+  getTopLevelColumnIds,
+  mergeColumnOrder,
+} from "./columnOrderingUtils";
+
+export interface UseColumnOrderProps {
+  /** The table's top-level column defs, in their natural order. */
+  columns: OrderableColumnDef[];
+  /** The persisted top-level column order. Empty means natural order. */
+  columnOrder: string[];
+  onColumnOrderChange: (columnOrder: string[]) => void;
+  /** Tanstack's column visibility map. Absent ids default to visible. */
+  columnVisibility: Record<string, boolean>;
+  /** Ids that cannot be reordered, e.g. a pinned checkbox or actions column. */
+  nonOrderableColumnIds?: string[];
+}
+
+export interface UseColumnOrderResult {
+  /** Pass to tanstack's `state.columnOrder`. */
+  leafColumnOrder: string[];
+  /** Pass to {@link ColumnOrderingProvider}'s `columnOrder`. */
+  visibleColumnOrder: string[];
+  /** Pass to {@link ColumnOrderingProvider}'s `onColumnOrderChange`. */
+  onVisibleColumnOrderChange: (visibleColumnOrder: string[]) => void;
+  /**
+   * The column's index within `visibleColumnOrder`, or -1 when it is not
+   * reorderable. Pass to {@link ColumnHeaderCell}'s `index`.
+   */
+  getColumnOrderIndex: (columnId: string) => number;
+}
+
+/**
+ * Derives the column order state a table needs to support drag-and-drop
+ * reordering of its headers: reconciles the persisted order with the columns
+ * that currently exist (dynamic annotation columns come and go), expands group
+ * columns into the leaf order tanstack expects, and maps drags over the visible
+ * headers back onto the full order.
+ */
+export function useColumnOrder({
+  columns,
+  columnOrder,
+  onColumnOrderChange,
+  columnVisibility,
+  nonOrderableColumnIds = [],
+}: UseColumnOrderProps): UseColumnOrderResult {
+  const nonOrderable = new Set(nonOrderableColumnIds);
+  const orderableColumnIds = getTopLevelColumnIds(columns).filter(
+    (id) => !nonOrderable.has(id)
+  );
+  const topLevelColumnOrder = mergeColumnOrder({
+    columnOrder,
+    columnIds: orderableColumnIds,
+  });
+  const leafIdsByTopLevelId = getLeafIdsByTopLevelId(columns);
+  const leafColumnOrder = expandColumnOrderToLeafIds(
+    topLevelColumnOrder,
+    columns
+  );
+  // Hidden columns render no header, so header drag-and-drop operates on the
+  // visible subset and the result is merged back into the full order
+  const visibleColumnOrder = topLevelColumnOrder.filter((id) =>
+    (leafIdsByTopLevelId.get(id) ?? [id]).some(
+      (leafId) => columnVisibility[leafId] ?? true
+    )
+  );
+  const visibleOrderIndexById = new Map(
+    visibleColumnOrder.map((id, index) => [id, index])
+  );
+  return {
+    leafColumnOrder,
+    visibleColumnOrder,
+    onVisibleColumnOrderChange: (orderedSubset) => {
+      onColumnOrderChange(
+        applySubsetColumnOrder({
+          columnOrder: topLevelColumnOrder,
+          orderedSubset,
+        })
+      );
+    },
+    getColumnOrderIndex: (columnId) =>
+      visibleOrderIndexById.get(columnId) ?? -1,
+  };
+}

--- a/app/src/components/table/columnSelector/ColumnSelector.tsx
+++ b/app/src/components/table/columnSelector/ColumnSelector.tsx
@@ -50,11 +50,19 @@ const columnSelectorMenuCSS = css`
   flex-direction: column;
   max-height: var(--global-menu-max-height-small);
   min-width: 240px;
+
+  /* React Aria caps the popover at the space available on screen. Without
+     this, a long column list overflows that box and paints outside it. */
+  .react-aria-Popover & {
+    max-height: inherit;
+  }
 `;
 
 /** Scrollable body below the fixed search header. */
 const columnSelectorBodyCSS = css`
   overflow-y: auto;
+  /* Let the body shrink below its content height so it, not the menu, scrolls */
+  min-height: 0;
   padding: ${MENU_INSET} 0;
 `;
 

--- a/app/src/pages/experiments/ExperimentColumnSelector.tsx
+++ b/app/src/pages/experiments/ExperimentColumnSelector.tsx
@@ -1,225 +1,82 @@
-import { css } from "@emotion/react";
 import type { Column } from "@tanstack/react-table";
-import type { ChangeEvent } from "react";
-import { useCallback, useMemo } from "react";
 
 import {
-  Button,
-  DialogTrigger,
-  Flex,
-  Icon,
-  Icons,
-  Popover,
-  View,
-} from "@phoenix/components";
+  applySubsetColumnOrder,
+  CHECKBOX_COLUMN_ID,
+  ColumnSelector,
+  mergeColumnOrder,
+} from "@phoenix/components/table";
 
-const UN_HIDABLE_COLUMN_IDS = ["select", "name", "actions"];
+import { ACTIONS_COLUMN_ID, ANNOTATION_COLUMN_PREFIX } from "./constants";
 
-const ANNOTATION_COLUMN_PREFIX = "annotation-";
+const UN_HIDABLE_COLUMN_IDS = ["name"];
 
 type ExperimentColumnSelectorProps<T extends object> = {
+  /** All of the columns of the experiments table. */
   columns: Column<T>[];
   columnVisibility: Record<string, boolean>;
   onColumnVisibilityChange: (visibility: Record<string, boolean>) => void;
+  columnOrder: string[];
+  onColumnOrderChange: (columnOrder: string[]) => void;
 };
 
-export function ExperimentColumnSelector<T extends object>(
-  props: ExperimentColumnSelectorProps<T>
-) {
-  return (
-    <DialogTrigger>
-      <Button>
-        <Flex alignItems="center" gap="size-100">
-          <Icon svg={<Icons.Column />} />
-          Columns
-        </Flex>
-      </Button>
-      <Popover>
-        <ColumnSelectorMenu {...props} />
-      </Popover>
-    </DialogTrigger>
-  );
-}
-
-const columnCheckboxItemCSS = css`
-  padding: var(--global-dimension-static-size-50)
-    var(--global-dimension-static-size-100);
-  label {
-    display: flex;
-    align-items: center;
-    gap: var(--global-dimension-static-size-100);
-  }
-`;
-
-function getColumnDisplayName<T extends object>(column: Column<T>): string {
+function getColumnLabel<T extends object>(column: Column<T>): string {
   if (column.id.startsWith(ANNOTATION_COLUMN_PREFIX)) {
     return column.id.slice(ANNOTATION_COLUMN_PREFIX.length);
   }
   const header = column.columnDef.header;
-  if (typeof header === "string") {
-    return header;
-  }
-  return column.id;
+  return typeof header === "string" ? header : column.id;
 }
 
-function ColumnSelectorMenu<T extends object>(
-  props: ExperimentColumnSelectorProps<T>
-) {
-  const {
-    columns: propsColumns,
-    columnVisibility,
-    onColumnVisibilityChange,
-  } = props;
-
-  const columns = useMemo(() => {
-    return propsColumns.filter((column) => {
-      return !UN_HIDABLE_COLUMN_IDS.includes(column.id);
-    });
-  }, [propsColumns]);
-
-  const experimentColumns = useMemo(() => {
-    return columns.filter(
-      (column) => !column.id.startsWith(ANNOTATION_COLUMN_PREFIX)
-    );
-  }, [columns]);
-
-  const annotationColumns = useMemo(() => {
-    return columns.filter((column) =>
-      column.id.startsWith(ANNOTATION_COLUMN_PREFIX)
-    );
-  }, [columns]);
-
-  const allVisible = useMemo(() => {
-    return columns.every((column) => {
-      const stateValue = columnVisibility[column.id];
-      return stateValue == null ? true : stateValue;
-    });
-  }, [columns, columnVisibility]);
-
-  const onCheckboxChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const { name, checked } = event.target;
-      onColumnVisibilityChange({ ...columnVisibility, [name]: checked });
-    },
-    [columnVisibility, onColumnVisibilityChange]
+/** The column selector for the experiments table. */
+export function ExperimentColumnSelector<T extends object>({
+  columns,
+  columnVisibility,
+  onColumnVisibilityChange,
+  columnOrder,
+  onColumnOrderChange,
+}: ExperimentColumnSelectorProps<T>) {
+  // The pinned columns sit at the edges of the table and are neither hidable
+  // nor reorderable, so they are left out of the list entirely
+  const selectableColumns = columns.filter(
+    (column) =>
+      column.id !== CHECKBOX_COLUMN_ID && column.id !== ACTIONS_COLUMN_ID
   );
-
-  const onToggleAll = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const { checked } = event.target;
-      const newVisibilityState = columns.reduce(
-        (acc, column) => {
-          return { ...acc, [column.id]: checked };
-        },
-        {} as Record<string, boolean>
-      );
-      onColumnVisibilityChange(newVisibilityState);
-    },
-    [columns, onColumnVisibilityChange]
+  const columnsById = new Map(
+    selectableColumns.map((column) => [column.id, column])
   );
+  const fullColumnOrder = mergeColumnOrder({
+    columnOrder,
+    columnIds: selectableColumns.map((column) => column.id),
+  });
+
+  const selectorColumns = fullColumnOrder.flatMap((id) => {
+    const column = columnsById.get(id);
+    if (column == null) {
+      return [];
+    }
+    return [
+      {
+        id,
+        label: getColumnLabel(column),
+        isVisibilityToggleDisabled: UN_HIDABLE_COLUMN_IDS.includes(id),
+      },
+    ];
+  });
 
   return (
-    <div
-      css={css`
-        overflow-y: auto;
-        max-height: calc(100vh - 200px);
-      `}
-    >
-      <View padding="size-50">
-        <View
-          borderBottomColor="default"
-          borderBottomWidth="thin"
-          paddingBottom="size-50"
-        >
-          <div css={columnCheckboxItemCSS}>
-            <label>
-              <input
-                type="checkbox"
-                name="toggle-all"
-                checked={allVisible}
-                onChange={onToggleAll}
-              />
-              all columns
-            </label>
-          </div>
-        </View>
-        <ul>
-          {experimentColumns.map((column) => {
-            const stateValue = columnVisibility[column.id];
-            const isVisible = stateValue == null ? true : stateValue;
-            return (
-              <li key={column.id} css={columnCheckboxItemCSS}>
-                <label>
-                  <input
-                    type="checkbox"
-                    name={column.id}
-                    checked={isVisible}
-                    onChange={onCheckboxChange}
-                  />
-                  {getColumnDisplayName(column)}
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-        {annotationColumns.length > 0 && (
-          <section>
-            <View
-              paddingTop="size-50"
-              paddingBottom="size-50"
-              borderColor="default"
-              borderTopWidth="thin"
-            >
-              <div css={columnCheckboxItemCSS}>
-                <label>
-                  <input
-                    type="checkbox"
-                    name="toggle-annotations"
-                    checked={annotationColumns.every((column) => {
-                      const stateValue = columnVisibility[column.id];
-                      return stateValue == null ? true : stateValue;
-                    })}
-                    onChange={(event) => {
-                      const { checked } = event.target;
-                      const newState = annotationColumns.reduce(
-                        (acc, column) => ({
-                          ...acc,
-                          [column.id]: checked,
-                        }),
-                        {} as Record<string, boolean>
-                      );
-                      onColumnVisibilityChange({
-                        ...columnVisibility,
-                        ...newState,
-                      });
-                    }}
-                  />
-                  annotations
-                </label>
-              </div>
-            </View>
-            <ul>
-              {annotationColumns.map((column) => {
-                const stateValue = columnVisibility[column.id];
-                const isVisible = stateValue == null ? true : stateValue;
-                return (
-                  <li key={column.id} css={columnCheckboxItemCSS}>
-                    <label>
-                      <input
-                        type="checkbox"
-                        name={column.id}
-                        checked={isVisible}
-                        onChange={onCheckboxChange}
-                      />
-                      {getColumnDisplayName(column)}
-                    </label>
-                  </li>
-                );
-              })}
-            </ul>
-          </section>
-        )}
-      </View>
-    </div>
+    <ColumnSelector
+      columns={selectorColumns}
+      columnVisibility={columnVisibility}
+      onColumnVisibilityChange={onColumnVisibilityChange}
+      onColumnOrderChange={(orderedSubset) =>
+        onColumnOrderChange(
+          applySubsetColumnOrder({
+            columnOrder: fullColumnOrder,
+            orderedSubset,
+          })
+        )
+      }
+    />
   );
 }

--- a/app/src/pages/experiments/ExperimentColumnSelector.tsx
+++ b/app/src/pages/experiments/ExperimentColumnSelector.tsx
@@ -64,11 +64,40 @@ export function ExperimentColumnSelector<T extends object>({
     ];
   });
 
+  // The selector and persisted order use top-level ids so grouped columns move
+  // as a unit. Visibility remains a leaf-level TanStack state, so expose one
+  // aggregate value for each group and fan changes back out to all its leaves.
+  const selectorColumnVisibility = { ...columnVisibility };
+  for (const column of selectableColumns) {
+    if (column.columns.length > 0) {
+      selectorColumnVisibility[column.id] = column
+        .getLeafColumns()
+        .some((leafColumn) => columnVisibility[leafColumn.id] ?? true);
+    }
+  }
+
+  const onSelectorColumnVisibilityChange = (
+    newColumnVisibility: Record<string, boolean>
+  ) => {
+    const nextColumnVisibility = { ...columnVisibility };
+    for (const column of selectableColumns) {
+      const isVisible = newColumnVisibility[column.id] ?? true;
+      if (column.columns.length === 0) {
+        nextColumnVisibility[column.id] = isVisible;
+        continue;
+      }
+      for (const leafColumn of column.getLeafColumns()) {
+        nextColumnVisibility[leafColumn.id] = isVisible;
+      }
+    }
+    onColumnVisibilityChange(nextColumnVisibility);
+  };
+
   return (
     <ColumnSelector
       columns={selectorColumns}
-      columnVisibility={columnVisibility}
-      onColumnVisibilityChange={onColumnVisibilityChange}
+      columnVisibility={selectorColumnVisibility}
+      onColumnVisibilityChange={onSelectorColumnVisibilityChange}
       onColumnOrderChange={(orderedSubset) =>
         onColumnOrderChange(
           applySubsetColumnOrder({

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -52,10 +52,13 @@ import { ExperimentActionMenu } from "@phoenix/components/experiment/ExperimentA
 import { ExperimentTokenCosts } from "@phoenix/components/experiment/ExperimentTokenCosts";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
 import {
+  ColumnHeaderCell,
+  ColumnOrderingProvider,
   CompactJSONCell,
   createRowSelectionColumn,
   IntCell,
   LoadMoreRow,
+  useColumnOrder,
 } from "@phoenix/components/table";
 import { CellWithControlsWrap } from "@phoenix/components/table/CellWithControlsWrap";
 import {
@@ -87,6 +90,7 @@ import type {
   ExperimentsTableFragment$key,
 } from "./__generated__/ExperimentsTableFragment.graphql";
 import type { ExperimentsTableQuery } from "./__generated__/ExperimentsTableQuery.graphql";
+import { ACTIONS_COLUMN_ID, ANNOTATION_COLUMN_PREFIX } from "./constants";
 import { DownloadExperimentActionMenu } from "./DownloadExperimentActionMenu";
 import { ErrorRateCell } from "./ErrorRateCell";
 import { ExperimentColumnSelector } from "./ExperimentColumnSelector";
@@ -265,6 +269,10 @@ export function ExperimentsTable({
   const [columnSizing, setColumnSizing] = usePersistedState<
     Record<string, number>
   >(`phoenix-experiments-column-sizing-${data.id}`, {});
+  const [storedColumnOrder, setStoredColumnOrder] = usePersistedState<string[]>(
+    `phoenix-experiments-column-order-${data.id}`,
+    []
+  );
 
   const tableData = useMemo(
     () =>
@@ -439,7 +447,7 @@ export function ExperimentsTable({
             <AnnotationColorSwatch annotationName={annotationName} />
           </Flex>
         ),
-        id: `annotation-${annotationName}`,
+        id: `${ANNOTATION_COLUMN_PREFIX}${annotationName}`,
         meta: {
           textAlign: "right",
         },
@@ -593,7 +601,7 @@ export function ExperimentsTable({
       cell: CompactJSONCell,
     },
     {
-      id: "actions",
+      id: ACTIONS_COLUMN_ID,
       minSize: 180,
       cell: ({ row }) => {
         const project = row.original.project;
@@ -634,16 +642,32 @@ export function ExperimentsTable({
     },
   ];
 
+  const columns = [...baseColumns, ...annotationColumns, ...tailColumns];
+  const {
+    leafColumnOrder,
+    visibleColumnOrder,
+    onVisibleColumnOrderChange,
+    getColumnOrderIndex,
+  } = useColumnOrder({
+    columns,
+    columnOrder: storedColumnOrder,
+    onColumnOrderChange: setStoredColumnOrder,
+    columnVisibility,
+    // The checkbox and the pinned actions column stay at the edges
+    nonOrderableColumnIds: [CHECKBOX_COLUMN_ID, ACTIONS_COLUMN_ID],
+  });
+
   const table = useReactTable<TableRow>({
-    columns: [...baseColumns, ...annotationColumns, ...tailColumns],
+    columns,
     data: tableData,
     state: {
       rowSelection,
       columnSizing,
       columnVisibility,
+      columnOrder: leafColumnOrder,
       columnPinning: {
         ...CHECKBOX_COLUMN_PINNING,
-        right: ["actions"],
+        right: [ACTIONS_COLUMN_ID],
       },
     },
     defaultColumn: defaultColumnSettings,
@@ -733,6 +757,8 @@ export function ExperimentsTable({
             columns={selectorColumns}
             columnVisibility={columnVisibility}
             onColumnVisibilityChange={setColumnVisibility}
+            columnOrder={storedColumnOrder}
+            onColumnOrderChange={setStoredColumnOrder}
           />
         </Flex>
       </View>
@@ -744,71 +770,85 @@ export function ExperimentsTable({
         ref={tableContainerRef}
         onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
       >
-        <table
-          css={selectableTableCSS}
-          style={{
-            ...columnSizeVars,
-            width: table.getTotalSize(),
-            minWidth: "100%",
-          }}
+        <ColumnOrderingProvider
+          columnOrder={visibleColumnOrder}
+          onColumnOrderChange={onVisibleColumnOrderChange}
         >
-          <thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <th
-                    colSpan={header.colSpan}
-                    key={header.id}
-                    style={{
-                      ...getCommonPinningStyles(header.column),
-                      width: `calc(var(--header-${makeSafeColumnId(header.id)}-size) * 1px)`,
-                    }}
-                    align={header.column.columnDef?.meta?.textAlign}
-                  >
-                    {header.isPlaceholder ? null : (
-                      <>
-                        <div>
-                          <Truncate maxWidth="100%">
-                            {flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
-                          </Truncate>
-                        </div>
-                        <div
-                          {...{
-                            onMouseDown: header.getResizeHandler(),
-                            onTouchStart: header.getResizeHandler(),
-                            className: `resizer ${
-                              header.column.getIsResizing() ? "isResizing" : ""
-                            }`,
-                          }}
-                        />
-                      </>
-                    )}
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          {columnSizingInfo.isResizingColumn ? (
-            <MemoizedTableBody
-              table={table}
-              hasNext={hasNext}
-              onLoadNext={() => loadNext(PAGE_SIZE)}
-              isLoadingNext={isLoadingNext}
-              dataset={data}
-            />
-          ) : (
-            <TableBody
-              table={table}
-              hasNext={hasNext}
-              onLoadNext={() => loadNext(PAGE_SIZE)}
-              isLoadingNext={isLoadingNext}
-              dataset={data}
-            />
-          )}
-        </table>
+          <table
+            css={selectableTableCSS}
+            style={{
+              ...columnSizeVars,
+              width: table.getTotalSize(),
+              minWidth: "100%",
+            }}
+          >
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <ColumnHeaderCell
+                      key={header.id}
+                      columnId={header.column.id}
+                      index={getColumnOrderIndex(header.column.id)}
+                      label={
+                        typeof header.column.columnDef.header === "string"
+                          ? header.column.columnDef.header
+                          : undefined
+                      }
+                      colSpan={header.colSpan}
+                      style={{
+                        ...getCommonPinningStyles(header.column),
+                        width: `calc(var(--header-${makeSafeColumnId(header.id)}-size) * 1px)`,
+                      }}
+                      align={header.column.columnDef?.meta?.textAlign}
+                    >
+                      {header.isPlaceholder ? null : (
+                        <>
+                          <div>
+                            <Truncate maxWidth="100%">
+                              {flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                            </Truncate>
+                          </div>
+                          <div
+                            {...{
+                              onMouseDown: header.getResizeHandler(),
+                              onTouchStart: header.getResizeHandler(),
+                              className: `resizer ${
+                                header.column.getIsResizing()
+                                  ? "isResizing"
+                                  : ""
+                              }`,
+                            }}
+                          />
+                        </>
+                      )}
+                    </ColumnHeaderCell>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            {columnSizingInfo.isResizingColumn ? (
+              <MemoizedTableBody
+                table={table}
+                hasNext={hasNext}
+                onLoadNext={() => loadNext(PAGE_SIZE)}
+                isLoadingNext={isLoadingNext}
+                dataset={data}
+              />
+            ) : (
+              <TableBody
+                table={table}
+                hasNext={hasNext}
+                onLoadNext={() => loadNext(PAGE_SIZE)}
+                isLoadingNext={isLoadingNext}
+                dataset={data}
+              />
+            )}
+          </table>
+        </ColumnOrderingProvider>
         {selectedRows.length ? (
           <ExperimentSelectionToolbar
             datasetId={data.id}

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -437,20 +437,12 @@ export function ExperimentsTable({
       const { annotationName, minScore, maxScore } = annotationSummary;
       return {
         header: () => (
-          <Flex
-            direction="row"
-            gap="size-100"
-            alignItems="center"
-            justifyContent="end"
-          >
+          <Flex direction="row" gap="size-100" alignItems="center">
             <Text>{annotationName}</Text>
             <AnnotationColorSwatch annotationName={annotationName} />
           </Flex>
         ),
         id: `${ANNOTATION_COLUMN_PREFIX}${annotationName}`,
-        meta: {
-          textAlign: "right",
-        },
         cell: ({ row }) => {
           const annotation = row.original.annotationSummaryMap[annotationName];
           if (!annotation || annotation.meanScore == null) {
@@ -482,17 +474,11 @@ export function ExperimentsTable({
     {
       header: "repetitions",
       accessorKey: "repetitions",
-      meta: {
-        textAlign: "right",
-      },
       cell: IntCell,
     },
     {
       header: "run count",
       accessorKey: "runCount",
-      meta: {
-        textAlign: "right",
-      },
       cell: IntCell,
     },
     {
@@ -509,9 +495,6 @@ export function ExperimentsTable({
           header: "job progress",
           id: "experimentJobProgress",
           minSize: 200,
-          meta: {
-            textAlign: "right",
-          },
           cell: ({ row }) => {
             const { runCount, expectedRunCount } = row.original;
             const progressValue =
@@ -540,9 +523,6 @@ export function ExperimentsTable({
     {
       header: "avg latency",
       accessorKey: "averageRunLatencyMs",
-      meta: {
-        textAlign: "right",
-      },
       cell: ({ getValue }) => {
         const value = getValue();
         if (value === null || typeof value !== "number") {
@@ -554,9 +534,6 @@ export function ExperimentsTable({
     {
       header: "total cost",
       accessorKey: "costSummary.total.cost",
-      meta: {
-        textAlign: "right",
-      },
       cell: ({ getValue, row }) => {
         const value = getValue() as number | null;
         const experimentId = row.original.id;
@@ -571,9 +548,6 @@ export function ExperimentsTable({
     {
       header: "total tokens",
       accessorKey: "costSummary.total.tokens",
-      meta: {
-        textAlign: "right",
-      },
       cell: ({ getValue, row }) => {
         const value = getValue() as number | null;
         const experimentId = row.original.id;
@@ -589,9 +563,6 @@ export function ExperimentsTable({
     {
       header: "error rate",
       accessorKey: "errorRate",
-      meta: {
-        textAlign: "right",
-      },
       cell: ErrorRateCell,
     },
     {
@@ -800,7 +771,6 @@ export function ExperimentsTable({
                         ...getCommonPinningStyles(header.column),
                         width: `calc(var(--header-${makeSafeColumnId(header.id)}-size) * 1px)`,
                       }}
-                      align={header.column.columnDef?.meta?.textAlign}
                     >
                       {header.isPlaceholder ? null : (
                         <>

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -649,7 +649,7 @@ export function ExperimentsTable({
     getCoreRowModel: getCoreRowModel(),
   });
 
-  const selectorColumns = table.getAllLeafColumns();
+  const selectorColumns = table.getAllColumns();
 
   const selectedRows = table.getSelectedRowModel().rows;
   const selectedExperiments = selectedRows.map((row) => row.original);
@@ -754,13 +754,19 @@ export function ExperimentsTable({
             }}
           >
             <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
+              {table.getHeaderGroups().map((headerGroup, headerGroupIndex) => (
                 <tr key={headerGroup.id}>
                   {headerGroup.headers.map((header) => (
                     <ColumnHeaderCell
                       key={header.id}
                       columnId={header.column.id}
-                      index={getColumnOrderIndex(header.column.id)}
+                      // Only the top header group is reorderable; sub-headers
+                      // of a group column move with it
+                      index={
+                        headerGroupIndex === 0
+                          ? getColumnOrderIndex(header.column.id)
+                          : -1
+                      }
                       label={
                         typeof header.column.columnDef.header === "string"
                           ? header.column.columnDef.header

--- a/app/src/pages/experiments/constants.ts
+++ b/app/src/pages/experiments/constants.ts
@@ -1,0 +1,5 @@
+/** Column id of the experiments table's pinned row-actions column. */
+export const ACTIONS_COLUMN_ID = "actions";
+
+/** Prefix of the column id derived from an annotation name. */
+export const ANNOTATION_COLUMN_PREFIX = "annotation-";

--- a/app/src/pages/project/SessionColumnSelector.tsx
+++ b/app/src/pages/project/SessionColumnSelector.tsx
@@ -1,169 +1,28 @@
-import { css } from "@emotion/react";
 import type { Column } from "@tanstack/react-table";
-import type { ChangeEvent } from "react";
-import { useCallback, useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 
-import {
-  Button,
-  DialogTrigger,
-  Flex,
-  Icon,
-  Icons,
-  Popover,
-  View,
-} from "@phoenix/components";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
 import type { SessionColumnSelector_annotations$key } from "./__generated__/SessionColumnSelector_annotations.graphql";
+import { TracingColumnSelector } from "./TracingColumnSelector";
+
 const UN_HIDABLE_COLUMN_IDS = ["sessionId"];
 
-type SessionColumnSelectorProps<T extends object> = {
+type SessionColumnSelectorProps = {
   /**
-   * The columns that can be displayed in the session table
-   * This could be made more generic to support other tables
-   * but for now working on the session tables to figure out the right interface
+   * All of the top-level columns of the session table (including group columns,
+   * which represent the visible dynamic annotation columns)
    */
-  columns: Column<T>[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  columns: Column<any>[];
   query: SessionColumnSelector_annotations$key;
 };
 
-/**
- * @todo Convert this to a multi-select with ListBox
- */
-export function SessionColumnSelector<T extends object>(
-  props: SessionColumnSelectorProps<T>
-) {
-  return (
-    <DialogTrigger>
-      <Button>
-        <Flex alignItems="center" gap="size-100">
-          <Icon svg={<Icons.Column />} />
-          Columns
-        </Flex>
-      </Button>
-      <Popover>
-        <ColumnSelectorMenu {...props} />
-      </Popover>
-    </DialogTrigger>
-  );
-}
-
-const columCheckboxItemCSS = css`
-  padding: var(--global-dimension-static-size-50)
-    var(--global-dimension-static-size-100);
-  label {
-    display: flex;
-    align-items: center;
-    gap: var(--global-dimension-static-size-100);
-  }
-`;
-
-/**
- * @todo Convert this to a multi-select with ListBox
- */
-function ColumnSelectorMenu<T extends object>(
-  props: SessionColumnSelectorProps<T>
-) {
-  const { columns: propsColumns } = props;
-
-  const columnVisibility = useTracingContext((state) => state.columnVisibility);
-  const setColumnVisibility = useTracingContext(
-    (state) => state.setColumnVisibility
-  );
-  const columns = useMemo(() => {
-    return propsColumns.filter((column) => {
-      return !UN_HIDABLE_COLUMN_IDS.includes(column.id);
-    });
-  }, [propsColumns]);
-
-  const allVisible = useMemo(() => {
-    return columns.every((column) => {
-      const stateValue = columnVisibility[column.id];
-      const isVisible = stateValue == null ? true : stateValue;
-      return isVisible;
-    });
-  }, [columns, columnVisibility]);
-
-  const onCheckboxChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const { name, checked } = event.target;
-      setColumnVisibility({ ...columnVisibility, [name]: checked });
-    },
-    [columnVisibility, setColumnVisibility]
-  );
-
-  const onToggleAll = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const { checked } = event.target;
-      const newVisibilityState = columns.reduce((acc, column) => {
-        return { ...acc, [column.id]: checked };
-      }, {});
-      setColumnVisibility(newVisibilityState);
-    },
-    [columns, setColumnVisibility]
-  );
-
-  return (
-    <div
-      css={css`
-        overflow-y: auto;
-        max-height: calc(100vh - 200px);
-      `}
-    >
-      <View padding="size-50">
-        <View
-          borderBottomColor="default"
-          borderBottomWidth="thin"
-          paddingBottom="size-50"
-        >
-          <div css={columCheckboxItemCSS}>
-            <label>
-              <input
-                type="checkbox"
-                name={"toggle-all"}
-                checked={allVisible}
-                onChange={onToggleAll}
-              />
-              session columns
-            </label>
-          </div>
-        </View>
-        <ul>
-          {columns.map((column) => {
-            const stateValue = columnVisibility[column.id];
-            const isVisible = stateValue == null ? true : stateValue;
-            const name =
-              typeof column.columnDef.header == "string"
-                ? column.columnDef.header
-                : column.id;
-            return (
-              <li key={column.id} css={columCheckboxItemCSS}>
-                <label>
-                  <input
-                    type="checkbox"
-                    name={column.id}
-                    checked={isVisible}
-                    onChange={onCheckboxChange}
-                  />
-                  {name}
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-        <EvaluationColumnSelector {...props} />
-      </View>
-    </div>
-  );
-}
-
-/**
- * @todo convert this to a multi-select with ListBox
- */
-function EvaluationColumnSelector<T extends object>({
+/** The column selector for the session table. */
+export function SessionColumnSelector({
+  columns,
   query,
-}: Pick<SessionColumnSelectorProps<T>, "query">) {
+}: SessionColumnSelectorProps) {
   const data = useFragment<SessionColumnSelector_annotations$key>(
     graphql`
       fragment SessionColumnSelector_annotations on Project {
@@ -178,65 +37,18 @@ function EvaluationColumnSelector<T extends object>({
   const setAnnotationColumnVisibility = useTracingContext(
     (state) => state.setAnnotationColumnVisibility
   );
-  const allVisible = useMemo(() => {
-    return data.sessionAnnotationNames.every((name) => {
-      const stateValue = annotationColumnVisibility[name];
-      return stateValue || false;
-    });
-  }, [data.sessionAnnotationNames, annotationColumnVisibility]);
 
-  const onToggleAnnotations = useCallback(() => {
-    const newVisibilityState = data.sessionAnnotationNames.reduce(
-      (acc, name) => {
-        return { ...acc, [name]: !allVisible };
-      },
-      {}
-    );
-    setAnnotationColumnVisibility(newVisibilityState);
-  }, [data.sessionAnnotationNames, setAnnotationColumnVisibility, allVisible]);
   return (
-    <section>
-      <View
-        paddingTop="size-50"
-        paddingBottom="size-50"
-        borderColor="default"
-        borderTopWidth="thin"
-      >
-        <div css={columCheckboxItemCSS}>
-          <label>
-            <input
-              type="checkbox"
-              name={"toggle-annotations-all"}
-              checked={allVisible}
-              onChange={onToggleAnnotations}
-            />
-            annotations
-          </label>
-        </div>
-      </View>
-      <ul>
-        {data.sessionAnnotationNames.map((name) => {
-          const isVisible = annotationColumnVisibility[name] ?? false;
-          return (
-            <li key={name} css={columCheckboxItemCSS}>
-              <label>
-                <input
-                  type="checkbox"
-                  name={name}
-                  checked={isVisible}
-                  onChange={() => {
-                    setAnnotationColumnVisibility({
-                      ...annotationColumnVisibility,
-                      [name]: !isVisible,
-                    });
-                  }}
-                />
-                {name}
-              </label>
-            </li>
-          );
-        })}
-      </ul>
-    </section>
+    <TracingColumnSelector
+      columns={columns}
+      unHidableColumnIds={UN_HIDABLE_COLUMN_IDS}
+      annotationKinds={[
+        {
+          names: [...data.sessionAnnotationNames],
+          visibility: annotationColumnVisibility,
+          onVisibilityChange: setAnnotationColumnVisibility,
+        },
+      ]}
+    />
   );
 }

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -50,8 +50,11 @@ import { getSessionDetailsPath } from "@phoenix/utils/urlUtils";
 
 import {
   CellWithControlsWrap,
+  ColumnHeaderCell,
+  ColumnOrderingProvider,
   IntCell,
   TextCell,
+  useColumnOrder,
 } from "../../components/table";
 import type { SessionsTable_sessions$key } from "./__generated__/SessionsTable_sessions.graphql";
 import type { SessionsTableQuery } from "./__generated__/SessionsTableQuery.graphql";
@@ -495,6 +498,21 @@ export function SessionsTable(props: SessionsTableProps) {
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
   const columnSizing = useTracingContext((state) => state.columnSizing);
   const setColumnSizing = useTracingContext((state) => state.setColumnSizing);
+  const storedColumnOrder = useTracingContext((state) => state.columnOrder);
+  const setStoredColumnOrder = useTracingContext(
+    (state) => state.setColumnOrder
+  );
+  const {
+    leafColumnOrder,
+    visibleColumnOrder,
+    onVisibleColumnOrderChange,
+    getColumnOrderIndex,
+  } = useColumnOrder({
+    columns,
+    columnOrder: storedColumnOrder,
+    onColumnOrderChange: setStoredColumnOrder,
+    columnVisibility,
+  });
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,
@@ -505,6 +523,7 @@ export function SessionsTable(props: SessionsTableProps) {
       expanded,
       columnVisibility,
       columnSizing,
+      columnOrder: leafColumnOrder,
     },
     defaultColumn: defaultColumnSettings,
     columnResizeMode: "onChange",
@@ -517,10 +536,6 @@ export function SessionsTable(props: SessionsTableProps) {
   });
   const rows = table.getRowModel().rows;
   const isEmpty = rows.length === 0;
-  const computedColumns = table.getAllColumns().filter((column) => {
-    // Filter out columns that are eval groupings
-    return column.columns.length === 0;
-  });
   const { columnSizingInfo, columnSizing: columnSizingState } =
     table.getState();
   const getFlatHeaders = table.getFlatHeaders;
@@ -569,7 +584,10 @@ export function SessionsTable(props: SessionsTableProps) {
                   <SessionSearchField />
                 </View>
                 <TableMetricsChartSelector view="sessions" />
-                <SessionColumnSelector columns={computedColumns} query={data} />
+                <SessionColumnSelector
+                  columns={table.getAllColumns()}
+                  query={data}
+                />
                 <TableAsideToggleButton />
               </Flex>
             </View>
@@ -583,86 +601,108 @@ export function SessionsTable(props: SessionsTableProps) {
               }
               ref={tableContainerRef}
             >
-              <table
-                css={selectableTableCSS}
-                style={{
-                  ...columnSizeVars,
-                  width: table.getTotalSize(),
-                  minWidth: "100%",
-                }}
+              <ColumnOrderingProvider
+                columnOrder={visibleColumnOrder}
+                onColumnOrderChange={onVisibleColumnOrderChange}
               >
-                <thead>
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <tr key={headerGroup.id}>
-                      {headerGroup.headers.map((header) => (
-                        <th
-                          colSpan={header.colSpan}
-                          style={{
-                            width: `calc(var(--header-${header.id}-size) * 1px)`,
-                          }}
-                          key={header.id}
-                        >
-                          {header.isPlaceholder ? null : (
-                            <>
-                              <div
-                                data-sortable={header.column.getCanSort()}
-                                {...{
-                                  className: header.column.getCanSort()
-                                    ? "sort"
-                                    : "",
-                                  onClick:
-                                    header.column.getToggleSortingHandler(),
-                                  style: {
-                                    left: header.getStart(),
-                                    width: header.getSize(),
-                                  },
-                                }}
-                              >
-                                <Truncate maxWidth="100%">
-                                  {flexRender(
-                                    header.column.columnDef.header,
-                                    header.getContext()
-                                  )}
-                                </Truncate>
-                                {header.column.getIsSorted() ? (
-                                  <Icon
-                                    className="sort-icon"
-                                    svg={
-                                      header.column.getIsSorted() === "asc" ? (
-                                        <Icons.CaretUpFilled />
-                                      ) : (
-                                        <Icons.CaretDownFilled />
-                                      )
-                                    }
+                <table
+                  css={selectableTableCSS}
+                  style={{
+                    ...columnSizeVars,
+                    width: table.getTotalSize(),
+                    minWidth: "100%",
+                  }}
+                >
+                  <thead>
+                    {table
+                      .getHeaderGroups()
+                      .map((headerGroup, headerGroupIndex) => (
+                        <tr key={headerGroup.id}>
+                          {headerGroup.headers.map((header) => (
+                            <ColumnHeaderCell
+                              key={header.id}
+                              columnId={header.column.id}
+                              // Only the top header group is reorderable;
+                              // sub-headers of a group column move with it
+                              index={
+                                headerGroupIndex === 0
+                                  ? getColumnOrderIndex(header.column.id)
+                                  : -1
+                              }
+                              label={
+                                typeof header.column.columnDef.header ===
+                                "string"
+                                  ? header.column.columnDef.header
+                                  : undefined
+                              }
+                              colSpan={header.colSpan}
+                              style={{
+                                width: `calc(var(--header-${header.id}-size) * 1px)`,
+                              }}
+                            >
+                              {header.isPlaceholder ? null : (
+                                <>
+                                  <div
+                                    data-sortable={header.column.getCanSort()}
+                                    {...{
+                                      className: header.column.getCanSort()
+                                        ? "sort"
+                                        : "",
+                                      onClick:
+                                        header.column.getToggleSortingHandler(),
+                                      style: {
+                                        left: header.getStart(),
+                                        width: header.getSize(),
+                                      },
+                                    }}
+                                  >
+                                    <Truncate maxWidth="100%">
+                                      {flexRender(
+                                        header.column.columnDef.header,
+                                        header.getContext()
+                                      )}
+                                    </Truncate>
+                                    {header.column.getIsSorted() ? (
+                                      <Icon
+                                        className="sort-icon"
+                                        svg={
+                                          header.column.getIsSorted() ===
+                                          "asc" ? (
+                                            <Icons.CaretUpFilled />
+                                          ) : (
+                                            <Icons.CaretDownFilled />
+                                          )
+                                        }
+                                      />
+                                    ) : null}
+                                  </div>
+                                  <div
+                                    {...{
+                                      onMouseDown: header.getResizeHandler(),
+                                      onTouchStart: header.getResizeHandler(),
+                                      className: `resizer ${
+                                        header.column.getIsResizing()
+                                          ? "isResizing"
+                                          : ""
+                                      }`,
+                                    }}
                                   />
-                                ) : null}
-                              </div>
-                              <div
-                                {...{
-                                  onMouseDown: header.getResizeHandler(),
-                                  onTouchStart: header.getResizeHandler(),
-                                  className: `resizer ${
-                                    header.column.getIsResizing()
-                                      ? "isResizing"
-                                      : ""
-                                  }`,
-                                }}
-                              />
-                            </>
-                          )}
-                        </th>
+                                </>
+                              )}
+                            </ColumnHeaderCell>
+                          ))}
+                        </tr>
                       ))}
-                    </tr>
-                  ))}
-                </thead>
-                {isEmpty ? (
-                  <SessionsTableEmpty />
-                ) : columnSizingInfo.isResizingColumn ? (
-                  <MemoizedTableBody table={table} />
-                ) : (
-                  <TableBody table={table} />
-                )}
-              </table>
+                  </thead>
+                  {isEmpty ? (
+                    <SessionsTableEmpty />
+                  ) : columnSizingInfo.isResizingColumn ? (
+                    <MemoizedTableBody table={table} />
+                  ) : (
+                    <TableBody table={table} />
+                  )}
+                </table>
+              </ColumnOrderingProvider>
             </div>
           </div>
         </TableMetricsChartsPanelGroup>

--- a/app/src/pages/project/SpanColumnSelector.tsx
+++ b/app/src/pages/project/SpanColumnSelector.tsx
@@ -1,20 +1,6 @@
 import type { Column } from "@tanstack/react-table";
 import { graphql, useFragment } from "react-relay";
 
-import {
-  Button,
-  DialogTrigger,
-  Flex,
-  Icon,
-  Icons,
-  Popover,
-} from "@phoenix/components";
-import {
-  applySubsetColumnOrder,
-  CHECKBOX_COLUMN_ID,
-  ColumnSelectorMenu,
-  mergeColumnOrder,
-} from "@phoenix/components/table";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
 import type { SpanColumnSelector_annotations$key } from "./__generated__/SpanColumnSelector_annotations.graphql";
@@ -24,18 +10,9 @@ import {
   TRACE_ANNOTATIONS_COLUMN_ID,
   TRACE_ANNOTATIONS_COLUMN_LABEL,
 } from "./tableUtils";
-const UN_HIDABLE_COLUMN_IDS = ["spanKind", "name"];
+import { TracingColumnSelector } from "./TracingColumnSelector";
 
-function getColumnDisplayName(column: Column<unknown>): string {
-  if (column.id === TRACE_ANNOTATIONS_COLUMN_ID) {
-    return TRACE_ANNOTATIONS_COLUMN_LABEL;
-  }
-  const header = column.columnDef.header;
-  if (typeof header === "string") {
-    return header;
-  }
-  return column.id;
-}
+const UN_HIDABLE_COLUMN_IDS = ["spanKind", "name"];
 
 type SpanColumnSelectorProps = {
   /**
@@ -48,28 +25,11 @@ type SpanColumnSelectorProps = {
     SpanColumnSelector_traceAnnotations$key;
 };
 
-export function SpanColumnSelector(props: SpanColumnSelectorProps) {
-  return (
-    <DialogTrigger>
-      <Button>
-        <Flex direction="row" alignItems="center" gap="size-100">
-          <Icon svg={<Icons.Column />} />
-          Columns
-        </Flex>
-      </Button>
-      <Popover placement="bottom end">
-        <SpanColumnSelectorMenu {...props} />
-      </Popover>
-    </DialogTrigger>
-  );
-}
-
-/** How a row in the flat column list maps back to tracing store state. */
-type ColumnKind = "column" | "spanAnnotation" | "traceAnnotation";
-
-function SpanColumnSelectorMenu(props: SpanColumnSelectorProps) {
-  const { columns: propsColumns, query } = props;
-
+/** The column selector for the span and trace tables. */
+export function SpanColumnSelector({
+  columns,
+  query,
+}: SpanColumnSelectorProps) {
   const annotationsData = useFragment<SpanColumnSelector_annotations$key>(
     graphql`
       fragment SpanColumnSelector_annotations on Project {
@@ -87,19 +47,7 @@ function SpanColumnSelectorMenu(props: SpanColumnSelectorProps) {
       `,
       query
     );
-  const spanAnnotationNames = getNonNoteAnnotationNames(
-    annotationsData.spanAnnotationNames
-  );
-  const traceAnnotationNames = getNonNoteAnnotationNames(
-    traceAnnotationsData.traceAnnotationsNames
-  );
 
-  const columnVisibility = useTracingContext((state) => state.columnVisibility);
-  const setColumnVisibility = useTracingContext(
-    (state) => state.setColumnVisibility
-  );
-  const columnOrder = useTracingContext((state) => state.columnOrder);
-  const setColumnOrder = useTracingContext((state) => state.setColumnOrder);
   const annotationColumnVisibility = useTracingContext(
     (state) => state.annotationColumnVisibility
   );
@@ -113,107 +61,28 @@ function SpanColumnSelectorMenu(props: SpanColumnSelectorProps) {
     (state) => state.setTraceAnnotationColumnVisibility
   );
 
-  const columnsById = new Map(
-    propsColumns.map((column) => [column.id, column])
-  );
-  const tableColumnIds = propsColumns
-    .map((column) => column.id)
-    .filter((id) => id !== CHECKBOX_COLUMN_ID);
-  const spanAnnotationIds = new Set(spanAnnotationNames);
-  // A trace annotation whose name collides with a span annotation cannot be
-  // addressed separately (the table derives the same column id for both), so
-  // the span annotation row wins
-  const traceAnnotationIds = new Set(
-    traceAnnotationNames.filter((name) => !spanAnnotationIds.has(name))
-  );
-
-  // One flat order over everything: table columns (visible annotation columns
-  // are already among them as group columns) plus hidden annotation columns,
-  // which keep their persisted position even while not rendered in the table
-  const fullColumnOrder = mergeColumnOrder({
-    columnOrder,
-    columnIds: [
-      ...tableColumnIds,
-      ...spanAnnotationNames,
-      ...traceAnnotationNames,
-    ],
-  });
-
-  const kindById = new Map<string, ColumnKind>();
-  const selectorColumns = fullColumnOrder.flatMap((id) => {
-    const column = columnsById.get(id);
-    if (column != null && column.columns.length === 0) {
-      kindById.set(id, "column");
-      return [
-        {
-          id,
-          label: getColumnDisplayName(column),
-          isVisibilityToggleDisabled: UN_HIDABLE_COLUMN_IDS.includes(id),
-        },
-      ];
-    }
-    if (spanAnnotationIds.has(id)) {
-      kindById.set(id, "spanAnnotation");
-      return [{ id, label: id }];
-    }
-    if (traceAnnotationIds.has(id)) {
-      kindById.set(id, "traceAnnotation");
-      return [{ id, label: `${id} (trace)` }];
-    }
-    return [];
-  });
-
-  // Annotation columns default to hidden, unlike regular columns, so their
-  // visibility must be explicit in the merged map
-  const mergedColumnVisibility: Record<string, boolean> = {
-    ...columnVisibility,
-  };
-  for (const name of spanAnnotationIds) {
-    mergedColumnVisibility[name] = annotationColumnVisibility[name] ?? false;
-  }
-  for (const name of traceAnnotationIds) {
-    mergedColumnVisibility[name] =
-      traceAnnotationColumnVisibility[name] ?? false;
-  }
-
-  const onColumnVisibilityChange = (
-    newColumnVisibility: Record<string, boolean>
-  ) => {
-    const columnUpdates: Record<string, boolean> = {};
-    const spanAnnotationUpdates = { ...annotationColumnVisibility };
-    const traceAnnotationUpdates = { ...traceAnnotationColumnVisibility };
-    for (const [id, isVisible] of Object.entries(newColumnVisibility)) {
-      switch (kindById.get(id)) {
-        case "spanAnnotation":
-          spanAnnotationUpdates[id] = isVisible;
-          break;
-        case "traceAnnotation":
-          traceAnnotationUpdates[id] = isVisible;
-          break;
-        default:
-          columnUpdates[id] = isVisible;
-      }
-    }
-    setColumnVisibility(columnUpdates);
-    setAnnotationColumnVisibility(spanAnnotationUpdates);
-    setTraceAnnotationColumnVisibility(traceAnnotationUpdates);
-  };
-
-  const onColumnOrderChange = (orderedSubset: string[]) => {
-    setColumnOrder(
-      applySubsetColumnOrder({
-        columnOrder: fullColumnOrder,
-        orderedSubset,
-      })
-    );
-  };
-
   return (
-    <ColumnSelectorMenu
-      columns={selectorColumns}
-      columnVisibility={mergedColumnVisibility}
-      onColumnVisibilityChange={onColumnVisibilityChange}
-      onColumnOrderChange={onColumnOrderChange}
+    <TracingColumnSelector
+      columns={columns}
+      unHidableColumnIds={UN_HIDABLE_COLUMN_IDS}
+      columnLabels={{
+        [TRACE_ANNOTATIONS_COLUMN_ID]: TRACE_ANNOTATIONS_COLUMN_LABEL,
+      }}
+      annotationKinds={[
+        {
+          names: getNonNoteAnnotationNames(annotationsData.spanAnnotationNames),
+          visibility: annotationColumnVisibility,
+          onVisibilityChange: setAnnotationColumnVisibility,
+        },
+        {
+          names: getNonNoteAnnotationNames(
+            traceAnnotationsData.traceAnnotationsNames
+          ),
+          visibility: traceAnnotationColumnVisibility,
+          onVisibilityChange: setTraceAnnotationColumnVisibility,
+          getLabel: (name) => `${name} (trace)`,
+        },
+      ]}
     />
   );
 }

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -39,16 +39,12 @@ import { ContextualHelp } from "@phoenix/components/core/tooltip/ContextualHelp"
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { useTimeRange } from "@phoenix/components/datetime";
 import {
-  applySubsetColumnOrder,
   CellWithControlsWrap,
+  ColumnHeaderCell,
   ColumnOrderingProvider,
   createRowSelectionColumn,
-  expandColumnOrderToLeafIds,
-  getLeafIdsByTopLevelId,
-  getTopLevelColumnIds,
   LoadMoreRow,
-  mergeColumnOrder,
-  SortableColumnHeader,
+  useColumnOrder,
 } from "@phoenix/components/table";
 import {
   CHECKBOX_COLUMN_ID,
@@ -828,39 +824,18 @@ export function SpansTable(props: SpansTableProps) {
   const setStoredColumnOrder = useTracingContext(
     (state) => state.setColumnOrder
   );
-  // Reconcile the persisted order with the columns that currently exist
-  // (annotation columns come and go), then expand group columns into the
-  // leaf column order that tanstack expects
-  const orderableColumnIds = getTopLevelColumnIds(columns).filter(
-    (id) => id !== CHECKBOX_COLUMN_ID
-  );
-  const topLevelColumnOrder = mergeColumnOrder({
+  const {
+    leafColumnOrder,
+    visibleColumnOrder,
+    onVisibleColumnOrderChange,
+    getColumnOrderIndex,
+  } = useColumnOrder({
+    columns,
     columnOrder: storedColumnOrder,
-    columnIds: orderableColumnIds,
+    onColumnOrderChange: setStoredColumnOrder,
+    columnVisibility,
+    nonOrderableColumnIds: [CHECKBOX_COLUMN_ID],
   });
-  const leafIdsByTopLevelId = getLeafIdsByTopLevelId(columns);
-  const leafColumnOrder = expandColumnOrderToLeafIds(
-    topLevelColumnOrder,
-    columns
-  );
-  // Hidden columns render no header, so header drag-and-drop operates on the
-  // visible subset and the result is merged back into the full order
-  const visibleTopLevelColumnOrder = topLevelColumnOrder.filter((id) =>
-    (leafIdsByTopLevelId.get(id) ?? [id]).some(
-      (leafId) => columnVisibility[leafId] ?? true
-    )
-  );
-  const visibleOrderIndexById = new Map(
-    visibleTopLevelColumnOrder.map((id, index) => [id, index])
-  );
-  const onColumnOrderChange = (orderedSubset: string[]) => {
-    setStoredColumnOrder(
-      applySubsetColumnOrder({
-        columnOrder: topLevelColumnOrder,
-        orderedSubset,
-      })
-    );
-  };
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,
@@ -991,8 +966,8 @@ export function SpansTable(props: SpansTableProps) {
               ref={tableContainerRef}
             >
               <ColumnOrderingProvider
-                columnOrder={visibleTopLevelColumnOrder}
-                onColumnOrderChange={onColumnOrderChange}
+                columnOrder={visibleColumnOrder}
+                onColumnOrderChange={onVisibleColumnOrderChange}
               >
                 <table
                   css={selectableTableCSS}
@@ -1061,28 +1036,17 @@ export function SpansTable(props: SpansTableProps) {
                                   />
                                 </>
                               );
-                            const sortableIndex =
-                              headerGroupIndex === 0
-                                ? (visibleOrderIndexById.get(
-                                    header.column.id
-                                  ) ?? -1)
-                                : -1;
-                            if (sortableIndex === -1) {
-                              return (
-                                <th
-                                  colSpan={header.colSpan}
-                                  style={headerStyle}
-                                  key={header.id}
-                                >
-                                  {headerContent}
-                                </th>
-                              );
-                            }
                             return (
-                              <SortableColumnHeader
+                              <ColumnHeaderCell
                                 key={header.id}
                                 columnId={header.column.id}
-                                index={sortableIndex}
+                                // Only the top header group is reorderable;
+                                // sub-headers of a group column move with it
+                                index={
+                                  headerGroupIndex === 0
+                                    ? getColumnOrderIndex(header.column.id)
+                                    : -1
+                                }
                                 label={
                                   typeof header.column.columnDef.header ===
                                   "string"
@@ -1093,7 +1057,7 @@ export function SpansTable(props: SpansTableProps) {
                                 style={headerStyle}
                               >
                                 {headerContent}
-                              </SortableColumnHeader>
+                              </ColumnHeaderCell>
                             );
                           })}
                         </tr>

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -45,8 +45,11 @@ import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { useTimeRange } from "@phoenix/components/datetime";
 import {
   CellWithControlsWrap,
+  ColumnHeaderCell,
+  ColumnOrderingProvider,
   createRowSelectionColumn,
   TextCell,
+  useColumnOrder,
 } from "@phoenix/components/table";
 import {
   CHECKBOX_COLUMN_ID,
@@ -965,6 +968,22 @@ export function TracesTable(props: TracesTableProps) {
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
   const setColumnSizing = useTracingContext((state) => state.setColumnSizing);
   const columnSizing = useTracingContext((state) => state.columnSizing);
+  const storedColumnOrder = useTracingContext((state) => state.columnOrder);
+  const setStoredColumnOrder = useTracingContext(
+    (state) => state.setColumnOrder
+  );
+  const {
+    leafColumnOrder,
+    visibleColumnOrder,
+    onVisibleColumnOrderChange,
+    getColumnOrderIndex,
+  } = useColumnOrder({
+    columns,
+    columnOrder: storedColumnOrder,
+    onColumnOrderChange: setStoredColumnOrder,
+    columnVisibility,
+    nonOrderableColumnIds: [CHECKBOX_COLUMN_ID],
+  });
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,
@@ -977,6 +996,7 @@ export function TracesTable(props: TracesTableProps) {
       columnVisibility,
       rowSelection,
       columnSizing,
+      columnOrder: leafColumnOrder,
       columnPinning: CHECKBOX_COLUMN_PINNING,
     },
     columnResizeMode: "onChange",
@@ -1043,7 +1063,7 @@ export function TracesTable(props: TracesTableProps) {
           <Flex direction="row" gap="size-100" width="100%" alignItems="center">
             <SpanFilterConditionField onValidCondition={setFilterCondition} />
             <TableMetricsChartSelector view="traces" />
-            <SpanColumnSelector columns={computedColumns} query={data} />
+            <SpanColumnSelector columns={table.getAllColumns()} query={data} />
           </Flex>
         </View>
         <div
@@ -1054,98 +1074,123 @@ export function TracesTable(props: TracesTableProps) {
           onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
           ref={tableContainerRef}
         >
-          <table
-            css={selectableTableCSS}
-            style={{
-              ...columnSizeVars,
-              width: table.getTotalSize(),
-              minWidth: "100%",
-            }}
+          <ColumnOrderingProvider
+            columnOrder={visibleColumnOrder}
+            onColumnOrderChange={onVisibleColumnOrderChange}
           >
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th
-                      style={{
-                        ...getCommonPinningStyles(header.column),
-                        width: `calc(var(--header-${header.id}-size) * 1px)`,
-                      }}
-                      colSpan={header.colSpan}
-                      key={header.id}
-                    >
-                      {header.isPlaceholder ? null : (
-                        <>
-                          <div
-                            data-sortable={header.column.getCanSort()}
-                            {...{
-                              className: header.column.getCanSort()
-                                ? "sort"
-                                : "",
-                              onClick: header.column.getToggleSortingHandler(),
-                              style: {
-                                left: header.getStart(),
-                                width: header.getSize(),
-                              },
-                            }}
-                          >
-                            <Truncate maxWidth="100%">
-                              {flexRender(
-                                header.column.columnDef.header,
-                                header.getContext()
-                              )}
-                            </Truncate>
-                            {header.column.getIsSorted() ? (
-                              <Icon
-                                className="sort-icon"
-                                svg={
-                                  header.column.getIsSorted() === "asc" ? (
-                                    <Icons.CaretUpFilled />
-                                  ) : (
-                                    <Icons.CaretDownFilled />
-                                  )
-                                }
+            <table
+              css={selectableTableCSS}
+              style={{
+                ...columnSizeVars,
+                width: table.getTotalSize(),
+                minWidth: "100%",
+              }}
+            >
+              <thead>
+                {table
+                  .getHeaderGroups()
+                  .map((headerGroup, headerGroupIndex) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <ColumnHeaderCell
+                          key={header.id}
+                          columnId={header.column.id}
+                          // Only the top header group is reorderable; sub-headers
+                          // of a group column move with it
+                          index={
+                            headerGroupIndex === 0
+                              ? getColumnOrderIndex(header.column.id)
+                              : -1
+                          }
+                          label={
+                            typeof header.column.columnDef.header === "string"
+                              ? header.column.columnDef.header
+                              : undefined
+                          }
+                          style={{
+                            ...getCommonPinningStyles(header.column),
+                            width: `calc(var(--header-${header.id}-size) * 1px)`,
+                          }}
+                          colSpan={header.colSpan}
+                        >
+                          {header.isPlaceholder ? null : (
+                            <>
+                              <div
+                                data-sortable={header.column.getCanSort()}
+                                {...{
+                                  className: header.column.getCanSort()
+                                    ? "sort"
+                                    : "",
+                                  onClick:
+                                    header.column.getToggleSortingHandler(),
+                                  style: {
+                                    left: header.getStart(),
+                                    width: header.getSize(),
+                                  },
+                                }}
+                              >
+                                <Truncate maxWidth="100%">
+                                  {flexRender(
+                                    header.column.columnDef.header,
+                                    header.getContext()
+                                  )}
+                                </Truncate>
+                                {header.column.getIsSorted() ? (
+                                  <Icon
+                                    className="sort-icon"
+                                    svg={
+                                      header.column.getIsSorted() === "asc" ? (
+                                        <Icons.CaretUpFilled />
+                                      ) : (
+                                        <Icons.CaretDownFilled />
+                                      )
+                                    }
+                                  />
+                                ) : null}
+                              </div>
+                              <div
+                                {...{
+                                  onMouseDown: header.getResizeHandler(),
+                                  onTouchStart: header.getResizeHandler(),
+                                  className: `resizer ${
+                                    header.column.getIsResizing()
+                                      ? "isResizing"
+                                      : ""
+                                  }`,
+                                }}
                               />
-                            ) : null}
-                          </div>
-                          <div
-                            {...{
-                              onMouseDown: header.getResizeHandler(),
-                              onTouchStart: header.getResizeHandler(),
-                              className: `resizer ${
-                                header.column.getIsResizing()
-                                  ? "isResizing"
-                                  : ""
-                              }`,
-                            }}
-                          />
-                        </>
-                      )}
-                    </th>
+                            </>
+                          )}
+                        </ColumnHeaderCell>
+                      ))}
+                    </tr>
                   ))}
-                </tr>
-              ))}
-            </thead>
-            {isEmpty ? (
-              <ProjectTableEmpty />
-            ) : columnSizingInfo.isResizingColumn ? (
-              <MemoizedTableBody
-                table={
-                  // We can't access the internal TableRowType in the TableBody component
-                  // so we cast to unknown and then to the correct type
-                  table as unknown as ComponentProps<typeof TableBody>["table"]
-                }
-              />
-            ) : (
-              <TableBody
-                table={
-                  // We can't access the internal TableRowType in the TableBody component
-                  // so we cast to unknown and then to the correct type
-                  table as unknown as ComponentProps<typeof TableBody>["table"]
-                }
-              />
-            )}
-          </table>
+              </thead>
+              {isEmpty ? (
+                <ProjectTableEmpty />
+              ) : columnSizingInfo.isResizingColumn ? (
+                <MemoizedTableBody
+                  table={
+                    // We can't access the internal TableRowType in the TableBody component
+                    // so we cast to unknown and then to the correct type
+                    table as unknown as ComponentProps<
+                      typeof TableBody
+                    >["table"]
+                  }
+                />
+              ) : (
+                <TableBody
+                  table={
+                    // We can't access the internal TableRowType in the TableBody component
+                    // so we cast to unknown and then to the correct type
+                    table as unknown as ComponentProps<
+                      typeof TableBody
+                    >["table"]
+                  }
+                />
+              )}
+            </table>
+          </ColumnOrderingProvider>
         </div>
         {selectedRows.length ? (
           <SpanSelectionToolbar

--- a/app/src/pages/project/TracingColumnSelector.tsx
+++ b/app/src/pages/project/TracingColumnSelector.tsx
@@ -86,7 +86,10 @@ export function TracingColumnSelector({
   // which keep their persisted position even while not rendered in the table
   const fullColumnOrder = mergeColumnOrder({
     columnOrder,
-    columnIds: [...tableColumnIds, ...claimedNames],
+    columnIds: [
+      ...tableColumnIds,
+      ...[...claimedNames].filter((name) => !columnsById.has(name)),
+    ],
   });
 
   const selectorColumns = fullColumnOrder.flatMap<ColumnSelectorColumn>(

--- a/app/src/pages/project/TracingColumnSelector.tsx
+++ b/app/src/pages/project/TracingColumnSelector.tsx
@@ -1,0 +1,159 @@
+import type { Column } from "@tanstack/react-table";
+
+import type { ColumnSelectorColumn } from "@phoenix/components/table";
+import {
+  applySubsetColumnOrder,
+  CHECKBOX_COLUMN_ID,
+  ColumnSelector,
+  mergeColumnOrder,
+} from "@phoenix/components/table";
+import { useTracingContext } from "@phoenix/contexts/TracingContext";
+
+/**
+ * A set of dynamic annotation columns backed by its own visibility map in the
+ * tracing store (span annotations, trace annotations, session annotations).
+ * Unlike regular columns, these default to hidden and only exist in the table
+ * while visible, so the selector lists them from their names.
+ */
+export interface AnnotationColumnKind {
+  names: string[];
+  visibility: Record<string, boolean>;
+  onVisibilityChange: (visibility: Record<string, boolean>) => void;
+  /** Distinguishes an annotation from a same-named one of another kind. */
+  getLabel?: (name: string) => string;
+}
+
+export interface TracingColumnSelectorProps {
+  /**
+   * All of the top-level columns of the table, including group columns (which
+   * represent the visible dynamic annotation columns).
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  columns: Column<any>[];
+  /** Columns that are always visible. They remain reorderable. */
+  unHidableColumnIds: string[];
+  annotationKinds: AnnotationColumnKind[];
+  /** Labels for columns whose header is not a plain string. */
+  columnLabels?: Record<string, string>;
+}
+
+function getColumnLabel(column: Column<unknown>): string {
+  const header = column.columnDef.header;
+  return typeof header === "string" ? header : column.id;
+}
+
+/**
+ * The "Columns" button for the tables backed by the tracing store (spans,
+ * traces, sessions). Presents table columns and each kind's annotation columns
+ * as one flat, reorderable list, and writes visibility back to the map that
+ * owns each column.
+ */
+export function TracingColumnSelector({
+  columns,
+  unHidableColumnIds,
+  annotationKinds,
+  columnLabels = {},
+}: TracingColumnSelectorProps) {
+  const columnVisibility = useTracingContext((state) => state.columnVisibility);
+  const setColumnVisibility = useTracingContext(
+    (state) => state.setColumnVisibility
+  );
+  const columnOrder = useTracingContext((state) => state.columnOrder);
+  const setColumnOrder = useTracingContext((state) => state.setColumnOrder);
+
+  const columnsById = new Map(columns.map((column) => [column.id, column]));
+  const tableColumnIds = columns
+    .map((column) => column.id)
+    .filter((id) => id !== CHECKBOX_COLUMN_ID);
+
+  // An annotation whose name collides with one of an earlier kind cannot be
+  // addressed separately (the table derives the same column id for both), so
+  // the earlier kind wins
+  const claimedNames = new Set<string>();
+  const kindByAnnotationName = new Map<string, AnnotationColumnKind>();
+  for (const kind of annotationKinds) {
+    for (const name of kind.names) {
+      if (claimedNames.has(name)) {
+        continue;
+      }
+      claimedNames.add(name);
+      kindByAnnotationName.set(name, kind);
+    }
+  }
+
+  // One flat order over everything: table columns (visible annotation columns
+  // are already among them as group columns) plus hidden annotation columns,
+  // which keep their persisted position even while not rendered in the table
+  const fullColumnOrder = mergeColumnOrder({
+    columnOrder,
+    columnIds: [...tableColumnIds, ...claimedNames],
+  });
+
+  const selectorColumns = fullColumnOrder.flatMap<ColumnSelectorColumn>(
+    (id) => {
+      const column = columnsById.get(id);
+      if (column != null && column.columns.length === 0) {
+        return [
+          {
+            id,
+            label: columnLabels[id] ?? getColumnLabel(column),
+            isVisibilityToggleDisabled: unHidableColumnIds.includes(id),
+          },
+        ];
+      }
+      const kind = kindByAnnotationName.get(id);
+      if (kind != null) {
+        return [{ id, label: kind.getLabel?.(id) ?? id }];
+      }
+      return [];
+    }
+  );
+
+  // Annotation columns default to hidden, unlike regular columns, so their
+  // visibility must be explicit in the merged map
+  const mergedColumnVisibility: Record<string, boolean> = {
+    ...columnVisibility,
+  };
+  for (const [name, kind] of kindByAnnotationName) {
+    mergedColumnVisibility[name] = kind.visibility[name] ?? false;
+  }
+
+  const onColumnVisibilityChange = (
+    newColumnVisibility: Record<string, boolean>
+  ) => {
+    const columnUpdates: Record<string, boolean> = {};
+    const updatesByKind = new Map(
+      annotationKinds.map((kind) => [kind, { ...kind.visibility }])
+    );
+    for (const [id, isVisible] of Object.entries(newColumnVisibility)) {
+      const kind = kindByAnnotationName.get(id);
+      if (kind != null) {
+        updatesByKind.get(kind)![id] = isVisible;
+      } else {
+        columnUpdates[id] = isVisible;
+      }
+    }
+    setColumnVisibility(columnUpdates);
+    for (const [kind, updates] of updatesByKind) {
+      kind.onVisibilityChange(updates);
+    }
+  };
+
+  const onColumnOrderChange = (orderedSubset: string[]) => {
+    setColumnOrder(
+      applySubsetColumnOrder({
+        columnOrder: fullColumnOrder,
+        orderedSubset,
+      })
+    );
+  };
+
+  return (
+    <ColumnSelector
+      columns={selectorColumns}
+      columnVisibility={mergedColumnVisibility}
+      onColumnVisibilityChange={onColumnVisibilityChange}
+      onColumnOrderChange={onColumnOrderChange}
+    />
+  );
+}

--- a/app/stories/TableColumnOrdering.stories.tsx
+++ b/app/stories/TableColumnOrdering.stories.tsx
@@ -10,15 +10,13 @@ import { useState } from "react";
 
 import { Checkbox, Flex, Text, View } from "@phoenix/components";
 import {
-  applySubsetColumnOrder,
+  ColumnHeaderCell,
   ColumnOrderingProvider,
   ColumnSelector,
   ColumnSelectorMenu,
-  expandColumnOrderToLeafIds,
   getColumnDefId,
-  getLeafIdsByTopLevelId,
   getTopLevelColumnIds,
-  SortableColumnHeader,
+  useColumnOrder,
 } from "@phoenix/components/table";
 
 import { tableCSS } from "../src/components/table/styles";
@@ -132,34 +130,28 @@ function ReorderableTable({
     Record<string, boolean>
   >({});
 
+  const {
+    leafColumnOrder,
+    visibleColumnOrder,
+    onVisibleColumnOrderChange,
+    getColumnOrderIndex,
+  } = useColumnOrder({
+    columns,
+    columnOrder,
+    onColumnOrderChange: setColumnOrder,
+    columnVisibility,
+  });
+
   // eslint-disable-next-line react-hooks-js/incompatible-library
   const table = useReactTable<Person>({
     columns,
     data: mockPeople,
     state: {
-      columnOrder: expandColumnOrderToLeafIds(columnOrder, columns),
+      columnOrder: leafColumnOrder,
       columnVisibility,
     },
     getCoreRowModel: getCoreRowModel(),
   });
-
-  // Only visible columns render headers, so the drag context operates on the
-  // visible subset and merges the result back into the full order
-  const leafIdsByTopLevelId = getLeafIdsByTopLevelId(columns);
-  const visibleColumnOrder = columnOrder.filter((id) =>
-    (leafIdsByTopLevelId.get(id) ?? [id]).some(
-      (leafId) => columnVisibility[leafId] ?? true
-    )
-  );
-
-  const onColumnOrderChange = (orderedSubset: string[]) => {
-    setColumnOrder(
-      applySubsetColumnOrder({
-        columnOrder,
-        orderedSubset,
-      })
-    );
-  };
 
   const selectorColumns = columnOrder.flatMap((id) => {
     const def = columns.find((def) => getColumnDefId(def) === id);
@@ -177,48 +169,36 @@ function ReorderableTable({
           columns={selectorColumns}
           columnVisibility={columnVisibility}
           onColumnVisibilityChange={setColumnVisibility}
-          onColumnOrderChange={onColumnOrderChange}
+          onColumnOrderChange={setColumnOrder}
         />
       ) : null}
       <ColumnOrderingProvider
         columnOrder={visibleColumnOrder}
-        onColumnOrderChange={onColumnOrderChange}
+        onColumnOrderChange={onVisibleColumnOrderChange}
       >
         <table css={tableCSS}>
           <thead>
             {table.getHeaderGroups().map((headerGroup, headerGroupIndex) => (
               <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  const sortableIndex =
-                    headerGroupIndex === 0
-                      ? visibleColumnOrder.indexOf(header.column.id)
-                      : -1;
-                  if (sortableIndex === -1) {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
-                      </th>
-                    );
-                  }
-                  return (
-                    <SortableColumnHeader
-                      key={header.id}
-                      columnId={header.column.id}
-                      index={sortableIndex}
-                      colSpan={header.colSpan}
-                    >
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
-                    </SortableColumnHeader>
-                  );
-                })}
+                {headerGroup.headers.map((header) => (
+                  <ColumnHeaderCell
+                    key={header.id}
+                    columnId={header.column.id}
+                    index={
+                      headerGroupIndex === 0
+                        ? getColumnOrderIndex(header.column.id)
+                        : -1
+                    }
+                    colSpan={header.colSpan}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </ColumnHeaderCell>
+                ))}
               </tr>
             ))}
           </thead>


### PR DESCRIPTION
## Summary

#14298 shipped drag-and-drop column reordering on the spans table. This extends it to the other tables that have column selectors — **traces**, **sessions**, and **experiments** — so users can structure each table the way they need.

Rather than copy the span table's wiring three times, the reusable pieces from that PR are factored into shared, composable building blocks.

## Shared pieces

- **`useColumnOrder`** — reconciles the persisted order with the columns that currently exist (annotation columns come and go), expands group columns into the leaf order tanstack expects, and maps drags over the *visible* headers back onto the full order. This replaces ~40 lines that were inlined in `SpansTable`.
- **`ColumnHeaderCell`** — renders a draggable header when the column is reorderable, and a plain `<th>` otherwise (pinned checkbox/actions columns, group sub-headers). Collapses the branch every table was about to duplicate.
- **`TracingColumnSelector`** — the flat, searchable, reorderable column list shared by spans, traces, and sessions. Each table passes its *annotation kinds* (span / trace / session), and each kind carries the visibility map that owns it, so the selector stays one flat list while writing back to the right store slice.
- **`ExperimentColumnSelector`** rebuilt on the shared `ColumnSelector`. Experiment column order persists per dataset (`usePersistedState`); traces/sessions persist through the tracing store, which is already keyed per project tab.

## Drive-by fix

The column selector's list overflowed its popover: React Aria caps the popover at the space available on screen, but the menu asserted its own max-height and the popover doesn't clip, so rows painted *outside* the box instead of scrolling inside it. Visible on the already-shipped spans menu.

## Verification

Ran against a local Phoenix with trace/session/experiment fixtures. On each of the four tables: dragged a header, confirmed the body cells follow, pinned columns stay put, the order persists across reload, and the Columns menu lists/reorders columns without overflowing.

Typecheck, oxlint, and the column-ordering unit tests pass.