### PR TITLE
feat(sandboxes): add Islo sandbox backend

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2313,6 +2313,13 @@ enum InternetAccessMode {
   BOOLEAN
 }
 
+input IsloConfigInput {
+  language: Language! = PYTHON
+  envVars: [EnvVarInput!]! = []
+  internetAccess: InternetAccessInput = null
+  dependencies: DependenciesInput = null
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
 """
@@ -3659,6 +3666,7 @@ enum SandboxBackendType {
   VERCEL
   DENO
   MODAL
+  ISLO
 }
 
 type SandboxConfig implements Node {
@@ -3706,6 +3714,7 @@ input SandboxConfigVariantInput @oneOf {
   vercel: VercelConfigInput
   wasm: WASMConfigInput
   modal: ModalConfigInput
+  islo: IsloConfigInput
 }
 
 """

--- a/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateCodeDatasetEvaluatorSlideoverQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5bcde803d573c23e37d770ade0fbfae7>>
+ * @generated SignedSource<<db0f80face0805dbed25e153e85c5241>>
  * @lightSyntaxTransform
  */
 
@@ -12,7 +12,7 @@ export type InternetAccessChoice = "ALLOW" | "DENY";
 export type InternetAccessMode = "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
-export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
+export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "ISLO" | "MODAL" | "VERCEL" | "WASM";
 export type CreateCodeDatasetEvaluatorSlideoverQuery$variables = Record<PropertyKey, never>;
 export type CreateCodeDatasetEvaluatorSlideoverQuery$data = {
   readonly sandboxBackends: ReadonlyArray<{

--- a/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<faa379502fc2046d067cfec0cfaea572>>
+ * @generated SignedSource<<e1bb7353fb201e77512aa4e97beaf8cc>>
  * @lightSyntaxTransform
  */
 
@@ -14,7 +14,7 @@ export type InternetAccessMode = "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
-export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
+export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "ISLO" | "MODAL" | "VERCEL" | "WASM";
 export type EditCodeDatasetEvaluatorSlideover_datasetEvaluatorQuery$variables = {
   datasetEvaluatorId: string;
   datasetId: string;

--- a/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
+++ b/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
@@ -187,6 +187,7 @@ const BACKEND_TYPE_LABELS: Record<SandboxBackendType, string> = {
   VERCEL: "Vercel",
   DENO: "Deno",
   MODAL: "Modal",
+  ISLO: "Islo",
 };
 
 const backendTypeLabel = (backendType: SandboxBackendType): string =>

--- a/app/src/components/sandbox/SandboxProviderIcon.tsx
+++ b/app/src/components/sandbox/SandboxProviderIcon.tsx
@@ -183,6 +183,26 @@ const WasmSVG = ({ height }: IconProps) => (
   </svg>
 );
 
+// Placeholder mark (isolated box) rendered in currentColor; swap for the
+// official Islo asset once it's hosted on arize-phoenix-assets.
+const IsloSVG = ({ height }: IconProps) => (
+  <svg
+    viewBox="0 0 128 128"
+    width={height}
+    height={height}
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>Islo</title>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M28 8h72c11.046 0 20 8.954 20 20v72c0 11.046-8.954 20-20 20H28c-11.046 0-20-8.954-20-20V28C8 16.954 16.954 8 28 8zm0 12c-4.418 0-8 3.582-8 8v72c0 4.418 3.582 8 8 8h72c4.418 0 8-3.582 8-8V28c0-4.418-3.582-8-8-8H28z"
+    />
+    <rect x="40" y="40" width="48" height="48" rx="10" />
+  </svg>
+);
+
 const ICONS_BY_BACKEND_TYPE: Record<SandboxBackendType, React.FC<IconProps>> = {
   WASM: WasmSVG,
   E2B: E2BSVG,
@@ -190,6 +210,7 @@ const ICONS_BY_BACKEND_TYPE: Record<SandboxBackendType, React.FC<IconProps>> = {
   VERCEL: VercelSVG,
   DENO: DenoSVG,
   MODAL: ModalSVG,
+  ISLO: IsloSVG,
 };
 
 export type SandboxProviderIconProps = {

--- a/app/src/components/sandbox/__generated__/SandboxProviderSelectQuery.graphql.ts
+++ b/app/src/components/sandbox/__generated__/SandboxProviderSelectQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<99de645242c4ab6d9a4fbf35ce1ffebc>>
+ * @generated SignedSource<<501b4f0423ff492fa7d5214e2fa2f17e>>
  * @lightSyntaxTransform
  */
 
@@ -10,7 +10,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
-export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
+export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "ISLO" | "MODAL" | "VERCEL" | "WASM";
 export type SandboxHostingType = "HOSTED" | "LOCAL";
 export type SandboxProviderSelectQuery$variables = Record<PropertyKey, never>;
 export type SandboxProviderSelectQuery$data = {

--- a/app/src/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorDetails_datasetEvaluator.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/CodeDatasetEvaluatorDetails_datasetEvaluator.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d00e8172d5b7c8f1822d6f0c5562128c>>
+ * @generated SignedSource<<075a5a1f746054b59ab278dec4b094d0>>
  * @lightSyntaxTransform
  */
 
@@ -12,7 +12,7 @@ export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
 export type InternetAccessChoice = "ALLOW" | "DENY";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
-export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
+export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "ISLO" | "MODAL" | "VERCEL" | "WASM";
 import { FragmentRefs } from "relay-runtime";
 export type CodeDatasetEvaluatorDetails_datasetEvaluator$data = {
   readonly evaluator: {

--- a/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
+++ b/app/src/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e71d73fe11b74b2edc82ee4624c2a088>>
+ * @generated SignedSource<<c88a7a0c56a51802830e453d5ab3c3f6>>
  * @lightSyntaxTransform
  */
 
@@ -11,7 +11,7 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
 export type InternetAccessMode = "BOOLEAN" | "NONE";
-export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
+export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "ISLO" | "MODAL" | "VERCEL" | "WASM";
 export type datasetEvaluatorDetailsLoaderQuery$variables = {
   datasetEvaluatorId: string;
   datasetId: string;

--- a/app/src/pages/evaluators/__generated__/DatasetEvaluatorsTable_row.graphql.ts
+++ b/app/src/pages/evaluators/__generated__/DatasetEvaluatorsTable_row.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<76751ed6fad012efc3937ec534422c95>>
+ * @generated SignedSource<<c09f118f4f6ccc62e70e8df8758f5c72>>
  * @lightSyntaxTransform
  */
 
@@ -11,7 +11,7 @@ import { ReaderInlineDataFragment } from 'relay-runtime';
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
-export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
+export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "ISLO" | "MODAL" | "VERCEL" | "WASM";
 import { FragmentRefs } from "relay-runtime";
 export type DatasetEvaluatorsTable_row$data = {
   readonly description: string | null;

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogCreateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8180a7ffdeb5a1af63cecd6426bb6cd6>>
+ * @generated SignedSource<<d1cecb54fa223c495bb24e51aea90524>>
  * @lightSyntaxTransform
  */
 
@@ -22,6 +22,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b: E2BConfigInput;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -29,6 +30,7 @@ export type SandboxConfigVariantInput = {
   daytona: DaytonaConfigInput;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -36,6 +38,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno: DenoConfigInput;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -43,6 +46,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel: VercelConfigInput;
   wasm?: never;
@@ -50,6 +54,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm: WASMConfigInput;
@@ -57,7 +62,16 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal: ModalConfigInput;
+  vercel?: never;
+  wasm?: never;
+} | {
+  daytona?: never;
+  deno?: never;
+  e2b?: never;
+  islo: IsloConfigInput;
+  modal?: never;
   vercel?: never;
   wasm?: never;
 };
@@ -96,6 +110,12 @@ export type WASMConfigInput = {
   language?: Language;
 };
 export type ModalConfigInput = {
+  dependencies?: DependenciesInput | null;
+  envVars?: ReadonlyArray<EnvVarInput>;
+  internetAccess?: InternetAccessInput | null;
+  language?: Language;
+};
+export type IsloConfigInput = {
   dependencies?: DependenciesInput | null;
   envVars?: ReadonlyArray<EnvVarInput>;
   internetAccess?: InternetAccessInput | null;

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigDialogUpdateSandboxConfigMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fc4dc29f6676785e35c46aaed27471af>>
+ * @generated SignedSource<<b9c3049fcd940908af6991e1667b9962>>
  * @lightSyntaxTransform
  */
 
@@ -22,6 +22,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b: E2BConfigInput;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -29,6 +30,7 @@ export type SandboxConfigVariantInput = {
   daytona: DaytonaConfigInput;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -36,6 +38,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno: DenoConfigInput;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -43,6 +46,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel: VercelConfigInput;
   wasm?: never;
@@ -50,6 +54,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm: WASMConfigInput;
@@ -57,7 +62,16 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal: ModalConfigInput;
+  vercel?: never;
+  wasm?: never;
+} | {
+  daytona?: never;
+  deno?: never;
+  e2b?: never;
+  islo: IsloConfigInput;
+  modal?: never;
   vercel?: never;
   wasm?: never;
 };
@@ -96,6 +110,12 @@ export type WASMConfigInput = {
   language?: Language;
 };
 export type ModalConfigInput = {
+  dependencies?: DependenciesInput | null;
+  envVars?: ReadonlyArray<EnvVarInput>;
+  internetAccess?: InternetAccessInput | null;
+  language?: Language;
+};
+export type IsloConfigInput = {
   dependencies?: DependenciesInput | null;
   envVars?: ReadonlyArray<EnvVarInput>;
   internetAccess?: InternetAccessInput | null;

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e79843b8d67649c1f494db018b0808ae>>
+ * @generated SignedSource<<c88cc7d46d12330e0821d77a0c965db4>>
  * @lightSyntaxTransform
  */
 
@@ -22,6 +22,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b: E2BConfigInput;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -29,6 +30,7 @@ export type SandboxConfigVariantInput = {
   daytona: DaytonaConfigInput;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -36,6 +38,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno: DenoConfigInput;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm?: never;
@@ -43,6 +46,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel: VercelConfigInput;
   wasm?: never;
@@ -50,6 +54,7 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal?: never;
   vercel?: never;
   wasm: WASMConfigInput;
@@ -57,7 +62,16 @@ export type SandboxConfigVariantInput = {
   daytona?: never;
   deno?: never;
   e2b?: never;
+  islo?: never;
   modal: ModalConfigInput;
+  vercel?: never;
+  wasm?: never;
+} | {
+  daytona?: never;
+  deno?: never;
+  e2b?: never;
+  islo: IsloConfigInput;
+  modal?: never;
   vercel?: never;
   wasm?: never;
 };
@@ -96,6 +110,12 @@ export type WASMConfigInput = {
   language?: Language;
 };
 export type ModalConfigInput = {
+  dependencies?: DependenciesInput | null;
+  envVars?: ReadonlyArray<EnvVarInput>;
+  internetAccess?: InternetAccessInput | null;
+  language?: Language;
+};
+export type IsloConfigInput = {
   dependencies?: DependenciesInput | null;
   envVars?: ReadonlyArray<EnvVarInput>;
   internetAccess?: InternetAccessInput | null;

--- a/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SettingsSandboxesPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9d23927b52cd14b188cfbe8ab92638ea>>
+ * @generated SignedSource<<648e92efc32daa587584c176f95335d6>>
  * @lightSyntaxTransform
  */
 
@@ -12,7 +12,7 @@ export type InternetAccessChoice = "ALLOW" | "DENY";
 export type InternetAccessMode = "BOOLEAN" | "NONE";
 export type Language = "PYTHON" | "TYPESCRIPT";
 export type SandboxBackendStatus = "AVAILABLE" | "DISABLED" | "MISSING_CREDENTIALS" | "NOT_INSTALLED" | "UNAVAILABLE";
-export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "MODAL" | "VERCEL" | "WASM";
+export type SandboxBackendType = "DAYTONA" | "DENO" | "E2B" | "ISLO" | "MODAL" | "VERCEL" | "WASM";
 export type SandboxHostingType = "HOSTED" | "LOCAL";
 import { FragmentRefs } from "relay-runtime";
 export type SettingsSandboxesPageFragment$data = {

--- a/app/src/pages/settings/sandboxes/__tests__/formValuesToConfigPatch.test.ts
+++ b/app/src/pages/settings/sandboxes/__tests__/formValuesToConfigPatch.test.ts
@@ -127,6 +127,37 @@ describe("formValuesToConfigPatch — variant + capability output", () => {
     expect(result["wasm"]).not.toHaveProperty("internetAccess");
   });
 
+  it("maps ISLO to the islo variant key with full capabilities", () => {
+    const isloFullCapabilityBackend: PartialBackend = {
+      backendType: "ISLO",
+      supportsEnvVars: true,
+      internetAccess: "BOOLEAN",
+      supportsDependencies: true,
+    };
+    const values: SandboxConfigFormValues = {
+      ...emptyValues,
+      envVars: [{ name: "KEY", secretKey: "key_secret" }],
+      internetAccessEnabled: true,
+      dependenciesText: "numpy\npandas",
+    };
+
+    const result = formValuesToConfigPatch(
+      values,
+      isloFullCapabilityBackend as BackendInfo
+    );
+
+    expect(result).toEqual({
+      islo: {
+        language: "PYTHON",
+        envVars: [{ name: "KEY", secretKey: "key_secret" }],
+        internetAccess: { mode: "ALLOW" },
+        dependencies: {
+          packages: ["numpy", "pandas"],
+        },
+      },
+    });
+  });
+
   it("env vars produce flattened secretKey values", () => {
     const values: SandboxConfigFormValues = {
       ...emptyValues,

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -221,6 +221,8 @@ export function getBackendDescription(backendType: BackendInfo["backendType"]) {
       return "Local Deno TypeScript runtime";
     case "MODAL":
       return "Modal cloud Python sandbox";
+    case "ISLO":
+      return "Islo cloud Python sandbox";
     default:
       return "Sandbox runtime";
   }
@@ -347,6 +349,7 @@ const VARIANT_KEY_BY_BACKEND_TYPE: Record<BackendInfo["backendType"], string> =
     VERCEL: "vercel",
     WASM: "wasm",
     MODAL: "modal",
+    ISLO: "islo",
   };
 
 export function formValuesToConfigPatch(

--- a/app/src/types/evaluators.ts
+++ b/app/src/types/evaluators.ts
@@ -152,7 +152,8 @@ export type SandboxBackendType =
   | "DAYTONA"
   | "VERCEL"
   | "DENO"
-  | "MODAL";
+  | "MODAL"
+  | "ISLO";
 
 /**
  * The source data for evaluator input mappings.

--- a/docs.json
+++ b/docs.json
@@ -384,7 +384,8 @@
                   "docs/phoenix/settings/sandboxes/e2b",
                   "docs/phoenix/settings/sandboxes/daytona",
                   "docs/phoenix/settings/sandboxes/vercel",
-                  "docs/phoenix/settings/sandboxes/modal"
+                  "docs/phoenix/settings/sandboxes/modal",
+                  "docs/phoenix/settings/sandboxes/islo"
                 ]
               }
             ]

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -394,6 +394,7 @@
 - [Daytona Sandbox Settings](https://arize.com/docs/phoenix/settings/sandboxes/daytona): Configure Daytona credentials and snapshot settings for hosted code evaluation
 - [Vercel Sandbox Settings](https://arize.com/docs/phoenix/settings/sandboxes/vercel): Configure Vercel team and project credentials for hosted code evaluation
 - [Modal Sandbox Settings](https://arize.com/docs/phoenix/settings/sandboxes/modal): Configure Modal token and workspace for hosted Python code evaluation
+- [Islo Sandbox Settings](https://arize.com/docs/phoenix/settings/sandboxes/islo): Configure an Islo API key for hosted Python code evaluation in isolated cloud sandboxes
 
 ## Concepts
 

--- a/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
+++ b/docs/phoenix/self-hosting/features/sandbox-runtimes.mdx
@@ -6,7 +6,7 @@ description: Set up the sandbox providers that run code evaluators on your self-
 Phoenix runs code evaluators (and other LLM-driven workloads that need to execute code) inside sandboxes. This page tells you which sandbox providers are ready to use in the official `arizephoenix/phoenix` container, what extra setup the others need, and how to read the status badges shown on **Settings → Sandboxes**.
 
 <Warning>
-**Local sandboxes (Deno, WebAssembly) are for simple code evaluation only.** Environment variables, network access, and third-party dependencies are supported **only** in hosted sandboxes (E2B, Daytona, Vercel, Modal).
+**Local sandboxes (Deno, WebAssembly) are for simple code evaluation only.** Environment variables, network access, and third-party dependencies are supported **only** in hosted sandboxes (E2B, Daytona, Vercel, Modal, Islo).
 </Warning>
 
 ## Reading the status on Settings → Sandboxes
@@ -25,7 +25,7 @@ If you deploy the official `arizephoenix/phoenix` container, these providers are
 
 - **Deno (local)** — runs TypeScript inside Phoenix. The Deno binary is bundled in the container.
 - **WebAssembly (local)** — runs Python inside Phoenix using a WebAssembly Python interpreter. The interpreter is bundled in the container.
-- **Hosted providers (E2B, Modal, Daytona, Vercel)** — the integration code ships inside the container, so you only need to add your credentials before each becomes **Available**.
+- **Hosted providers (E2B, Modal, Daytona, Vercel, Islo)** — the integration code ships inside the container, so you only need to add your credentials before each becomes **Available**.
 
 If you're not using the official container — for example, you installed Phoenix with `pip install arize-phoenix` on your own host, or you're building a custom image — you'll need to install the runtime tooling for local sandboxes and the relevant Phoenix extras for hosted ones. See [Non-container deployments](#non-container-deployments) below.
 
@@ -74,13 +74,14 @@ Once `PHOENIX_WASM_BINARY_PATH` is set, Phoenix will only use that file. If the 
 
 ### Hosted providers
 
-Each hosted provider ships as a separate Phoenix extra and has its own credentials. The official `arizephoenix/phoenix` container already includes all four extras — you only need to install one of these when you're running on a custom image or a plain `pip install arize-phoenix`:
+Each hosted provider ships as a separate Phoenix extra and has its own credentials. The official `arizephoenix/phoenix` container already includes all five extras — you only need to install one of these when you're running on a custom image or a plain `pip install arize-phoenix`:
 
 ```bash
 pip install 'arize-phoenix[e2b]'      # E2B
 pip install 'arize-phoenix[modal]'    # Modal
 pip install 'arize-phoenix[daytona]'  # Daytona
 pip install 'arize-phoenix[vercel]'   # Vercel Sandbox (Python and TypeScript)
+pip install 'arize-phoenix[islo]'     # Islo
 ```
 
 Add the credentials each hosted provider needs — for example, `E2B_API_KEY`, `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`, or the Vercel token / project / team triple. You can either set them as environment variables on the Phoenix server or paste them directly into the provider's row in **Settings → Sandboxes**. The full list of credential variables for each provider is in the [compatibility matrix](#compatibility-matrix) below.
@@ -91,7 +92,7 @@ To restrict which sandbox providers your deployment can use, set the `PHOENIX_AL
 
 - **Leave it unset** to allow every supported provider (the default).
 - **Set it to `NONE`** to disable every sandbox provider.
-- **Set it to one or more provider names** to allow only those. Valid names are `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, and `MODAL` (lowercase works too — the variable is case-insensitive). An unknown name will stop Phoenix from starting so a typo can't silently disable a provider.
+- **Set it to one or more provider names** to allow only those. Valid names are `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, `MODAL`, and `ISLO` (lowercase works too — the variable is case-insensitive). An unknown name will stop Phoenix from starting so a typo can't silently disable a provider.
 
 ```bash
 export PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO   # allow local sandboxes only
@@ -121,6 +122,7 @@ The container-ready column reflects the post-install state of the `arizephoenix/
 | **Daytona** (`DAYTONA`) | Python, TypeScript | Ready with credentials — already in container | `pip install 'arize-phoenix[daytona]'` | `DAYTONA_API_KEY` | Daytona cloud |
 | **Vercel Sandbox** (`VERCEL`) | Python, TypeScript | Ready with credentials — already in container | `pip install 'arize-phoenix[vercel]'` | `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` ([auth docs](https://vercel.com/docs/vercel-sandbox/concepts/authentication)) | Vercel cloud |
 | **Modal** (`MODAL`) | Python | Ready with credentials — already in container | `pip install 'arize-phoenix[modal]'` | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | Modal cloud |
+| **Islo** (`ISLO`) | Python | Ready with credentials — already in container | `pip install 'arize-phoenix[islo]'` | `ISLO_API_KEY` | Islo cloud |
 
 <Info>
 "Container-ready" means the necessary code or binary is already inside the official `arizephoenix/phoenix` image. For hosted providers you still need to enter credentials before the status changes from **Missing credentials** to **Available**. The two local providers (Deno and WebAssembly) become **Available** the moment the container starts.

--- a/docs/phoenix/settings/sandboxes.mdx
+++ b/docs/phoenix/settings/sandboxes.mdx
@@ -38,7 +38,7 @@ flowchart TB
         Server --> localBox
     end
 
-    subgraph provider ["Hosted Sandbox — E2B / Daytona / Vercel / Modal"]
+    subgraph provider ["Hosted Sandbox — E2B / Daytona / Vercel / Modal / Islo"]
         direction LR
         Libs("Third-party libraries")
         Net("Outbound internet")
@@ -93,6 +93,9 @@ flowchart TB
       <Card title="Modal" icon="https://storage.googleapis.com/arize-phoenix-assets/assets/svgs/modal.svg" href="/docs/phoenix/settings/sandboxes/modal">
         Serverless containers with sub-second cold starts and Python-first ergonomics.
       </Card>
+      <Card title="Islo" icon="box" href="/docs/phoenix/settings/sandboxes/islo">
+        Isolated cloud sandbox VMs purpose-built for autonomous coding agents.
+      </Card>
     </CardGroup>
   </Accordion>
 </AccordionGroup>
@@ -108,7 +111,7 @@ A **provider** is a sandbox runtime that Phoenix can run code on — for example
 The **Enabled** switch above is a per-deployment, admin-facing control. Self-hosted deployments can also restrict providers at the *server* level with the `PHOENIX_ALLOWED_SANDBOX_PROVIDERS` environment variable, which is set before Phoenix starts and cannot be overridden from this page.
 
 - **Leave it unset** to allow every supported provider (the default).
-- **Set it to a comma-separated list** — e.g. `PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO` — to allow only those providers. Accepted values are `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, and `MODAL` (case-insensitive).
+- **Set it to a comma-separated list** — e.g. `PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO` — to allow only those providers. Accepted values are `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, `MODAL`, and `ISLO` (case-insensitive).
 - **Set it to `NONE`** to disable every sandbox provider.
 
 A provider that isn't on the allowlist shows the status **Disabled** with the tooltip "Disabled on the server," and its **Enabled** switch is unavailable. See [Sandbox Backends](/docs/phoenix/self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) for the full details.
@@ -121,6 +124,7 @@ Click the gear icon next to a provider to open the credentials dialog. The dialo
 - **Daytona** — `DAYTONA_API_KEY`
 - **Modal** — `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`
 - **Vercel Sandbox** — `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, `VERCEL_TEAM_ID`
+- **Islo** — `ISLO_API_KEY`
 
 Values are stored encrypted at rest using the server's `PHOENIX_SECRET`. The dialog shows each field's environment-variable name and a short description; required fields are marked. Local backends (Deno, WebAssembly) have no credentials, and the gear button is disabled for them.
 

--- a/docs/phoenix/settings/sandboxes/islo.mdx
+++ b/docs/phoenix/settings/sandboxes/islo.mdx
@@ -1,0 +1,28 @@
+---
+title: "Islo"
+description: "Run code evaluators in Islo's isolated cloud sandboxes."
+---
+
+[**Islo**](https://islo.dev/) runs each Python evaluation in an isolated cloud sandbox VM, purpose-built for autonomous coding agents. Sandboxes are created on demand, reused across evaluations in the same run, and cleaned up automatically. See the [Islo documentation](https://docs.islo.dev/) for platform details.
+
+## Setup
+
+1. **Create an Islo account** at [islo.dev](https://islo.dev/) if you don't already have one.
+2. **Create an API key** at [app.islo.dev/api-keys](https://app.islo.dev/api-keys).
+3. **Add the credential to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Islo** row, click the gear icon, and paste the value as `ISLO_API_KEY`. You can also set it as an environment variable on the Phoenix server instead.
+4. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Islo**, set the timeout and any environment variables or dependencies, and save.
+
+## Capabilities
+
+- **Python only.** Islo configurations run Python evaluators.
+- **Environment variables** are injected per execution, so rotating a secret takes effect on the next evaluation without recreating the sandbox.
+- **Internet access** can be toggled per configuration. When off, the sandbox runs with no network egress.
+- **Dependencies** are installed with `pip` inside the sandbox at runtime, which requires internet access to be enabled.
+
+## Non-container installs
+
+The official `arizephoenix/phoenix` container bundles the Islo SDK. If you installed Phoenix with pip, add the `islo` extra:
+
+```bash
+pip install 'arize-phoenix[islo]'
+```

--- a/docs/phoenix/settings/sandboxes/islo.mdx
+++ b/docs/phoenix/settings/sandboxes/islo.mdx
@@ -8,7 +8,12 @@ description: "Run code evaluators in Islo's isolated cloud sandboxes."
 ## Setup
 
 1. **Create an Islo account** at [islo.dev](https://islo.dev/) if you don't already have one.
-2. **Create an API key** at [app.islo.dev/api-keys](https://app.islo.dev/api-keys).
+2. **Create an API key with the Islo CLI.** Install the CLI, run `islo login`, then create a key:
+
+   ```bash
+   islo api-key create phoenix --expires 90 --show
+   ```
+
 3. **Add the credential to Phoenix.** Open [Settings → Sandboxes](/docs/phoenix/settings/sandboxes), find the **Islo** row, click the gear icon, and paste the value as `ISLO_API_KEY`. You can also set it as an environment variable on the Phoenix server instead.
 4. **Create a configuration.** In **Sandbox Configurations**, click **New Sandbox**, pick **Islo**, set the timeout and any environment variables or dependencies, and save.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ dev = [
   "ldap3",
   "litellm>=1.83.14; python_version < '3.14'",  # >=1.83.14 fixes CVE-2026-42208; excluded because upstream metadata does not support Python 3.14 (https://github.com/BerriAI/litellm/issues/26343)
   "modal>=1.2.0",  # type-checking only; runtime is gated by the [modal] extra
+  "islo>=0.3.11",  # type-checking only; runtime is gated by the [islo] extra
   "vercel>=0.5.8",  # type-checking only; runtime is gated by the [vercel] extra. 0.5.8 exposes `network_policy` on AsyncSandbox.create.
   "wasmtime>=15.0",  # bundled in dev so the local WASM sandbox runs without an extra opt-in; the [wasm] extra still gates production installs
   "mypy==2.2.0",
@@ -198,6 +199,9 @@ vercel = [
 modal = [
   "modal>=1.2.0",
 ]
+islo = [
+  "islo>=0.3.11",
+]
 pg = [
   "asyncpg",
 ]
@@ -233,13 +237,14 @@ container = [
   "types-aiobotocore-bedrock-runtime>=3.6.0",
   # Sandbox provider SDKs — bundled so the shipped container can use any
   # configured provider without a rebuild. Each pin matches the matching
-  # single-provider extra above ([wasm], [e2b], [daytona], [vercel], [modal]).
+  # single-provider extra above ([wasm], [e2b], [daytona], [vercel], [modal], [islo]).
   "wasmtime>=15.0",
   "e2b-code-interpreter>=0.0.12",
   "daytona-sdk>=0.140.0",
   "vercel>=0.5.8",
   "websockets>=14.0",
   "modal>=1.2.0",
+  "islo>=0.3.11",
 ]
 
 [project.urls]

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -795,7 +795,7 @@ The default retention policy for traces in days.
 ENV_PHOENIX_ALLOWED_SANDBOX_PROVIDERS = "PHOENIX_ALLOWED_SANDBOX_PROVIDERS"
 """
 A comma-separated list of sandbox providers to allow.
-Accepted values: WASM, E2B, DAYTONA, VERCEL, DENO, MODAL. Case-insensitive.
+Accepted values: WASM, E2B, DAYTONA, VERCEL, DENO, MODAL, ISLO. Case-insensitive.
 When not set, all providers are allowed. To disable all sandbox providers, set to NONE.
 Example: PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO
 """

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -173,7 +173,9 @@ def render_values_w_union(
 UserRoleName: TypeAlias = Literal["SYSTEM", "ADMIN", "MEMBER", "VIEWER"]
 AuthMethod: TypeAlias = Literal["LOCAL", "OAUTH2", "LDAP"]
 EvaluatorKind: TypeAlias = Literal["LLM", "CODE", "BUILTIN"]
-SandboxBackendType: TypeAlias = Literal["WASM", "E2B", "DAYTONA", "VERCEL", "DENO", "MODAL"]
+SandboxBackendType: TypeAlias = Literal[
+    "WASM", "E2B", "DAYTONA", "VERCEL", "DENO", "MODAL", "ISLO"
+]
 LanguageName: TypeAlias = Literal["PYTHON", "TYPESCRIPT"]
 GenerativeModelSDK: TypeAlias = Literal[
     "openai",

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -36,6 +36,7 @@ from phoenix.server.sandbox.types import (
     E2BDeployment,
     EnvVarValue,
     InternetAccessConfig,
+    IsloConfig,
     ModalConfig,
     SandboxConfigModel,
     SandboxDeploymentModel,
@@ -183,6 +184,27 @@ class ModalConfigInput:
         return ModalConfig.model_validate(fields)
 
 
+@strawberry.input
+class IsloConfigInput:
+    language: Language = Language.PYTHON
+    env_vars: list[EnvVarInput] = strawberry.field(default_factory=list)
+    internet_access: Optional[InternetAccessInput] = None
+    dependencies: Optional[DependenciesInput] = None
+
+    def __post_init__(self) -> None:
+        _names_are_unique(self.env_vars)
+
+    def to_orm(self) -> IsloConfig:
+        fields: dict[str, Any] = {"language": self.language.to_orm()}
+        if self.env_vars:
+            fields["env_vars"] = {ev.name: ev.to_orm() for ev in self.env_vars}
+        if self.internet_access is not None:
+            fields["internet_access"] = self.internet_access.to_orm()
+        if self.dependencies is not None:
+            fields["dependencies"] = self.dependencies.to_orm()
+        return IsloConfig.model_validate(fields)
+
+
 @strawberry.input(one_of=True)
 class SandboxConfigVariantInput:
     """Config payload, discriminated by provider kind. Exactly one variant must be set."""
@@ -193,6 +215,7 @@ class SandboxConfigVariantInput:
     vercel: Optional[VercelConfigInput] = strawberry.UNSET
     wasm: Optional[WASMConfigInput] = strawberry.UNSET
     modal: Optional[ModalConfigInput] = strawberry.UNSET
+    islo: Optional[IsloConfigInput] = strawberry.UNSET
 
     def to_orm(self) -> SandboxConfigModel:
         if self.e2b is not None and self.e2b is not strawberry.UNSET:
@@ -207,6 +230,8 @@ class SandboxConfigVariantInput:
             return self.wasm.to_orm()
         if self.modal is not None and self.modal is not strawberry.UNSET:
             return self.modal.to_orm()
+        if self.islo is not None and self.islo is not strawberry.UNSET:
+            return self.islo.to_orm()
         raise BadRequest("config: exactly one provider variant must be set")
 
 

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -64,6 +64,7 @@ class SandboxBackendType(Enum):
     VERCEL = "VERCEL"
     DENO = "DENO"
     MODAL = "MODAL"
+    ISLO = "ISLO"
 
 
 @strawberry.enum

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -29,6 +29,7 @@ from phoenix.db.models import LanguageName, SandboxBackendType
 from phoenix.server.sandbox.daytona_backend import DaytonaAdapter
 from phoenix.server.sandbox.deno_backend import DenoAdapter
 from phoenix.server.sandbox.e2b_backend import E2BAdapter
+from phoenix.server.sandbox.islo_backend import IsloAdapter
 from phoenix.server.sandbox.modal_backend import ModalAdapter
 from phoenix.server.sandbox.types import (
     EnvVarValue,
@@ -105,6 +106,7 @@ def _build_sandbox_adapter_metadata() -> Mapping[SandboxBackendType, AdapterMeta
             VercelAdapter,
             DenoAdapter,
             ModalAdapter,
+            IsloAdapter,
         )
     }
 
@@ -375,3 +377,4 @@ _try_register_adapter(DaytonaAdapter)
 _try_register_adapter(VercelAdapter)
 _try_register_adapter(DenoAdapter)
 _try_register_adapter(ModalAdapter)
+_try_register_adapter(IsloAdapter)

--- a/src/phoenix/server/sandbox/islo_backend.py
+++ b/src/phoenix/server/sandbox/islo_backend.py
@@ -1,0 +1,384 @@
+"""Islo sandbox backend. Credentials passed explicitly to the SDK, never via os.environ."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import hashlib
+import logging
+import time
+import uuid
+from typing import TYPE_CHECKING, ClassVar, Mapping, Optional, Sequence
+
+from pydantic import SecretStr
+from typing_extensions import override
+
+from .types import (
+    ExecutionResult,
+    IsloConfig,
+    IsloCredentials,
+    IsloDeployment,
+    SandboxAdapter,
+    SandboxBackend,
+    compose_secret_values,
+    compute_config_fingerprint,
+)
+
+if TYPE_CHECKING:
+    from islo import AsyncIslo
+
+logger = logging.getLogger(__name__)
+
+ENV_ISLO_API_KEY = "ISLO_API_KEY"
+
+_DEFAULT_IMAGE = "ghcr.io/islo-labs/islo-runner:latest"
+
+# Provider-side max-lifetime ceiling so orphans get reaped after a hard
+# Phoenix crash. Mid-experiment deletion recovers via is_session_gone rebind.
+_SESSION_DELETE_AFTER_SECONDS = 3600
+
+# Islo exec is async two-step: start the command, then poll for its result.
+_EXEC_POLL_INTERVAL_SECONDS = 1.0
+_TERMINAL_EXEC_STATUSES = frozenset({"completed", "failed", "timeout"})
+
+# Deadline for a freshly created (or resumed) sandbox VM to reach 'running'.
+_CREATE_READY_DEADLINE_SECONDS = 120
+
+# Sandbox states that will never transition back to 'running'.
+_DEAD_SANDBOX_STATUSES = frozenset({"failed", "stopped", "deleted"})
+
+
+@functools.cache
+def _islo_session_gone_exception_classes() -> tuple[type[BaseException], ...]:
+    """Islo SDK exception classes meaning the remote sandbox is gone (lazy import)."""
+    try:
+        from islo.errors import NotFoundError
+    except ImportError:
+        return ()
+    return (NotFoundError,)
+
+
+class IsloSandboxBackend(SandboxBackend):
+    """Sandbox backend executing code in Islo cloud sandboxes."""
+
+    provider: ClassVar[str] = "ISLO"
+
+    def __init__(
+        self,
+        api_key: SecretStr,
+        *,
+        user_env: Optional[Mapping[str, str]] = None,
+        allow_internet_access: bool = True,
+        packages: Optional[Sequence[str]] = None,
+    ) -> None:
+        self._api_key = api_key
+        self._user_env: dict[str, str] = dict(user_env or {})
+        self._allow_internet_access = allow_internet_access
+        self._packages: list[str] = list(packages) if packages else []
+        self._client: Optional[AsyncIslo] = None
+        self._client_lock = asyncio.Lock()
+        self.secret_values = compose_secret_values(user_env, api_key)
+
+    @override
+    def config_fingerprint(self) -> str:
+        return compute_config_fingerprint(
+            backend_type="ISLO",
+            packages=self._packages,
+            internet_access_mode=str(self._allow_internet_access),
+        )
+
+    @override
+    def provider_session_id(self, session_key: str) -> str:
+        # Provider-safe name charset/length (Modal precedent): hex digest only.
+        return "phx-" + hashlib.sha256(session_key.encode()).hexdigest()[:32]
+
+    def _get_client_cls(self) -> type[AsyncIslo]:
+        """Lazy-import ``AsyncIslo``; tests patch this to avoid the islo extra."""
+        from islo import AsyncIslo
+
+        return AsyncIslo
+
+    async def _ensure_client(self) -> AsyncIslo:
+        # NEVER rely on the SDK's os.getenv("ISLO_API_KEY") fallback: the key
+        # must come from Phoenix's credential resolution.
+        if self._client is not None:
+            return self._client
+        client_cls = self._get_client_cls()
+        async with self._client_lock:
+            if self._client is None:
+                self._client = client_cls(api_key=self._api_key.get_secret_value())
+        return self._client
+
+    async def _create_sandbox(self, name: str) -> None:
+        from islo.types import LifecyclePolicy
+
+        client = await self._ensure_client()
+        await client.sandboxes.create_sandbox(
+            name=name,
+            image=_DEFAULT_IMAGE,
+            internet_enabled=self._allow_internet_access,
+            lifecycle=LifecyclePolicy(delete_after=_SESSION_DELETE_AFTER_SECONDS),
+        )
+
+    async def _wait_until_running(self, name: str) -> None:
+        """Poll ``get_sandbox`` until the VM reaches 'running' or a dead state."""
+        client = await self._ensure_client()
+        deadline = time.monotonic() + _CREATE_READY_DEADLINE_SECONDS
+        while True:
+            sandbox = await client.sandboxes.get_sandbox(sandbox_name=name)
+            if sandbox.status == "running":
+                return
+            if sandbox.status in _DEAD_SANDBOX_STATUSES:
+                raise RuntimeError(
+                    f"Islo sandbox {name!r} entered terminal state "
+                    f"{sandbox.status!r} before becoming ready"
+                )
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"Islo sandbox {name!r} did not reach 'running' within "
+                    f"{_CREATE_READY_DEADLINE_SECONDS}s (last status: {sandbox.status!r})"
+                )
+            await asyncio.sleep(_EXEC_POLL_INTERVAL_SECONDS)
+
+    async def _install_packages(self, name: str) -> None:
+        # List-form argv, no shell: quoting would break specs like 'numpy>=1.0'.
+        if not self._packages:
+            return
+        result = await self._exec(name, ["python3", "-m", "pip", "install", *self._packages])
+        if not result.success:
+            raise RuntimeError(f"pip install failed for {self._packages!r}: {result.error}")
+
+    async def _delete_sandbox_if_exists(self, name: str) -> None:
+        """Delete the named sandbox, swallowing NotFoundError (idempotent)."""
+        from islo.errors import NotFoundError
+
+        client = await self._ensure_client()
+        try:
+            await client.sandboxes.delete_sandbox(sandbox_name=name)
+        except NotFoundError:
+            return
+
+    async def _create_ready_sandbox(self, name: str) -> None:
+        """Create a sandbox by name, wait for it to boot, and install packages."""
+        await self._create_sandbox(name)
+        try:
+            await self._wait_until_running(name)
+            await self._install_packages(name)
+        except BaseException:
+            # Names are unique among non-deleted sandboxes: leaving a broken
+            # sandbox parked under the deterministic name would make every
+            # subsequent find_or_create_session fail until the delete_after
+            # lifecycle reaps it (~1h). Free the name for the next attempt.
+            try:
+                await self._delete_sandbox_if_exists(name)
+            except Exception:
+                logger.exception(f"Failed to clean up broken Islo sandbox '{name}'")
+            raise
+
+    async def _create_session_sandbox(self, name: str) -> None:
+        """Create a ready session sandbox, re-attaching on a concurrent-create race."""
+        from islo.errors import ConflictError
+
+        try:
+            await self._create_ready_sandbox(name)
+            logger.debug(f"Created Islo session '{name}'")
+        except ConflictError:
+            # Concurrent winner from another replica; re-attach by name.
+            await self._wait_until_running(name)
+            logger.debug(f"Islo session '{name}' won by concurrent creator; attaching")
+
+    @override
+    async def find_or_create_session(self, session_key: str) -> object:
+        """Converge on a named Islo sandbox: reuse running, resume paused, else create.
+
+        Two replicas with the same key converge on the same remote sandbox
+        (create-by-name is unique server-side; the ConflictError loser
+        re-attaches to the winner's sandbox).
+        """
+        from islo.errors import NotFoundError
+
+        client = await self._ensure_client()
+        name = self.provider_session_id(session_key)
+        try:
+            sandbox = await client.sandboxes.get_sandbox(sandbox_name=name)
+        except NotFoundError:
+            await self._create_session_sandbox(name)
+            return name
+        if sandbox.status in _DEAD_SANDBOX_STATUSES:
+            # A dead sandbox still occupies the deterministic name (names are
+            # unique among non-deleted sandboxes), so it must be deleted before
+            # a fresh one can be created — raising here would hard-fail every
+            # execution for this session until the lifecycle reaper runs.
+            logger.debug(f"Islo session '{name}' is {sandbox.status!r}; deleting and recreating")
+            await self._delete_sandbox_if_exists(name)
+            await self._create_session_sandbox(name)
+            return name
+        if sandbox.status == "paused":
+            await client.sandboxes.resume_sandbox(sandbox_name=name)
+            await self._wait_until_running(name)
+            logger.debug(f"Resumed paused Islo session '{name}'")
+        elif sandbox.status != "running":
+            await self._wait_until_running(name)
+        logger.debug(f"Islo session '{name}' already exists; reusing")
+        return name
+
+    async def _exec(
+        self,
+        name: str,
+        command: Sequence[str],
+        timeout: Optional[int] = None,
+    ) -> ExecutionResult:
+        """Two-step Islo exec: start the command, then poll for its result."""
+        client = await self._ensure_client()
+        started = await client.sandboxes.exec_in_sandbox(
+            sandbox_name=name,
+            command=list(command),
+            env=self._user_env or None,
+            timeout_secs=timeout,
+        )
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        while True:
+            result = await client.sandboxes.get_exec_result(
+                sandbox_name=name, exec_id=started.exec_id
+            )
+            if result.status in _TERMINAL_EXEC_STATUSES:
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                # timeout_secs is a server-side hint only; enforce client-side.
+                return ExecutionResult(
+                    stdout="",
+                    stderr="",
+                    error=f"Execution timed out after {timeout}s",
+                )
+            await asyncio.sleep(_EXEC_POLL_INTERVAL_SECONDS)
+
+        error: Optional[str] = None
+        if result.status == "timeout":
+            # Server-side timeout: exit_code is None, so the generic
+            # "exit code None" message would mislead. Mirror the client-side
+            # deadline message above.
+            error = result.stderr or (
+                f"Execution timed out after {timeout}s"
+                if timeout is not None
+                else "Execution timed out"
+            )
+        elif result.status != "completed" or result.exit_code != 0:
+            if result.exit_code is None:
+                error = result.stderr or f"Execution failed (status={result.status!r})"
+            else:
+                error = result.stderr or f"exit code {result.exit_code}"
+        if error is not None and result.truncated:
+            error = f"{error}\n[output truncated]"
+        return ExecutionResult(stdout=result.stdout, stderr=result.stderr, error=error)
+
+    @override
+    async def execute_in_session(
+        self,
+        handle: object,
+        code: str,
+        timeout: Optional[int] = None,
+    ) -> ExecutionResult:
+        name: str = handle  # type: ignore[assignment]
+        try:
+            return await self._exec(name, ["python3", "-c", code], timeout)
+        except Exception as exc:
+            if self.is_session_gone(exc):
+                raise
+            return ExecutionResult(stdout="", stderr=str(exc), error=str(exc))
+
+    @override
+    async def execute(
+        self,
+        code: str,
+        session_key: str,
+        timeout: Optional[int] = None,
+    ) -> ExecutionResult:
+        """Direct one-shot ephemeral execution: create, run, delete."""
+        name = f"phx-ephemeral-{uuid.uuid4().hex[:12]}"
+        try:
+            client = await self._ensure_client()
+            await self._create_sandbox(name)
+            try:
+                await self._wait_until_running(name)
+                await self._install_packages(name)
+                return await self._exec(name, ["python3", "-c", code], timeout)
+            finally:
+                await client.sandboxes.delete_sandbox(sandbox_name=name)
+        except Exception as exc:
+            return ExecutionResult(stdout="", stderr=str(exc), error=str(exc))
+
+    @override
+    async def close_session(self, session_key: str) -> None:
+        """Delete the named Islo sandbox bound to ``session_key`` (idempotent)."""
+        from islo.errors import NotFoundError
+
+        client = await self._ensure_client()
+        name = self.provider_session_id(session_key)
+        try:
+            await client.sandboxes.delete_sandbox(sandbox_name=name)
+            logger.debug(f"Deleted Islo session '{name}'")
+        except NotFoundError:
+            return
+
+    @override
+    async def close(self) -> None:
+        # The SDK exposes no public close; its httpx client is reaped with the
+        # client object.
+        return None
+
+    @override
+    def is_session_gone(self, exc: BaseException) -> bool:
+        """Classify ``NotFoundError`` as session-gone.
+
+        Other Islo exceptions are NOT classified: auth/5xx errors recur on a
+        fresh session, so classifying them would churn rebinds without
+        recovering.
+        """
+        return isinstance(exc, _islo_session_gone_exception_classes())
+
+
+class IsloAdapter(SandboxAdapter[IsloConfig, IsloCredentials, IsloDeployment]):
+    backend_type = "ISLO"
+    display_name = "Islo"
+    hosting_type = "hosted"
+    dependency_hints = (
+        "Install Phoenix with the `islo` extra.",
+        "Provide `ISLO_API_KEY`.",
+    )
+    config_model = IsloConfig
+    credentials_model = IsloCredentials
+    deployment_config_model = IsloDeployment
+
+    @classmethod
+    def probe_dependencies(cls) -> None:
+        import islo  # noqa: F401
+
+    def build_backend(
+        self,
+        config: IsloConfig,
+        *,
+        credentials: IsloCredentials,
+        deployment: IsloDeployment,
+        user_env: Optional[Mapping[str, str]] = None,
+    ) -> SandboxBackend:
+        # Fail-closed: empty api_key would let the SDK silently fall back to
+        # os.getenv("ISLO_API_KEY"), bypassing Phoenix's credential resolution.
+        api_key = credentials.ISLO_API_KEY.get_secret_value()
+        if not api_key:
+            raise ValueError(
+                "Islo sandbox authentication is not configured. Set "
+                "ISLO_API_KEY in Settings → Sandboxes → Islo → Credentials, "
+                "or as a process environment variable."
+            )
+        allow_internet_access = (
+            config.internet_access is None or config.internet_access.mode != "deny"
+        )
+        packages: list[str] = (
+            list(config.dependencies.packages) if config.dependencies is not None else []
+        )
+        return IsloSandboxBackend(
+            api_key=SecretStr(api_key),
+            user_env=user_env,
+            allow_internet_access=allow_internet_access,
+            packages=packages or None,
+        )

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -244,6 +244,17 @@ class ModalConfig(
     language: Literal["PYTHON"] = "PYTHON"
 
 
+class IsloConfig(
+    _Config,
+    SupportsEnvVars,
+    SupportsInternetAccess,
+    SupportsDependencies,
+    _RuntimePackageInstallation,
+):
+    backend_type: Literal["ISLO"] = "ISLO"
+    language: Literal["PYTHON"] = "PYTHON"
+
+
 SandboxConfigModel: TypeAlias = Annotated[
     Union[
         E2BConfig,
@@ -252,6 +263,7 @@ SandboxConfigModel: TypeAlias = Annotated[
         VercelConfig,
         WASMConfig,
         ModalConfig,
+        IsloConfig,
     ],
     Field(discriminator="backend_type"),
 ]
@@ -377,6 +389,13 @@ class DenoDeployment(NoDeployment):
     backend_type: Literal["DENO"] = "DENO"
 
 
+class IsloDeployment(NoDeployment):
+    """No routing kwargs; self-hosted Islo routes via the ``ISLO_BASE_URL`` /
+    ``ISLO_COMPUTE_URL`` env vars (read by the SDK)."""
+
+    backend_type: Literal["ISLO"] = "ISLO"
+
+
 SandboxDeploymentModel: TypeAlias = Annotated[
     Union[
         DaytonaDeployment,
@@ -385,6 +404,7 @@ SandboxDeploymentModel: TypeAlias = Annotated[
         ModalDeployment,
         WASMDeployment,
         DenoDeployment,
+        IsloDeployment,
     ],
     Field(discriminator="backend_type"),
 ]
@@ -438,6 +458,15 @@ class ModalCredentials(_BaseModel):
     MODAL_TOKEN_SECRET: SecretStr = Field(
         title="Modal Token Secret",
         description="Modal authentication token secret.",
+    )
+
+
+class IsloCredentials(_BaseModel):
+    ISLO_API_KEY: SecretStr = Field(
+        title="Islo API Key",
+        description=(
+            "API key for the Islo sandbox service. Create one at https://app.islo.dev/api-keys"
+        ),
     )
 
 

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -465,7 +465,8 @@ class IsloCredentials(_BaseModel):
     ISLO_API_KEY: SecretStr = Field(
         title="Islo API Key",
         description=(
-            "API key for the Islo sandbox service. Create one at https://app.islo.dev/api-keys"
+            "API key for the Islo sandbox service. Create one with "
+            "`islo api-key create phoenix --expires 90 --show`."
         ),
     )
 

--- a/tests/unit/server/api/test_sync.py
+++ b/tests/unit/server/api/test_sync.py
@@ -256,6 +256,7 @@ class TestSyncSandboxDefaultConfigs:
             "DAYTONA": False,
             "VERCEL": False,
             "MODAL": False,
+            "ISLO": False,
         }
         for backend_type, want in expected.items():
             meta = SANDBOX_ADAPTER_METADATA[backend_type]

--- a/tests/unit/server/sandbox/test_islo_backend.py
+++ b/tests/unit/server/sandbox/test_islo_backend.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+pytest.importorskip("islo")
+
+from islo.core.api_error import ApiError  # noqa: E402
+from islo.errors import ConflictError, NotFoundError  # noqa: E402
+from islo.types import ErrorCode, ErrorResponse, LifecyclePolicy  # noqa: E402
+
+import phoenix.server.sandbox.islo_backend as islo_backend_module  # noqa: E402
+from phoenix.server.sandbox.islo_backend import (  # noqa: E402
+    _DEFAULT_IMAGE,
+    _SESSION_DELETE_AFTER_SECONDS,
+    IsloAdapter,
+    IsloSandboxBackend,
+)
+from phoenix.server.sandbox.types import (  # noqa: E402
+    IsloConfig,
+    IsloCredentials,
+    IsloDeployment,
+)
+
+_API_KEY_RAW = "ak-test-key"
+_API_KEY = SecretStr(_API_KEY_RAW)
+_ISLO_CREDS = IsloCredentials(ISLO_API_KEY=_API_KEY_RAW)
+_ISLO_DEPLOY = IsloDeployment()
+
+
+def _islo_config(payload: Optional[dict[str, Any]] = None) -> IsloConfig:
+    fields = dict(payload or {})
+    fields.setdefault("language", "PYTHON")
+    return IsloConfig.model_validate(fields)
+
+
+def _sandbox_response(status: str = "running") -> SimpleNamespace:
+    return SimpleNamespace(id="sbx-1", name="phx-x", image=_DEFAULT_IMAGE, status=status)
+
+
+def _exec_response(exec_id: str = "exec-1") -> SimpleNamespace:
+    return SimpleNamespace(exec_id=exec_id, sandbox_id="sbx-1", status="running")
+
+
+def _exec_result(
+    status: str = "completed",
+    exit_code: Optional[int] = 0,
+    stdout: str = "",
+    stderr: str = "",
+    truncated: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        exec_id="exec-1",
+        status=status,
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr=stderr,
+        truncated=truncated,
+    )
+
+
+def _make_islo_client_mock() -> MagicMock:
+    client = MagicMock(name="islo-client")
+    client.sandboxes.create_sandbox = AsyncMock(return_value=_sandbox_response("starting"))
+    client.sandboxes.get_sandbox = AsyncMock(return_value=_sandbox_response("running"))
+    client.sandboxes.delete_sandbox = AsyncMock(return_value=None)
+    client.sandboxes.resume_sandbox = AsyncMock(return_value=_sandbox_response("starting"))
+    client.sandboxes.exec_in_sandbox = AsyncMock(return_value=_exec_response())
+    client.sandboxes.get_exec_result = AsyncMock(return_value=_exec_result())
+    return client
+
+
+def _make_backend(**kwargs: Any) -> tuple[IsloSandboxBackend, MagicMock]:
+    """Build a backend with the SDK client replaced by a mock (never hits the network)."""
+    backend = IsloSandboxBackend(api_key=_API_KEY, **kwargs)
+    client = _make_islo_client_mock()
+    backend._client = client
+    return backend, client
+
+
+def test_build_backend_requires_api_key() -> None:
+    """Fail-closed: empty key must raise, never fall back to the SDK's env-var lookup."""
+    adapter = IsloAdapter()
+    with pytest.raises(ValueError, match="ISLO_API_KEY"):
+        adapter.build_backend(
+            _islo_config(),
+            credentials=IsloCredentials(ISLO_API_KEY=""),
+            deployment=_ISLO_DEPLOY,
+        )
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        ({"internet_access": {"mode": "deny"}}, False),
+        ({"internet_access": {"mode": "allow"}}, True),
+        ({}, True),
+    ],
+)
+def test_build_backend_sets_internet_access_from_config(
+    config: dict[str, Any], expected: bool
+) -> None:
+    adapter = IsloAdapter()
+    backend: Any = adapter.build_backend(
+        _islo_config(config),
+        credentials=_ISLO_CREDS,
+        deployment=_ISLO_DEPLOY,
+    )
+    assert backend._allow_internet_access is expected
+
+
+def test_build_backend_wires_packages() -> None:
+    adapter = IsloAdapter()
+    backend: Any = adapter.build_backend(
+        _islo_config({"dependencies": {"packages": ["numpy>=1.0"]}}),
+        credentials=_ISLO_CREDS,
+        deployment=_ISLO_DEPLOY,
+    )
+    assert backend._packages == ["numpy>=1.0"]
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_kwargs() -> None:
+    backend, client = _make_backend(allow_internet_access=False)
+    await backend._create_sandbox("phx-test")
+
+    _, kwargs = client.sandboxes.create_sandbox.call_args
+    assert kwargs["name"] == "phx-test"
+    assert kwargs["image"] == _DEFAULT_IMAGE
+    assert kwargs["internet_enabled"] is False
+    assert kwargs["lifecycle"] == LifecyclePolicy(delete_after=_SESSION_DELETE_AFTER_SECONDS)
+
+
+def test_config_fingerprint_stability() -> None:
+    backend_a, _ = _make_backend(packages=["numpy"])
+    backend_b, _ = _make_backend(packages=["numpy"])
+    assert backend_a.config_fingerprint() == backend_b.config_fingerprint()
+
+    with_more_packages, _ = _make_backend(packages=["numpy", "pandas"])
+    assert with_more_packages.config_fingerprint() != backend_a.config_fingerprint()
+
+    no_internet, _ = _make_backend(packages=["numpy"], allow_internet_access=False)
+    assert no_internet.config_fingerprint() != backend_a.config_fingerprint()
+
+    # Env-var value changes must NOT fragment sessions.
+    with_env, _ = _make_backend(packages=["numpy"], user_env={"KEY": "value"})
+    assert with_env.config_fingerprint() == backend_a.config_fingerprint()
+
+
+def test_provider_session_id_is_deterministic_and_provider_safe() -> None:
+    backend, _ = _make_backend()
+    session_id = backend.provider_session_id("session-key")
+    assert session_id == backend.provider_session_id("session-key")
+    assert session_id != backend.provider_session_id("other-key")
+    assert session_id.startswith("phx-")
+    suffix = session_id.removeprefix("phx-")
+    assert len(suffix) == 32
+    assert all(c in "0123456789abcdef" for c in suffix)
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_session_reuses_running_sandbox() -> None:
+    backend, client = _make_backend()
+    handle = await backend.find_or_create_session("session-key")
+
+    assert handle == backend.provider_session_id("session-key")
+    client.sandboxes.create_sandbox.assert_not_called()
+    client.sandboxes.resume_sandbox.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_session_resumes_paused_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(islo_backend_module, "_EXEC_POLL_INTERVAL_SECONDS", 0.0)
+    backend, client = _make_backend()
+    client.sandboxes.get_sandbox = AsyncMock(
+        side_effect=[_sandbox_response("paused"), _sandbox_response("running")]
+    )
+
+    handle = await backend.find_or_create_session("session-key")
+
+    assert handle == backend.provider_session_id("session-key")
+    client.sandboxes.resume_sandbox.assert_awaited_once_with(sandbox_name=handle)
+    client.sandboxes.create_sandbox.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_session_creates_and_installs_packages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(islo_backend_module, "_EXEC_POLL_INTERVAL_SECONDS", 0.0)
+    backend, client = _make_backend(packages=["numpy>=1.0"])
+    client.sandboxes.get_sandbox = AsyncMock(
+        side_effect=[
+            NotFoundError(body=None),
+            _sandbox_response("starting"),
+            _sandbox_response("running"),
+        ]
+    )
+
+    handle = await backend.find_or_create_session("session-key")
+
+    assert handle == backend.provider_session_id("session-key")
+    _, create_kwargs = client.sandboxes.create_sandbox.call_args
+    assert create_kwargs["name"] == handle
+    assert create_kwargs["image"] == _DEFAULT_IMAGE
+    assert create_kwargs["internet_enabled"] is True
+    assert create_kwargs["lifecycle"] == LifecyclePolicy(delete_after=_SESSION_DELETE_AFTER_SECONDS)
+    # List-form argv keeps specs like 'numpy>=1.0' unquoted (no shell).
+    _, exec_kwargs = client.sandboxes.exec_in_sandbox.call_args
+    assert exec_kwargs["command"] == ["python3", "-m", "pip", "install", "numpy>=1.0"]
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_session_skips_install_without_packages() -> None:
+    backend, client = _make_backend()
+    client.sandboxes.get_sandbox = AsyncMock(
+        side_effect=[NotFoundError(body=None), _sandbox_response("running")]
+    )
+
+    await backend.find_or_create_session("session-key")
+
+    client.sandboxes.create_sandbox.assert_awaited_once()
+    client.sandboxes.exec_in_sandbox.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_session_conflict_reattaches() -> None:
+    """Concurrent winner from another replica: the loser re-attaches by name."""
+    backend, client = _make_backend()
+    client.sandboxes.get_sandbox = AsyncMock(
+        side_effect=[NotFoundError(body=None), _sandbox_response("running")]
+    )
+    client.sandboxes.create_sandbox = AsyncMock(
+        side_effect=ConflictError(
+            body=ErrorResponse(code=ErrorCode.SANDBOX_ALREADY_EXISTS, message="already exists")
+        )
+    )
+
+    handle = await backend.find_or_create_session("session-key")
+
+    assert handle == backend.provider_session_id("session-key")
+    # The loser must never delete the winner's sandbox.
+    client.sandboxes.delete_sandbox.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_session_raises_and_cleans_up_on_dead_boot() -> None:
+    """A sandbox that dies while booting must be deleted so the name is freed."""
+    backend, client = _make_backend()
+    client.sandboxes.get_sandbox = AsyncMock(
+        side_effect=[NotFoundError(body=None), _sandbox_response("failed")]
+    )
+
+    with pytest.raises(RuntimeError, match="terminal state"):
+        await backend.find_or_create_session("session-key")
+
+    client.sandboxes.delete_sandbox.assert_awaited_once_with(
+        sandbox_name=backend.provider_session_id("session-key")
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_path_cleans_up_sandbox_when_pip_install_fails() -> None:
+    """A sandbox whose package install fails must be deleted so the name is freed."""
+    backend, client = _make_backend(packages=["numpy"])
+    client.sandboxes.get_sandbox = AsyncMock(
+        side_effect=[NotFoundError(body=None), _sandbox_response("running")]
+    )
+    client.sandboxes.get_exec_result = AsyncMock(
+        return_value=_exec_result(status="failed", exit_code=1, stderr="no matching distribution")
+    )
+
+    with pytest.raises(RuntimeError, match="pip install failed"):
+        await backend.find_or_create_session("session-key")
+
+    client.sandboxes.delete_sandbox.assert_awaited_once_with(
+        sandbox_name=backend.provider_session_id("session-key")
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dead_status", ["failed", "stopped", "deleted"])
+async def test_find_or_create_session_recovers_from_dead_sandbox(dead_status: str) -> None:
+    """A dead-but-still-present sandbox is deleted and recreated, not raised on.
+
+    Islo names are unique among non-deleted sandboxes, so a 'failed'/'stopped'
+    sandbox blocks recreation under the deterministic session name until it is
+    deleted — raising here would hard-fail every execution for this session
+    until the delete_after lifecycle reaps it.
+    """
+    backend, client = _make_backend()
+    client.sandboxes.get_sandbox = AsyncMock(
+        side_effect=[_sandbox_response(dead_status), _sandbox_response("running")]
+    )
+
+    handle = await backend.find_or_create_session("session-key")
+
+    assert handle == backend.provider_session_id("session-key")
+    client.sandboxes.delete_sandbox.assert_awaited_once_with(sandbox_name=handle)
+    client.sandboxes.create_sandbox.assert_awaited_once()
+    client.sandboxes.resume_sandbox.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_session_dead_sandbox_recovery_tolerates_missing_delete() -> None:
+    """The recovery delete swallows NotFoundError (sandbox reaped between calls)."""
+    backend, client = _make_backend()
+    client.sandboxes.get_sandbox = AsyncMock(
+        side_effect=[_sandbox_response("stopped"), _sandbox_response("running")]
+    )
+    client.sandboxes.delete_sandbox = AsyncMock(side_effect=NotFoundError(body=None))
+
+    handle = await backend.find_or_create_session("session-key")
+
+    assert handle == backend.provider_session_id("session-key")
+    client.sandboxes.create_sandbox.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_in_session_sends_command_env_and_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(islo_backend_module, "_EXEC_POLL_INTERVAL_SECONDS", 0.0)
+    backend, client = _make_backend(user_env={"KEY": "value"})
+    # Non-terminal poll first, then terminal: exercises the poll loop.
+    client.sandboxes.get_exec_result = AsyncMock(
+        side_effect=[
+            _exec_result(status="running", exit_code=None),
+            _exec_result(status="completed", exit_code=0, stdout="ok"),
+        ]
+    )
+
+    result = await backend.execute_in_session("phx-handle", "print('hi')", timeout=60)
+
+    _, exec_kwargs = client.sandboxes.exec_in_sandbox.call_args
+    assert exec_kwargs["sandbox_name"] == "phx-handle"
+    assert exec_kwargs["command"] == ["python3", "-c", "print('hi')"]
+    assert exec_kwargs["env"] == {"KEY": "value"}
+    assert exec_kwargs["timeout_secs"] == 60
+    assert client.sandboxes.get_exec_result.await_count == 2
+    assert result.error is None
+    assert result.stdout == "ok"
+
+
+@pytest.mark.asyncio
+async def test_execute_in_session_omits_env_when_empty() -> None:
+    backend, client = _make_backend()
+    await backend.execute_in_session("phx-handle", "print('hi')")
+    _, exec_kwargs = client.sandboxes.exec_in_sandbox.call_args
+    assert exec_kwargs["env"] is None
+    assert exec_kwargs["timeout_secs"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exec_result,expected_error",
+    [
+        (_exec_result(status="completed", exit_code=0, stdout="ok"), None),
+        (
+            _exec_result(status="completed", exit_code=1, stderr="Traceback: boom"),
+            "Traceback: boom",
+        ),
+        (_exec_result(status="completed", exit_code=2, stderr=""), "exit code 2"),
+        (
+            _exec_result(status="failed", exit_code=None, stderr=""),
+            "Execution failed (status='failed')",
+        ),
+        (_exec_result(status="timeout", exit_code=None, stderr=""), "Execution timed out"),
+        (
+            _exec_result(status="timeout", exit_code=None, stderr="killed"),
+            "killed",
+        ),
+        (
+            _exec_result(status="completed", exit_code=1, stderr="boom", truncated=True),
+            "boom\n[output truncated]",
+        ),
+    ],
+)
+async def test_execute_in_session_maps_exec_result(
+    exec_result: SimpleNamespace, expected_error: Optional[str]
+) -> None:
+    backend, client = _make_backend()
+    client.sandboxes.get_exec_result = AsyncMock(return_value=exec_result)
+
+    result = await backend.execute_in_session("phx-handle", "noop")
+
+    assert result.error == expected_error
+    assert result.stdout == exec_result.stdout
+    assert result.stderr == exec_result.stderr
+
+
+@pytest.mark.asyncio
+async def test_server_side_timeout_includes_timeout_seconds_when_known() -> None:
+    """A server-side 'timeout' status must surface a timeout message, not 'exit code None'."""
+    backend, client = _make_backend()
+    client.sandboxes.get_exec_result = AsyncMock(
+        return_value=_exec_result(status="timeout", exit_code=None)
+    )
+
+    result = await backend.execute_in_session("phx-handle", "while True: pass", timeout=30)
+
+    assert result.error == "Execution timed out after 30s"
+
+
+@pytest.mark.asyncio
+async def test_exec_client_side_deadline_returns_timeout_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exec poll loop must enforce the timeout itself (timeout_secs is a hint only)."""
+    monkeypatch.setattr(islo_backend_module, "_EXEC_POLL_INTERVAL_SECONDS", 0.0)
+    backend, client = _make_backend()
+    client.sandboxes.get_exec_result = AsyncMock(
+        return_value=_exec_result(status="running", exit_code=None)
+    )
+
+    result = await backend.execute_in_session("phx-handle", "while True: pass", timeout=0)
+
+    assert result.error == "Execution timed out after 0s"
+    assert result.stdout == ""
+
+
+def test_is_session_gone_classifies_not_found_only() -> None:
+    """NotFoundError → True; 5xx / auth / generic errors → False.
+
+    Deliberately under-classifies: a false ``True`` triggers an unnecessary
+    rebind, and auth/5xx errors recur on a fresh session anyway.
+    """
+    backend, _ = _make_backend()
+    assert backend.is_session_gone(NotFoundError(body=None)) is True
+    assert backend.is_session_gone(ApiError(status_code=500, body="server error")) is False
+    assert backend.is_session_gone(RuntimeError("user oops")) is False
+
+
+@pytest.mark.asyncio
+async def test_execute_in_session_propagates_session_gone_exception() -> None:
+    backend, client = _make_backend()
+    client.sandboxes.exec_in_sandbox = AsyncMock(side_effect=NotFoundError(body=None))
+
+    with pytest.raises(NotFoundError):
+        await backend.execute_in_session("phx-handle", "print('hi')")
+
+
+@pytest.mark.asyncio
+async def test_execute_in_session_wraps_non_session_gone_exception() -> None:
+    backend, client = _make_backend()
+    client.sandboxes.exec_in_sandbox = AsyncMock(side_effect=RuntimeError("user oops"))
+
+    result = await backend.execute_in_session("phx-handle", "print('hi')")
+
+    assert result.error == "user oops"
+    assert result.stderr == "user oops"
+
+
+@pytest.mark.asyncio
+async def test_close_session_deletes_hashed_name_and_is_idempotent() -> None:
+    backend, client = _make_backend()
+    await backend.close_session("session-key")
+    client.sandboxes.delete_sandbox.assert_awaited_once_with(
+        sandbox_name=backend.provider_session_id("session-key")
+    )
+
+    client.sandboxes.delete_sandbox = AsyncMock(side_effect=NotFoundError(body=None))
+    await backend.close_session("session-key")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_execute_creates_and_deletes_sandbox() -> None:
+    backend, client = _make_backend()
+    result = await backend.execute("print('hi')", session_key="ephemeral")
+
+    assert result.error is None
+    _, create_kwargs = client.sandboxes.create_sandbox.call_args
+    assert create_kwargs["name"].startswith("phx-ephemeral-")
+    client.sandboxes.delete_sandbox.assert_awaited_once_with(sandbox_name=create_kwargs["name"])
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_execute_deletes_sandbox_even_when_exec_raises() -> None:
+    backend, client = _make_backend()
+    client.sandboxes.exec_in_sandbox = AsyncMock(side_effect=RuntimeError("provider error"))
+
+    result = await backend.execute("print('hi')", session_key="ephemeral")
+
+    assert result.error == "provider error"
+    client.sandboxes.delete_sandbox.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_execute_never_raises() -> None:
+    backend, client = _make_backend()
+    client.sandboxes.create_sandbox = AsyncMock(side_effect=RuntimeError("quota exceeded"))
+
+    result = await backend.execute("print('hi')", session_key="ephemeral")
+
+    assert result.error == "quota exceeded"
+    assert result.stderr == "quota exceeded"
+
+
+def test_secret_values_contains_api_key_and_user_env_plaintexts() -> None:
+    backend, _ = _make_backend(user_env={"SECRET_TOKEN": "user-env-plaintext"})
+    assert _API_KEY_RAW in backend.secret_values
+    assert "user-env-plaintext" in backend.secret_values
+
+
+@pytest.mark.asyncio
+async def test_client_construction_is_memoized_and_uses_explicit_api_key() -> None:
+    backend = IsloSandboxBackend(api_key=_API_KEY)
+    client_cls = MagicMock(name="AsyncIslo", return_value=_make_islo_client_mock())
+    backend._get_client_cls = lambda: client_cls  # type: ignore[method-assign]
+
+    first = await backend._ensure_client()
+    second = await backend._ensure_client()
+
+    assert first is second
+    client_cls.assert_called_once_with(api_key=_API_KEY_RAW)

--- a/tests/unit/server/sandbox/test_unified_config_contract.py
+++ b/tests/unit/server/sandbox/test_unified_config_contract.py
@@ -16,6 +16,7 @@ _ADAPTER_MODULES: dict[SandboxBackendType, tuple[str, str]] = {
     "VERCEL": ("phoenix.server.sandbox.vercel_backend", "VercelAdapter"),
     "DENO": ("phoenix.server.sandbox.deno_backend", "DenoAdapter"),
     "MODAL": ("phoenix.server.sandbox.modal_backend", "ModalAdapter"),
+    "ISLO": ("phoenix.server.sandbox.islo_backend", "IsloAdapter"),
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -554,6 +554,7 @@ container = [
     { name = "daytona-sdk" },
     { name = "e2b-code-interpreter" },
     { name = "google-genai" },
+    { name = "islo" },
     { name = "modal" },
     { name = "openai" },
     { name = "opentelemetry-exporter-otlp" },
@@ -577,6 +578,9 @@ daytona = [
 ]
 e2b = [
     { name = "e2b-code-interpreter" },
+]
+islo = [
+    { name = "islo" },
 ]
 modal = [
     { name = "modal" },
@@ -617,6 +621,7 @@ dev = [
     { name = "grpcio" },
     { name = "grpcio-tools" },
     { name = "httpx" },
+    { name = "islo" },
     { name = "jinja2" },
     { name = "jsonpath-ng" },
     { name = "jupyter" },
@@ -724,6 +729,8 @@ requires-dist = [
     { name = "grpc-interceptor" },
     { name = "grpcio" },
     { name = "httpx" },
+    { name = "islo", marker = "extra == 'container'", specifier = ">=0.3.11" },
+    { name = "islo", marker = "extra == 'islo'", specifier = ">=0.3.11" },
     { name = "jinja2" },
     { name = "jmespath" },
     { name = "joserfc" },
@@ -783,7 +790,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'vercel'", specifier = ">=14.0" },
     { name = "wrapt", specifier = ">=1.17.2,<3" },
 ]
-provides-extras = ["aws", "azure", "container", "daytona", "e2b", "evals", "experimental", "modal", "pg", "vercel", "wasm"]
+provides-extras = ["aws", "azure", "container", "daytona", "e2b", "evals", "experimental", "islo", "modal", "pg", "vercel", "wasm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -810,6 +817,7 @@ dev = [
     { name = "grpcio" },
     { name = "grpcio-tools", specifier = ">=1.78.0" },
     { name = "httpx" },
+    { name = "islo", specifier = ">=0.3.11" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonpath-ng" },
     { name = "jupyter", specifier = ">=1.1.1" },
@@ -2884,15 +2892,15 @@ name = "huggingface-hub"
 version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "filelock", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "hf-xet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and platform_machine == 'x86_64') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'win32') or (platform_machine == 'amd64' and sys_platform == 'win32') or (platform_machine == 'arm64' and sys_platform == 'win32') or (platform_machine == 'x86_64' and sys_platform == 'win32')" },
-    { name = "httpx", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "packaging", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "tqdm", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.14'" },
+    { name = "hf-xet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/8f/999e4dda11c6187c78f090eac00895a47e11a0049308f07579bcb7aa3aa2/huggingface_hub-1.23.0.tar.gz", hash = "sha256:c04997fb8bbdace1e57b7703d30ed7678af51f70d00d241819ff411b92ae9a88", size = 919163, upload-time = "2026-07-09T14:49:32.315Z" }
 wheels = [
@@ -2934,7 +2942,7 @@ name = "importlib-metadata"
 version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "zipp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
@@ -3074,6 +3082,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
+name = "islo"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/2a/8a1fc0d5a056deda8a54a47ddb62a0f75fff7fd341f7f1542f7587b2d4cc/islo-0.3.11.tar.gz", hash = "sha256:7eda29022686429f6308c1ffa71da6d3747d3594935bb8941184be3d1587119c", size = 111539, upload-time = "2026-07-12T14:39:02.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/f9/b162c490115383fe83409c2cecb86b6a731a82dc079b9aace85505b3f759/islo-0.3.11-py3-none-any.whl", hash = "sha256:fbfd3ea7048d0cf820ed33897d6556edff38eed8598ef0b89d61ee803ed5d3a3", size = 258479, upload-time = "2026-07-12T14:39:01.348Z" },
 ]
 
 [[package]]
@@ -3778,18 +3800,18 @@ name = "litellm"
 version = "1.92.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "click", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "fastuuid", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "httpx", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "jsonschema", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "openai", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "pydantic", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "tiktoken", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "tokenizers", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "fastuuid", marker = "python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "jsonschema", marker = "python_full_version < '3.14'" },
+    { name = "openai", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
+    { name = "tiktoken", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/ea/5522be7e0dbcaa7c3fddfd2834f387c6e8eab47c0cc65f2a74657c815af7/litellm-1.92.0.tar.gz", hash = "sha256:773adf5503ee1793289689c899394a83df8122993760d9acd782e32aa798db9d", size = 15098143, upload-time = "2026-07-12T01:15:59.828Z" }
 wheels = [
@@ -7684,7 +7706,7 @@ name = "tokenizers"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
 wheels = [


### PR DESCRIPTION
resolves #N/A — no pre-existing issue; happy to open one and link it if maintainers prefer (per CONTRIBUTING's issue-first flow). Opening as a proposal since the sandbox spec explicitly anticipates additional backends.

## What is Islo?

[Islo](https://islo.dev) is a sandbox platform for coding agents: hosted, per-tenant isolated cloud sandboxes for executing untrusted code, built by the Incredibuild team. [Documentation](https://docs.islo.dev).

**Disclosure:** I am affiliated with the Islo team at Incredibuild, and this contribution was prepared with assistance from Claude Code and finalized with Codex — flagging both up front for review context.

## What this PR adds

Islo as a seventh sandbox backend (`ISLO`) for Phoenix code evaluators, alongside WASM, Deno, E2B, Daytona, Vercel, and Modal.

- **Backend/adapter** (`src/phoenix/server/sandbox/islo_backend.py`): `IsloSandboxBackend` and `IsloAdapter` with deterministic session reuse, paused-sandbox resume, dead-sandbox recovery, concurrent-create reattachment, cleanup after boot/install failures, ephemeral dry-run cleanup, async execution polling, and result mapping. All SDK imports are lazy and the adapter is skipped when the optional package is absent.
- **Types/config** (`src/phoenix/server/sandbox/types.py`, `db/models.py`): `IsloConfig`, fail-closed `IsloCredentials`, and `IsloDeployment`, with environment, internet-access, and runtime dependency capabilities. No database migration is needed because provider identifiers are stored as strings and seeded from adapter metadata.
- **GraphQL/UI**: `IsloConfigInput`, the `islo` oneOf variant, `ISLO` enum value, regenerated schema/Relay artifacts, and an Islo provider row under Settings → Sandboxes.
- **Packaging** (`pyproject.toml`, `uv.lock`): `islo>=0.3.11` as an optional extra, bundled in the container extra and present in the dev group for typing.
- **Docs**: Islo setup page, sandbox overview/runtime matrix/navigation updates, and CLI key acquisition. The CLI is used only to mint `ISLO_API_KEY`; Phoenix sandbox operations use the official Python SDK.

## Validation

### Live SDK E2E

- Minted a temporary key with `islo api-key create ... --show`, then supplied it directly to `IsloSandboxBackend` as a `SecretStr`.
- In Islo's France region, the real ephemeral backend path created a fresh `phx-ephemeral-*` sandbox and executed Python through the SDK.
- Verified user environment propagation, expected stdout, empty stderr, and no execution error.
- Verified the backend's `finally` cleanup path removed the ephemeral sandbox.
- Checked France and Canada for leftover test sandboxes, then revoked the temporary key and verified it absent.

### Automated and local checks

- `tests/unit/server/sandbox/test_islo_backend.py` → **39 passed**, covering credentials, configuration, session lifecycle, concurrency, execution polling/results/timeouts, cleanup, and secret masking.
- `uv run pytest tests/unit/server/sandbox/ -q` → **263 passed**.
- Capability/provider/config mutation suites → **46 passed** with 43 pre-existing PostgreSQL skips; import side-effects test passes.
- Ruff check and format check pass.
- `make typecheck-python` with the repository-pinned `uv==0.11.8` → **no issues in 964 files**.
- `make schema-graphql` and `make relay-build` are idempotent; app type-check and sandbox-scoped frontend tests pass.
- The full app test suite's previously documented playground/localStorage failures reproduce on clean `main` and are outside this diff.
- `git diff --check` → passed.

No real credential is present in source, tests, commits, or the PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
