### PR TITLE
feat(server): generate the /mcp tool surface from /v1 and pass principal on dispatch

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,6 +49,16 @@ Operators who do not want the MCP surface exposed can disable it with:
 - `PHOENIX_ENABLE_MCP_SERVER` (default `true`). When set to `false`, the `/mcp` mount and the path-inserted protected
   resource metadata at `/.well-known/oauth-protected-resource/mcp` respond with `404`.
 
+By default the `/mcp` endpoint now presents FastMCP's **code-mode** tool surface: instead of the `/v1`-derived tool
+list, clients see discovery meta-tools (`search`, `get_schema`, `tags`, `list_tools`) and an `execute` tool that runs
+model-written Python in a `pydantic-monty` sandbox where `call_tool(name, params)` is the only function in scope. The
+`execute` tool can only invoke tools the caller is already authorized for, and each block is bounded by the FastMCP
+sandbox defaults (30s wall clock, 100 MB memory, at most 50 `call_tool` invocations). To restore the previous
+group-gated progressive-disclosure tool list instead, set:
+
+- `PHOENIX_MCP_CODE_MODE` (default `true`). When set to `false`, `/mcp` presents the group-gated tool surface. Has no
+  effect unless `PHOENIX_ENABLE_MCP_SERVER` is also set.
+
 ### Deployments behind a reverse proxy
 
 The authorization server and the MCP endpoint place requirements on a fronting reverse proxy that ordinary UI and API

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -15,10 +15,10 @@ export interface paths {
          * List annotation configurations
          * @description Retrieve a paginated list of all annotation configurations in the system.
          */
-        get: operations["list_annotation_configs_v1_annotation_configs_get"];
+        get: operations["listAnnotationConfigs"];
         put?: never;
         /** Create an annotation configuration */
-        post: operations["create_annotation_config_v1_annotation_configs_post"];
+        post: operations["createAnnotationConfig"];
         delete?: never;
         options?: never;
         head?: never;
@@ -33,7 +33,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get an annotation configuration by ID or name */
-        get: operations["get_annotation_config_by_name_or_id_v1_annotation_configs__config_identifier__get"];
+        get: operations["getAnnotationConfig"];
         put?: never;
         post?: never;
         delete?: never;
@@ -51,10 +51,10 @@ export interface paths {
         };
         get?: never;
         /** Update an annotation configuration */
-        put: operations["update_annotation_config_v1_annotation_configs__config_id__put"];
+        put: operations["updateAnnotationConfig"];
         post?: never;
         /** Delete an annotation configuration */
-        delete: operations["delete_annotation_config_v1_annotation_configs__config_id__delete"];
+        delete: operations["deleteAnnotationConfig"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1190,7 +1190,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Annotate Span Documents */
+        /** Create span document annotations */
         post: operations["annotateSpanDocuments"];
         delete?: never;
         options?: never;
@@ -6004,7 +6004,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    list_annotation_configs_v1_annotation_configs_get: {
+    listAnnotationConfigs: {
         parameters: {
             query?: {
                 /** @description Cursor for pagination (base64-encoded annotation config ID) */
@@ -6047,7 +6047,7 @@ export interface operations {
             };
         };
     };
-    create_annotation_config_v1_annotation_configs_post: {
+    createAnnotationConfig: {
         parameters: {
             query?: never;
             header?: never;
@@ -6089,7 +6089,7 @@ export interface operations {
             };
         };
     };
-    get_annotation_config_by_name_or_id_v1_annotation_configs__config_identifier__get: {
+    getAnnotationConfig: {
         parameters: {
             query?: never;
             header?: never;
@@ -6130,7 +6130,7 @@ export interface operations {
             };
         };
     };
-    update_annotation_config_v1_annotation_configs__config_id__put: {
+    updateAnnotationConfig: {
         parameters: {
             query?: never;
             header?: never;
@@ -6175,7 +6175,7 @@ export interface operations {
             };
         };
     };
-    delete_annotation_config_v1_annotation_configs__config_id__delete: {
+    deleteAnnotationConfig: {
         parameters: {
             query?: never;
             header?: never;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -15,10 +15,10 @@ export interface paths {
          * List annotation configurations
          * @description Retrieve a paginated list of all annotation configurations in the system.
          */
-        get: operations["list_annotation_configs_v1_annotation_configs_get"];
+        get: operations["listAnnotationConfigs"];
         put?: never;
         /** Create an annotation configuration */
-        post: operations["create_annotation_config_v1_annotation_configs_post"];
+        post: operations["createAnnotationConfig"];
         delete?: never;
         options?: never;
         head?: never;
@@ -33,7 +33,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get an annotation configuration by ID or name */
-        get: operations["get_annotation_config_by_name_or_id_v1_annotation_configs__config_identifier__get"];
+        get: operations["getAnnotationConfig"];
         put?: never;
         post?: never;
         delete?: never;
@@ -51,10 +51,10 @@ export interface paths {
         };
         get?: never;
         /** Update an annotation configuration */
-        put: operations["update_annotation_config_v1_annotation_configs__config_id__put"];
+        put: operations["updateAnnotationConfig"];
         post?: never;
         /** Delete an annotation configuration */
-        delete: operations["delete_annotation_config_v1_annotation_configs__config_id__delete"];
+        delete: operations["deleteAnnotationConfig"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1190,7 +1190,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Annotate Span Documents */
+        /** Create span document annotations */
         post: operations["annotateSpanDocuments"];
         delete?: never;
         options?: never;
@@ -6004,7 +6004,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    list_annotation_configs_v1_annotation_configs_get: {
+    listAnnotationConfigs: {
         parameters: {
             query?: {
                 /** @description Cursor for pagination (base64-encoded annotation config ID) */
@@ -6047,7 +6047,7 @@ export interface operations {
             };
         };
     };
-    create_annotation_config_v1_annotation_configs_post: {
+    createAnnotationConfig: {
         parameters: {
             query?: never;
             header?: never;
@@ -6089,7 +6089,7 @@ export interface operations {
             };
         };
     };
-    get_annotation_config_by_name_or_id_v1_annotation_configs__config_identifier__get: {
+    getAnnotationConfig: {
         parameters: {
             query?: never;
             header?: never;
@@ -6130,7 +6130,7 @@ export interface operations {
             };
         };
     };
-    update_annotation_config_v1_annotation_configs__config_id__put: {
+    updateAnnotationConfig: {
         parameters: {
             query?: never;
             header?: never;
@@ -6175,7 +6175,7 @@ export interface operations {
             };
         };
     };
-    delete_annotation_config_v1_annotation_configs__config_id__delete: {
+    deleteAnnotationConfig: {
         parameters: {
             query?: never;
             header?: never;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
   "arize-phoenix-evals>=3.1.1",
   "arize-phoenix-otel>=0.16.1",
   "fastapi>=0.137.0",  # 0.137 keeps included routers as a lazy _IncludedRouter tree; older versions raise AssertionError on 204 routes, see https://github.com/Arize-ai/phoenix/issues/12384
-  "fastmcp-slim[server]>=3.4.2",  # server extra powers the in-process MCP server mounted at /mcp; client extra is already pulled transitively by pydantic-ai-slim[mcp]
+  "fastmcp-slim[server,code-mode]>=3.4.2",  # server extra powers the in-process MCP server mounted at /mcp (generated from the v1 OpenAPI routes); code-mode extra provides the pydantic-monty sandbox for the PHOENIX_MCP_CODE_MODE tool surface; client extra is already pulled transitively by pydantic-ai-slim[mcp]
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai,ui]>=2.0.0,<3",
   "bashkit>=0.10.0",
@@ -422,6 +422,13 @@ exclude-newer-package = { arize-phoenix-client = "2099-12-31T00:00:00Z", arize-p
 override-dependencies = [
   "openai>=2.30.0",
   "python-dotenv>=1.1.0",
+  # Security stopgap: fastmcp-slim[code-mode] hard-pins pydantic-monty==0.0.17, which has
+  # an uncatchable in-process stack-overflow DoS in the code-mode sandbox — a
+  # few-thousand-term bool-op/ternary chain segfaults the interpreter at compile time and
+  # crashes the whole Phoenix process (verified end-to-end). 0.0.18 fixes it (monty
+  # #437/#449) with no filesystem-isolation regression. Override fastmcp's exact pin until
+  # a fastmcp-slim release adopts 0.0.18.
+  "pydantic-monty==0.0.18",
 ]
 
 [tool.uv.workspace]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -13,7 +13,7 @@
         ],
         "summary": "List annotation configurations",
         "description": "Retrieve a paginated list of all annotation configurations in the system.",
-        "operationId": "list_annotation_configs_v1_annotation_configs_get",
+        "operationId": "listAnnotationConfigs",
         "parameters": [
           {
             "name": "cursor",
@@ -85,7 +85,7 @@
           "annotation_configs"
         ],
         "summary": "Create an annotation configuration",
-        "operationId": "create_annotation_config_v1_annotation_configs_post",
+        "operationId": "createAnnotationConfig",
         "requestBody": {
           "required": true,
           "content": {
@@ -136,7 +136,7 @@
           "annotation_configs"
         ],
         "summary": "Get an annotation configuration by ID or name",
-        "operationId": "get_annotation_config_by_name_or_id_v1_annotation_configs__config_identifier__get",
+        "operationId": "getAnnotationConfig",
         "parameters": [
           {
             "name": "config_identifier",
@@ -190,7 +190,7 @@
           "annotation_configs"
         ],
         "summary": "Update an annotation configuration",
-        "operationId": "update_annotation_config_v1_annotation_configs__config_id__put",
+        "operationId": "updateAnnotationConfig",
         "parameters": [
           {
             "name": "config_id",
@@ -252,7 +252,7 @@
           "annotation_configs"
         ],
         "summary": "Delete an annotation configuration",
-        "operationId": "delete_annotation_config_v1_annotation_configs__config_id__delete",
+        "operationId": "deleteAnnotationConfig",
         "parameters": [
           {
             "name": "config_id",
@@ -6798,7 +6798,7 @@
         "tags": [
           "spans"
         ],
-        "summary": "Annotate Span Documents",
+        "summary": "Create span document annotations",
         "operationId": "annotateSpanDocuments",
         "parameters": [
           {

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -102,8 +102,19 @@ it off for the whole deployment.
 """
 ENV_PHOENIX_ENABLE_MCP_SERVER = "PHOENIX_ENABLE_MCP_SERVER"
 """
-Whether to mount the in-process MCP server at /mcp. Defaults to True. When
-enabled, the MCP server reuses Phoenix's existing bearer-token authentication.
+Whether to mount the in-process MCP server (generated from the /v1 REST API) at
+/mcp. Defaults to True. When enabled, the MCP server reuses Phoenix's existing
+bearer-token authentication.
+"""
+ENV_PHOENIX_MCP_CODE_MODE = "PHOENIX_MCP_CODE_MODE"
+"""
+Whether the mounted MCP server presents its tools through FastMCP's code-mode
+surface. Defaults to True. Under code mode, clients see discovery meta-tools
+(search, get_schema, tags, list_tools) plus an `execute` tool that runs
+LLM-written Python in a sandbox where `call_tool(name, params)` is the only
+available function. Set to False to present the group-gated progressive-
+disclosure tool list instead. Has no effect unless PHOENIX_ENABLE_MCP_SERVER is
+also set.
 """
 ENV_PHOENIX_WORKING_DIR = "PHOENIX_WORKING_DIR"
 """
@@ -3540,6 +3551,10 @@ def get_env_disable_agent_assistant() -> bool:
 
 def get_env_enable_mcp_server() -> bool:
     return _bool_val(ENV_PHOENIX_ENABLE_MCP_SERVER, True)
+
+
+def get_env_mcp_code_mode() -> bool:
+    return _bool_val(ENV_PHOENIX_MCP_CODE_MODE, True)
 
 
 def get_env_mask_internal_server_errors() -> bool:

--- a/src/phoenix/server/api/routers/v1/annotation_configs.py
+++ b/src/phoenix/server/api/routers/v1/annotation_configs.py
@@ -219,6 +219,7 @@ class SetProjectAnnotationConfigsResponseBody(PaginatedResponseBody[AnnotationCo
 
 @router.get(
     "/annotation_configs",
+    operation_id="listAnnotationConfigs",
     summary="List annotation configurations",
     description="Retrieve a paginated list of all annotation configurations in the system.",
     response_description="A list of annotation configurations with pagination information",
@@ -277,6 +278,7 @@ async def list_annotation_configs(
 
 @router.get(
     "/annotation_configs/{config_identifier}",
+    operation_id="getAnnotationConfig",
     summary="Get an annotation configuration by ID or name",
 )
 async def get_annotation_config_by_name_or_id(
@@ -300,6 +302,7 @@ async def get_annotation_config_by_name_or_id(
 @router.post(
     "/annotation_configs",
     dependencies=[Depends(is_not_locked)],
+    operation_id="createAnnotationConfig",
     summary="Create an annotation configuration",
 )
 async def create_annotation_config(
@@ -335,6 +338,7 @@ async def create_annotation_config(
 @router.put(
     "/annotation_configs/{config_id}",
     dependencies=[Depends(is_not_locked)],
+    operation_id="updateAnnotationConfig",
     summary="Update an annotation configuration",
 )
 async def update_annotation_config(
@@ -380,6 +384,7 @@ async def update_annotation_config(
 
 @router.delete(
     "/annotation_configs/{config_id}",
+    operation_id="deleteAnnotationConfig",
     summary="Delete an annotation configuration",
 )
 async def delete_annotation_config(

--- a/src/phoenix/server/api/routers/v1/documents.py
+++ b/src/phoenix/server/api/routers/v1/documents.py
@@ -38,6 +38,7 @@ class AnnotateSpanDocumentsResponseBody(ResponseBody[list[InsertedSpanDocumentAn
     "/document_annotations",
     dependencies=[Depends(is_not_locked)],
     operation_id="annotateSpanDocuments",
+    summary="Create span document annotations",
     responses=add_errors_to_responses(
         [
             {

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -1155,16 +1155,17 @@ def create_app(
     app.openapi = _openapi  # type: ignore[method-assign]
     mcp_http_app = None
     if mcp_mount_path is not None:
-        # Mount before the static UI ("/") catch-all so requests to the MCP
-        # endpoint are not swallowed by it. The app's lifespan (its session
-        # manager) is entered in ``_lifespan`` above.
+        # Build after ``app.openapi`` is customized so the generated tools mirror
+        # the same /v1 schema, and mount before the static UI ("/") catch-all so
+        # requests to the MCP endpoint are not swallowed by it. The app's
+        # lifespan (its session manager) is entered in ``_lifespan`` above.
         from phoenix.server.mcp_server import (
             BearerAuthGuard,
             MountPathNormalizer,
             create_phoenix_mcp_app,
         )
 
-        mcp_http_app = create_phoenix_mcp_app()
+        mcp_http_app = create_phoenix_mcp_app(app)
         # The guard reads scope["user"], so it is installed exactly when the
         # AuthenticationMiddleware that populates it is (token_store above).
         app.mount(

--- a/src/phoenix/server/bearer_auth.py
+++ b/src/phoenix/server/bearer_auth.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Collection
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from typing import Any, Optional, cast
@@ -33,6 +33,13 @@ from phoenix.server.types import (
     UserId,
 )
 
+#: ASGI scope key under which in-process dispatch (the mounted MCP server calling
+#: back into /v1) places the caller's already-authenticated principal. Scope
+#: entries have no wire representation — an external request can choose its
+#: headers but never its scope keys — so the presence of this key proves the
+#: request was constructed inside this process.
+INTERNAL_PRINCIPAL_SCOPE_KEY = "phoenix.internal.principal"
+
 
 class HasTokenStore(ABC):
     def __init__(self, token_store: CanReadToken) -> None:
@@ -45,6 +52,13 @@ class BearerTokenAuthBackend(HasTokenStore, AuthenticationBackend):
         self,
         conn: HTTPConnection,
     ) -> Optional[tuple[AuthCredentials, BaseUser]]:
+        # In-process dispatch carries the principal that was already authenticated
+        # at the outer request; accepting it directly (instead of replaying the
+        # caller's bearer token) keeps the outer token's audience meaningful — the
+        # internal request is attributed to the acting user without pretending
+        # their token was presented here.
+        if isinstance((principal := conn.scope.get(INTERNAL_PRINCIPAL_SCOPE_KEY)), PhoenixUser):
+            return AuthCredentials(), principal
         if header := conn.headers.get("Authorization"):
             scheme, _, token = header.partition(" ")
             if scheme.lower() != "bearer" or not token:
@@ -148,6 +162,62 @@ class ApiKeyInterceptor(HasTokenStore, AsyncServerInterceptor):
         await context.abort(grpc.StatusCode.UNAUTHENTICATED)
 
 
+def token_audience_permits(claims: UserClaimSet, allowed_resources: Collection[str]) -> bool:
+    """RFC 8707 audience confinement, enforced at resource-access time.
+
+    A token that names no resource (``audience`` is falsy — web-session tokens,
+    API keys, and OAuth2 access tokens minted without a resource indicator) is
+    unscoped and valid at every resource. A token that names one or more
+    resources is valid only where one of them appears in ``allowed_resources``.
+
+    This is the access-time half of RFC 8707: the authorization server binds the
+    audience at issuance, and each resource server checks the presented token was
+    minted for it. Without this check an ``/mcp``-audience token would still
+    authenticate at ``/v1``, since token validity alone does not restrict where a
+    token may be spent.
+    """
+    audience = getattr(claims, "audience", None)
+    if not audience:
+        return True
+    return any(resource in audience for resource in allowed_resources)
+
+
+async def authenticated_claims(conn: HTTPConnection, *, websocket: bool) -> Optional[UserClaimSet]:
+    """Identity and token-status validation shared by the ``/v1`` dependency and
+    the ``/mcp`` guard.
+
+    Returns the connection's claims, or ``None`` for the system user (which
+    carries no token and no audience). Raises 401 when the connection is
+    unauthenticated, expired, or otherwise invalid. Audience confinement is left
+    to the caller, because the acceptable resource differs by endpoint.
+    """
+    if not isinstance((user := conn.user), PhoenixUser):
+        if websocket:
+            raise WebSocketException(code=401, reason="Invalid token")
+        raise HTTPException(status_code=401, detail="Invalid token")
+    if isinstance(user, PhoenixSystemUser):
+        return None
+    claims = user.claims
+    if claims.status is ClaimSetStatus.EXPIRED:
+        if websocket:
+            raise WebSocketException(code=401, reason="Expired token")
+        raise HTTPException(status_code=401, detail="Expired token")
+    if claims.status is not ClaimSetStatus.VALID:
+        if websocket:
+            raise WebSocketException(code=401, reason="Invalid token")
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return claims
+
+
+def _deployment_origin(conn: HTTPConnection) -> str:
+    # Lazy import: oauth2_authorization_server pulls in request-scoped helpers and
+    # importing it at module load risks a cycle. public_origin is env- or
+    # base_url-derived and cheap, and modules are cached after first import.
+    from phoenix.server.oauth2_authorization_server import public_origin
+
+    return public_origin(conn)  # type: ignore[arg-type]  # accepts any HTTPConnection
+
+
 async def is_authenticated(
     # fastapi dependencies require non-optional types
     request: Request = cast(Request, None),
@@ -155,19 +225,33 @@ async def is_authenticated(
 ) -> None:
     """
     Raises a 401 if the request or websocket connection is not authenticated.
+
+    Beyond identity and token status, this enforces RFC 8707 audience confinement
+    against the deployment-origin resource: a token minted for a sub-resource
+    (e.g. the ``/mcp`` endpoint) is rejected here, so an ``/mcp``-audience token
+    cannot be replayed against ``/v1`` or any other origin-scoped surface.
+
+    In-process principal-passing dispatch — the mounted MCP server calling back
+    into ``/v1`` — is exempt: those requests carry ``INTERNAL_PRINCIPAL_SCOPE_KEY``
+    and were already audience-checked at the ``/mcp`` guard, and the principal they
+    forward legitimately carries the ``/mcp`` audience.
     """
     assert request or websocket
-    if request and not isinstance((user := request.user), PhoenixUser):
-        raise HTTPException(status_code=401, detail="Invalid token")
-    if websocket and not isinstance((user := websocket.user), PhoenixUser):
-        raise WebSocketException(code=401, reason="Invalid token")
-    if isinstance(user, PhoenixSystemUser):
-        return
-    claims = user.claims
-    if claims.status is ClaimSetStatus.EXPIRED:
-        raise HTTPException(status_code=401, detail="Expired token")
-    if claims.status is not ClaimSetStatus.VALID:
-        raise HTTPException(status_code=401, detail="Invalid token")
+    conn: HTTPConnection = request if request is not None else websocket
+    is_websocket = request is None
+    claims = await authenticated_claims(conn, websocket=is_websocket)
+    # Only resource-scoped tokens can fail confinement, so derive the origin (and
+    # exempt internal dispatch) only when the token actually names an audience —
+    # unscoped tokens (the common case) skip the origin computation entirely.
+    if (
+        claims is not None
+        and getattr(claims, "audience", None)
+        and INTERNAL_PRINCIPAL_SCOPE_KEY not in conn.scope
+        and not token_audience_permits(claims, (_deployment_origin(conn),))
+    ):
+        if is_websocket:
+            raise WebSocketException(code=401, reason="Token is not valid for this resource")
+        raise HTTPException(status_code=401, detail="Token is not valid for this resource")
 
 
 async def create_access_and_refresh_tokens(

--- a/src/phoenix/server/mcp_server.py
+++ b/src/phoenix/server/mcp_server.py
@@ -1,33 +1,347 @@
-"""In-process MCP server mounted on the Phoenix FastAPI app.
+"""In-process MCP server generated from Phoenix's REST API.
 
-This is the minimal mount: a `FastMCP` server that advertises **no tools** —
-``initialize`` and ``tools/list`` work, and the tool list is empty. Its purpose
-is to demonstrate the authentication chain end to end: an unauthenticated MCP
-client is challenged with an HTTP 401 naming the protected-resource metadata
-(RFC 9728), bootstraps the OAuth flow from it, and connects with the minted
-bearer token. Tool surfaces can be layered on later without touching the auth
-plumbing here.
+This builds a `FastMCP` server whose tools mirror every ``/v1`` REST endpoint and
+returns an ASGI app that ``create_app`` mounts at :data:`MCP_MOUNT_PATH`. Tool
+calls are dispatched back into the Phoenix FastAPI app in-process via an ASGI
+transport (no network hop), so they pass through the same middleware stack that
+guards the REST API. Because the tool surface is derived from the OpenAPI schema,
+it stays in sync with the REST API automatically.
+
+The internal dispatch does not replay the caller's bearer token. The MCP request
+was already authenticated at the mount (``BearerAuthGuard``), so the dispatch
+carries that authenticated principal directly in the internal request's ASGI
+scope (see :class:`_InternalIdentityDispatch`), where ``BearerTokenAuthBackend``
+recognizes it. This keeps the caller's token spendable only where it was
+presented — a prerequisite for enforcing RFC 8707 audience at ``/v1``, since no
+legitimate ``/v1`` traffic carries an ``/mcp``-audience token.
+
+The ``/v1`` API has ~70 operations, which is far too many tools to advertise at
+once without degrading tool selection and wasting context. So the server applies
+*progressive disclosure*: tools are grouped by their REST router tag (``projects``,
+``spans``, ``datasets``, ...); only :data:`_DEFAULT_VISIBLE_GROUPS` are advertised
+initially, and a model reveals the rest on demand by calling ``enable_tool_group``.
+Reveals are scoped to the calling session (FastMCP session-visibility rules), so
+one client unlocking a group never affects another, and a ``tools/list_changed``
+notification is emitted to that session automatically.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
+import httpx
 from fastapi import HTTPException
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.experimental.transforms.code_mode import (
+    CodeMode,
+    GetSchemas,
+    GetTags,
+    GetToolCatalog,
+    ListTools,
+    MontySandboxProvider,
+    Search,
+)
+from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.providers.openapi import MCPType, RouteMap
+from fastmcp.tools.base import Tool
+from mcp.types import ToolAnnotations
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
-from phoenix.server.bearer_auth import is_authenticated
+from phoenix.config import get_env_mcp_code_mode
+from phoenix.server.bearer_auth import (
+    INTERNAL_PRINCIPAL_SCOPE_KEY,
+    PhoenixUser,
+    authenticated_claims,
+    token_audience_permits,
+)
 from phoenix.server.oauth2_authorization_server import public_origin
 from phoenix.server.utils import prepend_root_path
 
 if TYPE_CHECKING:
+    from fastapi import FastAPI
     from fastmcp.server.http import StarletteWithLifespan
     from starlette.types import ASGIApp, Receive, Scope, Send
 
 #: Path the MCP ASGI app is mounted at on the Phoenix FastAPI app.
 MCP_MOUNT_PATH = "/mcp"
+
+#: Tool groups (REST router tags) advertised before any progressive disclosure.
+#: ``projects`` is the natural entry point — list projects, then unlock the data
+#: groups (spans, traces, ...) for the project you care about. Every other group
+#: is hidden until ``enable_tool_group`` reveals it for the session.
+_DEFAULT_VISIBLE_GROUPS = frozenset({"projects"})
+
+#: Tag applied to the progressive-disclosure meta tools so they are never gated.
+_META_TAG = "phoenix-mcp-meta"
+
+# Tools dispatch back into the Phoenix app via an ASGI transport, so this host is
+# never resolved over the network; it only supplies a syntactically valid base URL.
+_INTERNAL_BASE_URL = "http://phoenix-mcp.internal"
+
+# A tool caller here is a non-deterministic model that can be steered by the data it
+# reads, so the safety of a call cannot live in the model's judgement. It has to be
+# legible to the *client*, which can then auto-approve harmless reads and require
+# confirmation before state changes. Tool annotations carry exactly that signal, so we
+# derive them from REST semantics: GET only reads; POST adds a new entity; PUT/PATCH
+# modify an existing one; DELETE removes one. Every /v1 operation acts on Phoenix's own
+# datastore, so none of them reach an "open world" of arbitrary external systems.
+_ANNOTATIONS_BY_METHOD: dict[str, ToolAnnotations] = {
+    "GET": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "POST": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "PUT": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
+    "PATCH": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=False
+    ),
+    "DELETE": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
+}
+
+# An unrecognized verb is treated as the worst case — possibly mutating — so a client
+# confirms rather than silently auto-approving something we could not classify.
+_DEFAULT_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=False, destructiveHint=True, openWorldHint=False
+)
+
+# The progressive-disclosure meta tools only read or adjust which tools are visible in
+# the current session; they never touch Phoenix data, so a client may auto-approve them.
+_META_ANNOTATIONS = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
+
+_DOCSTRING_SECTION = re.compile(
+    r"\n\s*(?:Args|Arguments|Parameters|Returns|Raises|Yields|Example[s]?|Note[s]?)\s*:",
+)
+
+
+def _agent_facing_description(route: Any, component: Any) -> Optional[str]:
+    """A concise, agent-facing description for a generated tool.
+
+    FastMCP builds the tool description from the OpenAPI ``description`` (the endpoint
+    docstring) in preference to the ``summary``. Docstrings here are written for human
+    API consumers: they carry ``Args:``/``Returns:`` sections and source indentation
+    that are noise on a tool surface an agent pays for by the token. Prefer the route's
+    curated one-line ``summary``; when absent, fall back to the first paragraph of the
+    docstring with structured sections and indentation stripped.
+    """
+    summary = (getattr(route, "summary", "") or "").strip()
+    if summary:
+        return summary
+    description = getattr(component, "description", None)
+    if not description:
+        return None
+    lead = _DOCSTRING_SECTION.split(description, maxsplit=1)[0]
+    paragraph = lead.strip().split("\n\n", 1)[0]
+    collapsed = " ".join(line.strip() for line in paragraph.splitlines() if line.strip())
+    return collapsed or None
+
+
+def _strip_schema_titles(node: Any) -> None:
+    """Recursively remove auto-generated ``title`` keys from a JSON schema.
+
+    Pydantic stamps a ``title`` on every field (``"Sync"`` for ``sync``) that only
+    repeats the property name. Across a catalog these dominate the schema an agent must
+    read — one ``get_schema(detail="full")`` on two tools returned 512 ``title`` keys
+    against 14 ``description`` keys. Types, enums, descriptions, and required markers
+    are preserved.
+    """
+    if isinstance(node, dict):
+        node.pop("title", None)
+        for value in node.values():
+            _strip_schema_titles(value)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_schema_titles(item)
+
+
+def _annotate_from_rest_method(route: Any, component: Any) -> None:
+    """Shape each generated tool for an agent audience.
+
+    ``from_openapi`` calls this for every component it generates. All of the shaping is
+    confined to the MCP surface; the human REST docs are untouched.
+
+    1. Stamp read/destructive hints from the HTTP verb, so a destructive ``DELETE``
+       does not look identical to a harmless ``GET`` to the client.
+    2. Replace the docstring-derived description with a concise, agent-facing one drawn
+       from the route summary (see :func:`_agent_facing_description`).
+    3. Strip auto-generated Pydantic ``title`` noise from the input and output schemas.
+    """
+    if not hasattr(component, "annotations"):
+        return
+    method = str(getattr(route, "method", "")).upper()
+    component.annotations = _ANNOTATIONS_BY_METHOD.get(method, _DEFAULT_ANNOTATIONS)
+
+    if (description := _agent_facing_description(route, component)) is not None:
+        component.description = description
+
+    if isinstance(getattr(component, "parameters", None), dict):
+        _strip_schema_titles(component.parameters)
+    if isinstance(getattr(component, "output_schema", None), dict):
+        _strip_schema_titles(component.output_schema)
+
+
+def _current_mcp_principal() -> Optional[PhoenixUser]:
+    """The authenticated user of the MCP request currently being served, if any.
+
+    ``scope["user"]`` is populated by the outer ``AuthenticationMiddleware`` and
+    verified by ``BearerAuthGuard`` before any tool runs; ``get_http_request``
+    resolves that request from ambient context at dispatch time. Returns None when
+    authentication is disabled (no middleware, so no user in the scope) or when
+    there is no live HTTP request to inherit from — e.g. a background task, whose
+    synthetic request snapshots only headers, never the authenticated principal.
+    """
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return None
+    user = request.scope.get("user")
+    return user if isinstance(user, PhoenixUser) else None
+
+
+class _InternalIdentityDispatch:
+    """ASGI wrapper for the in-process MCP→/v1 hop: identity, not token replay.
+
+    Tool calls dispatch into ``/v1`` as new requests, which must authenticate.
+    Replaying the caller's bearer token would satisfy that, but dishonestly: the
+    token's audience is ``/mcp``, and ``/v1`` would be accepting it as if the
+    user's own client had presented it there — which forecloses ever enforcing
+    audience at ``/v1``. Instead, the already-authenticated principal is placed
+    directly in the internal request's ASGI scope, where
+    ``BearerTokenAuthBackend`` accepts it. The scope is the right carrier because
+    it is unforgeable from outside: external requests choose their headers, never
+    their scope keys. The internal request itself carries no Authorization header
+    (``get_http_headers`` strips it, and nothing re-adds it).
+
+    Each MCP HTTP request re-authenticates at the mount, so the principal a tool
+    call runs under is exactly as fresh as the borrowed token would have been.
+    """
+
+    def __init__(self, app: "ASGIApp") -> None:
+        self._app = app
+
+    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+        if scope["type"] == "http" and (principal := _current_mcp_principal()) is not None:
+            scope = {**scope, INTERNAL_PRINCIPAL_SCOPE_KEY: principal}
+        await self._app(scope, receive, send)
+
+
+def _v1_group_sizes(openapi_spec: dict[str, Any]) -> dict[str, int]:
+    """Map each ``/v1`` router tag to the number of operations it contains."""
+    sizes: dict[str, int] = {}
+    for path, operations in openapi_spec.get("paths", {}).items():
+        if not path.startswith("/v1"):
+            continue
+        for operation in operations.values():
+            if not isinstance(operation, dict):
+                continue
+            for tag in operation.get("tags", []):
+                sizes[tag] = sizes.get(tag, 0) + 1
+    return sizes
+
+
+def _install_progressive_disclosure(mcp: FastMCP, openapi_spec: dict[str, Any]) -> None:
+    """Hide non-default tool groups and add meta tools to reveal them on demand."""
+    group_sizes = _v1_group_sizes(openapi_spec)
+    gated = {tag for tag in group_sizes if tag not in _DEFAULT_VISIBLE_GROUPS}
+    if not gated:
+        return
+
+    # Hidden by default; ``enable_tool_group`` re-enables a group per session.
+    mcp.disable(tags=gated)
+
+    groups_doc = "\n".join(f"- {tag} ({group_sizes[tag]} tools)" for tag in sorted(gated))
+
+    @mcp.tool(tags={_META_TAG}, annotations=_META_ANNOTATIONS)
+    async def list_tool_groups() -> dict[str, Any]:
+        """List the Phoenix tool groups that can be revealed for this session.
+
+        Tools are grouped by domain. Only a small default set is visible up front;
+        call ``enable_tool_group`` to reveal a group's tools before using them.
+        """
+        return {
+            "visible_by_default": sorted(_DEFAULT_VISIBLE_GROUPS & set(group_sizes)),
+            "available_to_enable": {tag: group_sizes[tag] for tag in sorted(gated)},
+        }
+
+    @mcp.tool(
+        tags={_META_TAG},
+        annotations=_META_ANNOTATIONS,
+        description=(
+            "Reveal a group of Phoenix tools for the current session, then use the "
+            "newly available tools. Call this before using tools outside the default "
+            f"set. Groups that can be enabled:\n{groups_doc}"
+        ),
+    )
+    async def enable_tool_group(group: str, ctx: Context) -> str:
+        if group not in gated:
+            raise ToolError(
+                f"Unknown tool group {group!r}. Groups that can be enabled: {sorted(gated)}."
+            )
+        await ctx.enable_components(tags={group})
+        return f"Enabled the {group!r} tool group ({group_sizes[group]} tools) for this session."
+
+
+def _read_only(
+    factory: "Callable[[GetToolCatalog], Tool]",
+) -> "Callable[[GetToolCatalog], Tool]":
+    """Stamp read-only annotations on a code-mode discovery tool.
+
+    The built-in discovery factories return unannotated tools; unannotated reads
+    look identical to mutations, so a client cannot safely auto-approve them (the
+    same legibility principle as ``_annotate_from_rest_method``).
+    """
+
+    def build(get_catalog: "GetToolCatalog") -> Tool:
+        tool = factory(get_catalog)
+        tool.annotations = _META_ANNOTATIONS
+        return tool
+
+    return build
+
+
+def _build_code_mode() -> CodeMode:
+    """Code-mode tool surface: discovery meta-tools plus a sandboxed ``execute``.
+
+    Clients see ``search``/``get_schema``/``tags``/``list_tools`` for discovery and
+    an ``execute`` tool that runs LLM-written Python in a pydantic-monty sandbox
+    where ``call_tool(name, params)`` is the only function in scope. ``tags``
+    browses the same REST router tags the group-gated surface uses, so both
+    surfaces share one vocabulary. ``execute`` is deliberately left unannotated:
+    it can invoke mutating tools, and an unannotated tool is treated as
+    possibly-destructive by clients, which is the correct default.
+
+    Sandbox bounds are the fastmcp defaults (30s wall clock, 100 MB memory, and
+    at most 50 ``call_tool`` invocations per ``execute`` block) plus an explicit
+    ``max_recursion_depth`` cap. The recursion cap is defense in depth against
+    Monty's *counted* recursion path; it does not bound native re-entry stack
+    growth (map/filter/sorted key callbacks re-entering the interpreter loop),
+    which overflows the native stack before any counted limit trips — that class
+    of crash is contained only by an out-of-process execution boundary.
+    """
+    return CodeMode(
+        discovery_tools=[
+            _read_only(Search()),
+            _read_only(GetSchemas()),
+            _read_only(GetTags()),
+            _read_only(ListTools()),
+        ],
+        sandbox_provider=MontySandboxProvider(
+            limits={
+                "max_duration_secs": 30.0,
+                "max_memory": 100_000_000,
+                "max_recursion_depth": 200,
+            },
+        ),
+    )
+
 
 #: Well-known path (RFC 9728 path-inserted form) serving the protected-resource
 #: metadata for the MCP endpoint. Served by ``auth_md.py``; referenced here so the
@@ -88,7 +402,19 @@ class BearerAuthGuard:
         # root_path/path reflect the mount, which would corrupt base_url-derived URLs.
         request = Request({**scope, "root_path": "", "path": "/"})
         try:
-            await is_authenticated(request)
+            claims = await authenticated_claims(request, websocket=False)
+            # This mount is the /mcp protected resource. Accept tokens scoped to it
+            # or to the deployment origin (and unscoped tokens: API keys, sessions);
+            # reject a token minted for some other resource. The general
+            # ``is_authenticated`` dependency does the mirror check at /v1, so an
+            # /mcp-audience token is confined here and cannot be replayed there.
+            if claims is not None:
+                origin = public_origin(request)
+                allowed = (origin, f"{origin}{MCP_MOUNT_PATH}")
+                if not token_audience_permits(claims, allowed):
+                    raise HTTPException(
+                        status_code=401, detail="Token is not valid for the MCP resource"
+                    )
         except HTTPException as exc:
             origin = public_origin(request)
             challenge = (
@@ -105,13 +431,44 @@ class BearerAuthGuard:
         await self._app(scope, receive, send)
 
 
-def create_phoenix_mcp_app() -> "StarletteWithLifespan":
-    """Build the (tool-less) MCP server and return its ASGI app.
+def create_phoenix_mcp_app(app: "FastAPI") -> "StarletteWithLifespan":
+    """Build the MCP server from ``app``'s REST API and return its ASGI app.
 
     The returned app's lifespan (its streamable-HTTP session manager) must be
     entered by the caller; mounting alone will not start it.
     """
-    mcp: FastMCP = FastMCP(name="Arize Phoenix")
+    # Tool dispatch authenticates by principal passing, not token replay — see
+    # ``_InternalIdentityDispatch``.
+    client = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=_InternalIdentityDispatch(app)),
+        base_url=_INTERNAL_BASE_URL,
+    )
+    openapi_spec = app.openapi()
+    mcp: FastMCP = FastMCP.from_openapi(
+        openapi_spec=openapi_spec,
+        client=client,
+        name="Arize Phoenix",
+        route_maps=[
+            # Expose every REST endpoint under /v1 as a tool; exclude everything
+            # else (GraphQL is mounted separately; health/version routes are not
+            # useful to MCP clients).
+            RouteMap(pattern=r"^/v1/", mcp_type=MCPType.TOOL),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+        # Make each tool's read/write nature legible to the client (see
+        # ``_annotate_from_rest_method``); unannotated tools hide that a mutation is
+        # a mutation.
+        mcp_component_fn=_annotate_from_rest_method,
+    )
+    if get_env_mcp_code_mode():
+        # Code mode replaces the tool surface wholesale: clients see only the
+        # discovery meta-tools and ``execute``. Group gating must NOT be installed
+        # with it — the code-mode catalog respects tool visibility, so gating would
+        # hide every non-default group from ``search``/``list_tools`` with no way
+        # to reveal them.
+        mcp.add_transform(_build_code_mode())
+    else:
+        _install_progressive_disclosure(mcp, openapi_spec)
     # path="/" because the app is mounted at MCP_MOUNT_PATH; the endpoint then
     # resolves to MCP_MOUNT_PATH itself rather than MCP_MOUNT_PATH + "/mcp".
     return mcp.http_app(path="/")

--- a/tests/integration/auth/conftest.py
+++ b/tests/integration/auth/conftest.py
@@ -474,6 +474,11 @@ def _env(
         # exercises it directly, and every other test doubles as evidence that
         # the mount does not interfere with the rest of the surface.
         "PHOENIX_ENABLE_MCP_SERVER": "true",
+        # Pin the group-gated progressive-disclosure surface for the shared
+        # package app. Code mode is the global default, but it replaces the tool
+        # surface wholesale, so the package app keeps the group-gated list;
+        # _app_mcp_code_mode is the dedicated fixture that opts into code mode.
+        "PHOENIX_MCP_CODE_MODE": "false",
     }
 
 

--- a/tests/integration/auth/test_mcp.py
+++ b/tests/integration/auth/test_mcp.py
@@ -6,9 +6,9 @@ HTTP 401 whose WWW-Authenticate header names the protected-resource metadata —
 signal MCP clients bootstrap their OAuth flow from; (2) the path-inserted RFC 9728
 document describes /mcp as the resource and Phoenix as its authorization server;
 (3) the authorization-code flow accepts the MCP endpoint as an RFC 8707 resource
-indicator, and the minted token authorizes a real MCP session end to end. The
-server advertises no tools yet, so the authenticated session is verified through
-``initialize`` and an empty ``tools/list``.
+indicator, and the minted token authorizes real MCP tool calls end to end. The
+resource indicator is also binding: a code or grant authorized for /mcp cannot be
+redeemed or refreshed for a different resource.
 
 These tests run against the package-scoped ``_app`` (which enables the MCP mount —
 see the package ``_env`` fixture), so they execute on the same database backend as
@@ -18,7 +18,7 @@ the rest of the suite (SQLite or PostgreSQL per ``CI_TEST_DB_BACKEND``).
 from __future__ import annotations
 
 from secrets import token_hex
-from typing import Any
+from typing import Any, Iterator
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -31,9 +31,10 @@ from tests.integration._helpers import (
     _get_ssl_context,
     _GetUser,
     _httpx_client,
+    _server,
 )
 
-from .conftest import _OAuthPublicClient
+from .conftest import _oauth2_app_env, _OAuthPublicClient
 
 
 def _base_url(app: _AppInfo) -> str:
@@ -111,7 +112,7 @@ class TestMcpProtectedResourceMetadata:
 
 
 class TestMcpResourceIndicator:
-    async def test_flow_with_mcp_resource_mints_token_that_authorizes_a_session(
+    async def test_flow_with_mcp_resource_mints_token_that_authorizes_tool_calls(
         self,
         _app: _AppInfo,
         _get_user: _GetUser,
@@ -132,11 +133,61 @@ class TestMcpResourceIndicator:
             verify=_get_ssl_context(_app.env) or False,
         )
         async with Client(transport) as mcp_client:
-            # Entering the client runs `initialize`, which the unauthenticated
-            # tests above show is rejected without a token. The server advertises
-            # no tools yet, so the authenticated session proves itself through an
-            # empty tools/list rather than a tool call.
-            assert await mcp_client.list_tools() == []
+            tool_names = {tool.name for tool in await mcp_client.list_tools()}
+            assert "getProjects" in tool_names  # the default-visible tool group
+            result = await mcp_client.call_tool("getProjects", {})
+        # The tool call dispatched in-process to GET /v1/projects under the granted
+        # user's identity; the database contains the "default" project.
+        text = "".join(getattr(block, "text", "") for block in result.content)
+        assert '"default"' in text
+
+    async def test_mcp_audience_token_is_rejected_at_v1(
+        self,
+        _app: _AppInfo,
+        _get_user: _GetUser,
+    ) -> None:
+        """RFC 8707 audience confinement at access time: a token minted for the
+        /mcp resource authenticates at /mcp but must be rejected if presented
+        directly to the /v1 REST API, so it cannot be replayed against the broader
+        surface. Audience is bound at issuance; this asserts it is also enforced at
+        the resource server, not only at the token endpoint."""
+        mcp_url = f"{_base_url(_app)}/mcp"
+        oauth_client = _register_public_client(_app, resource=mcp_url)
+        user = _get_user(_app, _MEMBER).log_in(_app)
+        access_token = oauth_client.complete_flow(user)["access_token"]
+
+        # The token is valid at the resource it was minted for.
+        transport = StreamableHttpTransport(
+            mcp_url,
+            headers={"Authorization": f"Bearer {access_token}"},
+            verify=_get_ssl_context(_app.env) or False,
+        )
+        async with Client(transport) as mcp_client:
+            assert await mcp_client.list_tools()
+
+        # The same otherwise-valid token is rejected at /v1: its audience is /mcp.
+        response = _httpx_client(_app).get(
+            "v1/projects", headers={"Authorization": f"Bearer {access_token}"}
+        )
+        assert response.status_code == 401
+
+    async def test_unscoped_token_is_accepted_at_v1(
+        self,
+        _app: _AppInfo,
+        _get_user: _GetUser,
+    ) -> None:
+        """Regression: a token minted with no resource indicator is unscoped and
+        must still authenticate at /v1 — audience confinement rejects only tokens
+        bound to a different resource, never unscoped tokens (API keys, sessions,
+        plain OAuth access tokens)."""
+        oauth_client = _register_public_client(_app)
+        user = _get_user(_app, _MEMBER).log_in(_app)
+        access_token = oauth_client.complete_flow(user)["access_token"]
+
+        response = _httpx_client(_app).get(
+            "v1/projects", headers={"Authorization": f"Bearer {access_token}"}
+        )
+        assert response.status_code == 200
 
     def test_code_authorized_for_mcp_cannot_mint_tokens_for_another_resource(
         self,
@@ -282,3 +333,61 @@ class TestMcpResourceIndicator:
         location = response.headers["location"]
         assert location.startswith(oauth_client.redirect_uri)
         assert parse_qs(urlparse(location).query)["error"] == ["invalid_target"]
+
+
+@pytest.fixture(scope="module")
+def _app_mcp_code_mode(
+    _ports: Iterator[int],
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[_AppInfo]:
+    """A server with auth, the /mcp mount, and PHOENIX_MCP_CODE_MODE all enabled.
+
+    Code mode replaces the tool surface, so it cannot share the package app.
+    SQLite only: the code-mode surface is request plumbing over the same /v1
+    paths the package app already exercises on both backends.
+    """
+    env = _oauth2_app_env(
+        port=next(_ports),
+        grpc_port=next(_ports),
+        database=str(tmp_path_factory.mktemp("oauth2_mcp_code_mode") / "phoenix.db"),
+        extra={
+            "PHOENIX_ENABLE_MCP_SERVER": "true",
+            "PHOENIX_MCP_CODE_MODE": "true",
+            "PHOENIX_DISABLE_RATE_LIMIT": "true",
+        },
+    )
+    with _server(_AppInfo(env)) as app:
+        yield app
+
+
+class TestMcpCodeMode:
+    async def test_oauth_token_drives_sandboxed_execute_end_to_end(
+        self,
+        _app_mcp_code_mode: _AppInfo,
+        _get_user: _GetUser,
+    ) -> None:
+        """The full code-mode chain under auth: OAuth token -> discovery meta-tools
+        -> execute -> sandboxed call_tool -> in-process /v1 dispatch. If the
+        caller's authenticated identity did not propagate into the sandbox's tool
+        calls, the /v1 dispatch would 401 and execute would fail."""
+        app = _app_mcp_code_mode
+        mcp_url = f"{_base_url(app)}/mcp"
+        oauth_client = _register_public_client(app, resource=mcp_url)
+        user = _get_user(app, _MEMBER).log_in(app)
+        token_response = oauth_client.complete_flow(user)
+
+        transport = StreamableHttpTransport(
+            mcp_url,
+            headers={"Authorization": f"Bearer {token_response['access_token']}"},
+            verify=_get_ssl_context(app.env) or False,
+        )
+        async with Client(transport) as mcp_client:
+            tool_names = {tool.name for tool in await mcp_client.list_tools()}
+            assert tool_names == {"search", "get_schema", "tags", "list_tools", "execute"}
+
+            result = await mcp_client.call_tool(
+                "execute",
+                {"code": 'return await call_tool("getProjects", {})'},
+            )
+        text = "".join(getattr(block, "text", "") for block in result.content)
+        assert '"default"' in text

--- a/tests/unit/server/test_app_mcp_mount.py
+++ b/tests/unit/server/test_app_mcp_mount.py
@@ -1,14 +1,14 @@
 """Tests for the in-process MCP server mounted at ``/mcp``.
 
-The MCP server advertises no tools and is mounted only when
-``PHOENIX_ENABLE_MCP_SERVER`` is enabled. Its session-manager lifespan must
-start during app startup, and the mounted endpoint must speak the MCP protocol.
+The MCP server is generated from the ``/v1`` REST API and mounted only when
+``PHOENIX_ENABLE_MCP_SERVER`` is enabled. Its session-manager lifespan must start
+during app startup, and its tool surface must mirror the ``/v1`` routes.
 """
 
 from __future__ import annotations
 
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 import httpx
 import pytest
@@ -16,8 +16,16 @@ from asgi_lifespan import LifespanManager
 from pydantic import SecretStr
 
 from phoenix.server.app import create_app
+from phoenix.server.bearer_auth import INTERNAL_PRINCIPAL_SCOPE_KEY, PhoenixUser
 from phoenix.server.mcp_server import MCP_MOUNT_PATH, MountPathNormalizer
-from phoenix.server.types import DbSessionFactory
+from phoenix.server.types import (
+    AccessTokenAttributes,
+    AccessTokenClaims,
+    AccessTokenId,
+    DbSessionFactory,
+    RefreshTokenId,
+    UserId,
+)
 from tests.unit.conftest import (
     TestBulkInserter,
     patch_batched_caller,
@@ -47,14 +55,15 @@ async def test_mcp_server_not_mounted_by_default(
         assert not any(getattr(r, "path", None) == MCP_MOUNT_PATH for r in app.routes)
 
 
-async def test_mcp_server_mounts_and_lifespan_starts(
+async def test_mcp_code_mode_replaces_tool_surface(
     db: DbSessionFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With the flag on, the MCP app is mounted, its lifespan starts, and the
-    endpoint speaks the MCP protocol (initialize succeeds; the tool list is
-    empty by design)."""
+    """With PHOENIX_MCP_CODE_MODE on, clients see only the discovery meta-tools and
+    ``execute``; the generated /v1 tools are reachable through the sandbox's
+    ``call_tool`` rather than tools/list, and group gating is not installed."""
     monkeypatch.setattr("phoenix.server.app.get_env_enable_mcp_server", lambda: True)
+    monkeypatch.setattr("phoenix.server.mcp_server.get_env_mcp_code_mode", lambda: True)
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(patch_batched_caller())
         await stack.enter_async_context(patch_grpc_server())
@@ -64,14 +73,8 @@ async def test_mcp_server_mounts_and_lifespan_starts(
             serve_ui=False,
             bulk_inserter_factory=TestBulkInserter,
         )
-        assert app.state.mcp_http_app is not None
-        assert any(getattr(r, "path", None) == MCP_MOUNT_PATH for r in app.routes)
-
-        # Startup must enter the MCP session-manager lifespan without error.
         await stack.enter_async_context(LifespanManager(app))
 
-        # Drive the mounted endpoint in-process over the real protocol via an
-        # ASGITransport-backed client.
         import httpx
         from fastmcp import Client
         from fastmcp.client.transports import StreamableHttpTransport
@@ -87,7 +90,6 @@ async def test_mcp_server_mounts_and_lifespan_starts(
                 transport=httpx.ASGITransport(app=app),
                 base_url="http://testserver",
                 headers=headers,
-                auth=auth,
                 follow_redirects=follow_redirects,
             )
 
@@ -96,7 +98,111 @@ async def test_mcp_server_mounts_and_lifespan_starts(
             httpx_client_factory=_factory,
         )
         async with Client(transport) as client:
-            assert await client.list_tools() == []
+            tools = {t.name: t for t in await client.list_tools()}
+            assert set(tools) == {"search", "get_schema", "tags", "list_tools", "execute"}
+
+            # Discovery tools are reads and say so; execute can invoke mutating
+            # tools, so it stays unannotated (treated as possibly destructive).
+            for name in ("search", "get_schema", "tags", "list_tools"):
+                assert tools[name].annotations is not None, f"{name} is missing annotations"
+                assert tools[name].annotations.readOnlyHint is True
+            assert tools["execute"].annotations is None
+
+            # Discovery browses the same REST router tags the gated surface uses.
+            tags_result = await client.call_tool("tags", {})
+            assert "projects" in tags_result.content[0].text
+
+            # The sandbox reaches the generated /v1 tools via call_tool.
+            result = await client.call_tool(
+                "execute",
+                {"code": 'return await call_tool("getProjects", {})'},
+            )
+            assert "data" in result.content[0].text
+
+
+async def test_mcp_server_mounts_and_lifespan_starts(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the flag on, the MCP app is mounted, its lifespan starts, and its
+    tools are generated from the /v1 REST routes."""
+    monkeypatch.setattr("phoenix.server.app.get_env_enable_mcp_server", lambda: True)
+    # This test asserts the group-gated progressive-disclosure surface, which is
+    # not the default (code mode is); pin it off so the assertions hold.
+    monkeypatch.setattr("phoenix.server.mcp_server.get_env_mcp_code_mode", lambda: False)
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        app = create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+        assert app.state.mcp_http_app is not None
+        assert any(getattr(r, "path", None) == MCP_MOUNT_PATH for r in app.routes)
+
+        # Startup must enter the MCP session-manager lifespan without error.
+        await stack.enter_async_context(LifespanManager(app))
+
+        # Tools are generated from the /v1 schema. Drive the mounted endpoint
+        # in-process over the real protocol via an ASGITransport-backed client.
+        import httpx
+        from fastmcp import Client
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        def _factory(
+            headers: dict[str, str] | None = None,
+            timeout: httpx.Timeout | None = None,
+            auth: httpx.Auth | None = None,
+            # fastmcp passes this beyond the McpHttpClientFactory protocol.
+            follow_redirects: bool = True,
+        ) -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+                headers=headers,
+                follow_redirects=follow_redirects,
+            )
+
+        transport = StreamableHttpTransport(
+            url=f"http://testserver{MCP_MOUNT_PATH}",
+            httpx_client_factory=_factory,
+        )
+        async with Client(transport) as client:
+            visible = {t.name for t in await client.list_tools()}
+            assert visible, "expected MCP tools generated from the /v1 REST API"
+
+            # Progressive disclosure: only the default group + meta tools show up;
+            # gated groups (e.g. spans) are hidden until revealed.
+            assert "enable_tool_group" in visible
+            assert "list_tool_groups" in visible
+            assert not any("span" in name.lower() for name in visible), (
+                "gated groups must be hidden by default"
+            )
+
+            # Every tool advertises its read/write nature so a client can gate calls.
+            tools = {t.name: t for t in await client.list_tools()}
+            for name, tool in tools.items():
+                assert tool.annotations is not None, f"{name} is missing tool annotations"
+                assert tool.annotations.readOnlyHint is not None, (
+                    f"{name} does not declare whether it is read-only"
+                )
+            # The meta tools never touch Phoenix data, so they are read-only.
+            assert tools["list_tool_groups"].annotations.readOnlyHint is True
+            assert tools["enable_tool_group"].annotations.readOnlyHint is True
+
+            # Revealing a group exposes its tools for this session only.
+            await client.call_tool("enable_tool_group", {"group": "spans"})
+            after_tools = {t.name: t for t in await client.list_tools()}
+            assert set(after_tools) > visible, "enabling a group must reveal additional tools"
+            # Read endpoints (GET) are marked read-only; mutating ones are not.
+            span_reads = [
+                t
+                for n, t in after_tools.items()
+                if "span" in n.lower() and t.annotations and t.annotations.readOnlyHint
+            ]
+            assert span_reads, "expected at least one read-only span tool after revealing the group"
 
 
 class TestMountPathNormalizer:
@@ -229,3 +335,76 @@ class TestMcpCors:
         exposed = resp.headers["access-control-expose-headers"]
         assert "WWW-Authenticate" in exposed
         assert "Mcp-Session-Id" in exposed
+
+
+class TestInternalIdentityDispatch:
+    """The MCP→/v1 hop authenticates by principal passing, not token replay."""
+
+    @staticmethod
+    def _phoenix_user() -> PhoenixUser:
+        user_id = UserId(1)
+        claims = AccessTokenClaims(
+            subject=user_id,
+            token_id=AccessTokenId(1),
+            attributes=AccessTokenAttributes(
+                user_role="MEMBER",
+                refresh_token_id=RefreshTokenId(1),
+            ),
+        )
+        return PhoenixUser(user_id, claims)
+
+    @staticmethod
+    async def _receive() -> dict[str, Any]:
+        return {}
+
+    @staticmethod
+    async def _send(message: Any) -> None:
+        return None
+
+    async def test_stamps_the_mcp_callers_principal_onto_the_internal_scope(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from starlette.requests import Request
+
+        from phoenix.server import mcp_server
+        from phoenix.server.mcp_server import _InternalIdentityDispatch
+
+        principal = self._phoenix_user()
+        mcp_request = Request({"type": "http", "headers": [], "user": principal})
+        monkeypatch.setattr(mcp_server, "get_http_request", lambda: mcp_request)
+
+        seen: list[dict[str, object]] = []
+
+        async def inner(scope: Any, receive: Any, send: Any) -> None:
+            seen.append(scope)
+
+        original_scope: dict[str, object] = {"type": "http", "headers": []}
+        await _InternalIdentityDispatch(inner)(original_scope, self._receive, self._send)
+
+        assert seen[0][INTERNAL_PRINCIPAL_SCOPE_KEY] is principal
+        # The caller's scope object is never mutated — the stamp is a copy.
+        assert INTERNAL_PRINCIPAL_SCOPE_KEY not in original_scope
+
+    async def test_no_live_mcp_request_means_no_principal_is_stamped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from phoenix.server import mcp_server
+        from phoenix.server.mcp_server import _InternalIdentityDispatch
+
+        def raise_no_request() -> None:
+            raise RuntimeError("No active HTTP request found.")
+
+        monkeypatch.setattr(mcp_server, "get_http_request", raise_no_request)
+
+        seen: list[dict[str, object]] = []
+
+        async def inner(scope: Any, receive: Any, send: Any) -> None:
+            seen.append(scope)
+
+        await _InternalIdentityDispatch(inner)(
+            {"type": "http", "headers": []}, self._receive, self._send
+        )
+
+        assert INTERNAL_PRINCIPAL_SCOPE_KEY not in seen[0]

--- a/tests/unit/server/test_bearer_auth.py
+++ b/tests/unit/server/test_bearer_auth.py
@@ -1,1 +1,123 @@
+"""Unit tests for bearer-token authentication.
 
+Covers the in-process principal path: internal dispatch (the mounted MCP server
+calling back into /v1) authenticates by placing an already-authenticated
+``PhoenixUser`` in the ASGI scope rather than replaying the caller's bearer
+token. The backend must accept exactly that — a ``PhoenixUser`` under the scope
+key — and nothing an external request could fabricate, since external requests
+control headers but never scope keys.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from starlette.requests import HTTPConnection
+
+from phoenix.server.bearer_auth import (
+    INTERNAL_PRINCIPAL_SCOPE_KEY,
+    BearerTokenAuthBackend,
+    PhoenixUser,
+    token_audience_permits,
+)
+from phoenix.server.types import (
+    AccessTokenAttributes,
+    AccessTokenClaims,
+    AccessTokenId,
+    RefreshTokenId,
+    UserId,
+)
+
+
+def _phoenix_user() -> PhoenixUser:
+    user_id = UserId(1)
+    claims = AccessTokenClaims(
+        subject=user_id,
+        token_id=AccessTokenId(1),
+        attributes=AccessTokenAttributes(
+            user_role="MEMBER",
+            refresh_token_id=RefreshTokenId(1),
+        ),
+    )
+    return PhoenixUser(user_id, claims)
+
+
+def _connection(
+    *,
+    scope_extra: dict[str, object] | None = None,
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> HTTPConnection:
+    scope = {
+        "type": "http",
+        "headers": headers or [],
+        **(scope_extra or {}),
+    }
+    return HTTPConnection(scope)
+
+
+async def test_internal_principal_in_scope_authenticates_without_a_token_read() -> None:
+    token_store = MagicMock()
+    backend = BearerTokenAuthBackend(token_store)
+    principal = _phoenix_user()
+
+    result = await backend.authenticate(
+        _connection(scope_extra={INTERNAL_PRINCIPAL_SCOPE_KEY: principal})
+    )
+
+    assert result is not None
+    _, user = result
+    # The internal request runs as the very principal authenticated at the outer
+    # request — same object, no second token-store round trip.
+    assert user is principal
+    token_store.read.assert_not_called()
+
+
+async def test_internal_principal_key_sent_as_header_does_not_authenticate() -> None:
+    """The scope key's spelling arriving as an HTTP header must mean nothing.
+
+    External requests can put any name in a header, but only in-process code can
+    put a key in the ASGI scope — that asymmetry is the entire security argument
+    for principal passing, so pin it."""
+    backend = BearerTokenAuthBackend(MagicMock())
+
+    result = await backend.authenticate(
+        _connection(headers=[(INTERNAL_PRINCIPAL_SCOPE_KEY.encode(), b"anything")])
+    )
+
+    assert result is None
+
+
+async def test_non_phoenix_user_under_internal_principal_key_is_ignored() -> None:
+    backend = BearerTokenAuthBackend(MagicMock())
+
+    result = await backend.authenticate(
+        _connection(scope_extra={INTERNAL_PRINCIPAL_SCOPE_KEY: "not-a-user"})
+    )
+
+    assert result is None
+
+
+def _claims_with_audience(audience: object) -> MagicMock:
+    claims = MagicMock()
+    claims.audience = audience
+    return claims
+
+
+def test_token_audience_permits_unscoped_token_valid_everywhere() -> None:
+    """A token with no audience (None or empty) is unscoped and valid at any
+    resource: API keys, web sessions, and OAuth tokens minted without a resource
+    indicator must never be rejected by audience confinement."""
+    origin = "https://phoenix.example"
+    assert token_audience_permits(_claims_with_audience(None), (origin,))
+    assert token_audience_permits(_claims_with_audience([]), (origin,))
+
+
+def test_token_audience_permits_confines_a_scoped_token_to_its_resource() -> None:
+    """A resource-scoped token is valid only where one of its audiences is
+    allowed. The /mcp guard allows {origin, origin/mcp}; the /v1 dependency allows
+    {origin} only, which is what rejects an /mcp token replayed at /v1."""
+    origin = "https://phoenix.example"
+    mcp = "https://phoenix.example/mcp"
+    assert token_audience_permits(_claims_with_audience([mcp]), (origin, mcp))
+    assert not token_audience_permits(_claims_with_audience([mcp]), (origin,))
+    assert token_audience_permits(_claims_with_audience([origin]), (origin,))

--- a/uv.lock
+++ b/uv.lock
@@ -32,6 +32,7 @@ members = [
 ]
 overrides = [
     { name = "openai", specifier = ">=2.30.0" },
+    { name = "pydantic-monty", specifier = "==0.0.18" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
 ]
 
@@ -369,16 +370,16 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.14.1"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -492,7 +493,7 @@ dependencies = [
     { name = "cachetools" },
     { name = "email-validator" },
     { name = "fastapi" },
-    { name = "fastmcp-slim", extra = ["server"] },
+    { name = "fastmcp-slim", extra = ["code-mode", "server"] },
     { name = "grpc-interceptor" },
     { name = "grpcio" },
     { name = "httpx" },
@@ -720,7 +721,7 @@ requires-dist = [
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=0.0.12" },
     { name = "email-validator" },
     { name = "fastapi", specifier = ">=0.137.0" },
-    { name = "fastmcp-slim", extras = ["server"], specifier = ">=3.4.2" },
+    { name = "fastmcp-slim", extras = ["code-mode", "server"], specifier = ">=3.4.2" },
     { name = "google-genai", marker = "python_full_version >= '3.10' and extra == 'container'", specifier = ">=1.50.0" },
     { name = "google-genai", marker = "python_full_version < '3.10' and extra == 'container'" },
     { name = "grpc-interceptor" },
@@ -2219,6 +2220,9 @@ client = [
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "starlette" },
 ]
+code-mode = [
+    { name = "pydantic-monty" },
+]
 server = [
     { name = "authlib" },
     { name = "cyclopts" },
@@ -2926,15 +2930,15 @@ name = "huggingface-hub"
 version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "filelock", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "hf-xet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and platform_machine == 'x86_64') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'win32') or (platform_machine == 'amd64' and sys_platform == 'win32') or (platform_machine == 'arm64' and sys_platform == 'win32') or (platform_machine == 'x86_64' and sys_platform == 'win32')" },
-    { name = "httpx", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "packaging", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "tqdm", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.14'" },
+    { name = "hf-xet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/8f/999e4dda11c6187c78f090eac00895a47e11a0049308f07579bcb7aa3aa2/huggingface_hub-1.23.0.tar.gz", hash = "sha256:c04997fb8bbdace1e57b7703d30ed7678af51f70d00d241819ff411b92ae9a88", size = 919163, upload-time = "2026-07-09T14:49:32.315Z" }
 wheels = [
@@ -2976,7 +2980,7 @@ name = "importlib-metadata"
 version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "zipp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
@@ -3844,18 +3848,18 @@ name = "litellm"
 version = "1.92.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "click", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "fastuuid", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "httpx", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "jsonschema", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "openai", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "pydantic", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "tiktoken", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
-    { name = "tokenizers", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "fastuuid", marker = "python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "jsonschema", marker = "python_full_version < '3.14'" },
+    { name = "openai", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
+    { name = "tiktoken", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/ea/5522be7e0dbcaa7c3fddfd2834f387c6e8eab47c0cc65f2a74657c815af7/litellm-1.92.0.tar.gz", hash = "sha256:773adf5503ee1793289689c899394a83df8122993760d9acd782e32aa798db9d", size = 15098143, upload-time = "2026-07-12T01:15:59.828Z" }
 wheels = [
@@ -6016,6 +6020,77 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-monty"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/5b/bb6a8bfdf13eb9808c966bdac064a40ce9ac881ec6d64dba3e055888f22b/pydantic_monty-0.0.18.tar.gz", hash = "sha256:c43794c7c4664fa1403d4841459d0e23f01b4f552283db638f5b40ced4dac6a1", size = 1197105, upload-time = "2026-05-29T08:31:41.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/74/36d50926a7b53b85723960fad50b34b5fc8da79cc8f6091a1f1b44a02b79/pydantic_monty-0.0.18-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:857b62bfc6f06cd9853d4fc51011391e0431187fe9d08034ae24eafcb797c60a", size = 8464519, upload-time = "2026-05-29T08:30:49.301Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7b/941e3c9c4816864a2c260df63d3be36c523022732154d2853e5376fcf1e1/pydantic_monty-0.0.18-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65918fac0835109de6f725069d0aa35b7454c26809634d5344d7b26686754381", size = 8719689, upload-time = "2026-05-29T08:30:27.115Z" },
+    { url = "https://files.pythonhosted.org/packages/31/20/84cfdf92732651e68aa52d846a22ae573294241b4aa75ae84c0b3d2782b0/pydantic_monty-0.0.18-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c5bee11eecbadf03b2e764feb11fdea12a6b176bf071bb2fa922a23a704a83b4", size = 9042115, upload-time = "2026-05-29T08:29:18.039Z" },
+    { url = "https://files.pythonhosted.org/packages/23/dc/e3dcdef2d0dc09751ed054c69c2363e05d94c985994197ce5748b22b8799/pydantic_monty-0.0.18-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de65d5a8c7ba74794d7f50dfa0b36014931abe2a5abe1a48778afc1bb7dd5d60", size = 8171553, upload-time = "2026-05-29T08:30:51.772Z" },
+    { url = "https://files.pythonhosted.org/packages/61/93/45d2b8867f74ddff0a45b96e78d1ff5bdd4bfcd68f6fd622009096b4324c/pydantic_monty-0.0.18-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8694f0897d611d6f81901eee31d5c73c6d677cd50efe95368b40e1dc1d034e8a", size = 8586169, upload-time = "2026-05-29T08:29:58.806Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2c/e46629bf65a4017e905db9b87158253869d329cb884604be78e74c0e3d88/pydantic_monty-0.0.18-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dcd3286f6b74a959acd32cdb4c3f0a423f91ff6d7775a08315091766f74a76dc", size = 9181554, upload-time = "2026-05-29T08:31:03.712Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f6/91af3acf83fe6b156134e90e7739ff167247d7a48aa53735b3b6a050a335/pydantic_monty-0.0.18-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aa2cc2dda0c7a271c6b0792ce7e60dd0bc5114263b83dccb147c6d0c88d28614", size = 9286056, upload-time = "2026-05-29T08:30:17.643Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/71/1b008c633a4767e518e4aebfd79eb1c2c20259282853b6967373d70ca0f9/pydantic_monty-0.0.18-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e87e5953fe1ad15f9e67c5dc590ae240889da28bc84c344e255579d4f33281f5", size = 9266143, upload-time = "2026-05-29T08:30:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c5/d2b44995729c884f682e499fea134f7b19883b3414c077431d80dc222802/pydantic_monty-0.0.18-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:83b82b7c235943081b31eb9a4c8a4af961640cfbc5b7d3a97dda1bf3efd83cff", size = 8350637, upload-time = "2026-05-29T08:30:20.061Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/7d/8326aca20b563cf656a2d7e52fca1ec98c9b2cde67eba06ecebffb5b73f7/pydantic_monty-0.0.18-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0526e5222cbb4cd0a253f49bfcf851dc87984b39d2a5e4eb041d8ce7d1b6987a", size = 8900794, upload-time = "2026-05-29T08:31:24.604Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a6/f62f187a1327ae3bf101de44439b62508da7895ca63c38295115c12a1006/pydantic_monty-0.0.18-cp310-cp310-win32.whl", hash = "sha256:668a4502e9bd67c7bb5d2c4c9d153e9f798d4f5f452845b9a72aaa1f8ce86ab8", size = 8280979, upload-time = "2026-05-29T08:30:47.128Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/62/455b679f3b5c00caf362b2388d8a191889f2496f834500989be404175997/pydantic_monty-0.0.18-cp310-cp310-win_amd64.whl", hash = "sha256:12c2ac68f2a12ac68bcd51beb1bf6c2e5fd81061584fd5a826d3454fc9220e36", size = 9482422, upload-time = "2026-05-29T08:31:10.421Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/50/06720fb35b73993aa9964403eff1ab35b1d7bd0db1b1ee0633e19311e254/pydantic_monty-0.0.18-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5140382a6ea68778c76f04ccb91fdbfd1a77b8cae3a89534e23a0e5afaf21e75", size = 8464367, upload-time = "2026-05-29T08:29:46.855Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8e/b3946ee663349fb35f9dceddf1aed394b8e5df1d8767b840844db9cee515/pydantic_monty-0.0.18-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421d1b7956e06a22dc13fe6a34bebf3a1bdde8cf78616eded018f7a9ca746295", size = 8718281, upload-time = "2026-05-29T08:31:06.121Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3f/9fb2e8d0ed660d0e5b281316be0c1cb1a023b156c02a8dc8a2c3ec007af7/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6609de4408ad54387ecd0b3eedce796497ee72c6ec888074519afcd4f6959a81", size = 9041289, upload-time = "2026-05-29T08:29:33.062Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/5e/cb242ba7bd63985eee94f0dff8864002bb5ded2da7190e73786ddcd5b4e8/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd2b37890d8a948606be184bd6e3fa4e445d26e3c7329c6a451a271bfc470f24", size = 8170676, upload-time = "2026-05-29T08:29:38.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/d144775ea57b813e97aef9edaf5f867fb82960597af517125e1b513c983c/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:19b86e4fc4b73c2c925906bbc31488b9e8b99b54101f8ea7bbdccfd60ded38f0", size = 8585337, upload-time = "2026-05-29T08:31:27.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/6291a4871fbdb8dfa66d1b1f2406c11066757caa1c53092320e5d11ea49d/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4de83f38b3658152697c524ea87ce307a13701d807801c9be27870e837829a02", size = 9181594, upload-time = "2026-05-29T08:31:36.736Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/00/28879cee77e24f70c756c4603b4a21b013e601b7821bd07e06cf6718b75a/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef3aaa4fb7af8fd84f42df5e1e43d7ff3eae7d81314580462c8ca716e7e6e361", size = 9285193, upload-time = "2026-05-29T08:30:58.727Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/07/52dece571ef47085d2f1053df4c1be8d5b42d8735da4797f5f79d650f81f/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d3dd72c195eca243b08c5d68b1f513124feaf22acb87b73cd8bfcdc3f6b4bb7", size = 9264997, upload-time = "2026-05-29T08:29:49.51Z" },
+    { url = "https://files.pythonhosted.org/packages/38/12/b010315be2927c5be43d3a4036cd6857d9981d5116efda5e40540f43a014/pydantic_monty-0.0.18-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6b0409a5f314af54f704d73cd97fe2a0cc8ef2635952bf57c5879b9313281614", size = 8350432, upload-time = "2026-05-29T08:30:10.984Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8b/9674a90269dc0f1a080e606cba642b256e138e7fcee1a3a0b55969946f83/pydantic_monty-0.0.18-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:790f169bb5700e3ab24a8d44fd7016d915c701e27bcd2feabe0de917306bbff0", size = 8900736, upload-time = "2026-05-29T08:29:42.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/6a/07351c22208814c466d9a26bab03642727e9f5570562cbd4fbde837e4644/pydantic_monty-0.0.18-cp311-cp311-win32.whl", hash = "sha256:3682f3bd67ef92ecd78a3f5f4efcd7659ba643aaca45412601a92691d6440250", size = 8280476, upload-time = "2026-05-29T08:31:17.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/de/937dcc0e828d324f037a5004f97c8ff245158fe735107023a10d8f672e32/pydantic_monty-0.0.18-cp311-cp311-win_amd64.whl", hash = "sha256:eecdf1175542ac2fd3f6a203c7744145be4e73e08755c6de1d35253dc6a872e7", size = 9480905, upload-time = "2026-05-29T08:30:15.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d1/307df5ac3a694acc5922f00fc7ce96357ad4afaa41bbfeec0b8379bed6ec/pydantic_monty-0.0.18-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1030bd49b813e67aedf4f7bb3dd4cc9edaa203554b3b8fe11eeab6d61139229f", size = 8462571, upload-time = "2026-05-29T08:29:21.081Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8ccf04b2f9642153702c6eb22d0a0abad57014fd85879ab1f6341b5a1946/pydantic_monty-0.0.18-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2988d3e511131680d9de60647bfe5c697b1e4e4cad474fecf1451c53314e8520", size = 8688756, upload-time = "2026-05-29T08:30:24.677Z" },
+    { url = "https://files.pythonhosted.org/packages/81/84/e3ce3294636b92a5eb238273026dd2825d97deac44f76e901990a4eeb306/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7d8d0f42162cb40da05f32d50d9d8d74411b3d4f1182117c8365f18457442c0d", size = 9046635, upload-time = "2026-05-29T08:30:06.38Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b8/c7881620a812850772ae0924863d1399cbecb3e4c8c455a9c7a9c20b06f8/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c688dc7c7b28a2f389a61217bae1d50658e28f960abe33a254328cadc8a17a", size = 8171342, upload-time = "2026-05-29T08:29:44.773Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ea/6d10ea1657e303295a75a3854f6dd6b378cbd501dcd1782844107b932acd/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f469293f5a776231b9617787a5dd6c58048c6568833ee6848338be6391f15449", size = 8591152, upload-time = "2026-05-29T08:31:29.944Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fb/ab85c4676ccffd0f3b7f509a4c8b396b07c7860577def2f58a22b3fe8aef/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6e0cd4991947b8a47210985836f94c14139bc3ea06253d2f38d0d752b165517", size = 9183064, upload-time = "2026-05-29T08:31:12.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/11292178b487052f9e0a1ea7b3d17e1e3bfcba598fefce8cb9ed8712021e/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:58b4b96863abbc0ffa5baf64779b3fbb6376cc763488b027ecaddb5052d5ff17", size = 9285440, upload-time = "2026-05-29T08:29:35.642Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/7afb8dde4414d84c042f2cc1b0870a7351cae2e4fbf3fef89b3aa683eca9/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1208bd5976c1254b2705559836511c86ea3cc51d9c6f688b1e3e22984715dbc", size = 9233438, upload-time = "2026-05-29T08:31:39.177Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/46/89124cf146725e354b44685b477da6b0b5dc07a8a3af2aec309e88c55405/pydantic_monty-0.0.18-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:977168253d8f6b49bb64f128d02c4b62ee8b435fd62876268377e1f2b00cc00f", size = 8351900, upload-time = "2026-05-29T08:31:08.348Z" },
+    { url = "https://files.pythonhosted.org/packages/00/c5/dda512f5a9c68242faea368844aacefb54c2a13f9b40bee5ab48ccdc78c5/pydantic_monty-0.0.18-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c21319a091dc1ff1fccb8647dae5bb543b3f528c556319ed15c7992dfa9b5e87", size = 8901559, upload-time = "2026-05-29T08:29:26.047Z" },
+    { url = "https://files.pythonhosted.org/packages/45/97/496655362d4bb6e74ff791cf40be6a502e794c296f0089912783325075a7/pydantic_monty-0.0.18-cp312-cp312-win32.whl", hash = "sha256:220fe77920af9033ae644887e747b68567df630b1a8afa39b0a830d84a3438b5", size = 8277428, upload-time = "2026-05-29T08:30:35.322Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/24/2913a50a9afbce681629408814ae94929589bed9aa347b176caf17842957/pydantic_monty-0.0.18-cp312-cp312-win_amd64.whl", hash = "sha256:f965a62993bd3fe7be94f99c86349d61d987b3d8cc07fb729d7d8af87c7d481d", size = 9453897, upload-time = "2026-05-29T08:31:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/70/86/5f1eb8b0743ba65821aa37285f131478672b2832baa08386e931c9e71969/pydantic_monty-0.0.18-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:765865634c2075ec816515db22acf0c71e42d25dcbf66638dc063d95c7d1a858", size = 8473615, upload-time = "2026-05-29T08:30:22.027Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9c/7628423f955efb669d2cc1d3a8909bf8271b543ce27036e18229ad0e51e8/pydantic_monty-0.0.18-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d47976a18e3e3da0e86f8cf6068fc8a125930422dc10d3d3bf0b5410a9e9282e", size = 8689116, upload-time = "2026-05-29T08:29:30.906Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/dd/ec6cbbe997205063c679ef17220a48fcb0a4c319fc336ca81a3c7c248c6d/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1c6bc7a776d9d97b899054263c0f0c7316523571da02b4c2a6d2ecd4793482e0", size = 9045884, upload-time = "2026-05-29T08:30:53.831Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/9c/51f8ffa4340bc1986eb9240b0756724f5fdf3c463d6d66c8cc8450e1446d/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb84fe51e3f6e00a0cc9628e0acf5904d982c8cc85d4db42b7532d071602f703", size = 8178458, upload-time = "2026-05-29T08:30:09.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ec/7eb84aeb86631571f9acffc91552217dc2b524b00db37b8d10517df467d1/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a2e86f3ba67b094d498bc8b071d5e3b8b034bb9f3006216a357c5f71d49d6132", size = 8591295, upload-time = "2026-05-29T08:29:23.357Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/d5210208fa116593bd81789e2e5abb6222d38087c9c1879e18f7e7620275/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eb8a412aa0336d4e0334a4e05a54b391d91fa334020bd295a280285ba17ab5ca", size = 9184647, upload-time = "2026-05-29T08:29:51.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/74/4d95c8f65072964c4cb798dbe87d2e1c1349607ab5905874bfa8a0b94de1/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1056ce3acef60ab880314caf97775c5ea41b30f9306d0dd28cefeffd42dda366", size = 9291637, upload-time = "2026-05-29T08:31:19.966Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/40/5817780313a3e089ca6f860fbdc836d3aa33790eb72c2e8fe2edc877820e/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9593caa45b68fd07ac67bea9974effbe2a1c5453d8a106b913596b0dff6d8471", size = 9233863, upload-time = "2026-05-29T08:31:42.838Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/55/f77565c5797502c7ba995dc23a26759cb33023590f9f2926bc4e8ab87afe/pydantic_monty-0.0.18-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:e15e18ed27a17ee607ad3bcbf82f25a9ec4d496ff493ff64cdabb83ca2174cec", size = 8358264, upload-time = "2026-05-29T08:31:32.531Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1f/c700eb800868d1be4078a99cb00e23fb7e5d8760c8e83b729bba27b5bf92/pydantic_monty-0.0.18-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:96d75a418d96640ff0c7f354a78fc4470a2d0f40ba69e886c2f32756d594d9a0", size = 8906664, upload-time = "2026-05-29T08:30:04.055Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/52/1b4599d5a6dccc65d46956431cfdf5a46df4a18005a93ffec4aab56a47b8/pydantic_monty-0.0.18-cp313-cp313-win32.whl", hash = "sha256:5cd5ff08e6749b3a4a2192856861b36feee8575e2cf81bd6bd1d8b4b39ac630e", size = 8276949, upload-time = "2026-05-29T08:30:12.968Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/eb/54c9011e2ef5e1358512ea23bb4a862b4f8fdda2d2f951a58854ff55ee3e/pydantic_monty-0.0.18-cp313-cp313-win_amd64.whl", hash = "sha256:52ce98be1e5bf76974597234ec857b7a6ef99374a036860cd2e2e1bd75c18f1e", size = 9453909, upload-time = "2026-05-29T08:31:01.275Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/04/e6462c2d4097189fc4af62b84273d6ef0a69473cbdf1c7f158d8cec25c11/pydantic_monty-0.0.18-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:8c38add825895ecfde75f3272126f07dd94f2db08440f165e76d7e321feec8da", size = 8473729, upload-time = "2026-05-29T08:30:32.648Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ff/6aca0ddd5c074b2757dd992b38e57f5e6b21ec0631007ec2d1b4dcbd3bff/pydantic_monty-0.0.18-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:186eaa80945c4a5bb19beba54471d423bffcf5daf64f93029b2d5df1939e201f", size = 8702897, upload-time = "2026-05-29T08:29:56.669Z" },
+    { url = "https://files.pythonhosted.org/packages/29/37/d56705a23d7c5ff5112f5f82d56e70a9073a46d6ebfdbce09bcb31a52921/pydantic_monty-0.0.18-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c7a568fd6db2389743d0d28f355273c0d6d2009c5252c0971dcb1e5629e60d4f", size = 9046049, upload-time = "2026-05-29T08:30:56.314Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/00/82a6ddb1ca7bf2b1ef4b1751d960671324f3a0a498fc80d335f3f0962176/pydantic_monty-0.0.18-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:324443ea73eb70bfd57b34e554278f52501592c4580edc6b9708b0d3d6a42f44", size = 8178495, upload-time = "2026-05-29T08:31:34.62Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9b/1a1aab97a113d718d6e6db9a7e5ad2fb9fd9cde8623d4885188983fa349b/pydantic_monty-0.0.18-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:936438027363474eecc5573eb635d1c5f3bf061ad02334d5b545a132fbb76e45", size = 8593356, upload-time = "2026-05-29T08:30:37.618Z" },
+    { url = "https://files.pythonhosted.org/packages/65/89/0f5212ccae4c29fa85c86dea553e45cf4729f94eba47187c747d44f7c890/pydantic_monty-0.0.18-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f700d2c7139f44ac29f51301c835a23e6c53402984cb23f3e3214e47df7ddaa3", size = 9184371, upload-time = "2026-05-29T08:29:28.574Z" },
+    { url = "https://files.pythonhosted.org/packages/26/1a/a2f3f0016a1326ef50d732f53bd8f447b3535fdb59a40287e77d0914935f/pydantic_monty-0.0.18-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:10abc11ae00d712b866b2a64e6a0f34c6a7d5f99903228f4699eeb4ced50299a", size = 9292432, upload-time = "2026-05-29T08:30:30.051Z" },
+    { url = "https://files.pythonhosted.org/packages/78/55/8bc4f8924c8bfd366b2c524a19083f86bb457c61f56c47e4ae4bd607536e/pydantic_monty-0.0.18-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8183aa8e2420aa4c1924cc05b87c8143f953b7c173f240cb7cf20e0b3f865cdb", size = 9247001, upload-time = "2026-05-29T08:30:40.061Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5e/f6ae7d18cfc058f4df49765420800dd5d7de3adbba6be864a8bc919847d2/pydantic_monty-0.0.18-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:03fccf00fd925b616e0b7ce59c354f3fa1e50eb2d511391e260e28793b5d3b0c", size = 8357641, upload-time = "2026-05-29T08:29:40.372Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d3/166961ca42ad855b7a2dd50d494be26ff0222b21b68750081962fb4568f9/pydantic_monty-0.0.18-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:d9dc4185bad6ca7f38d2d71b9d8ed2d68e48e4c4f0ccc89cd0188c08469bda7d", size = 8905773, upload-time = "2026-05-29T08:30:43.535Z" },
+    { url = "https://files.pythonhosted.org/packages/df/88/d8bd8e82ca624ca6bebe9ebfb6cfc461214303158ba735751a6c2277043e/pydantic_monty-0.0.18-cp314-cp314-win32.whl", hash = "sha256:4840805ecfe5a38c07126f02181d907c687ca765a73aaabc2b128184390a2c52", size = 8277373, upload-time = "2026-05-29T08:31:22.247Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0e/c395b22ddc32c746d7e2d271dd18bb585289576bb67483435e25643b7ecd/pydantic_monty-0.0.18-cp314-cp314-win_amd64.whl", hash = "sha256:83b6e2b73b0fa60c5641ecb6e8b588840023163ca6ab8b3e5da7ad088390ee7c", size = 9467375, upload-time = "2026-05-29T08:29:54.227Z" },
+]
+
+[[package]]
 name = "pydantic-settings"
 version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -7793,7 +7868,7 @@ name = "tokenizers"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
 wheels = [
@@ -7947,27 +8022,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.58"
+version = "0.0.59"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/4c/26c90732658903aeb1d289208f7b7b492fa21029e0c4d6c51bdd6f8f5e51/ty-0.0.58.tar.gz", hash = "sha256:8f22484174e65c630660a454bf81b80cae7a3a7e70479f19c170d6cd87949258", size = 6133665, upload-time = "2026-07-10T03:09:30.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/b0/84ae7b3bf6e3e9f57eb9635eeff5a80b36e57aa089f40be0fb5c384fa176/ty-0.0.59.tar.gz", hash = "sha256:53e53ffeed78ad59cd237fa8ea1316d2b94e13efdea9a945698acab549e005aa", size = 6145435, upload-time = "2026-07-12T20:22:02.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e1/5d1aa2a75829459834689f080e4be7a9d8828ce14b939ebed69161a35811/ty-0.0.58-py3-none-linux_armv6l.whl", hash = "sha256:47412850b6fbef61c42f244f6a51aa2f2c9e91f08cfbafd2d1e3730d2419d317", size = 11706915, upload-time = "2026-07-10T03:08:51.028Z" },
-    { url = "https://files.pythonhosted.org/packages/96/e1/929eda9cc72a9afe39a03c76f946a503508d37343cc8ff2e64226afda105/ty-0.0.58-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79deb7bb4e5b3a1eee6ab9abc724d6ce3559d4977982707f310a139ee11fc703", size = 11532079, upload-time = "2026-07-10T03:08:53.771Z" },
-    { url = "https://files.pythonhosted.org/packages/07/43/ebc58b3fc7d86a7abba2829f1674f7d4ae3a08f9794c1f31b707950c871f/ty-0.0.58-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a28af3187e661708a386d44a4fc32896a5f589fb07b734a11ab2f516e7572b7", size = 11092983, upload-time = "2026-07-10T03:08:56.025Z" },
-    { url = "https://files.pythonhosted.org/packages/92/6e/9547dbb8e51e47749cfb721a02b4fc862f9a932fa0f66a34a4d6dc429bb1/ty-0.0.58-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21a6977e34bc362fb378add46e59d5d56331c1c36727e6904767217ca8479718", size = 11490492, upload-time = "2026-07-10T03:08:58.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/76/9f83b51b5e7795d6c8d76b4bb1bb7cebf4c10d609e846c02ab138e404556/ty-0.0.58-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ac23e6bf6105ceca46632debf1b10b98125aaf60202aeae02f6abfeea242b3d", size = 11503696, upload-time = "2026-07-10T03:09:00.741Z" },
-    { url = "https://files.pythonhosted.org/packages/47/9d/9fd48a0696c680f74e50f31cd54e524eeb58c97ea9bb1c3b8e04230ba215/ty-0.0.58-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb6df6a8c6a21894807a49851370ec7fc64aa910296c78ada31db0ef19359112", size = 12158653, upload-time = "2026-07-10T03:09:02.998Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/ea/b5de845d2d8edae04d901c7585af7f04a057e18b26311f7fa4ca62b2da30/ty-0.0.58-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9df5847eebc026cde088b44420a03f7c6c169a7db747176bdf0a656eb1144713", size = 12723019, upload-time = "2026-07-10T03:09:05.291Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1c/54083b23eeff1e101f50b6df6a2c7f1e14b31abe0577c91bcae9e2c9395d/ty-0.0.58-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53a331a7f1f85872c810676a0f16096ef98c1b95c8c9a573fe7fde64d0a93e7c", size = 12275715, upload-time = "2026-07-10T03:09:07.564Z" },
-    { url = "https://files.pythonhosted.org/packages/22/88/16925434b06faa49d36aa7e7508a6821ec6feacb429ca2fd80a3d52716b4/ty-0.0.58-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb0b05cd479fdcedc2e6781d376ee1a33569f37ae7f58357004635f615c4374c", size = 12033075, upload-time = "2026-07-10T03:09:10.222Z" },
-    { url = "https://files.pythonhosted.org/packages/58/2b/b55708dd483982ae03d14da3667e3f0346cd384e11cca3dd3674a8b598c1/ty-0.0.58-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a0012786077e5becbb6add9fe51eda1d4d36d249afd3ae6cd141d554af15ae3", size = 12367729, upload-time = "2026-07-10T03:09:12.338Z" },
-    { url = "https://files.pythonhosted.org/packages/91/a3/99ad66652956408f7e9ac3db6b4a416199d773b6c073cf95b0eea126d340/ty-0.0.58-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4ede96d7f6d149156da254e784b062b817736b68d4c6d660555a3d02d96966fb", size = 11439798, upload-time = "2026-07-10T03:09:14.518Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/23/344ceed4fe02ed498711e1f4a47b6e311fb1e9c4fecc19d31894be7a3472/ty-0.0.58-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:47608e58f73901b989402e6f283249cda4c2314282ec368aa74ab61761c62bd5", size = 11512695, upload-time = "2026-07-10T03:09:16.852Z" },
-    { url = "https://files.pythonhosted.org/packages/55/cf/3801831812c468f3fd0b3043a80f557a9aa90e6c27375763d7c3121e03f2/ty-0.0.58-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9757de17cc17e4c6bc26e18d4e26dea52ffee53d41a10d9087c6465e6ab12e2b", size = 11812253, upload-time = "2026-07-10T03:09:19.151Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/80/bce4f245787b77d1ec9feec7d9161eade5e01a77dbc132e016b24df83b0d/ty-0.0.58-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f3776d54c1d935fcb8f814bd58efba402c86c555f93e1144c59d087e7aa8b906", size = 12123918, upload-time = "2026-07-10T03:09:21.636Z" },
-    { url = "https://files.pythonhosted.org/packages/46/00/bab3d6268e7e88c792bf7cdde81bd11b31aa587eaba75196502b729747c8/ty-0.0.58-py3-none-win32.whl", hash = "sha256:8f50ec0ac3b42baa4c75895dc367071dc86b00ab440d29fdc72c633286a94815", size = 11230897, upload-time = "2026-07-10T03:09:23.871Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/68/d9504c895864aaa84a840dce6ac7f8e681f6938be1882c8d4f60832dbe57/ty-0.0.58-py3-none-win_amd64.whl", hash = "sha256:de8847b3a65475ae4773bddd3126bfcf29f017e88967c4dcc9c75d743a4d3e5c", size = 12299376, upload-time = "2026-07-10T03:09:26.292Z" },
-    { url = "https://files.pythonhosted.org/packages/26/04/c9847cb680b5fe8e1f7d7b483edd5cedcc29394496e7b8ed40d96be796ba/ty-0.0.58-py3-none-win_arm64.whl", hash = "sha256:7334bb38789878f60677f2eb9c1de4bfdf4583e2443790989c77da9b10fe0989", size = 11710495, upload-time = "2026-07-10T03:09:28.478Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e8/650b42fbef4d48e6ca682b0b6e9b68fa8fcf55cbb0a6892ab89990018b6f/ty-0.0.59-py3-none-linux_armv6l.whl", hash = "sha256:f8fb08a767ef8f11ea3c537b9d77860726cc2bc39e6f77ad13c02d5b289f20a7", size = 11700328, upload-time = "2026-07-12T20:21:26.046Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ac/0ca3a89d5f59ae5f308e5e83428cac5f9143200767743e052fba90b4b81e/ty-0.0.59-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c7f4d5630836c8a0ba13dd4ac7bdae080a7d6ebe965b817ff642dc961bcf2a53", size = 11494310, upload-time = "2026-07-12T20:21:28.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f8/5076de6001cefbccd8e6dc8472262697e43308ff66b0e87c72abba136357/ty-0.0.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:872f6fb02c6db5553c4d5fb283b3d50f0985fb9a29a910e4fda4793a775c1926", size = 11026797, upload-time = "2026-07-12T20:21:30.879Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/fca28481b6a138e2b798ad9fdc98a095475f9104948ba242fce4b477782b/ty-0.0.59-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2af8eefbfe806337770eec12c0c819c5f1b8f5b85f8369cb1cc9fa25234a2208", size = 11475304, upload-time = "2026-07-12T20:21:33.041Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/1fed8b81b389ef4bbc0400f19e05fc16496b162577779dc0e5fc65ac216c/ty-0.0.59-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0acf8b76a1c9a7ddef460b42475f6c76193164426ab080783af1c3175b4b999b", size = 11533131, upload-time = "2026-07-12T20:21:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fc/04eec35e05a10e0fea1c6503a290ccc3935efda9c845aff64e83282c1af7/ty-0.0.59-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:043c2e00eb1d7475f928af7dedd71f69b64e69bfca55e36f4c968479e1373fc4", size = 12205932, upload-time = "2026-07-12T20:21:37.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dd/a61de859659fa11b55917ad38340a8f2c61f5ae17d1874929f29084c6990/ty-0.0.59-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0d688d857441df57f48fca66c029d85cf737c510e7be1d01144cdad1e58d968", size = 12758406, upload-time = "2026-07-12T20:21:39.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e8/fa66f05997eab8ca75fc4f17320140e25467849e0cc75597f898cc22099c/ty-0.0.59-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a96c9f88394a3b42c737e2125b2330543f0d90a43b49761f377d96f8c3ee0d62", size = 12288176, upload-time = "2026-07-12T20:21:41.784Z" },
+    { url = "https://files.pythonhosted.org/packages/15/68/0fca59963bd5123f42d5f7da50667e7a52e8e9615e3a16d8c2c0d3b2d143/ty-0.0.59-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08dbcb268edcafcb152e59475b5b495ce28d0b340a395c09943557678f4d5a6", size = 12028471, upload-time = "2026-07-12T20:21:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/cd7dabbbab392578f11179919da5c25d8c3322e5388a688f539ea0539603/ty-0.0.59-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8812764b9a40fdc98df1272826e73a298ef56b06681135e643bcf90aad1896f7", size = 12297646, upload-time = "2026-07-12T20:21:45.76Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/37/2e9c94f0b383d8cbe1a35517ab470b7810bc9d7501603ab532bcd5be5e90/ty-0.0.59-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd53b8581641d8dad7bfac6d5ea589e91a883d6837e0b9a286fdae30722b7c69", size = 11432519, upload-time = "2026-07-12T20:21:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0a/af93e9785200f11ac416cc20235fc2464c9bd978e791190684ea0e458795/ty-0.0.59-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:86da5872124a41877d95058bc17d33ddcff034b587eb5f1e2917ab88ba227dac", size = 11554993, upload-time = "2026-07-12T20:21:49.671Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/dd/651bf87e20d00376c81b19124756491cffaf20eb8bec05a8794e5a8cf641/ty-0.0.59-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a233eef5f2fd4d894881e4a0aec83c9f172bfae1d787d6596ee1939fcc7723e", size = 11818230, upload-time = "2026-07-12T20:21:51.659Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/c947c4155fea751d135b19affdf734bbce72a94e446b866cf0c62f8bed69/ty-0.0.59-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ff678c18b5f1e3128b75a35e50dee7908dea55155baa31cd790619d5014cbf5", size = 12135194, upload-time = "2026-07-12T20:21:53.796Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/13/e5feb138888de1e95037c843571bbbd4ac21bf0a190507468098599a321f/ty-0.0.59-py3-none-win32.whl", hash = "sha256:cf8abb4b8095c5fe39102b8127f5886db308c8d4600909ddbc905512ce9c8163", size = 11179249, upload-time = "2026-07-12T20:21:55.752Z" },
+    { url = "https://files.pythonhosted.org/packages/76/dd/52914dcbeeba92c207de40ef7109a58dcb5527aeb21c8f8feb7402aa9e29/ty-0.0.59-py3-none-win_amd64.whl", hash = "sha256:1dde20a82243d24407869e5a608c2f15efddd5cefc662aef461a5af84bfb3f8b", size = 12251079, upload-time = "2026-07-12T20:21:58.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/ac36fde77e223297454c1e0aeb8888c169eaacf3163bb609e3af942c88cb/ty-0.0.59-py3-none-win_arm64.whl", hash = "sha256:987043ee9e021f49493d9135891ac69c1affeee0d4ad4480c5fa4d9c975fc91b", size = 11650921, upload-time = "2026-07-12T20:22:00.348Z" },
 ]
 
 [[package]]
@@ -8035,11 +8110,11 @@ wheels = [
 
 [[package]]
 name = "types-cachetools"
-version = "7.0.0.20260518"
+version = "7.0.0.20260713"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/14/1e4fca2b250dbc75be9f0beab083acb3cd1151711e1031eb4a854dfd71be/types_cachetools-7.0.0.20260518.tar.gz", hash = "sha256:7730014e4fef0c6f01e2cd0f980f8ce6d1b1d2472c8459c1f382348ec1a6b435", size = 10072, upload-time = "2026-05-18T06:02:20.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/66d7efdb36ecf6826aca5415e59fe2df96e97d24157147e53acfbe8dda11/types_cachetools-7.0.0.20260713.tar.gz", hash = "sha256:f1acf079e9c66a81e096a897ef0b261a82117cf856834e37b4bd0c9a116a076a", size = 10199, upload-time = "2026-07-13T05:22:21.845Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/e0/767be6b60859fd2edc4512fabdedbce703fc8d4ec5007b31abaf37a51c6c/types_cachetools-7.0.0.20260518-py3-none-any.whl", hash = "sha256:997b356870915f8bbc9b2cdb4e7271c01d487996fdac2a9c8e91cc5b1261b3d1", size = 9500, upload-time = "2026-05-18T06:02:19.042Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c7/d3525c9dbdc1be7786bad46655ef051b6e7993f656d304719ec40079c91c/types_cachetools-7.0.0.20260713-py3-none-any.whl", hash = "sha256:6db9bcc7a3840d39e91c04117d85a9d0937eacc9d14d12a873e2b01a2d24a71d", size = 9615, upload-time = "2026-07-13T05:22:20.76Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> **Stacked PR** — based on `feat/mcp-server-auth-minimal`, not `main`. Review/merge that branch first; this diff is meaningful only on top of it.

## What this adds

The base branch mounts the MCP server at `/mcp` and wires its OAuth2 surface (401 challenge + `BearerAuthGuard`, RFC 9728 protected-resource metadata, RFC 8707 resource-indicator handling, the bare-path `MountPathNormalizer`). This branch fills in the **tool surface** behind that mount and changes how tool calls authenticate back into `/v1`.

- **Tools generated from `/v1`.** `create_phoenix_mcp_app` builds the MCP tools from the FastAPI app's OpenAPI schema (`FastMCP.from_openapi`): every `/v1` operation becomes one tool, and each tool's read/write nature is derived from its HTTP method so clients can gate mutations. Descriptions and schemas are reshaped for an agent audience, and missing `operation_id`s/summaries are filled in at the source to keep curated camelCase tool names.
- **Two mutually-exclusive tool surfaces, selected by `PHOENIX_MCP_CODE_MODE` (on by default):**
  - *Code mode (default):* read-only discovery meta-tools (`search`, `get_schema`, `tags`, `list_tools`) plus an `execute` tool that runs LLM-written Python in a `pydantic-monty` sandbox where `call_tool(name, params)` is the only in-scope function (bounded by 30 s / 100 MB / 50 `call_tool` calls, plus an explicit `max_recursion_depth` cap). `execute` is left unannotated so clients treat it as possibly destructive; it can only invoke tools the caller is already authorized for.
  - *Group-gated (`PHOENIX_MCP_CODE_MODE=false`):* progressive disclosure that groups tools by REST router tag and reveals more per session via `enable_tool_group`.
- **Sandbox pinned to `pydantic-monty==0.0.18` via a uv override.** fastmcp-slim's code-mode extra hard-pins 0.0.17, which has an uncatchable in-process stack-overflow DoS: a few-thousand-term boolean/ternary chain segfaults the interpreter at compile time, and because the sandbox runs in the server process this crashes all of Phoenix, not just the request (verified end-to-end — one `execute` call drove the container to `SIGSEGV` / exit 139). 0.0.18 fixes it (#437 bounds the fold depth, #449 returns a syntax error instead of panicking) with no filesystem-isolation regression. This is a stopgap; the durable fix is a fastmcp-slim release that adopts 0.0.18, or running the sandbox out-of-process so any crash is contained to a worker.
- **Dispatch authenticates by principal-passing, not token replay.** MCP tool calls dispatch into `/v1` as internal in-process requests that must authenticate. Instead of replaying the caller's `/mcp`-audience token (which would force `/v1` to accept `/mcp`-audience tokens and make audience unenforceable there), `_InternalIdentityDispatch` resolves the already-authenticated `PhoenixUser` from ambient context and places it into the internal request's ASGI scope under `INTERNAL_PRINCIPAL_SCOPE_KEY` — unforgeable from outside, since scope keys are set only by in-process code. The internal request carries no `Authorization` header.
- **Token audience confined at access time (RFC 8707).** Each resource server now checks the presented token was minted for it. An `/mcp`-audience token authenticates at `/mcp` but is rejected at `/v1`, closing the replay path that principal-passing alone left open. Unscoped tokens (API keys, web sessions, plain OAuth access tokens) remain valid everywhere; in-process principal-passing dispatch is exempt because it carries the scope key and was already audience-checked at the mount.

## Tests

- **Unit:** the auth-backend contract (scope principal authenticates without a token-store read; the same name as an HTTP header does not; non-`PhoenixUser` values ignored), the dispatch stamp, both mount tool surfaces, and the audience helper.
- **Integration** (`tests/integration/auth/test_mcp.py`): an OAuth authorization-code flow minting an `/mcp`-audience token driving a real group-gated tool call; the code-mode chain under auth (OAuth token → discovery → sandboxed `execute` → in-process `/v1` dispatch); an `/mcp`-audience token accepted at `/mcp` but rejected at `/v1`; and an unscoped token still accepted at `/v1`.

---

*Draft:* the `pydantic-monty==0.0.18` pin is a security stopgap and the code-mode availability posture (in-process crash containment) is still under review — see the commit body for the full rationale.
