### PR TITLE
fix(evals): count async executor timeouts as retries

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -324,7 +324,8 @@ class AsyncExecutor(Executor):
                     marked_done = True
                     continue
                 else:
-                    tqdm.write("Worker timeout, requeuing")
+                    retry_count = abs(priority)
+                    tqdm.write(f"Worker timeout on attempt {retry_count + 1}")
                     # Best-effort cancel the timed-out task without blocking the loop
                     if not generate_task.done():
                         generate_task.cancel()
@@ -332,12 +333,20 @@ class AsyncExecutor(Executor):
                             await asyncio.wait_for(generate_task, timeout=1)
                         except (asyncio.TimeoutError, asyncio.CancelledError):
                             pass
-                    # task timeouts are requeued at the same priority
-                    await queue.put((priority, item))
                     details = cast(ExecutionDetails, execution_details[index])
                     details.log_runtime(task_start_time)
                     if self._concurrency_controller is not None:
                         self._concurrency_controller.record_timeout()
+                    if retry_count < self.max_retries:
+                        tqdm.write("Requeuing...")
+                        await queue.put((priority - 1, item))
+                    else:
+                        details.fail()
+                        tqdm.write(f"Retries exhausted after {retry_count + 1} attempts")
+                        if self.exit_on_error:
+                            termination_event.set()
+                        else:
+                            progress_bar.update()
             except Exception as exc:
                 details = cast(ExecutionDetails, execution_details[index])
                 details.log_exception(exc)

--- a/packages/phoenix-evals/tests/phoenix/evals/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_executor.py
@@ -151,6 +151,32 @@ async def test_async_executor_can_continue_on_error():
     assert all(isinstance(exc, ValueError) for exc in exceptions[2])
 
 
+async def test_async_executor_timeout_counts_toward_max_retries():
+    call_count = 0
+
+    async def slow_fn(payload: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(1)
+        return payload
+
+    executor = AsyncExecutor(
+        slow_fn,
+        concurrency=1,
+        timeout=0.01,
+        max_retries=2,
+        exit_on_error=True,
+        fallback_return_value=52,
+        enable_dynamic_concurrency=False,
+    )
+
+    outputs, statuses = await executor.execute([1])
+
+    assert call_count == 3
+    assert outputs == [52]
+    assert [status.status for status in statuses] == [ExecutionStatus.FAILED]
+
+
 async def test_async_executor_marks_completed_with_retries_status():
     retry_counter = 0
 


### PR DESCRIPTION
fixes #14312

## Summary

`AsyncExecutor` now counts timed-out tasks against `max_retries`.

The timeout branch previously requeued the same item without ever reaching the retry exhaustion path. A task that always exceeded `timeout` could keep re-entering the queue even when `exit_on_error=True`.

This change applies the same retry accounting shape used by the exception branch:

- log the timeout attempt
- requeue with lower priority while retries remain
- mark the item failed when retries are exhausted
- set the termination event when `exit_on_error=True`

## Tests

- `uv run pytest packages/phoenix-evals/tests/phoenix/evals/test_executor.py::test_async_executor_timeout_counts_toward_max_retries -q`
- `uv run pytest packages/phoenix-evals/tests/phoenix/evals/test_executor.py::test_async_executor_can_continue_on_error packages/phoenix-evals/tests/phoenix/evals/test_executor.py::test_async_executor_retries -q`
- `uv run ruff check packages/phoenix-evals/src/phoenix/evals/executors.py packages/phoenix-evals/tests/phoenix/evals/test_executor.py`
- `uv run ruff format --check packages/phoenix-evals/src/phoenix/evals/executors.py packages/phoenix-evals/tests/phoenix/evals/test_executor.py`
