### PR TITLE
fix(js): make pkg.pr.new preview builds installable

### DIFF
--- a/.github/workflows/typescript-packages-publish-experimental.yml
+++ b/.github/workflows/typescript-packages-publish-experimental.yml
@@ -15,36 +15,24 @@ jobs:
       pull-requests: read
     # Set job outputs to values from filter step
     outputs:
-      workflow_file: ${{ steps.filter.outputs.workflow_file }}
-      phoenix-client: ${{ steps.filter.outputs.phoenix-client }}
-      phoenix-mcp: ${{ steps.filter.outputs.phoenix-mcp }}
-      phoenix-evals: ${{ steps.filter.outputs.phoenix-evals }}
-      phoenix-otel: ${{ steps.filter.outputs.phoenix-otel }}
-      phoenix-cli: ${{ steps.filter.outputs.phoenix-cli }}
+      packages: ${{ steps.filter.outputs.packages }}
     steps:
       # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          # Every publishable package is released together (see the Publish step),
+          # so a change to any one of them - or to this workflow - triggers the run.
           filters: |
-            phoenix-client:
-              - 'js/packages/phoenix-client/**'
-            phoenix-mcp:
-              - 'js/packages/phoenix-mcp/**'
-            phoenix-evals:
-              - 'js/packages/phoenix-evals/**'
-            phoenix-otel:
-              - 'js/packages/phoenix-otel/**'
-            phoenix-config:
-              - 'js/packages/phoenix-config/**'
-            phoenix-cli:
-              - 'js/packages/phoenix-cli/**'
-            workflow_file:
+            packages:
+              - 'js/packages/**'
+              - 'js/pnpm-lock.yaml'
+              - 'js/pnpm-workspace.yaml'
               - '.github/workflows/typescript-packages-publish-experimental.yml'
 
   publish-experimental-packages:
     needs: changes
-    if: ${{ needs.changes.outputs.phoenix-client == 'true' || needs.changes.outputs.phoenix-mcp == 'true' || needs.changes.outputs.phoenix-evals == 'true' || needs.changes.outputs.phoenix-otel == 'true' || needs.changes.outputs.phoenix-cli == 'true' || needs.changes.outputs.workflow_file == 'true' }}
+    if: ${{ needs.changes.outputs.packages == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -73,6 +61,11 @@ jobs:
         working-directory: ./js
         run: pnpm -r build
 
+      # pkg-pr-new only rewrites a `workspace:*` dependency into a preview URL when the
+      # depended-on package is part of the SAME publish invocation. Anything left out ships
+      # a literal `workspace:*` in its package.json, which npm/npx reject with
+      # `Unsupported URL Type "workspace:"`. Publishing the whole glob keeps every internal
+      # dependency resolvable; pkg-pr-new skips any package marked private.
       - name: Publish
         working-directory: ./js
-        run: pnpx pkg-pr-new publish ./packages/phoenix-client ./packages/phoenix-mcp ./packages/phoenix-evals ./packages/phoenix-otel ./packages/phoenix-cli
+        run: pnpx pkg-pr-new publish --pnpm ./packages/*

--- a/.github/workflows/typescript-packages-publish-experimental.yml
+++ b/.github/workflows/typescript-packages-publish-experimental.yml
@@ -7,17 +7,14 @@ on:
   pull_request:
 
 jobs:
-  # JOB to run change detection
   changes:
     runs-on: ubuntu-latest
-    # Required permissions
     permissions:
       pull-requests: read
-    # Set job outputs to values from filter step
     outputs:
       packages: ${{ steps.filter.outputs.packages }}
     steps:
-      # For pull requests it's not necessary to checkout the code
+      # No checkout needed: paths-filter reads the PR's changed files from the API.
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -52,14 +49,18 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: ./js/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: ./js
         run: pnpm install
 
+      # Only the publishable packages are needed; the examples/apps and benchmarks
+      # workspaces are private and their build output is discarded.
       - name: Build
         working-directory: ./js
-        run: pnpm -r build
+        run: pnpm --filter './packages/*' build
 
       # pkg-pr-new only rewrites a `workspace:*` dependency into a preview URL when the
       # depended-on package is part of the SAME publish invocation. Anything left out ships


### PR DESCRIPTION
## Problem

The StackBlitz / `pkg.pr.new` preview builds posted on PRs are not installable. Installing one fails with:

```
Unsupported URL Type "workspace:": workspace:*
```

## Root cause

`pkg-pr-new` rewrites a `workspace:*` dependency into a preview URL **only when the depended-on package is part of the same publish invocation**. Its `hijackDeps` builds the rewrite map exclusively from the paths passed on the CLI:

```js
function hijackDeps(newDeps, oldDeps) {
  if (!oldDeps) return;
  for (const [newDep, url] of newDeps) {
    if (newDep in oldDeps) oldDeps[newDep] = url;   // only rewrites what's in the publish set
  }
}
```

Anything workspace-linked but *not* in that set keeps a literal `workspace:*` in its published `package.json`, which npm/npx reject.

`@arizeai/phoenix-config` is a **runtime dependency** of `phoenix-client`, `phoenix-cli`, `phoenix-mcp` and `phoenix-otel` — and it was the one package missing from the publish list. So 4 of the 5 published preview packages were broken:

| package | before | after |
|---|---|---|
| `@arizeai/phoenix-client` | ships `"@arizeai/phoenix-config": "workspace:*"` | resolved to preview URL |
| `@arizeai/phoenix-cli` | ships `"@arizeai/phoenix-config": "workspace:*"` | resolved to preview URL |
| `@arizeai/phoenix-mcp` | ships `"@arizeai/phoenix-config": "workspace:*"` | resolved to preview URL |
| `@arizeai/phoenix-otel` | ships `"@arizeai/phoenix-config": "workspace:*"` | resolved to preview URL |
| `@arizeai/phoenix-evals` | (no internal deps) | unaffected |

It was never caught because `phoenix-config` had a `paths-filter` entry but was wired into neither the job `outputs` nor the `if` gate nor the publish command.

## Fix

- **Publish `./packages/*`** instead of an explicit list. Every internal dependency stays resolvable, and new packages are picked up automatically. `pkg-pr-new` globs directories itself (`onlyDirectories: true`) and skips packages marked `private`, so this is safe.
- **Add `--pnpm`** so it packs with `pnpm pack` rather than `npm pack` in this pnpm workspace.
- **Collapse the per-package `paths-filter` into a single gate.** The publish step always released *every* package regardless of which one changed, so the per-package outputs bought nothing — and that indirection is exactly how `phoenix-config` got dropped from both the gate and the publish list. Also added `pnpm-lock.yaml` / `pnpm-workspace.yaml` to the trigger paths.

## Verification

Replayed `pkg-pr-new`'s exact `hijackDeps` logic against the real package manifests for the old and new publish sets:

```
=== OLD (config omitted) ===
  ✗ @arizeai/phoenix-client ships literal {"@arizeai/phoenix-config":"workspace:*"} -> npx fails
  ✗ @arizeai/phoenix-mcp    ships literal {"@arizeai/phoenix-config":"workspace:*"} -> npx fails
  ✓ @arizeai/phoenix-evals
  ✗ @arizeai/phoenix-otel   ships literal {"@arizeai/phoenix-config":"workspace:*"} -> npx fails
  ✗ @arizeai/phoenix-cli    ships literal {"@arizeai/phoenix-config":"workspace:*"} -> npx fails
  => 4 broken package(s)

=== NEW (./packages/*) ===
  ✓ all 6 packages — internal deps resolved to preview URLs
  => 0 broken package(s)
```

`zizmor` reports no new findings (the one `adhoc-packages` hit is the pre-existing corepack workaround).

Since this PR touches the workflow file itself, it triggers its own preview build — so the `pkg.pr.new` comment below is the real end-to-end test. Once it lands, `npx https://pkg.pr.new/@arizeai/phoenix-cli@<sha>` should work.