### PR TITLE
feat(ui): add DaoXE OpenAI-compatible integration snippet

### DIFF
--- a/app/src/components/project/IntegrationIcons.tsx
+++ b/app/src/components/project/IntegrationIcons.tsx
@@ -1277,6 +1277,24 @@ export const TanStackAISVG = () => (
  * Registry of all integration icons keyed by component name.
  * Used by stories and anywhere a complete list is needed.
  */
+
+export const DaoXESVG = () => (
+  <svg
+    width="32"
+    height="32"
+    viewBox="0 0 32 32"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>DaoXE</title>
+    <rect width="32" height="32" rx="8" fill="currentColor" fillOpacity="0.12" />
+    <path
+      d="M8 22V10h5.2c3.1 0 5.1 1.8 5.1 4.55 0 2.75-2 4.55-5.1 4.55H11.1V22H8zm3.1-5.15h1.85c1.45 0 2.3-.75 2.3-1.95s-.85-1.95-2.3-1.95H11.1v3.9zM20.4 22l3.35-12h3.35L30.45 22h-3.2l-.55-2.15h-3.55L22.6 22h-2.2zm4.15-4.55h2.3l-1.15-4.35-1.15 4.35z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const INTEGRATION_ICONS: Record<string, () => React.JSX.Element> = {
   AgnoSVG,
   AnthropicSVG,
@@ -1306,6 +1324,7 @@ export const INTEGRATION_ICONS: Record<string, () => React.JSX.Element> = {
   NodeJSSVG,
   OpenAISVG,
   OpenRouterSVG,
+  DaoXESVG,
   PortkeySVG,
   PydanticAISVG,
   RubyLLMSVG,

--- a/app/src/components/project/integrationSnippets/daoxe.ts
+++ b/app/src/components/project/integrationSnippets/daoxe.ts
@@ -1,0 +1,60 @@
+export function getDaoxeCodePython({
+  projectName,
+}: {
+  projectName: string;
+}): string {
+  return `from phoenix.otel import register
+import os
+
+tracer_provider = register(
+  project_name="${projectName}",
+  auto_instrument=True
+)
+
+# SDK imports must come after register() so auto-instrumentation can patch them
+import openai
+
+# DaoXE is a multi-model multi-protocol gateway.
+# This snippet uses the OpenAI Chat Completions path.
+# DaoXE is not available in mainland China.
+client = openai.OpenAI(
+  base_url="https://daoxe.com/v1",
+  api_key=os.environ["DAOXE_API_KEY"],
+)
+response = client.chat.completions.create(
+  model="YOUR_DAOXE_MODEL_ID",
+  messages=[{"role": "user", "content": "Explain the theory of relativity in simple terms."}],
+)`;
+}
+
+export function getDaoxeCodeTypescript({
+  projectName,
+}: {
+  projectName: string;
+}): string {
+  return `import { register } from "@arizeai/phoenix-otel";
+import { OpenAIInstrumentation } from "@arizeai/openinference-instrumentation-openai";
+import OpenAI from "openai";
+
+const provider = register({
+  projectName: "${projectName}",
+});
+
+const instrumentation = new OpenAIInstrumentation();
+instrumentation.manuallyInstrument(OpenAI);
+
+// DaoXE is a multi-model multi-protocol gateway.
+// This snippet uses the OpenAI Chat Completions path.
+// DaoXE is not available in mainland China.
+const openai = new OpenAI({
+  baseURL: "https://daoxe.com/v1",
+  apiKey: process.env.DAOXE_API_KEY,
+});
+const response = await openai.chat.completions.create({
+  model: "YOUR_DAOXE_MODEL_ID",
+  messages: [{ role: "user", content: "Explain the theory of relativity in simple terms." }],
+});
+
+// Flush pending traces before the process exits
+await provider.forceFlush();`;
+}

--- a/app/src/components/project/integrationSnippets/index.ts
+++ b/app/src/components/project/integrationSnippets/index.ts
@@ -34,6 +34,7 @@ export {
   getOpenRouterCodePython,
   getOpenRouterCodeTypescript,
 } from "./openRouter";
+export { getDaoxeCodePython, getDaoxeCodeTypescript } from "./daoxe";
 export {
   getOtelInitCodePython,
   getOtelInitCodeTypescript,

--- a/app/src/pages/project/integrationRegistry.tsx
+++ b/app/src/pages/project/integrationRegistry.tsx
@@ -25,6 +25,7 @@ import {
   MistralAISVG,
   OpenAISVG,
   OpenRouterSVG,
+  DaoXESVG,
   PortkeySVG,
   PydanticAISVG,
   StrandsAgentsSVG,
@@ -58,6 +59,8 @@ import {
   getOpenLLMetryCodePython,
   getOpenRouterCodePython,
   getOpenRouterCodeTypescript,
+  getDaoxeCodePython,
+  getDaoxeCodeTypescript,
   getOtelInitCodePython,
   getOtelInitCodeTypescript,
   getStrandsAgentsCodePython,
@@ -81,6 +84,9 @@ const ANTHROPIC_ENV: readonly EnvVar[] = [
 ];
 const OPENROUTER_ENV: readonly EnvVar[] = [
   { name: "OPENROUTER_API_KEY", value: "<your-openrouter-api-key>" },
+];
+const DAOXE_ENV: readonly EnvVar[] = [
+  { name: "DAOXE_API_KEY", value: "<your-daoxe-api-key>" },
 ];
 const CEREBRAS_ENV: readonly EnvVar[] = [
   { name: "CEREBRAS_API_KEY", value: "<your-cerebras-api-key>" },
@@ -666,6 +672,37 @@ export const ONBOARDING_INTEGRATIONS: OnboardingIntegration[] = [
         envVars: OPENROUTER_ENV,
         docsHref:
           "https://arize.com/docs/phoenix/integrations/llm-providers/openrouter/openai-tracing",
+        githubHref:
+          "https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-openai",
+      },
+    },
+  },
+  {
+    id: "daoxe",
+    name: "DaoXE",
+    icon: <DaoXESVG />,
+    configs: {
+      Python: {
+        packages: [
+          "arize-phoenix-otel",
+          "openinference-instrumentation-openai",
+          "openai",
+        ],
+        getImplementationCode: getDaoxeCodePython,
+        envVars: DAOXE_ENV,
+        docsHref: "https://daoxe.com",
+        githubHref:
+          "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai",
+      },
+      TypeScript: {
+        packages: [
+          "@arizeai/phoenix-otel",
+          "@arizeai/openinference-instrumentation-openai",
+          "openai",
+        ],
+        getImplementationCode: getDaoxeCodeTypescript,
+        envVars: DAOXE_ENV,
+        docsHref: "https://daoxe.com",
         githubHref:
           "https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-openai",
       },


### PR DESCRIPTION
## Summary
- Add a **DaoXE** onboarding/project integration snippet (Python + TypeScript), mirroring OpenRouter/Together OpenAI-compatible providers.
- Wire the snippet into `integrationSnippets` exports and the onboarding `integrationRegistry` with a simple `DaoXESVG` icon.
- Uses Phoenix OTEL register + OpenAI client with:
  - `base_url` / `baseURL`: `https://daoxe.com/v1`
  - API key: `DAOXE_API_KEY`
  - Model placeholder: `YOUR_DAOXE_MODEL_ID` (account-scoped)

DaoXE is a multi-model multi-protocol gateway; this path is **OpenAI Chat Completions**. DaoXE is **not available in mainland China**.

## Files
- `app/src/components/project/integrationSnippets/daoxe.ts` (new)
- `app/src/components/project/integrationSnippets/index.ts`
- `app/src/pages/project/integrationRegistry.tsx`
- `app/src/components/project/IntegrationIcons.tsx`

## Test plan
- [ ] Open project onboarding integrations list and confirm **DaoXE** appears next to other OpenAI-compatible providers
- [ ] Switch language between Python and TypeScript and confirm snippet/env vars (`DAOXE_API_KEY`) render
- [ ] Confirm base URL is `https://daoxe.com/v1` and model placeholder is `YOUR_DAOXE_MODEL_ID`
- [ ] Typecheck / lint for app UI package if required by CI