### PR TITLE
feat(agents): add tool search

### DIFF
--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import replace
 
 from openinference.instrumentation import OITracer, TraceConfig
 from opentelemetry.trace import NoOpTracerProvider, Tracer, TracerProvider
@@ -11,9 +12,12 @@ from pydantic_ai.capabilities import (
     CapabilityFunc,
     CombinedCapability,
     DynamicCapability,
+    PrepareTools,
+    ToolSearch,
 )
 from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.models import Model
+from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.ui.vercel_ai.response_types import ToolOutputAvailableChunk
 
 from phoenix.server.agents.capabilities import (
@@ -42,6 +46,32 @@ from phoenix.server.agents.web_access import (
 )
 from phoenix.server.dml_event import DmlEvent
 from phoenix.server.types import CanPutItem, DbSessionFactory
+
+# These secondary tools are present across contexts and are useful on demand.
+# Context-gated action tools stay eager so direct UI requests remain one step.
+_DEFERRED_EXTERNAL_TOOL_NAMES = frozenset(
+    {
+        "batch_span_annotate",
+        "list_datasets",
+        "list_labels",
+        "list_splits",
+        "render_generative_ui",
+    }
+)
+
+
+def _defer_external_tools(
+    _: RunContext[AgentDependencies],
+    tool_definitions: list[ToolDefinition],
+) -> list[ToolDefinition]:
+    """Defer secondary global tools while keeping contextual actions eager."""
+    return [
+        replace(tool_definition, defer_loading=True)
+        if tool_definition.kind == "external"
+        and tool_definition.name in _DEFERRED_EXTERNAL_TOOL_NAMES
+        else tool_definition
+        for tool_definition in tool_definitions
+    ]
 
 
 def get_skills_capability_function(
@@ -100,6 +130,7 @@ def build_agent(
         config=TraceConfig(),
     )
     capabilities: list[AbstractCapability[AgentDependencies]] = [
+        PrepareTools(prepare_func=_defer_external_tools),
         WriteSpanNoteCapability(
             db=db,
             event_queue=event_queue,
@@ -167,6 +198,6 @@ def build_agent(
         deps_type=AgentDependencies,
         output_type=[str, DeferredToolRequests],
         instructions=resolved_prompts.base.render(),
-        capabilities=[traced_capability, NativeToolRetryCapability()],
+        capabilities=[ToolSearch(), traced_capability, NativeToolRetryCapability()],
     )
     return agent

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import replace
 
 import strawberry
 from openinference.instrumentation import OITracer, TraceConfig
@@ -12,9 +13,12 @@ from pydantic_ai.capabilities import (
     CapabilityFunc,
     CombinedCapability,
     DynamicCapability,
+    PrepareTools,
+    ToolSearch,
 )
 from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.models import Model
+from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.ui.vercel_ai.response_types import ToolOutputAvailableChunk
 
 from phoenix.server.agents.capabilities import (
@@ -45,6 +49,32 @@ from phoenix.server.agents.web_access import (
 from phoenix.server.api.context import Context
 from phoenix.server.dml_event import DmlEvent
 from phoenix.server.types import CanPutItem, DbSessionFactory
+
+# These secondary tools are present across contexts and are useful on demand.
+# Context-gated action tools stay eager so direct UI requests remain one step.
+_DEFERRED_EXTERNAL_TOOL_NAMES = frozenset(
+    {
+        "batch_span_annotate",
+        "list_datasets",
+        "list_labels",
+        "list_splits",
+        "render_generative_ui",
+    }
+)
+
+
+def _defer_external_tools(
+    _: RunContext[AgentDependencies],
+    tool_definitions: list[ToolDefinition],
+) -> list[ToolDefinition]:
+    """Defer secondary global tools while keeping contextual actions eager."""
+    return [
+        replace(tool_definition, defer_loading=True)
+        if tool_definition.kind == "external"
+        and tool_definition.name in _DEFERRED_EXTERNAL_TOOL_NAMES
+        else tool_definition
+        for tool_definition in tool_definitions
+    ]
 
 
 def get_skills_capability_function(
@@ -108,6 +138,7 @@ def build_agent(
         config=TraceConfig(),
     )
     capabilities: list[AbstractCapability[AgentDependencies]] = [
+        PrepareTools(prepare_func=_defer_external_tools),
         WriteSpanNoteCapability(
             db=db,
             event_queue=event_queue,
@@ -186,6 +217,6 @@ def build_agent(
         deps_type=AgentDependencies,
         output_type=[str, DeferredToolRequests],
         instructions=resolved_prompts.base.render(),
-        capabilities=[traced_capability, NativeToolRetryCapability()],
+        capabilities=[ToolSearch(), traced_capability, NativeToolRetryCapability()],
     )
     return agent

--- a/src/phoenix/server/agents/agent_factory.py
+++ b/src/phoenix/server/agents/agent_factory.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import replace
 
 import strawberry
 from openinference.instrumentation import OITracer, TraceConfig
@@ -18,13 +17,13 @@ from pydantic_ai.capabilities import (
 )
 from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.models import Model
-from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.ui.vercel_ai.response_types import ToolOutputAvailableChunk
 
 from phoenix.server.agents.capabilities import (
     MintlifyDocsMCPCapability,
     NativeToolRetryCapability,
     SkillsCapability,
+    assert_tools_deferred,
     build_anthropic_prompt_cache_capability,
     get_context_capability_function,
 )
@@ -49,32 +48,6 @@ from phoenix.server.agents.web_access import (
 from phoenix.server.api.context import Context
 from phoenix.server.dml_event import DmlEvent
 from phoenix.server.types import CanPutItem, DbSessionFactory
-
-# These secondary tools are present across contexts and are useful on demand.
-# Context-gated action tools stay eager so direct UI requests remain one step.
-_DEFERRED_EXTERNAL_TOOL_NAMES = frozenset(
-    {
-        "batch_span_annotate",
-        "list_datasets",
-        "list_labels",
-        "list_splits",
-        "render_generative_ui",
-    }
-)
-
-
-def _defer_external_tools(
-    _: RunContext[AgentDependencies],
-    tool_definitions: list[ToolDefinition],
-) -> list[ToolDefinition]:
-    """Defer secondary global tools while keeping contextual actions eager."""
-    return [
-        replace(tool_definition, defer_loading=True)
-        if tool_definition.kind == "external"
-        and tool_definition.name in _DEFERRED_EXTERNAL_TOOL_NAMES
-        else tool_definition
-        for tool_definition in tool_definitions
-    ]
 
 
 def get_skills_capability_function(
@@ -138,7 +111,7 @@ def build_agent(
         config=TraceConfig(),
     )
     capabilities: list[AbstractCapability[AgentDependencies]] = [
-        PrepareTools(prepare_func=_defer_external_tools),
+        PrepareTools(prepare_func=assert_tools_deferred),
         WriteSpanNoteCapability(
             db=db,
             event_queue=event_queue,

--- a/src/phoenix/server/agents/capabilities/__init__.py
+++ b/src/phoenix/server/agents/capabilities/__init__.py
@@ -2,6 +2,7 @@ from phoenix.server.agents.capabilities.anthropic_prompt_cache import (
     AnthropicPromptCacheCapability,
     build_anthropic_prompt_cache_capability,
 )
+from phoenix.server.agents.capabilities.base import assert_tools_deferred
 from phoenix.server.agents.capabilities.contexts import get_context_capability_function
 from phoenix.server.agents.capabilities.docs_mcp import (
     MintlifyDocsMCPCapability,
@@ -23,6 +24,7 @@ __all__ = [
     "MintlifyDocsMCPServer",
     "NativeToolRetryCapability",
     "SkillsCapability",
+    "assert_tools_deferred",
     "get_context_capability_function",
     "get_external_tool_capability_function",
     "get_external_tool_definition",

--- a/src/phoenix/server/agents/capabilities/base.py
+++ b/src/phoenix/server/agents/capabilities/base.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from pydantic_ai import RunContext
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.tools import AgentDepsT, SystemPromptFunc
+from pydantic_ai.tools import AgentDepsT, SystemPromptFunc, ToolDefinition
 
 
 @dataclass
@@ -45,3 +45,25 @@ class AbstractDynamicCapability(AbstractCapability[AgentDepsT], ABC):
 
     def get_instructions(self) -> SystemPromptFunc[AgentDepsT]:
         return self.get_dynamic_instructions()
+
+
+def assert_tools_deferred(
+    _: RunContext[AgentDepsT],
+    tool_definitions: list[ToolDefinition],
+) -> list[ToolDefinition]:
+    """Assert every tool opted into deferred loading at its definition site.
+
+    Nothing is advertised up front: the model reaches each tool through tool
+    search. Each tool sets ``defer_loading=True`` itself, so this only guards
+    against a new tool forgetting to. Output tools are exempt -- ``PrepareTools``
+    only sees function, external, and unapproved tools.
+    """
+    if eager := sorted(
+        tool_definition.name
+        for tool_definition in tool_definitions
+        if not tool_definition.defer_loading
+    ):
+        raise AssertionError(
+            f"tools must set defer_loading=True at their definition site: {', '.join(eager)}"
+        )
+    return tool_definitions

--- a/src/phoenix/server/agents/capabilities/docs_mcp.py
+++ b/src/phoenix/server/agents/capabilities/docs_mcp.py
@@ -28,7 +28,9 @@ class MintlifyDocsMCPCapability(AbstractStaticCapability[AgentDepsT]):
     instructions: Template
 
     def get_toolset(self) -> AgentToolset[AgentDepsT] | None:
-        return self.mcp_server
+        # MCP tools are discovered from the server, so they carry no
+        # ``defer_loading`` flag of their own; defer the whole toolset here.
+        return self.mcp_server.defer_loading()
 
     def get_static_instructions(self) -> str:
         return self.instructions.render()

--- a/src/phoenix/server/agents/capabilities/skills/toolset.py
+++ b/src/phoenix/server/agents/capabilities/skills/toolset.py
@@ -71,11 +71,13 @@ class SkillsToolset(FunctionToolset[AgentDepsT]):
                     load_skill,
                     takes_ctx=False,
                     description=load_skill_tool_template.render(),
+                    defer_loading=True,
                 ),
                 Tool(
                     read_skill_resource,
                     takes_ctx=True,
                     description=read_skill_resource_tool_template.render(),
+                    defer_loading=True,
                 ),
             ]
         )

--- a/src/phoenix/server/agents/capabilities/tools/external/add_dataset_examples.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/add_dataset_examples.py
@@ -67,6 +67,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/add_prompt_instance.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/add_prompt_instance.py
@@ -36,6 +36,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/add_spans_to_dataset.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/add_spans_to_dataset.py
@@ -50,6 +50,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/ask_user.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/ask_user.py
@@ -103,6 +103,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/batch_span_annotate.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/batch_span_annotate.py
@@ -92,6 +92,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/cancel_playground_run.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/cancel_playground_run.py
@@ -31,6 +31,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/clone_prompt_instance.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/clone_prompt_instance.py
@@ -45,6 +45,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/create_annotation_config.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/create_annotation_config.py
@@ -95,6 +95,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/create_dataset.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/create_dataset.py
@@ -68,6 +68,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/create_dataset_label.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/create_dataset_label.py
@@ -55,6 +55,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/create_dataset_split.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/create_dataset_split.py
@@ -58,6 +58,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/delete_dataset.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/delete_dataset.py
@@ -31,6 +31,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/delete_dataset_examples.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/delete_dataset_examples.py
@@ -42,6 +42,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/delete_dataset_labels.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/delete_dataset_labels.py
@@ -40,6 +40,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/delete_dataset_splits.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/delete_dataset_splits.py
@@ -39,6 +39,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/edit_code_evaluator_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/edit_code_evaluator_draft.py
@@ -211,6 +211,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/edit_llm_evaluator_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/edit_llm_evaluator_draft.py
@@ -243,6 +243,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/edit_prompt_instance.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/edit_prompt_instance.py
@@ -115,6 +115,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/get_route_info.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/get_route_info.py
@@ -50,6 +50,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/list_dataset_examples.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/list_dataset_examples.py
@@ -56,6 +56,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/list_dataset_labels.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/list_dataset_labels.py
@@ -32,6 +32,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/list_dataset_splits.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/list_dataset_splits.py
@@ -33,6 +33,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/list_datasets.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/list_datasets.py
@@ -61,6 +61,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/list_labels.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/list_labels.py
@@ -46,6 +46,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/list_playground_model_targets.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/list_playground_model_targets.py
@@ -32,6 +32,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/list_splits.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/list_splits.py
@@ -46,6 +46,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/load_dataset.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/load_dataset.py
@@ -47,6 +47,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/open_code_evaluator_form.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/open_code_evaluator_form.py
@@ -32,6 +32,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/open_dataset_evaluator_for_edit.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/open_dataset_evaluator_for_edit.py
@@ -45,6 +45,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/open_llm_evaluator_form.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/open_llm_evaluator_form.py
@@ -32,6 +32,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/patch_dataset.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/patch_dataset.py
@@ -45,6 +45,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/patch_dataset_examples.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/patch_dataset_examples.py
@@ -61,6 +61,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/patch_dataset_split.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/patch_dataset_split.py
@@ -55,6 +55,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/patch_experiment.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/patch_experiment.py
@@ -59,6 +59,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/read_code_evaluator_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_code_evaluator_draft.py
@@ -33,6 +33,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/read_dataset_evaluator_definition.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_dataset_evaluator_definition.py
@@ -51,6 +51,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/read_llm_evaluator_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_llm_evaluator_draft.py
@@ -33,6 +33,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/read_playground_output.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_playground_output.py
@@ -48,6 +48,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/read_prompt_instance.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_prompt_instance.py
@@ -43,6 +43,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/read_prompt_tools.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/read_prompt_tools.py
@@ -46,6 +46,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/remove_prompt_instance.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/remove_prompt_instance.py
@@ -40,6 +40,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/render_generative_ui.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/render_generative_ui.py
@@ -85,6 +85,7 @@ RENDER_GENERATIVE_UI_TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/run_code_evaluator_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/run_code_evaluator_draft.py
@@ -33,6 +33,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/run_llm_evaluator_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/run_llm_evaluator_draft.py
@@ -32,6 +32,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/run_playground.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/run_playground.py
@@ -33,6 +33,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/save_prompt.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/save_prompt.py
@@ -85,6 +85,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_appended_messages_path.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_appended_messages_path.py
@@ -41,6 +41,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_dataset_evaluator_selection.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_dataset_evaluator_selection.py
@@ -44,6 +44,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_dataset_example_splits.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_dataset_example_splits.py
@@ -50,6 +50,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_dataset_labels.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_dataset_labels.py
@@ -43,6 +43,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_playground_experiment_recording.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_playground_experiment_recording.py
@@ -65,6 +65,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_playground_model.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_playground_model.py
@@ -93,6 +93,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_playground_repetitions.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_playground_repetitions.py
@@ -42,6 +42,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_spans_filter.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_spans_filter.py
@@ -111,6 +111,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_template_variables_path.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_template_variables_path.py
@@ -41,6 +41,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_time_range.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_time_range.py
@@ -62,6 +62,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/set_variable_values.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/set_variable_values.py
@@ -62,6 +62,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/submit_code_evaluator_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/submit_code_evaluator_draft.py
@@ -31,6 +31,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/submit_llm_evaluator_draft.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/submit_llm_evaluator_draft.py
@@ -31,6 +31,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/update_annotation_config.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/update_annotation_config.py
@@ -93,6 +93,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/external/write_prompt_tools.py
+++ b/src/phoenix/server/agents/capabilities/tools/external/write_prompt_tools.py
@@ -134,6 +134,7 @@ TOOL_DEFINITION = ToolDefinition(
     description=DESCRIPTION,
     parameters_json_schema=PARAMETERS,
     kind="external",
+    defer_loading=True,
 )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/internal/bash.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/bash.py
@@ -421,6 +421,7 @@ class BashToolset(FunctionToolset[AgentDepsT], Generic[AgentDepsT]):
                     bash,
                     takes_ctx=False,
                     description=_BASH_TOOL_DESCRIPTION_TEMPLATE.render(),
+                    defer_loading=True,
                 )
             ]
         )

--- a/src/phoenix/server/agents/capabilities/tools/internal/call_subagent.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/call_subagent.py
@@ -122,7 +122,14 @@ class CallSubAgentToolset(FunctionToolset[AgentDepsT], Generic[AgentDepsT]):
             return summary
 
         super().__init__(
-            tools=[Tool(call_subagent, takes_ctx=True, description=CALL_SUBAGENT_TOOL_DESCRIPTION)]
+            tools=[
+                Tool(
+                    call_subagent,
+                    takes_ctx=True,
+                    description=CALL_SUBAGENT_TOOL_DESCRIPTION,
+                    defer_loading=True,
+                )
+            ]
         )
 
 

--- a/src/phoenix/server/agents/capabilities/tools/internal/current_datetime.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/current_datetime.py
@@ -61,6 +61,7 @@ class GetCurrentDatetimeToolset(FunctionToolset[AgentDependencies]):
                     name=GET_CURRENT_DATETIME_TOOL_NAME,
                     description=_GET_CURRENT_DATETIME_DESCRIPTION,
                     takes_ctx=True,
+                    defer_loading=True,
                 )
             ]
         )

--- a/src/phoenix/server/agents/capabilities/tools/internal/write_span_note.py
+++ b/src/phoenix/server/agents/capabilities/tools/internal/write_span_note.py
@@ -88,6 +88,7 @@ class WriteSpanNoteToolset(FunctionToolset[AgentDepsT]):
                     name=WRITE_SPAN_NOTE_TOOL_NAME,
                     description=_WRITE_SPAN_NOTE_DESCRIPTION,
                     takes_ctx=False,
+                    defer_loading=True,
                 )
             ]
         )

--- a/src/phoenix/server/agents/server_agents.py
+++ b/src/phoenix/server/agents/server_agents.py
@@ -7,7 +7,7 @@ from openinference.instrumentation import OITracer, TraceConfig
 from opentelemetry.trace import NoOpTracerProvider, Tracer, TracerProvider
 from pydantic_ai import Agent
 from pydantic_ai.agent.abstract import AbstractAgent
-from pydantic_ai.capabilities import AbstractCapability, CombinedCapability
+from pydantic_ai.capabilities import AbstractCapability, CombinedCapability, ToolSearch
 from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.models import Model
 from pydantic_ai.ui.vercel_ai.response_types import ToolOutputAvailableChunk
@@ -153,6 +153,6 @@ def build_server_agent(
         name="ServerAgent",
         deps_type=type(None),
         instructions=resolved_prompts.base.render(),
-        capabilities=[traced_capability],
+        capabilities=[ToolSearch(), traced_capability],
     )
     return OpenInferenceAgentWrapper(agent, tracer=tracer)

--- a/src/phoenix/server/agents/server_agents.py
+++ b/src/phoenix/server/agents/server_agents.py
@@ -7,7 +7,7 @@ from openinference.instrumentation import OITracer, TraceConfig
 from opentelemetry.trace import NoOpTracerProvider, Tracer, TracerProvider
 from pydantic_ai import Agent
 from pydantic_ai.agent.abstract import AbstractAgent
-from pydantic_ai.capabilities import AbstractCapability, CombinedCapability
+from pydantic_ai.capabilities import AbstractCapability, CombinedCapability, ToolSearch
 from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.models import Model
 from pydantic_ai.ui.vercel_ai.response_types import ToolOutputAvailableChunk
@@ -157,6 +157,6 @@ def build_server_agent(
         name="ServerAgent",
         deps_type=type(None),
         instructions=resolved_prompts.base.render(),
-        capabilities=[traced_capability],
+        capabilities=[ToolSearch(), traced_capability],
     )
     return OpenInferenceAgentWrapper(agent, tracer=tracer)

--- a/src/phoenix/server/agents/server_agents.py
+++ b/src/phoenix/server/agents/server_agents.py
@@ -7,13 +7,19 @@ from openinference.instrumentation import OITracer, TraceConfig
 from opentelemetry.trace import NoOpTracerProvider, Tracer, TracerProvider
 from pydantic_ai import Agent
 from pydantic_ai.agent.abstract import AbstractAgent
-from pydantic_ai.capabilities import AbstractCapability, CombinedCapability, ToolSearch
+from pydantic_ai.capabilities import (
+    AbstractCapability,
+    CombinedCapability,
+    PrepareTools,
+    ToolSearch,
+)
 from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.models import Model
 from pydantic_ai.ui.vercel_ai.response_types import ToolOutputAvailableChunk
 
 from phoenix.server.agents.capabilities import (
     MintlifyDocsMCPCapability,
+    assert_tools_deferred,
     build_anthropic_prompt_cache_capability,
 )
 from phoenix.server.agents.capabilities.skills import SkillsCapability, SkillsToolset
@@ -80,6 +86,7 @@ def build_server_agent(
         config=TraceConfig(),
     )
     capabilities: list[AbstractCapability[None]] = [
+        PrepareTools(prepare_func=assert_tools_deferred),
         BashCapability[None](
             schema=schema,
             build_graphql_context=build_graphql_context,

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -225,16 +225,20 @@ def docs_mcp_server() -> _OfflineDocsMCPToolset:
 def model_with_web_access() -> TestModel:
     """Model whose profile advertises both native web tools."""
     return TestModel(
+        call_tools=[],
         profile=ModelProfile(
             supported_native_tools=frozenset({WebSearchTool, WebFetchTool}),
-        )
+        ),
     )
 
 
 @pytest.fixture
 def model_without_web_access() -> TestModel:
     """Model whose profile advertises no native web tools."""
-    return TestModel(profile=ModelProfile(supported_native_tools=frozenset()))
+    return TestModel(
+        call_tools=[],
+        profile=ModelProfile(supported_native_tools=frozenset()),
+    )
 
 
 def _get_system_text_blocks(body: MessageCreateParams) -> list[BetaTextBlockParam]:
@@ -1700,6 +1704,45 @@ class TestWebAccessCapabilities:
         native_tool_types = self._get_native_tool_types(model_without_web_access)
         assert WebSearchTool not in native_tool_types
         assert WebFetchTool not in native_tool_types
+
+
+class TestToolSearchCapability:
+    async def test_external_tools_use_native_anthropic_tool_search(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(contexts=ResolvedContexts())
+
+        await agent.run("hello", deps=deps)
+
+        tools_by_name = {tool.get("name"): tool for tool in captured_request.body.get("tools", [])}
+        assert "tool_search_tool_bm25" in tools_by_name
+        assert tools_by_name["list_datasets"].get("defer_loading") is True
+        assert "defer_loading" not in tools_by_name["get_route_info"]
+        assert "defer_loading" not in tools_by_name["write_span_note"]
+
+    async def test_external_tools_are_deferred_to_local_search_fallback(self) -> None:
+        model = TestModel(call_tools=[])
+        agent = build_agent(model=model)
+        deps = AgentDependencies(contexts=ResolvedContexts())
+
+        await agent.run("hello", deps=deps)
+
+        request_parameters = model.last_model_request_parameters
+        assert request_parameters is not None
+        tools_by_name = {
+            tool_definition.name: tool_definition
+            for tool_definition in request_parameters.function_tools
+        }
+        assert "search_tools" in tools_by_name
+        assert tools_by_name["search_tools"].tool_kind == "tool-search"
+        assert "list_datasets" not in tools_by_name
+        assert "get_route_info" in tools_by_name
+        assert tools_by_name["get_route_info"].defer_loading is False
+        assert "write_span_note" in tools_by_name
+        assert tools_by_name["write_span_note"].defer_loading is False
 
 
 class TestDatasetEvaluatorSelectAndEditToolGates:

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass, field, replace
+from typing import Any, cast
 from unittest.mock import Mock
 
 import httpx
@@ -25,11 +25,13 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers.anthropic import AnthropicProvider
+from pydantic_ai.tools import ToolDefinition
 from typing_extensions import TypeIs, assert_never
 
 from phoenix.server.agents.agent_factory import build_agent as _build_agent
 from phoenix.server.agents.capabilities import (
     MintlifyDocsMCPServer,
+    assert_tools_deferred,
     build_anthropic_prompt_cache_capability,
 )
 from phoenix.server.agents.context import (
@@ -1706,7 +1708,7 @@ class TestWebAccessCapabilities:
 
 
 class TestToolSearchCapability:
-    async def test_external_tools_use_native_anthropic_tool_search(
+    async def test_all_tools_use_native_anthropic_tool_search(
         self,
         anthropic_model: AnthropicModel,
         captured_request: CapturedRequest,
@@ -1718,11 +1720,10 @@ class TestToolSearchCapability:
 
         tools_by_name = {tool.get("name"): tool for tool in captured_request.body.get("tools", [])}
         assert "tool_search_tool_bm25" in tools_by_name
-        assert tools_by_name["list_datasets"].get("defer_loading") is True
-        assert "defer_loading" not in tools_by_name["get_route_info"]
-        assert "defer_loading" not in tools_by_name["write_span_note"]
+        for name in ("list_datasets", "get_route_info", "write_span_note"):
+            assert tools_by_name[name].get("defer_loading") is True
 
-    async def test_external_tools_are_deferred_to_local_search_fallback(self) -> None:
+    async def test_all_tools_are_deferred_to_local_search_fallback(self) -> None:
         model = TestModel(call_tools=[])
         agent = build_agent(model=model)
         deps = AgentDependencies(contexts=ResolvedContexts())
@@ -1739,15 +1740,17 @@ class TestToolSearchCapability:
         assert tools_by_name["search_tools"].tool_kind == "tool-search"
         tool_visibility = request_parameters.tool_visibility
         assert tool_visibility is not None
-        assert "list_datasets" in tools_by_name
-        assert tools_by_name["list_datasets"].defer_loading is True
-        assert tool_visibility["list_datasets"] == "withheld"
-        assert "get_route_info" in tools_by_name
-        assert tools_by_name["get_route_info"].defer_loading is False
-        assert tool_visibility["get_route_info"] == "visible"
-        assert "write_span_note" in tools_by_name
-        assert tools_by_name["write_span_note"].defer_loading is False
-        assert tool_visibility["write_span_note"] == "visible"
+        for name in ("list_datasets", "get_route_info", "write_span_note"):
+            assert name in tools_by_name
+            assert tools_by_name[name].defer_loading is True
+            assert tool_visibility[name] == "withheld"
+
+    def test_assert_tools_deferred_rejects_an_eager_tool(self) -> None:
+        eager = ToolDefinition(name="forgot_to_defer", description="", parameters_json_schema={})
+        deferred = replace(eager, name="remembered", defer_loading=True)
+
+        with pytest.raises(AssertionError, match="forgot_to_defer"):
+            assert_tools_deferred(cast(RunContext[AgentDependencies], None), [deferred, eager])
 
 
 class TestDatasetEvaluatorSelectAndEditToolGates:

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -1737,11 +1737,17 @@ class TestToolSearchCapability:
         }
         assert "search_tools" in tools_by_name
         assert tools_by_name["search_tools"].tool_kind == "tool-search"
-        assert "list_datasets" not in tools_by_name
+        tool_visibility = request_parameters.tool_visibility
+        assert tool_visibility is not None
+        assert "list_datasets" in tools_by_name
+        assert tools_by_name["list_datasets"].defer_loading is True
+        assert tool_visibility["list_datasets"] == "withheld"
         assert "get_route_info" in tools_by_name
         assert tools_by_name["get_route_info"].defer_loading is False
+        assert tool_visibility["get_route_info"] == "visible"
         assert "write_span_note" in tools_by_name
         assert tools_by_name["write_span_note"].defer_loading is False
+        assert tool_visibility["write_span_note"] == "visible"
 
 
 class TestDatasetEvaluatorSelectAndEditToolGates:

--- a/tests/unit/server/agents/test_agent_factory.py
+++ b/tests/unit/server/agents/test_agent_factory.py
@@ -224,16 +224,20 @@ def docs_mcp_server() -> _OfflineDocsMCPToolset:
 def model_with_web_access() -> TestModel:
     """Model whose profile advertises both native web tools."""
     return TestModel(
+        call_tools=[],
         profile=ModelProfile(
             supported_native_tools=frozenset({WebSearchTool, WebFetchTool}),
-        )
+        ),
     )
 
 
 @pytest.fixture
 def model_without_web_access() -> TestModel:
     """Model whose profile advertises no native web tools."""
-    return TestModel(profile=ModelProfile(supported_native_tools=frozenset()))
+    return TestModel(
+        call_tools=[],
+        profile=ModelProfile(supported_native_tools=frozenset()),
+    )
 
 
 def _get_system_text_blocks(body: MessageCreateParams) -> list[BetaTextBlockParam]:
@@ -1699,6 +1703,45 @@ class TestWebAccessCapabilities:
         native_tool_types = self._get_native_tool_types(model_without_web_access)
         assert WebSearchTool not in native_tool_types
         assert WebFetchTool not in native_tool_types
+
+
+class TestToolSearchCapability:
+    async def test_external_tools_use_native_anthropic_tool_search(
+        self,
+        anthropic_model: AnthropicModel,
+        captured_request: CapturedRequest,
+    ) -> None:
+        agent = build_agent(model=anthropic_model)
+        deps = AgentDependencies(contexts=ResolvedContexts())
+
+        await agent.run("hello", deps=deps)
+
+        tools_by_name = {tool.get("name"): tool for tool in captured_request.body.get("tools", [])}
+        assert "tool_search_tool_bm25" in tools_by_name
+        assert tools_by_name["list_datasets"].get("defer_loading") is True
+        assert "defer_loading" not in tools_by_name["get_route_info"]
+        assert "defer_loading" not in tools_by_name["write_span_note"]
+
+    async def test_external_tools_are_deferred_to_local_search_fallback(self) -> None:
+        model = TestModel(call_tools=[])
+        agent = build_agent(model=model)
+        deps = AgentDependencies(contexts=ResolvedContexts())
+
+        await agent.run("hello", deps=deps)
+
+        request_parameters = model.last_model_request_parameters
+        assert request_parameters is not None
+        tools_by_name = {
+            tool_definition.name: tool_definition
+            for tool_definition in request_parameters.function_tools
+        }
+        assert "search_tools" in tools_by_name
+        assert tools_by_name["search_tools"].tool_kind == "tool-search"
+        assert "list_datasets" not in tools_by_name
+        assert "get_route_info" in tools_by_name
+        assert tools_by_name["get_route_info"].defer_loading is False
+        assert "write_span_note" in tools_by_name
+        assert tools_by_name["write_span_note"].defer_loading is False
 
 
 class TestDatasetEvaluatorSelectAndEditToolGates:

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -359,13 +359,13 @@ def _client_tool_model() -> FunctionModel:
         agent_info: AgentInfo,
     ) -> AsyncIterator[str | DeltaToolCalls]:
         has_tool_result = any(
-            isinstance(part, ToolReturnPart) and part.tool_name == "list_datasets"
+            isinstance(part, ToolReturnPart) and part.tool_name == "get_route_info"
             for part in messages[-1].parts
         )
         if has_tool_result:
             yield "done"
         else:
-            yield {1: DeltaToolCall(name="list_datasets", json_args="{}")}
+            yield {1: DeltaToolCall(name="get_route_info", json_args="{}")}
 
     def function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
         return ModelResponse(parts=[])
@@ -387,14 +387,14 @@ def _two_client_tool_model() -> FunctionModel:
             1
             for message in messages
             for part in message.parts
-            if isinstance(part, ToolReturnPart) and part.tool_name == "list_datasets"
+            if isinstance(part, ToolReturnPart) and part.tool_name == "get_route_info"
         )
         if tool_result_count >= 2:
             yield "done"
         else:
             yield {
-                1: DeltaToolCall(name="list_datasets", json_args="{}"),
-                2: DeltaToolCall(name="list_datasets", json_args="{}"),
+                1: DeltaToolCall(name="get_route_info", json_args="{}"),
+                2: DeltaToolCall(name="get_route_info", json_args="{}"),
             }
 
     def function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
@@ -1137,7 +1137,7 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
 
     first_response = await httpx_client.post(
         _chat_url(agent_session_id),
-        json=_chat_body(session_id, _user_message("list my datasets")),
+        json=_chat_body(session_id, _user_message("look up a route")),
     )
     assert first_response.status_code == 200
     first_chunks = _stream_chunks(first_response.text)
@@ -1152,14 +1152,16 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
     resolved_assistant_message = stored_messages[-1]
     assert resolved_assistant_message["id"] == assistant_message_id
     tool_part = next(
-        part for part in resolved_assistant_message["parts"] if part["type"] == "tool-list_datasets"
+        part
+        for part in resolved_assistant_message["parts"]
+        if part["type"] == "tool-get_route_info"
     )
     tool_output = {
-        "type": "tool-list_datasets",
+        "type": "tool-get_route_info",
         "toolCallId": tool_part["toolCallId"],
         "state": "output-available",
         "input": tool_part.get("input"),
-        "output": {"datasets": []},
+        "output": {"routes": []},
     }
 
     continuation_response = await httpx_client.post(
@@ -1198,7 +1200,7 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
         if getattr(part, "tool_call_id", None) == tool_part["toolCallId"]
     )
     assert isinstance(persisted_tool_part, ToolOutputAvailablePart)
-    assert persisted_tool_part.output == {"datasets": []}
+    assert persisted_tool_part.output == {"routes": []}
     assert any(
         isinstance(part, TextUIPart) and part.text == "done"
         for part in persisted_assistant.message.parts
@@ -1227,7 +1229,7 @@ async def test_submitted_tool_outputs_persist_partially_without_running_the_mode
 
     first_response = await httpx_client.post(
         _chat_url(agent_session_id),
-        json=_chat_body(session_id, _user_message("list my datasets twice")),
+        json=_chat_body(session_id, _user_message("look up two routes")),
     )
     assert first_response.status_code == 200
     first_start = next(
@@ -1241,7 +1243,7 @@ async def test_submitted_tool_outputs_persist_partially_without_running_the_mode
         assert agent_session_rowid is not None
         stored_messages = await _load_session_messages(session, agent_session_rowid)
     pending_parts = [
-        part for part in stored_messages[-1]["parts"] if part["type"] == "tool-list_datasets"
+        part for part in stored_messages[-1]["parts"] if part["type"] == "tool-get_route_info"
     ]
     assert len(pending_parts) == 2
     assert all(part["state"] == "input-available" for part in pending_parts)
@@ -1249,11 +1251,11 @@ async def test_submitted_tool_outputs_persist_partially_without_running_the_mode
 
     def _tool_output_for(pending_part: dict[str, Any]) -> dict[str, Any]:
         return {
-            "type": "tool-list_datasets",
+            "type": "tool-get_route_info",
             "toolCallId": pending_part["toolCallId"],
             "state": "output-available",
             "input": pending_part.get("input"),
-            "output": {"datasets": []},
+            "output": {"routes": []},
         }
 
     submit_response = await httpx_client.post(
@@ -1272,7 +1274,7 @@ async def test_submitted_tool_outputs_persist_partially_without_running_the_mode
     response_parts_by_call_id = {
         part["toolCallId"]: part
         for part in response_message["parts"]
-        if part["type"] == "tool-list_datasets"
+        if part["type"] == "tool-get_route_info"
     }
     assert response_parts_by_call_id[answered_call["toolCallId"]]["state"] == "output-available"
     assert response_parts_by_call_id[unanswered_call["toolCallId"]]["state"] == "input-available"
@@ -1287,11 +1289,11 @@ async def test_submitted_tool_outputs_persist_partially_without_running_the_mode
     persisted_parts_by_call_id = {
         part["toolCallId"]: part
         for part in stored_messages[-1]["parts"]
-        if part["type"] == "tool-list_datasets"
+        if part["type"] == "tool-get_route_info"
     }
     applied_part = persisted_parts_by_call_id[answered_call["toolCallId"]]
     assert applied_part["state"] == "output-available"
-    assert applied_part["output"] == {"datasets": []}
+    assert applied_part["output"] == {"routes": []}
     # The unanswered call is untouched — still pending, not repaired.
     assert persisted_parts_by_call_id[unanswered_call["toolCallId"]] == unanswered_call
 
@@ -1323,7 +1325,7 @@ async def test_submitted_tool_outputs_persist_partially_without_running_the_mode
         stored_messages = await _load_session_messages(session, agent_session_rowid)
     final_assistant_message = stored_messages[-1]
     final_tool_parts = [
-        part for part in final_assistant_message["parts"] if part["type"] == "tool-list_datasets"
+        part for part in final_assistant_message["parts"] if part["type"] == "tool-get_route_info"
     ]
     assert all(part["state"] == "output-available" for part in final_tool_parts)
     assert any(


### PR DESCRIPTION
No issue.

## Summary

- mount the Pydantic AI ToolSearch capability explicitly on both the main PXI agent and the server agent
- defer secondary global browser tools on the main agent while keeping core routing and context-specific action tools immediately available
- use provider-native tool search when supported and the local search_tools fallback otherwise
- add request-shape coverage for Anthropic native search and the provider-agnostic fallback

## Why

Phoenix has separate user-facing and server-side agent builders. Both now declare the same tool-search infrastructure explicitly. The main agent progressively discloses secondary global browser tools without adding a search step to direct UI actions or internal capabilities such as skill loading and span notes.

## Validation

- uv run pytest tests/unit/server/agents/test_server_agents.py tests/unit/server/agents/test_agent_factory.py -n auto -q (81 passed, 3 skipped)
- uv run pytest tests/unit/server/agents -n auto -q (264 passed, 20 skipped)
- make typecheck-python (955 files)
- uv run ruff check
- uv run ruff format --check
