### PR TITLE
fix: overflow bars on tiledpanel extra actions

### DIFF
--- a/app/src/components/react-resizable-panels/TitledPanel.tsx
+++ b/app/src/components/react-resizable-panels/TitledPanel.tsx
@@ -153,7 +153,7 @@ const panelHeaderCSS = css`
     border-bottom: 1px solid var(--global-border-color-default);
   }
   &[data-collapsed="true"] {
-    border-bottom: none;
+    border-bottom-color: transparent;
   }
   transition: background-color 0.2s ease-in-out;
   /* highlight the whole strip when the collapse trigger is hovered so the
@@ -199,8 +199,8 @@ const panelTitleExtraCSS = css`
   gap: var(--global-dimension-size-100);
   /* right padding matches the page header's size-200 inset so the extra
      clusters align vertically across the page */
-  padding: var(--global-dimension-size-50) var(--global-dimension-size-200)
-    var(--global-dimension-size-50) 0;
+  padding-right: var(--global-dimension-size-200);
+  padding-left: var(--global-dimension-size-50);
 `;
 
 const panelTitleHeadingCSS = css`


### PR DESCRIPTION
#14324 introduced a layout overflow bug on prompt menus. This fixes it by removing unnecessary padding and maintaining a bit of left padding for focus ring. 

<img width="1070" height="223" alt="Screenshot 2026-07-15 at 5 38 04 PM" src="https://github.com/user-attachments/assets/326b0e88-e268-4b74-801e-84f91c222117" />

<img width="1029" height="591" alt="Screenshot 2026-07-15 at 5 37 24 PM" src="https://github.com/user-attachments/assets/622a3094-5c45-4aa6-bdcd-57613707caef" />
