### PR TITLE
docs(config): document .env.phoenix, PHOENIX_PROJECT, and endpoint/key/collector distinction

### DIFF
--- a/docs/phoenix/environments.mdx
+++ b/docs/phoenix/environments.mdx
@@ -73,4 +73,47 @@ phoenix serve
 
 This will start the phoenix server on port 6006. If you are running your instrumented notebook or application on the same machine, traces should automatically be exported to `http://127.0.0.1:6006` so no additional configuration is needed. However if the server is running remotely, you will have to modify the environment variable `PHOENIX_COLLECTOR_ENDPOINT` to point to that machine (e.g. `http://<my-remote-machine>:<port>`)
 
+## Configuration & environment variables
+
+Phoenix reads its connection settings from environment variables. Three of them are easy to confuse, so it's worth being precise about what each one is for:
+
+| Variable | What it is | When to set it |
+|----------|------------|----------------|
+| `PHOENIX_COLLECTOR_ENDPOINT` | The base URL of the Phoenix server that **receives your traces** (the OTel collector). Set the base URL only — e.g. `https://app.phoenix.arize.com` or `http://localhost:6006` — not a full `/v1/traces` path. | Whenever your app and the Phoenix server are not on the same machine, or you're using Phoenix Cloud. This is the variable the tracing SDKs (`register()`) use. |
+| `PHOENIX_API_KEY` | The credential used to **authenticate** to a Phoenix instance that has auth enabled (Phoenix Cloud, or a self-hosted instance with authentication turned on). | When connecting to Phoenix Cloud or any authenticated deployment. |
+| `PHOENIX_CLIENT_HEADERS` | Extra headers (JSON) sent with every request. Older Phoenix Cloud instances (created before June 24th, 2025) expect the API key here as `api_key=...`. | Only when a deployment requires custom headers, or for legacy Cloud instances. |
+
+<Warning>
+Point `PHOENIX_COLLECTOR_ENDPOINT` at the server's **base URL**. Setting it (or the legacy `PHOENIX_HOST`) to a full endpoint path such as `.../v1/traces` will misconfigure the exporter and your traces will not arrive.
+</Warning>
+
+### Choosing a project
+
+`PHOENIX_PROJECT` selects the project that project-scoped operations write to and read from. `PHOENIX_PROJECT_NAME` is a supported alias for the same setting. When both are set, `PHOENIX_PROJECT` wins and Phoenix logs a one-time conflict warning. If neither is set, the project defaults to `"default"`.
+
+```python
+import os
+
+os.environ["PHOENIX_PROJECT"] = "my-app"   # canonical
+# PHOENIX_PROJECT_NAME is accepted as an alias for the same value
+```
+
+### Credential file discovery (`.env.phoenix`)
+
+Instead of exporting variables in every shell, you can drop `PHOENIX_`-prefixed settings into a `.env.phoenix` file. The Phoenix SDKs and CLI auto-discover it: starting from the current working directory they walk **up** toward the filesystem root and load the first `.env.phoenix` they find (dotenv format).
+
+```bash
+# .env.phoenix
+PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006
+PHOENIX_API_KEY=your-api-key
+PHOENIX_PROJECT=my-app
+```
+
+A few rules worth knowing:
+
+- **The process environment always wins.** A value already set in the environment is never overridden by the file.
+- **The filename is `.env.phoenix`**, not `.env`.
+- **Add it to your ignore rules** before storing credentials in it — the Phoenix repository already git-ignores `.env.phoenix`.
+- **Opt out** by setting `PHOENIX_DISCOVER_CONFIG=false` (also accepts `0`, `no`, `off`), which disables file discovery entirely.
+
 

--- a/docs/phoenix/sdk-api-reference.mdx
+++ b/docs/phoenix/sdk-api-reference.mdx
@@ -78,11 +78,15 @@ All packages respect common Phoenix environment variables for seamless configura
 
 | Variable | Description | Used By |
 |----------|-------------|---------|
-| `PHOENIX_COLLECTOR_ENDPOINT` | Trace collector URL | OTEL |
+| `PHOENIX_COLLECTOR_ENDPOINT` | Trace collector URL (server base URL, not a `/v1/traces` path) | OTEL |
 | `PHOENIX_BASE_URL` | Phoenix server URL | Client |
 | `PHOENIX_API_KEY` | API key for authentication | Client, OTEL |
-| `PHOENIX_PROJECT_NAME` | Default project name | OTEL |
+| `PHOENIX_PROJECT` | Default project name (canonical) | Client, OTEL, CLI |
+| `PHOENIX_PROJECT_NAME` | Alias for `PHOENIX_PROJECT`; `PHOENIX_PROJECT` wins if both are set | Client, OTEL |
 | `PHOENIX_CLIENT_HEADERS` | Custom HTTP headers | Client, OTEL |
+| `PHOENIX_DISCOVER_CONFIG` | Set to `false` to disable `.env.phoenix` credential-file discovery | Client, OTEL, CLI |
+
+Phoenix SDKs and the CLI also auto-load `PHOENIX_`-prefixed settings from a `.env.phoenix` file, discovered by walking up from the current directory. Process environment variables always take precedence. See [Environments](/docs/phoenix/environments).
 
 ---
 

--- a/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel.mdx
+++ b/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel.mdx
@@ -36,10 +36,15 @@ The SDK automatically reads these environment variables:
 | Variable | Description |
 |----------|-------------|
 | `PHOENIX_COLLECTOR_ENDPOINT` | Phoenix server URL |
-| `PHOENIX_PROJECT_NAME` | Project name for traces |
+| `PHOENIX_PROJECT` | Project name for traces (canonical) |
+| `PHOENIX_PROJECT_NAME` | Alias for `PHOENIX_PROJECT`; if both are set, `PHOENIX_PROJECT` wins |
 | `PHOENIX_API_KEY` | API key (automatically adds auth header) |
 | `PHOENIX_CLIENT_HEADERS` | Custom headers for requests |
 | `PHOENIX_GRPC_PORT` | Override default gRPC port |
+
+<Note>
+`register()` also auto-loads `PHOENIX_`-prefixed settings from a `.env.phoenix` file discovered by walking up from the current directory (process environment variables take precedence). Set `PHOENIX_DISCOVER_CONFIG=false` to opt out. See [Environments](/docs/phoenix/environments).
+</Note>
 
 ```python
 # Environment variables are picked up automatically
@@ -76,7 +81,7 @@ When using the `endpoint` argument, you must specify the fully qualified URL. HT
 
 | Parameter | Description |
 |-----------|-------------|
-| `project_name` | Phoenix project name (or `PHOENIX_PROJECT_NAME` env var) |
+| `project_name` | Phoenix project name (or the `PHOENIX_PROJECT` env var, alias `PHOENIX_PROJECT_NAME`) |
 | `endpoint` | Collector endpoint URL |
 | `protocol` | Transport protocol: `"grpc"` or `"http/protobuf"` |
 | `headers` | Custom headers for requests |

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers.mdx
@@ -2,7 +2,7 @@
 title: "The phoenix.otel Helpers"
 sidebarTitle: "phoenix.otel helpers"
 description: "The arize-phoenix-otel SDK collapses raw OpenTelemetry setup into a single register() call, with auto-instrumentation discovery and Phoenix-aware defaults."
-keywords: ['phoenix.otel', 'register', 'auto_instrument', 'PHOENIX_API_KEY', 'PHOENIX_COLLECTOR_ENDPOINT', 'PHOENIX_PROJECT_NAME']
+keywords: ['phoenix.otel', 'register', 'auto_instrument', 'PHOENIX_API_KEY', 'PHOENIX_COLLECTOR_ENDPOINT', 'PHOENIX_PROJECT', 'PHOENIX_PROJECT_NAME']
 ---
 
 The previous four pages — [Resource](/docs/phoenix/tracing/concepts-tracing/otel-openinference/resource), [Exporter](/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter), [Span Processor](/docs/phoenix/tracing/concepts-tracing/otel-openinference/span-processor), and [Tracer Provider](/docs/phoenix/tracing/concepts-tracing/otel-openinference/tracer-provider) — walked through the OpenTelemetry tracing components one by one. Wiring them up by hand in every application is verbose. The `phoenix.otel` SDK collapses all of it into a single function call — and adds a few Phoenix-specific capabilities on top.
@@ -55,7 +55,7 @@ The convenience function handles four things for you. Each one has additional ca
 | **Tracer Provider** | A Phoenix-aware provider with sensible defaults. Combined with the OpenInference instrumentation libraries, it makes the [OpenInference context managers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/context-managers) (`using_session`, `using_user`, `using_metadata`, etc.) attach attributes to spans automatically. |
 | **Span Processor** | Configured and pre-attached. `SimpleSpanProcessor` by default, `BatchSpanProcessor` when you pass `batch=True`. |
 | **Span Exporter** | Auto-detects gRPC or HTTP from the endpoint URL and configures the matching OTLP exporter. If `api_key` is set, it adds the `Authorization: Bearer <key>` header for you. |
-| **Resource** | Sets the project name automatically from your `project_name` argument (or the `PHOENIX_PROJECT_NAME` environment variable). |
+| **Resource** | Sets the project name automatically from your `project_name` argument (or the `PHOENIX_PROJECT` environment variable, with `PHOENIX_PROJECT_NAME` accepted as an alias). |
 
 # Auto-instrumentation
 
@@ -80,7 +80,7 @@ For the full set of installable instrumentors, see the [OpenInference repository
 
 | Argument | Environment variable | Notes |
 | :--- | :--- | :--- |
-| `project_name` | `PHOENIX_PROJECT_NAME` | Name of the project in Phoenix. Defaults to `"default"`. |
+| `project_name` | `PHOENIX_PROJECT` (alias `PHOENIX_PROJECT_NAME`) | Name of the project in Phoenix. If both env vars are set, `PHOENIX_PROJECT` wins. Defaults to `"default"`. |
 | `endpoint` | `PHOENIX_COLLECTOR_ENDPOINT` | The collector endpoint. Defaults to `http://localhost:6006`. |
 | `api_key` | `PHOENIX_API_KEY` | Optional for local Phoenix. Required for Phoenix Cloud or any authenticated instance — added as a Bearer token header. |
 | `headers` | `PHOENIX_CLIENT_HEADERS` | Additional headers for the OTLP request (e.g. tenant identifiers). |


### PR DESCRIPTION
## Summary

Documents Phoenix configuration surfaces that had drifted from the SDK/CLI
behavior:

- **`environments.mdx`** — new **Configuration & environment variables** section:
  - The easily-confused trio `PHOENIX_COLLECTOR_ENDPOINT` (server **base URL**, not a `/v1/traces` path) vs `PHOENIX_API_KEY` vs `PHOENIX_CLIENT_HEADERS`, with a warning against setting a full endpoint path.
  - **Choosing a project**: `PHOENIX_PROJECT` (canonical) with `PHOENIX_PROJECT_NAME` as an alias; canonical wins on conflict; defaults to `"default"`.
  - **Credential file discovery (`.env.phoenix`)**: walk-up discovery, process-env-wins, filename gotcha, git-ignore guidance, and the `PHOENIX_DISCOVER_CONFIG=false` opt-out.
- **`sdk-api-reference.mdx`** — add `PHOENIX_PROJECT` and `PHOENIX_DISCOVER_CONFIG` to the env-var table; note the collector endpoint is a base URL; link to Environments.
- **`python/arize-phoenix-otel.mdx`** and **`phoenix-otel-helpers.mdx`** — present `PHOENIX_PROJECT` as canonical with `PHOENIX_PROJECT_NAME` as the alias (previously only `PHOENIX_PROJECT_NAME` was shown).

Source of truth: `js/packages/phoenix-config/README.md`, `packages/phoenix-client/README.md`.

## Issues addressed

- #14406 (G1 — `.env.phoenix` discovery / `PHOENIX_DISCOVER_CONFIG`; G3 — `PHOENIX_PROJECT` canonical alias & precedence)
- #9971 (clarify host endpoint vs API key vs collector)

> #14406 is a multi-gap audit; its remaining gaps land in a sibling PR that carries the `Closes` keyword.

Closes #9971
