### PR TITLE
fix(ui): prevent trace note overflow

### DIFF
--- a/app/src/components/chat/MessageBubble.tsx
+++ b/app/src/components/chat/MessageBubble.tsx
@@ -36,6 +36,7 @@ interface MessageBubbleProps {
 }
 
 const bubbleCSS = css`
+  min-width: 0;
   padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
   font-size: var(--global-font-size-s);
   line-height: var(--global-line-height-s);


### PR DESCRIPTION
## Summary

- allow trace note message bubbles to shrink within the annotation panel
- prevent long note content from being clipped at narrow panel widths

Closes #14357

## Root cause

Message bubbles are flex items beside a fixed-size avatar. Their default `min-width: auto` preserved the min-content width of long identifier-like text, pushing outgoing bubbles past the left edge of narrow trace annotation panels.

## Screenshot

Long identifier-heavy note content wraps inside the narrow Notes panel without clipping.

![Long trace note wrapping within the Notes panel](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14376-trace-note-overflow-fixed.png)

## Test plan

- `pnpm typecheck`
- `pnpm exec oxlint src/components/chat/MessageBubble.tsx`
- `pnpm exec oxfmt --check --config ../.oxfmtrc.jsonc src/components/chat/MessageBubble.tsx`
- `pnpm run build`
- verified long trace note content at a 220px panel width in Storybook
- verified the note in the trace drawer against a disposable local Phoenix instance
