### PR TITLE
feat(cli): offer the Phoenix docs MCP server during px setup

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -88,7 +88,12 @@ px setup --no-input --instrument --agent claude --yolo --format raw
 
 `--yolo` matters: a background agent has no terminal to approve its edits on,
 so without it the run stalls until trace verification times out. `--language
-python` skips the agent's language detection. `--format raw` prints
+python` skips the agent's language detection. `--docs-mcp` connects the
+Phoenix docs MCP server to the hand-off agent (`claude mcp add` for claude,
+config-file merge for cursor/opencode; codex unsupported) and skips the
+`.px/docs` download — the agent searches docs on demand instead; any failure
+falls back to the download. `--no-docs-mcp` suppresses the interactive offer.
+`--format raw` prints
 `{"endpoint","project","files","instrumentation","tracesVerified","tracesUrl"}`
 — check `tracesVerified`, which is set only when the API confirmed a trace
 arriving, not when the agent claims it finished.

--- a/js/packages/phoenix-cli/.gitignore
+++ b/js/packages/phoenix-cli/.gitignore
@@ -2,3 +2,8 @@ build/
 
 # Added by px setup — local Phoenix credentials
 .env.phoenix
+
+# Agent MCP configs written by dogfooding `px setup --docs-mcp` in this package
+.mcp.json
+opencode.json
+.cursor/

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -148,6 +148,14 @@ hands a coding agent (Claude Code, Codex, Cursor, OpenCode) an instrumentation
 task and waits until a real trace appears. After that it can point `px` at the
 new project and install Phoenix skills so the agent can query what you captured.
 
+Along the way it offers to connect the Phoenix docs MCP server to the agent
+doing the hand-off — through the agent's own CLI where it has one (`claude mcp
+add`), else its per-project config file (`.cursor/mcp.json`, `opencode.json`).
+Taking the offer skips the `.px/docs` download entirely — the agent searches
+the docs on demand instead, which is faster to set up and cheaper in tokens.
+Any failure falls back to the download. Pass `--docs-mcp` to take the offer
+without being asked, `--no-docs-mcp` to never ask.
+
 For CI or agents, pass flags instead of answering prompts:
 
 ```bash
@@ -156,6 +164,9 @@ px setup --no-input --endpoint http://localhost:6006 --project my-app
 
 # Instrument too — requires --agent when there's no TTY to choose one
 px setup --no-input --instrument --agent claude --yolo --language python --format raw
+
+# Same, but connect the docs MCP instead of downloading the docs
+px setup --no-input --instrument --agent claude --yolo --docs-mcp --format raw
 ```
 
 Re-run pieces later with:

--- a/js/packages/phoenix-cli/src/commands/formatSetup.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSetup.ts
@@ -27,6 +27,12 @@ export interface SetupOutput {
     /** Pages that failed to download; the agent reads those from the web. */
     failed: number;
   };
+  /** The docs MCP offer; "configured" means the docs prefetch was replaced. */
+  docsMcp?: {
+    outcome: "configured" | "declined" | "failed";
+    agents: string[];
+    files: string[];
+  };
   instrumentation?: {
     lane: "agent" | "clipboard" | "manual";
     agent?: string;
@@ -39,7 +45,7 @@ export interface SetupOutput {
 }
 
 export function toSetupOutput(report: SetupReport): SetupOutput {
-  const { docs, instrumentation } = report;
+  const { docs, docsMcp, instrumentation } = report;
   return {
     endpoint: report.connection.endpoint,
     project: report.connection.projectName,
@@ -53,6 +59,16 @@ export function toSetupOutput(report: SetupReport): SetupOutput {
       pages: docs.written,
       failed: docs.failed,
     },
+    // The report already omits a skipped offer; the guard also narrows the
+    // outcome union for the flat envelope.
+    docsMcp:
+      docsMcp && docsMcp.outcome !== "skipped"
+        ? {
+            outcome: docsMcp.outcome,
+            agents: docsMcp.agents,
+            files: docsMcp.files,
+          }
+        : undefined,
     instrumentation:
       instrumentation &&
       (instrumentation.kind === "agent"

--- a/js/packages/phoenix-cli/src/commands/setup.ts
+++ b/js/packages/phoenix-cli/src/commands/setup.ts
@@ -128,6 +128,16 @@ interface SetupCommandOptions {
    */
   docs?: boolean;
   /**
+   * `--docs-mcp` / `--no-docs-mcp`: Connect the Phoenix docs MCP server to the
+   * coding agent taking the hand-off (via the agent's own `mcp` subcommand
+   * when it has one, else its per-project config file); when taken, the docs
+   * prefetch is skipped — the agent searches the docs on demand instead.
+   * Undefined leaves it as an interactive prompt (headless runs then skip it).
+   *
+   * @example true // px setup --no-input --instrument --agent claude --docs-mcp --yolo
+   */
+  docsMcp?: boolean;
+  /**
    * `--workflow <name>`: Docs workflow to prefetch, repeatable. Same values as
    * `px docs fetch`; defaults to that command's defaults.
    *
@@ -217,6 +227,7 @@ function toSetupOptions(options: SetupCommandOptions): SetupOptions {
       refresh: options.refreshDocs,
       workers: options.workers,
     },
+    docsMcp: options.docsMcp,
   };
 }
 
@@ -362,6 +373,11 @@ function addInstrumentationOptions(command: Command): Command {
     )
     .option("--no-docs", "Skip the docs prefetch")
     .option(
+      "--docs-mcp",
+      "Connect the Phoenix docs MCP server to the hand-off agent (skips the docs prefetch)"
+    )
+    .option("--no-docs-mcp", "Skip the docs MCP offer")
+    .option(
       "--workflow <name>",
       "Docs workflow to prefetch (repeatable); same values as px docs fetch",
       collectString,
@@ -451,6 +467,7 @@ Examples:
   px setup --endpoint https://phoenix.example.com
   px setup --no-input --endpoint http://localhost:6006 --project my-app
   px setup --no-input --instrument --agent claude --yolo --format raw
+  px setup --no-input --instrument --agent claude --yolo --docs-mcp --format raw
 
 Subcommands:
   px setup instrument   Instrument and verify, without redoing the questions

--- a/js/packages/phoenix-cli/src/setup/agents/registry.ts
+++ b/js/packages/phoenix-cli/src/setup/agents/registry.ts
@@ -15,6 +15,66 @@ import type { Connection } from "../steps/establishConnection";
 
 export type CodingAgentId = "claude" | "codex" | "opencode" | "cursor";
 
+/** The server name the docs MCP is registered under in agent configs. */
+export const DOCS_MCP_SERVER_NAME = "phoenix-docs";
+
+/**
+ * The Mintlify-hosted Phoenix docs MCP server (streamable HTTP). Searching it
+ * returns just the relevant doc sections, so an agent connected to it needs
+ * neither the `.px/docs` download nor whole-page fetches.
+ */
+export const DOCS_MCP_SERVER_URL = "https://arizeai-433a7140.mintlify.app/mcp";
+
+/**
+ * How the docs MCP server is installed for an agent, scoped to the repo setup
+ * runs in. Absent when the agent has no per-project MCP config (Codex reads
+ * only a global TOML).
+ *
+ * `cli` is preferred wherever the agent ships an MCP subcommand: the installed
+ * binary writes the config format that same binary reads, so the CLI can never
+ * drift from the agent's schema. `file` is the fallback for agents whose only
+ * documented mechanism is hand-editing a JSON file — those shapes mirror
+ * `docs/phoenix/integrations/phoenix-mcp-server.mdx`, which is the contract to
+ * keep them true to.
+ */
+export type DocsMcpInstall =
+  | {
+      kind: "cli";
+      /**
+       * Best-effort removal of a previous entry, with its exit code ignored.
+       * Run only after an `add` was refused and `verifyArgs` confirmed an
+       * entry exists under our name — `add` refuses a name that already
+       * exists, and remove-then-retry is what makes a setup re-run
+       * idempotent, while removing any earlier would destroy a working
+       * registration a failed retry can't put back.
+       */
+      removeArgs: string[];
+      /** argv (after the binary) that registers the server. */
+      addArgs(serverUrl: string): string[];
+      /**
+       * Read-back of the entry after `add`; a non-zero exit means the server
+       * is not actually registered. This is the drift guard: if the agent's
+       * flags ever change meaning while still parsing, exit codes alone would
+       * lie, but an entry that doesn't show up in the agent's own listing
+       * cannot.
+       */
+      verifyArgs: string[];
+    }
+  | {
+      kind: "file";
+      /**
+       * Config file path, relative to the repo root. Always forward-slash:
+       * Node's fs resolves it on every platform, and the setup report stays
+       * platform-stable (`path.join` would put a backslash in the JSON
+       * envelope on Windows).
+       */
+      relativePath: string;
+      /** Keys applied only when the file is being created, e.g. `$schema`. */
+      createDefaults?: Record<string, unknown>;
+      /** The JSON fragment to merge into that file. */
+      patch(serverUrl: string): Record<string, unknown>;
+    };
+
 /**
  * How the agent is run.
  *
@@ -42,6 +102,8 @@ export interface CodingAgent {
    * after the `exec` subcommand, not before it.
    */
   launchArgs(prompt: string, mode: AgentRunMode): string[];
+  /** See {@link DocsMcpInstall}; absent when the agent has none. */
+  docsMcpInstall?: DocsMcpInstall;
 }
 
 export const CODING_AGENTS: readonly CodingAgent[] = [
@@ -54,6 +116,22 @@ export const CODING_AGENTS: readonly CodingAgent[] = [
       ...(mode.bypassPermissions ? ["--dangerously-skip-permissions"] : []),
       prompt,
     ],
+    // The default (local) scope is deliberate: nothing lands in the repo, and
+    // unlike a project-scoped .mcp.json the server needs no first-use
+    // approval, so the launched hand-off session can actually use it.
+    docsMcpInstall: {
+      kind: "cli",
+      removeArgs: ["mcp", "remove", DOCS_MCP_SERVER_NAME],
+      addArgs: (serverUrl) => [
+        "mcp",
+        "add",
+        "--transport",
+        "http",
+        DOCS_MCP_SERVER_NAME,
+        serverUrl,
+      ],
+      verifyArgs: ["mcp", "get", DOCS_MCP_SERVER_NAME],
+    },
   },
   {
     id: "codex",
@@ -78,6 +156,20 @@ export const CODING_AGENTS: readonly CodingAgent[] = [
       ...(mode.bypassPermissions ? ["--dangerously-skip-permissions"] : []),
       prompt,
     ],
+    docsMcpInstall: {
+      kind: "file",
+      relativePath: "opencode.json",
+      createDefaults: { $schema: "https://opencode.ai/config.json" },
+      patch: (serverUrl) => ({
+        mcp: {
+          [DOCS_MCP_SERVER_NAME]: {
+            type: "remote",
+            url: serverUrl,
+            enabled: true,
+          },
+        },
+      }),
+    },
   },
   {
     id: "cursor",
@@ -88,6 +180,13 @@ export const CODING_AGENTS: readonly CodingAgent[] = [
       ...(mode.bypassPermissions ? ["--force"] : []),
       prompt,
     ],
+    docsMcpInstall: {
+      kind: "file",
+      relativePath: ".cursor/mcp.json",
+      patch: (serverUrl) => ({
+        mcpServers: { [DOCS_MCP_SERVER_NAME]: { url: serverUrl } },
+      }),
+    },
   },
 ];
 

--- a/js/packages/phoenix-cli/src/setup/copy.ts
+++ b/js/packages/phoenix-cli/src/setup/copy.ts
@@ -4,6 +4,10 @@
  * Keep prose here so wording changes never touch step logic.
  */
 
+// The one allowed inbound name: the MCP server's registered name must read
+// the same in the prose as in the agent configs it lands in.
+import { DOCS_MCP_SERVER_NAME } from "./agents/registry";
+
 // ---------------------------------------------------------------------------
 // Docs contract — the only doc URLs setup emits.
 // ---------------------------------------------------------------------------
@@ -325,6 +329,38 @@ export const TOOLING = {
       "Phoenix skills installed. Your coding agent can now query and debug traces.",
     failed: `Skills install failed — install later with \`npx skills add ${SKILLS_SOURCE}\`.`,
   },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Docs MCP offer
+// ---------------------------------------------------------------------------
+
+export const DOCS_MCP = {
+  message: (agentLabel: string) =>
+    `Connect the Phoenix docs MCP server to ${agentLabel}? (it searches the docs on demand — no download needed)`,
+  yes: `Yes, connect ${DOCS_MCP_SERVER_NAME} (recommended)`,
+  yesHint: "fastest setup; pulls only the doc sections the agent needs",
+  no: "No, download the docs instead",
+  noHint: "writes ~100 pages to .px/docs for offline reading",
+  /** The decline pair when `--no-docs` means declining downloads nothing. */
+  noWithoutDownload: "No, skip it",
+  noWithoutDownloadHint:
+    "the docs download is off (--no-docs); the agent reads the docs from the web",
+  configured: (files: string[]) =>
+    `Added the ${DOCS_MCP_SERVER_NAME} MCP server to ${files.join(", ")} — skipping the docs download.`,
+  configuredCli: (agentLabel: string) =>
+    `Connected the ${DOCS_MCP_SERVER_NAME} MCP server to ${agentLabel} — skipping the docs download.`,
+  failedFor: (agentLabel: string, reason: string) =>
+    `Couldn't register the ${agentLabel} MCP config (${reason}).`,
+  verifyFailed:
+    "the entry did not show up in the agent's own MCP listing after adding it",
+  fallback: "The MCP server was not connected — downloading the docs instead.",
+  fallbackWithoutDownload:
+    "The MCP server was not connected — the agent will read the docs from the web.",
+  /** Printed when an explicit --docs-mcp met a lane with no agent to configure. */
+  noAgentLane: `The clipboard and manual lanes have no coding agent to connect the ${DOCS_MCP_SERVER_NAME} MCP server to — skipping the offer.`,
+  unsupported: (agentLabel: string) =>
+    `${agentLabel} has no per-project MCP config — skipping the offer.`,
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/js/packages/phoenix-cli/src/setup/options.ts
+++ b/js/packages/phoenix-cli/src/setup/options.ts
@@ -68,6 +68,12 @@ export interface SetupOptions {
   background?: boolean;
   /** Docs prefetch, so the agent instruments against local docs. */
   docs?: DocsPrefetchOptions;
+  /**
+   * --docs-mcp / --no-docs-mcp: connect the Phoenix docs MCP server to the
+   * coding agent's project config (replaces the docs prefetch when taken).
+   * Undefined means ask interactively; headless skips unless the flag opts in.
+   */
+  docsMcp?: boolean;
 }
 
 export interface SetupInputs {
@@ -97,6 +103,11 @@ export interface SetupInputs {
   bypassPermissions: boolean;
   /** Docs prefetch; only consulted when `instrument` is true. */
   docs: DocsPrefetchOptions;
+  /**
+   * Docs MCP offer; only consulted when `instrument` is true. Undefined means
+   * ask interactively — an unattended run skips it unless `--docs-mcp` opts in.
+   */
+  docsMcp?: boolean;
 }
 
 /**
@@ -162,5 +173,6 @@ export function resolveSetupInputs({
     background: options.background ?? headless,
     bypassPermissions: Boolean(options.bypassPermissions),
     docs: options.docs ?? { enabled: true },
+    docsMcp: options.docsMcp,
   };
 }

--- a/js/packages/phoenix-cli/src/setup/prompts/instrumentationPrompt.ts
+++ b/js/packages/phoenix-cli/src/setup/prompts/instrumentationPrompt.ts
@@ -11,6 +11,8 @@
  * self-report.
  */
 
+import { DOCS_MCP_SERVER_NAME } from "../agents/registry";
+
 export interface InstrumentationPromptDocs {
   /** Python quickstart (arize-phoenix-otel). */
   quickstartPython: string;
@@ -39,6 +41,12 @@ export interface InstrumentationPromptArgs {
    * pages from disk instead of fetching the URLs mid-run.
    */
   localDocsDir?: string;
+  /**
+   * True when the phoenix-docs MCP server was connected to the agent's
+   * project config. The agent then searches the docs on demand — cheaper
+   * than fetching whole pages — instead of reading a local prefetch.
+   */
+  docsMcpConfigured?: boolean;
 }
 
 export function buildInstrumentationPrompt({
@@ -50,6 +58,7 @@ export function buildInstrumentationPrompt({
   authEnabled,
   languages = [],
   localDocsDir,
+  docsMcpConfigured,
 }: InstrumentationPromptArgs): string {
   const credentialVars = authEnabled
     ? "PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY"
@@ -64,6 +73,9 @@ export function buildInstrumentationPrompt({
   const localDocsRule = localDocsDir
     ? `\nThese pages are already downloaded to ${localDocsDir} — read them from disk first, and only\nfetch a URL if the page you need is missing there.`
     : "";
+  const docsMcpRule = docsMcpConfigured
+    ? `\nThe "${DOCS_MCP_SERVER_NAME}" MCP server is connected in this project — search it for Phoenix docs\nfirst; it returns just the relevant sections. Fetch the URLs above only if its tools are\nunavailable.`
+    : "";
 
   return `You are running as part of the Phoenix setup script. Your ONLY task is to add Phoenix
 tracing to the application in the current working directory and emit one verification
@@ -73,7 +85,7 @@ Work from the official docs — do not guess package names or APIs from memory:
 - Python quickstart (arize-phoenix-otel): ${docs.quickstartPython}
 - TypeScript quickstart (@arizeai/phoenix-otel): ${docs.quickstartTypeScript}
 - register() reference: ${docs.phoenixOtelSetup}
-- Auto-instrumentation guides by framework/provider: ${docs.integrationsIndex}${localDocsRule}
+- Auto-instrumentation guides by framework/provider: ${docs.integrationsIndex}${localDocsRule}${docsMcpRule}
 ${languageRule}
 
 Rules:

--- a/js/packages/phoenix-cli/src/setup/runSetup.ts
+++ b/js/packages/phoenix-cli/src/setup/runSetup.ts
@@ -31,8 +31,8 @@ import {
   type ToolingResult,
 } from "./steps/installTooling";
 import { instrumentApp, type InstrumentationLane } from "./steps/instrumentApp";
+import type { DocsMcpResult } from "./steps/offerDocsMcp";
 import { offerPxProfile } from "./steps/offerPxProfile";
-import { prefetchDocs } from "./steps/prefetchDocs";
 import {
   hasSpansInSkewWindow,
   waitForFirstTrace,
@@ -50,6 +50,8 @@ export interface SetupReport {
   /** Paths appended to a .gitignore. */
   gitignored: string[];
   docs?: DocsPrefetchResult;
+  /** The docs MCP offer, when it was made (configured replaces `docs`). */
+  docsMcp?: DocsMcpResult;
   instrumentation?: InstrumentationLane;
   /** True once the API confirmed a trace arrived after this run started. */
   tracesVerified?: boolean;
@@ -193,14 +195,6 @@ async function registerAndInstrument(
     return base;
   }
 
-  // Only after registration's git-safety gate: the docs fetch writes into
-  // `.px/`, which an earlier download can make look like a pre-existing dirty
-  // tree in a fast or cached headless run.
-  const docs = await prefetchDocs(deps, {
-    docs: inputs.docs,
-    isGitRepository: registration.isGitRepository,
-  });
-
   const startedAt = deps.clock.now();
   // Any span already visible inside the clock-skew window predates this run —
   // verification must then require spans strictly after the start time, or a
@@ -209,7 +203,15 @@ async function registerAndInstrument(
     sinceMs: startedAt,
   });
 
-  const instrumentation = await instrumentApp(deps, connection, {
+  // The docs steps live inside instrumentApp, after its lane choice: the docs
+  // MCP offer targets exactly the agent doing the hand-off, and taking it
+  // replaces the `.px/docs` download outright. Both still run behind
+  // registration's git-safety gate, which this call comes after.
+  const {
+    lane: instrumentation,
+    docs,
+    docsMcp,
+  } = await instrumentApp(deps, connection, {
     authEnabled,
     agentDetection,
     agent: inputs.agent,
@@ -218,7 +220,10 @@ async function registerAndInstrument(
       background: inputs.background,
       bypassPermissions: inputs.bypassPermissions,
     },
-    ...(docs ? { docs } : {}),
+    docs: inputs.docs,
+    docsMcp: inputs.docsMcp,
+    headless: inputs.headless,
+    isGitRepository: registration.isGitRepository,
   });
 
   // The return value is setup's definition of done — a trace the API confirmed
@@ -234,8 +239,10 @@ async function registerAndInstrument(
   return {
     ...base,
     ...(docs ? { docs } : {}),
-    // The docs step gitignores its own output dir, so the report has to fold
-    // those appends in or it under-states what setup touched.
+    ...(docsMcp && docsMcp.outcome !== "skipped" ? { docsMcp } : {}),
+    // The MCP config files and the docs step's own gitignore appends have to
+    // fold into the report, or it under-states what setup touched.
+    files: [...base.files, ...(docsMcp?.files ?? [])],
     gitignored: [...base.gitignored, ...(docs?.gitignoreAppended ?? [])],
     instrumentation,
     tracesVerified,

--- a/js/packages/phoenix-cli/src/setup/steps/instrumentApp.ts
+++ b/js/packages/phoenix-cli/src/setup/steps/instrumentApp.ts
@@ -7,6 +7,12 @@
  * lanes converge on the trace-verification step — setup's definition of
  * done is API-verified data flow, not agent self-report.
  *
+ * The lane is resolved before anything docs-related happens: the docs MCP
+ * offer targets exactly the agent being launched, and taking it replaces the
+ * `.px/docs` download outright — the agent searches the docs server on demand
+ * instead of reading prefetched pages. The clipboard and manual lanes have no
+ * known agent to configure, so they keep the prefetch.
+ *
  * `--agent` pre-answers the lane, which is what makes an unattended run
  * possible: with no TTY there is no prompt to pick a lane from, and the agent
  * runs in background mode (no TUI to hand the terminal to).
@@ -21,10 +27,17 @@ import {
   type CodingAgentId,
 } from "../agents/registry";
 import * as COPY from "../copy";
-import type { DocsPrefetchResult, SelectOption, SetupDeps } from "../deps";
+import type {
+  DocsPrefetchOptions,
+  DocsPrefetchResult,
+  SelectOption,
+  SetupDeps,
+} from "../deps";
 import { SetupFatalError } from "../errors";
 import { buildInstrumentationPrompt } from "../prompts/instrumentationPrompt";
 import type { Connection } from "./establishConnection";
+import { offerDocsMcp, type DocsMcpResult } from "./offerDocsMcp";
+import { prefetchDocs } from "./prefetchDocs";
 import { tracesUrl } from "./verifyTraces";
 
 const DEFAULT_LOCAL_ENDPOINT = "http://localhost:6006";
@@ -42,8 +55,13 @@ export interface InstrumentAppArgs {
   languages: string[];
   /** How to run the agent — see {@link AgentRunMode}. */
   mode: AgentRunMode;
-  /** Where the prefetched docs landed, when the docs step ran. */
-  docs?: DocsPrefetchResult;
+  /** Docs prefetch options; the download runs unless the MCP replaces it. */
+  docs: DocsPrefetchOptions;
+  /** `--docs-mcp` / `--no-docs-mcp`; undefined means ask (when we can). */
+  docsMcp?: boolean;
+  headless: boolean;
+  /** Gates the prefetch's .gitignore append, as in the docs step itself. */
+  isGitRepository: boolean;
 }
 
 /** Which lane instrumentation actually took — reported in the summary. */
@@ -52,15 +70,98 @@ export type InstrumentationLane =
   | { kind: "clipboard" }
   | { kind: "manual" };
 
+export interface InstrumentAppResult {
+  lane: InstrumentationLane;
+  /** The docs download, when it ran (the MCP taking its place omits it). */
+  docs?: DocsPrefetchResult;
+  /** The docs MCP offer, when a launched agent was there to make it to. */
+  docsMcp?: DocsMcpResult;
+}
+
 export async function instrumentApp(
   deps: Pick<
     SetupDeps,
-    "context" | "processes" | "prompter" | "writeClipboard"
+    "context" | "processes" | "prompter" | "writeClipboard" | "fetchDocs"
   >,
   connection: Connection,
   args: InstrumentAppArgs
-): Promise<InstrumentationLane> {
+): Promise<InstrumentAppResult> {
   const { authEnabled, agentDetection, languages, mode } = args;
+
+  // Resolve the lane before the docs steps: the MCP offer needs to know which
+  // agent is doing the work, and only then can "skip the download" be decided.
+  let chosenAgent: CodingAgent | undefined;
+  let fallbackLane: "clipboard" | "manual" = "manual";
+
+  if (args.agent) {
+    // `--agent` short-circuits the lane prompt. The binary is probed rather
+    // than taken from the detection sweep so a named-but-missing agent fails
+    // with "not on your PATH" instead of silently dropping to another lane.
+    const agent = getCodingAgent(args.agent);
+    if (!agent) {
+      throw new SetupFatalError(COPY.INSTRUMENTATION.unknownAgent(args.agent));
+    }
+    if (!(await probeBinary(deps, agent.binary))) {
+      throw new SetupFatalError(
+        COPY.INSTRUMENTATION.agentNotFound(agent.label, agent.binary)
+      );
+    }
+    chosenAgent = agent;
+  } else {
+    const detectedAgents = await agentDetection;
+    const options: Array<SelectOption<LaneChoice>> = [
+      ...detectedAgents.map(
+        (agent): SelectOption<LaneChoice> => ({
+          value: `agent:${agent.id}`,
+          label: COPY.INSTRUMENTATION.launchLabel(agent.label),
+          hint: COPY.INSTRUMENTATION.launchHint,
+        })
+      ),
+      {
+        value: "clipboard",
+        label: COPY.INSTRUMENTATION.clipboardLabel,
+        hint: COPY.INSTRUMENTATION.clipboardHint,
+      },
+      {
+        value: "manual",
+        label: COPY.INSTRUMENTATION.manualLabel,
+        hint: COPY.INSTRUMENTATION.manualHint,
+      },
+    ];
+    const choice = await deps.prompter.select<LaneChoice>({
+      message: COPY.INSTRUMENTATION.modeMessage,
+      options,
+    });
+    chosenAgent = detectedAgents.find(
+      (agent) => choice === `agent:${agent.id}`
+    );
+    fallbackLane = choice === "clipboard" ? "clipboard" : "manual";
+  }
+
+  // The offer is an optimization and never takes setup down with it — that
+  // contract lives inside offerDocsMcp, which reports any failure and returns
+  // "failed" instead of throwing. Only a user cancel unwinds.
+  let docsMcp: DocsMcpResult | undefined;
+  if (chosenAgent) {
+    docsMcp = await offerDocsMcp(deps, {
+      docsMcp: args.docsMcp,
+      agent: chosenAgent,
+      headless: args.headless,
+      docsEnabled: args.docs.enabled,
+    });
+  } else if (args.docsMcp === true) {
+    // An explicit --docs-mcp deserves a word when the lane can't honor it,
+    // same as a pinned agent with no MCP install path.
+    deps.prompter.line(COPY.DOCS_MCP.noAgentLane);
+  }
+  const docs =
+    docsMcp?.outcome === "configured"
+      ? undefined
+      : await prefetchDocs(deps, {
+          docs: args.docs,
+          isGitRepository: args.isGitRepository,
+        });
+
   const prompt = buildInstrumentationPrompt({
     projectName: connection.projectName,
     endpoint: connection.endpoint,
@@ -77,60 +178,24 @@ export async function instrumentApp(
     // Only advertise the local docs dir when it holds pages — an empty one
     // (docs site down, over-narrow workflow filter) would send the agent to
     // read a directory with nothing in it instead of the web.
-    ...(args.docs?.hasPagesOnDisk ? { localDocsDir: args.docs.outputDir } : {}),
+    ...(docs?.hasPagesOnDisk ? { localDocsDir: docs.outputDir } : {}),
+    ...(docsMcp?.outcome === "configured" ? { docsMcpConfigured: true } : {}),
   });
 
-  // `--agent` short-circuits the lane prompt. The binary is probed rather
-  // than taken from the detection sweep so a named-but-missing agent fails
-  // with "not on your PATH" instead of silently dropping to another lane.
-  if (args.agent) {
-    const agent = getCodingAgent(args.agent);
-    if (!agent) {
-      throw new SetupFatalError(COPY.INSTRUMENTATION.unknownAgent(args.agent));
-    }
-    if (!(await probeBinary(deps, agent.binary))) {
-      throw new SetupFatalError(
-        COPY.INSTRUMENTATION.agentNotFound(agent.label, agent.binary)
-      );
-    }
-    return launchAgent(deps, connection, { agent, prompt, mode });
-  }
-
-  const detectedAgents = await agentDetection;
-
-  const options: Array<SelectOption<LaneChoice>> = [
-    ...detectedAgents.map(
-      (agent): SelectOption<LaneChoice> => ({
-        value: `agent:${agent.id}`,
-        label: COPY.INSTRUMENTATION.launchLabel(agent.label),
-        hint: COPY.INSTRUMENTATION.launchHint,
-      })
-    ),
-    {
-      value: "clipboard",
-      label: COPY.INSTRUMENTATION.clipboardLabel,
-      hint: COPY.INSTRUMENTATION.clipboardHint,
-    },
-    {
-      value: "manual",
-      label: COPY.INSTRUMENTATION.manualLabel,
-      hint: COPY.INSTRUMENTATION.manualHint,
-    },
-  ];
-
-  const choice = await deps.prompter.select<LaneChoice>({
-    message: COPY.INSTRUMENTATION.modeMessage,
-    options,
-  });
-
-  const chosenAgent = detectedAgents.find(
-    (agent) => choice === `agent:${agent.id}`
-  );
   if (chosenAgent) {
-    return launchAgent(deps, connection, { agent: chosenAgent, prompt, mode });
+    const lane = await launchAgent(deps, connection, {
+      agent: chosenAgent,
+      prompt,
+      mode,
+    });
+    return {
+      lane,
+      ...(docs ? { docs } : {}),
+      ...(docsMcp ? { docsMcp } : {}),
+    };
   }
 
-  if (choice === "clipboard") {
+  if (fallbackLane === "clipboard") {
     const copied = await deps.writeClipboard(prompt);
     if (copied) {
       deps.prompter.line(COPY.INSTRUMENTATION.promptCopied);
@@ -144,7 +209,7 @@ export async function instrumentApp(
         { value: true, label: COPY.INSTRUMENTATION.clipboardDoneLabel },
       ],
     });
-    return { kind: "clipboard" };
+    return { lane: { kind: "clipboard" }, ...(docs ? { docs } : {}) };
   }
 
   deps.prompter.line(
@@ -154,7 +219,7 @@ export async function instrumentApp(
     message: COPY.INSTRUMENTATION.manualDoneMessage,
     options: [{ value: true, label: COPY.INSTRUMENTATION.manualDoneLabel }],
   });
-  return { kind: "manual" };
+  return { lane: { kind: "manual" }, ...(docs ? { docs } : {}) };
 }
 
 /**

--- a/js/packages/phoenix-cli/src/setup/steps/offerDocsMcp.ts
+++ b/js/packages/phoenix-cli/src/setup/steps/offerDocsMcp.ts
@@ -1,0 +1,194 @@
+/**
+ * Offer to connect the Phoenix docs MCP server to the coding agent taking the
+ * hand-off, instead of downloading the docs.
+ *
+ * Taking the offer is the fast path: one small config step replaces the
+ * ~100-page `.px/docs` download, and the agent then searches the docs server
+ * on demand — pulling only the sections it needs instead of reading whole
+ * pages. Declining (or any failure) degrades to the docs prefetch, which is
+ * what setup did before this step existed.
+ *
+ * The offer is an optimization and must never take setup down with it:
+ * whatever goes wrong (an agent CLI whose flags drifted, a config format we
+ * no longer understand), this step reports it, returns a "failed" result, and
+ * the caller carries on with the docs download. The only throw that leaves
+ * this function is a user cancel.
+ *
+ * The offer targets exactly one agent — the lane the user chose (or `--agent`
+ * pinned) — so setup never sprays MCP config for agents that aren't doing the
+ * work. How the entry lands is the agent's own affair ({@link DocsMcpInstall}):
+ * agents with an MCP subcommand register it through their own CLI, the rest
+ * get a merge into their documented config file. Headless runs never touch
+ * agent config unless `--docs-mcp` asked for it.
+ */
+
+import { DOCS_MCP_SERVER_URL, type CodingAgent } from "../agents/registry";
+import * as COPY from "../copy";
+import type { SetupDeps } from "../deps";
+import { SetupCancelledError } from "../errors";
+import { selectBoolean } from "../ui/selectBoolean";
+import { writeMcpConfig } from "../util/mcpConfig";
+
+export type DocsMcpOutcome = "configured" | "declined" | "skipped" | "failed";
+
+/** What the offer did — reported in the setup summary. */
+export interface DocsMcpResult {
+  outcome: DocsMcpOutcome;
+  /** Agents whose config now names the server. */
+  agents: CodingAgent["id"][];
+  /** Repo-relative config files written (empty for a CLI-side install). */
+  files: string[];
+}
+
+const SKIPPED: DocsMcpResult = { outcome: "skipped", agents: [], files: [] };
+
+/** Registering a server is one config write; a slow CLI start is still fine. */
+const CLI_INSTALL_TIMEOUT_MS = 30_000;
+
+export interface OfferDocsMcpArgs {
+  /** `--docs-mcp` / `--no-docs-mcp`; undefined means ask (when we can). */
+  docsMcp?: boolean;
+  /** The agent taking the hand-off — the only one the offer configures. */
+  agent: CodingAgent;
+  headless: boolean;
+  /**
+   * Whether the docs prefetch would actually run on decline/failure — with
+   * `--no-docs` it won't, and the offer must not promise a download.
+   */
+  docsEnabled: boolean;
+}
+
+export async function offerDocsMcp(
+  deps: Pick<SetupDeps, "context" | "prompter" | "processes">,
+  args: OfferDocsMcpArgs
+): Promise<DocsMcpResult> {
+  try {
+    return await runOffer(deps, args);
+  } catch (error) {
+    if (error instanceof SetupCancelledError) {
+      throw error;
+    }
+    return reportFailure(
+      deps,
+      args,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+/** The single failure path: say what broke, say what happens instead. */
+function reportFailure(
+  deps: Pick<SetupDeps, "prompter">,
+  { agent, docsEnabled }: OfferDocsMcpArgs,
+  reason: string
+): DocsMcpResult {
+  deps.prompter.line(COPY.DOCS_MCP.failedFor(agent.label, reason));
+  deps.prompter.line(
+    docsEnabled ? COPY.DOCS_MCP.fallback : COPY.DOCS_MCP.fallbackWithoutDownload
+  );
+  return { outcome: "failed", agents: [], files: [] };
+}
+
+async function runOffer(
+  deps: Pick<SetupDeps, "context" | "prompter" | "processes">,
+  args: OfferDocsMcpArgs
+): Promise<DocsMcpResult> {
+  const { docsMcp, agent, headless, docsEnabled } = args;
+  if (docsMcp === false) {
+    return SKIPPED;
+  }
+
+  const install = agent.docsMcpInstall;
+  if (!install) {
+    // Only worth a line when the caller asked by flag — a pinned agent with
+    // no MCP install path (Codex) would otherwise silently ignore it.
+    if (docsMcp === true) {
+      deps.prompter.line(COPY.DOCS_MCP.unsupported(agent.label));
+    }
+    return SKIPPED;
+  }
+
+  // An unattended run never edits agent config unless --docs-mcp said so.
+  if (docsMcp === undefined && headless) {
+    return SKIPPED;
+  }
+
+  const optedIn =
+    docsMcp ??
+    (await selectBoolean({
+      prompter: deps.prompter,
+      message: COPY.DOCS_MCP.message(agent.label),
+      yesLabel: COPY.DOCS_MCP.yes,
+      yesHint: COPY.DOCS_MCP.yesHint,
+      noLabel: docsEnabled ? COPY.DOCS_MCP.no : COPY.DOCS_MCP.noWithoutDownload,
+      noHint: docsEnabled
+        ? COPY.DOCS_MCP.noHint
+        : COPY.DOCS_MCP.noWithoutDownloadHint,
+    }));
+  if (!optedIn) {
+    return { outcome: "declined", agents: [], files: [] };
+  }
+
+  if (install.kind === "cli") {
+    const exec = (execArgs: string[]) =>
+      deps.processes.exec({
+        command: agent.binary,
+        args: execArgs,
+        cwd: deps.context.cwd,
+        timeoutMs: CLI_INSTALL_TIMEOUT_MS,
+      });
+
+    // `add` first: the clean path is one registration plus the read-back.
+    // Only when `add` is refused AND the agent's own listing shows an entry
+    // under our name is that entry removed and the add retried — removing
+    // before knowing the add works would destroy a working registration
+    // that a failed retry can't put back.
+    let added = await exec(install.addArgs(DOCS_MCP_SERVER_URL));
+    if (added.exitCode !== 0) {
+      const existing = await exec(install.verifyArgs);
+      if (existing.exitCode !== 0) {
+        return reportFailure(
+          deps,
+          args,
+          added.stderr.trim() || `exit code ${added.exitCode}`
+        );
+      }
+      await exec(install.removeArgs);
+      added = await exec(install.addArgs(DOCS_MCP_SERVER_URL));
+      if (added.exitCode !== 0) {
+        return reportFailure(
+          deps,
+          args,
+          added.stderr.trim() || `exit code ${added.exitCode}`
+        );
+      }
+    }
+    // Don't trust the add's exit code alone: read the entry back through the
+    // agent's own listing, so a drifted command that "succeeds" without
+    // registering anything is caught here instead of silently costing the
+    // agent its docs.
+    const verified = await exec(install.verifyArgs);
+    if (verified.exitCode !== 0) {
+      return reportFailure(deps, args, COPY.DOCS_MCP.verifyFailed);
+    }
+    deps.prompter.line(COPY.DOCS_MCP.configuredCli(agent.label));
+    return { outcome: "configured", agents: [agent.id], files: [] };
+  }
+
+  // A write that throws (unparseable existing file, permissions) is handled
+  // by the catch-all in offerDocsMcp.
+  writeMcpConfig({
+    directory: deps.context.cwd,
+    relativePath: install.relativePath,
+    patch: install.patch(DOCS_MCP_SERVER_URL),
+    ...(install.createDefaults
+      ? { createDefaults: install.createDefaults }
+      : {}),
+  });
+  deps.prompter.line(COPY.DOCS_MCP.configured([install.relativePath]));
+  return {
+    outcome: "configured",
+    agents: [agent.id],
+    files: [install.relativePath],
+  };
+}

--- a/js/packages/phoenix-cli/src/setup/util/mcpConfig.ts
+++ b/js/packages/phoenix-cli/src/setup/util/mcpConfig.ts
@@ -1,0 +1,102 @@
+/**
+ * Merge an MCP server entry into an agent's project-scoped JSON config.
+ *
+ * A merge, never a rewrite: servers the user already has stay untouched, and
+ * an existing entry under the same server name is replaced — which is what
+ * makes a setup re-run idempotent. A file that exists but does not parse is
+ * refused rather than clobbered; the caller degrades to the docs download.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface WriteMcpConfigArgs {
+  /** Repo root the relative config path resolves against. */
+  directory: string;
+  /** Config file path, relative to `directory`. */
+  relativePath: string;
+  /**
+   * JSON fragment to merge in: container and server-name keys merge, a
+   * server entry itself is replaced wholesale.
+   */
+  patch: Record<string, unknown>;
+  /**
+   * Base content when the file does not exist yet (e.g. a `$schema` key).
+   * An existing file is never back-filled with these — that would be editing
+   * config the user didn't ask setup to touch.
+   */
+  createDefaults?: Record<string, unknown>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Both config shapes are container → server name → server config, so two
+ * levels of key-sets merge and everything below is replaced. Merging deeper
+ * would leave e.g. a `command` from an old stdio-style entry alongside the
+ * new `url` — a hybrid the agent may resolve to the stale command.
+ */
+const MERGE_LEVELS = 2;
+
+function mergeLevels(
+  base: Record<string, unknown>,
+  patch: Record<string, unknown>,
+  levels: number
+): Record<string, unknown> {
+  const merged = { ...base };
+  for (const [key, patchValue] of Object.entries(patch)) {
+    const baseValue = merged[key];
+    merged[key] =
+      levels > 1 && isPlainObject(baseValue) && isPlainObject(patchValue)
+        ? mergeLevels(baseValue, patchValue, levels - 1)
+        : patchValue;
+  }
+  return merged;
+}
+
+/** Thrown when the target file exists but is not a JSON object. */
+export class McpConfigUnreadableError extends Error {
+  constructor(relativePath: string, detail: string) {
+    super(`${relativePath} exists but could not be parsed (${detail})`);
+    this.name = "McpConfigUnreadableError";
+  }
+}
+
+export function writeMcpConfig({
+  directory,
+  relativePath,
+  patch,
+  createDefaults,
+}: WriteMcpConfigArgs): void {
+  const filePath = path.join(directory, relativePath);
+
+  let existing: Record<string, unknown> = createDefaults ?? {};
+  if (fs.existsSync(filePath)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    } catch (error) {
+      throw new McpConfigUnreadableError(
+        relativePath,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+    if (!isPlainObject(parsed)) {
+      throw new McpConfigUnreadableError(relativePath, "not a JSON object");
+    }
+    existing = parsed;
+  }
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  // Write-then-rename so a crash mid-write can never truncate a config the
+  // user already had.
+  const tempPath = `${filePath}.px-setup-tmp`;
+  fs.writeFileSync(
+    tempPath,
+    `${JSON.stringify(mergeLevels(existing, patch, MERGE_LEVELS), null, 2)}\n`,
+    "utf-8"
+  );
+  fs.renameSync(tempPath, filePath);
+}

--- a/js/packages/phoenix-cli/test/setup/instrumentApp.test.ts
+++ b/js/packages/phoenix-cli/test/setup/instrumentApp.test.ts
@@ -1,6 +1,7 @@
 /**
  * Instrumentation hand-off tests: the `--agent` lane (probe, launch spec, run
- * mode) and the interactive lane prompt (agent / clipboard / manual).
+ * mode), the interactive lane prompt (agent / clipboard / manual), and the
+ * docs decision that now follows the lane choice (MCP offer vs prefetch).
  */
 
 import { describe, expect, it } from "vitest";
@@ -22,6 +23,19 @@ const CONNECTION: Connection = {
 
 const INTERACTIVE = { background: false, bypassPermissions: false };
 const BACKGROUND_BYPASS = { background: true, bypassPermissions: true };
+
+/**
+ * The docs-neutral baseline: prefetch disabled and the MCP offer declined by
+ * flag, so lane-focused tests stay lane-focused.
+ */
+const NO_DOCS = {
+  authEnabled: false,
+  languages: [],
+  headless: false,
+  isGitRepository: false,
+  docs: { enabled: false },
+  docsMcp: false,
+} as const;
 
 function detected(...ids: Array<CodingAgent["id"]>): Promise<CodingAgent[]> {
   return Promise.resolve(
@@ -59,10 +73,11 @@ describe("instrumentApp with --agent", () => {
       },
     });
 
-    const lane = await instrumentApp(
+    const { lane } = await instrumentApp(
       deps,
       { ...CONNECTION, apiKey: "sk-test" },
       {
+        ...NO_DOCS,
         authEnabled: true,
         agentDetection: detected(),
         agent: "codex",
@@ -99,11 +114,10 @@ describe("instrumentApp with --agent", () => {
       },
     });
 
-    const lane = await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
+    const { lane } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
       agentDetection: detected(),
       agent: "claude",
-      languages: [],
       mode: BACKGROUND_BYPASS,
     });
 
@@ -123,10 +137,9 @@ describe("instrumentApp with --agent", () => {
     });
 
     await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
+      ...NO_DOCS,
       agentDetection: detected(),
       agent: "claude",
-      languages: [],
       mode: { background: true, bypassPermissions: false },
     });
 
@@ -143,10 +156,9 @@ describe("instrumentApp with --agent", () => {
     });
 
     await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
+      ...NO_DOCS,
       agentDetection: detected(),
       agent: "claude",
-      languages: [],
       mode: INTERACTIVE,
     });
 
@@ -169,10 +181,9 @@ describe("instrumentApp with --agent", () => {
 
     await expect(
       instrumentApp(deps, CONNECTION, {
-        authEnabled: false,
+        ...NO_DOCS,
         agentDetection: detected("claude"),
         agent: "opencode",
-        languages: [],
         mode: BACKGROUND_BYPASS,
       })
     ).rejects.toThrow(SetupFatalError);
@@ -186,11 +197,10 @@ describe("instrumentApp with --agent", () => {
     });
     await expect(
       instrumentApp(deps, CONNECTION, {
-        authEnabled: false,
+        ...NO_DOCS,
         agentDetection: detected(),
         // The command layer validates ids; the step defends the same contract.
         agent: "aider" as never,
-        languages: [],
         mode: BACKGROUND_BYPASS,
       })
     ).rejects.toThrow(SetupFatalError);
@@ -198,8 +208,8 @@ describe("instrumentApp with --agent", () => {
 });
 
 describe("instrumentApp lane prompt", () => {
-  it("offers the detected agents and launches the chosen one", async () => {
-    const prompter = scriptedPrompter(["agent:claude"]);
+  it("offers the detected agents, then the docs MCP for the chosen one", async () => {
+    const prompter = scriptedPrompter(["agent:claude", false]);
     const launched: CommandSpec[] = [];
     const deps = buildFakeDeps({
       context: { cwd: "/repo" },
@@ -212,17 +222,20 @@ describe("instrumentApp lane prompt", () => {
       },
     });
 
-    const lane = await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
+    const { lane, docsMcp } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
+      docsMcp: undefined,
       agentDetection: detected("claude", "cursor"),
-      languages: [],
       mode: INTERACTIVE,
     });
 
     expect(lane).toEqual({ kind: "agent", agent: "claude", exitCode: 0 });
-    expect(prompter.transcript).toEqual([
-      "How do you want to instrument this app?",
-    ]);
+    expect(docsMcp?.outcome).toBe("declined");
+    // The MCP offer comes after the lane choice — it targets the chosen agent.
+    expect(prompter.transcript[0]).toBe(
+      "How do you want to instrument this app?"
+    );
+    expect(prompter.transcript[1]).toContain("docs MCP server to Claude Code");
     expect(launched[0]?.command).toBe("claude");
     // Interactive: the agent keeps the terminal, no -p.
     expect(launched[0]?.args).toHaveLength(1);
@@ -239,10 +252,12 @@ describe("instrumentApp lane prompt", () => {
       },
     });
 
-    const lane = await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
+    const { lane } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
+      // The clipboard lane has no known agent, so the MCP question never
+      // appears even when nothing suppressed it.
+      docsMcp: undefined,
       agentDetection: detected(),
-      languages: [],
       mode: INTERACTIVE,
     });
 
@@ -263,10 +278,9 @@ describe("instrumentApp lane prompt", () => {
       writeClipboard: async () => false,
     });
 
-    const lane = await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
+    const { lane } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
       agentDetection: detected(),
-      languages: [],
       mode: INTERACTIVE,
     });
 
@@ -282,10 +296,9 @@ describe("instrumentApp lane prompt", () => {
     const prompter = scriptedPrompter(["manual", true]);
     const deps = buildFakeDeps({ prompter });
 
-    const lane = await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
+    const { lane } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
       agentDetection: detected(),
-      languages: [],
       mode: INTERACTIVE,
     });
 
@@ -294,7 +307,9 @@ describe("instrumentApp lane prompt", () => {
       "Follow the tracing quickstart: https://arize.com/docs/phoenix/quickstart"
     );
   });
+});
 
+describe("instrumentApp docs decision", () => {
   it("tells the agent where the prefetched docs landed", async () => {
     const prompter = scriptedPrompter(["clipboard", true]);
     const copied: string[] = [];
@@ -304,22 +319,23 @@ describe("instrumentApp lane prompt", () => {
         copied.push(text);
         return true;
       },
-    });
-
-    await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
-      agentDetection: detected(),
-      languages: [],
-      mode: INTERACTIVE,
-      docs: {
+      fetchDocs: async () => ({
         outputDir: ".px/docs",
         workflows: ["tracing"],
         written: 3,
         failed: 0,
         hasPagesOnDisk: true,
-      },
+      }),
     });
 
+    const { docs } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
+      docs: { enabled: true },
+      agentDetection: detected(),
+      mode: INTERACTIVE,
+    });
+
+    expect(docs?.written).toBe(3);
     expect(copied[0]).toContain(".px/docs");
   });
 
@@ -332,24 +348,138 @@ describe("instrumentApp lane prompt", () => {
         copied.push(text);
         return true;
       },
-    });
-
-    await instrumentApp(deps, CONNECTION, {
-      authEnabled: false,
-      agentDetection: detected(),
-      languages: [],
-      mode: INTERACTIVE,
       // Every page failed and nothing was there from a previous run — sending
       // the agent to read an empty directory would be worse than the web.
-      docs: {
+      fetchDocs: async () => ({
         outputDir: ".px/docs",
         workflows: ["tracing"],
         written: 0,
         failed: 12,
         hasPagesOnDisk: false,
-      },
+      }),
+    });
+
+    await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
+      docs: { enabled: true },
+      agentDetection: detected(),
+      mode: INTERACTIVE,
     });
 
     expect(copied[0]).not.toContain(".px/docs");
+  });
+
+  it("a connected docs MCP replaces the prefetch and steers the prompt", async () => {
+    const prompter = scriptedPrompter([]);
+    const launched: CommandSpec[] = [];
+    let docsFetched = false;
+    const deps = buildFakeDeps({
+      prompter,
+      fetchDocs: async () => {
+        docsFetched = true;
+        throw new Error("prefetch must not run when the MCP is connected");
+      },
+      processes: {
+        exec: binariesOnPath("claude"),
+        spawnInteractive: async (spec) => {
+          launched.push(spec);
+          return { exitCode: 0 };
+        },
+      },
+    });
+
+    const { docs, docsMcp } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
+      docs: { enabled: true },
+      docsMcp: true,
+      agentDetection: detected(),
+      agent: "claude",
+      headless: true,
+      mode: BACKGROUND_BYPASS,
+    });
+
+    expect(docsFetched).toBe(false);
+    expect(docs).toBeUndefined();
+    expect(docsMcp).toEqual({
+      outcome: "configured",
+      agents: ["claude"],
+      files: [],
+    });
+    const prompt = launched[0]?.args.at(-1);
+    expect(prompt).toContain('"phoenix-docs" MCP server');
+    expect(prompt).not.toContain(".px/docs");
+  });
+
+  it("survives an MCP install path that throws and falls back to the prefetch", async () => {
+    const prompter = scriptedPrompter([]);
+    const launched: CommandSpec[] = [];
+    const deps = buildFakeDeps({
+      prompter,
+      fetchDocs: async () => ({
+        outputDir: ".px/docs",
+        workflows: ["tracing"],
+        written: 3,
+        failed: 0,
+        hasPagesOnDisk: true,
+      }),
+      processes: {
+        // The exec seam contractually never throws — this simulates exactly
+        // the kind of drift the guard exists for.
+        exec: async (spec) => {
+          if (spec.args[0] === "mcp") {
+            throw new Error("mcp subcommand went away");
+          }
+          return { exitCode: 0, stdout: "1.0.0\n", stderr: "" };
+        },
+        spawnInteractive: async (spec) => {
+          launched.push(spec);
+          return { exitCode: 0 };
+        },
+      },
+    });
+
+    const { lane, docs, docsMcp } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
+      docs: { enabled: true },
+      docsMcp: true,
+      agentDetection: detected(),
+      agent: "claude",
+      headless: true,
+      mode: BACKGROUND_BYPASS,
+    });
+
+    // Setup carried on: the failure was reported, the docs downloaded, and
+    // the agent still launched with the local pages.
+    expect(docsMcp?.outcome).toBe("failed");
+    expect(docs?.written).toBe(3);
+    expect(lane).toEqual({ kind: "agent", agent: "claude", exitCode: 0 });
+    expect(launched[0]?.args.at(-1)).toContain(".px/docs");
+    expect(
+      prompter.output.some((message) =>
+        message.includes("downloading the docs instead")
+      )
+    ).toBe(true);
+  });
+
+  it("says so when an explicit --docs-mcp meets a lane with no agent", async () => {
+    const prompter = scriptedPrompter(["clipboard", true]);
+    const deps = buildFakeDeps({
+      prompter,
+      writeClipboard: async () => true,
+    });
+
+    const { docsMcp } = await instrumentApp(deps, CONNECTION, {
+      ...NO_DOCS,
+      docsMcp: true,
+      agentDetection: detected(),
+      mode: INTERACTIVE,
+    });
+
+    // The flag can't be honored — there is no agent to configure — but it
+    // must not be dropped silently.
+    expect(docsMcp).toBeUndefined();
+    expect(
+      prompter.output.some((message) => message.includes("no coding agent"))
+    ).toBe(true);
   });
 });

--- a/js/packages/phoenix-cli/test/setup/offerDocsMcp.test.ts
+++ b/js/packages/phoenix-cli/test/setup/offerDocsMcp.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Docs MCP offer tests. The CLI lane (claude registers through its own `mcp`
+ * subcommand) is exercised through an exec spy; the file lane (cursor,
+ * opencode) writes real temp dirs.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DOCS_MCP_SERVER_URL,
+  getCodingAgent,
+  type CodingAgent,
+  type CodingAgentId,
+} from "../../src/setup/agents/registry";
+import type { CommandSpec } from "../../src/setup/deps";
+import { offerDocsMcp } from "../../src/setup/steps/offerDocsMcp";
+import { buildFakeDeps, scriptedPrompter } from "./fakes";
+
+function agent(id: CodingAgentId): CodingAgent {
+  const found = getCodingAgent(id);
+  if (!found) {
+    throw new Error(`unknown agent in test: ${id}`);
+  }
+  return found;
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+describe("offerDocsMcp", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "px-docs-mcp-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("registers claude through its own CLI and verifies the entry landed", async () => {
+    const prompter = scriptedPrompter([]);
+    const execs: CommandSpec[] = [];
+    const deps = buildFakeDeps({
+      context: { cwd: dir },
+      prompter,
+      processes: {
+        exec: async (spec) => {
+          execs.push(spec);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      },
+    });
+
+    const result = await offerDocsMcp(deps, {
+      docsMcp: true,
+      agent: agent("claude"),
+      headless: true,
+      docsEnabled: true,
+    });
+
+    expect(result).toEqual({
+      outcome: "configured",
+      agents: ["claude"],
+      files: [],
+    });
+    expect(prompter.transcript).toEqual([]);
+    // The clean path: add, then read the entry back. No remove — nothing to
+    // remove, and running it up front would risk a working registration.
+    expect(execs.map((spec) => spec.args)).toEqual([
+      [
+        "mcp",
+        "add",
+        "--transport",
+        "http",
+        "phoenix-docs",
+        DOCS_MCP_SERVER_URL,
+      ],
+      ["mcp", "get", "phoenix-docs"],
+    ]);
+    // Local scope is keyed by directory — the exec must run in the repo.
+    expect(execs.every((spec) => spec.cwd === dir)).toBe(true);
+    expect(execs.every((spec) => spec.command === "claude")).toBe(true);
+    // Nothing lands in the repo on the CLI lane.
+    expect(fs.existsSync(path.join(dir, ".mcp.json"))).toBe(false);
+  });
+
+  it("an add refused because the entry exists is retried through remove", async () => {
+    const calls: string[][] = [];
+    let adds = 0;
+    const deps = buildFakeDeps({
+      context: { cwd: dir },
+      processes: {
+        exec: async (spec) => {
+          calls.push(spec.args);
+          if (spec.args[1] === "add" && ++adds === 1) {
+            return {
+              exitCode: 1,
+              stdout: "",
+              stderr: "phoenix-docs already exists",
+            };
+          }
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      },
+    });
+
+    const result = await offerDocsMcp(deps, {
+      docsMcp: true,
+      agent: agent("claude"),
+      headless: true,
+      docsEnabled: true,
+    });
+
+    expect(result.outcome).toBe("configured");
+    // add (refused) → get (entry exists) → remove → add → get (read-back).
+    expect(calls.map((args) => args[1])).toEqual([
+      "add",
+      "get",
+      "remove",
+      "add",
+      "get",
+    ]);
+  });
+
+  it("a failing add falls back with the CLI's own stderr, never removing an entry it didn't confirm", async () => {
+    const prompter = scriptedPrompter([]);
+    const calls: string[][] = [];
+    const deps = buildFakeDeps({
+      context: { cwd: dir },
+      prompter,
+      processes: {
+        // The add is broken and no phoenix-docs entry exists — the drifted-CLI
+        // case on a fresh machine. Nothing must be removed.
+        exec: async (spec) => {
+          calls.push(spec.args);
+          if (spec.args[1] === "add") {
+            return {
+              exitCode: 2,
+              stdout: "",
+              stderr: "unknown option --transport",
+            };
+          }
+          return { exitCode: 1, stdout: "", stderr: "not found" };
+        },
+      },
+    });
+
+    const result = await offerDocsMcp(deps, {
+      docsMcp: true,
+      agent: agent("claude"),
+      headless: true,
+      docsEnabled: true,
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(calls.every((args) => args[1] !== "remove")).toBe(true);
+    expect(
+      prompter.output.some((message) =>
+        message.includes("unknown option --transport")
+      )
+    ).toBe(true);
+    expect(
+      prompter.output.some((message) =>
+        message.includes("downloading the docs instead")
+      )
+    ).toBe(true);
+  });
+
+  it("an exec seam that throws is reported and never escapes the step", async () => {
+    const prompter = scriptedPrompter([]);
+    const deps = buildFakeDeps({
+      context: { cwd: dir },
+      prompter,
+      processes: {
+        exec: async () => {
+          throw new Error("mcp subcommand went away");
+        },
+      },
+    });
+
+    const result = await offerDocsMcp(deps, {
+      docsMcp: true,
+      agent: agent("claude"),
+      headless: true,
+      docsEnabled: false,
+    });
+
+    expect(result.outcome).toBe("failed");
+    // With --no-docs there is no download to promise.
+    expect(
+      prompter.output.some((message) =>
+        message.includes("read the docs from the web")
+      )
+    ).toBe(true);
+    expect(
+      prompter.output.every(
+        (message) => !message.includes("downloading the docs instead")
+      )
+    ).toBe(true);
+  });
+
+  it("an add that 'succeeds' without registering the entry is caught by the read-back", async () => {
+    const prompter = scriptedPrompter([]);
+    const deps = buildFakeDeps({
+      context: { cwd: dir },
+      prompter,
+      processes: {
+        // remove and add exit 0, but the entry never shows up in `mcp get`.
+        exec: async (spec) =>
+          spec.args[1] === "get"
+            ? { exitCode: 1, stdout: "", stderr: "not found" }
+            : { exitCode: 0, stdout: "", stderr: "" },
+      },
+    });
+
+    const result = await offerDocsMcp(deps, {
+      docsMcp: true,
+      agent: agent("claude"),
+      headless: true,
+      docsEnabled: true,
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(
+      prompter.output.some((message) => message.includes("did not show up"))
+    ).toBe(true);
+  });
+
+  it("writes cursor's config file, preserving servers already in it", async () => {
+    const cursorConfig = path.join(dir, ".cursor", "mcp.json");
+    fs.mkdirSync(path.dirname(cursorConfig), { recursive: true });
+    fs.writeFileSync(
+      cursorConfig,
+      JSON.stringify({ mcpServers: { mine: { command: "my-mcp" } } })
+    );
+    const prompter = scriptedPrompter([true]);
+    const deps = buildFakeDeps({ context: { cwd: dir }, prompter });
+
+    const result = await offerDocsMcp(deps, {
+      agent: agent("cursor"),
+      headless: false,
+      docsEnabled: true,
+    });
+
+    expect(result).toEqual({
+      outcome: "configured",
+      agents: ["cursor"],
+      // Forward-slash on every platform — the report must stay stable.
+      files: [".cursor/mcp.json"],
+    });
+    expect(readJson(cursorConfig)).toEqual({
+      mcpServers: {
+        mine: { command: "my-mcp" },
+        "phoenix-docs": { url: DOCS_MCP_SERVER_URL },
+      },
+    });
+  });
+
+  it("replaces a pre-existing entry under the server name wholesale", async () => {
+    const cursorConfig = path.join(dir, ".cursor", "mcp.json");
+    fs.mkdirSync(path.dirname(cursorConfig), { recursive: true });
+    // A stdio-style entry from an earlier manual install: its keys must not
+    // survive under the new url, or the agent may resolve the stale command.
+    fs.writeFileSync(
+      cursorConfig,
+      JSON.stringify({
+        mcpServers: {
+          "phoenix-docs": { command: "npx", args: ["@arizeai/phoenix-mcp"] },
+        },
+      })
+    );
+    const deps = buildFakeDeps({ context: { cwd: dir } });
+
+    const result = await offerDocsMcp(deps, {
+      docsMcp: true,
+      agent: agent("cursor"),
+      headless: true,
+      docsEnabled: true,
+    });
+
+    expect(result.outcome).toBe("configured");
+    expect(readJson(cursorConfig)).toEqual({
+      mcpServers: { "phoenix-docs": { url: DOCS_MCP_SERVER_URL } },
+    });
+  });
+
+  it("creates opencode.json with its $schema, but never back-fills an existing file", async () => {
+    const deps = () => buildFakeDeps({ context: { cwd: dir } });
+    const configPath = path.join(dir, "opencode.json");
+    const run = () =>
+      offerDocsMcp(deps(), {
+        docsMcp: true,
+        agent: agent("opencode"),
+        headless: true,
+        docsEnabled: true,
+      });
+
+    await run();
+    expect(readJson(configPath).$schema).toBe(
+      "https://opencode.ai/config.json"
+    );
+
+    // A user file without $schema stays without it — setup only asserts its
+    // own entry.
+    fs.writeFileSync(configPath, JSON.stringify({ theme: "dark" }));
+    await run();
+    const rewritten = readJson(configPath);
+    expect(rewritten.$schema).toBeUndefined();
+    expect(rewritten.theme).toBe("dark");
+    expect(rewritten.mcp).toEqual({
+      "phoenix-docs": {
+        type: "remote",
+        url: DOCS_MCP_SERVER_URL,
+        enabled: true,
+      },
+    });
+  });
+
+  it("declining keeps the repo and agent untouched", async () => {
+    const prompter = scriptedPrompter([false]);
+    const execs: CommandSpec[] = [];
+    const deps = buildFakeDeps({
+      context: { cwd: dir },
+      prompter,
+      processes: {
+        exec: async (spec) => {
+          execs.push(spec);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      },
+    });
+
+    const result = await offerDocsMcp(deps, {
+      agent: agent("claude"),
+      headless: false,
+      docsEnabled: true,
+    });
+
+    expect(result).toEqual({ outcome: "declined", agents: [], files: [] });
+    expect(execs).toEqual([]);
+  });
+
+  it("names the agent in the offer", async () => {
+    const prompter = scriptedPrompter([false]);
+    const deps = buildFakeDeps({ context: { cwd: dir }, prompter });
+
+    await offerDocsMcp(deps, {
+      agent: agent("cursor"),
+      headless: false,
+      docsEnabled: true,
+    });
+    expect(prompter.transcript[0]).toContain("Cursor");
+  });
+
+  it("headless without --docs-mcp never touches agent config", async () => {
+    const prompter = scriptedPrompter([]);
+    const deps = buildFakeDeps({ context: { cwd: dir }, prompter });
+
+    const result = await offerDocsMcp(deps, {
+      agent: agent("cursor"),
+      headless: true,
+      docsEnabled: true,
+    });
+
+    expect(result.outcome).toBe("skipped");
+    expect(fs.existsSync(path.join(dir, ".cursor"))).toBe(false);
+  });
+
+  it("--no-docs-mcp skips without prompting", async () => {
+    const prompter = scriptedPrompter([]);
+    const deps = buildFakeDeps({ context: { cwd: dir }, prompter });
+
+    const result = await offerDocsMcp(deps, {
+      docsMcp: false,
+      agent: agent("claude"),
+      headless: false,
+      docsEnabled: true,
+    });
+
+    expect(result.outcome).toBe("skipped");
+    expect(prompter.transcript).toEqual([]);
+  });
+
+  it("--docs-mcp with an agent that has no install path says so and skips", async () => {
+    const prompter = scriptedPrompter([]);
+    const deps = buildFakeDeps({ context: { cwd: dir }, prompter });
+
+    const result = await offerDocsMcp(deps, {
+      docsMcp: true,
+      agent: agent("codex"),
+      headless: true,
+      docsEnabled: true,
+    });
+
+    expect(result.outcome).toBe("skipped");
+    expect(prompter.output.some((message) => message.includes("Codex"))).toBe(
+      true
+    );
+  });
+
+  it("an unparseable existing config fails the offer instead of clobbering it", async () => {
+    const cursorConfig = path.join(dir, ".cursor", "mcp.json");
+    fs.mkdirSync(path.dirname(cursorConfig), { recursive: true });
+    fs.writeFileSync(cursorConfig, "{ not json");
+    const prompter = scriptedPrompter([true]);
+    const deps = buildFakeDeps({ context: { cwd: dir }, prompter });
+
+    const result = await offerDocsMcp(deps, {
+      agent: agent("cursor"),
+      headless: false,
+      docsEnabled: true,
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(fs.readFileSync(cursorConfig, "utf-8")).toBe("{ not json");
+    expect(
+      prompter.output.some((message) =>
+        message.includes("downloading the docs instead")
+      )
+    ).toBe(true);
+  });
+
+  it("re-running the file lane is idempotent", async () => {
+    const run = () =>
+      offerDocsMcp(buildFakeDeps({ context: { cwd: dir } }), {
+        docsMcp: true,
+        agent: agent("cursor"),
+        headless: true,
+        docsEnabled: true,
+      });
+    await run();
+    const configPath = path.join(dir, ".cursor", "mcp.json");
+    const first = fs.readFileSync(configPath, "utf-8");
+    const second = await run();
+    expect(second.outcome).toBe("configured");
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(first);
+  });
+});

--- a/js/packages/phoenix-cli/test/setup/runSetup.test.ts
+++ b/js/packages/phoenix-cli/test/setup/runSetup.test.ts
@@ -178,6 +178,7 @@ describe("runSetup", () => {
       "local", // endpoint
       "my-app", // project name
       "agent:claude", // hand off to Claude Code
+      false, // no docs MCP — keep the docs download
       // agent exits, verification succeeds via the API poll — no checkpoint
       false, // no px profile
       false, // no global CLI install
@@ -215,6 +216,151 @@ describe("runSetup", () => {
       PHOENIX_COLLECTOR_ENDPOINT: LOCAL,
       PHOENIX_PROJECT_NAME: "my-app",
     });
+  });
+
+  it("accepting the docs MCP offer replaces the docs download", async () => {
+    const prompter = scriptedPrompter([
+      "local", // endpoint
+      "my-app", // project name
+      "agent:claude", // hand off to Claude Code
+      true, // yes, connect the docs MCP
+      false, // no px profile
+      false, // no global CLI install
+      false, // no skills install
+    ]);
+    const git = gitExecFake();
+    const launched: Array<{ args: string[] }> = [];
+    const mcpCommands: string[][] = [];
+    let docsFetched = false;
+    const deps = buildFakeDeps({
+      context: { cwd: dir, settingsPath },
+      prompter,
+      fetch: authOffFetch(),
+      fetchDocs: async () => {
+        docsFetched = true;
+        throw new Error("prefetch must not run when the MCP is connected");
+      },
+      processes: {
+        exec: async (spec) => {
+          if (spec.command === "claude" && spec.args[0] === "--version") {
+            return { exitCode: 0, stdout: "1.0.0\n", stderr: "" };
+          }
+          if (spec.command === "claude" && spec.args[0] === "mcp") {
+            mcpCommands.push(spec.args);
+            return { exitCode: 0, stdout: "", stderr: "" };
+          }
+          return git(spec);
+        },
+        spawnInteractive: async (spec) => {
+          launched.push(spec);
+          return { exitCode: 0 };
+        },
+      },
+    });
+
+    const result = await runSetupLane(deps);
+    expect(docsFetched).toBe(false);
+    expect(result.docs).toBeUndefined();
+    // Claude registers through its own CLI (local scope) — no repo file.
+    expect(result.docsMcp).toEqual({
+      outcome: "configured",
+      agents: ["claude"],
+      files: [],
+    });
+    expect(fs.existsSync(path.join(dir, ".mcp.json"))).toBe(false);
+    expect(
+      mcpCommands.some(
+        (args) => args[1] === "add" && args.at(-1)?.startsWith("https://")
+      )
+    ).toBe(true);
+    // The hand-off prompt steers the agent at the MCP server, not local docs.
+    expect(launched[0]?.args?.[0]).toContain('"phoenix-docs" MCP server');
+    expect(launched[0]?.args?.[0]).not.toContain(".px/docs");
+  });
+
+  it("headless --docs-mcp configures the pinned agent without prompting", async () => {
+    const prompter = scriptedPrompter([]);
+    const git = gitExecFake();
+    const mcpCommands: Array<{ args: string[]; cwd?: string }> = [];
+    const deps = buildFakeDeps({
+      context: { cwd: dir },
+      prompter,
+      fetch: authOffFetch(),
+      fetchDocs: async () => {
+        throw new Error("prefetch must not run when the MCP is connected");
+      },
+      processes: {
+        exec: async (spec) => {
+          if (spec.command === "claude" && spec.args[0] === "--version") {
+            return { exitCode: 0, stdout: "1.0.0\n", stderr: "" };
+          }
+          if (spec.command === "claude" && spec.args[0] === "mcp") {
+            mcpCommands.push(spec);
+            return { exitCode: 0, stdout: "", stderr: "" };
+          }
+          return git(spec);
+        },
+      },
+    });
+
+    const result = await runSetupLane(deps, {
+      noInput: true,
+      instrument: true,
+      agent: "claude",
+      bypassPermissions: true,
+      docsMcp: true,
+      endpoint: LOCAL,
+      project: "my-app",
+    });
+    expect(prompter.transcript).toEqual([]);
+    expect(result.docsMcp?.outcome).toBe("configured");
+    expect(result.docs).toBeUndefined();
+    // Registered in the repo directory — claude's local scope is per-project.
+    expect(mcpCommands.length).toBeGreaterThan(0);
+    expect(mcpCommands.every((spec) => spec.cwd === dir)).toBe(true);
+  });
+
+  it("a drifted MCP install can never take setup down with it", async () => {
+    const prompter = scriptedPrompter([]);
+    const git = gitExecFake();
+    const launched: Array<{ args: string[] }> = [];
+    const deps = buildFakeDeps({
+      context: { cwd: dir },
+      prompter,
+      fetch: authOffFetch(),
+      processes: {
+        exec: async (spec) => {
+          if (spec.command === "claude" && spec.args[0] === "--version") {
+            return { exitCode: 0, stdout: "1.0.0\n", stderr: "" };
+          }
+          if (spec.command === "claude" && spec.args[0] === "mcp") {
+            // Harsher than a non-zero exit: the exec seam itself misbehaving.
+            throw new Error("mcp subcommand went away");
+          }
+          return git(spec);
+        },
+        spawnInteractive: async (spec) => {
+          launched.push(spec);
+          return { exitCode: 0 };
+        },
+      },
+    });
+
+    const result = await runSetupLane(deps, {
+      noInput: true,
+      instrument: true,
+      agent: "claude",
+      bypassPermissions: true,
+      docsMcp: true,
+      endpoint: LOCAL,
+      project: "my-app",
+    });
+    // The run completed: docs downloaded instead, agent launched, traces
+    // verified — the MCP failure cost nothing but the optimization.
+    expect(result.docsMcp?.outcome).toBe("failed");
+    expect(result.docs?.outputDir).toBe(".px/docs");
+    expect(result.tracesVerified).toBe(true);
+    expect(launched).toHaveLength(1);
   });
 
   it("offers a finish-anyway escape hatch when no traces arrive", async () => {


### PR DESCRIPTION
## What

`px setup` now offers to connect the [Phoenix docs MCP server](https://arizeai-433a7140.mintlify.app/mcp) to the coding agent taking the instrumentation hand-off, instead of always downloading ~100 docs pages to `.px/docs`. Taking the offer replaces the prefetch outright — the agent searches the docs on demand, which is faster to set up and cheaper in tokens. Declining or any failure degrades to the download (what setup did before this step existed).

## How

- The lane is resolved first, so the offer targets exactly the agent doing the work — setup never sprays MCP config for agents that aren't involved. The clipboard and manual lanes have no known agent and keep the prefetch.
- **claude** registers through its own CLI (`claude mcp add`, local scope — nothing lands in the repo, no first-use approval needed). **cursor** / **opencode** get a merge into their documented per-project config file (`.cursor/mcp.json`, `opencode.json`). **codex** reads only a global TOML, so it keeps the download.
- Config-file merges are level-limited: containers and server names merge (existing servers untouched), but a same-name server entry is replaced wholesale — a stale stdio-style entry can't survive as a stdio/http hybrid.
- The CLI lane runs `add` first and only removes-then-retries when the agent's own listing confirms an entry exists under our name, so a failing add can never destroy a working registration. A read-back after `add` guards against a drifted CLI that "succeeds" without registering.
- The offer never takes setup down with it: every failure is reported and falls back to the download; only a user cancel unwinds.
- `--docs-mcp` / `--no-docs-mcp` pre-answer the prompt (headless runs skip the offer unless `--docs-mcp` opts in). An explicit `--docs-mcp` that can't be honored (codex, clipboard/manual lane) says so instead of silently downloading. With `--no-docs`, the decline/fallback copy no longer promises a download that won't run.
- The hand-off prompt steers a connected agent at the MCP server instead of `.px/docs`.

## Report / raw output

`--format raw` gains an optional `docsMcp: { outcome: "configured" | "declined" | "failed", agents, files }` block; MCP config files written are folded into `files`.

## Tests

- `offerDocsMcp` unit tests: CLI lane ordering (add → read-back; refused add → get → remove → retry), destruction guard (no remove without a confirmed entry), exec-seam throws contained, file-lane merge/replace/idempotency, `--no-docs` copy, headless gating.
- `instrumentApp` / `runSetup` integration tests: MCP replaces the prefetch and steers the prompt, drifted installs can't take setup down, headless `--docs-mcp` configures the pinned agent without prompting.