### PR TITLE
feat(ui): add Requesty to integration registry

### DIFF
--- a/app/src/components/project/IntegrationIcons.tsx
+++ b/app/src/components/project/IntegrationIcons.tsx
@@ -956,6 +956,26 @@ export const OpenRouterSVG = () => (
   </svg>
 );
 
+// Generic placeholder mark for Requesty (brand asset not bundled in this repo).
+// Mirrors the inline-SVG approach used for other OpenAI-compatible providers.
+export const RequestySVG = () => (
+  <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+    <g clipPath="url(#requesty-clip)">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M16 2 L28 9 L28 23 L16 30 L4 23 L4 9 L16 2 Z M16 5.3 L6.8 10.6 L6.8 21.4 L16 26.7 L25.2 21.4 L25.2 10.6 L16 5.3 Z M16 10 L21.5 13.2 L21.5 18.8 L16 22 L10.5 18.8 L10.5 13.2 L16 10 Z"
+        fill="currentColor"
+      />
+    </g>
+    <defs>
+      <clipPath id="requesty-clip">
+        <rect width="32" height="32" fill="white" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
 export const RubyLLMSVG = () => (
   <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
     <g clipPath="url(#rubyllm-clip)">
@@ -1308,6 +1328,7 @@ export const INTEGRATION_ICONS: Record<string, () => React.JSX.Element> = {
   OpenRouterSVG,
   PortkeySVG,
   PydanticAISVG,
+  RequestySVG,
   RubyLLMSVG,
   StrandsAgentsSVG,
   TanStackAISVG,

--- a/app/src/components/project/integrationSnippets/index.ts
+++ b/app/src/components/project/integrationSnippets/index.ts
@@ -35,6 +35,10 @@ export {
   getOpenRouterCodeTypescript,
 } from "./openRouter";
 export {
+  getRequestyCodePython,
+  getRequestyCodeTypescript,
+} from "./requesty";
+export {
   getOtelInitCodePython,
   getOtelInitCodeTypescript,
 } from "./phoenixOtel";

--- a/app/src/components/project/integrationSnippets/requesty.ts
+++ b/app/src/components/project/integrationSnippets/requesty.ts
@@ -1,0 +1,54 @@
+export function getRequestyCodePython({
+  projectName,
+}: {
+  projectName: string;
+}): string {
+  return `from phoenix.otel import register
+import os
+
+tracer_provider = register(
+  project_name="${projectName}",
+  auto_instrument=True
+)
+
+# SDK imports must come after register() so auto-instrumentation can patch them
+import openai
+
+client = openai.OpenAI(
+  base_url="https://router.requesty.ai/v1",
+  api_key=os.environ["REQUESTY_API_KEY"],
+)
+response = client.chat.completions.create(
+  model="openai/gpt-4o-mini",
+  messages=[{"role": "user", "content": "Explain the theory of relativity in simple terms."}],
+)`;
+}
+
+export function getRequestyCodeTypescript({
+  projectName,
+}: {
+  projectName: string;
+}): string {
+  return `import { register } from "@arizeai/phoenix-otel";
+import { OpenAIInstrumentation } from "@arizeai/openinference-instrumentation-openai";
+import OpenAI from "openai";
+
+const provider = register({
+  projectName: "${projectName}",
+});
+
+const instrumentation = new OpenAIInstrumentation();
+instrumentation.manuallyInstrument(OpenAI);
+
+const openai = new OpenAI({
+  baseURL: "https://router.requesty.ai/v1",
+  apiKey: process.env.REQUESTY_API_KEY,
+});
+const response = await openai.chat.completions.create({
+  model: "openai/gpt-4o-mini",
+  messages: [{ role: "user", content: "Explain the theory of relativity in simple terms." }],
+});
+
+// Flush pending traces before the process exits
+await provider.forceFlush();`;
+}

--- a/app/src/pages/project/integrationRegistry.tsx
+++ b/app/src/pages/project/integrationRegistry.tsx
@@ -27,6 +27,7 @@ import {
   OpenRouterSVG,
   PortkeySVG,
   PydanticAISVG,
+  RequestySVG,
   StrandsAgentsSVG,
   TanStackAISVG,
   TraceLoopSVG,
@@ -60,6 +61,8 @@ import {
   getOpenRouterCodeTypescript,
   getOtelInitCodePython,
   getOtelInitCodeTypescript,
+  getRequestyCodePython,
+  getRequestyCodeTypescript,
   getStrandsAgentsCodePython,
   getTanStackAiCodeTypescript,
   getPerplexityCodePython,
@@ -81,6 +84,9 @@ const ANTHROPIC_ENV: readonly EnvVar[] = [
 ];
 const OPENROUTER_ENV: readonly EnvVar[] = [
   { name: "OPENROUTER_API_KEY", value: "<your-openrouter-api-key>" },
+];
+const REQUESTY_ENV: readonly EnvVar[] = [
+  { name: "REQUESTY_API_KEY", value: "<your-requesty-api-key>" },
 ];
 const CEREBRAS_ENV: readonly EnvVar[] = [
   { name: "CEREBRAS_API_KEY", value: "<your-cerebras-api-key>" },
@@ -666,6 +672,39 @@ export const ONBOARDING_INTEGRATIONS: OnboardingIntegration[] = [
         envVars: OPENROUTER_ENV,
         docsHref:
           "https://arize.com/docs/phoenix/integrations/llm-providers/openrouter/openai-tracing",
+        githubHref:
+          "https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-openai",
+      },
+    },
+  },
+  {
+    id: "requesty",
+    name: "Requesty",
+    icon: <RequestySVG />,
+    configs: {
+      Python: {
+        packages: [
+          "arize-phoenix-otel",
+          "openinference-instrumentation-openai",
+          "openai",
+        ],
+        getImplementationCode: getRequestyCodePython,
+        envVars: REQUESTY_ENV,
+        docsHref:
+          "https://arize.com/docs/phoenix/integrations/llm-providers/requesty/openai-tracing",
+        githubHref:
+          "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai",
+      },
+      TypeScript: {
+        packages: [
+          "@arizeai/phoenix-otel",
+          "@arizeai/openinference-instrumentation-openai",
+          "openai",
+        ],
+        getImplementationCode: getRequestyCodeTypescript,
+        envVars: REQUESTY_ENV,
+        docsHref:
+          "https://arize.com/docs/phoenix/integrations/llm-providers/requesty/openai-tracing",
         githubHref:
           "https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-openai",
       },

--- a/docs.json
+++ b/docs.json
@@ -569,6 +569,13 @@
                 ]
               },
               {
+                "group": "Requesty",
+                "pages": [
+                  "docs/phoenix/integrations/llm-providers/requesty",
+                  "docs/phoenix/integrations/llm-providers/requesty/openai-tracing"
+                ]
+              },
+              {
                 "group": "VertexAI",
                 "pages": [
                   "docs/phoenix/integrations/llm-providers/vertexai",

--- a/docs/phoenix/integrations/llm-providers/requesty.mdx
+++ b/docs/phoenix/integrations/llm-providers/requesty.mdx
@@ -1,0 +1,15 @@
+---
+title: "Requesty"
+description: "Requesty is an OpenAI-compatible LLM gateway that routes requests across multiple providers and models through a unified API, making it easier to compare, switch between, and integrate different models."
+sidebarTitle: "Overview"
+---
+
+
+<Card title="Requesty" href="https://requesty.ai/" icon="globe" horizontal>
+**Website**: [](https://requesty.ai/)
+</Card>
+
+
+<Columns cols={2}>
+  <Card title="Requesty Tracing" href="/docs/phoenix/integrations/llm-providers/requesty/openai-tracing"/>
+</Columns>

--- a/docs/phoenix/integrations/llm-providers/requesty/openai-tracing.mdx
+++ b/docs/phoenix/integrations/llm-providers/requesty/openai-tracing.mdx
@@ -1,0 +1,78 @@
+---
+title: "Requesty Tracing"
+description: "Phoenix provides auto-instrumentation for Requesty through the OpenAI Python Library since Requesty provides a fully OpenAI-compatible API endpoint."
+---
+
+
+## Install
+
+```bash
+pip install openinference-instrumentation-openai openai
+```
+
+## Setup
+
+Add your Requesty API key as an environment variable:
+
+```bash
+export REQUESTY_API_KEY='your_requesty_api_key'
+```
+
+Use the register function to connect your application to Phoenix:
+
+```python
+from phoenix.otel import register
+
+# configure the Phoenix tracer
+tracer_provider = register(
+  project_name="my-llm-app", # Default is 'default'
+  auto_instrument=True # Auto-instrument your app based on installed dependencies
+)
+```
+
+## Run Requesty
+
+```python
+import os
+import openai
+
+client = openai.OpenAI(
+    base_url="https://router.requesty.ai/v1",
+    api_key=os.environ["REQUESTY_API_KEY"]
+)
+
+response = client.chat.completions.create(
+    model="openai/gpt-4o-mini",
+    messages=[{"role": "user", "content": "Write a haiku about observability."}],
+)
+print(response.choices[0].message.content)
+```
+
+Models are addressed using the `<provider>/<model>` format (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`). EU users can point the client at `https://router.eu.requesty.ai/v1` instead.
+
+## Observe
+
+Now that you have tracing set up, all invocations of the OpenAI client pointed at Requesty will be streamed to your running Phoenix for observability and evaluation.
+
+## What Gets Traced
+
+All Requesty model calls are automatically traced and include:
+
+* Request/response data and timing
+* Model name and provider information
+* Token usage and cost data (when supported)
+* Error handling and debugging information
+
+## Common Issues
+
+* **API Key**: Use your Requesty API key, not OpenAI's
+* **Model Names**: Use the `<provider>/<model>` format. See [Requesty's model list](https://app.requesty.ai/router/list) for available models
+* **API Keys Dashboard**: Manage keys at [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys)
+* **Base URL**: Ensure you're using `https://router.requesty.ai/v1` as the base URL
+
+## Resources
+
+<Columns cols={2}>
+  <Card title="Requesty Documentation" href="https://docs.requesty.ai" icon="book" horizontal description="Requesty setup docs"/>
+  <Card title="OpenInference OpenAI Instrumentation" href="https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai" icon="puzzle-piece" horizontal description="OpenAI instrumentation package"/>
+</Columns>


### PR DESCRIPTION
## Summary

Adds [Requesty](https://requesty.ai) — an OpenAI-compatible LLM router — to the integration registry, mirroring the existing OpenRouter integration. Requesty exposes 400+ models through one endpoint, addressed as `provider/model`.

## Changes

Mirroring the OpenRouter integration:
- `app/src/components/project/integrationSnippets/requesty.ts` — code snippet (base URL `https://router.requesty.ai/v1`, env `REQUESTY_API_KEY`, model `openai/gpt-4o-mini`)
- `app/src/components/project/integrationSnippets/index.ts` — export
- `app/src/pages/project/integrationRegistry.tsx` — registry entry (placed after OpenRouter)
- `app/src/components/project/IntegrationIcons.tsx` — icon (inline SVG placeholder; happy to swap in a brand asset)
- `docs.json` + `docs/phoenix/integrations/llm-providers/requesty.mdx` (+ `openai-tracing.mdx`) — docs page and nav group

## Testing

The snippet documents wiring through Phoenix's OpenAI-compatible tracing path. Verified the documented base URL + `REQUESTY_API_KEY` + `openai/gpt-4o-mini` naming against the live `https://router.requesty.ai/v1` endpoint (returned successfully). The changes are verbatim structural mirrors of the working OpenRouter integration.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
