### PR TITLE
fix: resolve dataset code/built-in evaluators without querying unrelated subtype tables

### DIFF
--- a/src/phoenix/server/api/dataloaders/evaluator_by_id.py
+++ b/src/phoenix/server/api/dataloaders/evaluator_by_id.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from sqlalchemy import select
-from sqlalchemy.orm import with_polymorphic
+from sqlalchemy.orm import selectin_polymorphic
 from strawberry.dataloader import DataLoader
 from typing_extensions import TypeAlias
 
@@ -23,12 +23,15 @@ class EvaluatorByIdDataLoader(DataLoader[Key, Result]):
         evaluators_by_id: dict[Key, models.Evaluator] = {}
 
         async with self._db() as session:
-            evaluator_model = with_polymorphic(
-                models.Evaluator,
-                [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
-            )
             data = await session.stream_scalars(
-                select(evaluator_model).where(evaluator_model.id.in_(evaluator_ids))
+                select(models.Evaluator)
+                .where(models.Evaluator.id.in_(evaluator_ids))
+                .options(
+                    selectin_polymorphic(
+                        models.Evaluator,
+                        [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+                    )
+                )
             )
             async for evaluator in data:
                 evaluators_by_id[evaluator.id] = evaluator

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -20,7 +20,7 @@ from opentelemetry.trace import NoOpTracer, Status, StatusCode, Tracer, format_t
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import with_polymorphic
+from sqlalchemy.orm import selectin_polymorphic
 from strawberry.relay import GlobalID
 from typing_extensions import NotRequired, TypedDict, assert_never
 
@@ -763,18 +763,20 @@ async def get_evaluators(
     if not dataset_evaluator_ids:
         return []
 
-    # Join subclass tables so BuiltinEvaluator.key / LLM columns are loaded (see with_polymorphic).
-    PolymorphicEvaluator = with_polymorphic(
-        models.Evaluator, [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator]
-    )
     dataset_evaluators_result = (
         await session.execute(
-            select(models.DatasetEvaluators, PolymorphicEvaluator)
+            select(models.DatasetEvaluators, models.Evaluator)
             .join(
-                PolymorphicEvaluator,
-                models.DatasetEvaluators.evaluator_id == PolymorphicEvaluator.id,
+                models.Evaluator,
+                models.DatasetEvaluators.evaluator_id == models.Evaluator.id,
             )
             .where(models.DatasetEvaluators.id.in_(dataset_evaluator_ids))
+            .options(
+                selectin_polymorphic(
+                    models.Evaluator,
+                    [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+                )
+            )
         )
     ).all()
     dataset_evaluators_by_id: dict[int, tuple[models.DatasetEvaluators, models.Evaluator]] = {

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Annotated, Optional, cast
 import strawberry
 from sqlalchemy import Text, and_, func, or_, select
 from sqlalchemy import cast as sqlalchemy_cast
-from sqlalchemy.orm import with_polymorphic
 from sqlalchemy.sql.functions import count
 from sqlalchemy.sql.sqltypes import String
 from strawberry import UNSET
@@ -594,16 +593,8 @@ class Dataset(Node):
             before=before if isinstance(before, CursorString) else None,
         )
 
-        PolymorphicEvaluator = with_polymorphic(
-            models.Evaluator, [models.LLMEvaluator, models.CodeEvaluator]
-        )
-        stmt = (
-            select(models.DatasetEvaluators)
-            .outerjoin(
-                PolymorphicEvaluator,
-                models.DatasetEvaluators.evaluator_id == PolymorphicEvaluator.id,
-            )
-            .where(models.DatasetEvaluators.dataset_id == self.id)
+        stmt = select(models.DatasetEvaluators).where(
+            models.DatasetEvaluators.dataset_id == self.id
         )
         if filter:
             column = getattr(models.DatasetEvaluators, filter.col.value)
@@ -612,7 +603,11 @@ class Dataset(Node):
             stmt = stmt.where(column.ilike(f"%{filter.value}%"))
         if sort:
             if sort.col.value == "kind":
-                sort_col = PolymorphicEvaluator.kind
+                stmt = stmt.join(
+                    models.Evaluator,
+                    models.DatasetEvaluators.evaluator_id == models.Evaluator.id,
+                )
+                sort_col = models.Evaluator.kind
             else:
                 sort_col = getattr(models.DatasetEvaluators, sort.col.value)
             stmt = stmt.order_by(sort_col.desc() if sort.dir is SortDir.desc else sort_col.asc())
@@ -622,10 +617,6 @@ class Dataset(Node):
         async with info.context.db.read() as session:
             result = await session.scalars(stmt)
             data: list[DatasetEvaluator] = [DatasetEvaluator(id=record.id) for record in result]
-        # TODO: we need to handle sorting for builtin evaluators as their "kind"
-        # (and other evaluator fields) are not part of the polymorphic table
-        # re-sort the final results by kind, this is necessary because builtin evaluators are not
-        #  part of the polymorphic table
         return connection_from_list(data=data, args=args)
 
     @strawberry.field

--- a/tests/unit/server/api/dataloaders/test_evaluator_by_id.py
+++ b/tests/unit/server/api/dataloaders/test_evaluator_by_id.py
@@ -1,11 +1,28 @@
 from secrets import token_hex
+from typing import Any
 
 import sqlalchemy
 
 from phoenix.db import models
+from phoenix.db.types.evaluators import InputMapping
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.api.dataloaders.evaluator_by_id import EvaluatorByIdDataLoader
 from phoenix.server.types import DbSessionFactory
+
+
+def _capture_statements() -> tuple[list[str], Any]:
+    statements: list[str] = []
+
+    @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "before_cursor_execute")
+    def capture_statement(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+        if statement.lstrip().upper().startswith("SELECT"):
+            statements.append(statement)
+
+    return statements, capture_statement
+
+
+def _stop_capturing(listener: Any) -> None:
+    sqlalchemy.event.remove(sqlalchemy.engine.Engine, "before_cursor_execute", listener)
 
 
 async def test_evaluator_by_id_batches_lookups(db: DbSessionFactory) -> None:
@@ -15,30 +32,140 @@ async def test_evaluator_by_id_batches_lookups(db: DbSessionFactory) -> None:
         await session.flush()
 
         evaluators = [
-            models.LLMEvaluator(name=Identifier(token_hex(4)), prompt_id=prompt.id)
+            models.LLMEvaluator(
+                name=Identifier(token_hex(4)),
+                prompt_id=prompt.id,
+                output_configs=[],
+            )
             for _ in range(5)
         ]
         session.add_all(evaluators)
         await session.flush()
-        ids = [e.id for e in evaluators]
+        ids = [evaluator.id for evaluator in evaluators]
 
     loader = EvaluatorByIdDataLoader(db)
-
-    query_count = 0
-
-    @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "before_cursor_execute")
-    def count_queries(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
-        nonlocal query_count
-        if "FROM evaluators" in statement:
-            query_count += 1
-
+    statements, listener = _capture_statements()
     try:
         keys = [*ids, ids[0]]
         results = await loader._load_fn(keys)
     finally:
-        sqlalchemy.event.remove(sqlalchemy.engine.Engine, "before_cursor_execute", count_queries)
+        _stop_capturing(listener)
 
-    assert query_count == 1
-    assert [r.id if r is not None else None for r in results] == keys
+    assert len(statements) == 2
+    assert all(isinstance(result, models.LLMEvaluator) for result in results)
+    assert [result.id if result is not None else None for result in results] == keys
     missing = await loader._load_fn([max(ids) + 1000])
     assert missing == [None]
+
+
+async def test_evaluator_by_id_code_only_loads_code_fields(db: DbSessionFactory) -> None:
+    async with db() as session:
+        session.add(models.Language(name="PYTHON"))
+        await session.flush()
+        evaluator = models.CodeEvaluator(
+            name=Identifier(token_hex(4)),
+            language="PYTHON",
+            input_mapping=InputMapping(
+                literal_mapping={"threshold": 0.5},
+                path_mapping={"output": "$.output"},
+            ),
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        evaluator_id = evaluator.id
+
+    statements, listener = _capture_statements()
+    try:
+        result = (await EvaluatorByIdDataLoader(db)._load_fn([evaluator_id]))[0]
+    finally:
+        _stop_capturing(listener)
+
+    assert isinstance(result, models.CodeEvaluator)
+    assert result.language == "PYTHON"
+    assert result.input_mapping == InputMapping(
+        literal_mapping={"threshold": 0.5},
+        path_mapping={"output": "$.output"},
+    )
+    assert result.output_configs == []
+    assert len(statements) == 2
+    assert not any("llm_evaluators" in statement for statement in statements)
+    assert not any("builtin_evaluators" in statement for statement in statements)
+
+
+async def test_evaluator_by_id_builtin_only_loads_builtin_fields(db: DbSessionFactory) -> None:
+    async with db() as session:
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(token_hex(4)),
+            key=token_hex(4),
+            input_schema={"type": "object"},
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        evaluator_id = evaluator.id
+
+    statements, listener = _capture_statements()
+    try:
+        result = (await EvaluatorByIdDataLoader(db)._load_fn([evaluator_id]))[0]
+    finally:
+        _stop_capturing(listener)
+
+    assert isinstance(result, models.BuiltinEvaluator)
+    assert result.key == evaluator.key
+    assert result.input_schema == {"type": "object"}
+    assert result.output_configs == []
+    assert len(statements) == 2
+    assert not any("llm_evaluators" in statement for statement in statements)
+    assert not any("code_evaluators" in statement for statement in statements)
+
+
+async def test_evaluator_by_id_mixed_batch_loads_each_subtype_once(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        session.add(models.Language(name="PYTHON"))
+        prompt = models.Prompt(name=Identifier(token_hex(4)))
+        session.add(prompt)
+        await session.flush()
+        llm_evaluator = models.LLMEvaluator(
+            name=Identifier(token_hex(4)),
+            prompt_id=prompt.id,
+            output_configs=[],
+        )
+        code_evaluator = models.CodeEvaluator(
+            name=Identifier(token_hex(4)),
+            language="PYTHON",
+            input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+            output_configs=[],
+        )
+        builtin_evaluator = models.BuiltinEvaluator(
+            name=Identifier(token_hex(4)),
+            key=token_hex(4),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add_all([llm_evaluator, code_evaluator, builtin_evaluator])
+        await session.flush()
+        keys = [code_evaluator.id, llm_evaluator.id, builtin_evaluator.id, code_evaluator.id]
+
+    statements, listener = _capture_statements()
+    try:
+        results = await EvaluatorByIdDataLoader(db)._load_fn(keys)
+    finally:
+        _stop_capturing(listener)
+
+    assert len(statements) == 4
+    assert [type(result) for result in results] == [
+        models.CodeEvaluator,
+        models.LLMEvaluator,
+        models.BuiltinEvaluator,
+        models.CodeEvaluator,
+    ]
+    assert [result.id if result is not None else None for result in results] == keys
+    assert isinstance(results[0], models.CodeEvaluator)
+    assert results[0].language == "PYTHON"
+    assert isinstance(results[1], models.LLMEvaluator)
+    assert results[1].prompt_id == prompt.id
+    assert isinstance(results[2], models.BuiltinEvaluator)
+    assert results[2].key == builtin_evaluator.key

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 import httpx
 import pytest
 import respx
+import sqlalchemy
 from openai import AsyncOpenAI
 from openinference.semconv.trace import (
     MessageAttributes,
@@ -3927,21 +3928,36 @@ class TestGetEvaluators:
             await session.flush()
 
             input_ids = [de_levenshtein.id, de_json_distance.id, de_contains.id]
+            statements: list[str] = []
 
-            evaluators = await get_evaluators(
-                dataset_evaluator_ids=input_ids,
-                session=session,
-                decrypt=lambda x: x,
-                experiment_id=0,
-                credentials=None,
-                sandbox_session_manager=SandboxSessionManager(),
-            )
+            @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "before_cursor_execute")
+            def capture_statement(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+                if statement.lstrip().upper().startswith("SELECT"):
+                    statements.append(statement)
+
+            try:
+                evaluators = await get_evaluators(
+                    dataset_evaluator_ids=input_ids,
+                    session=session,
+                    decrypt=lambda x: x,
+                    experiment_id=0,
+                    credentials=None,
+                    sandbox_session_manager=SandboxSessionManager(),
+                )
+            finally:
+                sqlalchemy.event.remove(
+                    sqlalchemy.engine.Engine,
+                    "before_cursor_execute",
+                    capture_statement,
+                )
 
         assert len(evaluators) == 3
         assert all(isinstance(e, BuiltInEvaluator) for e in evaluators)
         assert evaluators[0].name == "levenshtein_distance"
         assert evaluators[1].name == "json_distance"
         assert evaluators[2].name == "contains"
+        assert not any("llm_evaluators" in statement for statement in statements)
+        assert not any("code_evaluators" in statement for statement in statements)
 
 
 @pytest.fixture

--- a/tests/unit/server/api/mutations/test_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_evaluator_mutations.py
@@ -58,6 +58,42 @@ def _canonical_tools(
     )
 
 
+@pytest.fixture
+async def dataset_code_evaluator(
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> models.CodeEvaluator:
+    output_config = CategoricalOutputConfig(
+        type="CATEGORICAL",
+        name="correctness",
+        description="Whether the output is correct",
+        optimization_direction=OptimizationDirection.MAXIMIZE,
+        values=[
+            CategoricalAnnotationValue(label="correct", score=1.0),
+            CategoricalAnnotationValue(label="incorrect", score=0.0),
+        ],
+    )
+    async with db() as session:
+        evaluator = models.CodeEvaluator(
+            name=IdentifierModel(f"dataset-code-evaluator-{token_hex(4)}"),
+            description="A code evaluator for dataset assignment tests",
+            language="PYTHON",
+            sandbox_config_id=sandbox_config.id,
+            input_mapping=InputMapping(literal_mapping={}, path_mapping={"output": "$.output"}),
+            output_configs=[output_config],
+        )
+        session.add(evaluator)
+        await session.flush()
+        session.add(
+            models.CodeEvaluatorVersion(
+                code_evaluator_id=evaluator.id,
+                source_code="def evaluate(output): return 'correct'",
+            )
+        )
+        await session.flush()
+    return evaluator
+
+
 class TestDatasetLLMEvaluatorMutations:
     _MUTATION = """
       mutation($input: CreateDatasetLLMEvaluatorInput!) {
@@ -2014,6 +2050,141 @@ class TestUpdateDatasetLLMEvaluatorMutation:
                 )
             )
             assert len(prompt_versions.all()) == 2
+
+
+class TestCreateDatasetCodeEvaluatorMutation:
+    _MUTATION = """
+      mutation($input: CreateDatasetCodeEvaluatorInput!) {
+        createDatasetCodeEvaluator(input: $input) {
+          evaluator {
+            id
+            name
+            evaluator {
+              ... on CodeEvaluator {
+                id
+                name
+                kind
+              }
+            }
+          }
+          query { __typename }
+        }
+      }
+    """
+
+    async def _create(self, gql_client: AsyncGraphQLClient, **input_fields: Any) -> Any:
+        input_fields.setdefault("inputMapping", {"literalMapping": {}, "pathMapping": {}})
+        return await gql_client.execute(self._MUTATION, {"input": input_fields})
+
+    async def test_create_dataset_code_evaluator(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        empty_dataset: models.Dataset,
+        dataset_code_evaluator: models.CodeEvaluator,
+    ) -> None:
+        dataset_id = str(GlobalID("Dataset", str(empty_dataset.id)))
+        evaluator_id = str(GlobalID("CodeEvaluator", str(dataset_code_evaluator.id)))
+        result = await self._create(
+            gql_client,
+            datasetId=dataset_id,
+            evaluatorId=evaluator_id,
+            name="assigned-code-evaluator",
+            description="Dataset-specific description",
+            inputMapping={
+                "literalMapping": {"threshold": 0.5},
+                "pathMapping": {"output": "$.context.output"},
+            },
+            outputConfigs=[
+                {
+                    "categorical": {
+                        "name": "correctness",
+                        "description": "Dataset-specific correctness",
+                        "optimizationDirection": "MAXIMIZE",
+                        "values": [
+                            {"label": "correct", "score": 1.0},
+                            {"label": "incorrect", "score": 0.0},
+                        ],
+                    }
+                }
+            ],
+        )
+
+        assert result.data and not result.errors
+        dataset_evaluator = result.data["createDatasetCodeEvaluator"]["evaluator"]
+        assert dataset_evaluator["name"] == "assigned-code-evaluator"
+        assert dataset_evaluator["evaluator"] == {
+            "id": evaluator_id,
+            "name": dataset_code_evaluator.name.root,
+            "kind": "CODE",
+        }
+
+        dataset_evaluator_id = int(GlobalID.from_id(dataset_evaluator["id"]).node_id)
+        async with db() as session:
+            assignment = await session.get(models.DatasetEvaluators, dataset_evaluator_id)
+            assert assignment is not None
+            assert assignment.dataset_id == empty_dataset.id
+            assert assignment.evaluator_id == dataset_code_evaluator.id
+            assert assignment.description == "Dataset-specific description"
+            assert assignment.input_mapping == InputMapping(
+                literal_mapping={"threshold": 0.5},
+                path_mapping={"output": "$.context.output"},
+            )
+            assert assignment.output_configs is not None
+            assert len(assignment.output_configs) == 1
+            assert assignment.output_configs[0].name == "correctness"
+
+            evaluator = await session.get(models.CodeEvaluator, assignment.evaluator_id)
+            assert evaluator is not None
+            assert evaluator.sandbox_config_id == dataset_code_evaluator.sandbox_config_id
+
+    async def test_create_dataset_code_evaluator_errors(
+        self,
+        gql_client: AsyncGraphQLClient,
+        empty_dataset: models.Dataset,
+        dataset_code_evaluator: models.CodeEvaluator,
+    ) -> None:
+        dataset_id = str(GlobalID("Dataset", str(empty_dataset.id)))
+        evaluator_id = str(GlobalID("CodeEvaluator", str(dataset_code_evaluator.id)))
+
+        result = await self._create(
+            gql_client,
+            datasetId=dataset_id,
+            evaluatorId=str(GlobalID("BuiltInEvaluator", str(dataset_code_evaluator.id))),
+            name="invalid-kind",
+        )
+        assert result.errors and "must be a code evaluator" in result.errors[0].message
+
+        result = await self._create(
+            gql_client,
+            datasetId=dataset_id,
+            evaluatorId=str(GlobalID("CodeEvaluator", "999999")),
+            name="missing-evaluator",
+        )
+        assert result.errors and "not found" in result.errors[0].message.lower()
+
+        result = await self._create(
+            gql_client,
+            datasetId=str(GlobalID("Dataset", "999999")),
+            evaluatorId=evaluator_id,
+            name="missing-dataset",
+        )
+        assert result.errors and "Dataset with id" in result.errors[0].message
+
+        result = await self._create(
+            gql_client,
+            datasetId=dataset_id,
+            evaluatorId=evaluator_id,
+            name="duplicate-code-assignment",
+        )
+        assert result.data and not result.errors
+        result = await self._create(
+            gql_client,
+            datasetId=dataset_id,
+            evaluatorId=evaluator_id,
+            name="duplicate-code-assignment",
+        )
+        assert result.errors and "already exists" in result.errors[0].message.lower()
 
 
 class TestCreateDatasetBuiltinEvaluatorMutation:

--- a/tests/unit/server/api/types/test_Dataset.py
+++ b/tests/unit/server/api/types/test_Dataset.py
@@ -4,6 +4,7 @@ from secrets import token_hex
 from typing import Any
 
 import pytest
+import sqlalchemy
 from sqlalchemy import insert, select
 from strawberry.relay import GlobalID
 
@@ -1325,6 +1326,48 @@ class TestDatasetsEvaluatorsResolver:
         assert edges[0]["node"]["evaluator"]["kind"] == "LLM"
         assert edges[1]["node"]["evaluator"]["name"] == "evaluator-2"
         assert edges[1]["node"]["evaluator"]["kind"] == "LLM"
+
+    async def test_sort_by_kind_uses_only_base_evaluator_table(
+        self,
+        gql_client: AsyncGraphQLClient,
+        dataset_with_evaluators: Any,
+    ) -> None:
+        statements: list[str] = []
+
+        @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "before_cursor_execute")
+        def capture_statement(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+            if statement.lstrip().upper().startswith("SELECT"):
+                statements.append(statement)
+
+        try:
+            response = await gql_client.execute(
+                query="""
+                  query ($datasetId: ID!) {
+                    node(id: $datasetId) {
+                      ... on Dataset {
+                        datasetEvaluators(sort: {col: kind, dir: asc}) {
+                          edges { node { name } }
+                        }
+                      }
+                    }
+                  }
+                """,
+                variables={"datasetId": str(GlobalID("Dataset", "1"))},
+            )
+        finally:
+            sqlalchemy.event.remove(
+                sqlalchemy.engine.Engine,
+                "before_cursor_execute",
+                capture_statement,
+            )
+
+        assert response.data and not response.errors
+        assert [
+            edge["node"]["name"] for edge in response.data["node"]["datasetEvaluators"]["edges"]
+        ] == ["evaluator-1", "evaluator-2"]
+        assert not any("llm_evaluators" in statement for statement in statements)
+        assert not any("code_evaluators" in statement for statement in statements)
+        assert not any("builtin_evaluators" in statement for statement in statements)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Fixes selective evaluator loading so evaluator subtypes are resolved correctly in dataloaders, related paths, and query helpers instead of being dropped or mis-typed
- Adjusts `Dataset` type, `evaluator_by_id` dataloader, and `db/helpers.py` to correctly join/filter on evaluator subtype
- Adds mutation and dataloader test coverage for dataset code evaluators to catch this class of regression

## Test plan
- [ ] `uv run pytest tests/unit/server/api/dataloaders/test_evaluator_by_id.py`
- [ ] `uv run pytest tests/unit/server/api/mutations/test_evaluator_mutations.py`
- [ ] `uv run pytest tests/unit/server/api/types/test_Dataset.py tests/unit/server/api/test_queries.py`
- [ ] `uv run pytest tests/unit/db/test_helpers.py tests/unit/server/api/helpers/test_evaluators.py`
- [ ] Manually create a dataset with a code evaluator in the UI and confirm it loads correctly on the dataset page

Closes #14354