### PR TITLE
fix: table row hover and cursor styles

### DIFF
--- a/app/src/pages/evaluators/EvaluatorsTable.tsx
+++ b/app/src/pages/evaluators/EvaluatorsTable.tsx
@@ -28,7 +28,7 @@ import { Flex, Icon, Icons, Text } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { EvaluatorKindToken } from "@phoenix/components/evaluators/EvaluatorKindToken";
 import { GenerativeProviderIcon } from "@phoenix/components/generative";
-import { tableCSS } from "@phoenix/components/table/styles";
+import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableExpandButton } from "@phoenix/components/table/TableExpandButton";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { UserPicture } from "@phoenix/components/user/UserPicture";
@@ -522,7 +522,7 @@ export const EvaluatorsTable = ({
       ref={tableContainerRef}
     >
       <table
-        css={tableCSS}
+        css={selectableTableCSS}
         style={{
           ...columnSizeVars,
           width: table.getTotalSize(),
@@ -594,9 +594,6 @@ export const EvaluatorsTable = ({
               <tr
                 key={row.id}
                 data-depth={row.depth}
-                style={{
-                  cursor: "pointer",
-                }}
                 onClick={() => {
                   if (rowIsExpandable) {
                     row.toggleExpanded();

--- a/app/src/pages/example/ExampleExperimentRunsTable.tsx
+++ b/app/src/pages/example/ExampleExperimentRunsTable.tsx
@@ -15,7 +15,7 @@ import {
   AnnotationTooltip,
 } from "@phoenix/components/annotation";
 import { EmptyState, EmptyStateGraphic } from "@phoenix/components/core/empty";
-import { selectableTableCSS } from "@phoenix/components/table/styles";
+import { tableCSS } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import { TextCell } from "@phoenix/components/table/TextCell";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
@@ -247,7 +247,7 @@ export function ExampleExperimentRunsTable({
       ref={tableContainerRef}
       onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
     >
-      <table css={selectableTableCSS}>
+      <table css={tableCSS}>
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -54,7 +54,7 @@ import {
 } from "@phoenix/components/datetime";
 import { TopNavActions } from "@phoenix/components/nav";
 import { GradientCircle } from "@phoenix/components/project/GradientCircle";
-import { tableCSS } from "@phoenix/components/table/styles";
+import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
@@ -880,7 +880,7 @@ function ProjectsTable({
           width: 100%;
         `}
       >
-        <table css={tableCSS} data-testid="projects-table">
+        <table css={selectableTableCSS} data-testid="projects-table">
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>


### PR DESCRIPTION
closes #14424
Projects and evaluators tables were missing hover styles for cursor and background.

Removed these style from the runs table in the tray for a single dataset example, since there is no action associated with those rows.

before:

https://github.com/user-attachments/assets/8a480cc0-538e-4d23-bb90-53c75bc755e0

after:

https://github.com/user-attachments/assets/8561f6d2-b144-4d8a-abf7-21cff1fe2e8c

