### PR TITLE
fix(ui): label condensed add-to-dataset action

### DIFF
--- a/app/src/pages/trace/AddSpanToDatasetTrigger.tsx
+++ b/app/src/pages/trace/AddSpanToDatasetTrigger.tsx
@@ -1,0 +1,27 @@
+import {
+  Button,
+  Icon,
+  Icons,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
+
+export function AddSpanToDatasetTrigger({
+  buttonText,
+}: {
+  buttonText: string | null;
+}) {
+  return (
+    <TooltipTrigger delay={0} isDisabled={buttonText !== null}>
+      <Button
+        aria-label="Add to Dataset"
+        variant="default"
+        size="S"
+        leadingVisual={<Icon svg={<Icons.Database />} />}
+      >
+        {buttonText}
+      </Button>
+      <Tooltip>Add to Dataset</Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -23,7 +23,6 @@ import { useNavigate } from "react-router";
 import type { CardProps } from "@phoenix/components";
 import {
   Alert,
-  Button,
   Card,
   ContextualHelp,
   CopyToClipboardButton,
@@ -93,6 +92,7 @@ import type {
   SpanDetailsQuery,
   SpanDetailsQuery$data,
 } from "./__generated__/SpanDetailsQuery.graphql";
+import { AddSpanToDatasetTrigger } from "./AddSpanToDatasetTrigger";
 import { DocumentItem } from "./DocumentItem";
 import { PreBlock, ReadonlyJSONBlock } from "./ReadonlyJSONBlock";
 import { SpanAside } from "./SpanAside";
@@ -456,13 +456,7 @@ function AddSpanToDatasetButton({
   const navigate = useNavigate();
   return (
     <DialogTrigger>
-      <Button
-        variant="default"
-        size="S"
-        leadingVisual={<Icon svg={<Icons.Database />} />}
-      >
-        {buttonText}
-      </Button>
+      <AddSpanToDatasetTrigger buttonText={buttonText} />
       <ModalOverlay>
         <Modal variant="slideover" size="L">
           <Suspense fallback={<Loading />}>

--- a/app/src/pages/trace/__tests__/AddSpanToDatasetTrigger.test.tsx
+++ b/app/src/pages/trace/__tests__/AddSpanToDatasetTrigger.test.tsx
@@ -1,0 +1,78 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
+
+import { AddSpanToDatasetTrigger } from "../AddSpanToDatasetTrigger";
+
+describe("AddSpanToDatasetTrigger", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function render(buttonText: string | null) {
+    act(() => {
+      root.render(
+        <ThemeProvider themeMode="dark">
+          <AddSpanToDatasetTrigger buttonText={buttonText} />
+        </ThemeProvider>
+      );
+    });
+  }
+
+  it("keeps a stable accessible name in the labeled state", () => {
+    render("Add to Dataset");
+
+    const button = container.querySelector("button");
+    expect(button?.getAttribute("aria-label")).toBe("Add to Dataset");
+    expect(button?.textContent).toBe("Add to Dataset");
+
+    act(() => {
+      button?.focus();
+    });
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it("shows a tooltip when the icon-only state is focused", () => {
+    vi.useFakeTimers();
+    render(null);
+
+    const button = container.querySelector("button");
+    expect(button?.getAttribute("aria-label")).toBe("Add to Dataset");
+    expect(button?.textContent).toBe("");
+
+    act(() => {
+      button?.focus();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(document.body.querySelector('[role="tooltip"]')?.textContent).toBe(
+      "Add to Dataset"
+    );
+  });
+});


### PR DESCRIPTION
resolves #14338

## Summary

- give the Add to Dataset action a stable accessible name in both labeled and condensed states
- show an Add to Dataset tooltip only when the action is icon-only
- add regression coverage for the labeled and condensed states

## Testing

- `vitest run src/pages/trace/__tests__/AddSpanToDatasetTrigger.test.tsx` (2 passed)
- `tsc --noEmit`
- `oxfmt --check` on the changed files
- `oxlint` on the changed files
