### PR TITLE
fix: Propagate IO tooltip cell clicks

### DIFF
--- a/app/src/pages/project/IOValueTooltipCell.tsx
+++ b/app/src/pages/project/IOValueTooltipCell.tsx
@@ -148,7 +148,10 @@ function IOValueTooltipCell({
         }
       }}
     >
-      <TriggerWrap css={triggerCSS}>
+      <TriggerWrap
+        css={triggerCSS}
+        onPress={(event) => event.continuePropagation()}
+      >
         <span>{previewText}</span>
       </TriggerWrap>
       <RichTooltip placement="bottom start" width="auto" css={tooltipCSS}>


### PR DESCRIPTION
## Summary

- allow clicks on IO tooltip text to propagate to the containing table row
- restore row navigation from input and output cells in trace, span, and session tables

## Root cause

React Aria press handling stops propagation by default. The new tooltip trigger wrapped the cell text in a pressable element, preventing the table row click handler from receiving the event.

## Validation

- frontend formatting check
- focused frontend lint
- frontend TypeScript typecheck