### PR TITLE
fix(evals): count AsyncExecutor timeouts against max_retries

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/utils/executors.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/executors.py
@@ -194,8 +194,8 @@ class AsyncExecutor(Executor):
         tqdm_bar_format (Optional[str], optional): The format string for the progress bar.
             Defaults to None.
 
-        max_retries (int, optional): The maximum number of times to retry on exceptions.
-            Defaults to 10.
+        max_retries (int, optional): The maximum number of times to retry on exceptions or
+            timeouts. Defaults to 10.
 
         exit_on_error (bool, optional): Whether to exit execution on the first encountered error.
             Defaults to True.
@@ -335,7 +335,6 @@ class AsyncExecutor(Executor):
                     marked_done = True
                     continue
                 else:
-                    tqdm.write("Worker timeout, requeuing")
                     # Best-effort cancel the timed-out task without blocking the loop
                     if not generate_task.done():
                         generate_task.cancel()
@@ -343,12 +342,21 @@ class AsyncExecutor(Executor):
                             await asyncio.wait_for(generate_task, timeout=1)
                         except (asyncio.TimeoutError, asyncio.CancelledError):
                             pass
-                    # task timeouts are requeued at the same priority
-                    await queue.put((priority, item))
                     details = cast(ExecutionDetails, execution_details[index])
+                    details.log_exception(TimeoutError(f"Task timed out after {self.timeout}s"))
                     details.log_runtime(task_start_time)
                     if self._concurrency_controller is not None:
                         self._concurrency_controller.record_timeout()
+                    if (retry_count := abs(priority)) < self.max_retries:
+                        tqdm.write(f"Worker timeout on attempt {retry_count + 1}, requeuing")
+                        await queue.put((priority - 1, item))
+                    else:
+                        details.fail()
+                        tqdm.write(f"Retries exhausted after {retry_count + 1} attempts: timeout")
+                        if self.exit_on_error:
+                            termination_event.set()
+                        else:
+                            progress_bar.update()
             except Exception as exc:
                 details = cast(ExecutionDetails, execution_details[index])
                 details.log_exception(exc)

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -183,8 +183,8 @@ class AsyncExecutor(Executor):
         tqdm_bar_format (Optional[str], optional): The format string for the progress bar.
             Defaults to None.
 
-        max_retries (int, optional): The maximum number of times to retry on exceptions.
-            Defaults to 10.
+        max_retries (int, optional): The maximum number of times to retry on exceptions or
+            timeouts. Defaults to 10.
 
         exit_on_error (bool, optional): Whether to exit execution on the first encountered error.
             Defaults to True.
@@ -324,7 +324,6 @@ class AsyncExecutor(Executor):
                     marked_done = True
                     continue
                 else:
-                    tqdm.write("Worker timeout, requeuing")
                     # Best-effort cancel the timed-out task without blocking the loop
                     if not generate_task.done():
                         generate_task.cancel()
@@ -332,12 +331,21 @@ class AsyncExecutor(Executor):
                             await asyncio.wait_for(generate_task, timeout=1)
                         except (asyncio.TimeoutError, asyncio.CancelledError):
                             pass
-                    # task timeouts are requeued at the same priority
-                    await queue.put((priority, item))
                     details = cast(ExecutionDetails, execution_details[index])
+                    details.log_exception(TimeoutError(f"Task timed out after {self.timeout}s"))
                     details.log_runtime(task_start_time)
                     if self._concurrency_controller is not None:
                         self._concurrency_controller.record_timeout()
+                    if (retry_count := abs(priority)) < self.max_retries:
+                        tqdm.write(f"Worker timeout on attempt {retry_count + 1}, requeuing")
+                        await queue.put((priority - 1, item))
+                    else:
+                        details.fail()
+                        tqdm.write(f"Retries exhausted after {retry_count + 1} attempts: timeout")
+                        if self.exit_on_error:
+                            termination_event.set()
+                        else:
+                            progress_bar.update()
             except Exception as exc:
                 details = cast(ExecutionDetails, execution_details[index])
                 details.log_exception(exc)

--- a/packages/phoenix-evals/tests/phoenix/evals/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_executor.py
@@ -712,3 +712,31 @@ async def test_executor_ramps_up_when_target_increases() -> None:
     assert outputs == inputs
     assert max_inflight <= 4
     assert max_inflight >= 3
+
+
+async def test_async_executor_timeouts_count_toward_max_retries():
+    attempts = 0
+
+    async def always_slow(payload: int) -> int:
+        nonlocal attempts
+        attempts += 1
+        await asyncio.sleep(10)
+        return payload
+
+    executor = AsyncExecutor(
+        always_slow,
+        timeout=1,
+        max_retries=2,
+        concurrency=1,
+        exit_on_error=True,
+        fallback_return_value=-1,
+        enable_dynamic_concurrency=False,
+    )
+
+    outputs, details = await executor.execute([42])
+
+    assert attempts == 3  # 1 initial + 2 retries
+    assert outputs == [-1]
+    assert details[0].status == ExecutionStatus.FAILED
+    assert len(details[0].exceptions) == 3
+    assert all(isinstance(exc, TimeoutError) for exc in details[0].exceptions)


### PR DESCRIPTION
Fixes #14312

## Problem

`AsyncExecutor` requeued timed-out tasks at unchanged priority, so the retry guard (`abs(priority) < max_retries`) never advanced. A task that always exceeded `timeout` was requeued forever, ignoring `max_retries` and `exit_on_error` — see the reproduction in #14312.

The exemption was originally deliberate: timeouts were treated as a congestion signal (rate-limit-induced slowness) rather than a task failure, with retry counting introduced in #1939 explicitly deferring timeout accounting until model-level tenacity retries were removed. Tenacity was removed in #2176 but the timeout branch was never revisited. Since then, the congestion-absorbing role has moved to the adaptive rate limiter and the AIMD concurrency controller, `RateLimitError` already consumes retry budget, and #6206 made `timeout` user-configurable — so an unbounded timeout requeue is now just a hang.

## Fix

- Timeout requeues decrement priority (same as the error path), so timeouts share the `max_retries` budget.
- Each timeout logs a `TimeoutError` to `ExecutionDetails`, so exhausted tasks report *why* they failed instead of `FAILED` with an empty exceptions list.
- On exhaustion the task is marked `FAILED` and `exit_on_error` is honored.
- `record_timeout()` / `record_error()` remain distinct in the concurrency controller — timeouts still shrink concurrency without triggering the error-collapse path.
- Mirrored in the vendored executor in `phoenix-client`.

## Credit

Root cause diagnosed by @RudraDudhat2509 in #14312 and first fixed in #14313 (co-authored on this commit); a similar fix was also proposed by @aryanputta in #14331. This PR additionally logs timeout exceptions to `ExecutionDetails` and applies the fix to the vendored `phoenix-client` copy. Supersedes #14313 and #14331 — thank you both!

## Testing

- New test: an always-slow task with `timeout=1, max_retries=2` makes exactly 3 attempts, returns the fallback value, reports `FAILED`, and logs 3 `TimeoutError`s.
- Full `test_executor.py` suites pass in both `phoenix-evals` (27 passed) and `phoenix-client` (27 passed).

https://claude.ai/code/session_01EFUR5pDcGGuLTcYF5Be6wW