### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -249,6 +249,7 @@
 - [LiteLLM Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/litellm/litellm-tracing): Auto-instrument LiteLLM unified API calls
 - [MistralAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai/mistralai-tracing): Auto-instrument MistralAI SDK
 - [OpenRouter Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/openrouter/openai-tracing): Trace OpenRouter API calls
+- [OrcaRouter Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing): Auto-instrument OrcaRouter via its OpenAI-compatible endpoint with openinference-instrumentation-openai
 - [VertexAI Tracing](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai/vertexai-tracing): Auto-instrument VertexAI SDK
 
 ### Python Frameworks
@@ -377,6 +378,7 @@
 - [MistralAI](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai): Mistral AI develops open-weight large language models, focusing on efficiency, customization, and
 - [OpenAI](https://arize.com/docs/phoenix/integrations/llm-providers/openai): OpenAI provides state-of-the-art LLMs for natural language understanding and generation
 - [OpenRouter](https://arize.com/docs/phoenix/integrations/llm-providers/openrouter): OpenRouter is a platform that connects developers to multiple AI models through a unified API, making it
+- [OrcaRouter](https://arize.com/docs/phoenix/integrations/llm-providers/orcarouter): OrcaRouter is an OpenAI-compatible AI gateway that routes requests across 200+ models
 - [VertexAI](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai): Vertex AI is a fully managed platform by Google Cloud for building, deploying, and scaling machine learning
 ## Settings
 
@@ -432,9 +434,6 @@
 ### Evaluation
 
 - [LLM as a Judge](https://arize.com/docs/phoenix/evaluation/concepts-evals/llm-as-a-judge): LLM-based evaluation best practices
-- [Eval Data Types](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluation-types): Categorize evaluations by output type — categorical, numeric, and continuous scores
-- [Custom Task Evaluation](https://arize.com/docs/phoenix/evaluation/concepts-evals/building-your-own-evals): Design and customize your own evaluator templates for task-specific quality checks
-- [Evaluating Multi-Agent Systems](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluating-multi-agent-systems): Evaluate multi-agent architectures with strategies for routing, coordination, and per-agent scoring
 
 ## Resources
 
@@ -792,6 +791,7 @@
 - [06.24.2026 Annotations, Labels, and PXI Server Tools](https://arize.com/docs/phoenix/release-notes/06-2026/06-24-2026-annotations-labels-and-pxi-server-tools): Trace-level annotations in the trace header, label management from prompts and datasets lists, and a server-side bash tool for PXI subagents
 - [06.26.2026 Evals as Tests — pytest and Vitest/Jest](https://arize.com/docs/phoenix/release-notes/06-2026/06-26-2026-eval-ci-pytest-vitest-jest): Write LLM evaluations as pytest, Vitest, or Jest tests that record every run to Phoenix and gate CI
 - [06.30.2026 PXI Terminal Client and Annotation Summary](https://arize.com/docs/phoenix/release-notes/06-2026/06-30-2026-pxi-terminal-client-and-annotation-summary): Run PXI as an interactive terminal chat from the CLI; review and bulk-delete annotations from project settings
+- [07.07.2026: Metric Charts, Trace Search, and REST API Expansion](https://arize.com/docs/phoenix/release-notes/07-2026/07-07-2026-metric-charts-trace-search-and-rest-api): Pin metric charts above data tables, search the trace tree, manage labels and annotation configs over REST, and use Claude Sonnet 5 in the Playground
 
 ### 2025
 


### PR DESCRIPTION
## Summary

Audited `docs/phoenix/llms.txt` for coverage against the docs tree (intersection of `docs.json` navigation and on-disk `.mdx` files, cross-checked against `sitemap.xml`). Added missing pages, removed stale entries that no longer route in production, and kept descriptions concise.

Nav-published pages: **664**. Indexed after this change: **657** (the 7 unindexed pages are all intentional exclusions — see below). Coverage ≈ **98.9%**, well above the 90% AFDocs target.

## Added (3)

- **OrcaRouter** — `integrations/llm-providers/orcarouter` (LLM provider overview)
- **OrcaRouter Tracing** — `integrations/llm-providers/orcarouter/openai-tracing` (real instrumentation guide using `openinference-instrumentation-openai`)
- **07.07.2026: Metric Charts, Trace Search, and REST API Expansion** — `release-notes/07-2026/07-07-2026-metric-charts-trace-search-and-rest-api` (newest release note; placed in the `### 2026` subsection)

## Removed (3 stale)

These three `.mdx` files exist on disk but are **not in `docs.json` navigation and not in `sitemap.xml`** — they 404 in production (they appear only as redirect *destinations*, not as routed pages):

- `evaluation/concepts-evals/evaluation-types` (was "Eval Data Types")
- `evaluation/concepts-evals/building-your-own-evals` (was "Custom Task Evaluation")
- `evaluation/concepts-evals/evaluating-multi-agent-systems` (was "Evaluating Multi-Agent Systems")

## Verified as intentional exclusions (no action)

- `agent-assisted-setup` — for AI coding agents, not doc consumers
- `end-to-end-features-notebook` — Colab notebook link
- `phoenix-demo` — interactive demo, not fetchable
- `resources/github`, `resources/openinference` — bare external `github.com` redirects with no docs content
- `resources/python-api`, `resources/typescript-api` — internal redirects to already-indexed SDK reference pages

## Notes

- Existing entries with `.`/`+` in their URLs (e.g. `...claude-sonnet-4.5`, `...openai-5-1-+-gemini-3`, `...vs.-langsmith`) were verified to be nav-published and already correctly indexed.
- No other description edits were needed; existing descriptions are within the 5–20 word action-oriented guideline.
