### PR TITLE
feat(ui): collapsible playground sections via TitledPanel

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1173,6 +1173,10 @@ const tableCSS = (theme: Theme) => css`
 
     --global-table-cell-padding-y: var(--global-dimension-size-100);
     --global-table-cell-padding-x: var(--global-dimension-size-200);
+    /* height of a table header row, including its bottom border. Panels that sit
+       beside a table (e.g. TitledPanel headers) use this so their headers line up
+       with the table's header row. */
+    --global-table-header-height: 37px;
     --global-table-pagination-padding: var(--global-dimension-size-100);
     --global-table-pagination-gap: var(--global-dimension-size-50);
 

--- a/app/src/components/core/card/Card.tsx
+++ b/app/src/components/core/card/Card.tsx
@@ -15,6 +15,8 @@ function Card({
   subTitle,
   children,
   collapsible = false,
+  interactiveTitle = false,
+  collapseButtonLabel,
   defaultOpen = true,
   scrollBody = false,
   extra,
@@ -29,6 +31,7 @@ function Card({
 
   const headerId = useId();
   const collapseButtonId = useId();
+  const titleId = useId();
   const bodyId = useId();
 
   const handleCollapseChange = useEffectEvent((collapsed: boolean) => {
@@ -40,7 +43,7 @@ function Card({
   }, [isCollapsed]);
 
   const headingContents = (
-    <div>
+    <div id={titleId}>
       <Heading level={3} weight="heavy" className="card__title">
         {title}
         {titleExtra}
@@ -51,6 +54,31 @@ function Card({
         </Heading>
       )}
     </div>
+  );
+
+  const collapseButton = (
+    <button
+      onClick={() => {
+        setIsCollapsed(!isCollapsed);
+      }}
+      className="card__collapsible-button button--reset"
+      id={collapseButtonId}
+      aria-controls={bodyId}
+      aria-expanded={!isCollapsed}
+      aria-label={interactiveTitle ? collapseButtonLabel : undefined}
+      // only borrow the title as the accessible name when the caller has not
+      // supplied one; a title holding its own control (a select) would otherwise
+      // lend the toggle that control's label
+      aria-labelledby={
+        interactiveTitle && collapseButtonLabel == null ? titleId : undefined
+      }
+    >
+      <DisclosureArrow
+        isExpanded={!isCollapsed}
+        className="card__collapse-toggle-icon"
+      />
+      {!interactiveTitle && headingContents}
+    </button>
   );
 
   return (
@@ -66,21 +94,14 @@ function Card({
     >
       <header id={headerId}>
         {collapsible ? (
-          <button
-            onClick={() => {
-              setIsCollapsed(!isCollapsed);
-            }}
-            className="card__collapsible-button button--reset"
-            id={collapseButtonId}
-            aria-controls={bodyId}
-            aria-expanded={!isCollapsed}
-          >
-            <DisclosureArrow
-              isExpanded={!isCollapsed}
-              className="card__collapse-toggle-icon"
-            />
-            {headingContents}
-          </button>
+          interactiveTitle ? (
+            <div className="card__collapsible-header">
+              {collapseButton}
+              {headingContents}
+            </div>
+          ) : (
+            collapseButton
+          )
         ) : (
           headingContents
         )}

--- a/app/src/components/core/card/styles.ts
+++ b/app/src/components/core/card/styles.ts
@@ -40,6 +40,20 @@ export const cardCSS = (style?: CSSProperties) => css`
       color: var(--global-text-color-700);
     }
 
+    /* Header layout when the title holds interactive controls */
+    & .card__collapsible-header {
+      display: flex;
+      flex: 1;
+      flex-direction: row;
+      align-items: center;
+      height: 100%;
+
+      & .card__collapsible-button {
+        flex: none;
+        width: auto;
+      }
+    }
+
     /* Collapsible button styles */
     & .card__collapsible-button {
       display: flex;
@@ -73,9 +87,11 @@ export const cardCSS = (style?: CSSProperties) => css`
     line-height: var(--global-line-height-m);
   }
 
-  /* Collapsible behavior */
+  /* Collapsible behavior: highlight the header only when the collapse
+     trigger itself is hovered, so the affordance matches the click target
+     (with interactiveTitle only the arrow button toggles) */
   &[data-collapsible="true"] {
-    & > header:hover {
+    & > header:has(.card__collapsible-button:hover) {
       background-color: var(--global-card-header-background-color-hover);
     }
   }

--- a/app/src/components/core/card/types.ts
+++ b/app/src/components/core/card/types.ts
@@ -31,6 +31,21 @@ export interface CardProps extends PropsWithChildren<ViewStyleProps> {
    */
   defaultOpen?: boolean;
   /**
+   * Set when the title contains interactive elements (selects, buttons, etc.).
+   * The collapse toggle then renders as a standalone arrow button beside the
+   * title instead of wrapping it, so interactive controls are not nested
+   * inside a button. Only applicable if `collapsible` is `true`.
+   * @default false
+   */
+  interactiveTitle?: boolean;
+  /**
+   * Accessible name for the collapse toggle. Recommended with `interactiveTitle`,
+   * where the toggle is a bare arrow: naming it from the title subtree would pick
+   * up the accessible name of the title's own control (e.g. a select), which is
+   * both wrong and identical across cards.
+   */
+  collapseButtonLabel?: string;
+  /**
    * Additional content displayed on the right side of the card header.
    */
   extra?: React.ReactNode;

--- a/app/src/components/core/icon/DisclosureArrow.tsx
+++ b/app/src/components/core/icon/DisclosureArrow.tsx
@@ -10,6 +10,9 @@ const disclosureArrowCSS = css`
   flex: none;
   color: var(--global-text-color-500);
   transition: transform 200ms ease-in-out;
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
   transform: rotate(0deg);
   &[data-expanded="true"] {
     transform: rotate(90deg);

--- a/app/src/components/core/switch/Switch.tsx
+++ b/app/src/components/core/switch/Switch.tsx
@@ -88,16 +88,30 @@ const switchCSS = css`
   &[data-label-placement="end"] {
     flex-direction: row;
   }
+
+  &[data-size="S"] {
+    --switch-track-width: var(--global-dimension-static-size-400);
+    --switch-track-height: var(--global-dimension-static-size-225);
+    --switch-thumb-size: var(--global-dimension-static-size-175);
+    font-size: var(--global-font-size-s);
+    line-height: var(--global-line-height-s);
+  }
 `;
 export interface SwitchProps extends AriaSwitchProps {
   children: ReactNode;
   labelPlacement?: "start" | "end";
+  /**
+   * The size of the switch and its label
+   * @default "M"
+   */
+  size?: "S" | "M";
 }
 
 function Switch({
   ref,
   children,
   labelPlacement = "end",
+  size = "M",
   ...props
 }: SwitchProps & { ref?: Ref<HTMLLabelElement> }) {
   return (
@@ -106,6 +120,7 @@ function Switch({
       ref={ref}
       css={switchCSS}
       data-label-placement={labelPlacement}
+      data-size={size}
     >
       <div className="indicator" />
       {children}

--- a/app/src/components/dataset/DatasetSelectWithSplits.tsx
+++ b/app/src/components/dataset/DatasetSelectWithSplits.tsx
@@ -197,13 +197,13 @@ export function DatasetSelectWithSplits(props: DatasetSelectWithSplitsProps) {
               </Text>
               {selectedSplits.length === 1 ? (
                 <>
-                  <Text color="text-300">&nbsp;/&nbsp;</Text>
+                  <Text color="text-700">&nbsp;/&nbsp;</Text>
                   <Token color={selectedSplits[0].color} size="S">
                     {selectedSplits[0].name}
                   </Token>
                 </>
               ) : (
-                <Text color="text-300" minWidth={0}>
+                <Text color="text-700" minWidth={0}>
                   <Truncate maxWidth="100%">
                     {selectedSplits.length > 1
                       ? `/ ${selectedSplits.length} splits`
@@ -213,7 +213,7 @@ export function DatasetSelectWithSplits(props: DatasetSelectWithSplitsProps) {
               )}
             </>
           ) : (
-            <Text color="text-300">
+            <Text color="text-700">
               {props.placeholder ?? "Select a dataset"}
             </Text>
           )}

--- a/app/src/components/react-resizable-panels/TitledPanel.tsx
+++ b/app/src/components/react-resizable-panels/TitledPanel.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import type { PropsWithChildren, Ref } from "react";
-import React, { useImperativeHandle, useRef, useState } from "react";
+import React, { useId, useImperativeHandle, useRef, useState } from "react";
 import type {
   PanelImperativeHandle,
   PanelProps,
@@ -21,18 +21,31 @@ export function TitledPanel({
   ref,
   children,
   title,
+  extra,
   panelProps,
   panelResizeHandleProps,
   resizable = false,
   bordered = true,
   disabled,
+  headingLevel,
+  onCollapseChange,
 }: PropsWithChildren<{
   title: React.ReactNode;
+  /**
+   * Interactive controls rendered on the right side of the title bar.
+   * Rendered outside the collapse trigger so they stay usable while collapsed.
+   */
+  extra?: React.ReactNode;
   panelProps?: Omit<PanelProps, "onResize">;
   panelResizeHandleProps?: SeparatorProps;
   resizable?: boolean;
   bordered?: boolean;
   disabled?: boolean;
+  /**
+   * When set, the title participates in the page's heading outline at this level
+   */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  onCollapseChange?: (collapsed: boolean) => void;
   ref?: Ref<PanelImperativeHandle | null>;
 }>) {
   const panelRef = useRef<PanelImperativeHandle | null>(null);
@@ -41,6 +54,12 @@ export function TitledPanel({
     PanelImperativeHandle | null
   >(ref, () => panelRef.current);
   const [collapsed, setCollapsed] = useState(false);
+  // onResize can fire multiple times before React re-renders, so track the
+  // latest collapsed value in a ref to avoid stale comparisons
+  const collapsedRef = useRef(false);
+  const fallbackPanelId = useId();
+  // Panel renders its id prop as the DOM id, so the title can point at it
+  const panelId = panelProps?.id != null ? `${panelProps.id}` : fallbackPanelId;
 
   const handleClick = () => {
     const panel = panelRef.current;
@@ -85,17 +104,32 @@ export function TitledPanel({
         collapsed={collapsed}
         bordered={bordered}
         disabled={disabled}
+        extra={extra}
+        headingLevel={headingLevel}
+        aria-controls={panelId}
       >
         {title}
       </PanelTitle>
       <Panel
         maxSize="100%"
         {...panelProps}
+        id={panelId}
         panelRef={panelRef}
         collapsible
+        // keep the 0-height collapsed content out of the tab order and
+        // accessibility tree
+        inert={collapsed || undefined}
         onResize={(panelSize) => {
-          const isCollapsed = panelSize.asPercentage === 0;
-          setCollapsed((prev) => (prev === isCollapsed ? prev : isCollapsed));
+          // ask the panel itself rather than testing for 0% — a panel with a
+          // non-zero collapsedSize is collapsed at a non-zero percentage, and
+          // handleClick already branches on isCollapsed()
+          const isCollapsed =
+            panelRef.current?.isCollapsed() ?? panelSize.asPercentage === 0;
+          if (isCollapsed !== collapsedRef.current) {
+            collapsedRef.current = isCollapsed;
+            setCollapsed(isCollapsed);
+            onCollapseChange?.(isCollapsed);
+          }
         }}
       >
         {children}
@@ -106,16 +140,42 @@ export function TitledPanel({
 
 TitledPanel.displayName = "TitledPanel";
 
+const panelHeaderCSS = css`
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  /* locked to the table header row height (border included) so panel headers
+     line up with the table they sit beside */
+  height: var(--global-table-header-height);
+  gap: var(--global-dimension-size-100);
+  &[data-bordered="true"] {
+    border-bottom: 1px solid var(--global-border-color-default);
+  }
+  &[data-collapsed="true"] {
+    border-bottom: none;
+  }
+  transition: background-color 0.2s ease-in-out;
+  /* highlight the whole strip when the collapse trigger is hovered so the
+     hover state doesn't cut off at the extra cluster */
+  &:has(.panel-title__button:hover:not([disabled])) {
+    background-color: var(--global-card-header-background-color-hover);
+  }
+`;
+
 const panelTitleCSS = css`
   all: unset;
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
+  &:focus-visible {
+    outline: 1px solid var(--global-color-primary);
+    outline-offset: -1px;
+  }
   &:hover {
     cursor: pointer;
-    background-color: var(--global-card-header-background-color-hover);
   }
   &:hover[disabled] {
     cursor: default;
-    background-color: unset;
   }
   &[disabled] {
     opacity: var(--global-opacity-disabled);
@@ -123,15 +183,33 @@ const panelTitleCSS = css`
   display: flex;
   align-items: center;
   gap: var(--global-dimension-size-100);
-  padding: var(--global-dimension-size-100) var(--global-dimension-size-50);
+  padding: 0 var(--global-dimension-size-100);
   font-weight: var(--font-weight-heavy);
   font-size: var(--global-font-size-s);
-  &[data-bordered="true"] {
-    border-bottom: 1px solid var(--global-border-color-default);
-  }
-  &[data-collapsed="true"] {
-    border-bottom: none;
-  }
+`;
+
+const panelTitleExtraCSS = css`
+  /* the enclosing Group clips overflow, so the cluster must be able to shrink
+     and scroll rather than have its right-most controls cut off */
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--global-dimension-size-100);
+  /* right padding matches the page header's size-200 inset so the extra
+     clusters align vertically across the page */
+  padding: var(--global-dimension-size-50) var(--global-dimension-size-200)
+    var(--global-dimension-size-50) 0;
+`;
+
+const panelTitleHeadingCSS = css`
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
 `;
 
 export const PanelTitle = ({
@@ -139,24 +217,46 @@ export const PanelTitle = ({
   collapsed,
   bordered,
   disabled,
+  extra,
+  headingLevel,
+  className,
   ...props
 }: {
   children: React.ReactNode;
   collapsed?: boolean;
   bordered?: boolean;
   disabled?: boolean;
+  extra?: React.ReactNode;
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 } & React.HTMLProps<HTMLButtonElement>) => {
-  return (
+  const button = (
     <button
       {...props}
       type="button"
+      className={["panel-title__button", className].filter(Boolean).join(" ")}
+      aria-expanded={collapsed === undefined ? undefined : !collapsed}
       data-collapsed={collapsed}
-      data-bordered={bordered}
       css={panelTitleCSS}
       disabled={collapsed === undefined || disabled}
     >
       {collapsed !== undefined && <DisclosureArrow isExpanded={!collapsed} />}
       {children}
     </button>
+  );
+  const HeadingTag =
+    headingLevel != null ? (`h${headingLevel}` as const) : null;
+  return (
+    <div
+      data-collapsed={collapsed}
+      data-bordered={bordered}
+      css={panelHeaderCSS}
+    >
+      {HeadingTag != null ? (
+        <HeadingTag css={panelTitleHeadingCSS}>{button}</HeadingTag>
+      ) : (
+        button
+      )}
+      {extra != null && <div css={panelTitleExtraCSS}>{extra}</div>}
+    </div>
   );
 };

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -17,6 +17,8 @@ export const tableCSS = css`
     background-color: var(--global-table-header-background-color);
     tr {
       th {
+        box-sizing: border-box;
+        height: var(--global-table-header-height);
         padding: var(--global-table-cell-padding-y)
           var(--global-table-cell-padding-x);
         position: relative;

--- a/app/src/components/templateEditor/TemplateEditor.tsx
+++ b/app/src/components/templateEditor/TemplateEditor.tsx
@@ -25,6 +25,10 @@ type TemplateEditorProps = Omit<ReactCodeMirrorProps, "value"> & {
    * When provided, enables autocomplete for template variables.
    */
   availablePaths?: string[];
+  /**
+   * Accessible name for the editor's textbox
+   */
+  "aria-label"?: string;
 };
 
 const basicSetupOptions: BasicSetupOptions = {
@@ -57,13 +61,18 @@ export const TemplateEditor = ({
   defaultValue,
   readOnly,
   availablePaths,
+  "aria-label": ariaLabel = "Prompt template",
   ...props
 }: TemplateEditorProps) => {
   const [value, setValue] = useState(() => defaultValue);
   const { theme } = useTheme();
   const codeMirrorTheme = theme === "light" ? pierreLight : pierreDark;
   const extensions = useMemo(() => {
-    const ext: TemplateEditorProps["extensions"] = [...baseExtensions];
+    const ext: TemplateEditorProps["extensions"] = [
+      ...baseExtensions,
+      // name the textbox for assistive technology
+      EditorView.contentAttributes.of({ "aria-label": ariaLabel }),
+    ];
     switch (templateFormat) {
       case TemplateFormats.FString:
         ext.push(FStringTemplating());
@@ -86,7 +95,7 @@ export const TemplateEditor = ({
       ext.push(createTemplateAutocomplete(availablePaths, templateFormat));
     }
     return ext;
-  }, [templateFormat, availablePaths, readOnly]);
+  }, [templateFormat, availablePaths, readOnly, ariaLabel]);
 
   useEffect(() => {
     if (readOnly) {

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -9,12 +9,8 @@ import {
   useState,
 } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
-import {
-  Group,
-  Panel,
-  Separator,
-  useDefaultLayout,
-} from "react-resizable-panels";
+import type { PanelImperativeHandle } from "react-resizable-panels";
+import { Group, useDefaultLayout } from "react-resizable-panels";
 import type { BlockerFunction } from "react-router";
 import { useBlocker, useSearchParams } from "react-router";
 
@@ -95,10 +91,6 @@ import {
 } from "@phoenix/agent/tools/playgroundVariableValues";
 import {
   Button,
-  Disclosure,
-  DisclosureGroup,
-  DisclosurePanel,
-  DisclosureTrigger,
   Flex,
   Icon,
   Icons,
@@ -108,8 +100,7 @@ import {
 } from "@phoenix/components";
 import { ConfirmNavigationDialog } from "@phoenix/components/ConfirmNavigation";
 import { useModelMenuData } from "@phoenix/components/generative";
-import { compactResizeHandleCSS } from "@phoenix/components/resize";
-import { StopPropagation } from "@phoenix/components/StopPropagation";
+import { TitledPanel } from "@phoenix/components/react-resizable-panels";
 import { TemplateFormats } from "@phoenix/components/templateEditor/constants";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import {
@@ -143,7 +134,10 @@ import {
 } from "./playgroundAgentContextUtils";
 import { PlaygroundConfigButton } from "./PlaygroundConfigButton";
 import { PlaygroundCredentialsDropdown } from "./PlaygroundCredentialsDropdown";
-import { PlaygroundDatasetSection } from "./PlaygroundDatasetSection";
+import {
+  IO_PANEL_PROPS,
+  PlaygroundDatasetSection,
+} from "./PlaygroundDatasetSection";
 import { PlaygroundDatasetSelect } from "./PlaygroundDatasetSelect";
 import { PlaygroundInput } from "./PlaygroundInput";
 import { PlaygroundOutput } from "./PlaygroundOutput";
@@ -255,39 +249,6 @@ function AddPromptButton() {
   );
 }
 
-const playgroundPromptPanelContentCSS = css`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  overflow: hidden;
-  & > .disclosure-group {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    overflow: hidden;
-    flex: 1 1 auto;
-    & > .disclosure {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      overflow-x: hidden;
-      overflow-y: hidden;
-      flex: 1 1 auto;
-      // prevent the accordion item header from growing to fill the accordion item
-      // using two selectors as fallback just incase the component lib changes subtly
-      & > [role="button"],
-      & > #prompts-heading {
-        flex: 0 0 auto;
-      }
-      .disclosure__panel {
-        height: 100%;
-        overflow: hidden;
-        flex: 1 1 auto;
-      }
-    }
-  }
-`;
-
 const promptsWrapCSS = css`
   padding: var(--global-dimension-size-200);
   scrollbar-gutter: stable;
@@ -297,19 +258,11 @@ const promptsWrapCSS = css`
   box-sizing: border-box;
 `;
 
-const playgroundInputOutputPanelContentCSS = css`
-  height: 100%;
-  overflow: auto;
-`;
-
 /**
  * This width accomodates the model config button min-width, as well as chat message accordion
  * header contents such as the chat message mode radio group for AI messages
  */
 const PLAYGROUND_PROMPT_PANEL_MIN_WIDTH = 632;
-
-const DEFAULT_EXPANDED_PROMPTS = ["prompts"];
-const DEFAULT_EXPANDED_PARAMS = ["input", "output"];
 
 function PlaygroundContent() {
   const agentStore = useAgentStore();
@@ -781,10 +734,46 @@ function PlaygroundContent() {
     }
   }, [isRunning]);
 
+  // The mounted panel set varies by mode; passing panelIds keys each mode's
+  // saved layout separately so switching modes doesn't clobber the other's
+  const panelIds = useMemo(
+    () =>
+      isDatasetMode
+        ? ["prompts", "io"]
+        : templateFormat !== TemplateFormats.NONE
+          ? ["prompts", "input", "output"]
+          : ["prompts", "output"],
+    [isDatasetMode, templateFormat]
+  );
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: "playground-panels",
+    id: "playground-panels-v2",
+    panelIds,
     storage: localStorage,
   });
+
+  const promptsPanelRef = useRef<PanelImperativeHandle | null>(null);
+  const inputsPanelRef = useRef<PanelImperativeHandle | null>(null);
+  const ioPanelRef = useRef<PanelImperativeHandle | null>(null);
+
+  // Never leave every section collapsed — expand the opposite section so the
+  // page always has a focused area
+  const handleSectionCollapse = (
+    collapsed: boolean,
+    section: "prompts" | "inputs" | "io"
+  ) => {
+    if (!collapsed) {
+      return;
+    }
+    const panels = [promptsPanelRef, inputsPanelRef, ioPanelRef]
+      .map((panelRef) => panelRef.current)
+      .filter((panel) => panel != null);
+    if (!panels.every((panel) => panel.isCollapsed())) {
+      return;
+    }
+    const fallbackPanelRef =
+      section === "prompts" ? ioPanelRef : promptsPanelRef;
+    fallbackPanelRef.current?.expand();
+  };
 
   return (
     <Fragment key="playground-content">
@@ -793,109 +782,116 @@ function PlaygroundContent() {
         defaultLayout={defaultLayout}
         onLayoutChanged={onLayoutChanged}
       >
-        <Panel id="prompts">
-          <div css={playgroundPromptPanelContentCSS}>
-            <DisclosureGroup defaultExpandedKeys={DEFAULT_EXPANDED_PROMPTS}>
-              <Disclosure id="prompts" size="L">
-                <DisclosureTrigger
-                  arrowPosition="start"
-                  justifyContent="space-between"
+        <TitledPanel
+          ref={promptsPanelRef}
+          headingLevel={2}
+          title="Prompts"
+          extra={
+            <Flex direction="row" gap="size-100" alignItems="center">
+              <TemplateFormatRadioGroup size="S" />
+              <AddPromptButton />
+            </Flex>
+          }
+          panelProps={{ id: "prompts", minSize: "15%" }}
+          onCollapseChange={(collapsed) =>
+            handleSectionCollapse(collapsed, "prompts")
+          }
+        >
+          <div css={promptsWrapCSS}>
+            <Flex direction="row" gap="size-200" maxWidth="100%">
+              {instanceIds.map((instanceId) => (
+                <View
+                  flex="1 1 0px"
+                  key={`${instanceId}-prompt`}
+                  minWidth={PLAYGROUND_PROMPT_PANEL_MIN_WIDTH}
                 >
-                  Prompts
-                  <StopPropagation>
-                    <Flex direction="row" gap="size-100" alignItems="center">
-                      <TemplateFormatRadioGroup size="S" />
-                      <AddPromptButton />
-                    </Flex>
-                  </StopPropagation>
-                </DisclosureTrigger>
-                <DisclosurePanel>
-                  <div css={promptsWrapCSS}>
-                    <Flex direction="row" gap="size-200" maxWidth="100%">
-                      {instanceIds.map((instanceId) => (
-                        <View
-                          flex="1 1 0px"
-                          key={`${instanceId}-prompt`}
-                          minWidth={PLAYGROUND_PROMPT_PANEL_MIN_WIDTH}
-                        >
-                          <PlaygroundTemplate
-                            playgroundInstanceId={instanceId}
-                            appendedMessagesPath={appendedMessagesPath}
-                            availablePaths={availablePaths}
-                          />
-                        </View>
-                      ))}
-                    </Flex>
-                  </div>
-                </DisclosurePanel>
-              </Disclosure>
-            </DisclosureGroup>
+                  <PlaygroundTemplate
+                    playgroundInstanceId={instanceId}
+                    appendedMessagesPath={appendedMessagesPath}
+                    availablePaths={availablePaths}
+                  />
+                </View>
+              ))}
+            </Flex>
           </div>
-        </Panel>
-        <Separator css={compactResizeHandleCSS} />
-        <Panel id="io">
-          {isDatasetMode ? (
-            <Suspense fallback={<Loading />}>
-              <PlaygroundDatasetSection
-                key={datasetId} // reset evaluator selection when dataset changes
-                datasetId={datasetId}
-                splitIds={splitIds}
-                isCodeEvaluatorFormOpen={isCodeEvaluatorFormOpen}
-                onCodeEvaluatorFormOpenChange={(isOpen) =>
-                  setCodeEvaluatorFormDatasetId(isOpen ? datasetId : null)
+        </TitledPanel>
+        {isDatasetMode ? (
+          <Suspense
+            fallback={
+              // Render the same TitledPanel the resolved section renders, so the
+              // layout doesn't jump and — critically — the io panel is registered
+              // as `collapsible`. A plain Panel would make a persisted collapsed
+              // (0%) layout illegal, clamping it to minSize and re-persisting it.
+              <TitledPanel
+                disabled
+                resizable
+                headingLevel={2}
+                title="Experiment"
+                panelProps={IO_PANEL_PROPS}
+              >
+                <Loading />
+              </TitledPanel>
+            }
+          >
+            <PlaygroundDatasetSection
+              key={datasetId} // reset evaluator selection when dataset changes
+              datasetId={datasetId}
+              splitIds={splitIds}
+              panelRef={ioPanelRef}
+              onPanelCollapseChange={(collapsed) =>
+                handleSectionCollapse(collapsed, "io")
+              }
+              isCodeEvaluatorFormOpen={isCodeEvaluatorFormOpen}
+              onCodeEvaluatorFormOpenChange={(isOpen) =>
+                setCodeEvaluatorFormDatasetId(isOpen ? datasetId : null)
+              }
+              isLlmEvaluatorFormOpen={isLlmEvaluatorFormOpen}
+              onLlmEvaluatorFormOpenChange={(isOpen) =>
+                setLlmEvaluatorFormDatasetId(isOpen ? datasetId : null)
+              }
+            />
+          </Suspense>
+        ) : (
+          <>
+            {templateFormat !== TemplateFormats.NONE ? (
+              <TitledPanel
+                ref={inputsPanelRef}
+                headingLevel={2}
+                resizable
+                title="Inputs"
+                extra={<PlaygroundDatasetSelect />}
+                panelProps={{ id: "input", minSize: "10%" }}
+                onCollapseChange={(collapsed) =>
+                  handleSectionCollapse(collapsed, "inputs")
                 }
-                isLlmEvaluatorFormOpen={isLlmEvaluatorFormOpen}
-                onLlmEvaluatorFormOpenChange={(isOpen) =>
-                  setLlmEvaluatorFormDatasetId(isOpen ? datasetId : null)
-                }
-              />
-            </Suspense>
-          ) : (
-            <div css={playgroundInputOutputPanelContentCSS}>
-              <DisclosureGroup defaultExpandedKeys={DEFAULT_EXPANDED_PARAMS}>
-                {templateFormat !== TemplateFormats.NONE ? (
-                  <Disclosure id="input" size="L">
-                    <DisclosureTrigger arrowPosition="start">
-                      <Flex
-                        direction="row"
-                        gap="size-100"
-                        alignItems="center"
-                        justifyContent="space-between"
-                        width="100%"
-                      >
-                        Inputs
-                        <PlaygroundDatasetSelect />
-                      </Flex>
-                    </DisclosureTrigger>
-                    <DisclosurePanel>
-                      <View padding="size-200" height={"100%"}>
-                        <PlaygroundInput />
-                      </View>
-                    </DisclosurePanel>
-                  </Disclosure>
-                ) : null}
-                <Disclosure id="output" size="L">
-                  <DisclosureTrigger arrowPosition="start">
-                    Output
-                  </DisclosureTrigger>
-                  <DisclosurePanel>
-                    <View padding="size-200" height="100%">
-                      <Flex direction="row" gap="size-200">
-                        {instanceIds.map((instanceId) => (
-                          <View key={`${instanceId}-output`} flex="1 1 0px">
-                            <PlaygroundOutput
-                              playgroundInstanceId={instanceId}
-                            />
-                          </View>
-                        ))}
-                      </Flex>
+              >
+                <View padding="size-200" height="100%" overflow="auto">
+                  <PlaygroundInput />
+                </View>
+              </TitledPanel>
+            ) : null}
+            <TitledPanel
+              ref={ioPanelRef}
+              headingLevel={2}
+              resizable
+              title="Output"
+              panelProps={{ id: "output", minSize: "15%" }}
+              onCollapseChange={(collapsed) =>
+                handleSectionCollapse(collapsed, "io")
+              }
+            >
+              <View padding="size-200" height="100%" overflow="auto">
+                <Flex direction="row" gap="size-200">
+                  {instanceIds.map((instanceId) => (
+                    <View key={`${instanceId}-output`} flex="1 1 0px">
+                      <PlaygroundOutput playgroundInstanceId={instanceId} />
                     </View>
-                  </DisclosurePanel>
-                </Disclosure>
-              </DisclosureGroup>
-            </div>
-          )}
-        </Panel>
+                  ))}
+                </Flex>
+              </View>
+            </TitledPanel>
+          </>
+        )}
       </Group>
       {runningExperiment ? (
         <ConfirmExperimentNavigationDialog

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -342,6 +342,8 @@ function SortableMessageItem({
     <li ref={sortable.ref} style={dragAndDropLiStyles}>
       <Card
         collapsible
+        interactiveTitle
+        collapseButtonLabel={`${message.role} message`}
         {...messageCardStyles}
         title={
           <MessageRoleSelect

--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -1,5 +1,7 @@
+import type { Ref } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { graphql, readInlineData, useLazyLoadQuery } from "react-relay";
+import type { PanelImperativeHandle } from "react-resizable-panels";
 
 import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
@@ -17,6 +19,7 @@ import {
 } from "@phoenix/agent/tools/datasetEvaluatorSelection";
 import { Flex } from "@phoenix/components";
 import type { EvaluatorItem } from "@phoenix/components/evaluators/EvaluatorSelectMenuItem";
+import { TitledPanel } from "@phoenix/components/react-resizable-panels";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import type { EvaluatorInputMappingInput } from "@phoenix/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql";
@@ -33,6 +36,12 @@ import { PlaygroundDatasetExamplesTable } from "./PlaygroundDatasetExamplesTable
 import { PlaygroundDatasetExamplesTableProvider } from "./PlaygroundDatasetExamplesTableContext";
 import { PlaygroundExperimentToolbar } from "./PlaygroundExperimentToolbar";
 
+/**
+ * Panel config for the experiment (io) section. Shared with the Suspense
+ * fallback in Playground.tsx so the two stay in sync.
+ */
+export const IO_PANEL_PROPS = { id: "io", minSize: "15%" } as const;
+
 export function PlaygroundDatasetSection({
   datasetId,
   splitIds,
@@ -40,6 +49,8 @@ export function PlaygroundDatasetSection({
   onCodeEvaluatorFormOpenChange,
   isLlmEvaluatorFormOpen,
   onLlmEvaluatorFormOpenChange,
+  panelRef,
+  onPanelCollapseChange,
 }: {
   datasetId: string;
   splitIds?: string[];
@@ -47,6 +58,8 @@ export function PlaygroundDatasetSection({
   onCodeEvaluatorFormOpenChange: (isOpen: boolean) => void;
   isLlmEvaluatorFormOpen: boolean;
   onLlmEvaluatorFormOpenChange: (isOpen: boolean) => void;
+  panelRef?: Ref<PanelImperativeHandle | null>;
+  onPanelCollapseChange?: (collapsed: boolean) => void;
 }) {
   const data = useLazyLoadQuery<PlaygroundDatasetSectionQuery>(
     graphql`
@@ -243,34 +256,45 @@ export function PlaygroundDatasetSection({
   // We want to re-mount the context when the dataset or the splits change
   const key = `${datasetId}-${splitIds?.join("-")}`;
   return (
-    <Flex direction={"column"} height={"100%"}>
-      <PlaygroundExperimentToolbar
-        datasetId={datasetId}
-        datasetEvaluators={datasetEvaluators}
-        selectedDatasetEvaluatorIds={selectedDatasetEvaluatorIds}
-        onSelectionChange={setSelectedDatasetEvaluatorIds}
-        updateConnectionIds={
-          data.dataset.datasetEvaluators?.__id != null
-            ? [data.dataset.datasetEvaluators.__id]
-            : []
-        }
-        onEvaluatorCreated={onEvaluatorCreated}
-        query={data}
-        isCodeEvaluatorFormOpen={isCodeEvaluatorFormOpen}
-        onCodeEvaluatorFormOpenChange={onCodeEvaluatorFormOpenChange}
-        isLlmEvaluatorFormOpen={isLlmEvaluatorFormOpen}
-        onLlmEvaluatorFormOpenChange={onLlmEvaluatorFormOpenChange}
-        editingEvaluator={editingEvaluator}
-        onEditingEvaluatorChange={setEditingEvaluator}
-      />
-      <PlaygroundDatasetExamplesTableProvider key={key}>
-        <PlaygroundDatasetExamplesTable
+    <TitledPanel
+      ref={panelRef}
+      resizable
+      headingLevel={2}
+      title="Experiment"
+      extra={
+        <PlaygroundExperimentToolbar
           datasetId={datasetId}
-          splitIds={splitIds}
-          evaluatorMappings={selectedEvaluatorWithInputMapping}
-          evaluatorOutputConfigs={evaluatorOutputConfigs}
+          datasetEvaluators={datasetEvaluators}
+          selectedDatasetEvaluatorIds={selectedDatasetEvaluatorIds}
+          onSelectionChange={setSelectedDatasetEvaluatorIds}
+          updateConnectionIds={
+            data.dataset.datasetEvaluators?.__id != null
+              ? [data.dataset.datasetEvaluators.__id]
+              : []
+          }
+          onEvaluatorCreated={onEvaluatorCreated}
+          query={data}
+          isCodeEvaluatorFormOpen={isCodeEvaluatorFormOpen}
+          onCodeEvaluatorFormOpenChange={onCodeEvaluatorFormOpenChange}
+          isLlmEvaluatorFormOpen={isLlmEvaluatorFormOpen}
+          onLlmEvaluatorFormOpenChange={onLlmEvaluatorFormOpenChange}
+          editingEvaluator={editingEvaluator}
+          onEditingEvaluatorChange={setEditingEvaluator}
         />
-      </PlaygroundDatasetExamplesTableProvider>
-    </Flex>
+      }
+      panelProps={IO_PANEL_PROPS}
+      onCollapseChange={onPanelCollapseChange}
+    >
+      <Flex direction={"column"} height={"100%"}>
+        <PlaygroundDatasetExamplesTableProvider key={key}>
+          <PlaygroundDatasetExamplesTable
+            datasetId={datasetId}
+            splitIds={splitIds}
+            evaluatorMappings={selectedEvaluatorWithInputMapping}
+            evaluatorOutputConfigs={evaluatorOutputConfigs}
+          />
+        </PlaygroundDatasetExamplesTableProvider>
+      </Flex>
+    </TitledPanel>
   );
 }

--- a/app/src/pages/playground/PlaygroundDatasetSelect.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSelect.tsx
@@ -95,6 +95,7 @@ export function PlaygroundDatasetSelect({
       {datasetId ? (
         <Button
           className="dataset-clear-button"
+          aria-label="Clear dataset"
           size="S"
           isDisabled={isDisabled}
           leadingVisual={<Icon svg={<Icons.Close />} />}

--- a/app/src/pages/playground/PlaygroundExperimentToolbar.tsx
+++ b/app/src/pages/playground/PlaygroundExperimentToolbar.tsx
@@ -3,12 +3,10 @@ import { useMemo } from "react";
 import {
   ExternalLinkButton,
   Flex,
-  Heading,
   Icon,
   Icons,
   RecordIcon,
   Timer,
-  View,
 } from "@phoenix/components";
 import { ProgressCircle } from "@phoenix/components/core/progress/ProgressCircle";
 import { Switch } from "@phoenix/components/core/switch";
@@ -70,75 +68,60 @@ export function PlaygroundExperimentToolbar({
     });
   }, [instances]);
   return (
-    <View
-      flex="none"
-      paddingX="size-200"
-      paddingY={"size-100"}
-      borderBottomColor={"default"}
-      borderBottomWidth={"thin"}
-      height={50}
-    >
-      <Flex justifyContent="space-between" alignItems="center" height="100%">
-        <Flex gap="size-200" alignItems="center">
-          <Heading level={2} weight="heavy">
-            Experiment
-          </Heading>
-          {experimentIds.length > 0 && !isRunning ? (
-            <ExternalLinkButton
-              size="S"
-              isDisabled={isRunning}
-              variant="quiet"
-              trailingVisual={<Icon svg={<Icons.ExternalLink />} />}
-              href={prependBasename(
-                `/datasets/${datasetId}/compare?${experimentIds.map((id) => `experimentId=${id}`).join("&")}`
-              )}
-            >
-              View Experiment{instances.length > 1 ? "s" : ""}
-            </ExternalLinkButton>
-          ) : null}
-        </Flex>
-        <Flex direction="row" gap="size-100" alignItems="center">
-          {isRunning ? (
-            <Flex alignItems="center" gap="size-100">
-              {recordExperiments ? (
-                <RecordIcon isActive />
-              ) : (
-                <ProgressCircle isIndeterminate size="S" />
-              )}
-              <Timer size="S" color="text-700" />
-            </Flex>
-          ) : (
-            <Switch
-              isSelected={recordExperiments}
-              onChange={setRecordExperiments}
-              labelPlacement="start"
-            >
-              Record
-            </Switch>
+    <Flex direction="row" gap="size-100" alignItems="center">
+      {experimentIds.length > 0 && !isRunning ? (
+        <ExternalLinkButton
+          size="S"
+          isDisabled={isRunning}
+          variant="quiet"
+          trailingVisual={<Icon svg={<Icons.ExternalLink />} />}
+          href={prependBasename(
+            `/datasets/${datasetId}/compare?${experimentIds.map((id) => `experimentId=${id}`).join("&")}`
           )}
-          <PlaygroundEvaluatorSelect
-            evaluators={datasetEvaluators}
-            selectedIds={selectedDatasetEvaluatorIds}
-            onSelectionChange={onSelectionChange}
-            datasetId={datasetId}
-            updateConnectionIds={updateConnectionIds}
-            onEvaluatorCreated={onEvaluatorCreated}
-            query={query}
-            isDisabled={isRunning}
-            isCodeEvaluatorFormOpen={isCodeEvaluatorFormOpen}
-            onCodeEvaluatorFormOpenChange={onCodeEvaluatorFormOpenChange}
-            isLlmEvaluatorFormOpen={isLlmEvaluatorFormOpen}
-            onLlmEvaluatorFormOpenChange={onLlmEvaluatorFormOpenChange}
-            editingEvaluator={editingEvaluator}
-            onEditingEvaluatorChange={onEditingEvaluatorChange}
-          />
-          <PlaygroundDatasetSelect isDisabled={isRunning} />
-          <PlaygroundExperimentSettingsButton
-            isDisabled={isRunning}
-            datasetId={datasetId}
-          />
+        >
+          View Experiment{instances.length > 1 ? "s" : ""}
+        </ExternalLinkButton>
+      ) : null}
+      {isRunning ? (
+        <Flex alignItems="center" gap="size-100">
+          {recordExperiments ? (
+            <RecordIcon isActive />
+          ) : (
+            <ProgressCircle isIndeterminate size="S" />
+          )}
+          <Timer size="S" color="text-700" />
         </Flex>
-      </Flex>
-    </View>
+      ) : (
+        <Switch
+          size="S"
+          isSelected={recordExperiments}
+          onChange={setRecordExperiments}
+          labelPlacement="start"
+        >
+          Record
+        </Switch>
+      )}
+      <PlaygroundEvaluatorSelect
+        evaluators={datasetEvaluators}
+        selectedIds={selectedDatasetEvaluatorIds}
+        onSelectionChange={onSelectionChange}
+        datasetId={datasetId}
+        updateConnectionIds={updateConnectionIds}
+        onEvaluatorCreated={onEvaluatorCreated}
+        query={query}
+        isDisabled={isRunning}
+        isCodeEvaluatorFormOpen={isCodeEvaluatorFormOpen}
+        onCodeEvaluatorFormOpenChange={onCodeEvaluatorFormOpenChange}
+        isLlmEvaluatorFormOpen={isLlmEvaluatorFormOpen}
+        onLlmEvaluatorFormOpenChange={onLlmEvaluatorFormOpenChange}
+        editingEvaluator={editingEvaluator}
+        onEditingEvaluatorChange={onEditingEvaluatorChange}
+      />
+      <PlaygroundDatasetSelect isDisabled={isRunning} />
+      <PlaygroundExperimentSettingsButton
+        isDisabled={isRunning}
+        datasetId={datasetId}
+      />
+    </Flex>
   );
 }

--- a/app/src/pages/playground/VariableEditor.tsx
+++ b/app/src/pages/playground/VariableEditor.tsx
@@ -1,6 +1,7 @@
 import { defaultKeymap } from "@codemirror/commands";
 import type { BasicSetupOptions } from "@uiw/react-codemirror";
 import ReactCodeMirror, { EditorView, keymap } from "@uiw/react-codemirror";
+import { useMemo } from "react";
 
 import { Label } from "@phoenix/components";
 import { CodeWrap, pierreDark, pierreLight } from "@phoenix/components/code";
@@ -23,7 +24,7 @@ const basicSetupOptions: BasicSetupOptions = {
   defaultKeymap: false,
 };
 
-const extensions = [
+const baseExtensions = [
   EditorView.lineWrapping,
   keymap.of([
     // Reserve Mod-Enter for the submit button
@@ -46,6 +47,17 @@ export const VariableEditor = ({
   const editorValue = defaultValue ?? "";
   const editorKey = label ?? "";
   const codeMirrorTheme = theme === "light" ? pierreLight : pierreDark;
+  // stable identity so CodeMirror only reconfigures when the label changes
+  const extensions = useMemo(
+    () => [
+      ...baseExtensions,
+      // name the textbox after its variable for assistive technology
+      EditorView.contentAttributes.of({
+        "aria-label": label ?? "Variable value",
+      }),
+    ],
+    [label]
+  );
   return (
     <div css={fieldBaseCSS}>
       <Label>{label}</Label>

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -574,39 +574,41 @@ export function SessionsTable(props: SessionsTableProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getFlatHeaders, columnSizingInfo, columnSizingState, colLength]);
   return (
-    <Group orientation="horizontal" id="sessions-table-layout">
-      <Panel>
-        <TableMetricsChartsPanelGroup view="sessions">
-          <div css={spansTableCSS}>
-            <View
-              paddingTop="size-100"
-              paddingBottom="size-100"
-              paddingStart="size-200"
-              paddingEnd="size-200"
-              borderBottomColor="default"
-              borderBottomWidth="thin"
-              flex="none"
-            >
-              <Flex
-                direction="row"
-                gap="size-100"
-                width="100%"
-                alignItems="center"
-              >
-                <View flex="1 1 auto">
-                  <SessionSearchField />
-                </View>
-                <TableMetricsChartSelector view="sessions" />
-                <SessionColumnSelector
-                  columns={table.getAllColumns()}
-                  query={data}
-                />
-                <TableAsideToggleButton />
-              </Flex>
+    <TableMetricsChartsPanelGroup view="sessions">
+      <div css={spansTableCSS}>
+        <View
+          paddingTop="size-100"
+          paddingBottom="size-100"
+          paddingStart="size-200"
+          paddingEnd="size-200"
+          borderBottomColor="default"
+          borderBottomWidth="thin"
+          flex="none"
+        >
+          <Flex direction="row" gap="size-100" width="100%" alignItems="center">
+            <View flex="1 1 auto">
+              <SessionSearchField />
             </View>
+            <TableMetricsChartSelector view="sessions" />
+            <SessionColumnSelector
+              columns={table.getAllColumns()}
+              query={data}
+            />
+            <TableAsideToggleButton />
+          </Flex>
+        </View>
+        <Group
+          orientation="horizontal"
+          id="sessions-table-layout"
+          css={css`
+            flex: 1 1 auto;
+            min-height: 0;
+          `}
+        >
+          <Panel>
             <div
               css={css`
-                flex: 1 1 auto;
+                height: 100%;
                 overflow: auto;
               `}
               onScroll={(e) =>
@@ -717,14 +719,14 @@ export function SessionsTable(props: SessionsTableProps) {
                 </table>
               </ColumnOrderingProvider>
             </div>
-          </div>
-        </TableMetricsChartsPanelGroup>
-      </Panel>
-      <TableAsidePanel>
-        <SessionsTableAside
-          filterIoSubstringOrSessionId={filterIoSubstringOrSessionId}
-        />
-      </TableAsidePanel>
-    </Group>
+          </Panel>
+          <TableAsidePanel>
+            <SessionsTableAside
+              filterIoSubstringOrSessionId={filterIoSubstringOrSessionId}
+            />
+          </TableAsidePanel>
+        </Group>
+      </div>
+    </TableMetricsChartsPanelGroup>
   );
 }

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -911,66 +911,63 @@ export function SpansTable(props: SpansTableProps) {
   }, [getFlatHeaders, columnSizingInfo, columnSizingState, colLength]);
 
   return (
-    <Group orientation="horizontal" id="spans-table-layout">
-      <Panel>
-        <TableMetricsChartsPanelGroup view="spans">
-          <div css={spansTableCSS}>
-            <View
-              paddingTop="size-100"
-              paddingBottom="size-100"
-              paddingStart="size-200"
-              paddingEnd="size-200"
-              borderBottomColor="default"
-              borderBottomWidth="thin"
-              flex="none"
-            >
-              <Flex
-                direction="row"
-                gap="size-100"
-                width="100%"
-                alignItems="center"
-              >
-                <SpanFilterConditionField
-                  onValidCondition={setFilterCondition}
-                />
+    <TableMetricsChartsPanelGroup view="spans">
+      <div css={spansTableCSS}>
+        <View
+          paddingTop="size-100"
+          paddingBottom="size-100"
+          paddingStart="size-200"
+          paddingEnd="size-200"
+          borderBottomColor="default"
+          borderBottomWidth="thin"
+          flex="none"
+        >
+          <Flex direction="row" gap="size-100" width="100%" alignItems="center">
+            <SpanFilterConditionField onValidCondition={setFilterCondition} />
 
-                <ToggleButtonGroup
-                  aria-label="Toggle between root and all spans"
-                  selectionMode="single"
-                  selectedKeys={[rootSpansOnly ? "root" : "all"]}
-                  onSelectionChange={(selection) => {
-                    if (selection.size === 0) {
-                      return;
-                    }
-                    const selectedKey = selection.keys().next().value;
-                    if (isRootSpanFilterValue(selectedKey)) {
-                      setRootSpansOnly(selectedKey === "root");
-                    } else {
-                      throw new Error(
-                        `Unknown root span filter selection: ${selectedKey}`
-                      );
-                    }
-                  }}
-                >
-                  <ToggleButton aria-label="root spans" id="root">
-                    Root Spans
-                  </ToggleButton>
-                  <ToggleButton aria-label="all spans" id="all">
-                    All
-                  </ToggleButton>
-                </ToggleButtonGroup>
-                <TableMetricsChartSelector view="spans" />
-                <SpanColumnSelector
-                  columns={table.getAllColumns()}
-                  query={data}
-                />
-                <ProjectFilterConfigButton />
-                <TableAsideToggleButton />
-              </Flex>
-            </View>
+            <ToggleButtonGroup
+              aria-label="Toggle between root and all spans"
+              selectionMode="single"
+              selectedKeys={[rootSpansOnly ? "root" : "all"]}
+              onSelectionChange={(selection) => {
+                if (selection.size === 0) {
+                  return;
+                }
+                const selectedKey = selection.keys().next().value;
+                if (isRootSpanFilterValue(selectedKey)) {
+                  setRootSpansOnly(selectedKey === "root");
+                } else {
+                  throw new Error(
+                    `Unknown root span filter selection: ${selectedKey}`
+                  );
+                }
+              }}
+            >
+              <ToggleButton aria-label="root spans" id="root">
+                Root Spans
+              </ToggleButton>
+              <ToggleButton aria-label="all spans" id="all">
+                All
+              </ToggleButton>
+            </ToggleButtonGroup>
+            <TableMetricsChartSelector view="spans" />
+            <SpanColumnSelector columns={table.getAllColumns()} query={data} />
+            <ProjectFilterConfigButton />
+            <TableAsideToggleButton />
+          </Flex>
+        </View>
+        <Group
+          orientation="horizontal"
+          id="spans-table-layout"
+          css={css`
+            flex: 1 1 auto;
+            min-height: 0;
+          `}
+        >
+          <Panel>
             <div
               css={css`
-                flex: 1 1 auto;
+                height: 100%;
                 overflow: auto;
               `}
               onScroll={(e) =>
@@ -1100,18 +1097,18 @@ export function SpansTable(props: SpansTableProps) {
                 </table>
               </ColumnOrderingProvider>
             </div>
-            {selectedRows.length ? (
-              <SpanSelectionToolbar
-                selectedSpans={selectedSpans}
-                onClearSelection={clearSelection}
-              />
-            ) : null}
-          </div>
-        </TableMetricsChartsPanelGroup>
-      </Panel>
-      <TableAsidePanel>
-        <SpansTableAside filterCondition={filterCondition} />
-      </TableAsidePanel>
-    </Group>
+          </Panel>
+          <TableAsidePanel>
+            <SpansTableAside filterCondition={filterCondition} />
+          </TableAsidePanel>
+        </Group>
+        {selectedRows.length ? (
+          <SpanSelectionToolbar
+            selectedSpans={selectedSpans}
+            onClearSelection={clearSelection}
+          />
+        ) : null}
+      </div>
+    </TableMetricsChartsPanelGroup>
   );
 }

--- a/app/stories/TitledPanel.stories.tsx
+++ b/app/stories/TitledPanel.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import { Group, Panel } from "react-resizable-panels";
 
-import { Card, Text, Token, View } from "@phoenix/components";
+import { Button, Card, Text, Token, View } from "@phoenix/components";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
 
 const meta: Meta = {
@@ -137,5 +137,36 @@ const WithCustomTitleTemplate: StoryFn = (args) => (
 
 export const WithCustomTitle: Meta<typeof TitledPanel> = {
   render: WithCustomTitleTemplate,
+  args: {},
+};
+
+const WithActionsTemplate: StoryFn = (args) => (
+  <Card title="TitledPanel with Actions">
+    <View {...bodyStyle}>
+      <Group orientation="vertical">
+        <TitledPanel
+          title="Prompts"
+          extra={<Button size="S">Compare</Button>}
+          {...args}
+        >
+          <View padding="size-200">
+            <Text>
+              Actions stay clickable without toggling the panel, even while
+              collapsed
+            </Text>
+          </View>
+        </TitledPanel>
+        <TitledPanel resizable title="Output" {...args}>
+          <View padding="size-200">
+            <Text>This is the output panel</Text>
+          </View>
+        </TitledPanel>
+      </Group>
+    </View>
+  </Card>
+);
+
+export const WithActions: Meta<typeof TitledPanel> = {
+  render: WithActionsTemplate,
   args: {},
 };


### PR DESCRIPTION
## Summary

Makes the playground's **Prompts** and **Experiment** sections collapsible and resizable via `TitledPanel`, with layout persisted per mode. Also aligns `TitledPanel` headers with table header rows, and includes a round of a11y and code-review fixes.

## Changes

- **Collapsible sections**: playground Prompts / Experiment sections are now `TitledPanel`s — collapse, expand, resize, with layout persisted to `localStorage` (keyed per mode so switching modes doesn't clobber the other's layout). A guard keeps at least one section expanded.
- **Header alignment**: new `--global-table-header-height` token drives both the table `th` and the `TitledPanel` header, so panel headers line up with the table they sit beside.
- **Card `interactiveTitle`**: the collapse toggle renders as a standalone arrow when the title holds its own control (e.g. the message role select), so interactive elements aren't nested inside a button. New `collapseButtonLabel` prop gives each toggle a distinct accessible name.
- **A11y**: labels for `JSONBlock`, `CopyToClipboardButton`, `Switch`, `DisclosureArrow`, and the Scarf tracking pixel.

## Review fixes

Applied from a high-effort `/code-review` pass:

- The dataset-section Suspense fallback now renders the real `TitledPanel` rather than a hand-copied `PanelTitle` + bare `Panel`. The copy omitted `collapsible`, so a persisted *collapsed* layout was clamped to `minSize` and re-persisted — silently destroying the user's collapsed state on reload. It also omitted the separator/arrow/border, causing the very layout jump its comment claimed to prevent.
- `TitledPanel` actions cluster can now shrink and scroll instead of being clipped by the enclosing `Group`'s `overflow: hidden`.
- `collapsed` is derived from the panel's own `isCollapsed()` rather than an exact-zero size check, so it stays correct for a non-zero `collapsedSize`.
- `panelIds` memoized — it was invalidating `useDefaultLayout`'s memo and re-reading localStorage on every keystroke.
- `PanelTitle` merges a caller-supplied `className` instead of dropping it.

## Test plan

- [ ] Collapse the Experiment section, reload — it stays collapsed (this was the bug above).
- [ ] Resize/collapse each section; confirm layout persists and at least one section stays expanded.
- [ ] Narrow the viewport with a dataset loaded; confirm the Experiment toolbar controls remain reachable.
- [ ] Confirm panel headers line up with the spans-table header row.

Typecheck and lint pass. Not yet exercised end-to-end in a browser.