### PR TITLE
docs: move one-click deploys to per-provider deployment pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1130,7 +1130,10 @@
               "docs/phoenix/self-hosting/deployment-options/kubernetes",
               "docs/phoenix/self-hosting/deployment-options/kubernetes-helm",
               "docs/phoenix/self-hosting/deployment-options/aws-with-cloudformation",
-              "docs/phoenix/self-hosting/deployment-options/railway"
+              "docs/phoenix/self-hosting/deployment-options/railway",
+              "docs/phoenix/self-hosting/deployment-options/render",
+              "docs/phoenix/self-hosting/deployment-options/google-cloud-run",
+              "docs/phoenix/self-hosting/deployment-options/azure"
             ]
           },
           {

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -654,7 +654,10 @@
 - [Kubernetes](https://arize.com/docs/phoenix/self-hosting/deployment-options/kubernetes): Deploy on Kubernetes
 - [Helm](https://arize.com/docs/phoenix/self-hosting/deployment-options/kubernetes-helm): Deploy with Helm charts
 - [AWS CloudFormation](https://arize.com/docs/phoenix/self-hosting/deployment-options/aws-with-cloudformation): Deploy on AWS
-- [Railway](https://arize.com/docs/phoenix/self-hosting/deployment-options/railway): Deploy on Railway
+- [Railway](https://arize.com/docs/phoenix/self-hosting/deployment-options/railway): Deploy on Railway via one-click template
+- [Render](https://arize.com/docs/phoenix/self-hosting/deployment-options/render): Deploy on Render via one-click blueprint with managed PostgreSQL
+- [Google Cloud Run](https://arize.com/docs/phoenix/self-hosting/deployment-options/google-cloud-run): Deploy on Google Cloud Run with a one-click button
+- [Azure](https://arize.com/docs/phoenix/self-hosting/deployment-options/azure): Deploy on Azure Container Instances via one-click ARM template
 
 ### Features
 

--- a/docs/phoenix/self-hosting.mdx
+++ b/docs/phoenix/self-hosting.mdx
@@ -21,26 +21,6 @@ Phoenix is **free to self-host** with no feature limitations. Your data stays en
 **New to Phoenix?** Try [Phoenix Cloud](/docs/phoenix/phoenix-cloud) to get started instantly without any setup, then self-host when you're ready for production.
 </Tip>
 
-## One-Click Deploy
-
-Deploy Phoenix to the cloud of your choice with a single click:
-
-<p>
-  <a href="https://railway.app/template/PTHRoq?referralCode=Xe2txW"><img src="https://railway.com/button.svg" alt="Deploy on Railway" height="30" noZoom /></a>
-  &nbsp;
-  <a href="https://render.com/deploy?repo=https://github.com/Arize-ai/phoenix"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="30" noZoom /></a>
-  &nbsp;
-  <a href="https://deploy.cloud.run/?git_repo=https://github.com/Arize-ai/phoenix"><img src="https://deploy.cloud.run/button.svg" alt="Run on Google Cloud" height="30" noZoom /></a>
-  &nbsp;
-  <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FArize-ai%2Fphoenix%2Fmain%2Fazuredeploy.json"><img src="https://aka.ms/deploytoazurebutton" alt="Deploy to Azure" height="30" noZoom /></a>
-  &nbsp;
-  <a href="/docs/phoenix/self-hosting/deployment-options/aws-with-cloudformation"><img src="https://img.shields.io/badge/Deploy%20to-AWS-FF9900?logo=amazonwebservices&logoColor=white&labelColor=232F3E" alt="Deploy to AWS" height="30" noZoom /></a>
-</p>
-
-<Note>
-  The Google Cloud button builds Phoenix from source in Cloud Shell rather than deploying the prebuilt Docker Hub image. The Azure template serves plain HTTP (Azure Container Instances does not terminate TLS) — front it with a TLS proxy such as an Application Gateway before production use.
-</Note>
-
 ## Choose Your Deployment
 
 <CardGroup cols={3}>
@@ -60,7 +40,16 @@ Deploy Phoenix to the cloud of your choice with a single click:
     CloudFormation
   </Card>
   <Card title="Railway" href="/docs/phoenix/self-hosting/deployment-options/railway" icon="train">
+    One-click template
+  </Card>
+  <Card title="Render" href="/docs/phoenix/self-hosting/deployment-options/render" icon="server">
+    One-click blueprint
+  </Card>
+  <Card title="Google Cloud Run" href="/docs/phoenix/self-hosting/deployment-options/google-cloud-run" icon="google">
     One-click deploy
+  </Card>
+  <Card title="Azure" href="/docs/phoenix/self-hosting/deployment-options/azure" icon="microsoft">
+    One-click ARM template
   </Card>
 </CardGroup>
 

--- a/docs/phoenix/self-hosting/deployment-options/azure.mdx
+++ b/docs/phoenix/self-hosting/deployment-options/azure.mdx
@@ -1,0 +1,39 @@
+---
+title: "Azure"
+description: Deploy Arize Phoenix on Azure Container Instances with a one-click ARM template.
+---
+
+You can deploy Arize Phoenix on [Azure Container Instances](https://azure.microsoft.com/en-us/products/container-instances) via a one-click ARM template. The template provisions Phoenix alongside an Azure Database for PostgreSQL flexible server for durable storage.
+
+## Deploy
+
+Use the following button to deploy the Phoenix template to Azure:
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FArize-ai%2Fphoenix%2Fmain%2Fazuredeploy.json" target="_blank">
+  <img src="https://aka.ms/deploytoazurebutton" alt="Deploy to Azure" height="30" noZoom />
+</a>
+
+## What the template provisions
+
+- A container group running the `arizephoenix/phoenix` image (2 CPU cores and 4 GB of memory by default) with a public DNS name
+- An Azure Database for PostgreSQL flexible server wired to Phoenix for durable storage
+- Authentication enabled by default, with a `PHOENIX_SECRET` and database password generated per deployment
+
+During deployment you choose an initial admin password and can override the image tag, CPU, memory, and region.
+
+<Warning>
+  Azure Container Instances does not terminate TLS, so the template serves plain HTTP on port 6006. Front the deployment with a TLS proxy such as an [Application Gateway](https://azure.microsoft.com/en-us/products/application-gateway) before production use.
+</Warning>
+
+## First login
+
+Once the container group is running, log in at the deployment's public DNS name on port 6006 with the default admin account:
+
+- **Email:** `admin@localhost`
+- **Password:** the initial admin password you chose during deployment
+
+You will be required to set a new password on first login.
+
+<Tip>
+  To review or customize the template, see [`azuredeploy.json`](https://github.com/Arize-ai/phoenix/blob/main/azuredeploy.json) in the Phoenix repository. Configuration options are documented in [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).
+</Tip>

--- a/docs/phoenix/self-hosting/deployment-options/azure.mdx
+++ b/docs/phoenix/self-hosting/deployment-options/azure.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Azure"
-description: Deploy Arize Phoenix on Azure Container Instances with a one-click ARM template.
+description: Use this guide to deploy Arize Phoenix on Azure Container Instances via the prebuilt ARM template.
 ---
 
-You can deploy Arize Phoenix on [Azure Container Instances](https://azure.microsoft.com/en-us/products/container-instances) via a one-click ARM template. The template provisions Phoenix alongside an Azure Database for PostgreSQL flexible server for durable storage.
+You can deploy Arize Phoenix on [Azure Container Instances](https://azure.microsoft.com/en-us/products/container-instances) via a prebuilt ARM template. The template runs the official Phoenix Docker image with an Azure Database for PostgreSQL flexible server and authentication enabled. It is defined by [`azuredeploy.json`](https://github.com/Arize-ai/phoenix/blob/main/azuredeploy.json) in the Phoenix repository, which is the source of truth for what gets provisioned.
 
 ## Deploy
 
@@ -13,27 +13,8 @@ Use the following button to deploy the Phoenix template to Azure:
   <img src="https://aka.ms/deploytoazurebutton" alt="Deploy to Azure" height="30" noZoom />
 </a>
 
-## What the template provisions
-
-- A container group running the `arizephoenix/phoenix` image (2 CPU cores and 4 GB of memory by default) with a public DNS name
-- An Azure Database for PostgreSQL flexible server wired to Phoenix for durable storage
-- Authentication enabled by default, with a `PHOENIX_SECRET` and database password generated per deployment
-
-During deployment you choose an initial admin password and can override the image tag, CPU, memory, and region.
-
 <Warning>
-  Azure Container Instances does not terminate TLS, so the template serves plain HTTP on port 6006. Front the deployment with a TLS proxy such as an [Application Gateway](https://azure.microsoft.com/en-us/products/application-gateway) before production use.
+  Azure Container Instances does not terminate TLS, so the template serves plain HTTP. Front the deployment with a TLS proxy such as an [Application Gateway](https://azure.microsoft.com/en-us/products/application-gateway) before production use.
 </Warning>
 
-## First login
-
-Once the container group is running, log in at the deployment's public DNS name on port 6006 with the default admin account:
-
-- **Email:** `admin@localhost`
-- **Password:** the initial admin password you chose during deployment
-
-You will be required to set a new password on first login.
-
-<Tip>
-  To review or customize the template, see [`azuredeploy.json`](https://github.com/Arize-ai/phoenix/blob/main/azuredeploy.json) in the Phoenix repository. Configuration options are documented in [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).
-</Tip>
+Once the container group is running, log in with the default admin account using the initial password you chose during deployment, as described in [Authentication](/docs/phoenix/self-hosting/features/authentication). To customize the instance, see [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).

--- a/docs/phoenix/self-hosting/deployment-options/google-cloud-run.mdx
+++ b/docs/phoenix/self-hosting/deployment-options/google-cloud-run.mdx
@@ -1,0 +1,43 @@
+---
+title: "Google Cloud Run"
+description: Deploy Arize Phoenix on Google Cloud Run with a one-click button.
+---
+
+You can deploy Arize Phoenix on [Google Cloud Run](https://cloud.google.com/run) with a one-click button. Cloud Run gives you a fully managed, autoscaling deployment with HTTPS out of the box.
+
+## Deploy
+
+Use the following button to deploy Phoenix to Cloud Run:
+
+<a href="https://deploy.cloud.run/?git_repo=https://github.com/Arize-ai/phoenix" target="_blank">
+  <img src="https://deploy.cloud.run/button.svg" alt="Run on Google Cloud" height="30" noZoom />
+</a>
+
+<Note>
+  The button clones the Phoenix repository into Cloud Shell and builds the image from source rather than deploying the prebuilt Docker Hub image. Expect the initial build to take several minutes.
+</Note>
+
+## What gets deployed
+
+The deployment runs Phoenix with 1 CPU and 1 GB of memory, and prompts you for configuration during setup:
+
+- Authentication is enabled by default, with a strong `PHOENIX_SECRET` generated for you
+- Secure cookies are enabled, since Cloud Run always serves over HTTPS
+- You can optionally set an initial admin password and a PostgreSQL connection string
+
+<Warning>
+  Cloud Run's container filesystem is ephemeral — data is lost whenever a new revision is deployed or an instance restarts. For anything beyond a quick trial, set `PHOENIX_SQL_DATABASE_URL` to a PostgreSQL instance (for example, [Cloud SQL](https://cloud.google.com/sql)) so your traces persist.
+</Warning>
+
+## First login
+
+Once the service is live, log in with the default admin account:
+
+- **Email:** `admin@localhost`
+- **Password:** `admin` (or the initial password you set during deployment)
+
+You will be required to set a new password on first login.
+
+<Tip>
+  Configuration options are documented in [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).
+</Tip>

--- a/docs/phoenix/self-hosting/deployment-options/google-cloud-run.mdx
+++ b/docs/phoenix/self-hosting/deployment-options/google-cloud-run.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Google Cloud Run"
-description: Deploy Arize Phoenix on Google Cloud Run with a one-click button.
+description: Use this guide to deploy Arize Phoenix on Google Cloud Run via the deploy button.
 ---
 
-You can deploy Arize Phoenix on [Google Cloud Run](https://cloud.google.com/run) with a one-click button. Cloud Run gives you a fully managed, autoscaling deployment with HTTPS out of the box.
+You can deploy Arize Phoenix on [Google Cloud Run](https://cloud.google.com/run) via a deploy button. The deployment runs Phoenix with authentication enabled and prompts you for configuration during setup. The prompts are defined by [`app.json`](https://github.com/Arize-ai/phoenix/blob/main/app.json) in the Phoenix repository, which is the source of truth for what gets provisioned.
 
 ## Deploy
 
@@ -14,30 +14,11 @@ Use the following button to deploy Phoenix to Cloud Run:
 </a>
 
 <Note>
-  The button clones the Phoenix repository into Cloud Shell and builds the image from source rather than deploying the prebuilt Docker Hub image. Expect the initial build to take several minutes.
+  The button clones the Phoenix repository into Cloud Shell and builds the image from source rather than deploying the prebuilt Docker Hub image.
 </Note>
-
-## What gets deployed
-
-The deployment runs Phoenix with 1 CPU and 1 GB of memory, and prompts you for configuration during setup:
-
-- Authentication is enabled by default, with a strong `PHOENIX_SECRET` generated for you
-- Secure cookies are enabled, since Cloud Run always serves over HTTPS
-- You can optionally set an initial admin password and a PostgreSQL connection string
 
 <Warning>
   Cloud Run's container filesystem is ephemeral — data is lost whenever a new revision is deployed or an instance restarts. For anything beyond a quick trial, set `PHOENIX_SQL_DATABASE_URL` to a PostgreSQL instance (for example, [Cloud SQL](https://cloud.google.com/sql)) so your traces persist.
 </Warning>
 
-## First login
-
-Once the service is live, log in with the default admin account:
-
-- **Email:** `admin@localhost`
-- **Password:** `admin` (or the initial password you set during deployment)
-
-You will be required to set a new password on first login.
-
-<Tip>
-  Configuration options are documented in [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).
-</Tip>
+Once the service is live, log in with the default admin account as described in [Authentication](/docs/phoenix/self-hosting/features/authentication). To customize the instance, see [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).

--- a/docs/phoenix/self-hosting/deployment-options/railway.mdx
+++ b/docs/phoenix/self-hosting/deployment-options/railway.mdx
@@ -12,3 +12,5 @@ Use the following button to deploy the Arize Phoenix template on Railway:
 <a href="https://railway.app/template/PTHRoq?referralCode=Xe2txW" target="_blank">
   <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/d2aee3a0-image.svg" alt="Deploy on Railway" />
 </a>
+
+To customize the instance, see [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).

--- a/docs/phoenix/self-hosting/deployment-options/render.mdx
+++ b/docs/phoenix/self-hosting/deployment-options/render.mdx
@@ -1,0 +1,37 @@
+---
+title: "Render"
+description: Deploy Arize Phoenix on Render via the one-click blueprint.
+---
+
+You can deploy Arize Phoenix on [Render](https://render.com/) via a one-click blueprint. The blueprint runs the official Phoenix Docker image alongside a managed PostgreSQL database for durable storage.
+
+## Deploy
+
+Use the following button to deploy the Phoenix blueprint on Render:
+
+<a href="https://render.com/deploy?repo=https://github.com/Arize-ai/phoenix" target="_blank">
+  <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="30" noZoom />
+</a>
+
+## What the blueprint provisions
+
+- A web service running the `arizephoenix/phoenix:latest` Docker image on the standard plan
+- A managed PostgreSQL database wired to Phoenix via `PHOENIX_SQL_DATABASE_URL`
+- Authentication enabled by default, with a strong `PHOENIX_SECRET` generated for you
+
+<Note>
+  Phoenix needs more than Render's 512 MB starter instance — heavy span queries will run the process out of memory. The blueprint defaults to the standard plan for this reason.
+</Note>
+
+## First login
+
+Once the service is live, log in with the default admin account:
+
+- **Email:** `admin@localhost`
+- **Password:** `admin`
+
+You will be required to set a new password on first login.
+
+<Tip>
+  To review or customize the blueprint (instance size, environment variables, admin password), see [`render.yaml`](https://github.com/Arize-ai/phoenix/blob/main/render.yaml) in the Phoenix repository. Configuration options are documented in [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).
+</Tip>

--- a/docs/phoenix/self-hosting/deployment-options/render.mdx
+++ b/docs/phoenix/self-hosting/deployment-options/render.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Render"
-description: Deploy Arize Phoenix on Render via the one-click blueprint.
+description: Use this guide to deploy Arize Phoenix on Render via the prebuilt blueprint.
 ---
 
-You can deploy Arize Phoenix on [Render](https://render.com/) via a one-click blueprint. The blueprint runs the official Phoenix Docker image alongside a managed PostgreSQL database for durable storage.
+You can deploy Arize Phoenix on [Render](https://render.com/) via a prebuilt blueprint. The blueprint runs the official Phoenix Docker image with a managed PostgreSQL database and authentication enabled. It is defined by [`render.yaml`](https://github.com/Arize-ai/phoenix/blob/main/render.yaml) in the Phoenix repository, which is the source of truth for what gets provisioned.
 
 ## Deploy
 
@@ -13,25 +13,4 @@ Use the following button to deploy the Phoenix blueprint on Render:
   <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height="30" noZoom />
 </a>
 
-## What the blueprint provisions
-
-- A web service running the `arizephoenix/phoenix:latest` Docker image on the standard plan
-- A managed PostgreSQL database wired to Phoenix via `PHOENIX_SQL_DATABASE_URL`
-- Authentication enabled by default, with a strong `PHOENIX_SECRET` generated for you
-
-<Note>
-  Phoenix needs more than Render's 512 MB starter instance — heavy span queries will run the process out of memory. The blueprint defaults to the standard plan for this reason.
-</Note>
-
-## First login
-
-Once the service is live, log in with the default admin account:
-
-- **Email:** `admin@localhost`
-- **Password:** `admin`
-
-You will be required to set a new password on first login.
-
-<Tip>
-  To review or customize the blueprint (instance size, environment variables, admin password), see [`render.yaml`](https://github.com/Arize-ai/phoenix/blob/main/render.yaml) in the Phoenix repository. Configuration options are documented in [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).
-</Tip>
+Once the service is live, log in with the default admin account as described in [Authentication](/docs/phoenix/self-hosting/features/authentication). To customize the instance, see [Environment Variables](/docs/phoenix/self-hosting/configuration#environment-variables).


### PR DESCRIPTION
## Summary

Cleans up the [self-hosting landing page](https://arize.com/docs/phoenix/self-hosting) by removing the wall of one-click deploy buttons and incorporating them into the docs the cleaner way: each cloud provider gets its own deployment-options guide, with the deploy button living next to that provider's specific caveats.

The one-click buttons remain on the top-level README.

## Design

All four one-click pages (Railway, Render, Google Cloud Run, Azure) share a uniform, minimal shape so they're easy to maintain:

1. One-paragraph intro that names the in-repo deploy template (`render.yaml`, `app.json`, `azuredeploy.json`) as the source of truth for what gets provisioned
2. The deploy button
3. Only the caveats that would bite users (Cloud Run: builds from source, ephemeral filesystem needs `PHOENIX_SQL_DATABASE_URL`; Azure: plain HTTP, front with a TLS proxy)
4. A closing line linking to the Authentication and Environment Variables docs instead of repeating login credentials or provisioning details that would drift

## Changes

- **New pages**: `deployment-options/render.mdx`, `google-cloud-run.mdx`, `azure.mdx`; `railway.mdx` aligned to the same shape
- **`self-hosting.mdx`** — removed the "One-Click Deploy" button section; the "Choose Your Deployment" grid is now a clean 3×3 covering Terminal, Docker, Kubernetes, Helm, AWS, Railway, Render, Google Cloud Run, and Azure
- **`docs.json`** — new pages added to the Deployment Options nav group
- **`llms.txt`** — entries added for the three new pages

## Testing

- `docs.json` parses as valid JSON
- All internal links on the new/edited pages resolve to real files
- phoenix-cli docs parser tests pass (32/32)