### PR TITLE
fix(cost-tracking): sync LiteLLM above_NNNk_tokens tier rates as threshold_based customizations

### DIFF
--- a/.github/.scripts/sync_models.py
+++ b/.github/.scripts/sync_models.py
@@ -3,16 +3,32 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal, Optional
 from urllib.request import urlopen
 
 from pydantic import AfterValidator, BaseModel
+
+PROMPT_TOKEN_ATTRIBUTE = "llm.token_count.prompt"
+
+TIER_THRESHOLDS: tuple[tuple[str, int], ...] = (
+    ("128k", 128_000),
+    ("200k", 200_000),
+    ("272k", 272_000),
+)
+
+
+class ThresholdBasedTokenPriceCustomization(BaseModel):
+    type: Literal["threshold_based"] = "threshold_based"
+    key: str
+    threshold: float
+    new_rate: float
 
 
 class TokenPrice(BaseModel):
     base_rate: float
     is_prompt: bool
     token_type: str
+    customization: Optional[ThresholdBasedTokenPriceCustomization] = None
 
 
 def validate_regular_expression(value: str) -> str:
@@ -135,6 +151,37 @@ def fetch_data(url: str) -> dict[str, Any]:
         raise Exception(f"Error fetching data from URL: {e}")
 
 
+def _tier_customization(
+    model_info: dict[str, Any],
+    base_field: str,
+) -> Optional[ThresholdBasedTokenPriceCustomization]:
+    """
+    LiteLLM publishes whole-prompt tier rates as ``<base_field>_above_NNNk_tokens`` variants
+    (e.g. ``input_cost_per_token_above_200k_tokens``). Emit the first configured tier as a
+    ThresholdBasedTokenPriceCustomization keyed on the prompt token count, so that once the
+    prompt strictly exceeds the threshold every token bills at the elevated rate. Only a
+    single tier per model is emitted today; no publicly-priced model in the LiteLLM manifest
+    configures more than one tier for the same base field.
+    """
+    for label, threshold in TIER_THRESHOLDS:
+        tier_field = f"{base_field}_above_{label}_tokens"
+        tier_rate = model_info.get(tier_field)
+        if tier_rate is None:
+            continue
+        try:
+            new_rate = float(tier_rate)
+        except (TypeError, ValueError):
+            continue
+        if new_rate <= 0:
+            continue
+        return ThresholdBasedTokenPriceCustomization(
+            key=PROMPT_TOKEN_ATTRIBUTE,
+            threshold=float(threshold),
+            new_rate=new_rate,
+        )
+    return None
+
+
 def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
     models_with_pricing = []
     for model_id, model_info in data.items():
@@ -163,6 +210,7 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="input",
                     base_rate=input_cost,
                     is_prompt=True,
+                    customization=_tier_customization(model_info, "input_cost_per_token"),
                 )
             )
 
@@ -172,6 +220,7 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="output",
                     base_rate=output_cost,
                     is_prompt=False,
+                    customization=_tier_customization(model_info, "output_cost_per_token"),
                 )
             )
 
@@ -181,6 +230,7 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="cache_read",
                     base_rate=cache_read_cost,
                     is_prompt=True,
+                    customization=_tier_customization(model_info, "cache_read_input_token_cost"),
                 )
             )
 
@@ -190,6 +240,9 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="cache_write",
                     base_rate=cache_creation_cost,
                     is_prompt=True,
+                    customization=_tier_customization(
+                        model_info, "cache_creation_input_token_cost"
+                    ),
                 )
             )
 

--- a/.github/.scripts/sync_models.py
+++ b/.github/.scripts/sync_models.py
@@ -10,12 +10,6 @@ from pydantic import AfterValidator, BaseModel
 
 PROMPT_TOKEN_ATTRIBUTE = "llm.token_count.prompt"
 
-TIER_THRESHOLDS: tuple[tuple[str, int], ...] = (
-    ("128k", 128_000),
-    ("200k", 200_000),
-    ("272k", 272_000),
-)
-
 
 class ThresholdBasedTokenPriceCustomization(BaseModel):
     type: Literal["threshold_based"] = "threshold_based"
@@ -157,29 +151,37 @@ def _tier_customization(
 ) -> Optional[ThresholdBasedTokenPriceCustomization]:
     """
     LiteLLM publishes whole-prompt tier rates as ``<base_field>_above_NNNk_tokens`` variants
-    (e.g. ``input_cost_per_token_above_200k_tokens``). Emit the first configured tier as a
+    (e.g. ``input_cost_per_token_above_200k_tokens``). Emit the lowest configured tier as a
     ThresholdBasedTokenPriceCustomization keyed on the prompt token count, so that once the
     prompt strictly exceeds the threshold every token bills at the elevated rate. Only a
     single tier per model is emitted today; no publicly-priced model in the LiteLLM manifest
     configures more than one tier for the same base field.
     """
-    for label, threshold in TIER_THRESHOLDS:
-        tier_field = f"{base_field}_above_{label}_tokens"
-        tier_rate = model_info.get(tier_field)
-        if tier_rate is None:
+    tier_field = re.compile(rf"{re.escape(base_field)}_above_(?P<thousands>\d+)k_tokens")
+
+    rates_by_threshold: dict[float, float] = {}
+    for field, rate in model_info.items():
+        match = tier_field.fullmatch(field)
+        if match is None or not _is_positive_number(rate):
             continue
-        try:
-            new_rate = float(tier_rate)
-        except (TypeError, ValueError):
-            continue
-        if new_rate <= 0:
-            continue
-        return ThresholdBasedTokenPriceCustomization(
-            key=PROMPT_TOKEN_ATTRIBUTE,
-            threshold=float(threshold),
-            new_rate=new_rate,
-        )
-    return None
+        threshold = float(match["thousands"]) * 1000
+        rates_by_threshold[threshold] = float(rate)
+
+    if not rates_by_threshold:
+        return None
+    lowest_threshold = min(rates_by_threshold)
+    return ThresholdBasedTokenPriceCustomization(
+        key=PROMPT_TOKEN_ATTRIBUTE,
+        threshold=lowest_threshold,
+        new_rate=rates_by_threshold[lowest_threshold],
+    )
+
+
+def _is_positive_number(value: Any) -> bool:
+    try:
+        return float(value) > 0
+    except (TypeError, ValueError):
+        return False
 
 
 def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:

--- a/scripts/verify_threshold_cost.py
+++ b/scripts/verify_threshold_cost.py
@@ -1,0 +1,218 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "arize-phoenix-otel",
+#     "httpx",
+# ]
+# ///
+"""Verify threshold-based (tiered) token cost calculation end to end.
+
+Sends two OpenInference LLM spans for a model with `threshold_based` tier
+pricing in the cost manifest — one below the 200k prompt-token threshold and
+one above — waits for Phoenix to ingest and compute span costs, then queries
+the GraphQL cost API and compares the results against expected values derived
+from the manifest.
+
+Usage:
+    uv run verify_threshold_cost.py [--base-url http://localhost:6006]
+
+The target Phoenix server must be running this branch, with a database that
+was (re)started on this branch so the facilitator has synced the manifest
+customizations into the `token_prices` table. Set PHOENIX_API_KEY if the
+server has auth enabled.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+MODEL_NAME = "claude-4-sonnet-20250514"
+BELOW_PROMPT_TOKENS = 100_000
+ABOVE_PROMPT_TOKENS = 250_000
+COMPLETION_TOKENS = 2_000
+MANIFEST_PATH = (
+    Path(__file__).parent.parent
+    / "src"
+    / "phoenix"
+    / "server"
+    / "cost_tracking"
+    / "model_cost_manifest.json"
+)
+
+SPANS_QUERY = """
+query VerifyThresholdCosts($projectId: ID!) {
+  node(id: $projectId) {
+    ... on Project {
+      spans(first: 50) {
+        edges {
+          node {
+            name
+            costSummary {
+              prompt { tokens cost }
+              completion { tokens cost }
+              total { tokens cost }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def expected_costs(prompt_tokens: int, completion_tokens: int) -> dict[str, float]:
+    """Compute expected prompt/completion costs for MODEL_NAME from the manifest."""
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    model = next(m for m in manifest["models"] if m["name"] == MODEL_NAME)
+    rates: dict[str, float] = {}
+    for price in model["token_prices"]:
+        token_type = price["token_type"]
+        if token_type not in ("input", "output"):
+            continue
+        rate = price["base_rate"]
+        if customization := price.get("customization"):
+            assert customization["type"] == "threshold_based"
+            assert customization["key"] == "llm.token_count.prompt"
+            if prompt_tokens > customization["threshold"]:
+                rate = customization["new_rate"]
+        rates[token_type] = rate
+    return {
+        "prompt": prompt_tokens * rates["input"],
+        "completion": completion_tokens * rates["output"],
+    }
+
+
+def send_spans(base_url: str, project_name: str, run_id: str) -> dict[str, int]:
+    """Emit one below-threshold and one above-threshold LLM span. Returns span names."""
+    from phoenix.otel import register
+
+    tracer_provider = register(
+        endpoint=f"{base_url}/v1/traces",
+        project_name=project_name,
+        batch=False,
+        set_global_tracer_provider=False,
+        verbose=False,
+    )
+    tracer = tracer_provider.get_tracer(__name__)
+    span_names = {}
+    for label, prompt_tokens in (
+        ("below", BELOW_PROMPT_TOKENS),
+        ("above", ABOVE_PROMPT_TOKENS),
+    ):
+        name = f"{label}-threshold-{run_id}"
+        span_names[name] = prompt_tokens
+        with tracer.start_as_current_span(name) as span:
+            span.set_attribute("openinference.span.kind", "LLM")
+            span.set_attribute("llm.model_name", MODEL_NAME)
+            span.set_attribute("llm.token_count.prompt", prompt_tokens)
+            span.set_attribute("llm.token_count.completion", COMPLETION_TOKENS)
+            span.set_attribute("llm.token_count.total", prompt_tokens + COMPLETION_TOKENS)
+    tracer_provider.force_flush()
+    return span_names
+
+
+def graphql(client: httpx.Client, base_url: str, query: str, variables: dict[str, Any]) -> Any:
+    response = client.post(f"{base_url}/graphql", json={"query": query, "variables": variables})
+    response.raise_for_status()
+    payload = response.json()
+    if payload.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+    return payload["data"]
+
+
+def fetch_project_id(client: httpx.Client, base_url: str, project_name: str) -> str | None:
+    data = graphql(
+        client,
+        base_url,
+        "query { projects(first: 200) { edges { node { id name } } } }",
+        {},
+    )
+    for edge in data["projects"]["edges"]:
+        if edge["node"]["name"] == project_name:
+            return str(edge["node"]["id"])
+    return None
+
+
+def fetch_cost_summaries(
+    client: httpx.Client, base_url: str, project_name: str, span_names: set[str]
+) -> dict[str, Any] | None:
+    """Return costSummary per span name once every span has a computed cost."""
+    if (project_id := fetch_project_id(client, base_url, project_name)) is None:
+        return None
+    data = graphql(client, base_url, SPANS_QUERY, {"projectId": project_id})
+    summaries = {
+        edge["node"]["name"]: edge["node"]["costSummary"]
+        for edge in data["node"]["spans"]["edges"]
+        if edge["node"]["name"] in span_names
+    }
+    if set(summaries) != span_names or any(v is None for v in summaries.values()):
+        return None
+    return summaries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", "http://localhost:6006"),
+    )
+    parser.add_argument("--timeout", type=float, default=30.0, help="seconds to wait for costs")
+    args = parser.parse_args()
+    base_url = args.base_url.rstrip("/")
+
+    run_id = uuid.uuid4().hex[:8]
+    project_name = f"threshold-cost-verification-{run_id}"
+    print(f"Sending spans for {MODEL_NAME} to {base_url} (project: {project_name})")
+    span_tokens = send_spans(base_url, project_name, run_id)
+
+    headers = {}
+    if api_key := os.environ.get("PHOENIX_API_KEY"):
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    with httpx.Client(headers=headers, timeout=10.0) as client:
+        deadline = time.time() + args.timeout
+        summaries = None
+        while time.time() < deadline:
+            summaries = fetch_cost_summaries(client, base_url, project_name, set(span_tokens))
+            if summaries is not None:
+                break
+            time.sleep(1.0)
+        if summaries is None:
+            print(f"FAIL: span costs not available after {args.timeout}s", file=sys.stderr)
+            return 1
+
+    ok = True
+    for name, prompt_tokens in span_tokens.items():
+        expected = expected_costs(prompt_tokens, COMPLETION_TOKENS)
+        actual = summaries[name]
+        print(f"\n{name} (prompt tokens: {prompt_tokens:,})")
+        for part in ("prompt", "completion"):
+            actual_cost = (actual.get(part) or {}).get("cost")
+            expected_cost = expected[part]
+            matches = actual_cost is not None and abs(actual_cost - expected_cost) < 1e-9
+            ok &= matches
+            status = "OK  " if matches else "FAIL"
+            print(f"  {status} {part}: actual={actual_cost} expected={expected_cost}")
+
+    if ok:
+        print("\nAll threshold-based costs match the manifest tier rates.")
+        return 0
+    print(
+        "\nMismatch detected. If costs match the BASE rates instead of tier rates for the"
+        " above-threshold span, the customization was not synced into the database —"
+        " restart the server on this branch to re-run the facilitator sync.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/phoenix/db/facilitator.py
+++ b/src/phoenix/db/facilitator.py
@@ -42,6 +42,7 @@ from phoenix.db.types.annotation_configs import (
     CategoricalAnnotationValue,
     OptimizationDirection,
 )
+from phoenix.db.types.token_price_customization import TokenPriceCustomizationParser
 from phoenix.db.types.trace_retention import (
     MaxDaysRule,
     TraceRetentionCronExpression,
@@ -591,6 +592,9 @@ async def _ensure_model_costs(db: DbSessionFactory) -> None:
                 if not (base_rate := manifest_token_price.get("base_rate")):
                     continue
 
+                customization = TokenPriceCustomizationParser.parse(
+                    manifest_token_price.get("customization")
+                )
                 key = _TokenTypeKey(
                     manifest_token_price["token_type"],
                     manifest_token_price["is_prompt"],
@@ -602,13 +606,18 @@ async def _ensure_model_costs(db: DbSessionFactory) -> None:
                         token_type=manifest_token_price["token_type"],
                         is_prompt=manifest_token_price["is_prompt"],
                         base_rate=base_rate,
+                        customization=customization,
                     )
                     model.token_prices.append(token_price)
                     token_prices_changed = True
-                elif token_price.base_rate != base_rate:
-                    # Update existing price if rate has changed
-                    token_price.base_rate = base_rate
-                    token_prices_changed = True
+                else:
+                    # Update existing price if the rate or customization changed
+                    if token_price.base_rate != base_rate:
+                        token_price.base_rate = base_rate
+                        token_prices_changed = True
+                    if token_price.customization != customization:
+                        token_price.customization = customization
+                        token_prices_changed = True
 
             # Remove any token prices that are no longer in the manifest
             # These are prices that weren't popped from the token_prices dict above

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2589,7 +2589,7 @@ class TokenPrice(HasId):
     token_type: Mapped[str]
     is_prompt: Mapped[bool]
     base_rate: Mapped[float]
-    customization: Mapped[TokenPriceCustomization] = mapped_column(_TokenCustomization)
+    customization: Mapped[Optional[TokenPriceCustomization]] = mapped_column(_TokenCustomization)
 
     model: Mapped["GenerativeModel"] = relationship(
         "GenerativeModel",

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -133,22 +133,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -511,22 +535,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -538,22 +586,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -565,22 +637,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -592,22 +688,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -781,12 +901,24 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         }
       ]
     },
@@ -1043,17 +1175,35 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         },
         {
           "base_rate": 1.25e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-7
+          }
         }
       ]
     },
@@ -1065,17 +1215,35 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         },
         {
           "base_rate": 1.25e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-7
+          }
         },
         {
           "base_rate": 7e-7,
@@ -1153,17 +1321,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -1290,17 +1476,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -1312,17 +1516,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -3126,17 +3348,35 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         }
       ]
     },
@@ -3148,17 +3388,35 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         }
       ]
     },
@@ -3258,17 +3516,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3280,17 +3556,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3302,17 +3596,35 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         }
       ]
     },
@@ -3324,17 +3636,35 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         }
       ]
     },
@@ -3346,17 +3676,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3368,17 +3716,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3390,22 +3756,46 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         },
         {
           "base_rate": 6.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000125
+          }
         }
       ]
     },
@@ -3417,22 +3807,46 @@
         {
           "base_rate": 1e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2e-6
+          }
         },
         {
           "base_rate": 6e-6,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 9e-6
+          }
         },
         {
           "base_rate": 1e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2e-7
+          }
         },
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2.5e-6
+          }
         }
       ]
     },
@@ -3444,22 +3858,46 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         },
         {
           "base_rate": 6.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000125
+          }
         }
       ]
     },
@@ -3471,22 +3909,46 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         },
         {
           "base_rate": 3.125e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6.25e-6
+          }
         }
       ]
     },

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -3905,7 +3905,7 @@
             "type": "threshold_based",
             "key": "llm.token_count.prompt",
             "threshold": 272000.0,
-            "new_rate": 2e-6
+            "new_rate": 4e-7
           }
         },
         {
@@ -3916,7 +3916,7 @@
             "type": "threshold_based",
             "key": "llm.token_count.prompt",
             "threshold": 272000.0,
-            "new_rate": 9e-6
+            "new_rate": 1.8e-6
           }
         },
         {
@@ -3927,7 +3927,7 @@
             "type": "threshold_based",
             "key": "llm.token_count.prompt",
             "threshold": 272000.0,
-            "new_rate": 2e-7
+            "new_rate": 4e-8
           }
         },
         {
@@ -3938,7 +3938,7 @@
             "type": "threshold_based",
             "key": "llm.token_count.prompt",
             "threshold": 272000.0,
-            "new_rate": 2.5e-6
+            "new_rate": 5e-7
           }
         }
       ]
@@ -4007,7 +4007,7 @@
             "type": "threshold_based",
             "key": "llm.token_count.prompt",
             "threshold": 272000.0,
-            "new_rate": 5e-6
+            "new_rate": 4e-6
           }
         },
         {
@@ -4018,7 +4018,7 @@
             "type": "threshold_based",
             "key": "llm.token_count.prompt",
             "threshold": 272000.0,
-            "new_rate": 0.0000225
+            "new_rate": 0.000018
           }
         },
         {
@@ -4029,7 +4029,7 @@
             "type": "threshold_based",
             "key": "llm.token_count.prompt",
             "threshold": 272000.0,
-            "new_rate": 5e-7
+            "new_rate": 4e-7
           }
         },
         {
@@ -4040,7 +4040,7 @@
             "type": "threshold_based",
             "key": "llm.token_count.prompt",
             "threshold": 272000.0,
-            "new_rate": 6.25e-6
+            "new_rate": 5e-6
           }
         }
       ]

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -133,22 +133,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -538,22 +562,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -565,22 +613,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -592,22 +664,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -619,22 +715,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -808,12 +928,24 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         }
       ]
     },
@@ -1070,17 +1202,35 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         },
         {
           "base_rate": 1.25e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-7
+          }
         }
       ]
     },
@@ -1092,17 +1242,35 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         },
         {
           "base_rate": 1.25e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-7
+          }
         },
         {
           "base_rate": 7e-7,
@@ -1180,17 +1348,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -1317,17 +1503,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -1339,17 +1543,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -3219,17 +3441,35 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         }
       ]
     },
@@ -3241,17 +3481,35 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         }
       ]
     },
@@ -3351,17 +3609,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3373,17 +3649,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3395,17 +3689,35 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         }
       ]
     },
@@ -3417,17 +3729,35 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         }
       ]
     },
@@ -3439,17 +3769,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3461,17 +3809,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3483,22 +3849,46 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         },
         {
           "base_rate": 6.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000125
+          }
         }
       ]
     },
@@ -3510,22 +3900,46 @@
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2e-6
+          }
         },
         {
           "base_rate": 1.2e-6,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 9e-6
+          }
         },
         {
           "base_rate": 2e-8,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2e-7
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2.5e-6
+          }
         }
       ]
     },
@@ -3537,22 +3951,46 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         },
         {
           "base_rate": 6.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000125
+          }
         }
       ]
     },
@@ -3564,22 +4002,46 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         },
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6.25e-6
+          }
         }
       ]
     },

--- a/tests/unit/db/test_facilitator.py
+++ b/tests/unit/db/test_facilitator.py
@@ -19,6 +19,9 @@ from phoenix.db.facilitator import (
     _ensure_model_costs,
     _ensure_oauth2_clients,
 )
+from phoenix.db.types.token_price_customization import (
+    ThresholdBasedTokenPriceCustomization,
+)
 from phoenix.db.types.trace_retention import (
     MaxDaysRule,
     TraceRetentionCronExpression,
@@ -680,6 +683,72 @@ class TestEnsureModelCosts:
         assert all_deleted_names == expected_all_deleted, (
             f"All models should be deleted: got {all_deleted_names}, expected {expected_all_deleted}"
         )
+
+    async def test_syncs_token_price_customizations_from_manifest(
+        self,
+        _patch_manifest: Path,
+        db: DbSessionFactory,
+    ) -> None:
+        """Tier-rate customizations in the manifest must land in the database,
+        propagate on change, and clear when removed upstream."""
+        await _ensure_enums(db)
+
+        customization = {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000006,
+        }
+        manifest: list[dict[str, Any]] = [
+            {
+                "name": "tiered-model",
+                "name_pattern": r"(?i)^(tiered-model)$",
+                "token_prices": [
+                    {
+                        "base_rate": 0.000003,
+                        "is_prompt": True,
+                        "token_type": "input",
+                        "customization": customization,
+                    },
+                    {
+                        "base_rate": 0.000015,
+                        "is_prompt": False,
+                        "token_type": "output",
+                    },
+                ],
+            }
+        ]
+        self._update_manifest(_patch_manifest, manifest)
+        await _ensure_model_costs(db)
+
+        async def _get_input_price(db: DbSessionFactory) -> models.TokenPrice:
+            model = (await self._get_models(db, is_built_in=True))["tiered-model"]
+            return next(tp for tp in model.token_prices if tp.token_type == "input")
+
+        input_price = await _get_input_price(db)
+        assert isinstance(input_price.customization, ThresholdBasedTokenPriceCustomization)
+        assert input_price.customization.model_dump() == customization
+        model = (await self._get_models(db, is_built_in=True))["tiered-model"]
+        output_price = next(tp for tp in model.token_prices if tp.token_type == "output")
+        assert output_price.customization is None
+
+        # A changed tier rate propagates on re-sync.
+        manifest[0]["token_prices"][0]["customization"] = {
+            **customization,
+            "new_rate": 0.000012,
+        }
+        self._update_manifest(_patch_manifest, manifest)
+        await _ensure_model_costs(db)
+        input_price = await _get_input_price(db)
+        assert isinstance(input_price.customization, ThresholdBasedTokenPriceCustomization)
+        assert input_price.customization.new_rate == 0.000012
+
+        # Removing the customization upstream clears the stored one.
+        del manifest[0]["token_prices"][0]["customization"]
+        self._update_manifest(_patch_manifest, manifest)
+        await _ensure_model_costs(db)
+        input_price = await _get_input_price(db)
+        assert input_price.customization is None
 
 
 class TestEnsureBuiltinEvaluators:

--- a/tests/unit/server/cost_tracking/test_model_cost_manifest.py
+++ b/tests/unit/server/cost_tracking/test_model_cost_manifest.py
@@ -1,0 +1,75 @@
+"""
+Regression tests for src/phoenix/server/cost_tracking/model_cost_manifest.json.
+
+Guards that LiteLLM whole-prompt tier rates (``*_above_NNNk_tokens``) survive the
+sync from LiteLLM through ``.github/.scripts/sync_models.py`` and land in the
+manifest as ``threshold_based`` customizations. See Arize-ai/phoenix#14314.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "phoenix"
+    / "server"
+    / "cost_tracking"
+    / "model_cost_manifest.json"
+)
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    with MANIFEST_PATH.open() as source:
+        return json.load(source)
+
+
+@pytest.fixture(scope="module")
+def models_by_name(manifest: dict) -> dict[str, dict]:
+    return {model["name"]: model for model in manifest["models"]}
+
+
+@pytest.mark.parametrize(
+    "model_name, token_type, threshold, base_rate, elevated_rate",
+    [
+        ("claude-sonnet-4-5", "input", 200_000, 3e-6, 6e-6),
+        ("claude-sonnet-4-5", "output", 200_000, 1.5e-5, 2.25e-5),
+        ("claude-sonnet-4-5", "cache_read", 200_000, 3e-7, 6e-7),
+        ("claude-sonnet-4-5", "cache_write", 200_000, 3.75e-6, 7.5e-6),
+        ("gemini-2.5-pro", "input", 200_000, 1.25e-6, 2.5e-6),
+        ("gemini-2.5-pro", "output", 200_000, 1e-5, 1.5e-5),
+        ("gpt-5.4", "input", 272_000, 2.5e-6, 5e-6),
+        ("gpt-5.4", "output", 272_000, 1.5e-5, 2.25e-5),
+        ("gpt-5.5", "input", 272_000, 5e-6, 1e-5),
+        ("gpt-5.5", "output", 272_000, 3e-5, 4.5e-5),
+    ],
+)
+def test_flagship_models_carry_threshold_based_tier_rates(
+    models_by_name: dict[str, dict],
+    model_name: str,
+    token_type: str,
+    threshold: float,
+    base_rate: float,
+    elevated_rate: float,
+) -> None:
+    assert model_name in models_by_name, f"missing model entry: {model_name}"
+    prices = models_by_name[model_name]["token_prices"]
+
+    matching = [price for price in prices if price["token_type"] == token_type]
+    assert matching, f"{model_name} is missing a {token_type!r} token_price row"
+    price = matching[0]
+
+    assert price["base_rate"] == pytest.approx(base_rate, rel=1e-9)
+
+    customization = price.get("customization")
+    assert customization is not None, (
+        f"{model_name}/{token_type} is missing a threshold_based customization; "
+        "LiteLLM tier rates were dropped by the sync"
+    )
+    assert customization["type"] == "threshold_based"
+    assert customization["key"] == "llm.token_count.prompt"
+    assert customization["threshold"] == pytest.approx(threshold, rel=1e-9)
+    assert customization["new_rate"] == pytest.approx(elevated_rate, rel=1e-9)

--- a/tests/unit/server/cost_tracking/test_model_cost_manifest.py
+++ b/tests/unit/server/cost_tracking/test_model_cost_manifest.py
@@ -8,6 +8,7 @@ manifest as ``threshold_based`` customizations. See Arize-ai/phoenix#14314.
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -22,13 +23,14 @@ MANIFEST_PATH = (
 
 
 @pytest.fixture(scope="module")
-def manifest() -> dict:
+def manifest() -> dict[str, Any]:
     with MANIFEST_PATH.open() as source:
-        return json.load(source)
+        data: dict[str, Any] = json.load(source)
+        return data
 
 
 @pytest.fixture(scope="module")
-def models_by_name(manifest: dict) -> dict[str, dict]:
+def models_by_name(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {model["name"]: model for model in manifest["models"]}
 
 
@@ -48,7 +50,7 @@ def models_by_name(manifest: dict) -> dict[str, dict]:
     ],
 )
 def test_flagship_models_carry_threshold_based_tier_rates(
-    models_by_name: dict[str, dict],
+    models_by_name: dict[str, dict[str, Any]],
     model_name: str,
     token_type: str,
     threshold: float,


### PR DESCRIPTION
Fixes #14314

## Summary

\`.github/.scripts/sync_models.py\` extracted only the base rate fields from LiteLLM's \`model_prices_and_context_window.json\` and dropped every whole-prompt tier variant (\`input_cost_per_token_above_128k_tokens\`, \`input_cost_per_token_above_200k_tokens\`, \`input_cost_per_token_above_272k_tokens\` and their matching \`output_cost_per_token_above_NNNk_tokens\` / \`cache_read_input_token_cost_above_NNNk_tokens\` / \`cache_creation_input_token_cost_above_NNNk_tokens\` variants). Every \`customization\` field in the generated manifest was \`null\` before this patch, so above-threshold traces silently under-billed by up to 2x on flagship models.

## Changes

\`sync_models.py\` learns to emit a \`ThresholdBasedTokenPriceCustomization\` on each affected \`TokenPrice\` when the LiteLLM entry carries an \`above_NNNk_tokens\` variant. The customization is keyed on \`llm.token_count.prompt\` (\`SpanAttributes.LLM_TOKEN_COUNT_PROMPT\`) so \`ThresholdBasedTokenCostCalculator\` applies the elevated rate once the prompt strictly exceeds the threshold; that path already exists, no changes to the cost calculator, DB schema, or API layer were needed. The manifest is regenerated from the current LiteLLM feed and a regression test in \`tests/unit/server/cost_tracking/test_model_cost_manifest.py\` guards the flagship rows so a future edit to the sync script cannot silently drop the customizations again.

Across the current 264-model manifest, the change adds 77 new \`threshold_based\` customizations spanning the OpenAI (\`gpt-5.4\` / \`gpt-5.5\` / \`gpt-realtime\` families at 272k), Anthropic (\`claude-sonnet-4-5\` / \`claude-opus-4-5\` at 200k), and Google (\`gemini-2.5-pro\` / \`gemini-3-pro\` / \`gemini-2.5-flash-lite\` at 200k) provider surfaces.

## Impact

| Model | Token type | Base rate | Above-NNNk rate | Threshold | Under-bill above threshold |
|---|---|---|---|---|---|
| \`claude-sonnet-4-5\` | input | 3e-6 | 6e-6 | 200,000 | 2x |
| \`claude-sonnet-4-5\` | output | 1.5e-5 | 2.25e-5 | 200,000 | 1.5x |
| \`claude-sonnet-4-5\` | cache_read | 3e-7 | 6e-7 | 200,000 | 2x |
| \`claude-sonnet-4-5\` | cache_write | 3.75e-6 | 7.5e-6 | 200,000 | 2x |
| \`gemini-2.5-pro\` | input | 1.25e-6 | 2.5e-6 | 200,000 | 2x |
| \`gemini-2.5-pro\` | output | 1e-5 | 1.5e-5 | 200,000 | 1.5x |
| \`gpt-5.4\` | input | 2.5e-6 | 5e-6 | 272,000 | 2x |
| \`gpt-5.4\` | output | 1.5e-5 | 2.25e-5 | 272,000 | 1.5x |
| \`gpt-5.5\` | input | 5e-6 | 1e-5 | 272,000 | 2x |
| \`gpt-5.5\` | output | 3e-5 | 4.5e-5 | 272,000 | 1.5x |

## Test plan

- Ran \`.github/.scripts/sync_models.py\` locally against the live LiteLLM feed; produces 77 new \`threshold_based\` customizations in the manifest and the sync is idempotent on a re-run.
- Added \`tests/unit/server/cost_tracking/test_model_cost_manifest.py\` parameterizing the flagship rows above; every case fails against the pre-fix manifest and passes against the regenerated one.

## Related

Same-family fixes I've shipped upstream at comet-ml/opik (whole-prompt tier semantics): comet-ml/opik#7023 (above_200k), comet-ml/opik#7347 (above_128k + above_272k), and the follow-up refactor comet-ml/opik#7438 that consolidated the per-tier fields into a single \`PromptTier\` record.