### PR TITLE
fix(auth): correct cookie names in auth.md discovery doc

### DIFF
--- a/src/phoenix/server/api/routers/auth_md.py
+++ b/src/phoenix/server/api/routers/auth_md.py
@@ -13,6 +13,11 @@ from fastapi import APIRouter
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse
 
+from phoenix.auth import (
+    PHOENIX_ACCESS_TOKEN_COOKIE_NAME,
+    PHOENIX_REFRESH_TOKEN_COOKIE_NAME,
+)
+
 router = APIRouter(include_in_schema=False)
 
 
@@ -80,9 +85,9 @@ def _build_auth_md(*, base_url: str, authentication_enabled: bool) -> str:
           **Settings → API Keys**. The key value is shown once at creation time;
           store it securely.
         - **Access token**: `POST {base_url}/auth/login` with JSON body
-          `{{"email": "...", "password": "..."}}` sets a `phoenix.access_token`
+          `{{"email": "...", "password": "..."}}` sets a `{PHOENIX_ACCESS_TOKEN_COOKIE_NAME}`
           cookie usable as a bearer token. Renew an expired token via
-          `POST {base_url}/auth/refresh` with the `phoenix.refresh_token` cookie.
+          `POST {base_url}/auth/refresh` with the `{PHOENIX_REFRESH_TOKEN_COOKIE_NAME}` cookie.
 
         ## Use the credential
 

--- a/tests/unit/server/api/routers/test_auth_md.py
+++ b/tests/unit/server/api/routers/test_auth_md.py
@@ -12,6 +12,10 @@ from fastapi import FastAPI
 from pydantic import SecretStr
 from starlette.types import ASGIApp
 
+from phoenix.auth import (
+    PHOENIX_ACCESS_TOKEN_COOKIE_NAME,
+    PHOENIX_REFRESH_TOKEN_COOKIE_NAME,
+)
 from phoenix.server.app import create_app
 from phoenix.server.types import DbSessionFactory
 from tests.unit.conftest import TestBulkInserter, patch_grpc_server
@@ -77,6 +81,8 @@ class TestGetAuthMd:
         assert "http://test/.well-known/oauth-protected-resource" in body
         assert "http://test/auth/login" in body
         assert "https://workos.com/auth-md/docs/apps" in body
+        assert PHOENIX_ACCESS_TOKEN_COOKIE_NAME in body
+        assert PHOENIX_REFRESH_TOKEN_COOKIE_NAME in body
 
 
 class TestWWWAuthenticateHeader:


### PR DESCRIPTION
## Summary

`GET /auth.md` advertised the auth cookies as `phoenix.access_token` / `phoenix.refresh_token`, but the server actually sets `phoenix-access-token` / `phoenix-refresh-token` (see `PHOENIX_ACCESS_TOKEN_COOKIE_NAME` / `PHOENIX_REFRESH_TOKEN_COOKIE_NAME` in `src/phoenix/auth.py`). Agents following the discovery doc would look for cookies that don't exist.

Rather than hardcoding the corrected strings, the doc template now interpolates the cookie-name constants from `phoenix.auth`, so the discovery doc can't drift from the server behavior again.

## Verification

Rendered `_build_auth_md(authentication_enabled=True)` and asserted the dotted names are gone and the hyphenated constants appear in the output.