### PR TITLE
fix(ui): cap IO tooltip height and add scroll fades

### DIFF
--- a/app/src/pages/project/IOValueTooltipCell.tsx
+++ b/app/src/pages/project/IOValueTooltipCell.tsx
@@ -225,7 +225,7 @@ function IOValueTooltipCell({
 
   return (
     <TooltipTrigger
-      delay={350}
+      delay={700}
       closeDelay={100}
       onOpenChange={(isOpen) => {
         if (isOpen) {

--- a/app/src/pages/project/IOValueTooltipCell.tsx
+++ b/app/src/pages/project/IOValueTooltipCell.tsx
@@ -1,4 +1,4 @@
-import { css } from "@emotion/react";
+import { css, keyframes } from "@emotion/react";
 import type { ReactNode } from "react";
 import { Suspense } from "react";
 import type { PreloadedQuery } from "react-relay";
@@ -87,10 +87,95 @@ const tooltipCSS = css`
     var(--global-dimension-size-5000),
     calc(100vw - var(--global-dimension-size-400))
   );
+  // Clip to the react-aria viewport cap so tall content can never spill past
+  // the page boundary; the inner scroll container handles the actual scrolling.
+  overflow: hidden;
+`;
+
+// The height cap and scroll live on an inner wrapper rather than the
+// RichTooltip root: react-aria applies its own viewport-aware max-height as an
+// inline style on the root, which would override a stylesheet max-height there.
+// Capping the inner content keeps the tooltip from growing too tall while
+// react-aria still keeps the root within the page boundary. Works for every
+// content type (CodeMirror JSON, markdown, plain text).
+const tooltipContentCSS = css`
+  position: relative;
   max-height: min(480px, calc(100vh - 64px));
   overflow: auto;
   white-space: normal;
   word-break: break-word;
+`;
+
+// Sticky fade overlays pinned to the top and bottom of the scroll viewport so
+// scrolled content dissolves into the tooltip background instead of ending on a
+// hard edge. Negative margins let them overlap the content rather than consume
+// layout height, and pointer-events are disabled so they never intercept
+// scroll or hover. They start hidden (opacity: 0) and are revealed only while
+// there is scrolled-away content in that direction, via a scroll-driven
+// animation (see below) — so a tooltip whose content fits shows no fade at all.
+const scrollFadeCSS = css`
+  position: sticky;
+  left: 0;
+  right: 0;
+  height: var(--global-dimension-size-300);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 1;
+`;
+
+const fadeInKeyframes = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const fadeOutKeyframes = keyframes`
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+`;
+
+// Scroll-timeline animations tie each fade's opacity to the scroll position of
+// the nearest scroll container (the content wrapper). When the content fits and
+// the container is not scrollable, the timeline is inactive and the base
+// opacity: 0 wins, so no fade appears. Chrome-only CSS, guarded by @supports so
+// unsupported browsers simply fall back to no fade.
+const scrollFadeTopCSS = css`
+  top: 0;
+  margin-bottom: calc(-1 * var(--global-dimension-size-300));
+  background: linear-gradient(
+    to bottom,
+    var(--global-tooltip-background-color),
+    transparent
+  );
+
+  @supports (animation-timeline: scroll()) {
+    animation: ${fadeInKeyframes} linear both;
+    animation-timeline: scroll(nearest);
+    animation-range: 0 var(--global-dimension-size-300);
+  }
+`;
+
+const scrollFadeBottomCSS = css`
+  bottom: 0;
+  margin-top: calc(-1 * var(--global-dimension-size-300));
+  background: linear-gradient(
+    to top,
+    var(--global-tooltip-background-color),
+    transparent
+  );
+
+  @supports (animation-timeline: scroll()) {
+    animation: ${fadeOutKeyframes} linear both;
+    animation-timeline: scroll(nearest);
+    animation-range: calc(100% - var(--global-dimension-size-300)) 100%;
+  }
 `;
 
 const loadingCSS = css`
@@ -155,9 +240,15 @@ function IOValueTooltipCell({
         <span>{previewText}</span>
       </TriggerWrap>
       <RichTooltip placement="bottom start" width="auto" css={tooltipCSS}>
-        <ErrorBoundary fallback={TextErrorBoundaryFallback}>
-          <Suspense fallback={<IOValueTooltipSkeleton />}>{children}</Suspense>
-        </ErrorBoundary>
+        <div css={tooltipContentCSS}>
+          <div css={[scrollFadeCSS, scrollFadeTopCSS]} aria-hidden />
+          <ErrorBoundary fallback={TextErrorBoundaryFallback}>
+            <Suspense fallback={<IOValueTooltipSkeleton />}>
+              {children}
+            </Suspense>
+          </ErrorBoundary>
+          <div css={[scrollFadeCSS, scrollFadeBottomCSS]} aria-hidden />
+        </div>
       </RichTooltip>
     </TooltipTrigger>
   );


### PR DESCRIPTION
## Summary

Constrains the span/trace/session IO value tooltip so tall content can no longer grow past the viewport, and adds subtle scroll fade gradients for a cleaner look.

- **Height cap that actually holds.** react-aria writes a viewport-aware `max-height` as an inline style on the tooltip root, which overrides a stylesheet `max-height` set there. The cap + scroll now live on an inner content wrapper, while the root clips to react-aria's viewport cap (`overflow: hidden`) so content can never spill past the page boundary. Works for every content type — CodeMirror JSON, markdown/code, and plain text.
- **Scroll fade gradients.** Sticky top/bottom overlays dissolve scrolled content into the tooltip background instead of ending on a hard edge.
- **Only when scrollable.** The fades are driven by scroll-timeline animations (`animation-timeline: scroll(nearest)`), so they appear only while there is scrolled-away content and stay fully hidden when the content fits. Pure CSS, no JS/`useEffect`, guarded by `@supports`.

## Test plan

- [ ] Hover an IO cell with very long JSON — tooltip caps in height and scrolls; fades appear top/bottom as appropriate.
- [ ] Hover a markdown cell with a long code block — scrolls and clips the same way.
- [ ] Hover a short-content cell — no fade gradient shown.
- [ ] Trigger the tooltip near the bottom of the viewport — never overflows the page boundary.