### PR TITLE
docs: fix broken internal links to moved/renamed pages

### DIFF
--- a/docs/phoenix/evaluation/concepts-evals/evaluating-multi-agent-systems.mdx
+++ b/docs/phoenix/evaluation/concepts-evals/evaluating-multi-agent-systems.mdx
@@ -79,7 +79,7 @@ Use our [pre-built evals](/docs/phoenix/evaluation/running-pre-tested-evals) tha
 
 Focus evaluations on coordination efficiency, overall system efficiency, and emergent behaviors.
 
-See our docs for creating your own [custom evals](/docs/phoenix/evaluation) in Phoenix.
+See our docs for creating your own [custom evals](/docs/phoenix/evaluation/how-to-evals) in Phoenix.
 
 ### **Hierarchical Evaluation**
 

--- a/docs/phoenix/integrations/python/pydantic/pydantic-evals.mdx
+++ b/docs/phoenix/integrations/python/pydantic/pydantic-evals.mdx
@@ -376,6 +376,6 @@ The Phoenix UI will display your evaluation results with detailed breakdowns, ma
 
 - [Pydantic Evals Documentation](https://github.com/pydantic/pydantic-evals)
 
-- [Phoenix Evaluation Guide](/docs/phoenix/evaluation)
+- [Phoenix Evaluation Guide](/docs/phoenix/evaluation/evals)
 
 - [Pydantic Evals Tutorial Notebook](https://github.com/Arize-ai/tutorials/blob/main/python/cookbooks/phoenix_evals_examples/pydantic-evals.ipynb)

--- a/docs/phoenix/release-notes/01-2025/01-18-2025-automatic-and-manual-span-tracing.mdx
+++ b/docs/phoenix/release-notes/01-2025/01-18-2025-automatic-and-manual-span-tracing.mdx
@@ -23,5 +23,5 @@ You can now access a tracer object with streamlined options to trace functions a
 * Using the **decorator** `@tracer.chain` traces the entire function automatically as a Span in Phoenix. The input, output, and status attributes are set based on the function's parameters and return value.
 * Using the tracer in a `with` clause allows you to trace specific code blocks within a function. You manually define the Span name, input, output, and status.
 
-Check out the [docs](/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument-python#using-your-tracer) for more on how to use tracer objects.
+Check out the [docs](/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument#using-helpers) for more on how to use tracer objects.
 </Update>

--- a/docs/phoenix/self-hosting/features/management.mdx
+++ b/docs/phoenix/self-hosting/features/management.mdx
@@ -17,6 +17,6 @@ Authorization: Bearer $PHOENIX_ADMIN_SECRET
 
 The API provides endpoints for creating, updating, and deleting users, projects, and more.
 
-See the [REST API](/docs/phoenix/sdk-api-reference/rest-api) for details.
+See the [REST API](/docs/phoenix/sdk-api-reference/rest-api/overview) for details.
 
 

--- a/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/importing-atif-trajectories.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/importing-atif-trajectories.mdx
@@ -94,7 +94,7 @@ Continuation root spans are annotated with `metadata.is_continuation = True`.
 
 ### Attribute mapping
 
-The converter maps ATIF fields to standard [OpenInference](/docs/phoenix/references/openinference) attributes:
+The converter maps ATIF fields to standard [OpenInference](/docs/phoenix/resources/openinference) attributes:
 
 | ATIF field | OpenInference attribute |
 |---|---|

--- a/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/importing-existing-traces.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/importing-existing-traces.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Import Existing Traces"
-description: "Phoenix supports loading data that contains [OpenInference traces](/docs/phoenix/references/openinference). This allows you to load an existing dataframe of traces into your Phoenix instance."
+description: "Phoenix supports loading data that contains [OpenInference traces](/docs/phoenix/resources/openinference). This allows you to load an existing dataframe of traces into your Phoenix instance."
 ---
 
 

--- a/docs/phoenix/tracing/llm-traces.mdx
+++ b/docs/phoenix/tracing/llm-traces.mdx
@@ -59,7 +59,7 @@ By using tracing in Phoenix, you can gain increased visibility into your LLM app
   <Card title="Quickstart" icon="rocket" href="/docs/phoenix/get-started/get-started-tracing">
     Send your first traces to Phoenix
   </Card>
-  <Card title="Concepts" icon="book" href="/docs/phoenix/tracing/concepts-tracing">
+  <Card title="Concepts" icon="book" href="/docs/phoenix/tracing/concepts-tracing/what-are-traces">
     Learn how traces and spans work
   </Card>
   <Card title="How-To Guides" icon="compass" href="/docs/phoenix/tracing/how-to-tracing">


### PR DESCRIPTION
## Summary

Fixes broken internal documentation links pointing at pages that were moved or
renamed. Found by a sweep that validates every internal `/docs/phoenix/...`
link (markdown links **and** `href=` attributes) against `docs.json` navigation,
`docs.json` redirects, and on-disk `.mdx` files — so redirect-backed links (e.g.
`running-pre-tested-evals`) are correctly treated as valid and not touched.

**5 dead targets, 7 occurrences repaired:**

| Broken target | Fixed to |
|---|---|
| `/docs/phoenix/evaluation` | `.../evaluation/evals` (guide) and `.../evaluation/how-to-evals` (custom evals) |
| `/docs/phoenix/references/openinference` | `/docs/phoenix/resources/openinference` |
| `/docs/phoenix/sdk-api-reference/rest-api` | `.../rest-api/overview` |
| `/docs/phoenix/tracing/concepts-tracing` | `.../concepts-tracing/what-are-traces` |
| `.../setup-tracing/instrument-python#using-your-tracer` | `.../setup-tracing/instrument#using-helpers` (path + anchor) |

After the fix the sweep reports **0 broken internal links**. Follow-up to the
broken-link report in #14300 (a proactive sweep for the same class of issue).

## Notes

- Links whose target `.mdx` exists but isn't in the sidebar nav were left alone — Mintlify serves those by path.
- The `instrument-python` anchor was also stale; retargeted to the current `#using-helpers` heading.
