### PR TITLE
docs: fix OrcaRouter integration card image

### DIFF
--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -130,7 +130,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="VertexAI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/9a7aa063-image.avif" href="/docs/phoenix/integrations/llm-providers/vertexai" />
   <Card title="LiteLLM" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/a22c16d3-image.avif" href="/docs/phoenix/integrations/llm-providers/litellm" />
   <Card title="OpenRouter" img="https://storage.googleapis.com/arize-assets/gitbook_openrouter.png" href="/docs/phoenix/integrations/llm-providers/openrouter" />
-  <Card title="OrcaRouter" img="https://www.orcarouter.ai/orca-logo-classic.png" href="/docs/phoenix/integrations/llm-providers/orcarouter" />
+  <Card title="OrcaRouter" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/orcarouter-card.avif" href="/docs/phoenix/integrations/llm-providers/orcarouter" />
 </CardGroup>
 
 ### Platforms

--- a/docs/phoenix/integrations/llm-providers/orcarouter.mdx
+++ b/docs/phoenix/integrations/llm-providers/orcarouter.mdx
@@ -4,13 +4,12 @@ description: "OrcaRouter is an OpenAI-compatible AI gateway that routes requests
 sidebarTitle: "Overview"
 ---
 
-<img noZoom width="400px" style={{margin: "0 auto", borderRadius: "10px"}} src="https://www.orcarouter.ai/orca-logo-classic.png" className="hidden dark:block"/>
-<img noZoom width="400px" style={{margin: "0 auto", borderRadius: "10px"}} src="https://www.orcarouter.ai/orca-logo-classic.png" className="block dark:hidden"/>
+<img noZoom width="400px" style={{margin: "0 auto", borderRadius: "10px"}} src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/orcarouter-card.avif" />
 
 <Card title="OrcaRouter" href="https://www.orcarouter.ai/" icon="globe" horizontal>
 **Website**: [](https://www.orcarouter.ai/)
 </Card>
 
 <Columns cols={2}>
-  <Card img="https://www.orcarouter.ai/orca-logo-classic.png" title="OrcaRouter Tracing" href="/docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing"/>
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/orcarouter-card.avif" title="OrcaRouter Tracing" href="/docs/phoenix/integrations/llm-providers/orcarouter/openai-tracing"/>
 </Columns>


### PR DESCRIPTION
Replaces the hot-linked square orca logo with a branded card image matching the other integration cards.
