### PR TITLE
docs(skills): weekly audit — 2026-07-15

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -135,7 +135,9 @@ px auth status --profile staging              # check a named profile's connecti
 
 Named profiles let you switch between multiple Phoenix instances (local, staging, cloud) without juggling environment variables. Profiles are stored in `~/.px/settings.json` (or `$XDG_CONFIG_HOME/px/settings.json`).
 
-Configuration priority (highest to lowest): CLI flags > env vars > active profile > built-in defaults.
+Configuration priority (highest to lowest): CLI flags > env vars > active profile > nearest `.env.phoenix` file > built-in defaults.
+
+The CLI also discovers the nearest `.env.phoenix` file at or above the current working directory (the same file `px setup` writes). Credentials are resolved as one group, so a process API key is never combined with file-provided headers. Set `PHOENIX_DISCOVER_CONFIG=false` to disable discovery.
 
 ```bash
 px profile list                              # list all profiles (shows active profile)

--- a/.agents/skills/phoenix-evals/references/evaluate-dataframe-python.md
+++ b/.agents/skills/phoenix-evals/references/evaluate-dataframe-python.md
@@ -15,7 +15,7 @@ results_df = await async_evaluate_dataframe(
     evaluators=[eval1, eval2], # List of evaluators
     concurrency=5,             # Max concurrent LLM calls (default 3)
     exit_on_error=False,       # Optional: stop on first error (default True)
-    max_retries=3,             # Optional: retry failed LLM calls (default 10)
+    max_retries=3,             # Optional: retry failed or timed-out LLM calls (default 10)
 )
 ```
 
@@ -28,7 +28,7 @@ results_df = evaluate_dataframe(
     dataframe=df,              # pandas DataFrame with columns matching evaluator params
     evaluators=[eval1, eval2], # List of evaluators
     exit_on_error=False,       # Optional: stop on first error (default True)
-    max_retries=3,             # Optional: retry failed LLM calls (default 10)
+    max_retries=3,             # Optional: retry failed or timed-out LLM calls (default 10)
 )
 ```
 

--- a/.agents/skills/phoenix-tracing/references/projects-python.md
+++ b/.agents/skills/phoenix-tracing/references/projects-python.md
@@ -13,15 +13,18 @@ Projects group traces for a single application or experiment.
 ### Environment Variable (Recommended)
 
 ```bash
-export PHOENIX_PROJECT_NAME="my-app-prod"
+export PHOENIX_PROJECT="my-app-prod"  # PHOENIX_PROJECT_NAME is a supported alias
 ```
 
 ```python
 import os
-os.environ["PHOENIX_PROJECT_NAME"] = "my-app-prod"
+os.environ["PHOENIX_PROJECT"] = "my-app-prod"
 from phoenix.otel import register
 register()  # Uses "my-app-prod"
 ```
+
+`PHOENIX_PROJECT` is canonical and takes precedence over the `PHOENIX_PROJECT_NAME`
+alias when both are set.
 
 ### Code
 

--- a/.agents/skills/phoenix-tracing/references/projects-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/projects-typescript.md
@@ -13,14 +13,17 @@ Projects group traces for a single application or experiment.
 ### Environment Variable (Recommended)
 
 ```bash
-export PHOENIX_PROJECT_NAME="my-app-prod"
+export PHOENIX_PROJECT="my-app-prod"  # PHOENIX_PROJECT_NAME is a supported alias
 ```
 
 ```typescript
-process.env.PHOENIX_PROJECT_NAME = "my-app-prod";
+process.env.PHOENIX_PROJECT = "my-app-prod";
 import { register } from "@arizeai/phoenix-otel";
 register();  // Uses "my-app-prod"
 ```
+
+`PHOENIX_PROJECT` is canonical and takes precedence over the `PHOENIX_PROJECT_NAME`
+alias when both are set.
 
 ### Code
 

--- a/.agents/skills/phoenix-tracing/references/setup-python.md
+++ b/.agents/skills/phoenix-tracing/references/setup-python.md
@@ -33,8 +33,32 @@ pip install arize-phoenix-otel
 ```bash
 export PHOENIX_API_KEY="your-api-key"  # Required for Phoenix Cloud
 export PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"  # Or Cloud URL
-export PHOENIX_PROJECT_NAME="my-app"  # Optional
+export PHOENIX_PROJECT="my-app"  # Optional; PHOENIX_PROJECT_NAME is a supported alias
 ```
+
+`PHOENIX_PROJECT` is the canonical project-name variable and takes precedence;
+`PHOENIX_PROJECT_NAME` is a supported alias. If both are set to different
+values, `PHOENIX_PROJECT` wins and a one-time warning naming both is logged.
+
+### Credential File Discovery (`.env.phoenix`)
+
+When a setting is not passed as an argument or set in the process environment,
+`register()` looks for a `.env.phoenix` file in the current working directory —
+walking up toward the filesystem root and stopping at the first match — and
+reads `PHOENIX_`-prefixed keys from it (dotenv format):
+
+```bash
+# .env.phoenix
+PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006
+PHOENIX_API_KEY=your-api-key
+```
+
+Explicit arguments and environment variables always win — the file never
+overrides anything already set. Set `PHOENIX_DISCOVER_CONFIG=false` to disable
+discovery. Discovery is cached per working directory for the process lifetime;
+long-running processes (e.g. notebooks) can call
+`phoenix.otel.settings.clear_env_file_cache()` after creating or changing the
+file.
 
 ### Python Code
 
@@ -51,7 +75,7 @@ tracer_provider = register(
 
 **Parameters:**
 
-- `project_name`: Project name (overrides `PHOENIX_PROJECT_NAME`)
+- `project_name`: Project name (overrides `PHOENIX_PROJECT` / `PHOENIX_PROJECT_NAME`)
 - `endpoint`: Phoenix URL (overrides `PHOENIX_COLLECTOR_ENDPOINT`)
 - `auto_instrument`: Enable auto-instrumentation (default: False)
 - `batch`: Use BatchSpanProcessor (default: True, production-recommended)

--- a/.agents/skills/phoenix-tracing/references/setup-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/setup-typescript.md
@@ -40,8 +40,29 @@ register({
 ```bash
 export PHOENIX_API_KEY="your-api-key"
 export PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"
-export PHOENIX_PROJECT_NAME="my-app"
+export PHOENIX_PROJECT="my-app"  # PHOENIX_PROJECT_NAME is a supported alias
 ```
+
+`PHOENIX_PROJECT` is the canonical project-name variable and takes precedence;
+`PHOENIX_PROJECT_NAME` is a supported alias. If both are set to different
+values, `PHOENIX_PROJECT` wins and a one-time warning naming both is logged.
+
+### Credential File Discovery (`.env.phoenix`)
+
+When a setting is not passed to `register()` or set in the process environment,
+`@arizeai/phoenix-otel` looks for a `.env.phoenix` file in the current working
+directory — walking up toward the filesystem root and stopping at the first
+match — and reads `PHOENIX_`-prefixed keys from it (dotenv format):
+
+```bash
+# .env.phoenix
+PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006
+PHOENIX_API_KEY=your-api-key
+```
+
+Explicit arguments and environment variables always win — the file never
+overrides anything already set. Set `PHOENIX_DISCOVER_CONFIG=false` to disable
+discovery.
 
 ## ESM vs CommonJS
 


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-07-08 → 2026-07-15 (last 7 days)

**Audited against:** `origin/main` at `047694f72024b0938309c14dca42c158d15219b1`
**Commits analyzed:** 110 (4 user-facing edits, rest skipped as internal/UI/deps/release)

## Edits applied

### phoenix-tracing

- `references/setup-python.md` — Two user-facing SDK changes:
  - **`PHOENIX_PROJECT` is now the canonical project-name env var** (`PHOENIX_PROJECT_NAME` is a supported alias, `PHOENIX_PROJECT` wins on conflict, one-time warning logged). Changed the env-var example and the `project_name` parameter note. Grounded in `packages/phoenix-otel/src/phoenix/otel/settings.py:41-73` and `packages/phoenix-client/src/phoenix/client/utils/config.py:108-137` (commit `1e7d9fc3c`).
  - **`.env.phoenix` credential-file discovery** — added a section documenting the walk-up dotenv discovery, precedence (args/env always win), the `PHOENIX_DISCOVER_CONFIG=false` opt-out, and `phoenix.otel.settings.clear_env_file_cache()`. Grounded in `packages/phoenix-otel/src/phoenix/otel/settings.py:24-28,69-70,188` (commit `c0ab6a971`).
- `references/setup-typescript.md` — Mirror of the above for `@arizeai/phoenix-otel`: canonical `PHOENIX_PROJECT` + alias, and a `.env.phoenix` discovery section with `PHOENIX_DISCOVER_CONFIG=false`. Grounded in `js/packages/phoenix-config/src/envFileParser.ts:17` (`ENV_PHOENIX_DISCOVER_CONFIG = "PHOENIX_DISCOVER_CONFIG"`) and `js/packages/phoenix-config/src/envFile.test.ts` (`getProjectFromEnvironment` precedence tests) (commits `1e7d9fc3c`, `c0ab6a971`).
- `references/projects-python.md` — Updated the recommended env-var example from `PHOENIX_PROJECT_NAME` to `PHOENIX_PROJECT` with an alias/precedence note (commit `1e7d9fc3c`).
- `references/projects-typescript.md` — Same update for the TS example (commit `1e7d9fc3c`).

### phoenix-cli

- `SKILL.md` — Updated the **configuration-priority line** in the Profiles section to insert the `.env.phoenix` tier between the active profile and built-in defaults, and added a short note on `.env.phoenix` discovery + the `PHOENIX_DISCOVER_CONFIG=false` opt-out. This reconciles the skill with the CLI's actual precedence (`js/packages/phoenix-cli/README.md`, commit `c0ab6a971`) and the existing `px setup` section, which already documents writing `.env.phoenix`.

### phoenix-evals

- `references/evaluate-dataframe-python.md` — Updated the `max_retries` inline comment (both `async_evaluate_dataframe` and `evaluate_dataframe` snippets) from "retry failed LLM calls" to "retry failed or timed-out LLM calls." **Behavior change:** timeouts now decrement retry priority and count against `max_retries` instead of requeuing forever; the docstring was updated to "retry on exceptions or timeouts." Grounded in `packages/phoenix-evals/src/phoenix/evals/executors.py:183-341` (commit `90eee082b`).

## Notable non-edits (tagged in triage, then dropped with reason)

- **`32458453c` feat(tracing): surface `user.id` span attribute** — Server/GraphQL + frontend change that *displays* the existing OpenInference `SpanAttributes.USER_ID` (`user.id`) in the UI. It does not change how the attribute is *set*, which the tracing skill already documents (`references/fundamentals-universal-attributes.md`, `references/sessions-*.md`). The CLI does not select the new GraphQL `userId` field, and `user.id` already appears in the CLI's span-attribute filter examples. No skill edit needed.
- **`cd173576e` feat(sessions)!: interval-overlap session time-range filters** — Breaking change to GraphQL/server session filtering semantics. The `px session` CLI command exposes no time-range flags (`--since`/`--last-n-minutes` exist only for `trace`/`span`), so the change is not surfaced through any of the three skills. Server/UI only.
- **`fa79dc0f2` feat(client): `name_contains` filter on Python `projects.list()`** — A project-management method on the generic Python client; not documented in any of the three skills (tracing covers *setting* the project for instrumentation, not project CRUD). No hand-written TS resource mirror exists (only the generated REST types in `js/packages/phoenix-client/src/__generated__/api/v1.ts` carry the filter), so this is effectively Python-only at the resource-method level — flagging in case the TS client should gain a matching wrapper.

## Skipped commits (representative)

- **Releases / version bumps / deps:** `8acd96d16`, `5c8941a09`, `6249d4807`, `079da29a4`, `510c1e9b3`, `284a05bad`, `d7a21d924`, `75d06c263`, `92e027e54`, and the various `chore: update phoenix version …` / `chore(main): release …` / `chore(js): update versions` entries.
- **Frontend-only (`app/src/`) UI features:** `3a8061b4a` (⌘K search), `522a9a9e0` (session annotation editing), `8a75d673c` (playground error count), `2f2c4c135`/`4da943b5d` (column reordering), `2858f8f49`, `93016bfa5`, `12be3cc94` (batch annotation-config management — UI toolbar only), `c9770a27d`, `02eb5dc1b`, `f1eb3b8fa`, `2c00ee52c`, and other `feat(ui)`/`fix(ui)` commits.
- **PXI / agent internals:** `dcf466c95`, `1dbf5ff6a` (debug feature flag), `e4b94b404`, `61fc1e46b`, `ea40aea40`, `189271b38`, `2d5052cd0`, `cb765a385` (`app/scripts/setup-remote-export.ts` — internal dev script + Makefile target, not a `px` command), `a6f867ea1`, `029b6f6c2`.
- **Playground/cost model data:** `2128417de` (adds GPT 5.6 to the playground/PXI curated model list in `playground_clients.py` + `agentCuratedModels.ts` — not a `phoenix-evals` evaluator or model wrapper), `047694f72` / `6f16e4ead` (built-in token-price updates).
- **Docs / CI / tests / server-internal:** `ec7aba56b`, `7a2d9bd3b`, `52f05c470`, `377a5fa15`, `04f5e40f2`, `15b3069ad`, `c26fdfeb3`, `36d0e6ef0`, `cd3989660`, `55e058e8a`, `bcb9527c8` (TS 7 migration), and similar.

## Out-of-scope findings (for other skill owners)

- `32458453c` (user.id in UI) and `cd173576e` (session filter semantics) are user-visible in the Phoenix app and may warrant updates to `phoenix-server` / `phoenix-frontend` docs — not edited here.
- `fa79dc0f2` (`projects.list(name_contains=...)`) is a generic-client feature with no matching TS resource wrapper; a client-docs owner may want to mirror it in `@arizeai/phoenix-client`.
