### PR TITLE
feat(ui): design audit of alerts, counters, and session selection

### DIFF
--- a/app/src/components/core/alert/Alert.tsx
+++ b/app/src/components/core/alert/Alert.tsx
@@ -101,10 +101,16 @@ const alertCSS = css`
     flex-direction: row;
 
     .icon-wrap {
-      margin-top: 4px;
-      margin-right: var(--global-dimension-static-size-200);
-      font-size: var(--global-font-size-l);
+      margin-right: var(--global-dimension-static-size-100);
+      font-size: var(--global-font-size-m);
+      display: flex;
+      align-items: center;
+      height: var(--global-line-height-s);
     }
+  }
+
+  &[data-has-title="true"] .alert__icon-title-wrap .icon-wrap {
+    height: var(--global-line-height-m);
   }
 `;
 
@@ -157,11 +163,11 @@ export const Alert = ({
         {icon}
         <div>
           {title ? (
-            <Text elementType="h5" size="L" weight="heavy" color="inherit">
+            <Text elementType="h5" size="M" weight="heavy" color="inherit">
               {title}
             </Text>
           ) : null}
-          <Text color="inherit" size="M">
+          <Text color="inherit" size="S">
             {children}
           </Text>
         </div>

--- a/app/src/components/core/counter/Counter.tsx
+++ b/app/src/components/core/counter/Counter.tsx
@@ -1,6 +1,8 @@
 import { css } from "@emotion/react";
 import type { PropsWithChildren } from "react";
 
+import { useTheme } from "@phoenix/contexts/ThemeContext";
+
 export type CounterProps = PropsWithChildren<{
   /**
    * The color of the counter
@@ -22,7 +24,28 @@ const counterCSS = css`
   color: var(--global-text-color-900);
   font-family: var(--global-font-family-mono);
   &[data-variant="danger"] {
-    background-color: var(--global-color-danger-700);
+    --counter-base-color: var(--global-color-danger);
+    --counter-bg-color: lch(from var(--counter-base-color) 96 calc(c * 0.3) h);
+    --counter-border-color: lch(
+      from var(--counter-base-color) 88 calc(c * 0.4) h
+    );
+    --counter-text-color: lch(from var(--counter-base-color) 45 c h);
+
+    background-color: var(--counter-bg-color);
+    border-color: var(--counter-border-color);
+    color: var(--counter-text-color);
+
+    &[data-theme="dark"] {
+      --counter-bg-color: lch(
+        from var(--counter-base-color) 18 calc(c * 0.2) h
+      );
+      --counter-border-color: lch(
+        from var(--counter-base-color) 28 calc(c * 0.3) h
+      );
+      --counter-text-color: lch(
+        from var(--counter-base-color) 90 calc(c * 0.8) h
+      );
+    }
   }
   &[data-variant="quiet"] {
     border: none;
@@ -36,8 +59,14 @@ const counterCSS = css`
  */
 export function Counter(props: CounterProps) {
   const { children, variant = "default" } = props;
+  const { theme } = useTheme();
   return (
-    <span css={counterCSS} data-variant={variant} className="counter">
+    <span
+      css={counterCSS}
+      data-variant={variant}
+      data-theme={theme}
+      className="counter"
+    >
       {children}
     </span>
   );

--- a/app/src/pages/project/IOValueTooltipCell.tsx
+++ b/app/src/pages/project/IOValueTooltipCell.tsx
@@ -194,10 +194,9 @@ function createIOValueTooltipCell<TQuery extends OperationType>({
         preview={preview}
         onOpen={() => {
           if (queryRef == null) {
-            loadQuery(
-              { id: nodeId } as TQuery["variables"],
-              { fetchPolicy: "store-or-network" }
-            );
+            loadQuery({ id: nodeId } as TQuery["variables"], {
+              fetchPolicy: "store-or-network",
+            });
           }
         }}
       >

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -542,7 +542,13 @@ function ProjectItem({
       `}
     >
       <Flex direction="row" justifyContent="space-between" alignItems="start">
-        <Flex direction="row" gap="size-100" alignItems="center" minWidth={0}>
+        <Flex
+          direction="row"
+          gap="size-100"
+          alignItems="center"
+          flex={1}
+          minWidth={0}
+        >
           <GradientCircle
             gradientStartColor={gradientStartColor}
             gradientEndColor={gradientEndColor}

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -541,7 +541,12 @@ function ProjectItem({
         height: 100%;
       `}
     >
-      <Flex direction="row" justifyContent="space-between" alignItems="start">
+      <Flex
+        direction="row"
+        justifyContent="space-between"
+        alignItems="start"
+        gap="size-100"
+      >
         <Flex
           direction="row"
           gap="size-100"
@@ -553,14 +558,13 @@ function ProjectItem({
             gradientStartColor={gradientStartColor}
             gradientEndColor={gradientEndColor}
           />
-          <Flex direction="column" minWidth={0}>
+          <Flex direction="column" flex={1} minWidth={0}>
             <Heading
               level={2}
               css={css`
                 overflow: hidden;
-                display: -webkit-box;
-                -webkit-box-orient: vertical;
-                -webkit-line-clamp: 1;
+                text-overflow: ellipsis;
+                white-space: nowrap;
               `}
             >
               {project.name}

--- a/app/src/pages/trace/SessionDetailsTracesView.tsx
+++ b/app/src/pages/trace/SessionDetailsTracesView.tsx
@@ -725,6 +725,14 @@ const traceTreeContainerCSS = css`
   overflow: auto;
   border-top: 1px solid var(--global-border-color-default);
   background: var(--global-color-gray-75);
+
+  /* The tree renders inside a trace row that is itself selected, so tone the
+   * span selection down a step — the strong list-item selection color stays
+   * on the trace row. */
+  & .span-node-wrap.is-selected {
+    background-color: var(--global-color-gray-100);
+    border-color: var(--global-color-gray-200);
+  }
 `;
 
 const spanDetailsContainerCSS = css`

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -497,9 +497,7 @@ function SpanInfo({ span }: { span: Span }) {
 
   const statusDescription = useMemo(() => {
     return span.statusMessage ? (
-      <Alert variant="danger" title="Status Description">
-        {span.statusMessage}
-      </Alert>
+      <Alert variant="danger">{span.statusMessage}</Alert>
     ) : null;
   }, [span]);
 

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -14,6 +14,8 @@ import invariant from "tiny-invariant";
 
 import {
   Flex,
+  Icon,
+  Icons,
   LinkButton,
   Loading,
   RichTooltip,
@@ -306,6 +308,7 @@ function TraceHeader({
             <LinkButton
               size="S"
               variant="primary"
+              leadingVisual={<Icon svg={<Icons.MessagesSquare />} />}
               to={{
                 pathname: `/projects/${projectId}/sessions/${sessionId}`,
                 search: sessionSearch,

--- a/app/src/pages/trace/__tests__/SessionViewTabs.test.tsx
+++ b/app/src/pages/trace/__tests__/SessionViewTabs.test.tsx
@@ -2,6 +2,8 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
+
 import { SessionViewTabs } from "../SessionViewTabs";
 
 describe("SessionViewTabs", () => {
@@ -9,6 +11,15 @@ describe("SessionViewTabs", () => {
   let root: Root;
 
   beforeEach(() => {
+    // ThemeProvider resolves the system theme via matchMedia, which jsdom lacks
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })
+    );
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -20,6 +31,7 @@ describe("SessionViewTabs", () => {
     });
     container.remove();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("emits a view change when a different tab is clicked", () => {
@@ -27,13 +39,15 @@ describe("SessionViewTabs", () => {
 
     act(() => {
       root.render(
-        <SessionViewTabs
-          sessionView="turns"
-          onSessionViewChange={onSessionViewChange}
-          traceCount={12}
-        >
-          <div>Session content</div>
-        </SessionViewTabs>
+        <ThemeProvider themeMode="dark">
+          <SessionViewTabs
+            sessionView="turns"
+            onSessionViewChange={onSessionViewChange}
+            traceCount={12}
+          >
+            <div>Session content</div>
+          </SessionViewTabs>
+        </ThemeProvider>
       );
     });
 

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -315,7 +315,7 @@ export const createPreferencesStore = (
         type: "setPlaygroundStreamingEnabled",
       });
     },
-    isAnnotatingSpans: true,
+    isAnnotatingSpans: false,
     setIsAnnotatingSpans: (isAnnotatingSpans) => {
       set({ isAnnotatingSpans }, false, { type: "setIsAnnotatingSpans" });
     },


### PR DESCRIPTION
## Summary

Design audit pass on alerts and related surfaces:

- **Alert typography**: title now uses text size M (matching card header text) and body uses size S (default UI body text) instead of L/M which were one step too large. Icon is scaled to match and vertically centers on the first text line; the alert text now aligns horizontally with card header text (16px padding + icon + 8px gap, matching card header anatomy).
- **Span error alert**: removed the redundant "Status Description" title.
- **Counter danger variant**: replaced the solid `danger-700` background with the same theme-aware lch color derivation used by Badge and Alert, so danger counters (e.g. the Events tab count) read as part of the same family.
- **Session traces view selection hierarchy**: the selected trace row and the selected span in its nested trace tree both resolved to `gray-200`, making them indistinguishable. The nested tree selection is now a step subtler (`gray-100` bg, `gray-200` border, scoped to the session view) so the two selection levels are visually separable.
- **View Session button**: added a leading session icon (`MessagesSquare`).
- **Span annotation aside**: collapsed by default in trace details.

## Testing

Verified in Storybook and against a live Phoenix instance via browser automation: computed font sizes, pixel alignment against card headers, selection colors, and default aside state.