### PR TITLE
fix(agent): prevent PXI activation when modals close

### DIFF
--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -59,6 +59,10 @@ const positionerCSS = css`
     visibility: hidden;
   }
 
+  &[data-activation-suppressed="true"] {
+    pointer-events: none;
+  }
+
   &[data-dragging="true"],
   &[data-dragging="true"] * {
     cursor: grabbing;
@@ -230,6 +234,9 @@ export function AgentFabPositioner({
   const hasDraggedRef = useRef(false);
   const suppressNextClickRef = useRef(false);
   const suppressClickResetTimeoutIdRef = useRef<number | null>(null);
+  const suppressActivationRef = useRef(false);
+  const suppressActivationTimeoutIdRef = useRef<number | null>(null);
+  const previousLayerRef = useRef(layer);
   const [isDragging, setIsDragging] = useState(false);
   const requiresBoundary = Boolean(boundaryRef);
   const [resolvedBoundary, setResolvedBoundary] = useState<HTMLElement | null>(
@@ -378,6 +385,12 @@ export function AgentFabPositioner({
   const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== PRIMARY_POINTER_BUTTON) return;
 
+    if (suppressActivationRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
     const positioner = positionerRef.current;
     if (!positioner) return;
 
@@ -464,6 +477,11 @@ export function AgentFabPositioner({
   };
 
   const handleClickCapture = (event: ReactMouseEvent<HTMLDivElement>) => {
+    if (suppressActivationRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
     if (!suppressNextClickRef.current) return;
     suppressNextClickRef.current = false;
     if (suppressClickResetTimeoutIdRef.current != null) {
@@ -489,6 +507,36 @@ export function AgentFabPositioner({
       event.currentTarget.style.removeProperty("transition");
     }
   };
+
+  useLayoutEffect(() => {
+    const previousLayer = previousLayerRef.current;
+    previousLayerRef.current = layer;
+    if (previousLayer !== "modal" || layer !== "content") {
+      return;
+    }
+
+    finishDragSessionRef.current({
+      activateOnClick: false,
+      releaseTarget: positionerRef.current,
+    });
+    const positioner = positionerRef.current;
+    suppressActivationRef.current = true;
+    positioner?.setAttribute("data-activation-suppressed", "true");
+    suppressActivationTimeoutIdRef.current = window.setTimeout(() => {
+      suppressActivationRef.current = false;
+      positioner?.removeAttribute("data-activation-suppressed");
+      suppressActivationTimeoutIdRef.current = null;
+    }, 0);
+
+    return () => {
+      if (suppressActivationTimeoutIdRef.current != null) {
+        window.clearTimeout(suppressActivationTimeoutIdRef.current);
+        suppressActivationTimeoutIdRef.current = null;
+      }
+      suppressActivationRef.current = false;
+      positioner?.removeAttribute("data-activation-suppressed");
+    };
+  }, [layer]);
 
   useLayoutEffect(() => {
     if (!requiresBoundary) {

--- a/app/src/components/agent/__tests__/AgentFabPositioner.test.tsx
+++ b/app/src/components/agent/__tests__/AgentFabPositioner.test.tsx
@@ -281,6 +281,70 @@ describe("AgentFabPositioner", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses activation while moving out of a closing modal", () => {
+    vi.useFakeTimers();
+    const onActivate = vi.fn();
+    const onClick = vi.fn();
+    renderPositioner({ onActivate, onClick });
+
+    act(() => {
+      root.render(
+        <AgentFabPositioner
+          layer="modal"
+          placement="bottom-end"
+          size={{ width: 58, height: 36 }}
+          onActivate={onActivate}
+          onPlacementChange={vi.fn()}
+        >
+          <button type="button" onClick={onClick}>
+            PXI
+          </button>
+        </AgentFabPositioner>
+      );
+    });
+
+    act(() => {
+      root.render(
+        <AgentFabPositioner
+          layer="content"
+          placement="bottom-end"
+          size={{ width: 58, height: 36 }}
+          onActivate={onActivate}
+          onPlacementChange={vi.fn()}
+        >
+          <button type="button" onClick={onClick}>
+            PXI
+          </button>
+        </AgentFabPositioner>
+      );
+    });
+
+    const positioner = container.querySelector(".agent-chat-widget-positioner");
+    const button = container.querySelector("button");
+    expect(positioner?.getAttribute("data-activation-suppressed")).toBe("true");
+
+    act(() => {
+      dispatchPointerEvent(button!, "pointerdown", {
+        clientX: 1135,
+        clientY: 958,
+      });
+      dispatchPointerEvent(button!, "pointerup", {
+        clientX: 1135,
+        clientY: 958,
+      });
+      button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onActivate).not.toHaveBeenCalled();
+    expect(onClick).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    expect(positioner?.getAttribute("data-activation-suppressed")).toBeNull();
+    vi.useRealTimers();
+  });
+
   it("captures the pointer while a drag is pending without blocking normal click", () => {
     const onClick = vi.fn();
     const { button, positioner } = renderPositioner({ onClick });


### PR DESCRIPTION
resolves #14197

## Summary

- Prevent the PXI FAB from receiving the pointer sequence that closes a modal.
- Cancel pending FAB pointer sessions when moving from the modal layer back to the content layer.
- Add regression coverage for modal-to-content activation suppression.

## Testing

- `pnpm test -- AgentFabPositioner.test.tsx AgentChatWidget.test.tsx`
- `pnpm exec oxfmt --check --config ../.oxfmtrc.jsonc src/components/agent/AgentFabPositioner.tsx src/components/agent/__tests__/AgentFabPositioner.test.tsx`
- `pnpm exec oxlint src/components/agent/AgentFabPositioner.tsx src/components/agent/__tests__/AgentFabPositioner.test.tsx`
- `pnpm typecheck`
