### PR TITLE
fix(ui): contain timeout fallback in chart panels

### DIFF
--- a/app/src/components/exception/BugReportErrorBoundaryFallback.tsx
+++ b/app/src/components/exception/BugReportErrorBoundaryFallback.tsx
@@ -7,6 +7,31 @@ import { View } from "../core/view";
 import { isConnectionTimeoutError } from "./isConnectionTimeoutError";
 import type { ErrorBoundaryFallbackProps } from "./types";
 
+const containedFallbackCSS = css`
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  height: 100%;
+  max-height: 100%;
+  padding: var(--global-dimension-size-200);
+  overflow: auto;
+  overflow-wrap: anywhere;
+
+  > .flex,
+  details,
+  pre {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  h1 {
+    max-width: 100%;
+    text-align: center;
+    overflow-wrap: anywhere;
+  }
+`;
+
 export function BugReportErrorBoundaryFallback({
   error,
 }: ErrorBoundaryFallbackProps) {
@@ -58,7 +83,7 @@ function ConnectionTimeoutFallback({
   error: string | null | undefined;
 }) {
   return (
-    <View padding="size-200">
+    <div css={containedFallbackCSS} data-testid="connection-timeout-fallback">
       <Flex direction="column">
         <Flex direction="column" width="100%" alignItems="center">
           <h1>Connection timed out</h1>
@@ -107,6 +132,6 @@ function ConnectionTimeoutFallback({
           </details>
         )}
       </Flex>
-    </View>
+    </div>
   );
 }

--- a/app/src/components/exception/__tests__/BugReportErrorBoundaryFallback.test.tsx
+++ b/app/src/components/exception/__tests__/BugReportErrorBoundaryFallback.test.tsx
@@ -1,0 +1,46 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { BugReportErrorBoundaryFallback } from "../BugReportErrorBoundaryFallback";
+
+describe("BugReportErrorBoundaryFallback", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("contains timeout details within a bounded parent", () => {
+    act(() => {
+      root.render(
+        <BugReportErrorBoundaryFallback error="504 Gateway Timeout" />
+      );
+    });
+
+    const fallback = container.querySelector<HTMLElement>(
+      '[data-testid="connection-timeout-fallback"]'
+    );
+    expect(fallback).not.toBeNull();
+
+    const style = getComputedStyle(fallback!);
+    expect(style.boxSizing).toBe("border-box");
+    expect(style.width).toBe("100%");
+    expect(style.maxWidth).toBe("100%");
+    expect(style.minWidth).toBe("0px");
+    expect(style.height).toBe("100%");
+    expect(style.maxHeight).toBe("100%");
+    expect(style.overflow).toBe("auto");
+  });
+});


### PR DESCRIPTION
resolves #14353

## Summary

- constrain the connection-timeout fallback to its parent dimensions
- allow long fallback content to scroll inside fixed-height chart panels
- preserve the existing timeout detection and copy
- add computed-style regression coverage

## Testing

- `pnpm test -- BugReportErrorBoundaryFallback.test.tsx isConnectionTimeoutError.test.ts`
- targeted `oxfmt --check`
- targeted `oxlint`
- `pnpm typecheck`
- `git diff --check`