### PR TITLE
feat(agents): force tracing with debug env

### DIFF
--- a/app/__tests__/setup-remote-export.test.ts
+++ b/app/__tests__/setup-remote-export.test.ts
@@ -35,7 +35,7 @@ describe("setup-remote-export", () => {
             "https://example.com/collector",
           ],
           ["PHOENIX_AGENTS_COLLECTOR_API_KEY", "secret"],
-          ["PHOENIX_DEBUG_AGENTS", "true"],
+          ["PHOENIX_AGENTS_FORCE_TRACING", "true"],
         ]),
       })
     ).toBe(
@@ -44,7 +44,7 @@ describe("setup-remote-export", () => {
         "export OTHER=value",
         "export PHOENIX_AGENTS_COLLECTOR_ENDPOINT='https://example.com/collector'",
         "export PHOENIX_AGENTS_COLLECTOR_API_KEY='secret'",
-        "export PHOENIX_DEBUG_AGENTS='true'",
+        "export PHOENIX_AGENTS_FORCE_TRACING='true'",
         "",
       ].join("\n")
     );

--- a/app/__tests__/setup-remote-export.test.ts
+++ b/app/__tests__/setup-remote-export.test.ts
@@ -35,6 +35,7 @@ describe("setup-remote-export", () => {
             "https://example.com/collector",
           ],
           ["PHOENIX_AGENTS_COLLECTOR_API_KEY", "secret"],
+          ["PHOENIX_DEBUG_AGENTS", "true"],
         ]),
       })
     ).toBe(
@@ -43,6 +44,7 @@ describe("setup-remote-export", () => {
         "export OTHER=value",
         "export PHOENIX_AGENTS_COLLECTOR_ENDPOINT='https://example.com/collector'",
         "export PHOENIX_AGENTS_COLLECTOR_API_KEY='secret'",
+        "export PHOENIX_DEBUG_AGENTS='true'",
         "",
       ].join("\n")
     );

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -111,9 +111,9 @@ type AgentsConfig {
   assistantProjectName: String!
 
   """
-  Whether PXI tracing and remote export are forced for all users by the PHOENIX_DEBUG_AGENTS environment variable.
+  Whether PXI tracing and remote export are forced for all users by the PHOENIX_AGENTS_FORCE_TRACING environment variable.
   """
-  debugAgents: Boolean!
+  forceTracing: Boolean!
 
   """
   Whether PXI can expose native web search and web fetch capabilities. False when external resources are disabled or PHOENIX_AGENTS_DISABLE_WEB_ACCESS is true.

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -111,6 +111,11 @@ type AgentsConfig {
   assistantProjectName: String!
 
   """
+  Whether PXI tracing and remote export are forced for all users by the PHOENIX_DEBUG_AGENTS environment variable.
+  """
+  debugAgents: Boolean!
+
+  """
   Whether PXI can expose native web search and web fetch capabilities. False when external resources are disabled or PHOENIX_AGENTS_DISABLE_WEB_ACCESS is true.
   """
   webAccessEnabled: Boolean!

--- a/app/scripts/setup-remote-export.ts
+++ b/app/scripts/setup-remote-export.ts
@@ -18,7 +18,7 @@ const ENV_PATH = path.resolve(
 const COLLECTOR_ENDPOINT = "PHOENIX_AGENTS_COLLECTOR_ENDPOINT";
 const COLLECTOR_API_KEY = "PHOENIX_AGENTS_COLLECTOR_API_KEY";
 const ASSISTANT_PROJECT_NAME = "PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME";
-const DEBUG_AGENTS = "PHOENIX_DEBUG_AGENTS";
+const FORCE_TRACING = "PHOENIX_AGENTS_FORCE_TRACING";
 
 class SecretOutput extends Writable {
   isMuted = false;
@@ -150,7 +150,7 @@ async function main() {
         [COLLECTOR_ENDPOINT, endpoint],
         [COLLECTOR_API_KEY, nextApiKey],
         [ASSISTANT_PROJECT_NAME, projectName],
-        [DEBUG_AGENTS, "true"],
+        [FORCE_TRACING, "true"],
       ]),
     });
 

--- a/app/scripts/setup-remote-export.ts
+++ b/app/scripts/setup-remote-export.ts
@@ -18,6 +18,7 @@ const ENV_PATH = path.resolve(
 const COLLECTOR_ENDPOINT = "PHOENIX_AGENTS_COLLECTOR_ENDPOINT";
 const COLLECTOR_API_KEY = "PHOENIX_AGENTS_COLLECTOR_API_KEY";
 const ASSISTANT_PROJECT_NAME = "PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME";
+const DEBUG_AGENTS = "PHOENIX_DEBUG_AGENTS";
 
 class SecretOutput extends Writable {
   isMuted = false;
@@ -149,12 +150,13 @@ async function main() {
         [COLLECTOR_ENDPOINT, endpoint],
         [COLLECTOR_API_KEY, nextApiKey],
         [ASSISTANT_PROJECT_NAME, projectName],
+        [DEBUG_AGENTS, "true"],
       ]),
     });
 
     await writeEnvFile({ path: ENV_PATH, contents: updatedContents });
     process.stdout.write(
-      "\nPXI remote export environment configured. Restart Phoenix, then enable remote export in Assistant system and personal settings.\n"
+      "\nPXI remote export and tracing configured. Restart Phoenix to apply the changes.\n"
     );
   } finally {
     prompt.close();

--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -15,6 +15,7 @@ import type { AgentUIMessage } from "../types";
 const agentsConfig = {
   collectorEndpoint: null,
   assistantProjectName: "assistant_agent",
+  debugAgents: false,
   webAccessEnabled: false,
   assistantEnabled: true,
   allowLocalTraces: false,

--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -15,7 +15,7 @@ import type { AgentUIMessage } from "../types";
 const agentsConfig = {
   collectorEndpoint: null,
   assistantProjectName: "assistant_agent",
-  debugAgents: false,
+  forceTracing: false,
   webAccessEnabled: false,
   assistantEnabled: true,
   allowLocalTraces: false,
@@ -252,7 +252,7 @@ describe("buildAgentChatRequestBody", () => {
         attachUserId: false,
         acknowledgedTraceConsent: null,
       },
-      agentsConfig: { ...agentsConfig, debugAgents: true },
+      agentsConfig: { ...agentsConfig, forceTracing: true },
       permissions: { edits: "manual" },
       contexts: [],
       modelSelection: {

--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -237,6 +237,33 @@ describe("buildAgentChatRequestBody", () => {
     expect(body.attachUserId).toBe(true);
     expect(body.ingestTraces).toBe(true);
   });
+
+  it("forces attachUserId when agent debugging is enabled", () => {
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "session-1",
+      messages: [] as AgentUIMessage[],
+      trigger: "submit-message",
+      messageId: undefined,
+      capabilities: createDefaultAgentCapabilities(),
+      observability: {
+        storeLocalTraces: false,
+        exportRemoteTraces: false,
+        attachUserId: false,
+        acknowledgedTraceConsent: null,
+      },
+      agentsConfig: { ...agentsConfig, debugAgents: true },
+      permissions: { edits: "manual" },
+      contexts: [],
+      modelSelection: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-4o-mini",
+      },
+    });
+
+    expect(body.attachUserId).toBe(true);
+  });
 });
 
 describe("enrichMessagesWithClientToolTimings", () => {

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -5,6 +5,7 @@ import type { AgentCapabilities } from "@phoenix/agent/extensions/capabilities";
 import type { components } from "@phoenix/api/__generated__/v1";
 import type { AgentModelSelection } from "@phoenix/components/agent/useGenerateSessionSummary";
 import {
+  getEffectiveAttachUserId,
   getEffectiveTraceRecordingSettings,
   type AgentObservabilitySettings,
   type AgentPermissions,
@@ -151,7 +152,7 @@ export function buildAgentChatRequestBody({
     messageId,
     ingestTraces: traceRecording.ingestTraces,
     exportRemoteTraces: traceRecording.exportRemoteTraces,
-    attachUserId: observability.attachUserId,
+    attachUserId: getEffectiveAttachUserId({ agentsConfig, observability }),
     editPermission: permissions.edits,
     contexts: requestContexts,
     model: modelSelection,

--- a/app/src/components/agent/AgentObservabilitySettings.tsx
+++ b/app/src/components/agent/AgentObservabilitySettings.tsx
@@ -106,7 +106,7 @@ export function AgentObservabilitySettings({
   const setObservability = useAgentContext((state) => state.setObservability);
   const isAdmin = useIsAdmin();
   const isRemoteCollectorConfigured = Boolean(agentsConfig.collectorEndpoint);
-  const isTracingForced = agentsConfig.debugAgents;
+  const isTracingForced = agentsConfig.forceTracing;
 
   const localTracesOffInSystemSettings = !agentsConfig.allowLocalTraces;
   const remoteExportOffInSystemSettings = !agentsConfig.allowRemoteExport;

--- a/app/src/components/agent/AgentObservabilitySettings.tsx
+++ b/app/src/components/agent/AgentObservabilitySettings.tsx
@@ -4,7 +4,10 @@ import type { ReactNode } from "react";
 import { ContextualHelp, Switch, Text } from "@phoenix/components";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useIsAdmin } from "@phoenix/contexts/ViewerContext";
-import { getEffectiveTraceRecordingSettings } from "@phoenix/store/agentStore";
+import {
+  getEffectiveAttachUserId,
+  getEffectiveTraceRecordingSettings,
+} from "@phoenix/store/agentStore";
 
 import { SystemSettingsWarning } from "./SystemSettingsWarning";
 
@@ -116,13 +119,17 @@ export function AgentObservabilitySettings({
   });
   const isTracingEnabled =
     effectiveRecording.ingestTraces || effectiveRecording.exportRemoteTraces;
+  const effectiveAttachUserId = getEffectiveAttachUserId({
+    agentsConfig,
+    observability,
+  });
 
   return (
     <div css={settingsContainerCSS}>
       {isTracingForced ? (
         <Text color="text-500" size="S">
-          Tracing and remote export are enabled for all users by this Phoenix
-          deployment.
+          Tracing, remote export, and user attribution are enabled for all users
+          by this Phoenix deployment.
         </Text>
       ) : !isOnSettingsPage ? (
         <Text color="text-500" size="S">
@@ -203,8 +210,8 @@ export function AgentObservabilitySettings({
         ) : null}
         <li css={settingRowCSS}>
           <Switch
-            isSelected={observability.attachUserId}
-            isDisabled={!isTracingEnabled}
+            isSelected={effectiveAttachUserId}
+            isDisabled={!isTracingEnabled || isTracingForced}
             onChange={(attachUserId) => {
               setObservability({ attachUserId });
             }}

--- a/app/src/components/agent/AgentObservabilitySettings.tsx
+++ b/app/src/components/agent/AgentObservabilitySettings.tsx
@@ -103,6 +103,7 @@ export function AgentObservabilitySettings({
   const setObservability = useAgentContext((state) => state.setObservability);
   const isAdmin = useIsAdmin();
   const isRemoteCollectorConfigured = Boolean(agentsConfig.collectorEndpoint);
+  const isTracingForced = agentsConfig.debugAgents;
 
   const localTracesOffInSystemSettings = !agentsConfig.allowLocalTraces;
   const remoteExportOffInSystemSettings = !agentsConfig.allowRemoteExport;
@@ -118,17 +119,21 @@ export function AgentObservabilitySettings({
 
   return (
     <div css={settingsContainerCSS}>
-      {/* The settings page already scopes its personal section to the browser. */}
-      {!isOnSettingsPage && (
+      {isTracingForced ? (
+        <Text color="text-500" size="S">
+          Tracing and remote export are enabled for all users by this Phoenix
+          deployment.
+        </Text>
+      ) : !isOnSettingsPage ? (
         <Text color="text-500" size="S">
           These settings apply only to this browser.
         </Text>
-      )}
+      ) : null}
       <ul css={settingsListCSS}>
         <li css={settingRowCSS}>
           <Switch
             isSelected={effectiveRecording.ingestTraces}
-            isDisabled={localTracesOffInSystemSettings}
+            isDisabled={localTracesOffInSystemSettings || isTracingForced}
             onChange={(storeLocalTraces) => {
               setObservability({ storeLocalTraces });
             }}
@@ -163,7 +168,7 @@ export function AgentObservabilitySettings({
           <li css={settingRowCSS}>
             <Switch
               isSelected={effectiveRecording.exportRemoteTraces}
-              isDisabled={remoteExportOffInSystemSettings}
+              isDisabled={remoteExportOffInSystemSettings || isTracingForced}
               onChange={(exportRemoteTraces) => {
                 setObservability({ exportRemoteTraces });
               }}

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -146,7 +146,7 @@ describe("AgentChatWidget", () => {
               agentsConfig={{
                 collectorEndpoint: null,
                 assistantProjectName: "assistant_agent",
-                debugAgents: false,
+                forceTracing: false,
                 webAccessEnabled: false,
                 assistantEnabled: true,
                 allowLocalTraces: true,
@@ -431,7 +431,7 @@ describe("AgentChatWidget", () => {
               agentsConfig={{
                 collectorEndpoint: null,
                 assistantProjectName: "assistant_agent",
-                debugAgents: false,
+                forceTracing: false,
                 webAccessEnabled: false,
                 assistantEnabled: true,
                 allowLocalTraces: true,

--- a/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatWidget.test.tsx
@@ -146,6 +146,7 @@ describe("AgentChatWidget", () => {
               agentsConfig={{
                 collectorEndpoint: null,
                 assistantProjectName: "assistant_agent",
+                debugAgents: false,
                 webAccessEnabled: false,
                 assistantEnabled: true,
                 allowLocalTraces: true,
@@ -430,6 +431,7 @@ describe("AgentChatWidget", () => {
               agentsConfig={{
                 collectorEndpoint: null,
                 assistantProjectName: "assistant_agent",
+                debugAgents: false,
                 webAccessEnabled: false,
                 assistantEnabled: true,
                 allowLocalTraces: true,

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -108,7 +108,7 @@ function renderChatView(
           agentsConfig={{
             collectorEndpoint: null,
             assistantProjectName: "assistant_agent",
-            debugAgents: false,
+            forceTracing: false,
             webAccessEnabled: false,
             assistantEnabled: true,
             allowLocalTraces: true,

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -108,6 +108,7 @@ function renderChatView(
           agentsConfig={{
             collectorEndpoint: null,
             assistantProjectName: "assistant_agent",
+            debugAgents: false,
             webAccessEnabled: false,
             assistantEnabled: true,
             allowLocalTraces: true,

--- a/app/src/components/agent/useGenerateSessionSummary.ts
+++ b/app/src/components/agent/useGenerateSessionSummary.ts
@@ -4,7 +4,10 @@ import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import type { components, paths } from "@phoenix/api/__generated__/v1";
 import { authApiFetch } from "@phoenix/api/authApiFetch";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
-import { getEffectiveTraceRecordingSettings } from "@phoenix/store/agentStore";
+import {
+  getEffectiveAttachUserId,
+  getEffectiveTraceRecordingSettings,
+} from "@phoenix/store/agentStore";
 
 const SUMMARIZE_PATH =
   "/agents/{agent_id}/sessions/{session_id}/summary" as const satisfies keyof paths;
@@ -89,7 +92,10 @@ export function useGenerateSessionSummary() {
         messages: session.messages,
         ingestTraces: traceRecording.ingestTraces,
         exportRemoteTraces: traceRecording.exportRemoteTraces,
-        attachUserId: state.observability.attachUserId,
+        attachUserId: getEffectiveAttachUserId({
+          agentsConfig: state.agentsConfig,
+          observability: state.observability,
+        }),
       })
         .then((summary) => {
           if (summary) {

--- a/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b2dc46bcc3064ee53938f5dfab5873fe>>
+ * @generated SignedSource<<b547d3d770c717049adcddaecc2af73a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type authenticatedRootLoaderQuery$data = {
     readonly assistantEnabled: boolean;
     readonly assistantProjectName: string;
     readonly collectorEndpoint: string | null;
+    readonly debugAgents: boolean;
     readonly webAccessEnabled: boolean;
   };
   readonly viewer: {
@@ -54,6 +55,13 @@ var v0 = {
       "args": null,
       "kind": "ScalarField",
       "name": "assistantProjectName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "debugAgents",
       "storageKey": null
     },
     {
@@ -247,16 +255,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c4d76dc1d6016faf2d55d3694b970ece",
+    "cacheID": "84ef739d54667f2eecd41f720e815878",
     "id": null,
     "metadata": {},
     "name": "authenticatedRootLoaderQuery",
     "operationKind": "query",
-    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n    webAccessEnabled\n    assistantEnabled\n    allowLocalTraces\n    allowRemoteExport\n  }\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n    debugAgents\n    webAccessEnabled\n    assistantEnabled\n    allowLocalTraces\n    allowRemoteExport\n  }\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e66d05013f311a15863e40c44d7bb33f";
+(node as any).hash = "eb588a594c1bc9d53bedd22e872dc559";
 
 export default node;

--- a/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b547d3d770c717049adcddaecc2af73a>>
+ * @generated SignedSource<<c6528dc9461699f0077206fa59b53c01>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,7 +18,7 @@ export type authenticatedRootLoaderQuery$data = {
     readonly assistantEnabled: boolean;
     readonly assistantProjectName: string;
     readonly collectorEndpoint: string | null;
-    readonly debugAgents: boolean;
+    readonly forceTracing: boolean;
     readonly webAccessEnabled: boolean;
   };
   readonly viewer: {
@@ -61,7 +61,7 @@ var v0 = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "debugAgents",
+      "name": "forceTracing",
       "storageKey": null
     },
     {
@@ -255,16 +255,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "84ef739d54667f2eecd41f720e815878",
+    "cacheID": "bad27b002fbdcc54d8235a2a4e5704ef",
     "id": null,
     "metadata": {},
     "name": "authenticatedRootLoaderQuery",
     "operationKind": "query",
-    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n    debugAgents\n    webAccessEnabled\n    assistantEnabled\n    allowLocalTraces\n    allowRemoteExport\n  }\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n    forceTracing\n    webAccessEnabled\n    assistantEnabled\n    allowLocalTraces\n    allowRemoteExport\n  }\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "eb588a594c1bc9d53bedd22e872dc559";
+(node as any).hash = "5664be46b399644bab48856bc94821a0";
 
 export default node;

--- a/app/src/pages/authenticatedRootLoader.ts
+++ b/app/src/pages/authenticatedRootLoader.ts
@@ -12,7 +12,7 @@ export const authenticatedRootLoaderQueryNode = graphql`
     agentsConfig {
       collectorEndpoint
       assistantProjectName
-      debugAgents
+      forceTracing
       webAccessEnabled
       assistantEnabled
       allowLocalTraces

--- a/app/src/pages/authenticatedRootLoader.ts
+++ b/app/src/pages/authenticatedRootLoader.ts
@@ -12,6 +12,7 @@ export const authenticatedRootLoaderQueryNode = graphql`
     agentsConfig {
       collectorEndpoint
       assistantProjectName
+      debugAgents
       webAccessEnabled
       assistantEnabled
       allowLocalTraces

--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -129,7 +129,7 @@ export function SettingsAgentsAdminSettingsSection() {
     <Flex direction="column" gap="size-150">
       <Text color="text-500">
         {debugAgents
-          ? "PXI tracing and remote export are enabled for all users by PHOENIX_DEBUG_AGENTS."
+          ? "PXI tracing, remote export, and user attribution are enabled for all users by PHOENIX_DEBUG_AGENTS."
           : "Applies to all users. When a system setting is off, the matching personal setting is unavailable."}
       </Text>
       <ul css={settingsListCSS}>

--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -58,8 +58,8 @@ export function SettingsAgentsAdminSettingsSection() {
   const allowRemoteExport = useAgentContext(
     (state) => state.agentsConfig.allowRemoteExport
   );
-  const debugAgents = useAgentContext(
-    (state) => state.agentsConfig.debugAgents
+  const forceTracing = useAgentContext(
+    (state) => state.agentsConfig.forceTracing
   );
   const store = useAgentStore();
 
@@ -128,8 +128,8 @@ export function SettingsAgentsAdminSettingsSection() {
   return (
     <Flex direction="column" gap="size-150">
       <Text color="text-500">
-        {debugAgents
-          ? "PXI tracing, remote export, and user attribution are enabled for all users by PHOENIX_DEBUG_AGENTS."
+        {forceTracing
+          ? "PXI tracing, remote export, and user attribution are enabled for all users by PHOENIX_AGENTS_FORCE_TRACING."
           : "Applies to all users. When a system setting is off, the matching personal setting is unavailable."}
       </Text>
       <ul css={settingsListCSS}>
@@ -150,7 +150,7 @@ export function SettingsAgentsAdminSettingsSection() {
             onChange={(allowLocalTraces) =>
               handleTraceRecordingChange({ allowLocalTraces })
             }
-            isDisabled={isBusy || debugAgents}
+            isDisabled={isBusy || forceTracing}
           />
         </li>
         {isRemoteCollectorConfigured ? (
@@ -162,7 +162,7 @@ export function SettingsAgentsAdminSettingsSection() {
               onChange={(allowRemoteExport) =>
                 handleTraceRecordingChange({ allowRemoteExport })
               }
-              isDisabled={isBusy || debugAgents}
+              isDisabled={isBusy || forceTracing}
             />
           </li>
         ) : null}

--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -58,6 +58,9 @@ export function SettingsAgentsAdminSettingsSection() {
   const allowRemoteExport = useAgentContext(
     (state) => state.agentsConfig.allowRemoteExport
   );
+  const debugAgents = useAgentContext(
+    (state) => state.agentsConfig.debugAgents
+  );
   const store = useAgentStore();
 
   const [setAgentAssistantEnabled, isUpdatingEnabled] =
@@ -125,8 +128,9 @@ export function SettingsAgentsAdminSettingsSection() {
   return (
     <Flex direction="column" gap="size-150">
       <Text color="text-500">
-        Applies to all users. When a system setting is off, the matching
-        personal setting is unavailable.
+        {debugAgents
+          ? "PXI tracing and remote export are enabled for all users by PHOENIX_DEBUG_AGENTS."
+          : "Applies to all users. When a system setting is off, the matching personal setting is unavailable."}
       </Text>
       <ul css={settingsListCSS}>
         <li css={settingRowCSS}>
@@ -146,7 +150,7 @@ export function SettingsAgentsAdminSettingsSection() {
             onChange={(allowLocalTraces) =>
               handleTraceRecordingChange({ allowLocalTraces })
             }
-            isDisabled={isBusy}
+            isDisabled={isBusy || debugAgents}
           />
         </li>
         {isRemoteCollectorConfigured ? (
@@ -158,7 +162,7 @@ export function SettingsAgentsAdminSettingsSection() {
               onChange={(allowRemoteExport) =>
                 handleTraceRecordingChange({ allowRemoteExport })
               }
-              isDisabled={isBusy}
+              isDisabled={isBusy || debugAgents}
             />
           </li>
         ) : null}

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   createAgentStore,
+  getEffectiveAttachUserId,
   getEffectiveTraceRecordingSettings,
   hasAcknowledgedCurrentTraceConsent,
   resolveAssistantStorageKey,
@@ -614,6 +615,12 @@ describe("agentStore", () => {
       ).toEqual({ ingestTraces: true, exportRemoteTraces: true });
       expect(
         hasAcknowledgedCurrentTraceConsent({
+          agentsConfig: store.getState().agentsConfig,
+          observability: store.getState().observability,
+        })
+      ).toBe(true);
+      expect(
+        getEffectiveAttachUserId({
           agentsConfig: store.getState().agentsConfig,
           observability: store.getState().observability,
         })

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   createAgentStore,
+  getEffectiveTraceRecordingSettings,
   hasAcknowledgedCurrentTraceConsent,
   resolveAssistantStorageKey,
 } from "../agentStore";
@@ -540,6 +541,7 @@ describe("agentStore", () => {
         agentsConfig: {
           collectorEndpoint: "https://collector.example.com",
           assistantProjectName: "assistant_agent",
+          debugAgents: false,
           webAccessEnabled: false,
           assistantEnabled: true,
           allowLocalTraces: true,
@@ -583,6 +585,39 @@ describe("agentStore", () => {
           observability: store.getState().observability,
         })
       ).toBe(false);
+    });
+
+    it("forces tracing and bypasses consent when agent debugging is enabled", () => {
+      const store = createAgentStore({
+        agentsConfig: {
+          collectorEndpoint: "https://collector.example.com",
+          assistantProjectName: "assistant_agent",
+          debugAgents: true,
+          webAccessEnabled: false,
+          assistantEnabled: true,
+          allowLocalTraces: false,
+          allowRemoteExport: false,
+        },
+        observability: {
+          storeLocalTraces: false,
+          exportRemoteTraces: false,
+          attachUserId: false,
+          acknowledgedTraceConsent: null,
+        },
+      });
+
+      expect(
+        getEffectiveTraceRecordingSettings({
+          agentsConfig: store.getState().agentsConfig,
+          observability: store.getState().observability,
+        })
+      ).toEqual({ ingestTraces: true, exportRemoteTraces: true });
+      expect(
+        hasAcknowledgedCurrentTraceConsent({
+          agentsConfig: store.getState().agentsConfig,
+          observability: store.getState().observability,
+        })
+      ).toBe(true);
     });
   });
 

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -542,7 +542,7 @@ describe("agentStore", () => {
         agentsConfig: {
           collectorEndpoint: "https://collector.example.com",
           assistantProjectName: "assistant_agent",
-          debugAgents: false,
+          forceTracing: false,
           webAccessEnabled: false,
           assistantEnabled: true,
           allowLocalTraces: true,
@@ -593,7 +593,7 @@ describe("agentStore", () => {
         agentsConfig: {
           collectorEndpoint: "https://collector.example.com",
           assistantProjectName: "assistant_agent",
-          debugAgents: true,
+          forceTracing: true,
           webAccessEnabled: false,
           assistantEnabled: true,
           allowLocalTraces: false,

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -53,7 +53,7 @@ export type AgentServerConfig = {
   /** Local Phoenix project used for PXI trace persistence. */
   assistantProjectName: string;
   /** Whether tracing and remote export are forced by the Phoenix instance. */
-  debugAgents: boolean;
+  forceTracing: boolean;
   /** Whether this Phoenix instance allows PXI web search/fetch. */
   webAccessEnabled: boolean;
   assistantEnabled: boolean;
@@ -151,7 +151,7 @@ const DEFAULT_MODEL_CONFIG: ModelConfig = {
 const DEFAULT_AGENT_SERVER_CONFIG: AgentServerConfig = {
   collectorEndpoint: null,
   assistantProjectName: "assistant_agent",
-  debugAgents: false,
+  forceTracing: false,
   webAccessEnabled: false,
   assistantEnabled: false,
   allowLocalTraces: false,
@@ -224,7 +224,7 @@ export function hasAcknowledgedCurrentTraceConsent({
   agentsConfig: AgentServerConfig;
   observability: AgentObservabilitySettings;
 }): boolean {
-  if (agentsConfig.debugAgents) {
+  if (agentsConfig.forceTracing) {
     return true;
   }
   const acknowledgedTraceConsent = observability.acknowledgedTraceConsent;
@@ -247,7 +247,7 @@ export function getEffectiveTraceRecordingSettings({
   agentsConfig: AgentServerConfig;
   observability: AgentObservabilitySettings;
 }): AgentTraceRecordingSettings {
-  if (agentsConfig.debugAgents) {
+  if (agentsConfig.forceTracing) {
     return {
       ingestTraces: true,
       exportRemoteTraces: true,
@@ -268,7 +268,7 @@ export function getEffectiveAttachUserId({
   agentsConfig: AgentServerConfig;
   observability: AgentObservabilitySettings;
 }): boolean {
-  return agentsConfig.debugAgents || observability.attachUserId;
+  return agentsConfig.forceTracing || observability.attachUserId;
 }
 
 /**

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -52,6 +52,8 @@ export type AgentServerConfig = {
   collectorEndpoint: string | null;
   /** Local Phoenix project used for PXI trace persistence. */
   assistantProjectName: string;
+  /** Whether tracing and remote export are forced by the Phoenix instance. */
+  debugAgents: boolean;
   /** Whether this Phoenix instance allows PXI web search/fetch. */
   webAccessEnabled: boolean;
   assistantEnabled: boolean;
@@ -149,6 +151,7 @@ const DEFAULT_MODEL_CONFIG: ModelConfig = {
 const DEFAULT_AGENT_SERVER_CONFIG: AgentServerConfig = {
   collectorEndpoint: null,
   assistantProjectName: "assistant_agent",
+  debugAgents: false,
   webAccessEnabled: false,
   assistantEnabled: false,
   allowLocalTraces: false,
@@ -221,6 +224,9 @@ export function hasAcknowledgedCurrentTraceConsent({
   agentsConfig: AgentServerConfig;
   observability: AgentObservabilitySettings;
 }): boolean {
+  if (agentsConfig.debugAgents) {
+    return true;
+  }
   const acknowledgedTraceConsent = observability.acknowledgedTraceConsent;
   if (!acknowledgedTraceConsent) {
     return false;
@@ -241,6 +247,12 @@ export function getEffectiveTraceRecordingSettings({
   agentsConfig: AgentServerConfig;
   observability: AgentObservabilitySettings;
 }): AgentTraceRecordingSettings {
+  if (agentsConfig.debugAgents) {
+    return {
+      ingestTraces: true,
+      exportRemoteTraces: true,
+    };
+  }
   const ceiling = getCurrentTraceConsentSettings(agentsConfig);
   return {
     ingestTraces: ceiling.allowLocalTraces && observability.storeLocalTraces,

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -261,6 +261,16 @@ export function getEffectiveTraceRecordingSettings({
   };
 }
 
+export function getEffectiveAttachUserId({
+  agentsConfig,
+  observability,
+}: {
+  agentsConfig: AgentServerConfig;
+  observability: AgentObservabilitySettings;
+}): boolean {
+  return agentsConfig.debugAgents || observability.attachUserId;
+}
+
 /**
  * Serializable properties that define the agent's state.
  * These are the values persisted to local storage.

--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -357,7 +357,7 @@ present, so it does not offer an action that cannot succeed on your current page
   | `PHOENIX_ALLOW_EXTERNAL_RESOURCES=false` | Disable external resource access, including the Phoenix docs MCP lookups. |
   | `PHOENIX_AGENTS_DISABLE_WEB_ACCESS=true` | Disable PXI's web search/fetch tools while leaving other external resources available. |
   | `PHOENIX_AGENTS_DISABLE_BASH=true` | Disable PXI's **server-side** bash tool by preventing subagents from being attached to the assistant. The subagents toggle is also hidden from **Settings → Assistant**. The browser-side bash sandbox is unaffected; to turn PXI off entirely use `PHOENIX_DISABLE_AGENT_ASSISTANT`. |
-  | `PHOENIX_DEBUG_AGENTS=true` | Force local PXI tracing and remote trace export for every user, regardless of workspace or browser settings. Configure the remote collector variables below before enabling it. |
+  | `PHOENIX_DEBUG_AGENTS=true` | Force local PXI tracing, remote trace export, and signed-in user email attribution for every user, regardless of workspace or browser settings. Configure the remote collector variables below before enabling it. |
   | `PHOENIX_AGENTS_COLLECTOR_ENDPOINT` | Remote collector endpoint for assistant trace export. |
   | `PHOENIX_AGENTS_COLLECTOR_API_KEY` | API key for the remote collector, if required. |
   | `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME` | Project name for locally recorded assistant traces (default `assistant_agent`). |

--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -357,6 +357,7 @@ present, so it does not offer an action that cannot succeed on your current page
   | `PHOENIX_ALLOW_EXTERNAL_RESOURCES=false` | Disable external resource access, including the Phoenix docs MCP lookups. |
   | `PHOENIX_AGENTS_DISABLE_WEB_ACCESS=true` | Disable PXI's web search/fetch tools while leaving other external resources available. |
   | `PHOENIX_AGENTS_DISABLE_BASH=true` | Disable PXI's **server-side** bash tool by preventing subagents from being attached to the assistant. The subagents toggle is also hidden from **Settings → Assistant**. The browser-side bash sandbox is unaffected; to turn PXI off entirely use `PHOENIX_DISABLE_AGENT_ASSISTANT`. |
+  | `PHOENIX_DEBUG_AGENTS=true` | Force local PXI tracing and remote trace export for every user, regardless of workspace or browser settings. Configure the remote collector variables below before enabling it. |
   | `PHOENIX_AGENTS_COLLECTOR_ENDPOINT` | Remote collector endpoint for assistant trace export. |
   | `PHOENIX_AGENTS_COLLECTOR_API_KEY` | API key for the remote collector, if required. |
   | `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME` | Project name for locally recorded assistant traces (default `assistant_agent`). |

--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -357,7 +357,7 @@ present, so it does not offer an action that cannot succeed on your current page
   | `PHOENIX_ALLOW_EXTERNAL_RESOURCES=false` | Disable external resource access, including the Phoenix docs MCP lookups. |
   | `PHOENIX_AGENTS_DISABLE_WEB_ACCESS=true` | Disable PXI's web search/fetch tools while leaving other external resources available. |
   | `PHOENIX_AGENTS_DISABLE_BASH=true` | Disable PXI's **server-side** bash tool by preventing subagents from being attached to the assistant. The subagents toggle is also hidden from **Settings → Assistant**. The browser-side bash sandbox is unaffected; to turn PXI off entirely use `PHOENIX_DISABLE_AGENT_ASSISTANT`. |
-  | `PHOENIX_DEBUG_AGENTS=true` | Force local PXI tracing, remote trace export, and signed-in user email attribution for every user, regardless of workspace or browser settings. Configure the remote collector variables below before enabling it. |
+  | `PHOENIX_AGENTS_FORCE_TRACING=true` | Force local PXI tracing, remote trace export, and signed-in user email attribution for every user, regardless of workspace or browser settings. Configure the remote collector variables below before enabling it. |
   | `PHOENIX_AGENTS_COLLECTOR_ENDPOINT` | Remote collector endpoint for assistant trace export. |
   | `PHOENIX_AGENTS_COLLECTOR_API_KEY` | API key for the remote collector, if required. |
   | `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME` | Project name for locally recorded assistant traces (default `assistant_agent`). |

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -80,7 +80,7 @@ ENV_PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME = "PHOENIX_AGENTS_ASSISTANT_PROJECT_NA
 """
 Project name used for assistant agent traces.
 """
-ENV_PHOENIX_DEBUG_AGENTS = "PHOENIX_DEBUG_AGENTS"
+ENV_PHOENIX_AGENTS_FORCE_TRACING = "PHOENIX_AGENTS_FORCE_TRACING"
 """
 Forces local tracing and remote export for all PXI agent requests.
 """
@@ -1358,8 +1358,8 @@ def get_env_phoenix_agents_assistant_project_name() -> str:
     return getenv(ENV_PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME, "assistant_agent")
 
 
-def get_env_phoenix_debug_agents() -> bool:
-    return _bool_val(ENV_PHOENIX_DEBUG_AGENTS, False)
+def get_env_phoenix_agents_force_tracing() -> bool:
+    return _bool_val(ENV_PHOENIX_AGENTS_FORCE_TRACING, False)
 
 
 def get_env_phoenix_agents_disable_web_access() -> bool:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -80,6 +80,10 @@ ENV_PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME = "PHOENIX_AGENTS_ASSISTANT_PROJECT_NA
 """
 Project name used for assistant agent traces.
 """
+ENV_PHOENIX_DEBUG_AGENTS = "PHOENIX_DEBUG_AGENTS"
+"""
+Forces local tracing and remote export for all PXI agent requests.
+"""
 ENV_PHOENIX_AGENTS_DISABLE_WEB_ACCESS = "PHOENIX_AGENTS_DISABLE_WEB_ACCESS"
 """
 Disables PXI native web search and web fetch capabilities even when external
@@ -1352,6 +1356,10 @@ def get_env_phoenix_agents_collector_api_key() -> Optional[str]:
 
 def get_env_phoenix_agents_assistant_project_name() -> str:
     return getenv(ENV_PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME, "assistant_agent")
+
+
+def get_env_phoenix_debug_agents() -> bool:
+    return _bool_val(ENV_PHOENIX_DEBUG_AGENTS, False)
 
 
 def get_env_phoenix_agents_disable_web_access() -> bool:

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -21,6 +21,7 @@ from phoenix.config import (
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_collector_endpoint,
     get_env_phoenix_agents_web_access_enabled,
+    get_env_phoenix_debug_agents,
     getenv,
 )
 from phoenix.db import models
@@ -1620,13 +1621,15 @@ class Query:
     def agents_config(self, info: Info[Context, None]) -> AgentsConfig:
         agent_assistant_enabled = info.context.settings.agent_assistant_enabled
         trace_recording = info.context.settings.agent_trace_recording
+        debug_agents = get_env_phoenix_debug_agents()
         return AgentsConfig(
             collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
             assistant_project_name=get_env_phoenix_agents_assistant_project_name(),
+            debug_agents=debug_agents,
             web_access_enabled=get_env_phoenix_agents_web_access_enabled(),
             assistant_enabled=agent_assistant_enabled.enabled,
-            allow_local_traces=trace_recording.allow_local_traces,
-            allow_remote_export=trace_recording.allow_remote_export,
+            allow_local_traces=debug_agents or trace_recording.allow_local_traces,
+            allow_remote_export=debug_agents or trace_recording.allow_remote_export,
         )
 
     @strawberry.field(description="The assistant skills available given the supplied UI context.")  # type: ignore

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -20,8 +20,8 @@ from phoenix.config import (
     get_env_database_allocated_storage_capacity_gibibytes,
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_collector_endpoint,
+    get_env_phoenix_agents_force_tracing,
     get_env_phoenix_agents_web_access_enabled,
-    get_env_phoenix_debug_agents,
     getenv,
 )
 from phoenix.db import models
@@ -1621,15 +1621,15 @@ class Query:
     def agents_config(self, info: Info[Context, None]) -> AgentsConfig:
         agent_assistant_enabled = info.context.settings.agent_assistant_enabled
         trace_recording = info.context.settings.agent_trace_recording
-        debug_agents = get_env_phoenix_debug_agents()
+        force_tracing = get_env_phoenix_agents_force_tracing()
         return AgentsConfig(
             collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
             assistant_project_name=get_env_phoenix_agents_assistant_project_name(),
-            debug_agents=debug_agents,
+            force_tracing=force_tracing,
             web_access_enabled=get_env_phoenix_agents_web_access_enabled(),
             assistant_enabled=agent_assistant_enabled.enabled,
-            allow_local_traces=debug_agents or trace_recording.allow_local_traces,
-            allow_remote_export=debug_agents or trace_recording.allow_remote_export,
+            allow_local_traces=force_tracing or trace_recording.allow_local_traces,
+            allow_remote_export=force_tracing or trace_recording.allow_remote_export,
         )
 
     @strawberry.field(description="The assistant skills available given the supplied UI context.")  # type: ignore

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -70,8 +70,8 @@ from typing_extensions import TypeIs, assert_never
 from phoenix.config import (
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_disable_bash,
+    get_env_phoenix_agents_force_tracing,
     get_env_phoenix_agents_web_access_enabled,
-    get_env_phoenix_debug_agents,
 )
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
@@ -909,7 +909,7 @@ def _resolve_trace_recording(
     allow_local_traces: bool,
     allow_remote_export: bool,
 ) -> tuple[bool, bool]:
-    if get_env_phoenix_debug_agents():
+    if get_env_phoenix_agents_force_tracing():
         return True, True
     return (
         ingest_traces and allow_local_traces,
@@ -918,7 +918,7 @@ def _resolve_trace_recording(
 
 
 def _resolve_attach_user_id(attach_user_id: bool) -> bool:
-    return get_env_phoenix_debug_agents() or attach_user_id
+    return get_env_phoenix_agents_force_tracing() or attach_user_id
 
 
 class _SubagentMessageChunksClosed:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -917,6 +917,10 @@ def _resolve_trace_recording(
     )
 
 
+def _resolve_attach_user_id(attach_user_id: bool) -> bool:
+    return get_env_phoenix_debug_agents() or attach_user_id
+
+
 class _SubagentMessageChunksClosed:
     """Sentinel marking the subagent message chunk queue as closed."""
 
@@ -1265,6 +1269,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             raise HTTPException(status_code=403, detail="Agents are disabled")
         body = request_body.root
         request_received_at = datetime.now(timezone.utc)
+        attach_user_id = _resolve_attach_user_id(body.attach_user_id)
         recording = request.app.state.system_settings.agent_trace_recording
         ingest_traces, export_remote_traces = _resolve_trace_recording(
             ingest_traces=body.ingest_traces,
@@ -1477,7 +1482,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 with (
                     detached_otel_context(parent_context),
                     using_session(session_id=session_id),
-                    _maybe_using_user(body.attach_user_id, phoenix_user_email),
+                    _maybe_using_user(attach_user_id, phoenix_user_email),
                 ):
                     raw_stream = adapter.run_stream(deps=deps, on_complete=_on_complete)
                     assert _is_async_generator(raw_stream)
@@ -1550,7 +1555,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                                 else (str(stream_error) or type(stream_error).__name__)
                             ),
                             end_time=datetime.now(timezone.utc),
-                            user_email=phoenix_user_email if body.attach_user_id else None,
+                            user_email=phoenix_user_email if attach_user_id else None,
                         )
                     tracer.tracer_provider.force_flush()
                     if ingest_traces:
@@ -1581,6 +1586,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
         if not request.app.state.system_settings.agent_assistant_enabled.enabled:
             raise HTTPException(status_code=403, detail="Agents are disabled")
+        attach_user_id = _resolve_attach_user_id(body.attach_user_id)
         recording = request.app.state.system_settings.agent_trace_recording
         ingest_traces, export_remote_traces = _resolve_trace_recording(
             ingest_traces=body.ingest_traces,
@@ -1623,7 +1629,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             with (
                 detached_otel_context(parent_context),
                 using_metadata({"session_id": session_id}),
-                _maybe_using_user(body.attach_user_id, phoenix_user_email),
+                _maybe_using_user(attach_user_id, phoenix_user_email),
             ):
                 result = await summarize_messages(messages=history, model=model)
         except SummarizationError as exc:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -71,6 +71,7 @@ from phoenix.config import (
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_disable_bash,
     get_env_phoenix_agents_web_access_enabled,
+    get_env_phoenix_debug_agents,
 )
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
@@ -901,6 +902,21 @@ def _contexts_need_model_provider_availability(contexts: ResolvedContexts) -> bo
     return contexts.dataset is not None or contexts.llm_evaluator is not None
 
 
+def _resolve_trace_recording(
+    *,
+    ingest_traces: bool,
+    export_remote_traces: bool,
+    allow_local_traces: bool,
+    allow_remote_export: bool,
+) -> tuple[bool, bool]:
+    if get_env_phoenix_debug_agents():
+        return True, True
+    return (
+        ingest_traces and allow_local_traces,
+        export_remote_traces and allow_remote_export,
+    )
+
+
 class _SubagentMessageChunksClosed:
     """Sentinel marking the subagent message chunk queue as closed."""
 
@@ -1134,8 +1150,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             raise HTTPException(status_code=403, detail="Viewer users cannot enable mutations")
 
         recording = request.app.state.system_settings.agent_trace_recording
-        ingest_traces = bool(body.ingest_traces and recording.allow_local_traces)
-        export_remote_traces = bool(body.export_remote_traces and recording.allow_remote_export)
+        ingest_traces, export_remote_traces = _resolve_trace_recording(
+            ingest_traces=body.ingest_traces,
+            export_remote_traces=body.export_remote_traces,
+            allow_local_traces=recording.allow_local_traces,
+            allow_remote_export=recording.allow_remote_export,
+        )
         project_name = get_env_phoenix_agents_assistant_project_name()
         tracer = (
             Tracer(
@@ -1246,8 +1266,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         body = request_body.root
         request_received_at = datetime.now(timezone.utc)
         recording = request.app.state.system_settings.agent_trace_recording
-        ingest_traces = bool(body.ingest_traces and recording.allow_local_traces)
-        export_remote_traces = bool(body.export_remote_traces and recording.allow_remote_export)
+        ingest_traces, export_remote_traces = _resolve_trace_recording(
+            ingest_traces=body.ingest_traces,
+            export_remote_traces=body.export_remote_traces,
+            allow_local_traces=recording.allow_local_traces,
+            allow_remote_export=recording.allow_remote_export,
+        )
         project_name = get_env_phoenix_agents_assistant_project_name()
         tracer = (
             Tracer(
@@ -1558,8 +1582,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         if not request.app.state.system_settings.agent_assistant_enabled.enabled:
             raise HTTPException(status_code=403, detail="Agents are disabled")
         recording = request.app.state.system_settings.agent_trace_recording
-        ingest_traces = bool(body.ingest_traces and recording.allow_local_traces)
-        export_remote_traces = bool(body.export_remote_traces and recording.allow_remote_export)
+        ingest_traces, export_remote_traces = _resolve_trace_recording(
+            ingest_traces=body.ingest_traces,
+            export_remote_traces=body.export_remote_traces,
+            allow_local_traces=recording.allow_local_traces,
+            allow_remote_export=recording.allow_remote_export,
+        )
         project_name = get_env_phoenix_agents_assistant_project_name()
         tracer = (
             Tracer(

--- a/src/phoenix/server/api/types/AgentsConfig.py
+++ b/src/phoenix/server/api/types/AgentsConfig.py
@@ -17,6 +17,12 @@ class AgentsConfig:
             "Resolved from the PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME environment variable."
         ),
     )
+    debug_agents: bool = strawberry.field(
+        description=(
+            "Whether PXI tracing and remote export are forced for all users by the "
+            "PHOENIX_DEBUG_AGENTS environment variable."
+        ),
+    )
     web_access_enabled: bool = strawberry.field(
         description=(
             "Whether PXI can expose native web search and web fetch capabilities. "

--- a/src/phoenix/server/api/types/AgentsConfig.py
+++ b/src/phoenix/server/api/types/AgentsConfig.py
@@ -17,10 +17,10 @@ class AgentsConfig:
             "Resolved from the PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME environment variable."
         ),
     )
-    debug_agents: bool = strawberry.field(
+    force_tracing: bool = strawberry.field(
         description=(
             "Whether PXI tracing and remote export are forced for all users by the "
-            "PHOENIX_DEBUG_AGENTS environment variable."
+            "PHOENIX_AGENTS_FORCE_TRACING environment variable."
         ),
     )
     web_access_enabled: bool = strawberry.field(

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -24,6 +24,7 @@ from phoenix.server.api.routers.agents import (
     _load_sandbox_availability,
     _maybe_using_user,
     _persist_db_traces_and_emit_event,
+    _resolve_attach_user_id,
     _resolve_trace_recording,
     _SubagentMessageChunksClosed,
 )
@@ -64,6 +65,14 @@ def test_resolve_trace_recording_forced_by_debug_agents(
         allow_local_traces=False,
         allow_remote_export=False,
     ) == (True, True)
+
+
+def test_resolve_attach_user_id_forced_by_debug_agents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOENIX_DEBUG_AGENTS", "true")
+
+    assert _resolve_attach_user_id(False) is True
 
 
 class TestPersistDbTracesAndEmitEvent:

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -6,7 +6,6 @@ from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-import pytest
 from jinja2 import Template
 from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, ToolOutputAvailableChunk
 from sqlalchemy import func, select
@@ -24,8 +23,6 @@ from phoenix.server.api.routers.agents import (
     _load_sandbox_availability,
     _maybe_using_user,
     _persist_db_traces_and_emit_event,
-    _resolve_attach_user_id,
-    _resolve_trace_recording,
     _SubagentMessageChunksClosed,
 )
 from phoenix.server.bearer_auth import PhoenixUser
@@ -39,40 +36,6 @@ class _EventQueue:
 
     def put(self, item: DmlEvent) -> None:
         self.events.append(item)
-
-
-def test_resolve_trace_recording_respects_request_and_workspace_settings(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("PHOENIX_AGENTS_FORCE_TRACING", raising=False)
-
-    assert _resolve_trace_recording(
-        ingest_traces=True,
-        export_remote_traces=True,
-        allow_local_traces=False,
-        allow_remote_export=True,
-    ) == (False, True)
-
-
-def test_resolve_trace_recording_forced_by_env(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("PHOENIX_AGENTS_FORCE_TRACING", "true")
-
-    assert _resolve_trace_recording(
-        ingest_traces=False,
-        export_remote_traces=False,
-        allow_local_traces=False,
-        allow_remote_export=False,
-    ) == (True, True)
-
-
-def test_resolve_attach_user_id_forced_by_env(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("PHOENIX_AGENTS_FORCE_TRACING", "true")
-
-    assert _resolve_attach_user_id(False) is True
 
 
 class TestPersistDbTracesAndEmitEvent:

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -44,7 +44,7 @@ class _EventQueue:
 def test_resolve_trace_recording_respects_request_and_workspace_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("PHOENIX_DEBUG_AGENTS", raising=False)
+    monkeypatch.delenv("PHOENIX_AGENTS_FORCE_TRACING", raising=False)
 
     assert _resolve_trace_recording(
         ingest_traces=True,
@@ -54,10 +54,10 @@ def test_resolve_trace_recording_respects_request_and_workspace_settings(
     ) == (False, True)
 
 
-def test_resolve_trace_recording_forced_by_debug_agents(
+def test_resolve_trace_recording_forced_by_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("PHOENIX_DEBUG_AGENTS", "true")
+    monkeypatch.setenv("PHOENIX_AGENTS_FORCE_TRACING", "true")
 
     assert _resolve_trace_recording(
         ingest_traces=False,
@@ -67,10 +67,10 @@ def test_resolve_trace_recording_forced_by_debug_agents(
     ) == (True, True)
 
 
-def test_resolve_attach_user_id_forced_by_debug_agents(
+def test_resolve_attach_user_id_forced_by_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("PHOENIX_DEBUG_AGENTS", "true")
+    monkeypatch.setenv("PHOENIX_AGENTS_FORCE_TRACING", "true")
 
     assert _resolve_attach_user_id(False) is True
 

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
 from jinja2 import Template
 from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, ToolOutputAvailableChunk
 from sqlalchemy import func, select
@@ -23,6 +24,7 @@ from phoenix.server.api.routers.agents import (
     _load_sandbox_availability,
     _maybe_using_user,
     _persist_db_traces_and_emit_event,
+    _resolve_trace_recording,
     _SubagentMessageChunksClosed,
 )
 from phoenix.server.bearer_auth import PhoenixUser
@@ -36,6 +38,32 @@ class _EventQueue:
 
     def put(self, item: DmlEvent) -> None:
         self.events.append(item)
+
+
+def test_resolve_trace_recording_respects_request_and_workspace_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PHOENIX_DEBUG_AGENTS", raising=False)
+
+    assert _resolve_trace_recording(
+        ingest_traces=True,
+        export_remote_traces=True,
+        allow_local_traces=False,
+        allow_remote_export=True,
+    ) == (False, True)
+
+
+def test_resolve_trace_recording_forced_by_debug_agents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOENIX_DEBUG_AGENTS", "true")
+
+    assert _resolve_trace_recording(
+        ingest_traces=False,
+        export_remote_traces=False,
+        allow_local_traces=False,
+        allow_remote_export=False,
+    ) == (True, True)
 
 
 class TestPersistDbTracesAndEmitEvent:

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -481,6 +481,7 @@ async def test_agents_config_returns_env_values(
 ) -> None:
     monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "http://collector.example:4318")
     monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", "custom_assistant")
+    monkeypatch.setenv("PHOENIX_DEBUG_AGENTS", "true")
     monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "true")
     monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", "false")
     query = """
@@ -488,7 +489,10 @@ async def test_agents_config_returns_env_values(
         agentsConfig {
           collectorEndpoint
           assistantProjectName
+          debugAgents
           webAccessEnabled
+          allowLocalTraces
+          allowRemoteExport
         }
       }
     """
@@ -498,7 +502,10 @@ async def test_agents_config_returns_env_values(
     assert data["agentsConfig"] == {
         "collectorEndpoint": "http://collector.example:4318",
         "assistantProjectName": "custom_assistant",
+        "debugAgents": True,
         "webAccessEnabled": True,
+        "allowLocalTraces": True,
+        "allowRemoteExport": True,
     }
 
 
@@ -508,6 +515,7 @@ async def test_agents_config_defaults_when_env_unset(
 ) -> None:
     monkeypatch.delenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", raising=False)
     monkeypatch.delenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", raising=False)
+    monkeypatch.delenv("PHOENIX_DEBUG_AGENTS", raising=False)
     monkeypatch.delenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", raising=False)
     monkeypatch.delenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", raising=False)
     query = """
@@ -515,6 +523,7 @@ async def test_agents_config_defaults_when_env_unset(
         agentsConfig {
           collectorEndpoint
           assistantProjectName
+          debugAgents
           webAccessEnabled
         }
       }
@@ -525,6 +534,7 @@ async def test_agents_config_defaults_when_env_unset(
     assert data["agentsConfig"] == {
         "collectorEndpoint": None,
         "assistantProjectName": "assistant_agent",
+        "debugAgents": False,
         "webAccessEnabled": True,
     }
 

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -481,7 +481,7 @@ async def test_agents_config_returns_env_values(
 ) -> None:
     monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "http://collector.example:4318")
     monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", "custom_assistant")
-    monkeypatch.setenv("PHOENIX_DEBUG_AGENTS", "true")
+    monkeypatch.setenv("PHOENIX_AGENTS_FORCE_TRACING", "true")
     monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "true")
     monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", "false")
     query = """
@@ -489,7 +489,7 @@ async def test_agents_config_returns_env_values(
         agentsConfig {
           collectorEndpoint
           assistantProjectName
-          debugAgents
+          forceTracing
           webAccessEnabled
           allowLocalTraces
           allowRemoteExport
@@ -502,7 +502,7 @@ async def test_agents_config_returns_env_values(
     assert data["agentsConfig"] == {
         "collectorEndpoint": "http://collector.example:4318",
         "assistantProjectName": "custom_assistant",
-        "debugAgents": True,
+        "forceTracing": True,
         "webAccessEnabled": True,
         "allowLocalTraces": True,
         "allowRemoteExport": True,
@@ -515,7 +515,7 @@ async def test_agents_config_defaults_when_env_unset(
 ) -> None:
     monkeypatch.delenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", raising=False)
     monkeypatch.delenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", raising=False)
-    monkeypatch.delenv("PHOENIX_DEBUG_AGENTS", raising=False)
+    monkeypatch.delenv("PHOENIX_AGENTS_FORCE_TRACING", raising=False)
     monkeypatch.delenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", raising=False)
     monkeypatch.delenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", raising=False)
     query = """
@@ -523,7 +523,7 @@ async def test_agents_config_defaults_when_env_unset(
         agentsConfig {
           collectorEndpoint
           assistantProjectName
-          debugAgents
+          forceTracing
           webAccessEnabled
         }
       }
@@ -534,7 +534,7 @@ async def test_agents_config_defaults_when_env_unset(
     assert data["agentsConfig"] == {
         "collectorEndpoint": None,
         "assistantProjectName": "assistant_agent",
-        "debugAgents": False,
+        "forceTracing": False,
         "webAccessEnabled": True,
     }
 


### PR DESCRIPTION
## Summary
- add `PHOENIX_AGENTS_FORCE_TRACING=true` to force local PXI tracing, remote export, and signed-in user attribution for every user
- enforce the override in server agent routes and expose it through `agentsConfig`
- bypass per-browser consent/preferences while showing forced, disabled observability controls in settings
- enable the flag from `app/scripts/setup-remote-export.ts` and document the deployment option

## Test plan
- `uv run pytest tests/unit/server/api/routers/test_agents.py -k "resolve_trace_recording or resolve_attach_user_id"`
- `uv run pytest tests/unit/server/api/test_queries.py -k agents_config`
- `pnpm exec vitest run __tests__/setup-remote-export.test.ts src/store/__tests__/agentStore.test.ts src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts`
- `pnpm typecheck`
- Python and app formatting/lint hooks

## Screenshots
### Workspace settings
Before: workspace trace controls follow persisted system settings.

![Workspace settings before](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14358-debug-agents-before-system-settings.png)

After: `PHOENIX_AGENTS_FORCE_TRACING=true` forces trace collection and identifies user attribution as deployment policy.

![Workspace settings after](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14358-debug-agents-after-system-settings.png)

### Personal settings
Before: each browser can independently disable remote export and user attribution.

![Personal settings before](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14358-debug-agents-before-personal-settings.png)

After: local tracing, remote export, and email attribution are enabled and locked by deployment policy.

![Personal settings after](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14358-debug-agents-after-personal-settings.png)

### First-use assistant flow
Before: users must acknowledge trace handling before starting a chat.

![Assistant consent before](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14358-debug-agents-before-assistant.png)

After: the forced deployment policy bypasses the per-browser consent gate and opens the assistant directly.

![Assistant after](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14358-debug-agents-after-assistant.png)