### PR TITLE
docs(cli): sync TypeScript CLI reference with phoenix-cli README

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
@@ -172,6 +172,46 @@ px profile delete staging --yes  # skip confirmation
 
 ## Commands
 
+### `px setup`
+
+Wire your app up to Phoenix. Run it from your app's root directory. Setup establishes the connection (endpoint, project, auth) and saves it to a gitignored `.env.phoenix` file, then optionally hands a coding agent (Claude Code, Codex, Cursor, OpenCode) an instrumentation task and waits until a real trace arrives. After that it can point `px` at the new project and install Phoenix skills so the agent can query what you captured.
+
+```bash
+px setup                                          # Interactive
+px setup --endpoint https://phoenix.example.com   # Skip the endpoint prompt
+npx -y @arizeai/phoenix-cli setup                 # Run without installing
+```
+
+For CI or non-interactive agents, pass flags instead of answering prompts:
+
+```bash
+# Connection only — write .env.phoenix, no source changes
+px setup --no-input --endpoint http://localhost:6006 --project my-app
+
+# Instrument too — requires --agent when there's no TTY to choose one
+px setup --no-input --instrument --agent claude --yolo --language python --format raw
+```
+
+Re-run individual steps later with the subcommands:
+
+```bash
+px setup instrument --agent codex   # Instrument and verify again
+px setup skills                     # Install coding-agent skills only
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--project <name>` | Project name to target | From env |
+| `--no-input` | Never prompt; fail instead of asking (for CI/agents) | — |
+| `--instrument` / `--no-instrument` | Whether to hand instrumentation to a coding agent | Prompted |
+| `--agent <agent>` | Coding agent to hand off to: `claude`, `codex`, `cursor`, `opencode` | Prompted |
+| `--language <lang...>` | Language(s) to instrument (repeatable) | Detected |
+| `--skills` / `--no-skills` | Whether to install Phoenix coding-agent skills | Prompted |
+| `--docs-mcp` / `--no-docs-mcp` | Connect the Phoenix docs MCP server to the agent instead of downloading docs | Prompted |
+| `--yolo` | Let the agent run without per-step confirmation | — |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+
 ### `px project list`
 
 List all available projects.
@@ -188,6 +228,24 @@ px project list --format raw  # JSON output for piping
 | `--format <format>` | Output format: `pretty`, `json`, or `raw` | `pretty` |
 | `--no-progress` | Disable progress indicators | — |
 | `--limit <number>` | Maximum projects to fetch per page | 100 |
+
+### `px project get <name>`
+
+Fetch a single project by exact name. Output is a single record (not an array). On a name miss, the command exits with a failure code and writes a structured error to stderr in `--format json`/`raw`.
+
+```bash
+px project get my-project
+px project get my-project --format raw --no-progress | jq -r '.id'  # Resolve name to ID
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<name>` | Exact project name | — |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--limit <number>` | Page size for the underlying lookup | 100 |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--no-progress` | Disable progress indicators | — |
 
 ### `px trace list [directory]`
 
@@ -212,6 +270,8 @@ px trace list --format raw --no-progress | jq     # Pipe to jq
 | `--api-key <key>` | Phoenix API key | From env |
 | `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
 | `--no-progress` | Disable progress output | — |
+| `--include-annotations` | Include trace and span annotations | — |
+| `--include-notes` | Include trace and span notes | — |
 | `--max-concurrent <number>` | Maximum concurrent fetches | 10 |
 
 ### `px trace get <trace-id>`
@@ -220,18 +280,90 @@ Fetch a specific trace by ID.
 
 ```bash
 px trace get abc123def456
-px trace get abc123def456 --file trace.json      # Save to file
-px trace get abc123def456 --format raw | jq      # Pipe to jq
+px trace get abc123def456 --file trace.json                # Save to file
+px trace get abc123def456 --include-notes --format raw | jq # Include notes
+px trace get abc123def456 --format raw | jq                # Pipe to jq
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--file <path>` | Save to file instead of stdout | stdout |
+| `--include-annotations` | Include trace and span annotations | — |
+| `--include-notes` | Include trace and span notes | — |
 | `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
 | `--endpoint <url>` | Phoenix API endpoint | From env |
 | `--project <name>` | Project name or ID | From env |
 | `--api-key <key>` | Phoenix API key | From env |
 | `--no-progress` | Disable progress indicators | — |
+
+### `px trace annotate <trace-id>`
+
+Create or update a trace annotation by OpenTelemetry trace ID. Passing `--identifier` upserts a specific annotation instance, so repeated calls with the same identifier overwrite rather than append — the key primitive for reversible, script-driven coding sessions.
+
+```bash
+px trace annotate abc123def456 --name reviewer --label pass
+px trace annotate abc123def456 --name reviewer --score 0.9 --format raw --no-progress
+px trace annotate abc123def456 --name evaluator --label pass --annotator-kind LLM
+px trace annotate abc123def456 --name reviewer --explanation "needs follow-up"
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<trace-id>` | OpenTelemetry trace ID | — |
+| `--name <name>` | Annotation name (what is being measured) | Required |
+| `--label <label>` | Categorical result (e.g. `pass`, `fail`) | — |
+| `--score <number>` | Numeric score | — |
+| `--explanation <text>` | Free-text justification | — |
+| `--annotator-kind <kind>` | `HUMAN`, `LLM`, or `CODE` | `HUMAN` |
+| `--identifier <id>` | Annotation identifier; repeated calls with the same value upsert in place | — |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--no-progress` | Disable progress indicators | — |
+
+At least one of `--label`, `--score`, or `--explanation` is required.
+
+### `px trace add-note <trace-id>`
+
+Add a free-text note to a trace by OpenTelemetry trace ID. Notes are a reserved annotation type: a trace can carry multiple notes, and passing `--identifier` upserts a specific note instead of appending.
+
+```bash
+px trace add-note abc123def456 --text "needs follow-up"
+px trace add-note abc123def456 --text "agent triage complete" --format raw --no-progress
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<trace-id>` | OpenTelemetry trace ID | — |
+| `--text <text>` | Note text to attach to the trace | Required |
+| `--identifier <id>` | Note identifier; repeated calls with the same value upsert in place | — |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--no-progress` | Disable progress indicators | — |
+
+### `px trace-annotations delete`
+
+Bulk-delete trace annotations for the configured project. Requires `--all` (delete every matching row) **or** both `--start-time` and `--end-time` to bound the delete to a `[start_time, end_time)` window — `--name`, `--identifier`, and `--annotator-kind` are narrowing filters and never authorize the request on their own. Deletes are disabled by default; set `PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` first.
+
+```bash
+px trace-annotations delete --identifier "$PHOENIX_CODING_IDENTIFIER" --all -y
+px trace-annotations delete --start-time 2026-01-01T00:00:00Z --end-time 2026-01-02T00:00:00Z -y
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--all` | Delete every matching row (authorizes the request) | — |
+| `--start-time <timestamp>` | Start of the delete window (with `--end-time`, authorizes the request) | — |
+| `--end-time <timestamp>` | End of the delete window (exclusive) | — |
+| `--name <name>` | Narrow to annotations with this name | — |
+| `--identifier <id>` | Narrow to annotations with this identifier | — |
+| `--annotator-kind <kind>` | Narrow to `HUMAN`, `LLM`, or `CODE` | — |
+| `-y, --yes` | Skip the confirmation prompt | — |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--no-progress` | Disable progress indicators | — |
+
+Set `PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` to enable this command.
 
 ### `px span list [file]`
 
@@ -265,15 +397,43 @@ px span list --format raw --no-progress | jq               # Pipe to jq
 | `--parent-id <id>` | Filter by parent span ID (use `"null"` for root spans) | — |
 | `--attribute <filters...>` | Filter by attribute key-value pairs. Format: `key:value`. Repeat to AND multiple filters. Values containing colons are supported (split on first `:` only). To match a string attribute that looks like a number or boolean, JSON-quote the value (e.g., `'user.id:"12345"'`). Requires Phoenix server ≥ 14.9.0. | — |
 | `--include-annotations` | Include span annotations in output | Off |
+| `--include-notes` | Include span notes in output | Off |
 | `--endpoint <url>` | Phoenix API endpoint | From env |
 | `--project <name>` | Project name or ID | From env |
 | `--api-key <key>` | Phoenix API key | From env |
 | `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
 | `--no-progress` | Disable progress indicators | — |
 
+### `px span annotate <span-id>`
+
+Create or update a span annotation by OpenTelemetry span ID. As with `px trace annotate`, passing `--identifier` upserts a specific annotation instance so repeated calls overwrite rather than append.
+
+```bash
+px span annotate 7e2f08cb43bbf521 --name reviewer --label pass
+px span annotate 7e2f08cb43bbf521 --name reviewer --score 0.9 --format raw --no-progress
+px span annotate 7e2f08cb43bbf521 --name checker --score 1 --annotator-kind CODE
+px span annotate 7e2f08cb43bbf521 --name reviewer --explanation "looks good"
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<span-id>` | OpenTelemetry span ID | — |
+| `--name <name>` | Annotation name (what is being measured) | Required |
+| `--label <label>` | Categorical result (e.g. `pass`, `fail`) | — |
+| `--score <number>` | Numeric score | — |
+| `--explanation <text>` | Free-text justification | — |
+| `--annotator-kind <kind>` | `HUMAN`, `LLM`, or `CODE` | `HUMAN` |
+| `--identifier <id>` | Annotation identifier; repeated calls with the same value upsert in place | — |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--no-progress` | Disable progress indicators | — |
+
+At least one of `--label`, `--score`, or `--explanation` is required.
+
 ### `px span add-note <span-id>`
 
-Notes are a reserved annotation type. Unlike other annotations, notes are open-ended and multiple notes can be attached to the same span.
+Notes are a reserved annotation type. Unlike other annotations, notes are open-ended and multiple notes can be attached to the same span. Passing `--identifier` upserts a specific note instead of appending.
 
 ```bash
 px span add-note abc123def456 --text "Escalated: retrieval returned empty results"
@@ -284,10 +444,21 @@ px span add-note abc123def456 --text "Reviewed by on-call" --format json
 |--------|-------------|---------|
 | `<span-id>` | OpenTelemetry span ID | — |
 | `--text <text>` | Note text to attach to the span | **Required** |
+| `--identifier <id>` | Note identifier; repeated calls with the same value upsert in place | — |
 | `--endpoint <url>` | Phoenix API endpoint | From env |
 | `--api-key <key>` | Phoenix API key | From env |
 | `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
 | `--no-progress` | Disable progress indicators | — |
+
+### `px span-annotations delete`
+
+Bulk-delete span annotations for the configured project. Same authorization gate as `px trace-annotations delete` — requires `--all` or both `--start-time` and `--end-time`, with `--name`/`--identifier`/`--annotator-kind` as narrowing filters. Set `PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` to enable it.
+
+```bash
+px span-annotations delete --identifier "$PHOENIX_CODING_IDENTIFIER" --all -y
+```
+
+Accepts the same options as `px trace-annotations delete`.
 
 ### `px session list`
 
@@ -355,6 +526,7 @@ px session annotate my-session-id --name correctness --explanation "needs follow
 | `--score <number>` | Numeric score | — |
 | `--explanation <text>` | Free-text justification | — |
 | `--annotator-kind <kind>` | `HUMAN`, `LLM`, or `CODE` | `HUMAN` |
+| `--identifier <id>` | Annotation identifier; repeated calls with the same value upsert in place | — |
 | `--endpoint <url>` | Phoenix API endpoint | From env |
 | `--api-key <key>` | Phoenix API key | From env |
 | `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
@@ -364,7 +536,7 @@ At least one of `--label`, `--score`, or `--explanation` is required.
 
 ### `px session add-note <session-id>`
 
-Add a free-text note to a session. Address the session by GlobalID or by user-provided `session_id`. A session can carry multiple notes; each receives a unique identifier. Requires Phoenix server `>= 14.17.0`.
+Add a free-text note to a session. Address the session by GlobalID or by user-provided `session_id`. A session can carry multiple notes; passing `--identifier` upserts a specific note instead of appending. Requires Phoenix server `>= 14.17.0`.
 
 ```bash
 px session add-note my-session-id --text "needs follow-up"
@@ -374,10 +546,21 @@ px session add-note my-session-id --text "agent triage complete" --format raw --
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--text <text>` | Note text to add | Required |
+| `--identifier <id>` | Note identifier; repeated calls with the same value upsert in place | — |
 | `--endpoint <url>` | Phoenix API endpoint | From env |
 | `--api-key <key>` | Phoenix API key | From env |
 | `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
 | `--no-progress` | Disable progress indicators | — |
+
+### `px session-annotations delete`
+
+Bulk-delete session annotations for the configured project. Same authorization gate as the trace and span equivalents — requires `--all` or both `--start-time` and `--end-time`. Set `PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES=true` to enable it.
+
+```bash
+px session-annotations delete --identifier "$PHOENIX_CODING_IDENTIFIER" --all -y
+```
+
+Accepts the same options as `px trace-annotations delete`.
 
 ### `px dataset list`
 


### PR DESCRIPTION
## Summary

The Mintlify CLI reference (`arizeai-phoenix-cli.mdx`) had drifted from the
`@arizeai/phoenix-cli` README across several releases. This resyncs it, adding
the missing command sections and flags (source of truth:
`js/packages/phoenix-cli/README.md`):

- **`px setup`** (+ `instrument` / `skills` subcommands and flags)
- **`px trace annotate`**, **`px trace add-note`**, **`px trace-annotations delete`**
- **`px span annotate`**, **`px span-annotations delete`**
- **`px session-annotations delete`**
- **`px project get <name>`**
- `--identifier` on all annotate/add-note commands (upsert semantics);
  `--include-notes` / `--include-annotations` on `trace list` / `trace get` / `span list`

## Issues addressed

Resolves the CLI-reference gaps flagged in the weekly docs gap audits:

- #14406 (G2 — `px setup`)
- #13212 (G1 — annotation-delete commands, `px project get`, `--identifier`)
- #12919 (G1 — `px trace add-note`)
- #12691 (G1 — `px trace annotate` / `px span annotate`)

> These audit issues also contain non-CLI gaps handled in sibling PRs
> (environment/config docs and small feature-gap fills). To avoid closing them
> prematurely, the `Closes #…` keywords live on the final PR in that set; this PR
> only advances them.
