### PR TITLE
fix: timeout retries in AsyncExecutor now respect max_retries and exit_on_error

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -324,7 +324,6 @@ class AsyncExecutor(Executor):
                     marked_done = True
                     continue
                 else:
-                    tqdm.write("Worker timeout, requeuing")
                     # Best-effort cancel the timed-out task without blocking the loop
                     if not generate_task.done():
                         generate_task.cancel()
@@ -332,12 +331,24 @@ class AsyncExecutor(Executor):
                             await asyncio.wait_for(generate_task, timeout=1)
                         except (asyncio.TimeoutError, asyncio.CancelledError):
                             pass
-                    # task timeouts are requeued at the same priority
-                    await queue.put((priority, item))
                     details = cast(ExecutionDetails, execution_details[index])
                     details.log_runtime(task_start_time)
                     if self._concurrency_controller is not None:
                         self._concurrency_controller.record_timeout()
+                    if (retry_count := abs(priority)) < self.max_retries:
+                        tqdm.write(
+                            f"Worker timeout on attempt {retry_count + 1}, requeuing"
+                        )
+                        await queue.put((priority - 1, item))
+                    else:
+                        tqdm.write(
+                            f"Timeout retries exhausted after {retry_count + 1} attempts"
+                        )
+                        details.fail()
+                        if self.exit_on_error:
+                            termination_event.set()
+                        else:
+                            progress_bar.update()
             except Exception as exc:
                 details = cast(ExecutionDetails, execution_details[index])
                 details.log_exception(exc)

--- a/packages/phoenix-evals/tests/phoenix/evals/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_executor.py
@@ -712,3 +712,53 @@ async def test_executor_ramps_up_when_target_increases() -> None:
     assert outputs == inputs
     assert max_inflight <= 4
     assert max_inflight >= 3
+
+
+async def test_async_executor_timeout_respects_max_retries():
+    call_count = 0
+
+    async def always_slow(x: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(10)
+        return x
+
+    executor = AsyncExecutor(
+        always_slow,
+        timeout=1,
+        max_retries=2,
+        concurrency=1,
+        exit_on_error=True,
+        fallback_return_value=-1,
+        enable_dynamic_concurrency=False,
+    )
+    outputs, statuses = await executor.execute([42])
+
+    assert call_count == 3  # 1 initial + 2 retries
+    assert outputs == [-1]
+    assert statuses[0].status == ExecutionStatus.FAILED
+
+
+async def test_async_executor_timeout_exit_on_error_false():
+    call_count = 0
+
+    async def always_slow(x: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(10)
+        return x
+
+    executor = AsyncExecutor(
+        always_slow,
+        timeout=1,
+        max_retries=1,
+        concurrency=1,
+        exit_on_error=False,
+        fallback_return_value=-1,
+        enable_dynamic_concurrency=False,
+    )
+    outputs, statuses = await executor.execute([1, 2])
+
+    assert call_count == 4  # 2 items x (1 initial + 1 retry)
+    assert outputs == [-1, -1]
+    assert all(s.status == ExecutionStatus.FAILED for s in statuses)


### PR DESCRIPTION
fixes #14312

## What changed

Timed-out tasks in `AsyncExecutor` were requeued at the same priority on every attempt. The retry guard checks `abs(priority) < max_retries`, but since priority never changed for timeouts, the counter never grew and `max_retries` was never reached. The executor would loop indefinitely regardless of `exit_on_error`.

**Before:** timeout requeue used `(priority, item)` with no `max_retries` check.
**After:** timeout requeue uses `(priority - 1, item)`, and once retries are exhausted the task is marked `FAILED` and `exit_on_error` is respected.

## What was tested

Two new tests in `test_executor.py`:

- `test_async_executor_timeout_respects_max_retries`: verifies the executor stops after `1 initial + max_retries` attempts and marks the task `FAILED`.
- `test_async_executor_timeout_exit_on_error_false`: verifies all items are attempted and marked `FAILED` when `exit_on_error=False`.