### PR TITLE
docs: add one-click deploy buttons for self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,35 @@ pip install arize-phoenix
 
 Phoenix container images are available via [Docker Hub](https://hub.docker.com/r/arizephoenix/phoenix) and can be deployed using Docker or Kubernetes. Arize AI also provides cloud instances at [app.phoenix.arize.com](https://app.phoenix.arize.com/).
 
+## Deploy Phoenix
+
+Phoenix is **open source and built to be self-hosted** — run it on your own infrastructure so your traces, evaluations, and prompts never leave your environment. On-prem and private-cloud deployment is a first-class goal, not an afterthought. Deploy the production Docker image to the cloud of your choice with a single click:
+
+<p align="center">
+  <a href="https://railway.app/template/PTHRoq?referralCode=Xe2txW"><img src="https://railway.com/button.svg" alt="Deploy on Railway" height="40"></a>
+  &nbsp;
+  <a href="https://render.com/deploy?repo=https://github.com/Arize-ai/phoenix"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="40"></a>
+  &nbsp;
+  <a href="https://deploy.cloud.run/?git_repo=https://github.com/Arize-ai/phoenix"><img src="https://deploy.cloud.run/button.svg" alt="Run on Google Cloud" height="40"></a>
+  &nbsp;
+  <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FArize-ai%2Fphoenix%2Fmain%2Fazuredeploy.json"><img src="https://aka.ms/deploytoazurebutton" alt="Deploy to Azure" height="40"></a>
+  &nbsp;
+  <a href="https://arize.com/docs/phoenix/self-hosting/deployment-options/aws-with-cloudformation"><img src="https://img.shields.io/badge/Deploy%20to-AWS-FF9900?logo=amazonwebservices&logoColor=white&labelColor=232F3E" alt="Deploy to AWS" height="34"></a>
+</p>
+
+| Platform | What gets deployed | Persistence |
+| --- | --- | --- |
+| **[Railway](https://arize.com/docs/phoenix/self-hosting/deployment-options/railway)** | Phoenix container from a prebuilt template | Managed volume / Postgres |
+| **[Render](./render.yaml)** | Phoenix Docker image + managed PostgreSQL | Managed Postgres |
+| **[Google Cloud Run](./app.json)** | Phoenix container on Cloud Run | Add [Cloud SQL](https://arize.com/docs/phoenix/self-hosting/deployment-options/docker) for durable storage |
+| **[Azure](./azuredeploy.json)** | Phoenix on Azure Container Instances + Azure Files | Azure Files volume |
+| **[AWS](https://arize.com/docs/phoenix/self-hosting/deployment-options/aws-with-cloudformation)** | Phoenix on ECS Fargate via CloudFormation | Guided setup |
+
+> [!IMPORTANT]
+> **Authentication is enabled by default.** The Render, Google Cloud, Azure, and AWS templates set `PHOENIX_ENABLE_AUTH=true` and provision a strong `PHOENIX_SECRET` for you. On first login, use the default admin account — email **`admin@localhost`**, password **`admin`** — and you'll be prompted to set a new password. See the [authentication guide](https://arize.com/docs/phoenix/self-hosting/features/authentication) to configure OAuth2/SSO, LDAP, and role mapping.
+
+For Docker Compose, Kubernetes/Helm, and other deployment options, see the [self-hosting documentation](https://arize.com/docs/phoenix/self-hosting).
+
 ## Packages
 
 The `arize-phoenix` package includes the entire Phoenix platform. However, if you have deployed the Phoenix platform, there are lightweight Python sub-packages and TypeScript packages that can be used in conjunction with the platform.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,32 @@
+{
+  "name": "Arize Phoenix",
+  "description": "Open-source AI observability platform for tracing, evaluation, experimentation, and prompt engineering. Deployed to Google Cloud Run with authentication enabled by default.",
+  "env": {
+    "PHOENIX_ENABLE_AUTH": {
+      "description": "Enable authentication so the UI and API require a login. Leave as 'true' to keep your deployment private.",
+      "value": "true"
+    },
+    "PHOENIX_SECRET": {
+      "description": "Secret used to sign authentication tokens (must be at least 32 characters with a digit and a lowercase letter). A strong value is generated for you automatically.",
+      "generator": "secret"
+    },
+    "PHOENIX_USE_SECURE_COOKIES": {
+      "description": "Store auth tokens in secure cookies. Recommended when serving Phoenix over HTTPS (Cloud Run always uses HTTPS).",
+      "value": "true"
+    },
+    "PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD": {
+      "description": "Initial password for the default admin account (email: admin@localhost). Only used on first startup. Leave blank to use 'admin' and change it on first login.",
+      "required": false
+    },
+    "PHOENIX_SQL_DATABASE_URL": {
+      "description": "PostgreSQL connection string (e.g. a Cloud SQL instance) for durable storage. Cloud Run's container filesystem is ephemeral, so set this to persist your data across revisions. Leave blank to try Phoenix with temporary local storage.",
+      "required": false
+    }
+  },
+  "options": {
+    "allow-unauthenticated": true,
+    "memory": "1Gi",
+    "cpu": "1",
+    "port": 6006
+  }
+}

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -84,7 +84,7 @@
         "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
       ],
       "properties": {
-        "shareQuota": 100
+        "shareQuota": 500
       }
     },
     {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Deploys Arize Phoenix to Azure Container Instances with authentication enabled by default and an Azure Files share for persistent storage."
+  },
+  "parameters": {
+    "containerGroupName": {
+      "type": "string",
+      "defaultValue": "phoenix",
+      "metadata": {
+        "description": "Name of the Azure Container Instances container group."
+      }
+    },
+    "imageTag": {
+      "type": "string",
+      "defaultValue": "latest",
+      "metadata": {
+        "description": "Tag of the arizephoenix/phoenix image to deploy."
+      }
+    },
+    "phoenixSecret": {
+      "type": "securestring",
+      "defaultValue": "[concat(uniqueString(resourceGroup().id, 'phoenix-secret'), uniqueString(subscription().subscriptionId, 'phoenix'), uniqueString(deployment().name, 'secret'), 'a1b2')]",
+      "metadata": {
+        "description": "Secret used to sign authentication tokens (at least 32 characters with a digit and a lowercase letter). A strong value is generated automatically; override it to supply your own."
+      }
+    },
+    "adminInitialPassword": {
+      "type": "securestring",
+      "defaultValue": "admin",
+      "metadata": {
+        "description": "Initial password for the default admin account (email: admin@localhost). Only applied on first startup. If left as 'admin', you will be required to change it on first login."
+      }
+    },
+    "cpuCores": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "Number of CPU cores to allocate to the Phoenix container."
+      }
+    },
+    "memoryInGb": {
+      "type": "int",
+      "defaultValue": 4,
+      "metadata": {
+        "description": "Amount of memory (in GB) to allocate to the Phoenix container."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat('phx', uniqueString(resourceGroup().id))]",
+    "fileShareName": "phoenix-data",
+    "dnsNameLabel": "[concat('phoenix-', uniqueString(resourceGroup().id))]",
+    "image": "[concat('docker.io/arizephoenix/phoenix:', parameters('imageTag'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "minimumTlsVersion": "TLS1_2",
+        "allowBlobPublicAccess": false
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-01-01",
+      "name": "[format('{0}/default/{1}', variables('storageAccountName'), variables('fileShareName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "shareQuota": 100
+      }
+    },
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2023-05-01",
+      "name": "[parameters('containerGroupName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('fileShareName'))]"
+      ],
+      "properties": {
+        "osType": "Linux",
+        "restartPolicy": "OnFailure",
+        "ipAddress": {
+          "type": "Public",
+          "dnsNameLabel": "[variables('dnsNameLabel')]",
+          "ports": [
+            {
+              "protocol": "TCP",
+              "port": 6006
+            }
+          ]
+        },
+        "volumes": [
+          {
+            "name": "phoenix-data",
+            "azureFile": {
+              "shareName": "[variables('fileShareName')]",
+              "storageAccountName": "[variables('storageAccountName')]",
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2023-01-01').keys[0].value]"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "phoenix",
+            "properties": {
+              "image": "[variables('image')]",
+              "ports": [
+                {
+                  "protocol": "TCP",
+                  "port": 6006
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "[parameters('cpuCores')]",
+                  "memoryInGB": "[parameters('memoryInGb')]"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "name": "phoenix-data",
+                  "mountPath": "/mnt/phoenix"
+                }
+              ],
+              "environmentVariables": [
+                {
+                  "name": "PHOENIX_PORT",
+                  "value": "6006"
+                },
+                {
+                  "name": "PHOENIX_WORKING_DIR",
+                  "value": "/mnt/phoenix"
+                },
+                {
+                  "name": "PHOENIX_ENABLE_AUTH",
+                  "value": "true"
+                },
+                {
+                  "name": "PHOENIX_SECRET",
+                  "secureValue": "[parameters('phoenixSecret')]"
+                },
+                {
+                  "name": "PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD",
+                  "secureValue": "[parameters('adminInitialPassword')]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "phoenixUrl": {
+      "type": "string",
+      "value": "[concat('http://', reference(resourceId('Microsoft.ContainerInstance/containerGroups', parameters('containerGroupName'))).ipAddress.fqdn, ':6006')]"
+    },
+    "adminEmail": {
+      "type": "string",
+      "value": "admin@localhost"
+    }
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -42,6 +42,6 @@ services:
 
 databases:
   - name: phoenix-db
-    plan: basic-256mb
+    plan: basic-1gb
     databaseName: phoenix
     user: phoenix

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,47 @@
+# Render Blueprint for Arize Phoenix
+# https://render.com/docs/infrastructure-as-code
+#
+# One-click deploy: https://render.com/deploy?repo=https://github.com/Arize-ai/phoenix
+#
+# This blueprint runs the official Phoenix Docker image alongside a managed
+# PostgreSQL database. Authentication is enabled by default: Render generates a
+# strong PHOENIX_SECRET for you, and the first login uses the default admin
+# account (email: admin@localhost). Set PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD
+# below before deploying, or you will be prompted to change the password
+# ("admin") on first login.
+services:
+  - type: web
+    name: phoenix
+    runtime: image
+    image:
+      url: docker.io/arizephoenix/phoenix:latest
+    plan: starter
+    autoDeploy: false
+    healthCheckPath: /healthz
+    envVars:
+      - key: PORT
+        value: "6006"
+      - key: PHOENIX_PORT
+        value: "6006"
+      # --- Authentication (enabled by default) ---
+      - key: PHOENIX_ENABLE_AUTH
+        value: "true"
+      - key: PHOENIX_SECRET
+        generateValue: true
+      - key: PHOENIX_USE_SECURE_COOKIES
+        value: "true"
+      # Optional: uncomment and set to override the default admin password
+      # ("admin"). Otherwise you'll be forced to change it on first login.
+      # - key: PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD
+      #   sync: false
+      # --- Persistent storage ---
+      - key: PHOENIX_SQL_DATABASE_URL
+        fromDatabase:
+          name: phoenix-db
+          property: connectionString
+
+databases:
+  - name: phoenix-db
+    plan: basic-256mb
+    databaseName: phoenix
+    user: phoenix


### PR DESCRIPTION
## Summary

Adds a **Deploy Phoenix** section to the top-level `README.md` with one-click deploy buttons, framing self-hosting / on-prem as a first-class goal. Each button (for the platforms we control) provisions Phoenix with **authentication enabled by default**.

Buttons: **Railway** · **Render** · **Google Cloud Run** · **Azure** · **AWS**

## What's included

| Platform | How | Auth by default |
| --- | --- | --- |
| Railway | Existing prebuilt template (`railway.app/template/PTHRoq`) | ⚠️ external template — see note below |
| Render | New `render.yaml` blueprint (Phoenix image + managed PostgreSQL) | ✅ `PHOENIX_ENABLE_AUTH=true` + generated `PHOENIX_SECRET` |
| Google Cloud Run | New `app.json` (Cloud Run Button) | ✅ auth on + `PHOENIX_SECRET` via `generator: secret` |
| Azure | New `azuredeploy.json` ARM template (Azure Container Instances + Azure Files) | ✅ auth on + auto-generated `PHOENIX_SECRET` |
| AWS | Links to the existing CloudFormation guide | ✅ existing `phoenix-auth.yml` enables auth |

## Approach / audit notes

Audited how LiteLLM, Langfuse, Dify, and n8n present deploy buttons. Stateful server apps (Langfuse, Dify) generally ship IaC + docs rather than buttons; LiteLLM uses branded buttons for Render/Railway. This PR uses the official branded buttons where they exist plus a badge for AWS.

- **Vercel was intentionally dropped** in favor of **Render**. Vercel is serverless/edge with no long-lived stateful container or persistent volume, so a "Deploy to Vercel" button would dead-end users on a stateful server + database like Phoenix.
- **AWS** links to the existing CloudFormation guide rather than a true "Launch Stack" button, because one-click CloudFormation requires the template to be hosted at a public S3 URL.
- All new templates set auth via `PHOENIX_ENABLE_AUTH=true` and a `PHOENIX_SECRET` that satisfies Phoenix's requirements (≥32 chars, ≥1 digit, ≥1 lowercase). First login uses `admin@localhost` / `admin` and forces a password change.

## Follow-up

- The **Railway template is external** (not editable from this repo). To fully meet "auth enabled by default" it should be updated on Railway's side to set `PHOENIX_ENABLE_AUTH` + a generated `PHOENIX_SECRET`.
- The **Azure** button references `azuredeploy.json` on the `main` branch, so it becomes live once this merges.
- Consider dedicated docs pages for Render / Cloud Run / Azure under `docs/phoenix/self-hosting/deployment-options/`.

## Files

- `README.md` — new **Deploy Phoenix** section (buttons + table + auth note)
- `render.yaml` — Render blueprint
- `app.json` — Google Cloud Run button config
- `azuredeploy.json` — Azure ARM template

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SB9bvh1VxLPKwhPk21m1Mq)_