### PR TITLE
fix(cost): sync LiteLLM threshold token rates

### DIFF
--- a/.github/.scripts/sync_models.py
+++ b/.github/.scripts/sync_models.py
@@ -3,16 +3,25 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from urllib.request import urlopen
 
+from openinference.semconv.trace import SpanAttributes
 from pydantic import AfterValidator, BaseModel
+
+
+class ThresholdBasedTokenPriceCustomization(BaseModel):
+    type: Literal["threshold_based"] = "threshold_based"
+    key: str
+    threshold: float
+    new_rate: float
 
 
 class TokenPrice(BaseModel):
     base_rate: float
     is_prompt: bool
     token_type: str
+    customization: ThresholdBasedTokenPriceCustomization | None = None
 
 
 def validate_regular_expression(value: str) -> str:
@@ -52,6 +61,26 @@ PROVIDER_PREFIXES: dict[str, str | None] = {
     "perplexity/": None,
     "together_ai/": "together",
 }
+
+TOKEN_PRICE_FIELDS: dict[str, tuple[str, bool]] = {
+    "input_cost_per_token": ("input", True),
+    "output_cost_per_token": ("output", False),
+    "cache_read_input_token_cost": ("cache_read", True),
+    "cache_creation_input_token_cost": ("cache_write", True),
+    "input_cost_per_audio_token": ("audio", True),
+    "output_cost_per_audio_token": ("audio", False),
+}
+
+THRESHOLD_BASED_TOKEN_PRICE_FIELDS = {
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "cache_read_input_token_cost",
+    "cache_creation_input_token_cost",
+}
+
+THRESHOLD_FIELD_PATTERN = re.compile(
+    r"^(?P<base_field>.+)_above_(?P<threshold_in_thousands>\d+)k_tokens$"
+)
 
 
 def parse_provider_prefix(model_id: str) -> tuple[bool, str | None, str]:
@@ -135,6 +164,49 @@ def fetch_data(url: str) -> dict[str, Any]:
         raise Exception(f"Error fetching data from URL: {e}")
 
 
+def extract_threshold_based_customization(
+    model_info: dict[str, Any],
+    base_field: str,
+) -> ThresholdBasedTokenPriceCustomization | None:
+    if base_field not in THRESHOLD_BASED_TOKEN_PRICE_FIELDS:
+        return None
+
+    customizations: list[ThresholdBasedTokenPriceCustomization] = []
+    for field, value in model_info.items():
+        match = THRESHOLD_FIELD_PATTERN.match(field)
+        if not match or match.group("base_field") != base_field:
+            continue
+        if new_rate := float(value or 0):
+            customizations.append(
+                ThresholdBasedTokenPriceCustomization(
+                    key=SpanAttributes.LLM_TOKEN_COUNT_PROMPT,
+                    threshold=float(match.group("threshold_in_thousands")) * 1000,
+                    new_rate=new_rate,
+                )
+            )
+
+    if not customizations:
+        return None
+    if len(customizations) > 1:
+        raise ValueError(f"Multiple threshold-based rates found for {base_field}")
+    return customizations[0]
+
+
+def token_price_from_litellm_field(
+    model_info: dict[str, Any],
+    field: str,
+) -> TokenPrice | None:
+    if not (base_rate := float(model_info.get(field, 0))):
+        return None
+    token_type, is_prompt = TOKEN_PRICE_FIELDS[field]
+    return TokenPrice(
+        token_type=token_type,
+        base_rate=base_rate,
+        is_prompt=is_prompt,
+        customization=extract_threshold_based_customization(model_info, field),
+    )
+
+
 def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
     models_with_pricing = []
     for model_id, model_info in data.items():
@@ -157,59 +229,9 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
 
         token_prices: list[TokenPrice] = []
 
-        if input_cost := float(model_info.get("input_cost_per_token", 0)):
-            token_prices.append(
-                TokenPrice(
-                    token_type="input",
-                    base_rate=input_cost,
-                    is_prompt=True,
-                )
-            )
-
-        if output_cost := float(model_info.get("output_cost_per_token", 0)):
-            token_prices.append(
-                TokenPrice(
-                    token_type="output",
-                    base_rate=output_cost,
-                    is_prompt=False,
-                )
-            )
-
-        if cache_read_cost := float(model_info.get("cache_read_input_token_cost", 0)):
-            token_prices.append(
-                TokenPrice(
-                    token_type="cache_read",
-                    base_rate=cache_read_cost,
-                    is_prompt=True,
-                )
-            )
-
-        if cache_creation_cost := float(model_info.get("cache_creation_input_token_cost", 0)):
-            token_prices.append(
-                TokenPrice(
-                    token_type="cache_write",
-                    base_rate=cache_creation_cost,
-                    is_prompt=True,
-                )
-            )
-
-        if input_audio_cost := float(model_info.get("input_cost_per_audio_token", 0)):
-            token_prices.append(
-                TokenPrice(
-                    token_type="audio",
-                    base_rate=input_audio_cost,
-                    is_prompt=True,
-                )
-            )
-
-        if output_audio_cost := float(model_info.get("output_cost_per_audio_token", 0)):
-            token_prices.append(
-                TokenPrice(
-                    token_type="audio",
-                    base_rate=output_audio_cost,
-                    is_prompt=False,
-                )
-            )
+        for field in TOKEN_PRICE_FIELDS:
+            if token_price := token_price_from_litellm_field(model_info, field):
+                token_prices.append(token_price)
 
         if token_prices:
             _, provider, stripped_name = parse_provider_prefix(model_id)

--- a/src/phoenix/db/facilitator.py
+++ b/src/phoenix/db/facilitator.py
@@ -42,6 +42,7 @@ from phoenix.db.types.annotation_configs import (
     CategoricalAnnotationValue,
     OptimizationDirection,
 )
+from phoenix.db.types.token_price_customization import TokenPriceCustomizationParser
 from phoenix.db.types.trace_retention import (
     MaxDaysRule,
     TraceRetentionCronExpression,
@@ -543,6 +544,9 @@ async def _ensure_model_costs(db: DbSessionFactory) -> None:
                 # Skip if this token type has no rate in the manifest
                 if not (base_rate := manifest_token_price.get("base_rate")):
                     continue
+                customization = TokenPriceCustomizationParser.parse(
+                    manifest_token_price.get("customization")
+                )
 
                 key = _TokenTypeKey(
                     manifest_token_price["token_type"],
@@ -555,12 +559,16 @@ async def _ensure_model_costs(db: DbSessionFactory) -> None:
                         token_type=manifest_token_price["token_type"],
                         is_prompt=manifest_token_price["is_prompt"],
                         base_rate=base_rate,
+                        customization=customization,
                     )
                     model.token_prices.append(token_price)
                     token_prices_changed = True
-                elif token_price.base_rate != base_rate:
+                elif (
+                    token_price.base_rate != base_rate or token_price.customization != customization
+                ):
                     # Update existing price if rate has changed
                     token_price.base_rate = base_rate
+                    token_price.customization = customization
                     token_prices_changed = True
 
             # Remove any token prices that are no longer in the manifest

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -133,22 +133,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -511,22 +535,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -538,22 +586,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -565,22 +637,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -592,22 +688,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -781,12 +901,24 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         }
       ]
     },
@@ -1043,17 +1175,35 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         },
         {
           "base_rate": 1.25e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-7
+          }
         }
       ]
     },
@@ -1065,17 +1215,35 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000015
+          }
         },
         {
           "base_rate": 1.25e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 2.5e-7
+          }
         },
         {
           "base_rate": 7e-7,
@@ -1153,17 +1321,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -1290,17 +1476,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -1312,17 +1516,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -3126,17 +3348,35 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         }
       ]
     },
@@ -3148,17 +3388,35 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         }
       ]
     },
@@ -3258,17 +3516,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3280,17 +3556,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3302,17 +3596,35 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         }
       ]
     },
@@ -3324,17 +3636,35 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         }
       ]
     },
@@ -3346,17 +3676,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3368,17 +3716,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3390,22 +3756,46 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         },
         {
           "base_rate": 6.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000125
+          }
         }
       ]
     },
@@ -3417,22 +3807,46 @@
         {
           "base_rate": 1e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2e-6
+          }
         },
         {
           "base_rate": 6e-6,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 9e-6
+          }
         },
         {
           "base_rate": 1e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2e-7
+          }
         },
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 2.5e-6
+          }
         }
       ]
     },
@@ -3444,22 +3858,46 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 1e-6
+          }
         },
         {
           "base_rate": 6.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000125
+          }
         }
       ]
     },
@@ -3471,22 +3909,46 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 5e-7
+          }
         },
         {
           "base_rate": 3.125e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000.0,
+            "new_rate": 6.25e-6
+          }
         }
       ]
     },

--- a/tests/unit/db/test_facilitator.py
+++ b/tests/unit/db/test_facilitator.py
@@ -286,6 +286,17 @@ class TestEnsureModelCosts:
         """Extract token prices as a comparable dictionary."""
         return {(tp.token_type, tp.is_prompt): tp.base_rate for tp in model.token_prices}
 
+    def _extract_token_price_customizations(
+        self, model: models.GenerativeModel
+    ) -> dict[tuple[str, bool], dict[str, Any] | None]:
+        """Extract token price customizations as a comparable dictionary."""
+        return {
+            (tp.token_type, tp.is_prompt): (
+                tp.customization.model_dump() if tp.customization else None
+            )
+            for tp in model.token_prices
+        }
+
     async def _get_deleted_model_names(self, db: DbSessionFactory) -> set[str]:
         """Get names of soft-deleted built-in models."""
         async with db() as session:
@@ -301,6 +312,74 @@ class TestEnsureModelCosts:
         import json
 
         manifest_path.write_text(json.dumps({"models": models}, indent=2))
+
+    async def test_ensure_model_costs_syncs_token_price_customization(
+        self,
+        _patch_manifest: Path,
+        db: DbSessionFactory,
+    ) -> None:
+        await _ensure_enums(db)
+
+        self._update_manifest(
+            _patch_manifest,
+            [
+                {
+                    "name": "threshold-model",
+                    "name_pattern": r"(?i)^(threshold-model)$",
+                    "token_prices": [
+                        {
+                            "base_rate": 0.000001,
+                            "is_prompt": True,
+                            "token_type": "input",
+                            "customization": {
+                                "type": "threshold_based",
+                                "key": "llm.token_count.prompt",
+                                "threshold": 200000.0,
+                                "new_rate": 0.000002,
+                            },
+                        },
+                    ],
+                },
+            ],
+        )
+
+        await _ensure_model_costs(db)
+
+        built_in_models = await self._get_models(db, is_built_in=True)
+        customizations = self._extract_token_price_customizations(
+            built_in_models["threshold-model"]
+        )
+        assert customizations[("input", True)] == {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000.0,
+            "new_rate": 0.000002,
+        }
+
+        self._update_manifest(
+            _patch_manifest,
+            [
+                {
+                    "name": "threshold-model",
+                    "name_pattern": r"(?i)^(threshold-model)$",
+                    "token_prices": [
+                        {
+                            "base_rate": 0.000001,
+                            "is_prompt": True,
+                            "token_type": "input",
+                        },
+                    ],
+                },
+            ],
+        )
+
+        await _ensure_model_costs(db)
+
+        built_in_models = await self._get_models(db, is_built_in=True)
+        customizations = self._extract_token_price_customizations(
+            built_in_models["threshold-model"]
+        )
+        assert customizations[("input", True)] is None
 
     async def test_ensure_model_costs(
         self,

--- a/tests/unit/test_sync_models.py
+++ b/tests/unit/test_sync_models.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from openinference.semconv.trace import SpanAttributes
+
+
+def _load_sync_models_module() -> ModuleType:
+    script_path = Path(__file__).parents[2] / ".github" / ".scripts" / "sync_models.py"
+    spec = importlib.util.spec_from_file_location("sync_models", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_litellm_entries_emits_threshold_based_customizations() -> None:
+    sync_models = _load_sync_models_module()
+
+    entries = sync_models.extract_litellm_entries(
+        {
+            "gpt-test": {
+                "input_cost_per_token": 0.000001,
+                "output_cost_per_token": 0.000002,
+                "cache_creation_input_token_cost": 0.000003,
+                "input_cost_per_token_above_200k_tokens": 0.000004,
+                "output_cost_per_token_above_200k_tokens": 0.000005,
+                "cache_creation_input_token_cost_above_200k_tokens": 0.000006,
+                "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 0.000007,
+            }
+        }
+    )
+
+    assert len(entries) == 1
+    prices = {
+        (price.token_type, price.is_prompt): price.model_dump(exclude_none=True)
+        for price in entries[0].token_prices
+    }
+
+    assert prices[("input", True)]["customization"] == {
+        "type": "threshold_based",
+        "key": SpanAttributes.LLM_TOKEN_COUNT_PROMPT,
+        "threshold": 200000.0,
+        "new_rate": 0.000004,
+    }
+    assert prices[("output", False)]["customization"] == {
+        "type": "threshold_based",
+        "key": SpanAttributes.LLM_TOKEN_COUNT_PROMPT,
+        "threshold": 200000.0,
+        "new_rate": 0.000005,
+    }
+    assert prices[("cache_write", True)]["customization"] == {
+        "type": "threshold_based",
+        "key": SpanAttributes.LLM_TOKEN_COUNT_PROMPT,
+        "threshold": 200000.0,
+        "new_rate": 0.000006,
+    }


### PR DESCRIPTION
fixes #14314

## Summary

Phoenix now carries LiteLLM `above_NNNk_tokens` tier rates into built-in token prices.

The sync script already copied flat token rates from LiteLLM, but ignored above-threshold prompt-tier rates. The manifest could not represent those rates, and the built-in model loader also did not persist token price customizations from the manifest.

This change:

- parses known `above_<number>k_tokens` fields for input, output, cache read, and cache write rates
- emits `threshold_based` customizations keyed on `llm.token_count.prompt`
- ignores unrelated threshold-shaped fields that are not whole-prompt token tiers
- persists manifest `customization` values into `models.TokenPrice`
- regenerates `model_cost_manifest.json` from current LiteLLM data

The regenerated manifest has 77 threshold-based customizations across 23 models.

## Tests

- `uv run pytest tests/unit/test_sync_models.py tests/unit/db/test_facilitator.py::TestEnsureModelCosts::test_ensure_model_costs_syncs_token_price_customization -q`
- `uv run ruff check .github/.scripts/sync_models.py src/phoenix/db/facilitator.py tests/unit/db/test_facilitator.py tests/unit/test_sync_models.py`
- `uv run ruff format --check .github/.scripts/sync_models.py src/phoenix/db/facilitator.py tests/unit/db/test_facilitator.py tests/unit/test_sync_models.py`
