### PR TITLE
docs: fill small feature-gap docs (evals, playground, annotations, datasets, packages)

### DIFF
--- a/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments.mdx
+++ b/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments.mdx
@@ -351,6 +351,17 @@ To set or remove a baseline from the experiments table:
 
 The current baseline is indicated by a **baseline** badge next to the experiment in the table. Setting a new baseline replaces any existing one — a dataset has at most one baseline at a time.
 
+## View Dataset Metrics
+
+The dataset page has a **Metrics** tab that charts how your experiments trend over time, so you can spot regressions without opening each experiment. Open a dataset and select the **Metrics** tab (next to **Experiments** and **Versions**) to see bar charts across the dataset's most recent experiments for:
+
+- **Run latency** — how long runs take
+- **Error rate** — the share of failed runs
+- **Cost** — token spend per experiment
+- **Token usage** — prompt and completion tokens
+
+Use it to confirm a new prompt or model isn't quietly getting slower, more expensive, or more error-prone than earlier experiments on the same dataset.
+
 ## Review Failure Modes
 
 After the run completes, open the experiment to understand where the prompt or model is underperforming.

--- a/docs/phoenix/evaluation/llm-evals/executors.mdx
+++ b/docs/phoenix/evaluation/llm-evals/executors.mdx
@@ -18,3 +18,13 @@ When performing evaluations, speed is paramount so that you can focus on improvi
 ## Why Use Executors
 
 Running thousands of evaluations manually is slow and error-prone. Executors automatically handle the complexity so you can focus on your evaluation logic instead of infrastructure.
+
+## Retries and Timeouts
+
+Both `evaluate_dataframe` and `async_evaluate_dataframe` accept a `max_retries` argument (default `10`) that bounds how many times a failing evaluation task is retried before it is marked failed.
+
+When you use the asynchronous executor (`async_evaluate_dataframe`), each task also has a `timeout` (default 60 seconds). **A timed-out task counts against `max_retries`.** A timeout is logged and the task requeued, and once the retry budget is exhausted the task is marked `FAILED` — honoring `exit_on_error` — rather than being retried forever. If you have long-running eval tasks that legitimately need more time, raise the timeout or increase `max_retries`; if tasks are hanging, lowering `max_retries` makes them fail faster.
+
+<Note>
+This applies to the async executor's per-task timeout. The synchronous executor retries on exceptions only and has no per-task timeout.
+</Note>

--- a/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers.mdx
+++ b/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers.mdx
@@ -129,3 +129,9 @@ Phoenix supports adding custom HTTP headers to requests sent to AI providers. Th
   "application-name": "phoenix"
 }
 ```
+
+## Set a Default Provider and Model
+
+You can choose which provider and model the Prompt Playground selects by default. Go to **Settings → AI Providers** and use the **AI Provider Settings** card to pick a default provider and model. The preference is saved in your browser and applied the first time the playground opens in a session, so you don't have to reselect your usual model each time.
+
+This is distinct from the playground's **"save as default"** control in the model configuration panel: the Settings preference chooses the initial provider/model, while "save as default" makes a full model configuration (including invocation parameters) sticky across sessions.

--- a/docs/phoenix/prompt-engineering/how-to-prompts/using-the-playground.mdx
+++ b/docs/phoenix/prompt-engineering/how-to-prompts/using-the-playground.mdx
@@ -33,6 +33,15 @@ Every prompt instance can be configured to use a specific LLM and set of invocat
 For OpenAI and Azure OpenAI models, you can select the **OpenAI API type** in the model configuration panel. Choose **Chat Completions** (`chat.completions.create`) or **Responses** (`responses.create`) depending on the model and feature set you need.
 </Info>
 
+### Reasoning / extended thinking
+
+For models that support reasoning, the model configuration panel exposes controls for how much the model thinks before responding:
+
+- **Anthropic** (Claude 3.7 Sonnet and later) — toggle extended thinking between **disabled**, **adaptive** (the default), and **enabled** with an explicit `budget_tokens` allocation and a visibility toggle. You can also set output **effort** (`high` / `medium` / `low`). Enabling extended thinking automatically raises `max_tokens` to at least `budget_tokens + 1`.
+- **Google** (Gemini 2.5 models) — set a `thinkingBudget` and/or `thinkingLevel` (`low` / `medium` / `high`).
+
+Higher thinking budgets and effort levels can improve quality on hard tasks at the cost of latency and tokens; start with the defaults and raise them only when a task needs more reasoning.
+
 ## Comparing Prompts
 
 The Prompt Playground offers the capability to compare multiple prompt variants directly within the playground. Simply click the **+ Compare** button at the top of the first prompt to create duplicate instances. Each prompt variant manages its own independent template, model, and parameters. This allows you to quickly compare prompts (labeled A, B, C, and D in the UI) and run experiments to determine which prompt and model configuration is optimal for the given task.

--- a/docs/phoenix/sdk-api-reference/python/arize-phoenix-client.mdx
+++ b/docs/phoenix/sdk-api-reference/python/arize-phoenix-client.mdx
@@ -254,6 +254,9 @@ projects = client.projects.list()
 for project in projects:
     print(f"Project: {project['name']} (ID: {project['id']})")
 
+# Filter server-side by a case-insensitive substring of the project name
+support_projects = client.projects.list(name_contains="support")
+
 # Create a new project
 new_project = client.projects.create(
     name="Customer Support Bot",

--- a/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/annotating-in-the-ui.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/annotating-in-the-ui.mdx
@@ -22,6 +22,10 @@ To annotate data in the UI, you first will want to setup a rubric for how to ann
   <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/55fe6610-image.jpeg" />
 </Frame>
 
+<Note>
+Every Phoenix instance ships with a built-in `user_feedback` annotation config — a **Categorical** config with `positive` (score `1.0`) and `negative` (score `0.0`) labels. It is seeded automatically on startup and backs the thumbs-up / thumbs-down feedback in the assistant, so it will already appear when you list annotation configs on a fresh deployment.
+</Note>
+
 ## Adding Annotations
 
 <Frame caption="Once annotations are configured, you can add them to your project to build out a custom annotation form">
@@ -29,6 +33,8 @@ To annotate data in the UI, you first will want to setup a rubric for how to ann
 </Frame>
 
 Once you have annotations configured, you can associate annotations to the data that you have traced. Click on the `Annotate` button and fill out the form to rate different steps in your AI application. 
+
+You can annotate at the **span**, **trace**, and **session** level. Spans and traces are annotated from their detail views; to annotate a whole conversation, open a session and use the `Annotate` button in the session details view to add and edit session-level annotations from the `Annotations` tab there.
 
 You can also take notes as you go by either clicking on the `explain` link or by adding your notes to the bottom messages UI. 
 

--- a/docs/phoenix/tracing/llm-traces/projects.mdx
+++ b/docs/phoenix/tracing/llm-traces/projects.mdx
@@ -49,6 +49,10 @@ Bulk deletion is **destructive and cannot be undone**, and is restricted to admi
   When you need data segmentation above the project level, for example by department or business unit, [Arize AX](https://arize.com/docs/ax/security-and-settings/sso-and-rbac#spaces) provides Workspaces to isolate and scope access across organizational boundaries.
 </Info>
 
+## Jump to any resource with the command palette
+
+Press **⌘K** (macOS) or **Ctrl+K** (Windows/Linux) anywhere in Phoenix to open the global command palette. Start typing to fuzzy-search across your projects, datasets, experiments, and prompts, jump to top-level pages, or reopen something you recently viewed — a fast way to switch context without clicking through the navigation.
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -128,6 +128,8 @@ The following LLM provider SDKs are supported:
 - OpenAI: `openai` [openai](https://www.npmjs.com/package/openai)
 - Anthropic: `anthropic` [@anthropic-ai/sdk](https://www.npmjs.com/package/@anthropic-ai/sdk)
 
+> **Note:** These provider SDKs are optional peer dependencies — installing `@arizeai/phoenix-client` does not pull them in. Install the one you convert to yourself, e.g. `npm install ai`, `npm install openai`, or `npm install @anthropic-ai/sdk`. Calling `toSDK({ sdk: "ai" | "openai" | "anthropic" })` without the matching SDK installed fails at runtime.
+
 ```ts
 import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";

--- a/packages/phoenix-client/README.md
+++ b/packages/phoenix-client/README.md
@@ -495,6 +495,9 @@ projects = client.projects.list()
 for project in projects:
     print(f"Project: {project['name']} (ID: {project['id']})")
 
+# Filter server-side by a case-insensitive substring of the project name
+support_projects = client.projects.list(name_contains="support")
+
 # Create a new project
 new_project = client.projects.create(
     name="Customer Support Bot",

--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -1583,8 +1583,9 @@ async def async_evaluate_dataframe(
             progress bar is shown. Defaults to False.
         exit_on_error: Optional flag to control whether execution should stop on the first
             error. If None, uses AsyncExecutor's default (True).
-        max_retries: Optional number of times to retry on exceptions. If None, uses
-            AsyncExecutor's default (10).
+        max_retries: Optional number of times to retry on exceptions or timeouts. A task that
+            times out (default 60s per task) counts against this budget and is marked failed once
+            it is exhausted. If None, uses AsyncExecutor's default (10).
 
     Returns:
         A copy of the input dataframe with additional columns for scores and exceptions.

--- a/packages/phoenix-otel/docs/source/index.md
+++ b/packages/phoenix-otel/docs/source/index.md
@@ -515,7 +515,7 @@ def generate_embedding(text: str) -> List[float]:
 Use the `suppress_tracing()` context manager to temporarily disable tracing:
 
 ```python
-from openinference.instrumentation import suppress_tracing
+from phoenix.otel import suppress_tracing
 
 with suppress_tracing():
     # This function call will not be traced
@@ -527,7 +527,7 @@ with suppress_tracing():
 Use `using_attributes()` to add context attributes to spans:
 
 ```python
-from openinference.instrumentation import using_attributes
+from phoenix.otel import using_attributes
 
 with using_attributes(session_id="123", user_id="user456"):
     # All spans created within this context will have these attributes


### PR DESCRIPTION
## Summary

Fills a batch of small, self-contained documentation gaps flagged across the
weekly docs gap audits. Each is one section or note against current behavior:

- **Evals** — `executors.mdx` now documents `max_retries`/`timeout` and the
  async executor's *timeout-counts-as-retry* semantics; the
  `async_evaluate_dataframe` docstring is updated to match (`exceptions or timeouts`).
- **Python client** — `projects.list(name_contains=...)` example added to the
  reference page and package README.
- **Datasets** — documents the dataset-page **Metrics** tab (run latency, error
  rate, cost, token usage).
- **Annotations** — notes in-UI **session** annotation editing and the built-in
  **`user_feedback`** annotation config seeded on startup.
- **Playground** — documents Anthropic/Google **reasoning (thinking/effort)**
  controls and the **default provider/model preference** in Settings → AI Providers.
- **Tracing** — documents the global **command palette (⌘K / Ctrl+K)**.
- **Packages** — `@arizeai/phoenix-client` README notes provider SDKs are
  optional peer dependencies; `arize-phoenix-otel` Sphinx docs import the
  context managers from `phoenix.otel`.

> The `user.id`-as-a-column note (audit #14406 G7) was intentionally skipped —
> the attribute is already documented; only the "now shows as a column" nuance
> was outstanding and isn't worth a standalone edit.

## Issues addressed

This is the **final PR** in a three-part docs-audit cleanup and completes the
remaining gaps in these audits (CLI-reference and env/config gaps land in
#14439 and #14440 — merge this alongside them):

Closes #14406
Closes #13212
Closes #12691
Closes #12919
