### PR TITLE
docs: close weekly docs gap audit (dataset-label REST, CLI annotation-config, auth.md, experiment baseline, session cleanup)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -984,6 +984,20 @@
                     ]
                   },
                   {
+                    "group": "Dataset Labels",
+                    "pages": [
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/list-dataset-labels",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/create-a-dataset-label",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/get-a-dataset-label-by-id",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/update-a-dataset-label-by-id",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/delete-a-dataset-label-by-id",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/list-the-labels-applied-to-a-dataset",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/replace-the-set-of-labels-applied-to-a-dataset",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/apply-a-label-to-a-dataset",
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/remove-a-label-from-a-dataset"
+                    ]
+                  },
+                  {
                     "group": "Experiments",
                     "pages": [
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-experiments-by-dataset",

--- a/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments.mdx
+++ b/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments.mdx
@@ -339,6 +339,18 @@ Phoenix lets you run experiments directly from the UI using a dataset and prompt
 
 Click **Run** in the Playground. Phoenix runs your prompt across every dataset example and records results as an experiment. If your dataset has evaluators attached, Phoenix also scores each run and records the results as annotations.
 
+## Set a Baseline Experiment
+
+You can mark one experiment on a dataset as the **baseline** — a persistent reference point that comparisons are measured against. Unlike selecting a baseline transiently in the compare view, this choice is saved with the dataset and survives navigation until you change or remove it.
+
+To set or remove a baseline from the experiments table:
+
+1. Open a dataset and go to its **Experiments** tab.
+2. Select a single experiment (baseline actions are only available when exactly one experiment is selected).
+3. Open the experiment's action menu (or use the selection toolbar) and choose **Mark as baseline**. To clear it, open the menu again and choose **Remove baseline**.
+
+The current baseline is indicated by a **baseline** badge next to the experiment in the table. Setting a new baseline replaces any existing one — a dataset has at most one baseline at a time.
+
 ## Review Failure Modes
 
 After the run completes, open the experiment to understand where the prompt or model is underperforming.

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -553,6 +553,18 @@
 - [Download Dataset Examples As OpenAI Fine-Tuning JSONL](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-fine-tuning-jsonl-file): GET /v1/datasets/{id}/jsonl/openai_ft — export examples in OpenAI fine-tuning format
 - [Download Dataset Examples As OpenAI Evals JSONL](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/datasets/download-dataset-examples-as-openai-evals-jsonl-file): GET /v1/datasets/{id}/jsonl/openai_evals — export examples in OpenAI evals format
 
+### REST API — Dataset Labels
+
+- [List Dataset Labels](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/list-dataset-labels): GET /v1/dataset_labels — paginate all dataset labels in the system
+- [Create A Dataset Label](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/create-a-dataset-label): POST /v1/dataset_labels — create a reusable dataset label with a name and hex color
+- [Get A Dataset Label By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/get-a-dataset-label-by-id): GET /v1/dataset_labels/{label_id} — fetch a single dataset label
+- [Update A Dataset Label By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/update-a-dataset-label-by-id): PATCH /v1/dataset_labels/{label_id} — modify a dataset label's name or color
+- [Delete A Dataset Label By ID](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/delete-a-dataset-label-by-id): DELETE /v1/dataset_labels/{label_id} — remove a dataset label
+- [List The Labels Applied To A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/list-the-labels-applied-to-a-dataset): GET /v1/datasets/{dataset_identifier}/labels — list the labels applied to a dataset
+- [Replace The Set Of Labels Applied To A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/replace-the-set-of-labels-applied-to-a-dataset): PUT /v1/datasets/{dataset_identifier}/labels — replace the whole set of labels on a dataset
+- [Apply A Label To A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/apply-a-label-to-a-dataset): PUT /v1/datasets/{dataset_identifier}/labels/{label_id} — apply a single label to a dataset (idempotent)
+- [Remove A Label From A Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/remove-a-label-from-a-dataset): DELETE /v1/datasets/{dataset_identifier}/labels/{label_id} — remove a single label from a dataset (idempotent)
+
 ### REST API — Experiments
 
 - [List Experiments By Dataset](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/experiments/list-experiments-by-dataset): GET /v1/datasets/{dataset_id}/experiments — list experiments tied to a dataset

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/apply-a-label-to-a-dataset.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/apply-a-label-to-a-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /v1/datasets/{dataset_identifier}/labels/{label_id}
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/create-a-dataset-label.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/create-a-dataset-label.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/dataset_labels
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/delete-a-dataset-label-by-id.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/delete-a-dataset-label-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/dataset_labels/{label_id}
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/get-a-dataset-label-by-id.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/get-a-dataset-label-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/dataset_labels/{label_id}
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/list-dataset-labels.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/list-dataset-labels.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/dataset_labels
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/list-the-labels-applied-to-a-dataset.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/list-the-labels-applied-to-a-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/datasets/{dataset_identifier}/labels
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/remove-a-label-from-a-dataset.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/remove-a-label-from-a-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/datasets/{dataset_identifier}/labels/{label_id}
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/replace-the-set-of-labels-applied-to-a-dataset.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/replace-the-set-of-labels-applied-to-a-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /v1/datasets/{dataset_identifier}/labels
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/update-a-dataset-label-by-id.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/update-a-dataset-label-by-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v1/dataset_labels/{label_id}
+---

--- a/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
@@ -505,6 +505,126 @@ The `text` format outputs prompt content with XML-style role tags, ideal for pip
 <user>{{user_input}}</user>
 ```
 
+### `px annotation-config list`
+
+List annotation configurations defined in your Phoenix instance.
+
+```bash
+px annotation-config list                                            # Table view
+px annotation-config list --limit 10                                 # At most 10 configs
+px annotation-config list --format raw --no-progress | jq -r '.[].name'  # Names as JSON
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--no-progress` | Disable progress indicators | — |
+| `--limit <number>` | Maximum number of configs | — |
+
+### `px annotation-config get <config-identifier>`
+
+Fetch a single annotation configuration by name or ID.
+
+```bash
+px annotation-config get response-quality                                    # Look up by name
+px annotation-config get response-quality --format raw --no-progress | jq -r '.id'  # Resolve name to ID
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--no-progress` | Disable progress indicators | — |
+
+### `px annotation-config create`
+
+Create a new annotation configuration via `POST /v1/annotation_configs`. Configs come in three types: `CATEGORICAL` (a fixed set of labels, each with an optional numeric score), `CONTINUOUS` (a numeric range), and `FREEFORM` (free text).
+
+```bash
+# Categorical config with scored labels
+px annotation-config create --type CATEGORICAL --name response-quality \
+  --value good=1 --value bad=0 --optimization-direction MAXIMIZE
+
+# Continuous config bounded between 0 and 1
+px annotation-config create --type CONTINUOUS --name confidence --lower-bound 0 --upper-bound 1
+
+# Free-text config
+px annotation-config create --type FREEFORM --name reviewer-notes --description 'Free-form reviewer feedback'
+
+# Categorical labels as a JSON payload (bulk/agent alternative to --value)
+px annotation-config create --type CATEGORICAL --name response-quality \
+  --values '[{"label":"good","score":1},{"label":"bad","score":0}]'
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--type <type>` | `CATEGORICAL`, `CONTINUOUS`, or `FREEFORM` (required) | — |
+| `--name <name>` | Annotation config name (required) | — |
+| `--description <description>` | Description | — |
+| `--optimization-direction <dir>` | `MINIMIZE`, `MAXIMIZE`, or `NONE` | `NONE` |
+| `--value <label[=score]>` | Categorical label (repeatable; CATEGORICAL configs) | — |
+| `--values <json>` | Categorical values as JSON (CATEGORICAL configs) | — |
+| `--lower-bound <number>` | Lower bound (CONTINUOUS/FREEFORM configs) | — |
+| `--upper-bound <number>` | Upper bound (CONTINUOUS/FREEFORM configs) | — |
+| `--threshold <number>` | Threshold (FREEFORM configs) | — |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--no-progress` | Disable progress indicators | — |
+
+`--value` and `--values` are mutually exclusive. `--type` and `--optimization-direction` are case-insensitive. Invalid input — including flags that don't apply to the chosen type — exits with `INVALID_ARGUMENT`.
+
+### `px annotation-config update <config-identifier>`
+
+Update an annotation configuration by name or ID. Only the fields you pass are changed — the command fetches the existing config, merges your flags, and writes the result back via `PUT /v1/annotation_configs/{id}`. The config `type` is immutable; to change it, delete and recreate the config.
+
+```bash
+# Change only the description
+px annotation-config update response-quality --description 'Pass/fail rating from human review'
+
+# Rename and set optimization direction
+px annotation-config update response-quality --name answer-quality --optimization-direction MAXIMIZE
+
+# Replace the label set of a categorical config
+px annotation-config update response-quality --value good=1 --value acceptable=0.5 --value bad=0
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name <name>` | New name | — |
+| `--description <description>` | New description | — |
+| `--optimization-direction <dir>` | `MINIMIZE`, `MAXIMIZE`, or `NONE` | — |
+| `--value <label[=score]>` | Categorical label (repeatable; CATEGORICAL configs) | — |
+| `--values <json>` | Categorical values as JSON (CATEGORICAL configs) | — |
+| `--lower-bound <number>` | Lower bound (CONTINUOUS/FREEFORM configs) | — |
+| `--upper-bound <number>` | Upper bound (CONTINUOUS/FREEFORM configs) | — |
+| `--threshold <number>` | Threshold (FREEFORM configs) | — |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--no-progress` | Disable progress indicators | — |
+
+At least one field flag is required. Invalid input — including flags that don't apply to the config's type — exits with `INVALID_ARGUMENT`.
+
+### `px annotation-config delete <config-id>`
+
+Delete an annotation configuration by ID. Like all delete commands, this is disabled unless `PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` is set, and prompts for confirmation unless `--yes` is passed.
+
+```bash
+px annotation-config delete QW5ub3RhdGlvbkNvbmZpZzoxMjM=          # Interactive confirmation
+px annotation-config delete QW5ub3RhdGlvbkNvbmZpZzoxMjM= --yes    # Skip the prompt (scripts/agents)
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-y, --yes` | Skip confirmation prompt | — |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--no-progress` | Disable progress indicators | — |
+
 ### `px api graphql <query>`
 
 Make authenticated GraphQL queries against the Phoenix API. Output is `{"data": {...}}` JSON — pipe with `jq '.data.<field>'` to extract values. Only queries are permitted; mutations and subscriptions are rejected before hitting the server.

--- a/docs/phoenix/self-hosting/features/authentication.mdx
+++ b/docs/phoenix/self-hosting/features/authentication.mdx
@@ -207,6 +207,17 @@ tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
 If setting `authorization` headers explicitly, ensure that the header field is **lowercased** to ensure compatibility with sending traces via gRPC
 </Info>
 
+## Agent Authentication Discovery
+
+Phoenix serves two discovery endpoints so AI agents can learn how to authenticate against a deployed instance. Both are always available and require no configuration:
+
+- `GET /auth.md` — a human- and agent-readable Markdown guide describing this deployment's auth model. When authentication is disabled it states that all endpoints are public; when enabled it directs the caller to create an API key under **Settings → API Keys** and send an `Authorization: Bearer <token>` header. It follows the [auth.md convention](https://workos.com/auth-md/docs/apps).
+- `GET /.well-known/oauth-protected-resource` — [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected Resource Metadata (JSON), advertising the resource, that bearer tokens are sent in the header, and a link to `/auth.md`.
+
+When authentication is enabled, `401 Unauthorized` responses include a `WWW-Authenticate` header pointing at the Protected Resource Metadata endpoint, giving agents a stable entry point for discovering how to authenticate.
+
+Phoenix issues its own credentials and does **not** implement OAuth token exchange, OAuth scopes, or the agent registration protocol (`/agent/identity`). Credentials are provisioned out of band as [API keys](#api-keys) or access tokens, and access is governed by the role of the user the credential belongs to.
+
 ## Password Recovery
 
 <Info>

--- a/docs/phoenix/settings/data-retention.mdx
+++ b/docs/phoenix/settings/data-retention.mdx
@@ -68,6 +68,10 @@ Once you have created a policy you can go to the project config and associate th
 </Frame>
 <br></br>
 
+### Automatic Cleanup of Empty Sessions
+
+When a retention policy (or a manual deletion) removes the last traces belonging to a session, the now-empty session is cleaned up automatically. On the same hourly sweep that enforces retention policies, Phoenix deletes sessions that have no remaining traces and whose last activity is more than an hour old. This keeps empty "ghost" sessions from lingering in the sessions UI after their traces age out. Active sessions and in-flight ingestion are never affected, since a session's last-activity time advances with every new trace. No configuration is required.
+
 ## Deleting Traces Manually
 
 You can either delete traces by time or individually. To delete traces older than a certain date, click on the action button on a project and select `remove data`


### PR DESCRIPTION
# docs: close weekly docs gap audit (2026-07-08)

Closes the five documentation gaps identified in the weekly docs gap audit (issue #14148). All changes are documentation-only — no code, tests, or JS/TS packages were modified, so no changeset is required.

## What changed

### 1. Dataset label REST endpoints added to the REST API reference (High)
The dataset-label endpoints shipped in #14024 were live in `schemas/openapi.json` but had no navigable reference pages. Added one `openapi:`-stub MDX page per operation under `docs/phoenix/sdk-api-reference/rest-api/api-reference/dataset-labels/` and registered a new **Dataset Labels** navigation group in `docs.json` (after the Datasets group), mirroring the annotation-configs pattern. Nine operations are covered:

- `GET/POST /v1/dataset_labels` (list, create)
- `GET/PATCH/DELETE /v1/dataset_labels/{label_id}` (get, update, delete)
- `GET/PUT /v1/datasets/{dataset_identifier}/labels` (list-for-dataset, replace set)
- `PUT/DELETE /v1/datasets/{dataset_identifier}/labels/{label_id}` (apply, remove)

The methods, paths, and summaries were taken directly from `schemas/openapi.json` (verified against `src/phoenix/server/api/routers/v1/dataset_labels.py`). The audit said "eight pages"; the spec actually defines nine operations, so nine stubs were created. The same nine entries were added to `docs/phoenix/llms.txt` under a new **REST API — Dataset Labels** section.

### 2. CLI `annotation-config` commands added to the Mintlify CLI reference (Medium)
`docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx` had zero mentions of `annotation-config` while the package README documents the full family. Ported `list`, `get`, `create`, `update`, and `delete` into the Mintlify page in the existing per-command format (description, example block, options table). Flags and applicability notes were verified against `js/packages/phoenix-cli/src/commands/annotationConfig.ts` (e.g. `--lower-bound`/`--upper-bound` apply to CONTINUOUS/FREEFORM configs). `annotationConfigValues.ts` only exports helper functions, not subcommands, so there is nothing further to document there.

### 3. Agent authentication discovery documented (Medium)
Added an **Agent Authentication Discovery** section to `docs/phoenix/self-hosting/features/authentication.mdx` describing `GET /auth.md` and `GET /.well-known/oauth-protected-resource` (RFC 9728 Protected Resource Metadata), plus the `WWW-Authenticate` header on 401s. Grounded in `src/phoenix/server/api/routers/auth_md.py`. These routers are registered with `include_in_schema=False`, so no REST reference stubs were added — a human-facing note is the correct surface.

### 4. Setting an experiment baseline documented (Low)
Added a **Set a Baseline Experiment** section to `docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments.mdx` explaining how to mark/remove a persistent baseline from the experiments table (single-selection action menu / toolbar, "Mark as baseline" / "Remove baseline", the `baseline` badge). Grounded in the UI code under `app/src/components/experiment/` (`useSetExperimentBaseline.tsx`, `ExperimentActionMenu.tsx`, `BaselineExperimentBadge.tsx`).

### 5. Automatic orphaned-session cleanup documented (Low)
Added an **Automatic Cleanup of Empty Sessions** note to `docs/phoenix/settings/data-retention.mdx` explaining that empty sessions are removed on the hourly retention sweep once their last activity is more than an hour old. Grounded in `src/phoenix/server/retention.py` (`_ORPHAN_SESSION_GRACE_PERIOD`, `_delete_orphan_sessions`).

## Why
Each feature shipped in the audit window without corresponding user-facing docs. This PR closes those gaps so the published REST reference, CLI reference, self-hosting auth guide, experiments how-to, and data-retention docs reflect what actually shipped.

## How to verify
- **Grounding:** every path/method/flag/behavior above is copied from the cited source files, not invented.
- `docs.json` remains valid JSON — the new **Dataset Labels** group is a well-formed object inserted between the Datasets and Experiments groups.
- The new stub filenames are the kebab-cased operation summaries, matching the existing `annotation-configs/` and `datasets/` stub naming convention, and each contains only `openapi: <method> <path>` frontmatter that resolves against `schemas/openapi.json`.
- In a Mintlify preview, the nine new dataset-label pages render from the OpenAPI spec, and the CLI page shows the `px annotation-config` command group.

## Notes
- No `js/` package code changed, so `pnpm changeset` is not applicable.
- Skipped commits and already-documented changes from the audit were left untouched, consistent with the audit's own "Commits skipped" section.
