### PR TITLE
feat(ui): clarify AI provider credential storage with browser/server tabs

### DIFF
--- a/app/src/components/generative/ProviderBrowserCredentialsPanel.tsx
+++ b/app/src/components/generative/ProviderBrowserCredentialsPanel.tsx
@@ -1,0 +1,193 @@
+import { css } from "@emotion/react";
+import { useMemo } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import {
+  Button,
+  CredentialField,
+  CredentialInput,
+  FieldError,
+  Flex,
+  Form,
+  Label,
+  Text,
+  View,
+} from "@phoenix/components";
+import { useNotifySuccess } from "@phoenix/contexts";
+import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
+import { isModelProvider } from "@phoenix/utils/generativeUtils";
+
+import type { ProviderServerCredentialsPanelProvider } from "./ProviderServerCredentialsPanel";
+
+type BrowserCredentialsFormValues = Record<string, string>;
+
+/**
+ * A form for a user's personal provider credentials, persisted only in the
+ * browser's local storage. Mirrors the form pattern of
+ * ProviderServerCredentialsPanel so the two credential destinations present
+ * the same way.
+ */
+export function ProviderBrowserCredentialsPanel({
+  provider,
+  onSaved,
+}: {
+  provider: ProviderServerCredentialsPanelProvider;
+  /**
+   * Called after the credentials are successfully saved
+   */
+  onSaved?: () => void;
+}) {
+  return (
+    <>
+      <View paddingBottom="size-100">
+        <Text size="XS" color="text-700">
+          Stored only in this browser. Sent with your API requests and never
+          saved on the server.
+        </Text>
+      </View>
+      <Form>
+        <BrowserCredentials provider={provider} onSaved={onSaved} />
+      </Form>
+    </>
+  );
+}
+
+function BrowserCredentials({
+  provider,
+  onSaved,
+}: {
+  provider: ProviderServerCredentialsPanelProvider;
+  onSaved?: () => void;
+}) {
+  const providerKey = provider.key;
+  const isValidProvider = isModelProvider(providerKey);
+  const notifySuccess = useNotifySuccess();
+
+  const { setCredential, credentials } = useCredentialsContext((state) => ({
+    setCredential: state.setCredential,
+    credentials: isValidProvider ? state[providerKey] : undefined,
+  }));
+  const credentialRequirements = provider.credentialRequirements;
+
+  // Values currently persisted in the browser
+  const savedValues = useMemo(() => {
+    const values: BrowserCredentialsFormValues = {};
+    credentialRequirements.forEach(({ envVarName }) => {
+      values[envVarName] = credentials?.[envVarName] ?? "";
+    });
+    return values;
+  }, [credentials, credentialRequirements]);
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isDirty },
+  } = useForm<BrowserCredentialsFormValues>({
+    defaultValues: savedValues,
+    values: savedValues, // Syncs form when the store changes after save/clear
+    mode: "onChange",
+  });
+
+  const hasSavedCredentials = credentialRequirements.some(
+    ({ envVarName }) => !!credentials?.[envVarName]
+  );
+
+  const onSubmit = (formValues: BrowserCredentialsFormValues) => {
+    if (!isValidProvider) return;
+    credentialRequirements.forEach(({ envVarName }) => {
+      setCredential({
+        provider: providerKey,
+        envVarName,
+        value: formValues[envVarName]?.trim() || null,
+      });
+    });
+    notifySuccess({
+      title: "Browser credentials saved",
+      message: `${provider.name} credentials are stored in this browser.`,
+    });
+    onSaved?.();
+  };
+
+  const handleClear = () => {
+    if (!isValidProvider) return;
+    const emptyValues: BrowserCredentialsFormValues = {};
+    credentialRequirements.forEach(({ envVarName }) => {
+      setCredential({
+        provider: providerKey,
+        envVarName,
+        value: null,
+      });
+      emptyValues[envVarName] = "";
+    });
+    reset(emptyValues);
+    notifySuccess({
+      title: "Browser credentials cleared",
+      message: `${provider.name} credentials were removed from this browser.`,
+    });
+  };
+
+  if (!isValidProvider) {
+    return <Text color="warning">Unknown provider type: {providerKey}</Text>;
+  }
+
+  if (credentialRequirements.length === 0) {
+    return <Text color="text-700">Browser credentials are not required.</Text>;
+  }
+
+  return (
+    <Flex direction="column" gap="size-100">
+      {credentialRequirements.map(({ envVarName, isRequired }) => (
+        <Controller
+          key={envVarName}
+          name={envVarName}
+          control={control}
+          rules={{
+            validate: isRequired
+              ? (value) => !!value?.trim() || `${envVarName} is required`
+              : undefined,
+          }}
+          render={({
+            field: { name, onChange, onBlur, value },
+            fieldState: { error },
+          }) => (
+            <CredentialField
+              name={name}
+              isRequired={isRequired}
+              isInvalid={!!error}
+              value={value ?? ""}
+              onChange={onChange}
+              onBlur={onBlur}
+            >
+              <Label>{envVarName}</Label>
+              <CredentialInput />
+              {error && <FieldError>{error.message}</FieldError>}
+            </CredentialField>
+          )}
+        />
+      ))}
+      <Flex
+        direction="row"
+        gap="size-100"
+        justifyContent="end"
+        width="100%"
+        css={css`
+          margin-top: var(--global-dimension-size-100);
+        `}
+      >
+        {hasSavedCredentials && (
+          <Button variant="danger" onPress={handleClear}>
+            Clear
+          </Button>
+        )}
+        <Button
+          variant={isDirty ? "primary" : "default"}
+          isDisabled={!isDirty}
+          onPress={() => handleSubmit(onSubmit)()}
+        >
+          Save
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/src/components/generative/ProviderServerCredentialsPanel.tsx
+++ b/app/src/components/generative/ProviderServerCredentialsPanel.tsx
@@ -26,6 +26,7 @@ export type ProviderServerCredentialsPanelProvider = {
   readonly name: string;
   readonly key: string;
   readonly credentialRequirements: readonly ProviderCredentialRequirement[];
+  readonly credentialsSet: boolean;
 };
 
 // Form values type for react-hook-form
@@ -248,9 +249,20 @@ function ServerCredentials({
     );
   }
 
+  const setViaServerEnvironment =
+    provider.credentialsSet &&
+    existingSecretKeys.length === 0 &&
+    providerUnparsableSecrets.length === 0;
+
   return (
     <Flex direction="column" gap="size-100">
       {error && <Alert variant="danger">{error}</Alert>}
+      {setViaServerEnvironment && (
+        <Alert variant="info">
+          Set via a server environment variable. This can only be cleared by
+          removing the environment variable on the server.
+        </Alert>
+      )}
       {providerUnparsableSecrets.map(({ envVarName, parseError }) => (
         <Alert key={envVarName} variant="danger" title={envVarName}>
           {parseError}

--- a/app/src/components/generative/ProviderServerCredentialsPanel.tsx
+++ b/app/src/components/generative/ProviderServerCredentialsPanel.tsx
@@ -34,16 +34,21 @@ type ServerCredentialsFormValues = Record<string, string>;
 export function ProviderServerCredentialsPanel({
   provider,
   onCredentialsUpdated,
+  onSaved,
 }: {
   provider: ProviderServerCredentialsPanelProvider;
   onCredentialsUpdated?: () => void;
+  /**
+   * Called after the credentials are successfully saved
+   */
+  onSaved?: () => void;
 }) {
   return (
     <>
       <View paddingBottom="size-100">
         <Text size="XS" color="text-700">
-          Credentials are encrypted and stored in the database. These are shared
-          across all users and override environment variables.
+          Shared with all users. Stored encrypted and overrides server
+          environment variables.
         </Text>
       </View>
       <Suspense fallback={<Text color="text-700">Loading...</Text>}>
@@ -51,6 +56,7 @@ export function ProviderServerCredentialsPanel({
           <ServerCredentials
             provider={provider}
             onCredentialsUpdated={onCredentialsUpdated}
+            onSaved={onSaved}
           />
         </Form>
       </Suspense>
@@ -61,9 +67,11 @@ export function ProviderServerCredentialsPanel({
 function ServerCredentials({
   provider,
   onCredentialsUpdated,
+  onSaved,
 }: {
   provider: ProviderServerCredentialsPanelProvider;
   onCredentialsUpdated?: () => void;
+  onSaved?: () => void;
 }) {
   const notifySuccess = useNotifySuccess();
   const [error, setError] = useState<string | null>(null);
@@ -135,13 +143,16 @@ function ServerCredentials({
     savedServerValues[envVarName] = serverSecretMap.get(envVarName) ?? "";
   });
 
-  const { control, handleSubmit, reset } = useForm<ServerCredentialsFormValues>(
-    {
-      defaultValues: savedServerValues,
-      values: savedServerValues, // Syncs form when server data changes after refetch
-      mode: "onChange",
-    }
-  );
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isDirty },
+  } = useForm<ServerCredentialsFormValues>({
+    defaultValues: savedServerValues,
+    values: savedServerValues, // Syncs form when server data changes after refetch
+    mode: "onChange",
+  });
 
   const [commit, isCommitting] =
     useMutation<ProviderServerCredentialsPanelUpsertOrDeleteSecretsMutation>(
@@ -178,6 +189,7 @@ function ServerCredentials({
           title: "Secrets updated",
           message: `${secretsToUpsert.length} secret(s) updated`,
         });
+        onSaved?.();
       },
       onError: (error) => {
         setError(error instanceof Error ? error.message : String(error));
@@ -287,12 +299,12 @@ function ServerCredentials({
             isDisabled={isCommitting}
             onPress={handleDelete}
           >
-            Delete
+            Clear
           </Button>
         )}
         <Button
-          variant="primary"
-          isDisabled={isCommitting}
+          variant={isDirty ? "primary" : "default"}
+          isDisabled={!isDirty || isCommitting}
           isPending={isCommitting}
           onPress={() => handleSubmit(onSubmit)()}
         >

--- a/app/src/components/generative/index.ts
+++ b/app/src/components/generative/index.ts
@@ -3,4 +3,5 @@ export * from "./GenerativeProviderIcon";
 export * from "./ModelMenu";
 export * from "./modelProviderUtils";
 export * from "./useModelMenuData";
+export * from "./ProviderBrowserCredentialsPanel";
 export * from "./ProviderServerCredentialsPanel";

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -6,14 +6,13 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo } from "react";
+import { OverlayTriggerStateContext } from "react-aria-components";
 import { graphql, useFragment } from "react-relay";
 
 import {
   Button,
   Card,
-  CredentialField,
-  CredentialInput,
   Dialog,
   DialogCloseButton,
   DialogContent,
@@ -22,19 +21,20 @@ import {
   DialogTitleExtra,
   DialogTrigger,
   Flex,
-  Form,
   Icon,
   Icons,
-  Label,
+  LazyTabPanel,
   Modal,
   ModalOverlay,
+  Tab,
+  TabList,
+  Tabs,
   Text,
-  ToggleButton,
-  ToggleButtonGroup,
   View,
 } from "@phoenix/components";
 import {
   GenerativeProviderIcon,
+  ProviderBrowserCredentialsPanel,
   ProviderServerCredentialsPanel,
 } from "@phoenix/components/generative";
 import { tableCSS } from "@phoenix/components/table/styles";
@@ -230,7 +230,7 @@ function ProviderCredentialsStatus({
     return <Text color="success">no credentials required</Text>;
   }
   if (hasLocalCredentials) {
-    return <Text color="success">local</Text>;
+    return <Text color="success">configured in this browser</Text>;
   }
   if (credentialsSet) {
     return <Text color="success">configured on the server</Text>;
@@ -238,7 +238,20 @@ function ProviderCredentialsStatus({
   return <Text color="text-700">not configured</Text>;
 }
 
-type CredentialViewType = "browser" | "secrets";
+function CredentialsSetIndicator() {
+  return (
+    <Icon
+      color="success"
+      svg={<Icons.Checkmark />}
+      aria-label="credentials set"
+      css={css`
+        margin-left: var(--global-dimension-size-50);
+        font-size: var(--global-font-size-s);
+        vertical-align: middle;
+      `}
+    />
+  );
+}
 
 function ProviderCredentialsDialog({
   provider,
@@ -247,143 +260,82 @@ function ProviderCredentialsDialog({
 }) {
   const { viewer } = useViewer();
   const isAdmin = !viewer || viewer.role?.name === "ADMIN";
-  const [credentialView, setCredentialView] =
-    useState<CredentialViewType>("browser");
+  const providerKey = provider.key;
+  const hasBrowserCredentials = useCredentialsContext((state) => {
+    if (!isModelProvider(providerKey)) {
+      return false;
+    }
+    const providerCredentials = state[providerKey];
+    return provider.credentialRequirements.some(
+      ({ envVarName }) => !!providerCredentials?.[envVarName]
+    );
+  });
+  const overlayState = useContext(OverlayTriggerStateContext);
+  const closeDialog = useCallback(() => {
+    overlayState?.close();
+  }, [overlayState]);
 
   return (
     <Dialog>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>
-            Configure {isAdmin ? "" : "Local "}
-            {provider.name} Credentials
-          </DialogTitle>
+          <DialogTitle>Configure {provider.name} Credentials</DialogTitle>
           <DialogTitleExtra>
             <DialogCloseButton slot="close" />
           </DialogTitleExtra>
         </DialogHeader>
-        <View padding="size-200">
-          {isAdmin ? (
-            <Flex direction="column" gap="size-200">
-              <ToggleButtonGroup
-                selectedKeys={[credentialView]}
-                size="S"
-                aria-label="Credential Source"
-                onSelectionChange={(v) => {
-                  if (v.size === 0) {
-                    return;
-                  }
-                  const view = v.keys().next().value as CredentialViewType;
-                  if (view === "browser" || view === "secrets") {
-                    setCredentialView(view);
-                  }
-                }}
-              >
-                <ToggleButton aria-label="Browser" id="browser">
+        {isAdmin ? (
+          <>
+            <View paddingX="size-200" paddingY="size-100">
+              <Text size="XS" color="text-700">
+                Credentials can be stored in two places: in this browser for
+                your personal use, and on the server to share with all users.
+              </Text>
+            </View>
+            <Tabs defaultSelectedKey="browser">
+              <TabList aria-label="Credential storage location">
+                <Tab id="browser">
                   Browser
-                </ToggleButton>
-                <ToggleButton aria-label="Secrets" id="secrets">
-                  Secrets
-                </ToggleButton>
-              </ToggleButtonGroup>
-              {credentialView === "browser" && (
-                <>
-                  <View paddingBottom="size-100">
-                    <Text size="XS" color="text-700">
-                      Credentials stored in your browser. Only you can see
-                      these, and they are sent with each API request.
-                    </Text>
-                  </View>
-                  <Form>
-                    <BrowserCredentials provider={provider} />
-                  </Form>
-                </>
-              )}
-              {credentialView === "secrets" && (
-                <ProviderServerCredentialsPanel provider={provider} />
-              )}
+                  {hasBrowserCredentials && <CredentialsSetIndicator />}
+                </Tab>
+                <Tab id="server">
+                  Server
+                  {provider.credentialsSet && <CredentialsSetIndicator />}
+                </Tab>
+              </TabList>
+              <LazyTabPanel id="browser">
+                <View padding="size-200">
+                  <ProviderBrowserCredentialsPanel
+                    provider={provider}
+                    onSaved={closeDialog}
+                  />
+                </View>
+              </LazyTabPanel>
+              <LazyTabPanel id="server">
+                <View padding="size-200">
+                  <ProviderServerCredentialsPanel
+                    provider={provider}
+                    onSaved={closeDialog}
+                  />
+                </View>
+              </LazyTabPanel>
+            </Tabs>
+          </>
+        ) : (
+          <View padding="size-200" paddingTop="size-100">
+            <Flex direction="column" gap="size-100">
+              <Text size="XS" color="text-700">
+                To configure shared credentials for all users on the server,
+                contact an administrator.
+              </Text>
+              <ProviderBrowserCredentialsPanel
+                provider={provider}
+                onSaved={closeDialog}
+              />
             </Flex>
-          ) : (
-            <>
-              <View paddingBottom="size-100">
-                <Text size="XS">
-                  Set the credentials for the {provider.name} API. These
-                  credentials will be stored entirely in your browser and will
-                  only be sent to the server during API requests.
-                </Text>
-              </View>
-              <Form>
-                <BrowserCredentials provider={provider} />
-              </Form>
-            </>
-          )}
-        </View>
+          </View>
+        )}
       </DialogContent>
     </Dialog>
-  );
-}
-
-function BrowserCredentials({
-  provider,
-}: {
-  provider: GenerativeProvidersCard_data$data["modelProviders"][number];
-}) {
-  const providerKey = provider.key;
-  const isValidProvider = isModelProvider(providerKey);
-
-  const { setCredential, credentials } = useCredentialsContext((state) => ({
-    setCredential: state.setCredential,
-    credentials: isValidProvider ? state[providerKey] : undefined,
-  }));
-  const credentialRequirements = provider.credentialRequirements;
-
-  const clearLocalCredentials = useCallback(() => {
-    if (!isValidProvider) return;
-    provider.credentialRequirements.forEach(({ envVarName }) => {
-      setCredential({
-        provider: providerKey,
-        envVarName,
-        value: "",
-      });
-    });
-  }, [provider, providerKey, isValidProvider, setCredential]);
-
-  if (!isValidProvider) {
-    return <Text color="warning">Unknown provider type: {providerKey}</Text>;
-  }
-
-  if (provider.credentialRequirements.length === 0) {
-    return <Text color="text-700">Browser credentials are not required.</Text>;
-  }
-
-  return (
-    <Flex direction="column" gap="size-100">
-      {credentialRequirements.map(({ envVarName, isRequired }) => (
-        <CredentialField
-          key={envVarName}
-          isRequired={isRequired}
-          onChange={(value) => {
-            setCredential({
-              provider: providerKey,
-              envVarName,
-              value,
-            });
-          }}
-          value={credentials?.[envVarName] ?? ""}
-        >
-          <Label>{envVarName}</Label>
-          <CredentialInput />
-        </CredentialField>
-      ))}
-      <Button
-        onPress={clearLocalCredentials}
-        css={css`
-          align-self: flex-start;
-          margin-top: var(--global-dimension-size-100);
-        `}
-      >
-        Clear Local Credentials
-      </Button>
-    </Flex>
   );
 }

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -245,9 +245,7 @@ function CredentialsSetIndicator() {
       svg={<Icons.Checkmark />}
       aria-label="credentials set"
       css={css`
-        margin-left: var(--global-dimension-size-50);
         font-size: var(--global-font-size-s);
-        vertical-align: middle;
       `}
     />
   );
@@ -295,12 +293,16 @@ function ProviderCredentialsDialog({
             <Tabs defaultSelectedKey="browser">
               <TabList aria-label="Credential storage location">
                 <Tab id="browser">
-                  Browser
-                  {hasBrowserCredentials && <CredentialsSetIndicator />}
+                  <Flex direction="row" alignItems="center" gap="size-50">
+                    <Text>Browser</Text>
+                    {hasBrowserCredentials && <CredentialsSetIndicator />}
+                  </Flex>
                 </Tab>
                 <Tab id="server">
-                  Server
-                  {provider.credentialsSet && <CredentialsSetIndicator />}
+                  <Flex direction="row" alignItems="center" gap="size-50">
+                    <Text>Server</Text>
+                    {provider.credentialsSet && <CredentialsSetIndicator />}
+                  </Flex>
                 </Tab>
               </TabList>
               <LazyTabPanel id="browser">


### PR DESCRIPTION
## Summary

The provider credentials dialog previously presented two very different interaction models behind a Browser/Secrets toggle: browser credentials autosaved invisibly on each keystroke, while server secrets used an explicit form. Nothing explained that the two storage destinations coexist.

- Replace the toggle with standard Tabs (Browser / Server) plus a framing line explaining personal vs shared storage
- Show a green checkmark on each tab that has credentials configured, inline with the tab label
- Convert browser credentials to an explicit-save form (react-hook-form) matching the server panel: Clear (danger, only when values exist) and Save (primary when dirty) aligned bottom-right in both tabs
- Rename the server panel's Delete button to Clear and gate Save on dirty state
- When a provider's server credential is satisfied only by a server environment variable (no DB secret to clear), show an info alert explaining it can only be cleared by removing the env var on the server — previously this state showed "set" with an empty form and no action
- Non-admins get the browser form plus a note to contact an admin for shared server credentials
- Table status now reads "configured in this browser" / "configured on the server" instead of "local"

## Screenshots

Verified live: checkmark aligns inline with tab labels; env-var-only server credentials explain themselves instead of dead-ending.

## Test plan

- Save/clear browser credentials → checkmark appears/disappears on Browser tab
- Save/clear server secret → checkmark appears/disappears on Server tab, Clear button gated on existing secrets
- Start server with provider env var set → Server tab shows checkmark + info alert