### PR TITLE
feat(cli): streamline px setup credentials with browser OAuth login

### DIFF
--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -11,20 +11,11 @@ import {
 } from "../exitCodes";
 import { writeError, writeOutput } from "../io";
 import {
-  OAUTH_LOGIN_TIMEOUT_MS,
-  type PastedRedirectPrompt,
-  buildAuthorizationUrl,
-  exchangeAuthorizationCode,
-  generatePkcePair,
-  generateState,
-  openBrowser,
   resolveTargetProfileName,
   revokeOAuthToken,
-  startLoginCallbackServer,
+  runBrowserLoginFlow,
   tokenResponseToOAuthTokens,
-  waitForPastedRedirectUrl,
   withSettingsLock,
-  withTimeout,
 } from "../oauth";
 import {
   type OAuthTokens,
@@ -410,117 +401,74 @@ async function authLoginHandler(options: AuthLoginOptions): Promise<void> {
     const profileHasApiKey = Boolean(
       settingsAtLogin.profiles[targetProfileName]?.apiKey
     );
-    const pkce = generatePkcePair();
-    const state = generateState();
-    const callbackServer = await startLoginCallbackServer({
-      expectedState: state,
-    });
-    let pastedRedirectPrompt: PastedRedirectPrompt | undefined;
-    try {
-      const authorizationUrl = buildAuthorizationUrl({
-        endpoint,
-        redirectUri: callbackServer.redirectUri,
-        state,
-        codeChallenge: pkce.challenge,
-      });
-      writeError({ message: `Open this URL to log in:\n${authorizationUrl}` });
-
-      let browserOpened = false;
-      if (options.browser !== false) {
-        try {
-          await openBrowser(authorizationUrl);
-          browserOpened = true;
-        } catch (error) {
-          writeError({
-            message: `Could not open a browser automatically: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          });
-        }
-      }
-
-      pastedRedirectPrompt =
-        options.input !== false && (!browserOpened || options.browser === false)
-          ? waitForPastedRedirectUrl({ expectedState: state })
-          : undefined;
-      const callbackPromise =
-        pastedRedirectPrompt === undefined
-          ? callbackServer.resultPromise
-          : Promise.race([
-              callbackServer.resultPromise,
-              pastedRedirectPrompt.resultPromise,
-            ]);
-      const callbackResult = await withTimeout({
-        promise: callbackPromise,
-        timeoutMs: OAUTH_LOGIN_TIMEOUT_MS,
-      });
-
-      if (callbackResult.status === "access_denied") {
-        writeError({ message: "OAuth login cancelled." });
-        process.exit(ExitCode.CANCELLED);
-      }
-      if (callbackResult.status === "invalid") {
-        writeError({ message: callbackResult.message });
-        process.exit(ExitCode.FAILURE);
-      }
-
-      const tokenResponse = await exchangeAuthorizationCode({
-        endpoint,
-        code: callbackResult.code,
-        redirectUri: callbackServer.redirectUri,
-        verifier: pkce.verifier,
-      });
-      const oauthTokens = tokenResponseToOAuthTokens({
-        response: tokenResponse,
-      });
-      // Re-read and write under the settings lock so a token rotation running
-      // in another px process cannot be clobbered by this stale snapshot.
-      await withSettingsLock(getSettingsPath(), async () => {
-        saveSettings(
-          persistOAuthTokens({
-            settingsFile: loadSettings({ strict: true }),
-            profileName: targetProfileName,
-            endpoint,
-            oauthTokens,
-          })
-        );
-      });
-
-      const user = await verifyViewerOrExit({
-        ...config,
-        endpoint,
-        oauthTokens,
-        profileName: targetProfileName,
-        apiKey: undefined,
-        credentialSource: "oauth",
-      });
-      if (profileHasApiKey) {
+    const loginResult = await runBrowserLoginFlow({
+      endpoint,
+      onAuthorizationUrl: (url) =>
+        writeError({ message: `Open this URL to log in:\n${url}` }),
+      openBrowserWindow: options.browser !== false,
+      onBrowserOpenFailed: (error) =>
         writeError({
-          message:
-            `Note: profile "${targetProfileName}" also has an API key, which takes precedence over the OAuth session. ` +
-            "Remove the API key from the profile to use OAuth credentials.",
-        });
-      }
-      writeOutput({
-        message: formatAuthOutput(
-          {
-            endpoint,
-            profile: targetProfileName,
-            credentialSource: "oauth",
-            expiresAt: oauthTokens.expiresAt,
-            user,
-            status:
-              user.auth_method === "ANONYMOUS" ? "anonymous" : "authenticated",
-          },
-          options.format
-        ),
-      });
-    } finally {
-      // Release stdin when the loopback callback won the race — an open
-      // readline interface would keep the process alive after success.
-      pastedRedirectPrompt?.close();
-      await callbackServer.close();
+          message: `Could not open a browser automatically: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        }),
+      allowPastedRedirect: options.input !== false,
+    });
+
+    if (loginResult.status === "cancelled") {
+      writeError({ message: "OAuth login cancelled." });
+      process.exit(ExitCode.CANCELLED);
     }
+    if (loginResult.status === "invalid") {
+      writeError({ message: loginResult.message });
+      process.exit(ExitCode.FAILURE);
+    }
+
+    const oauthTokens = tokenResponseToOAuthTokens({
+      response: loginResult.tokens,
+    });
+    // Re-read and write under the settings lock so a token rotation running
+    // in another px process cannot be clobbered by this stale snapshot.
+    await withSettingsLock(getSettingsPath(), async () => {
+      saveSettings(
+        persistOAuthTokens({
+          settingsFile: loadSettings({ strict: true }),
+          profileName: targetProfileName,
+          endpoint,
+          oauthTokens,
+        })
+      );
+    });
+
+    const user = await verifyViewerOrExit({
+      ...config,
+      endpoint,
+      oauthTokens,
+      profileName: targetProfileName,
+      apiKey: undefined,
+      credentialSource: "oauth",
+    });
+    if (profileHasApiKey) {
+      writeError({
+        message:
+          `Note: profile "${targetProfileName}" also has an API key, which takes precedence over the OAuth session. ` +
+          "Remove the API key from the profile to use OAuth credentials.",
+      });
+    }
+    writeOutput({
+      message: formatAuthOutput(
+        {
+          endpoint,
+          profile: targetProfileName,
+          credentialSource: "oauth",
+          expiresAt: oauthTokens.expiresAt,
+          user,
+          status:
+            user.auth_method === "ANONYMOUS" ? "anonymous" : "authenticated",
+        },
+        options.format
+      ),
+    });
   } catch (error) {
     if (
       error instanceof AuthRequiredError ||

--- a/js/packages/phoenix-cli/src/oauth.ts
+++ b/js/packages/phoenix-cli/src/oauth.ts
@@ -20,7 +20,17 @@ import {
 
 export const OAUTH_CLIENT_ID = "phoenix-cli";
 export const OAUTH_CALLBACK_PATH = "/callback";
-export const OAUTH_LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+const OAUTH_LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+/**
+ * Bounds every token-endpoint round trip. Without it a proxy that accepts the
+ * socket but never answers strands the CLI for undici's 300s default, long
+ * past the point where the user has already consented in the browser. Generous
+ * because the code is single-use: aborting a slow-but-live exchange costs the
+ * user the whole browser consent, so this must clear a cold-starting server.
+ */
+export const OAUTH_TOKEN_REQUEST_TIMEOUT_MS = 30 * 1000;
+/** Best-effort and blocking a wizard, so it gives up sooner than a token call. */
+export const OAUTH_REVOKE_TIMEOUT_MS = 10 * 1000;
 export const OAUTH_REFRESH_BUFFER_MS = 60 * 1000;
 const SETTINGS_LOCK_TIMEOUT_MS = 10 * 1000;
 const SETTINGS_LOCK_RETRY_MS = 50;
@@ -36,6 +46,17 @@ export const OAuthTokenEndpointResponseSchema = z.object({
 export type OAuthTokenEndpointResponse = z.infer<
   typeof OAuthTokenEndpointResponseSchema
 >;
+
+/**
+ * The RFC 8414 discovery fields the login flow depends on. Only a document
+ * that parses proves an authorization server is really there: a Phoenix
+ * without one answers unknown paths with the SPA's index.html and a 200.
+ */
+export const OAuthAuthorizationServerMetadataSchema = z.object({
+  issuer: z.string().min(1),
+  authorization_endpoint: z.string().min(1),
+  token_endpoint: z.string().min(1),
+});
 
 export interface PkcePair {
   verifier: string;
@@ -61,7 +82,7 @@ export type CallbackParseResult =
   | CallbackDenied
   | CallbackInvalid;
 
-export interface LoginCallbackResult {
+interface LoginCallbackResult {
   redirectUri: string;
   resultPromise: Promise<CallbackParseResult>;
   close: () => Promise<void>;
@@ -181,7 +202,7 @@ export function isOAuthTokenExpiring({
   return Date.parse(tokens.expiresAt) - now.getTime() <= bufferMs;
 }
 
-export async function startLoginCallbackServer({
+async function startLoginCallbackServer({
   expectedState,
 }: {
   expectedState: string;
@@ -241,7 +262,7 @@ export async function startLoginCallbackServer({
   };
 }
 
-export interface PastedRedirectPrompt {
+interface PastedRedirectPrompt {
   resultPromise: Promise<CallbackParseResult>;
   /**
    * Release stdin. Must be called when the prompt loses the race to the
@@ -251,7 +272,7 @@ export interface PastedRedirectPrompt {
   close: () => void;
 }
 
-export function waitForPastedRedirectUrl({
+function waitForPastedRedirectUrl({
   expectedState,
   input = process.stdin,
   output = process.stderr,
@@ -276,7 +297,7 @@ export function waitForPastedRedirectUrl({
   return { resultPromise, close: () => reader.close() };
 }
 
-export function withTimeout<T>({
+function withTimeout<T>({
   promise,
   timeoutMs,
 }: {
@@ -300,7 +321,7 @@ export function withTimeout<T>({
   });
 }
 
-export async function openBrowser(url: string): Promise<void> {
+async function openBrowser(url: string): Promise<void> {
   const platform = process.platform;
   const command =
     platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
@@ -342,6 +363,134 @@ export async function exchangeAuthorizationCode({
   return postTokenRequest({ endpoint, body, fetchImpl });
 }
 
+export interface BrowserLoginFlowArgs {
+  endpoint: string;
+  /**
+   * Called with the authorization URL before the browser opens, so the user
+   * can complete the login by hand when the launch fails or goes unnoticed.
+   */
+  onAuthorizationUrl: (url: string) => void;
+  /** False keeps the browser shut, leaving the pasted-URL lane (if allowed). */
+  openBrowserWindow?: boolean;
+  /** Narrates a failed launch; the pasted-redirect prompt is the fallback. */
+  onBrowserOpenFailed?: (error: unknown) => void;
+  /**
+   * Accept a hand-pasted redirect URL when no browser was opened — the only
+   * way to finish a login over SSH or in a container.
+   */
+  allowPastedRedirect?: boolean;
+  /** Abandon the wait — the caller's escape hatch from an unanswered login. */
+  signal?: AbortSignal;
+}
+
+export type BrowserLoginFlowResult =
+  | { status: "success"; tokens: OAuthTokenEndpointResponse }
+  /** The user declined consent, or abandoned the wait via `signal`. */
+  | { status: "cancelled" }
+  | { status: "invalid"; message: string };
+
+/**
+ * The Authorization Code + PKCE browser login, end to end: callback server,
+ * browser launch, the wait, and the token exchange. Both `px auth login` (which
+ * persists the tokens) and `px setup` (which spends the access token once to
+ * mint an API key) drive it — the differences between them are the arguments
+ * above, not a second copy of the sequence.
+ */
+export async function runBrowserLoginFlow({
+  endpoint,
+  onAuthorizationUrl,
+  openBrowserWindow = true,
+  onBrowserOpenFailed,
+  allowPastedRedirect = false,
+  signal,
+}: BrowserLoginFlowArgs): Promise<BrowserLoginFlowResult> {
+  // Bail before binding a port or launching a browser for a login the caller
+  // has already given up on.
+  if (signal?.aborted) {
+    return { status: "cancelled" };
+  }
+  const pkce = generatePkcePair();
+  const state = generateState();
+  const callbackServer = await startLoginCallbackServer({
+    expectedState: state,
+  });
+  let pastedRedirectPrompt: PastedRedirectPrompt | undefined;
+  try {
+    const authorizationUrl = buildAuthorizationUrl({
+      endpoint,
+      redirectUri: callbackServer.redirectUri,
+      state,
+      codeChallenge: pkce.challenge,
+    });
+    onAuthorizationUrl(authorizationUrl);
+
+    let browserOpened = false;
+    if (openBrowserWindow) {
+      try {
+        await openBrowser(authorizationUrl);
+        browserOpened = true;
+      } catch (error) {
+        onBrowserOpenFailed?.(error);
+      }
+    }
+
+    // Only when no browser opened: otherwise the prompt would hold stdin for a
+    // login the browser is about to complete on its own.
+    pastedRedirectPrompt =
+      allowPastedRedirect && !browserOpened
+        ? waitForPastedRedirectUrl({ expectedState: state })
+        : undefined;
+
+    const races: Promise<CallbackParseResult | "aborted">[] = [
+      callbackServer.resultPromise,
+    ];
+    if (pastedRedirectPrompt !== undefined) {
+      races.push(pastedRedirectPrompt.resultPromise);
+    }
+    if (signal !== undefined) {
+      races.push(abortedPromise(signal));
+    }
+    const callbackResult = await withTimeout({
+      promise: Promise.race(races),
+      timeoutMs: OAUTH_LOGIN_TIMEOUT_MS,
+    });
+
+    if (
+      callbackResult === "aborted" ||
+      callbackResult.status === "access_denied"
+    ) {
+      return { status: "cancelled" };
+    }
+    if (callbackResult.status === "invalid") {
+      return { status: "invalid", message: callbackResult.message };
+    }
+
+    const tokens = await exchangeAuthorizationCode({
+      endpoint,
+      code: callbackResult.code,
+      redirectUri: callbackServer.redirectUri,
+      verifier: pkce.verifier,
+    });
+    return { status: "success", tokens };
+  } finally {
+    // Release stdin when the loopback callback won the race — an open readline
+    // interface would keep the process alive after success.
+    pastedRedirectPrompt?.close();
+    await callbackServer.close();
+  }
+}
+
+/** Resolves — never rejects — so it can lose a `Promise.race` harmlessly. */
+function abortedPromise(signal: AbortSignal): Promise<"aborted"> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve("aborted");
+      return;
+    }
+    signal.addEventListener("abort", () => resolve("aborted"), { once: true });
+  });
+}
+
 export async function refreshOAuthToken({
   endpoint,
   refreshToken,
@@ -368,16 +517,31 @@ async function postTokenRequest({
   body: URLSearchParams;
   fetchImpl: typeof fetch;
 }): Promise<OAuthTokenEndpointResponse> {
-  const response = await fetchImpl(
-    new URL("oauth2/token", normalizeEndpoint(endpoint)),
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body,
+  let response: Response;
+  try {
+    response = await fetchImpl(
+      new URL("oauth2/token", normalizeEndpoint(endpoint)),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body,
+        signal: AbortSignal.timeout(OAUTH_TOKEN_REQUEST_TIMEOUT_MS),
+      }
+    );
+  } catch (error) {
+    // A bare AbortError/DOMException is neither actionable nor mapped to an
+    // exit code by the callers, which recognize NetworkError.
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new NetworkError(
+        `The OAuth token endpoint at ${endpoint} did not respond within ${
+          OAUTH_TOKEN_REQUEST_TIMEOUT_MS / 1000
+        }s.`
+      );
     }
-  );
+    throw error;
+  }
 
   if (response.status === 404) {
     throw new AuthRequiredError(
@@ -414,6 +578,7 @@ export async function revokeOAuthToken({
       "Content-Type": "application/x-www-form-urlencoded",
     },
     body,
+    signal: AbortSignal.timeout(OAUTH_REVOKE_TIMEOUT_MS),
   });
 }
 

--- a/js/packages/phoenix-cli/src/setup/copy.ts
+++ b/js/packages/phoenix-cli/src/setup/copy.ts
@@ -158,6 +158,31 @@ export const CONNECT = {
 // Auth-on credential entry
 // ---------------------------------------------------------------------------
 
+export const CREDENTIALS = {
+  methodMessage: "How do you want to connect to Phoenix?",
+  loginLabel: "Log in with your browser (recommended)",
+  loginHint: "approve once in Phoenix; setup creates an API key for you",
+  pasteLabel: "Paste an existing API key",
+  pasteHint: "create or copy one in Phoenix under Settings",
+  authorizationUrl: (url: string) =>
+    [
+      "Complete the login in your browser. If it didn't open, visit:",
+      url,
+      "",
+      "Press Ctrl-C to skip and paste an API key instead.",
+    ].join("\n"),
+  browserOpenFailed: (detail: string) =>
+    `Couldn't open a browser (${detail}). Open the URL above by hand, or press Ctrl-C to paste an API key instead.`,
+  keyCreated: (name: string) =>
+    `Logged in — created API key "${name}" for this project.`,
+  // Covers both ways out of the login: declining consent, and Ctrl-C.
+  loginCancelled: "Login didn't finish — paste an API key instead.",
+  loginFailed: (detail: string) =>
+    `Browser login didn't complete (${detail}) — paste an API key instead.`,
+  keyCreateFailed: (detail: string) =>
+    `Logged in, but couldn't create an API key (${detail}) — paste one instead.`,
+} as const;
+
 export const API_KEY = {
   instructionsTitle: "Phoenix API key",
   instructions: [

--- a/js/packages/phoenix-cli/src/setup/deps/buildDefaultDeps.ts
+++ b/js/packages/phoenix-cli/src/setup/deps/buildDefaultDeps.ts
@@ -11,6 +11,7 @@ import { createSystemClipboardWriter } from "./clipboard";
 import { createSystemClock } from "./clock";
 import { captureRunContext } from "./context";
 import { fetchDocs } from "./docs";
+import { createSystemOAuthLogin } from "./oauthLogin";
 import { createPhoenixClientFactory } from "./phoenixClient";
 import { createSystemProcessRunner } from "./processes";
 import type { SetupDeps } from "./index";
@@ -32,5 +33,6 @@ export function buildDefaultDeps({
     writeClipboard: createSystemClipboardWriter(processes.exec),
     createClient: createPhoenixClientFactory({ apiUrl }),
     fetchDocs,
+    oauthLogin: createSystemOAuthLogin({ apiUrl, fetchImpl: fetch }),
   };
 }

--- a/js/packages/phoenix-cli/src/setup/deps/index.ts
+++ b/js/packages/phoenix-cli/src/setup/deps/index.ts
@@ -17,6 +17,7 @@ import type { ClipboardWriter } from "./clipboard";
 import type { Clock } from "./clock";
 import type { RunContext } from "./context";
 import type { DocsFetcher } from "./docs";
+import type { OAuthLogin } from "./oauthLogin";
 import type { PhoenixClientFactory } from "./phoenixClient";
 import type { ProcessRunner } from "./processes";
 import type { Prompter } from "./prompter";
@@ -32,6 +33,8 @@ export interface SetupDeps {
   /** Typed Phoenix client; tests inject a fake transport beneath it. */
   createClient: PhoenixClientFactory;
   fetchDocs: DocsFetcher;
+  /** Browser OAuth login for minting an API key; tests script outcomes. */
+  oauthLogin: OAuthLogin;
 }
 
 export type { ClipboardWriter } from "./clipboard";
@@ -43,6 +46,11 @@ export type {
   DocsPrefetchOptions,
   DocsPrefetchResult,
 } from "./docs";
+export type {
+  OAuthLogin,
+  OAuthLoginArgs,
+  OAuthLoginOutcome,
+} from "./oauthLogin";
 export type { PhoenixClientArgs, PhoenixClientFactory } from "./phoenixClient";
 export type { CommandSpec, ExecResult, ProcessRunner } from "./processes";
 export type { Prompter, SelectOption } from "./prompter";

--- a/js/packages/phoenix-cli/src/setup/deps/oauthLogin.ts
+++ b/js/packages/phoenix-cli/src/setup/deps/oauthLogin.ts
@@ -1,0 +1,146 @@
+/**
+ * The browser-login capability: an ephemeral OAuth2 Authorization Code +
+ * PKCE flow, used by setup to obtain a short-lived access token so it can
+ * mint an API key on the user's behalf instead of asking them to paste one.
+ *
+ * Contract plus the real, system-backed implementation (the flow is system
+ * glue: an HTTP callback server, a browser launch, and token exchange —
+ * exactly the effects the seam exists to keep out of steps). Tests script
+ * outcomes through a fake.
+ */
+
+import {
+  OAuthAuthorizationServerMetadataSchema,
+  normalizeEndpoint,
+  revokeOAuthToken,
+  runBrowserLoginFlow,
+} from "../../oauth";
+
+const SUPPORT_PROBE_TIMEOUT_MS = 5_000;
+
+export interface OAuthLoginArgs {
+  /** Normalized origin, no trailing slash. */
+  endpoint: string;
+  /**
+   * Called with the authorization URL before the browser opens, so the user
+   * can complete the login by hand when the launch fails or goes unnoticed.
+   */
+  onAuthorizationUrl: (url: string) => void;
+  /**
+   * The browser could not be launched (no `xdg-open`, a headless container).
+   * The URL was already narrated, so this is a nudge, not a failure.
+   */
+  onBrowserOpenFailed: (detail: string) => void;
+  /** Abandons an unanswered login, yielding a `cancelled` outcome. */
+  signal?: AbortSignal;
+}
+
+export type OAuthLoginOutcome =
+  | {
+      status: "success";
+      accessToken: string;
+      /**
+       * End the grant this login just created, once its token has served its
+       * purpose. Scoped to that grant alone — an existing `px auth login`
+       * session is a separate grant and survives. Best-effort: the tokens
+       * expire on their own regardless.
+       */
+      revoke: () => Promise<void>;
+    }
+  /** The user declined the consent screen — a choice, not a failure. */
+  | { status: "cancelled" }
+  | { status: "error"; detail: string };
+
+export interface OAuthLogin {
+  /**
+   * Whether the instance runs the OAuth2 authorization server. False on any
+   * failure — an unreachable or older server simply keeps the paste lane.
+   */
+  isSupported(endpoint: string): Promise<boolean>;
+  login(args: OAuthLoginArgs): Promise<OAuthLoginOutcome>;
+}
+
+/**
+ * `apiUrl` is the hidden `--api-url` dev override. It must reach every hop of
+ * the flow: the token this mints is spent against the same override by the
+ * client factory, so an authorization server at a different host would issue a
+ * token the key-minting server rejects. `fetchImpl` is the same transport seam
+ * the Phoenix client takes, so the probe is injectable rather than global.
+ */
+export function createSystemOAuthLogin({
+  apiUrl,
+  fetchImpl = fetch,
+}: {
+  apiUrl?: string;
+  fetchImpl?: typeof fetch;
+} = {}): OAuthLogin {
+  // Resolved once: the probe and the flow must agree on which host they talk
+  // to, and two `??` expressions are two chances to disagree.
+  const apiOrigin = (endpoint: string) => apiUrl ?? endpoint;
+  return {
+    async isSupported(endpoint) {
+      try {
+        const response = await fetchImpl(
+          new URL(
+            ".well-known/oauth-authorization-server",
+            normalizeEndpoint(apiOrigin(endpoint))
+          ),
+          { signal: AbortSignal.timeout(SUPPORT_PROBE_TIMEOUT_MS) }
+        );
+        if (!response.ok) {
+          return false;
+        }
+        const document: unknown = await response.json();
+        return OAuthAuthorizationServerMetadataSchema.safeParse(document)
+          .success;
+      } catch {
+        return false;
+      }
+    },
+
+    async login({ endpoint, onAuthorizationUrl, onBrowserOpenFailed, signal }) {
+      const origin = apiOrigin(endpoint);
+      try {
+        const result = await runBrowserLoginFlow({
+          endpoint: origin,
+          onAuthorizationUrl,
+          onBrowserOpenFailed: (error) =>
+            onBrowserOpenFailed(
+              error instanceof Error ? error.message : String(error)
+            ),
+          // No pasted-redirect lane here, unlike `px auth login`. It reads a
+          // raw readline off stdin, which would both land unannounced in the
+          // middle of the clack wizard and — because readline in terminal mode
+          // intercepts Ctrl-C itself — kill the interrupt this login promises
+          // as its way out. Setup's fallback is pasting an API key, which the
+          // prompter asks for properly.
+          allowPastedRedirect: false,
+          signal,
+        });
+        if (result.status === "cancelled") {
+          return { status: "cancelled" };
+        }
+        if (result.status === "invalid") {
+          return { status: "error", detail: result.message };
+        }
+        return {
+          status: "success",
+          accessToken: result.tokens.access_token,
+          revoke: () =>
+            revokeOAuthToken({
+              endpoint: origin,
+              refreshToken: result.tokens.refresh_token,
+            }),
+        };
+      } catch (error) {
+        // Every failure — a loopback port that will not bind, a token endpoint
+        // that never answers — is an outcome the wizard falls back from, never
+        // an exception that ends setup.
+        return {
+          status: "error",
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  };
+}

--- a/js/packages/phoenix-cli/src/setup/deps/prompter.ts
+++ b/js/packages/phoenix-cli/src/setup/deps/prompter.ts
@@ -32,6 +32,13 @@ export interface Prompter {
     message: string;
     validate?: (value: string) => string | undefined;
   }): Promise<string>;
+  /**
+   * Run `work` with a signal that aborts on Ctrl-C rather than raising
+   * SetupCancelledError. For the waits that have no prompt on screen to
+   * cancel — a browser login, say: this seam owns the terminal, so it owns the
+   * signal, and `work` decides what an interruption means.
+   */
+  runInterruptible<T>(work: (signal: AbortSignal) => Promise<T>): Promise<T>;
   /** Non-interactive display of a block of text between prompts. */
   note(message: string, title?: string): void;
   /** One-line status/warning between prompts (stderr). */

--- a/js/packages/phoenix-cli/src/setup/steps/establishConnection.ts
+++ b/js/packages/phoenix-cli/src/setup/steps/establishConnection.ts
@@ -5,8 +5,11 @@
  * first ingestion, so setup only needs to settle on a *name* and hand it
  * to the app via `PHOENIX_PROJECT_NAME`. What remains is credential
  * acquisition: the auth-on lanes verify the key with a read-only probe so a
- * bad paste is caught here rather than at first trace. Future OAuth
- * acquisition plugs into the auth-on interactive lane unchanged.
+ * bad paste is caught here rather than at first trace. When the instance runs
+ * the OAuth2 authorization server, the interactive lane offers a streamlined
+ * path first — log in with the browser, mint an API key over REST, revoke the
+ * grant that login created — and every failure along it falls back to the
+ * paste prompt rather than aborting setup.
  */
 
 import * as path from "node:path";
@@ -69,6 +72,19 @@ type KeyCheck =
   | { kind: "rejected"; status: number }
   | { kind: "error"; detail: string };
 
+/** A REST failure, as a short phrase to show the user. */
+function describeRestError(error: unknown): string {
+  if (error instanceof HttpError) {
+    return `HTTP ${error.status}`;
+  }
+  // A 2xx whose body will not parse: something answered, but not the Phoenix
+  // API. The raw parser message would only confuse.
+  if (error instanceof SyntaxError) {
+    return COPY.ENDPOINT.unexpectedBody;
+  }
+  return redactForDisplay(String(error));
+}
+
 /**
  * Read-only probe: list one project. Only the credential matters here — an
  * instance with no projects yet still answers 200.
@@ -86,13 +102,13 @@ async function checkApiKey(
     });
     return { kind: "ok" };
   } catch (error) {
-    if (error instanceof HttpError) {
-      if (error.status === 401 || error.status === 403) {
-        return { kind: "rejected", status: error.status };
-      }
-      return { kind: "error", detail: `HTTP ${error.status}` };
+    if (
+      error instanceof HttpError &&
+      (error.status === 401 || error.status === 403)
+    ) {
+      return { kind: "rejected", status: error.status };
     }
-    return { kind: "error", detail: redactForDisplay(String(error)) };
+    return { kind: "error", detail: describeRestError(error) };
   }
 }
 
@@ -123,17 +139,130 @@ async function promptForApiKey(
 }
 
 /**
- * A rejected key returns to the masked credential prompt without asking for
- * the project name again.
+ * Log in via the browser, then mint a personal API key over REST. Every
+ * failure returns `undefined` after narrating why, sending the lane to the
+ * paste prompt — the login is a shortcut, never a wall.
+ */
+async function acquireApiKeyViaLogin(
+  deps: Pick<SetupDeps, "createClient" | "prompter" | "oauthLogin">,
+  endpoint: string,
+  projectName: string
+): Promise<string | undefined> {
+  // Ctrl-C here means "give up on the browser", not "abandon setup" — the
+  // paste prompt below is still a way forward, and the project name the user
+  // already gave is still good.
+  const outcome = await deps.prompter.runInterruptible((signal) =>
+    deps.oauthLogin.login({
+      endpoint,
+      onAuthorizationUrl: (url) =>
+        deps.prompter.note(COPY.CREDENTIALS.authorizationUrl(url)),
+      onBrowserOpenFailed: (detail) =>
+        deps.prompter.line(
+          COPY.CREDENTIALS.browserOpenFailed(redactForDisplay(detail))
+        ),
+      signal,
+    })
+  );
+  if (outcome.status === "cancelled") {
+    deps.prompter.line(COPY.CREDENTIALS.loginCancelled);
+    return undefined;
+  }
+  if (outcome.status === "error") {
+    deps.prompter.line(
+      COPY.CREDENTIALS.loginFailed(redactForDisplay(outcome.detail))
+    );
+    return undefined;
+  }
+
+  try {
+    const client = deps.createClient({
+      endpoint,
+      apiKey: outcome.accessToken,
+    });
+    const name = `px-setup ${projectName}`;
+    const response = await client.POST("/v1/user/api_keys", {
+      body: {
+        data: {
+          name,
+          description: `Created by px setup for project "${projectName}".`,
+        },
+      },
+      signal: AbortSignal.timeout(REST_TIMEOUT_MS),
+    });
+    const key = response.data?.data.key;
+    if (!key) {
+      deps.prompter.line(
+        COPY.CREDENTIALS.keyCreateFailed("empty key in response")
+      );
+      return undefined;
+    }
+    deps.prompter.line(COPY.CREDENTIALS.keyCreated(name));
+    return key;
+  } catch (error) {
+    deps.prompter.line(
+      COPY.CREDENTIALS.keyCreateFailed(describeRestError(error))
+    );
+    return undefined;
+  } finally {
+    // The access token has served its one purpose. Ending the grant leaves the
+    // key in local files as the only credential this run created — without it,
+    // a refresh token setup no longer holds stays live for its full lifetime
+    // (a week by default). This does not touch an existing `px auth login`.
+    await outcome.revoke().catch(() => {});
+  }
+}
+
+/**
+ * The project name comes first so the browser-login path can stamp it into
+ * the minted key's name. A rejected key returns to the masked credential
+ * prompt without asking for the project name again.
  */
 async function connectAuthOnInteractive(
-  deps: Pick<SetupDeps, "context" | "createClient" | "prompter">,
+  deps: Pick<SetupDeps, "context" | "createClient" | "prompter" | "oauthLogin">,
   endpoint: string,
   inputs: SetupInputs
 ): Promise<Connection> {
+  // Start the probe before the prompt so it can run while the user types (when
+  // --project is given there is no prompt, and this is simply awaited below).
+  // The `catch` is not redundant: the contract returns Promise<boolean>, and an
+  // implementation that rejected would otherwise go unhandled on the path where
+  // the prompt throws SetupCancelledError before the await below is reached.
+  const supportsLogin = deps.oauthLogin
+    .isSupported(endpoint)
+    .catch(() => false);
+  const projectName = await promptForProjectName(deps, inputs);
+
+  if (await supportsLogin) {
+    const method = await deps.prompter.select<"login" | "paste">({
+      message: COPY.CREDENTIALS.methodMessage,
+      options: [
+        {
+          value: "login",
+          label: COPY.CREDENTIALS.loginLabel,
+          hint: COPY.CREDENTIALS.loginHint,
+        },
+        {
+          value: "paste",
+          label: COPY.CREDENTIALS.pasteLabel,
+          hint: COPY.CREDENTIALS.pasteHint,
+        },
+      ],
+    });
+    if (method === "login") {
+      const apiKey = await acquireApiKeyViaLogin(deps, endpoint, projectName);
+      if (apiKey !== undefined) {
+        // The key was just minted by an authenticated call to this same
+        // endpoint, so a probe could only re-prove what the mint proved. It
+        // could, however, fail transiently — and the ephemeral session is
+        // already revoked, so a throw here would strand a live key the user
+        // never received and cannot name.
+        deps.prompter.line(COPY.CONNECT.usingProject(projectName));
+        return { endpoint, projectName, apiKey };
+      }
+    }
+  }
   deps.prompter.note(COPY.API_KEY.instructions, COPY.API_KEY.instructionsTitle);
   let apiKey = await promptForApiKey(deps);
-  const projectName = await promptForProjectName(deps, inputs);
 
   for (;;) {
     const result = await checkApiKey(deps, endpoint, apiKey);
@@ -194,7 +323,7 @@ export interface EstablishConnectionArgs {
 }
 
 export async function establishConnection(
-  deps: Pick<SetupDeps, "context" | "createClient" | "prompter">,
+  deps: Pick<SetupDeps, "context" | "createClient" | "prompter" | "oauthLogin">,
   { endpoint, authEnabled, inputs }: EstablishConnectionArgs
 ): Promise<Connection> {
   // A --project / env-provided name bypasses the prompt in every lane, so

--- a/js/packages/phoenix-cli/src/setup/ui/clackPrompter.ts
+++ b/js/packages/phoenix-cli/src/setup/ui/clackPrompter.ts
@@ -106,6 +106,23 @@ export function createClackPrompter(): Prompter {
       return answer;
     },
 
+    async runInterruptible<T>(
+      work: (signal: AbortSignal) => Promise<T>
+    ): Promise<T> {
+      // Attaching a listener also suppresses Node's default terminate-on-SIGINT
+      // for the duration, which is the point: with no clack prompt on screen
+      // there is nothing to raise SetupCancelledError, so an unhandled Ctrl-C
+      // would kill the process and discard the answers already given.
+      const interrupted = new AbortController();
+      const onInterrupt = () => interrupted.abort();
+      process.once("SIGINT", onInterrupt);
+      try {
+        return await work(interrupted.signal);
+      } finally {
+        process.off("SIGINT", onInterrupt);
+      }
+    },
+
     note(message: string, title?: string): void {
       // A heading over an indented body, not clack's boxed `note`: clack's guide
       // rail already sets the block apart, and the box adds a border that has to

--- a/js/packages/phoenix-cli/test/oauth.test.ts
+++ b/js/packages/phoenix-cli/test/oauth.test.ts
@@ -14,6 +14,7 @@ import {
   parseOAuthCallbackUrl,
   refreshOAuthTokensForProfile,
   revokeOAuthToken,
+  runBrowserLoginFlow,
   tokenResponseToOAuthTokens,
 } from "../src/oauth";
 import { type SettingsFile, saveSettings } from "../src/settings";
@@ -149,6 +150,54 @@ describe("OAuth PKCE and callback helpers", () => {
         expectedState: "expected",
       })
     ).toMatchObject({ status: "invalid" });
+  });
+});
+
+describe("browser login flow", () => {
+  it("abandons the wait as cancelled when the signal aborts", async () => {
+    const abandon = new AbortController();
+    const flow = runBrowserLoginFlow({
+      endpoint: "http://127.0.0.1:1",
+      onAuthorizationUrl: () => abandon.abort(),
+      // No browser and no paste prompt: the abort is the only way this ends.
+      openBrowserWindow: false,
+      allowPastedRedirect: false,
+      signal: abandon.signal,
+    });
+    await expect(flow).resolves.toEqual({ status: "cancelled" });
+  });
+
+  it("exchanges the code once the callback arrives", async () => {
+    const tokenServer = await withServer((request, response) => {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(
+        JSON.stringify({
+          access_token: "access-abc",
+          refresh_token: "refresh-abc",
+          token_type: "Bearer",
+          expires_in: 3600,
+        })
+      );
+    });
+    try {
+      const result = await runBrowserLoginFlow({
+        endpoint: tokenServer.url,
+        // Drive the loopback callback ourselves, standing in for the browser.
+        onAuthorizationUrl: async (url) => {
+          const redirectUri = new URL(url).searchParams.get("redirect_uri")!;
+          const state = new URL(url).searchParams.get("state")!;
+          await fetch(`${redirectUri}?code=code-abc&state=${state}`);
+        },
+        openBrowserWindow: false,
+        allowPastedRedirect: false,
+      });
+      expect(result).toMatchObject({
+        status: "success",
+        tokens: { access_token: "access-abc" },
+      });
+    } finally {
+      await tokenServer.close();
+    }
   });
 });
 

--- a/js/packages/phoenix-cli/test/setup/establishConnection.test.ts
+++ b/js/packages/phoenix-cli/test/setup/establishConnection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import * as COPY from "../../src/setup/copy";
 import { HeadlessInputError, SetupFatalError } from "../../src/setup/errors";
 import {
   defaultProjectName,
@@ -142,7 +143,7 @@ describe("establishConnection interactive auth-off", () => {
 
 describe("establishConnection interactive auth-on", () => {
   it("reprompts when an API key is rejected with 403", async () => {
-    const prompter = scriptedPrompter(["sk-rejected", undefined, "sk-valid"]);
+    const prompter = scriptedPrompter([undefined, "sk-rejected", "sk-valid"]);
     const deps = buildFakeDeps({
       context: { cwd: "/home/user/my-app" },
       prompter,
@@ -165,7 +166,225 @@ describe("establishConnection interactive auth-on", () => {
       apiKey: "sk-valid",
     });
     expect(prompter.transcript).toEqual([
+      "Phoenix project name for this app's traces",
       "Phoenix API key",
+      "Phoenix API key",
+    ]);
+  });
+});
+
+describe("establishConnection interactive auth-on with OAuth support", () => {
+  const projectsOk = (_url: string, request: Request) =>
+    request.method === "GET" && request.url.includes("/v1/projects")
+      ? jsonResponse(200, { data: [] })
+      : undefined;
+
+  it("logs in, mints an API key, and revokes the session", async () => {
+    let revoked = false;
+    let createRequest: Request | undefined;
+    const prompter = scriptedPrompter([undefined, "login"]);
+    const deps = buildFakeDeps({
+      context: { cwd: "/home/user/my-app" },
+      prompter,
+      oauthLogin: {
+        isSupported: async () => true,
+        login: async ({ onAuthorizationUrl }) => {
+          onAuthorizationUrl("http://localhost:6006/oauth2/authorize?x=1");
+          return {
+            status: "success",
+            accessToken: "at-123",
+            revoke: async () => {
+              revoked = true;
+            },
+          };
+        },
+      },
+      fetch: fakeFetch(projectsOk, (_url, request) => {
+        if (
+          request.method === "POST" &&
+          request.url.includes("/v1/user/api_keys")
+        ) {
+          createRequest = request;
+          return jsonResponse(201, {
+            data: { id: "abc", name: "px-setup", key: "sk-minted" },
+          });
+        }
+        return undefined;
+      }),
+    });
+
+    const connection = await establishConnection(deps, {
+      endpoint: ENDPOINT,
+      authEnabled: true,
+      inputs: resolveFakeInputs(deps),
+    });
+
+    expect(connection).toEqual({
+      endpoint: ENDPOINT,
+      projectName: "my-app",
+      apiKey: "sk-minted",
+    });
+    expect(revoked).toBe(true);
+    expect(createRequest?.headers.get("authorization")).toBe("Bearer at-123");
+    // Never asked for a pasted key.
+    expect(prompter.transcript).toEqual([
+      "Phoenix project name for this app's traces",
+      "How do you want to connect to Phoenix?",
+    ]);
+  });
+
+  it("falls back to the paste prompt when the login fails", async () => {
+    const prompter = scriptedPrompter([undefined, "login", "sk-pasted"]);
+    const deps = buildFakeDeps({
+      prompter,
+      oauthLogin: {
+        isSupported: async () => true,
+        login: async () => ({ status: "error", detail: "timed out" }),
+      },
+      fetch: fakeFetch(projectsOk),
+    });
+
+    const connection = await establishConnection(deps, {
+      endpoint: ENDPOINT,
+      authEnabled: true,
+      inputs: resolveFakeInputs(deps),
+    });
+
+    expect(connection.apiKey).toBe("sk-pasted");
+    expect(
+      prompter.output.some((line) => line.includes("didn't complete"))
+    ).toBe(true);
+  });
+
+  it("narrates a browser that would not open, through the prompter", async () => {
+    // A launch failure must be explained: the URL is on screen and Ctrl-C is
+    // the way out, but neither is discoverable if the failure is silent.
+    const prompter = scriptedPrompter([undefined, "login", "sk-pasted"]);
+    const deps = buildFakeDeps({
+      prompter,
+      oauthLogin: {
+        isSupported: async () => true,
+        login: async ({ onBrowserOpenFailed }) => {
+          onBrowserOpenFailed("spawn xdg-open ENOENT");
+          return { status: "cancelled" };
+        },
+      },
+      fetch: fakeFetch(projectsOk),
+    });
+
+    const connection = await establishConnection(deps, {
+      endpoint: ENDPOINT,
+      authEnabled: true,
+      inputs: resolveFakeInputs(deps),
+    });
+
+    expect(connection.apiKey).toBe("sk-pasted");
+    expect(
+      prompter.output.some(
+        (line) =>
+          line.includes("Couldn't open a browser") && line.includes("ENOENT")
+      )
+    ).toBe(true);
+  });
+
+  it("falls back to the paste prompt when the user interrupts the login", async () => {
+    // Ctrl-C while the browser wait is on screen must keep the answers already
+    // given, not unwind setup: the prompter hands the login an aborted signal.
+    const prompter = scriptedPrompter([undefined, "login", "sk-pasted"], {
+      interruptWaits: true,
+    });
+    const deps = buildFakeDeps({
+      prompter,
+      oauthLogin: {
+        isSupported: async () => true,
+        login: async ({ signal }) =>
+          signal?.aborted
+            ? { status: "cancelled" }
+            : { status: "error", detail: "the wait was not interruptible" },
+      },
+      fetch: fakeFetch(projectsOk),
+    });
+
+    const connection = await establishConnection(deps, {
+      endpoint: ENDPOINT,
+      authEnabled: true,
+      inputs: resolveFakeInputs(deps),
+    });
+
+    expect(connection.apiKey).toBe("sk-pasted");
+    expect(connection.projectName).toBe(defaultProjectName(deps.context.cwd));
+    // The cancelled copy, not the failure copy: reaching the paste prompt is
+    // not enough — it must be the interrupt that sent us there.
+    expect(prompter.output).toContain(COPY.CREDENTIALS.loginCancelled);
+  });
+
+  it("falls back to the paste prompt when key creation fails", async () => {
+    let revoked = false;
+    const prompter = scriptedPrompter([undefined, "login", "sk-pasted"]);
+    const deps = buildFakeDeps({
+      prompter,
+      oauthLogin: {
+        isSupported: async () => true,
+        login: async () => ({
+          status: "success",
+          accessToken: "at-123",
+          revoke: async () => {
+            revoked = true;
+          },
+        }),
+      },
+      fetch: fakeFetch(projectsOk, (_url, request) =>
+        request.method === "POST" && request.url.includes("/v1/user/api_keys")
+          ? jsonResponse(403, { detail: "forbidden" })
+          : undefined
+      ),
+    });
+
+    const connection = await establishConnection(deps, {
+      endpoint: ENDPOINT,
+      authEnabled: true,
+      inputs: resolveFakeInputs(deps),
+    });
+
+    expect(connection.apiKey).toBe("sk-pasted");
+    expect(revoked).toBe(true);
+  });
+
+  it("respects choosing the paste lane over the login", async () => {
+    const prompter = scriptedPrompter([undefined, "paste", "sk-pasted"]);
+    const deps = buildFakeDeps({
+      prompter,
+      oauthLogin: {
+        isSupported: async () => true,
+        login: async () => {
+          throw new Error("login must not run when paste is chosen");
+        },
+      },
+      fetch: fakeFetch(projectsOk),
+    });
+
+    const connection = await establishConnection(deps, {
+      endpoint: ENDPOINT,
+      authEnabled: true,
+      inputs: resolveFakeInputs(deps),
+    });
+    expect(connection.apiKey).toBe("sk-pasted");
+  });
+
+  it("skips the method prompt when the server has no OAuth support", async () => {
+    const prompter = scriptedPrompter([undefined, "sk-pasted"]);
+    const deps = buildFakeDeps({
+      prompter,
+      fetch: fakeFetch(projectsOk),
+    });
+
+    const connection = await establishConnection(deps, {
+      endpoint: ENDPOINT,
+      authEnabled: true,
+      inputs: resolveFakeInputs(deps),
+    });
+    expect(connection.apiKey).toBe("sk-pasted");
+    expect(prompter.transcript).toEqual([
       "Phoenix project name for this app's traces",
       "Phoenix API key",
     ]);

--- a/js/packages/phoenix-cli/test/setup/fakes.ts
+++ b/js/packages/phoenix-cli/test/setup/fakes.ts
@@ -38,8 +38,14 @@ export interface ScriptedPrompter extends Prompter {
 /**
  * A prompter that answers prompts from a FIFO script. Selects verify the
  * scripted answer is one of the offered option values.
+ *
+ * `interruptWaits` stands in for Ctrl-C during an interruptible wait: the work
+ * is handed an already-aborted signal, as if the user gave up on it.
  */
-export function scriptedPrompter(answers: ScriptedAnswer[]): ScriptedPrompter {
+export function scriptedPrompter(
+  answers: ScriptedAnswer[],
+  { interruptWaits = false }: { interruptWaits?: boolean } = {}
+): ScriptedPrompter {
   const queue = [...answers];
   const transcript: string[] = [];
   const output: string[] = [];
@@ -108,6 +114,15 @@ export function scriptedPrompter(answers: ScriptedAnswer[]): ScriptedPrompter {
         );
       }
       return value;
+    },
+    async runInterruptible<T>(
+      work: (signal: AbortSignal) => Promise<T>
+    ): Promise<T> {
+      const interrupted = new AbortController();
+      if (interruptWaits) {
+        interrupted.abort();
+      }
+      return work(interrupted.signal);
     },
     note(message: string): void {
       output.push(message);
@@ -201,6 +216,7 @@ export interface FakeDepsOverrides {
   clock?: Partial<Clock>;
   writeClipboard?: SetupDeps["writeClipboard"];
   fetchDocs?: SetupDeps["fetchDocs"];
+  oauthLogin?: SetupDeps["oauthLogin"];
   /** Transport beneath the real Phoenix client `createClient` builds. */
   fetch?: typeof fetch;
 }
@@ -227,6 +243,11 @@ export function buildFakeDeps(overrides: FakeDepsOverrides = {}): SetupDeps {
     writeClipboard: overrides.writeClipboard ?? (async () => true),
     createClient: ({ endpoint, apiKey }) =>
       createPhoenixClient({ config: { endpoint, apiKey }, fetch }),
+    // Default fake: no OAuth support, so existing lanes stay on paste.
+    oauthLogin: overrides.oauthLogin ?? {
+      isSupported: async () => false,
+      login: async () => ({ status: "error", detail: "oauth not faked" }),
+    },
     fetchDocs:
       overrides.fetchDocs ??
       (async (options) => ({

--- a/js/packages/phoenix-cli/test/setup/oauthLogin.test.ts
+++ b/js/packages/phoenix-cli/test/setup/oauthLogin.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { createSystemOAuthLogin } from "../../src/setup/deps/oauthLogin";
+import { fakeFetch, jsonResponse } from "./fakes";
+
+const METADATA = {
+  issuer: "http://phoenix.example",
+  authorization_endpoint: "http://phoenix.example/oauth2/authorize",
+  token_endpoint: "http://phoenix.example/oauth2/token",
+};
+
+describe("setup OAuth login capability probe", () => {
+  it("reports support for a well-formed authorization server document", async () => {
+    const login = createSystemOAuthLogin({
+      fetchImpl: fakeFetch(() => jsonResponse(200, METADATA)),
+    });
+    await expect(login.isSupported("http://phoenix.example")).resolves.toBe(
+      true
+    );
+  });
+
+  it("rejects the SPA index.html an older Phoenix serves with a 200", async () => {
+    const login = createSystemOAuthLogin({
+      fetchImpl: fakeFetch(
+        () =>
+          new Response("<!doctype html><title>Phoenix</title>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          })
+      ),
+    });
+    await expect(login.isSupported("http://phoenix.example")).resolves.toBe(
+      false
+    );
+  });
+
+  it("rejects JSON that is missing the endpoints the flow needs", async () => {
+    const login = createSystemOAuthLogin({
+      fetchImpl: fakeFetch(() =>
+        jsonResponse(200, { issuer: "http://phoenix.example" })
+      ),
+    });
+    await expect(login.isSupported("http://phoenix.example")).resolves.toBe(
+      false
+    );
+  });
+
+  it("treats a 404 from a server without the authorization server as unsupported", async () => {
+    const login = createSystemOAuthLogin({
+      fetchImpl: fakeFetch(() => jsonResponse(404, { detail: "Not Found" })),
+    });
+    await expect(login.isSupported("http://phoenix.example")).resolves.toBe(
+      false
+    );
+  });
+
+  it("probes the --api-url override rather than the user-facing endpoint", async () => {
+    const probed: string[] = [];
+    const login = createSystemOAuthLogin({
+      apiUrl: "http://localhost:6006",
+      fetchImpl: fakeFetch((url) => {
+        probed.push(url);
+        return jsonResponse(200, METADATA);
+      }),
+    });
+    await login.isSupported("http://phoenix.example");
+    expect(probed).toEqual([
+      "http://localhost:6006/.well-known/oauth-authorization-server",
+    ]);
+  });
+
+  it("treats an unreachable server as unsupported", async () => {
+    const login = createSystemOAuthLogin({
+      // No handler matches, so fakeFetch throws — the transport-failure case.
+      fetchImpl: fakeFetch(() => undefined),
+    });
+    await expect(login.isSupported("http://phoenix.example")).resolves.toBe(
+      false
+    );
+  });
+
+  it("reports cancelled without opening a browser when the wait is already abandoned", async () => {
+    const abandoned = new AbortController();
+    abandoned.abort();
+    const login = createSystemOAuthLogin({
+      fetchImpl: fakeFetch(() => jsonResponse(200, METADATA)),
+    });
+    const outcome = await login.login({
+      endpoint: "http://phoenix.example",
+      onAuthorizationUrl: () => {
+        throw new Error("must not narrate a URL for an abandoned login");
+      },
+      onBrowserOpenFailed: () => {
+        throw new Error("must not launch a browser for an abandoned login");
+      },
+      signal: abandoned.signal,
+    });
+    expect(outcome).toEqual({ status: "cancelled" });
+  });
+});

--- a/js/packages/phoenix-cli/test/setup/runSetup.test.ts
+++ b/js/packages/phoenix-cli/test/setup/runSetup.test.ts
@@ -120,8 +120,8 @@ describe("runSetup", () => {
 
   it("auth-on happy path with a pasted API key", async () => {
     const prompter = scriptedPrompter([
-      "sk-pasted", // API key
       "my-app", // project name
+      "sk-pasted", // API key
       "clipboard", // instrumentation mode
       true, // I've run the prompt
       false, // no px profile
@@ -145,8 +145,8 @@ describe("runSetup", () => {
 
   it("re-prompts only for a rejected API key", async () => {
     const prompter = scriptedPrompter([
-      "sk-rejected", // API key
       "my-app", // project name
+      "sk-rejected", // API key
       "sk-pasted", // replacement API key
       "manual",
       true,


### PR DESCRIPTION
<img width="861" height="472" alt="Screenshot 2026-07-16 at 10 08 47 AM" src="https://github.com/user-attachments/assets/886c7615-04c6-4e65-90f4-ad36fdfa5d4d" />
<img width="1725" height="933" alt="Screenshot 2026-07-16 at 10 09 03 AM" src="https://github.com/user-attachments/assets/6b32c6b9-38e9-48cf-ae05-194f3d0d941b" />
<img width="756" height="435" alt="Screenshot 2026-07-16 at 10 10 21 AM" src="https://github.com/user-attachments/assets/6495494e-31d6-4195-8387-74bca6f73d98" />

This PR optimizes the `px setup` flow by first just doing on oath2 grant then issuing the API keys via rest instead