### PR TITLE
fix(ui): contain long experiment run errors

### DIFF
--- a/app/src/pages/example/ExampleExperimentRunsTable.tsx
+++ b/app/src/pages/example/ExampleExperimentRunsTable.tsx
@@ -15,6 +15,7 @@ import {
   AnnotationTooltip,
 } from "@phoenix/components/annotation";
 import { EmptyState, EmptyStateGraphic } from "@phoenix/components/core/empty";
+import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { tableCSS } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import { TextCell } from "@phoenix/components/table/TextCell";
@@ -25,6 +26,17 @@ import type { ExampleExperimentRunsTableFragment$key } from "./__generated__/Exa
 import type { ExampleExperimentRunsTableQuery } from "./__generated__/ExampleExperimentRunsTableQuery.graphql";
 
 const PAGE_SIZE = 100;
+
+const experimentRunsTableCSS = css`
+  table-layout: fixed;
+
+  th,
+  td {
+    overflow: hidden;
+  }
+`;
+
+const EXPERIMENT_RUN_COLUMN_WIDTHS = ["20%", "28%", "12%", "30%", "10%"];
 
 export function ExampleExperimentsTableEmpty() {
   return (
@@ -135,7 +147,11 @@ export function ExampleExperimentRunsTable({
         // eslint-disable-next-line react/prop-types
         const maybeError = props.row.original?.error;
         if (maybeError !== null) {
-          return <Text color="danger">{maybeError}</Text>;
+          return (
+            <Truncate maxWidth="100%" title={maybeError}>
+              <Text color="danger">{maybeError}</Text>
+            </Truncate>
+          );
         }
         return <TextCell {...props} />;
       },
@@ -247,7 +263,12 @@ export function ExampleExperimentRunsTable({
       ref={tableContainerRef}
       onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
     >
-      <table css={tableCSS}>
+      <table css={[tableCSS, experimentRunsTableCSS]}>
+        <colgroup>
+          {EXPERIMENT_RUN_COLUMN_WIDTHS.map((width, index) => (
+            <col key={index} style={{ width }} />
+          ))}
+        </colgroup>
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>

--- a/app/src/pages/example/__tests__/ExampleExperimentRunsTable.test.tsx
+++ b/app/src/pages/example/__tests__/ExampleExperimentRunsTable.test.tsx
@@ -1,0 +1,83 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { usePaginationFragment } from "react-relay";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ExampleExperimentRunsTable } from "../ExampleExperimentRunsTable";
+
+vi.mock("react-relay", () => ({
+  graphql: vi.fn(),
+  usePaginationFragment: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@phoenix/components/table/TimestampCell", () => ({
+  TimestampCell: () => <span>timestamp</span>,
+}));
+
+const longError = `/tmp/${"nested/".repeat(30)}experiment-run-error`;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  vi.mocked(usePaginationFragment).mockReturnValue({
+    data: {
+      experimentRuns: {
+        edges: [
+          {
+            run: {
+              id: "run-1",
+              startTime: "2026-07-16T00:00:00Z",
+              endTime: "2026-07-16T00:00:01Z",
+              error: longError,
+              output: null,
+              trace: {
+                id: "trace-1",
+                traceId: "trace-id-1",
+                projectId: "project-1",
+              },
+              annotations: { edges: [] },
+            },
+          },
+        ],
+      },
+    },
+    hasNext: false,
+    isLoadingNext: false,
+    loadNext: vi.fn(),
+  } as never);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("ExampleExperimentRunsTable", () => {
+  it("contains long errors without dropping later columns", () => {
+    act(() => {
+      root.render(<ExampleExperimentRunsTable example={{} as never} />);
+    });
+
+    const columnWidths = Array.from(
+      container.querySelectorAll<HTMLTableColElement>("colgroup col")
+    ).map((column) => column.style.width);
+    expect(columnWidths).toEqual(["20%", "28%", "12%", "30%", "10%"]);
+    expect(container.querySelector(`[title="${longError}"]`)).not.toBeNull();
+    expect(
+      container.querySelector('button[aria-label="view trace"]')
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
resolves #14427

## Summary

- constrain experiment run table columns so long errors cannot expand the drawer
- truncate error output while preserving the full message in a title tooltip
- keep evaluation and trace action columns present under width pressure
- add regression coverage for the constrained column layout

## Testing

- `pnpm exec vitest run src/pages/example/__tests__/ExampleExperimentRunsTable.test.tsx`
- `pnpm exec oxfmt --check --config ../.oxfmtrc.jsonc src/pages/example/ExampleExperimentRunsTable.tsx src/pages/example/__tests__/ExampleExperimentRunsTable.test.tsx`
- `pnpm exec oxlint src/pages/example/ExampleExperimentRunsTable.tsx src/pages/example/__tests__/ExampleExperimentRunsTable.test.tsx`
- `pnpm run typecheck`