### PR TITLE
fix(pxi): export agent telemetry from pytest eval runs

### DIFF
--- a/evals/pxi/conftest.py
+++ b/evals/pxi/conftest.py
@@ -15,12 +15,12 @@ from pathlib import Path
 from typing import Any, AsyncIterator
 
 import pytest_asyncio
+from phoenix.client.pytest.plugin import _get_state  # pyright: ignore[reportPrivateUsage]
 
 from evals.pxi.harness.agent_task import (
     build_shared_docs_mcp_server,
     flush_agent_telemetry,
 )
-from phoenix.client.pytest.plugin import _get_state  # pyright: ignore[reportPrivateUsage]
 
 RESULTS_PATH_ENV = "PXI_EVAL_RESULTS_PATH"
 DEFAULT_RESULTS_PATH = "pxi-eval-results.json"
@@ -69,9 +69,7 @@ def pytest_runtest_logreport(report: Any) -> None:
 
 
 def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
-    # Every process (xdist workers included) flushes its own buffered agent
-    # spans -- the batch exporter is process-local and must not lose spans to
-    # a teardown race.
+    # Before the worker early-return: each xdist process flushes its own spans.
     flush_agent_telemetry()
     # Workers post their reports to the controller, which owns the single write.
     if hasattr(session.config, "workerinput"):

--- a/evals/pxi/conftest.py
+++ b/evals/pxi/conftest.py
@@ -15,9 +15,12 @@ from pathlib import Path
 from typing import Any, AsyncIterator
 
 import pytest_asyncio
-from phoenix.client.pytest.plugin import _get_state  # pyright: ignore[reportPrivateUsage]
 
-from evals.pxi.harness.agent_task import build_shared_docs_mcp_server
+from evals.pxi.harness.agent_task import (
+    build_shared_docs_mcp_server,
+    flush_agent_telemetry,
+)
+from phoenix.client.pytest.plugin import _get_state  # pyright: ignore[reportPrivateUsage]
 
 RESULTS_PATH_ENV = "PXI_EVAL_RESULTS_PATH"
 DEFAULT_RESULTS_PATH = "pxi-eval-results.json"
@@ -66,6 +69,10 @@ def pytest_runtest_logreport(report: Any) -> None:
 
 
 def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
+    # Every process (xdist workers included) flushes its own buffered agent
+    # spans -- the batch exporter is process-local and must not lose spans to
+    # a teardown race.
+    flush_agent_telemetry()
     # Workers post their reports to the controller, which owns the single write.
     if hasattr(session.config, "workerinput"):
         return

--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -8,6 +8,8 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
+from openinference.instrumentation import OITracer, TraceConfig
+from opentelemetry.trace import TracerProvider
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.messages import (
@@ -39,6 +41,7 @@ from phoenix.server.agents.model_factory import (
 from phoenix.server.agents.model_factory import (
     azure_endpoint_to_base_url,
 )
+from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
 from phoenix.server.agents.types import AgentDependencies, AgentOutput
 from phoenix.server.dml_event import DmlEvent
 from phoenix.server.types import CanPutItem, DbSessionFactory
@@ -64,6 +67,78 @@ ENV_ASSISTANT_OPENAI_API_TYPE = "PHOENIX_AGENTS_ASSISTANT_OPENAI_API_TYPE"
 _MAX_ERROR_MESSAGE_LEN = 200
 _OFFLINE_DB = DbSessionFactory(db=_unavailable_db_session, dialect="sqlite")
 _OFFLINE_EVENT_QUEUE: CanPutItem[DmlEvent] = _NoOpEventQueue()
+
+# Fallback project for any agent span created outside a test's CHAIN span
+# context. Spans created inside a test are relabeled to the experiment's
+# project by the phoenix-client pytest plugin's ``capture_spans`` modifier
+# (Resource.merge gives the experiment resource precedence), so under normal
+# operation nothing lands here.
+_STRAY_SPAN_PROJECT = "pxi-evals"
+
+_tracer_provider: TracerProvider | None = None
+_tracer_provider_built = False
+
+
+def _get_tracer_provider() -> TracerProvider | None:
+    """Build (once per process) the OTel provider for agent telemetry.
+
+    ``build_agent`` defaults to a no-op tracer provider, which is why pytest
+    experiment runs previously showed no LLM telemetry (and therefore no
+    cost). This provider exports to the same Phoenix collector the pytest
+    plugin uses (``PHOENIX_COLLECTOR_ENDPOINT`` / ``PHOENIX_API_KEY``); the
+    plugin's CHAIN span is current during the test body, so agent spans nest
+    under the test's trace and attach to the experiment.
+
+    Returns ``None`` (agent runs untraced, exactly the previous behavior)
+    when no collector endpoint is configured or setup fails -- telemetry must
+    never fail an eval run.
+    """
+    global _tracer_provider, _tracer_provider_built
+    if _tracer_provider_built:
+        return _tracer_provider
+    _tracer_provider_built = True
+    if not os.getenv("PHOENIX_COLLECTOR_ENDPOINT"):
+        return None
+    try:
+        from phoenix.otel import register
+
+        _tracer_provider = register(
+            project_name=_STRAY_SPAN_PROJECT,
+            batch=True,
+            set_global_tracer_provider=False,
+            verbose=False,
+            # Without an explicit protocol, a bare collector endpoint is
+            # rewritten to gRPC on port 4317 -- wrong for both a local
+            # instance on a custom port and the remote Phoenix CI exports to.
+            # HTTP hits ``<PHOENIX_COLLECTOR_ENDPOINT>/v1/traces``, the same
+            # transport the pytest plugin's suite tracer uses.
+            protocol="http/protobuf",
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"warning: PXI eval agent tracing disabled ({type(exc).__name__}: {exc})",
+            file=sys.stderr,
+        )
+    return _tracer_provider
+
+
+def flush_agent_telemetry(timeout_millis: int = 30_000) -> None:
+    """Force-flush buffered agent spans (batch exporter) before process exit.
+
+    Called from ``conftest.pytest_sessionfinish`` on every process (xdist
+    workers included) so spans are not lost to a teardown race. Safe no-op
+    when tracing never initialized.
+    """
+    provider = _tracer_provider
+    if provider is None:
+        return
+    force_flush = getattr(provider, "force_flush", None)
+    if force_flush is None:
+        return
+    try:
+        force_flush(timeout_millis)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def _warn_placeholder_api_key(provider: str, base_url: str) -> None:
@@ -517,9 +592,23 @@ async def run_pxi_example(
     try:
         user_prompt, message_history = _build_run_inputs(input)
         model = await _build_model()
+        tracer_provider = _get_tracer_provider()
+        if tracer_provider is not None:
+            # Mirror ``model_factory.build_model``: LLM spans (and therefore
+            # token counts / cost) come from the model wrapper, which the
+            # production router applies before ``build_agent``. Without it
+            # only tool-execution spans would trace.
+            model = OpenInferenceModelWrapper(
+                model,
+                tracer=OITracer(
+                    tracer_provider.get_tracer("phoenix.server.agents"),
+                    config=TraceConfig(),
+                ),
+            )
         agent = build_agent(
             model=model,
             docs_mcp_server=docs_mcp_server,
+            tracer_provider=tracer_provider,
             db=_OFFLINE_DB,
             event_queue=_OFFLINE_EVENT_QUEUE,
             read_only=True,

--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
 from openinference.instrumentation import OITracer, TraceConfig
-from opentelemetry.trace import TracerProvider
+from opentelemetry.sdk.trace import TracerProvider
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.messages import (
@@ -25,6 +25,7 @@ from pydantic_ai.models import Model as PydanticAIModel
 
 from phoenix.config import (
     get_env_allow_external_resources,
+    get_env_collector_endpoint,
     get_env_disable_agent_assistant,
 )
 from phoenix.server.agents.agent_factory import build_agent
@@ -68,11 +69,8 @@ _MAX_ERROR_MESSAGE_LEN = 200
 _OFFLINE_DB = DbSessionFactory(db=_unavailable_db_session, dialect="sqlite")
 _OFFLINE_EVENT_QUEUE: CanPutItem[DmlEvent] = _NoOpEventQueue()
 
-# Fallback project for any agent span created outside a test's CHAIN span
-# context. Spans created inside a test are relabeled to the experiment's
-# project by the phoenix-client pytest plugin's ``capture_spans`` modifier
-# (Resource.merge gives the experiment resource precedence), so under normal
-# operation nothing lands here.
+# Fallback only: the pytest plugin's capture_spans relabels in-test spans to
+# the experiment's project.
 _STRAY_SPAN_PROJECT = "pxi-evals"
 
 _tracer_provider: TracerProvider | None = None
@@ -80,24 +78,15 @@ _tracer_provider_built = False
 
 
 def _get_tracer_provider() -> TracerProvider | None:
-    """Build (once per process) the OTel provider for agent telemetry.
-
-    ``build_agent`` defaults to a no-op tracer provider, which is why pytest
-    experiment runs previously showed no LLM telemetry (and therefore no
-    cost). This provider exports to the same Phoenix collector the pytest
-    plugin uses (``PHOENIX_COLLECTOR_ENDPOINT`` / ``PHOENIX_API_KEY``); the
-    plugin's CHAIN span is current during the test body, so agent spans nest
-    under the test's trace and attach to the experiment.
-
-    Returns ``None`` (agent runs untraced, exactly the previous behavior)
-    when no collector endpoint is configured or setup fails -- telemetry must
-    never fail an eval run.
-    """
+    """Process-local provider (built once per worker) exporting agent spans
+    to the same Phoenix collector the pytest plugin uses. ``None`` when no
+    collector is configured or setup fails, in which case the agent runs
+    untraced."""
     global _tracer_provider, _tracer_provider_built
     if _tracer_provider_built:
         return _tracer_provider
     _tracer_provider_built = True
-    if not os.getenv("PHOENIX_COLLECTOR_ENDPOINT"):
+    if not get_env_collector_endpoint():
         return None
     try:
         from phoenix.otel import register
@@ -107,11 +96,7 @@ def _get_tracer_provider() -> TracerProvider | None:
             batch=True,
             set_global_tracer_provider=False,
             verbose=False,
-            # Without an explicit protocol, a bare collector endpoint is
-            # rewritten to gRPC on port 4317 -- wrong for both a local
-            # instance on a custom port and the remote Phoenix CI exports to.
-            # HTTP hits ``<PHOENIX_COLLECTOR_ENDPOINT>/v1/traces``, the same
-            # transport the pytest plugin's suite tracer uses.
+            # Required: a bare collector endpoint is otherwise rewritten to gRPC :4317.
             protocol="http/protobuf",
         )
     except Exception as exc:  # noqa: BLE001
@@ -123,20 +108,12 @@ def _get_tracer_provider() -> TracerProvider | None:
 
 
 def flush_agent_telemetry(timeout_millis: int = 30_000) -> None:
-    """Force-flush buffered agent spans (batch exporter) before process exit.
-
-    Called from ``conftest.pytest_sessionfinish`` on every process (xdist
-    workers included) so spans are not lost to a teardown race. Safe no-op
-    when tracing never initialized.
-    """
-    provider = _tracer_provider
-    if provider is None:
-        return
-    force_flush = getattr(provider, "force_flush", None)
-    if force_flush is None:
+    """Flush buffered agent spans; conftest calls this at session finish on
+    every process."""
+    if _tracer_provider is None:
         return
     try:
-        force_flush(timeout_millis)
+        _tracer_provider.force_flush(timeout_millis)
     except Exception:  # noqa: BLE001
         pass
 
@@ -594,10 +571,7 @@ async def run_pxi_example(
         model = await _build_model()
         tracer_provider = _get_tracer_provider()
         if tracer_provider is not None:
-            # Mirror ``model_factory.build_model``: LLM spans (and therefore
-            # token counts / cost) come from the model wrapper, which the
-            # production router applies before ``build_agent``. Without it
-            # only tool-execution spans would trace.
+            # Mirrors model_factory.build_model: LLM spans come from the model wrapper.
             model = OpenInferenceModelWrapper(
                 model,
                 tracer=OITracer(


### PR DESCRIPTION
Fixes #14275

## Problem

PXI pytest experiment runs recorded no agent telemetry, so experiments showed no LLM spans and no cost (only the pytest plugin's thin CHAIN/EVALUATOR wrapper spans). This was structural, not a CI configuration gap — it reproduced locally too:

1. `evals/pxi/harness/agent_task.py` called `build_agent()` without a `tracer_provider`, which falls back to `NoOpTracerProvider` — every OpenInference wrapper emitted no-op spans.
2. Even with a provider, LLM spans come from `OpenInferenceModelWrapper`, which the production router applies via `model_factory.build_model()` — the harness builds its model through the low-level builder and never wrapped it.
3. The phoenix-client pytest plugin's suite tracer is deliberately process-local (never installed as the global OTel provider), so it only exports the spans it opens itself.

## Fix

- Build a process-local, non-global OTel provider once per worker via `phoenix.otel.register(set_global_tracer_provider=False, batch=True, protocol="http/protobuf")`, exporting to the same `PHOENIX_COLLECTOR_ENDPOINT` / `PHOENIX_API_KEY` the plugin uses. (`protocol` is explicit because a bare collector endpoint otherwise gets rewritten to gRPC :4317.)
- Pass it to `build_agent` and wrap the model in `OpenInferenceModelWrapper`, mirroring the production `build_model` path.
- Agent spans nest under the plugin's CHAIN span via the active OTel context and are relabeled to the experiment project by `capture_spans` (`Resource.merge` gives the experiment resource precedence), so the full trace attaches to the experiment run and cost is computed.
- `conftest.pytest_sessionfinish` force-flushes the batch exporter on every process (xdist workers included).
- Fail-open: when `PHOENIX_COLLECTOR_ENDPOINT` is unset or provider setup fails, behavior is exactly as before (agent runs untraced); telemetry can never fail an eval run.

## Validation

Ran `test_pxi_eval[set_time_range-current-year]` against a fresh local Phoenix with `PHOENIX_COLLECTOR_ENDPOINT` set, then inspected the DB:

- experiment project trace now contains `gpt-5.4` **LLM** span (13,816 tokens) parented under the test's CHAIN span, same trace id
- `span_costs` populated: **$0.005351** for the run
- offline path (`PHOENIX_COLLECTOR_ENDPOINT` unset) verified to degrade to `None` provider / no-op flush
- `ruff` + `mypy` clean on both files

https://claude.ai/code/session_01Px2hdGX6JSp5cqBPMDBAHc