### PR TITLE
refactor(agents): make persisted transcript authoritative

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -112,6 +112,11 @@ type AgentSessionEdge {
   node: AgentSession!
 }
 
+type AgentSessionMutationPayload {
+  agentSession: AgentSession!
+  query: Query!
+}
+
 type AgentSkill {
   """
   The unique skill identifier used to load the skill (e.g. 'debug-trace').
@@ -2100,6 +2105,11 @@ type FailureDetail {
   errorType: String!
 }
 
+input ForkAgentSessionInput {
+  sourceSessionId: ID!
+  lastMessageId: String
+}
+
 type FreeformAnnotationConfig implements Node & AnnotationConfigBase {
   """The Globally Unique ID of this object"""
   id: ID!
@@ -2430,6 +2440,8 @@ input ModelsInput {
 
 type Mutation {
   deleteAgentSession(input: DeleteAgentSessionInput!): DeleteAgentSessionMutationPayload!
+  truncateAgentSession(input: TruncateAgentSessionInput!): AgentSessionMutationPayload!
+  forkAgentSession(input: ForkAgentSessionInput!): AgentSessionMutationPayload!
   createAnnotationConfig(input: CreateAnnotationConfigInput!): CreateAnnotationConfigPayload!
   updateAnnotationConfig(input: UpdateAnnotationConfigInput!): UpdateAnnotationConfigPayload!
   deleteAnnotationConfigs(input: DeleteAnnotationConfigsInput!): DeleteAnnotationConfigsPayload!
@@ -4567,6 +4579,11 @@ type TraceTokenCountTimeSeriesDataPoint {
   totalTokenCount: Float
   promptTokenCountDetails: [TraceTokenCountDetailsTimeSeriesEntry!]!
   completionTokenCountDetails: [TraceTokenCountDetailsTimeSeriesEntry!]!
+}
+
+input TruncateAgentSessionInput {
+  id: ID!
+  lastMessageId: String
 }
 
 type UnparsableConfig {

--- a/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
+++ b/app/src/agent/chat/__tests__/buildAgentChatRequestBody.test.ts
@@ -22,7 +22,135 @@ const agentsConfig = {
   allowRemoteExport: false,
 };
 
+const userMessage: AgentUIMessage = {
+  id: "user-1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }],
+};
+
 describe("buildAgentChatRequestBody", () => {
+  it("sends only the next message instead of the local transcript", () => {
+    const nextMessage: AgentUIMessage = {
+      id: "user-2",
+      role: "user",
+      parts: [{ type: "text", text: "Next question" }],
+    };
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "session-1",
+      messages: [userMessage, nextMessage],
+      trigger: "submit-message",
+      messageId: undefined,
+      capabilities: createDefaultAgentCapabilities(),
+      observability: {
+        storeLocalTraces: false,
+        exportRemoteTraces: false,
+        attachUserId: false,
+        acknowledgedTraceConsent: null,
+      },
+      agentsConfig,
+      permissions: { edits: "manual" },
+      contexts: [],
+      modelSelection: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-4o-mini",
+      },
+    });
+
+    expect(body).toMatchObject({
+      message: nextMessage,
+      parentMessageId: userMessage.id,
+    });
+    expect(body).not.toHaveProperty("messages");
+  });
+
+  it("regenerates by message id without sending a message", () => {
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "session-1",
+      agentSessionId: "agent-session-1",
+      messages: [userMessage],
+      trigger: "regenerate-message",
+      messageId: userMessage.id,
+      capabilities: createDefaultAgentCapabilities(),
+      observability: {
+        storeLocalTraces: false,
+        exportRemoteTraces: false,
+        attachUserId: false,
+        acknowledgedTraceConsent: null,
+      },
+      agentsConfig,
+      permissions: { edits: "manual" },
+      contexts: [],
+      modelSelection: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-4o-mini",
+      },
+    });
+
+    expect(body).toMatchObject({
+      trigger: "regenerate-message",
+      messageId: userMessage.id,
+    });
+    expect(body).not.toHaveProperty("message");
+    expect(body).not.toHaveProperty("messages");
+  });
+
+  it("sends only resolved tool parts for an assistant continuation", () => {
+    const body = buildAgentChatRequestBody({
+      body: undefined,
+      id: "session-1",
+      agentSessionId: "agent-session-1",
+      messages: [
+        userMessage,
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Checking the prompt" },
+            {
+              type: "tool-read_prompt",
+              toolCallId: "call-1",
+              state: "output-available",
+              input: { id: "prompt-1" },
+              output: { name: "Prompt" },
+            },
+          ],
+        },
+      ],
+      trigger: "submit-message",
+      messageId: undefined,
+      capabilities: createDefaultAgentCapabilities(),
+      observability: {
+        storeLocalTraces: false,
+        exportRemoteTraces: false,
+        attachUserId: false,
+        acknowledgedTraceConsent: null,
+      },
+      agentsConfig,
+      permissions: { edits: "manual" },
+      contexts: [],
+      modelSelection: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-4o-mini",
+      },
+    });
+
+    expect(body.message).toEqual({
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        expect.objectContaining({
+          toolCallId: "call-1",
+          state: "output-available",
+        }),
+      ],
+    });
+  });
+
   it("echoes the active turn trace context", () => {
     const turnTraceContext = {
       traceId: "1".repeat(32),
@@ -32,7 +160,7 @@ describe("buildAgentChatRequestBody", () => {
     const body = buildAgentChatRequestBody({
       body: undefined,
       id: "session-1",
-      messages: [],
+      messages: [userMessage],
       trigger: "submit-message",
       messageId: undefined,
       capabilities: createDefaultAgentCapabilities(),
@@ -60,7 +188,7 @@ describe("buildAgentChatRequestBody", () => {
     const body = buildAgentChatRequestBody({
       body: { existing: true },
       id: "session-1",
-      messages: [] as AgentUIMessage[],
+      messages: [userMessage],
       trigger: "submit-message",
       messageId: undefined,
       capabilities: createDefaultAgentCapabilities(),
@@ -102,7 +230,7 @@ describe("buildAgentChatRequestBody", () => {
     const body = buildAgentChatRequestBody({
       body: undefined,
       id: "session-1",
-      messages: [] as AgentUIMessage[],
+      messages: [userMessage],
       trigger: "submit-message",
       messageId: undefined,
       capabilities,
@@ -132,7 +260,7 @@ describe("buildAgentChatRequestBody", () => {
     const body = buildAgentChatRequestBody({
       body: undefined,
       id: "session-1",
-      messages: [] as AgentUIMessage[],
+      messages: [userMessage],
       trigger: "submit-message",
       messageId: undefined,
       capabilities: {} as AgentCapabilities,
@@ -170,7 +298,7 @@ describe("buildAgentChatRequestBody", () => {
     const body = buildAgentChatRequestBody({
       body: undefined,
       id: "session-1",
-      messages: [] as AgentUIMessage[],
+      messages: [userMessage],
       trigger: "submit-message",
       messageId: undefined,
       capabilities: createDefaultAgentCapabilities(),
@@ -206,7 +334,7 @@ describe("buildAgentChatRequestBody", () => {
     const body = buildAgentChatRequestBody({
       body: undefined,
       id: "session-1",
-      messages: [] as AgentUIMessage[],
+      messages: [userMessage],
       trigger: "submit-message",
       messageId: undefined,
       capabilities: createDefaultAgentCapabilities(),
@@ -237,7 +365,7 @@ describe("buildAgentChatRequestBody", () => {
     const body = buildAgentChatRequestBody({
       body: undefined,
       id: "session-1",
-      messages: [] as AgentUIMessage[],
+      messages: [userMessage],
       trigger: "submit-message",
       messageId: undefined,
       capabilities: createDefaultAgentCapabilities(),

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -26,7 +26,7 @@ type BuildAgentChatRequestBodyOptions = {
   id: string;
   /** Node ID for agent session. */
   agentSessionId?: string | null;
-  /** Full UI message history sent with the request. */
+  /** Full local UI message history used to select the incremental payload. */
   messages: AgentUIMessage[];
   /** Reason the transport is sending this request. */
   trigger: "submit-message" | "regenerate-message";
@@ -49,7 +49,8 @@ type BuildAgentChatRequestBodyOptions = {
   toolTimings?: ClientToolTimingRecorder | null;
 };
 
-type BuildAgentChatRequestBodyResult = components["schemas"]["ChatRequest"];
+type BuildAgentChatRequestBodyResult =
+  components["schemas"]["AgentChatRequest"];
 
 /**
  * Browser-recorded execution timings added to the `phoenix` namespace of
@@ -131,15 +132,10 @@ export function buildAgentChatRequestBody({
     buildSubagentsContext(capabilities),
     ...contexts,
   ];
-  return {
+  const commonBody = {
     ...body,
     id,
     agentSessionId,
-    messages: toServerSafeUIMessages(
-      enrichMessagesWithClientToolTimings({ messages, toolTimings })
-    ),
-    trigger,
-    messageId,
     ingestTraces: traceRecording.ingestTraces,
     exportRemoteTraces: traceRecording.exportRemoteTraces,
     attachUserId: getEffectiveAttachUserId({ agentsConfig, observability }),
@@ -147,6 +143,35 @@ export function buildAgentChatRequestBody({
     contexts: requestContexts,
     model: modelSelection,
     turnTraceContext: turnTraceContext ?? undefined,
+  };
+  if (trigger === "regenerate-message") {
+    return { ...commonBody, trigger, messageId };
+  }
+  const message = toServerSafeUIMessages(
+    enrichMessagesWithClientToolTimings({
+      messages: messages.slice(-1),
+      toolTimings,
+    })
+  )[0];
+  if (message == null) {
+    throw new Error("A chat submission requires a message");
+  }
+  if (message.role !== "assistant") {
+    const parentMessageId = messages.at(-2)?.id;
+    return { ...commonBody, trigger, message, parentMessageId };
+  }
+  const toolResponses = message.parts.filter(
+    (part) =>
+      isToolUIPart(part) &&
+      (part.state === "approval-responded" ||
+        part.state === "output-available" ||
+        part.state === "output-denied" ||
+        part.state === "output-error")
+  );
+  return {
+    ...commonBody,
+    trigger,
+    message: { id: message.id, role: message.role, parts: toolResponses },
   };
 }
 

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1548,6 +1548,114 @@ export interface components {
             data: components["schemas"]["DatasetLabel"];
         };
         /**
+         * AgentChatRegenerateMessage
+         * @description Regenerate a persisted assistant response.
+         */
+        AgentChatRegenerateMessage: {
+            /**
+             * Ingesttraces
+             * @default false
+             */
+            ingestTraces?: boolean;
+            /**
+             * Exportremotetraces
+             * @default false
+             */
+            exportRemoteTraces?: boolean;
+            /**
+             * Attachuserid
+             * @description When true and the request is authenticated as a PhoenixUser, attaches the user's email as the OpenInference ``user.id`` span attribute on all traced work for this request.
+             * @default false
+             */
+            attachUserId?: boolean;
+            /** Contexts */
+            contexts?: components["schemas"]["ChatContext"][];
+            /** Agentsessionid */
+            agentSessionId?: string | null;
+            /**
+             * Editpermission
+             * @default manual
+             * @enum {string}
+             */
+            editPermission?: "manual" | "bypass";
+            /**
+             * Requestedskills
+             * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
+             */
+            requestedSkills?: string[];
+            /** Model */
+            model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
+            turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            trigger: "regenerate-message";
+            /** Id */
+            id: string;
+            /** Messageid */
+            messageId?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * AgentChatRequest
+         * @description Incremental request for a database-backed assistant session.
+         */
+        AgentChatRequest: components["schemas"]["AgentChatSubmitMessage"] | components["schemas"]["AgentChatRegenerateMessage"];
+        /**
+         * AgentChatSubmitMessage
+         * @description Submit one new user message or one assistant tool-response update.
+         */
+        AgentChatSubmitMessage: {
+            /**
+             * Ingesttraces
+             * @default false
+             */
+            ingestTraces?: boolean;
+            /**
+             * Exportremotetraces
+             * @default false
+             */
+            exportRemoteTraces?: boolean;
+            /**
+             * Attachuserid
+             * @description When true and the request is authenticated as a PhoenixUser, attaches the user's email as the OpenInference ``user.id`` span attribute on all traced work for this request.
+             * @default false
+             */
+            attachUserId?: boolean;
+            /** Contexts */
+            contexts?: components["schemas"]["ChatContext"][];
+            /** Agentsessionid */
+            agentSessionId?: string | null;
+            /**
+             * Editpermission
+             * @default manual
+             * @enum {string}
+             */
+            editPermission?: "manual" | "bypass";
+            /**
+             * Requestedskills
+             * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
+             */
+            requestedSkills?: string[];
+            /** Model */
+            model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
+            turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            trigger: "submit-message";
+            /** Id */
+            id: string;
+            message: components["schemas"]["PhoenixUIMessage"];
+            /** Parentmessageid */
+            parentMessageId?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * AgentSpanContext
          * @description Span the user has selected.
          *
@@ -1785,7 +1893,7 @@ export interface components {
             /** Id */
             id: string;
             /** Messages */
-            messages: components["schemas"]["PhoenixUIMessage"][];
+            messages: components["schemas"]["UIMessage"][];
             /** Messageid */
             messageId?: string | null;
             /**
@@ -1843,7 +1951,7 @@ export interface components {
             /** Id */
             id: string;
             /** Messages */
-            messages: components["schemas"]["PhoenixUIMessage"][];
+            messages: components["schemas"]["UIMessage"][];
             /**
              * Ingesttraces
              * @default false
@@ -5473,6 +5581,23 @@ export interface components {
              * Format: date-time
              */
             startedAt: string;
+        };
+        /**
+         * UIMessage
+         * @description A message as displayed in the UI by Vercel AI Elements.
+         */
+        UIMessage: {
+            /** Id */
+            id: string;
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "system" | "user" | "assistant";
+            /** Metadata */
+            metadata?: unknown | null;
+            /** Parts */
+            parts: (components["schemas"]["TextUIPart"] | components["schemas"]["ReasoningUIPart"] | components["schemas"]["ToolInputStreamingPart"] | components["schemas"]["ToolInputAvailablePart"] | components["schemas"]["ToolOutputAvailablePart"] | components["schemas"]["ToolOutputErrorPart"] | components["schemas"]["ToolApprovalRequestedPart"] | components["schemas"]["ToolApprovalRespondedPart"] | components["schemas"]["ToolOutputDeniedPart"] | components["schemas"]["DynamicToolInputStreamingPart"] | components["schemas"]["DynamicToolInputAvailablePart"] | components["schemas"]["DynamicToolOutputAvailablePart"] | components["schemas"]["DynamicToolOutputErrorPart"] | components["schemas"]["DynamicToolApprovalRequestedPart"] | components["schemas"]["DynamicToolApprovalRespondedPart"] | components["schemas"]["DynamicToolOutputDeniedPart"] | components["schemas"]["SourceUrlUIPart"] | components["schemas"]["SourceDocumentUIPart"] | components["schemas"]["FileUIPart"] | components["schemas"]["DataUIPart"] | components["schemas"]["StepStartUIPart"])[];
         };
         /** UpdateAnnotationConfigResponseBody */
         UpdateAnnotationConfigResponseBody: {
@@ -10385,7 +10510,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ChatRequest"];
+                "application/json": components["schemas"]["AgentChatRequest"];
             };
         };
         responses: {

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -36,7 +36,10 @@ import {
   AGENT_SESSIONS_CONNECTION_KEY,
   SESSION_PAGE_SIZE,
 } from "./agentSessionRelay";
-import { shouldHydrateAgentSession } from "./agentSessionRuntime";
+import {
+  getPersistedAgentSessionId,
+  shouldHydrateAgentSession,
+} from "./agentSessionRuntime";
 import { ChatView } from "./Chat";
 import type { AgentSessionListItem } from "./SessionListMenu";
 import {
@@ -309,9 +312,13 @@ function AgentSessionsContent({
   const activeSessionHasRuntime = activeSessionId
     ? runtime.hasChat(activeSessionId)
     : false;
+  const activePersistedSessionId = getPersistedAgentSessionId({
+    cachedSessionId: activeRuntimeSession?.id,
+    listedSessionId: activeSession?.id,
+  });
   const shouldHydrateActiveSession = shouldHydrateAgentSession({
     hasRuntime: activeSessionHasRuntime,
-    persistedSessionId: activeRuntimeSession?.id,
+    persistedSessionId: activePersistedSessionId,
   });
   const sessionDisplayName = activeSession
     ? getSessionDisplayName(activeSession)
@@ -366,11 +373,12 @@ function AgentSessionsContent({
         onClose={panelState.closePanel}
       />
       {activeSessionId ? (
-        shouldHydrateActiveSession ? (
+        shouldHydrateActiveSession && activePersistedSessionId ? (
           <Suspense fallback={<Loading />}>
             <AgentSessionTranscript
               key={activeSessionId}
-              sessionId={activeSessionId}
+              clientKey={activeSessionId}
+              persistedSessionId={activePersistedSessionId}
               onMissing={handleMissingSession}
             />
           </Suspense>
@@ -388,10 +396,12 @@ function AgentSessionsContent({
 }
 
 function AgentSessionTranscript({
-  sessionId,
+  clientKey,
+  persistedSessionId,
   onMissing,
 }: {
-  sessionId: string;
+  clientKey: string;
+  persistedSessionId: string;
   onMissing: (sessionId: string) => void;
 }) {
   const data = useLazyLoadQuery<AgentSessionsResourceSessionQuery>(
@@ -408,7 +418,7 @@ function AgentSessionTranscript({
         }
       }
     `,
-    { id: sessionId },
+    { id: persistedSessionId },
     { fetchPolicy: "store-or-network" }
   );
   const store = useAgentStore();
@@ -427,24 +437,24 @@ function AgentSessionTranscript({
 
   useEffect(() => {
     if (!agentSession) {
-      onMissing(sessionId);
+      onMissing(clientKey);
       return;
     }
     store.getState().cacheSession({
-      clientKey: sessionId,
+      clientKey,
       id: agentSession.id,
       title: agentSession.title,
       context: [],
       modelConfig: { ...defaultModelConfig },
       createdAt: Date.parse(agentSession.createdAt as string),
     });
-  }, [agentSession, defaultModelConfig, messages, onMissing, sessionId, store]);
+  }, [agentSession, clientKey, defaultModelConfig, messages, onMissing, store]);
 
   if (!agentSession) {
     return <Loading />;
   }
   return (
-    <AgentChatController sessionId={sessionId} initialMessages={messages} />
+    <AgentChatController sessionId={clientKey} initialMessages={messages} />
   );
 }
 

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -22,6 +22,7 @@ import { Button, Flex, Text } from "@phoenix/components";
 import { ChatSessionUsage } from "@phoenix/components/agent/ChatSessionUsage";
 import { Loading } from "@phoenix/components/core";
 import { useNotifyError } from "@phoenix/contexts";
+import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import type { AgentPosition } from "@phoenix/store/agentStore";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
@@ -35,6 +36,7 @@ import {
   AGENT_SESSIONS_CONNECTION_KEY,
   SESSION_PAGE_SIZE,
 } from "./agentSessionRelay";
+import { shouldHydrateAgentSession } from "./agentSessionRuntime";
 import { ChatView } from "./Chat";
 import type { AgentSessionListItem } from "./SessionListMenu";
 import {
@@ -132,6 +134,7 @@ function AgentSessionsContent({
     query
   );
   const store = useAgentStore();
+  const runtime = useAgentChatRuntime();
   const relayEnvironment = useRelayEnvironment();
   const activeSessionId = useAgentContext((state) => state.activeSessionId);
   const sessionMap = useAgentContext((state) => state.sessionMap);
@@ -179,7 +182,6 @@ function AgentSessionsContent({
       clientKey,
       id: node.id,
       title: runtimeSession?.title || node.title,
-      messages: runtimeSession?.messages ?? [],
       createdAt: Date.parse(node.createdAt as string),
       isDeleteDisabled:
         chatStatusBySessionId[clientKey] === "submitted" ||
@@ -202,7 +204,6 @@ function AgentSessionsContent({
           clientKey: activeLocalSession.clientKey,
           id: activeLocalSession.id,
           title: activeLocalSession.title,
-          messages: activeLocalSession.messages,
           createdAt: activeLocalSession.createdAt,
           isDeleteDisabled:
             chatStatusBySessionId[activeLocalSession.clientKey] ===
@@ -305,6 +306,13 @@ function AgentSessionsContent({
   const activeRuntimeSession = activeSessionId
     ? sessionMap[activeSessionId]
     : undefined;
+  const activeSessionHasRuntime = activeSessionId
+    ? runtime.hasChat(activeSessionId)
+    : false;
+  const shouldHydrateActiveSession = shouldHydrateAgentSession({
+    hasRuntime: activeSessionHasRuntime,
+    persistedSessionId: activeRuntimeSession?.id,
+  });
   const sessionDisplayName = activeSession
     ? getSessionDisplayName(activeSession)
     : activeRuntimeSession
@@ -358,13 +366,7 @@ function AgentSessionsContent({
         onClose={panelState.closePanel}
       />
       {activeSessionId ? (
-        activeRuntimeSession ? (
-          <AgentChatController
-            key={activeSessionId}
-            sessionId={activeSessionId}
-            initialMessages={activeRuntimeSession.messages}
-          />
-        ) : (
+        shouldHydrateActiveSession ? (
           <Suspense fallback={<Loading />}>
             <AgentSessionTranscript
               key={activeSessionId}
@@ -372,6 +374,11 @@ function AgentSessionsContent({
               onMissing={handleMissingSession}
             />
           </Suspense>
+        ) : (
+          <AgentChatController
+            key={activeSessionId}
+            sessionId={activeSessionId}
+          />
         )
       ) : (
         <Loading />
@@ -427,7 +434,6 @@ function AgentSessionTranscript({
       clientKey: sessionId,
       id: agentSession.id,
       title: agentSession.title,
-      messages,
       context: [],
       modelConfig: { ...defaultModelConfig },
       createdAt: Date.parse(agentSession.createdAt as string),
@@ -447,7 +453,7 @@ function AgentChatController({
   initialMessages,
 }: {
   sessionId: string;
-  initialMessages: AgentUIMessage[];
+  initialMessages?: AgentUIMessage[];
 }) {
   const { chatApiUrl, modelSelection, menuValue, handleModelChange } =
     useAgentChatPanelState();
@@ -489,7 +495,7 @@ function AgentChatController({
       onModelChange={handleModelChange}
       autoFocusInput
     >
-      <ChatSessionUsage sessionId={sessionId} />
+      <ChatSessionUsage sessionId={sessionId} messages={messages} />
     </ChatView>
   );
 }

--- a/app/src/components/agent/AssistantMessageActions.tsx
+++ b/app/src/components/agent/AssistantMessageActions.tsx
@@ -176,9 +176,6 @@ export function AssistantMessageActions({
   children?: ReactNode;
 }) {
   const { viewer } = useViewer();
-  const storeLocalTraces = useAgentContext(
-    (state) => state.observability.storeLocalTraces
-  );
   const assistantProjectName = useAgentContext(
     (state) => state.agentsConfig.assistantProjectName
   );
@@ -189,8 +186,8 @@ export function AssistantMessageActions({
   const messageText = getAssistantMessageText(message);
   const hasMessageText = messageText.trim().length > 0;
   const metadata = getAssistantMessageMetadata(message);
-  const canAnnotate = storeLocalTraces && metadata?.trace != null;
-  const canOpenTrace = storeLocalTraces && metadata?.trace != null;
+  const canAnnotate = metadata?.trace != null;
+  const canOpenTrace = metadata?.trace != null;
 
   if (!hasMessageText && !canAnnotate && !canOpenTrace && !children) {
     return null;

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -88,13 +88,14 @@ function shouldShowThinkingIndicator({
 
   const latestMessage = messages.at(-1);
   if (latestMessage?.role !== "assistant") {
-    return false;
+    return true;
   }
 
-  const latestRelevantPart = latestMessage.parts.findLast(
-    (part) => part.type !== "text" || part.text.trim() !== ""
+  const latestVisiblePart = latestMessage.parts.findLast(
+    (part) =>
+      isToolUIPart(part) || (part.type === "text" && part.text.trim() !== "")
   );
-  return latestRelevantPart != null && isToolUIPart(latestRelevantPart);
+  return latestVisiblePart == null || isToolUIPart(latestVisiblePart);
 }
 
 function createPendingElicitationDraft(

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -334,7 +334,9 @@ export function Chat({
       emptyStateSubtext={emptyStateSubtext}
       emptyStateQuickActions={emptyStateQuickActions}
     >
-      {sessionId ? <ChatSessionUsage sessionId={sessionId} /> : null}
+      {sessionId ? (
+        <ChatSessionUsage sessionId={sessionId} messages={messages} />
+      ) : null}
     </ChatView>
   );
 }

--- a/app/src/components/agent/ChatSessionUsage.tsx
+++ b/app/src/components/agent/ChatSessionUsage.tsx
@@ -26,6 +26,7 @@ const chatSessionUsageCSS = css`
 
 type ChatSessionUsage = {
   sessionId: string;
+  messages: AgentUIMessage[];
 };
 
 type CachePromptDetails = {
@@ -38,7 +39,7 @@ type CacheUsageDisplay = {
   promptDetails: CachePromptDetails | undefined;
 };
 
-function getLatestAssistantMessageUsage(
+export function getLatestAssistantMessageUsage(
   messages: AgentUIMessage[]
 ): AgentSessionUsage | null {
   for (let index = messages.length - 1; index >= 0; index--) {
@@ -96,12 +97,11 @@ export function getCacheUsageDisplay({
   };
 }
 
-export const ChatSessionUsage = ({ sessionId }: ChatSessionUsage) => {
-  const usage = useAgentContext((state) => {
-    const session = state.sessionMap[sessionId];
-    if (!session) return null;
-    return getLatestAssistantMessageUsage(session.messages) ?? session.usage;
-  });
+export const ChatSessionUsage = ({ sessionId, messages }: ChatSessionUsage) => {
+  const storedUsage = useAgentContext(
+    (state) => state.sessionMap[sessionId]?.usage ?? null
+  );
+  const usage = getLatestAssistantMessageUsage(messages) ?? storedUsage;
   if (!usage) return null;
   const { summaryText, promptDetails } = getCacheUsageDisplay({
     promptDetails: usage.tokenCount.promptDetails,

--- a/app/src/components/agent/SessionListMenu.tsx
+++ b/app/src/components/agent/SessionListMenu.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useRef, useState } from "react";
 
-import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import {
   Button,
   Flex,
@@ -43,7 +42,6 @@ export type AgentSessionListItem = {
   clientKey: string;
   id: string | null;
   title: string;
-  messages: AgentUIMessage[];
   createdAt: number;
   isDeleteDisabled?: boolean;
 };

--- a/app/src/components/agent/__generated__/useAgentChatForkMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatForkMutation.graphql.ts
@@ -1,0 +1,146 @@
+/**
+ * @generated SignedSource<<06506db5ae28f4b3050ffdef02427117>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type useAgentChatForkMutation$variables = {
+  lastMessageId?: string | null;
+  sourceSessionId: string;
+};
+export type useAgentChatForkMutation$data = {
+  readonly forkAgentSession: {
+    readonly agentSession: {
+      readonly createdAt: string;
+      readonly id: string;
+      readonly messages: any;
+      readonly title: string;
+    };
+  };
+};
+export type useAgentChatForkMutation = {
+  response: useAgentChatForkMutation$data;
+  variables: useAgentChatForkMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "lastMessageId"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "sourceSessionId"
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "fields": [
+          {
+            "kind": "Variable",
+            "name": "lastMessageId",
+            "variableName": "lastMessageId"
+          },
+          {
+            "kind": "Variable",
+            "name": "sourceSessionId",
+            "variableName": "sourceSessionId"
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "input"
+      }
+    ],
+    "concreteType": "AgentSessionMutationPayload",
+    "kind": "LinkedField",
+    "name": "forkAgentSession",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "AgentSession",
+        "kind": "LinkedField",
+        "name": "agentSession",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "messages",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*:: as any*/),
+      (v1/*:: as any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useAgentChatForkMutation",
+    "selections": (v2/*:: as any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*:: as any*/),
+      (v0/*:: as any*/)
+    ],
+    "kind": "Operation",
+    "name": "useAgentChatForkMutation",
+    "selections": (v2/*:: as any*/)
+  },
+  "params": {
+    "cacheID": "91f6922e36fe376ac0c6358d2094b99f",
+    "id": null,
+    "metadata": {},
+    "name": "useAgentChatForkMutation",
+    "operationKind": "mutation",
+    "text": "mutation useAgentChatForkMutation(\n  $sourceSessionId: ID!\n  $lastMessageId: String\n) {\n  forkAgentSession(input: {sourceSessionId: $sourceSessionId, lastMessageId: $lastMessageId}) {\n    agentSession {\n      id\n      title\n      createdAt\n      messages\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "bf273677bbcd829f2206727d7858f1cb";
+
+export default node;

--- a/app/src/components/agent/__generated__/useAgentChatTruncateMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatTruncateMutation.graphql.ts
@@ -1,0 +1,134 @@
+/**
+ * @generated SignedSource<<b162db06c2bf4fc253167e68c33b55ad>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type useAgentChatTruncateMutation$variables = {
+  id: string;
+  lastMessageId?: string | null;
+};
+export type useAgentChatTruncateMutation$data = {
+  readonly truncateAgentSession: {
+    readonly agentSession: {
+      readonly id: string;
+      readonly messages: any;
+      readonly updatedAt: string;
+    };
+  };
+};
+export type useAgentChatTruncateMutation = {
+  response: useAgentChatTruncateMutation$data;
+  variables: useAgentChatTruncateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "lastMessageId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "fields": [
+          {
+            "kind": "Variable",
+            "name": "id",
+            "variableName": "id"
+          },
+          {
+            "kind": "Variable",
+            "name": "lastMessageId",
+            "variableName": "lastMessageId"
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "input"
+      }
+    ],
+    "concreteType": "AgentSessionMutationPayload",
+    "kind": "LinkedField",
+    "name": "truncateAgentSession",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "AgentSession",
+        "kind": "LinkedField",
+        "name": "agentSession",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "messages",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useAgentChatTruncateMutation",
+    "selections": (v1/*:: as any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "useAgentChatTruncateMutation",
+    "selections": (v1/*:: as any*/)
+  },
+  "params": {
+    "cacheID": "4bc1a5253236806ff8671cff8f7adc3a",
+    "id": null,
+    "metadata": {},
+    "name": "useAgentChatTruncateMutation",
+    "operationKind": "mutation",
+    "text": "mutation useAgentChatTruncateMutation(\n  $id: ID!\n  $lastMessageId: String\n) {\n  truncateAgentSession(input: {id: $id, lastMessageId: $lastMessageId}) {\n    agentSession {\n      id\n      messages\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "acad0d918cc1a5974f30baf361e89277";
+
+export default node;

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -93,7 +93,7 @@ function renderChatView(
     chatKey?: string;
     chatMessages?: AgentUIMessage[];
     error?: Error;
-    status?: "ready" | "error";
+    status?: "submitted" | "streaming" | "ready" | "error";
     initialDraftInputBySessionId?: Record<string, string>;
     sendMessage?: ChatViewSendMessage;
     retryMessage?: (messageId?: string) => void;
@@ -313,6 +313,67 @@ describe("ChatView", () => {
     expect(retryMessage).toHaveBeenCalledWith("assistant-message");
     expect(container.textContent).toContain("Show technical details");
     expect(container.textContent).toContain("provider unavailable");
+  });
+
+  it.each([
+    {
+      name: "while submitted",
+      status: "submitted" as const,
+      chatMessages: unansweredUserMessages,
+    },
+    {
+      name: "before the streaming assistant has parts",
+      status: "streaming" as const,
+      chatMessages: [
+        messages[0]!,
+        { id: "assistant-message", role: "assistant", parts: [] },
+      ] as AgentUIMessage[],
+    },
+    {
+      name: "while the streaming assistant has only step boundaries",
+      status: "streaming" as const,
+      chatMessages: [
+        messages[0]!,
+        {
+          id: "assistant-message",
+          role: "assistant",
+          parts: [{ type: "step-start" }],
+        },
+      ] as AgentUIMessage[],
+    },
+    {
+      name: "after a streaming tool call",
+      status: "streaming" as const,
+      chatMessages: [
+        messages[0]!,
+        {
+          id: "assistant-message",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Checking." },
+            {
+              type: "tool-read_prompt",
+              toolCallId: "call-1",
+              state: "input-available",
+              input: {},
+            },
+          ],
+        },
+      ] as AgentUIMessage[],
+    },
+  ])("shows Thinking... $name", ({ status, chatMessages }) => {
+    renderChatView(root, { status, chatMessages });
+
+    expect(container.textContent).toContain("Thinking...");
+  });
+
+  it("hides Thinking... once streaming text is visible", () => {
+    renderChatView(root, {
+      status: "streaming",
+      chatMessages: messages,
+    });
+
+    expect(container.textContent).not.toContain("Thinking...");
   });
 
   it("shows interrupted recovery when history ends on a user message", () => {

--- a/app/src/components/agent/__tests__/ChatSessionUsage.test.ts
+++ b/app/src/components/agent/__tests__/ChatSessionUsage.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it } from "vitest";
 
-import { getCacheUsageDisplay } from "../ChatSessionUsage";
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+
+import {
+  getCacheUsageDisplay,
+  getLatestAssistantMessageUsage,
+} from "../ChatSessionUsage";
+
+describe("getLatestAssistantMessageUsage", () => {
+  it("reads usage from the latest assistant message", () => {
+    const messages: AgentUIMessage[] = [
+      { id: "user-1", role: "user", parts: [] },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        metadata: {
+          type: "assistant",
+          sessionId: "session-1",
+          usage: {
+            tokens: { prompt: 10, completion: 5, total: 15 },
+          },
+        },
+        parts: [],
+      },
+    ];
+
+    expect(getLatestAssistantMessageUsage(messages)).toEqual({
+      tokenCount: { prompt: 10, completion: 5, total: 15 },
+    });
+  });
+});
 
 describe("getCacheUsageDisplay", () => {
   it("renders only cache read when cache write is zero", () => {

--- a/app/src/components/agent/__tests__/agentSessionRuntime.test.ts
+++ b/app/src/components/agent/__tests__/agentSessionRuntime.test.ts
@@ -1,6 +1,38 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldHydrateAgentSession } from "../agentSessionRuntime";
+import {
+  getPersistedAgentSessionId,
+  shouldHydrateAgentSession,
+} from "../agentSessionRuntime";
+
+describe("getPersistedAgentSessionId", () => {
+  it("prefers the Relay ID already reconciled into the session cache", () => {
+    expect(
+      getPersistedAgentSessionId({
+        cachedSessionId: "QWdlbnRTZXNzaW9uOjE=",
+        listedSessionId: "QWdlbnRTZXNzaW9uOjI=",
+      })
+    ).toBe("QWdlbnRTZXNzaW9uOjE=");
+  });
+
+  it("uses the server-listed ID before a session is cached", () => {
+    expect(
+      getPersistedAgentSessionId({
+        cachedSessionId: undefined,
+        listedSessionId: "QWdlbnRTZXNzaW9uOjI=",
+      })
+    ).toBe("QWdlbnRTZXNzaW9uOjI=");
+  });
+
+  it("returns null for a new browser-only session", () => {
+    expect(
+      getPersistedAgentSessionId({
+        cachedSessionId: null,
+        listedSessionId: null,
+      })
+    ).toBeNull();
+  });
+});
 
 describe("shouldHydrateAgentSession", () => {
   it("hydrates an unvisited server-listed session", () => {

--- a/app/src/components/agent/__tests__/agentSessionRuntime.test.ts
+++ b/app/src/components/agent/__tests__/agentSessionRuntime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldHydrateAgentSession } from "../agentSessionRuntime";
+
+describe("shouldHydrateAgentSession", () => {
+  it("hydrates an unvisited server-listed session", () => {
+    expect(
+      shouldHydrateAgentSession({
+        hasRuntime: false,
+        persistedSessionId: undefined,
+      })
+    ).toBe(true);
+  });
+
+  it("hydrates cached persisted metadata after runtime eviction", () => {
+    expect(
+      shouldHydrateAgentSession({
+        hasRuntime: false,
+        persistedSessionId: "session-node-id",
+      })
+    ).toBe(true);
+  });
+
+  it("does not hydrate a new local session", () => {
+    expect(
+      shouldHydrateAgentSession({
+        hasRuntime: false,
+        persistedSessionId: null,
+      })
+    ).toBe(false);
+  });
+
+  it("reuses an existing runtime", () => {
+    expect(
+      shouldHydrateAgentSession({
+        hasRuntime: true,
+        persistedSessionId: "session-node-id",
+      })
+    ).toBe(false);
+  });
+});

--- a/app/src/components/agent/agentSessionRuntime.ts
+++ b/app/src/components/agent/agentSessionRuntime.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns whether an active session needs its persisted transcript loaded.
+ * An undefined ID represents a server-listed session not yet cached locally;
+ * null represents a new browser-only session with no transcript to load.
+ */
+export function shouldHydrateAgentSession({
+  hasRuntime,
+  persistedSessionId,
+}: {
+  hasRuntime: boolean;
+  persistedSessionId: string | null | undefined;
+}): boolean {
+  return !hasRuntime && persistedSessionId !== null;
+}

--- a/app/src/components/agent/agentSessionRuntime.ts
+++ b/app/src/components/agent/agentSessionRuntime.ts
@@ -12,3 +12,17 @@ export function shouldHydrateAgentSession({
 }): boolean {
   return !hasRuntime && persistedSessionId !== null;
 }
+
+/**
+ * Resolves the Relay identity without replacing the browser client key used by
+ * the chat runtime. Newly-created sessions intentionally use different values.
+ */
+export function getPersistedAgentSessionId({
+  cachedSessionId,
+  listedSessionId,
+}: {
+  cachedSessionId: string | null | undefined;
+  listedSessionId: string | null | undefined;
+}): string | null {
+  return cachedSessionId ?? listedSessionId ?? null;
+}

--- a/app/src/components/agent/sessionTitleUtils.ts
+++ b/app/src/components/agent/sessionTitleUtils.ts
@@ -1,47 +1,5 @@
-import { isTextUIPart, type UIMessage } from "ai";
-
-const MAX_TITLE_LENGTH = 50;
-
-/**
- * Extracts the text content from the first user message in a conversation.
- * Returns the concatenated text parts, or `null` if no user message exists.
- */
-export function getFirstUserMessageText(messages: UIMessage[]): string | null {
-  const firstUserMessage = messages.find((message) => message.role === "user");
-  if (!firstUserMessage) return null;
-
-  const textContent = firstUserMessage.parts
-    .filter(isTextUIPart)
-    .map((part) => part.text)
-    .join(" ")
-    .trim();
-
-  return textContent || null;
-}
-
 export const EMPTY_SESSION_DISPLAY_NAME = "New chat";
 
-/**
- * Derives the display name for a session using a cascading strategy:
- * 1. LLM-generated `title` (set asynchronously after first exchange)
- * 2. Truncated first user message
- * 3. Hardcoded "New chat" fallback
- */
-export function getSessionDisplayName({
-  title,
-  messages,
-}: {
-  title: string;
-  messages: UIMessage[];
-}): string {
-  if (title) return title;
-
-  const firstMessage = getFirstUserMessageText(messages);
-  if (firstMessage) {
-    return firstMessage.length > MAX_TITLE_LENGTH
-      ? `${firstMessage.slice(0, MAX_TITLE_LENGTH)}...`
-      : firstMessage;
-  }
-
-  return EMPTY_SESSION_DISPLAY_NAME;
+export function getSessionDisplayName({ title }: { title: string }): string {
+  return title || EMPTY_SESSION_DISPLAY_NAME;
 }

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -1,7 +1,7 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
 import { DefaultChatTransport, getToolName, isToolUIPart } from "ai";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
 import { graphql, useMutation, useRelayEnvironment } from "react-relay";
 
 import {
@@ -76,8 +76,7 @@ const turnClientStateByChat = new WeakMap<
  * in the app-level runtime registry, then binds the current React surface to
  * whichever runtime instance should own the session right now.
  *
- * Durable state still lives in the agent store:
- * - messages are mirrored into Zustand so an idle chat can be reconstructed
+ * App-local metadata still lives in the agent store:
  * - pending elicitation is store-backed and survives remounts
  * - titles arrive in-band from the chat stream and are store-backed
  */
@@ -148,12 +147,7 @@ export function useAgentChat({
           sessionId,
           chatApiUrl,
           createChat: () => {
-            // Rehydrate from store-backed messages so evicted idle runtimes can
-            // be recreated without losing visible conversation history.
-            const runtimeMessages =
-              store.getState().sessionMap[sessionId]?.messages ??
-              initialMessages ??
-              [];
+            const runtimeMessages = initialMessages ?? [];
             const turnTraceContext = createTurnTraceContextManager();
             const toolTimings = createClientToolTimingRecorder();
             const turnCompletionGate = createTurnCompletionGate({
@@ -161,7 +155,7 @@ export function useAgentChat({
                 turnTraceContext.clear();
                 toolTimings.clear();
               },
-              finalize: ({ finalMessages, message }) => {
+              finalize: ({ message }) => {
                 const usage = getAssistantMessageMetadata(message)?.usage;
                 if (usage != null) {
                   store.getState().setSessionUsage(sessionId, {
@@ -170,11 +164,6 @@ export function useAgentChat({
                       ? { promptDetails: usage.promptDetails }
                       : {}),
                   });
-                }
-                // Finalized history is mirrored into the durable store so idle
-                // runtimes can be reclaimed and later reconstructed from state.
-                if (finalMessages) {
-                  store.getState().setSessionMessages(sessionId, finalMessages);
                 }
               },
             });
@@ -389,20 +378,6 @@ export function useAgentChat({
     );
   };
 
-  const messagesRef = useRef(messages);
-  messagesRef.current = messages;
-
-  // Persist the latest in-memory transcript when this binding unmounts because
-  // the visible surface moved, the active session changed, or the model swap
-  // caused the runtime instance to be replaced.
-  useEffect(() => {
-    return () => {
-      if (sessionId && messagesRef.current.length > 0) {
-        store.getState().setSessionMessages(sessionId, messagesRef.current);
-      }
-    };
-  }, [sessionId, store]);
-
   // Elicitation responses are written back through the runtime-owned chat so
   // the pending tool call resolves against the correct assistant turn.
   const handleElicitationSubmit = (output: ElicitToolOutput) => {
@@ -508,7 +483,6 @@ export function useAgentChat({
           },
           onError: (error) => {
             setMessages(previousMessages);
-            store.getState().setSessionMessages(sessionId, previousMessages);
             const messages = getErrorMessagesFromRelayMutationError(error);
             notifyError({
               title: "Session could not be rewound",
@@ -523,7 +497,6 @@ export function useAgentChat({
       });
       setMessages(result.messages);
       clearError();
-      store.getState().setSessionMessages(sessionId, result.messages);
       return result.restoredInput;
     },
     [
@@ -568,14 +541,10 @@ export function useAgentChat({
         },
         onCompleted: (response) => {
           const forkedSession = response.forkAgentSession.agentSession;
-          const forkedMessages = Array.isArray(forkedSession.messages)
-            ? (forkedSession.messages as AgentUIMessage[])
-            : [];
           store.getState().cacheSession({
             clientKey: forkedSession.id,
             id: forkedSession.id,
             title: forkedSession.title,
-            messages: forkedMessages,
             context: [...sourceSession.context],
             modelConfig: { ...sourceSession.modelConfig },
             createdAt: Date.parse(forkedSession.createdAt as string),

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -2,7 +2,7 @@ import { Chat, useChat } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
 import { DefaultChatTransport, getToolName, isToolUIPart } from "ai";
 import { useCallback, useEffect, useRef } from "react";
-import { useRelayEnvironment } from "react-relay";
+import { graphql, useMutation, useRelayEnvironment } from "react-relay";
 
 import {
   buildAgentChatRequestBody,
@@ -46,9 +46,13 @@ import {
 import { WRITE_PROMPT_TOOLS_TOOL_NAME } from "@phoenix/agent/tools/playgroundPromptTools";
 import { SAVE_PROMPT_TOOL_NAME } from "@phoenix/agent/tools/playgroundSavePrompt";
 import { authFetch } from "@phoenix/authFetch";
+import { useNotifyError } from "@phoenix/contexts";
 import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
+import type { useAgentChatForkMutation } from "./__generated__/useAgentChatForkMutation.graphql";
+import type { useAgentChatTruncateMutation } from "./__generated__/useAgentChatTruncateMutation.graphql";
 import { refetchAgentSessions } from "./agentSessionRelay";
 
 type TurnClientState = {
@@ -91,6 +95,38 @@ export function useAgentChat({
   const store = useAgentStore();
   const runtime = useAgentChatRuntime();
   const relayEnvironment = useRelayEnvironment();
+  const notifyError = useNotifyError();
+  const [commitTruncate] = useMutation<useAgentChatTruncateMutation>(graphql`
+    mutation useAgentChatTruncateMutation($id: ID!, $lastMessageId: String) {
+      truncateAgentSession(input: { id: $id, lastMessageId: $lastMessageId }) {
+        agentSession {
+          id
+          messages
+          updatedAt
+        }
+      }
+    }
+  `);
+  const [commitFork] = useMutation<useAgentChatForkMutation>(graphql`
+    mutation useAgentChatForkMutation(
+      $sourceSessionId: ID!
+      $lastMessageId: String
+    ) {
+      forkAgentSession(
+        input: {
+          sourceSessionId: $sourceSessionId
+          lastMessageId: $lastMessageId
+        }
+      ) {
+        agentSession {
+          id
+          title
+          createdAt
+          messages
+        }
+      }
+    }
+  `);
   const pendingElicitation = useAgentContext((state) =>
     sessionId ? (state.pendingElicitationBySessionId[sessionId] ?? null) : null
   );
@@ -462,6 +498,25 @@ export function useAgentChat({
       if (!result) {
         return null;
       }
+      const persistedSessionId = store.getState().sessionMap[sessionId]?.id;
+      if (persistedSessionId) {
+        const previousMessages = chatInstance.messages;
+        commitTruncate({
+          variables: {
+            id: persistedSessionId,
+            lastMessageId: result.messages.at(-1)?.id ?? null,
+          },
+          onError: (error) => {
+            setMessages(previousMessages);
+            store.getState().setSessionMessages(sessionId, previousMessages);
+            const messages = getErrorMessagesFromRelayMutationError(error);
+            notifyError({
+              title: "Session could not be rewound",
+              message: messages?.[0] ?? error.message,
+            });
+          },
+        });
+      }
       clearDroppedToolState({
         previous: chatInstance.messages,
         next: result.messages,
@@ -475,6 +530,8 @@ export function useAgentChat({
       chatInstance,
       clearDroppedToolState,
       clearError,
+      commitTruncate,
+      notifyError,
       sessionId,
       setMessages,
       store,
@@ -496,13 +553,60 @@ export function useAgentChat({
         return null;
       }
       clearError();
-      return store.getState().forkSession({
-        sourceSessionId: sessionId,
-        messages: result.messages,
-        restoredInput: result.restoredInput,
+      const sourceSession = store.getState().sessionMap[sessionId];
+      if (!sourceSession?.id) {
+        notifyError({
+          title: "Session could not be branched",
+          message: "The session must be persisted before it can be branched.",
+        });
+        return null;
+      }
+      commitFork({
+        variables: {
+          sourceSessionId: sourceSession.id,
+          lastMessageId: result.messages.at(-1)?.id ?? null,
+        },
+        onCompleted: (response) => {
+          const forkedSession = response.forkAgentSession.agentSession;
+          const forkedMessages = Array.isArray(forkedSession.messages)
+            ? (forkedSession.messages as AgentUIMessage[])
+            : [];
+          store.getState().cacheSession({
+            clientKey: forkedSession.id,
+            id: forkedSession.id,
+            title: forkedSession.title,
+            messages: forkedMessages,
+            context: [...sourceSession.context],
+            modelConfig: { ...sourceSession.modelConfig },
+            createdAt: Date.parse(forkedSession.createdAt as string),
+          });
+          if (result.restoredInput) {
+            store
+              .getState()
+              .setDraftInput(forkedSession.id, result.restoredInput);
+          }
+          store.getState().setActiveSession(forkedSession.id);
+          void refetchAgentSessions({ environment: relayEnvironment });
+        },
+        onError: (error) => {
+          const messages = getErrorMessagesFromRelayMutationError(error);
+          notifyError({
+            title: "Session could not be branched",
+            message: messages?.[0] ?? error.message,
+          });
+        },
       });
+      return null;
     },
-    [chatInstance, clearError, sessionId, store]
+    [
+      chatInstance,
+      clearError,
+      commitFork,
+      notifyError,
+      relayEnvironment,
+      sessionId,
+      store,
+    ]
   );
 
   const retryMessage = useCallback(

--- a/app/src/contexts/AgentChatRuntimeContext.tsx
+++ b/app/src/contexts/AgentChatRuntimeContext.tsx
@@ -26,6 +26,8 @@ type AgentChatRuntime = {
     chatApiUrl: string;
     createChat: () => Chat<AgentUIMessage>;
   }) => Chat<AgentUIMessage>;
+  /** Returns whether a session already has a live browser transcript runtime. */
+  hasChat: (sessionId: string) => boolean;
   /**
    * Reconciles the runtime registry against current app state, reclaiming chats
    * that no longer need to remain imperative singletons.
@@ -45,10 +47,8 @@ type AgentChatRuntime = {
  * Policy:
  * - deleted sessions are always evicted
  * - the active session is always retained, even when idle
- * - inactive sessions are retained only while a response is in flight so
- *   streaming can survive surface changes or session switches
- * - idle inactive sessions are reconstructed from store-backed messages when
- *   revisited, so their runtime can be reclaimed eagerly
+ * - inactive sessions are retained while a response or tool continuation is active
+ * - inactive idle sessions can be evicted and later rehydrated from Relay
  */
 export function shouldRetainChatRuntime({
   sessionId,
@@ -63,14 +63,12 @@ export function shouldRetainChatRuntime({
   status: ChatStatus;
   hasPendingToolOutput?: boolean;
 }) {
-  if (!liveSessionIds.has(sessionId)) {
-    return false;
-  }
-
   if (sessionId === activeSessionId) {
     return true;
   }
-
+  if (!liveSessionIds.has(sessionId)) {
+    return false;
+  }
   return (
     status === "submitted" || status === "streaming" || hasPendingToolOutput
   );
@@ -84,11 +82,10 @@ const AgentChatRuntimeContext = createContext<AgentChatRuntime | null>(null);
  * The important split is:
  * - React components are disposable view bindings
  * - AI SDK `Chat` instances are imperative runtimes owned here
- * - Zustand remains the durable source of truth for session metadata/messages
+ * - Relay hydrates committed transcripts and Zustand stores session metadata
  *
  * That lets requests continue while the visible surface moves between layouts,
- * while still allowing idle runtimes to be reclaimed and reconstructed from
- * store-backed state when revisited.
+ * while active work survives remounts and idle sessions rehydrate from Relay.
  */
 export function AgentChatRuntimeProvider({ children }: PropsWithChildren) {
   const store = useAgentStore();
@@ -133,6 +130,7 @@ export function AgentChatRuntimeProvider({ children }: PropsWithChildren) {
         });
         return chat;
       },
+      hasChat: (sessionId) => chatRegistry.has(sessionId),
       pruneChats: ({ activeSessionId, liveSessionIds }) => {
         const liveSessionIdSet = new Set(liveSessionIds);
         for (const sessionId of chatRegistry.keys()) {
@@ -151,9 +149,6 @@ export function AgentChatRuntimeProvider({ children }: PropsWithChildren) {
             continue;
           }
 
-          // Once a chat no longer needs to remain runtime-resident, the store
-          // becomes the only durable source of truth until the chat is created
-          // again for a future surface/session visit.
           entry?.unsubscribe();
           chatRegistry.delete(sessionId);
           store.getState().setSessionChatStatus(sessionId, "ready");

--- a/app/src/contexts/__tests__/AgentChatRuntimeContext.test.ts
+++ b/app/src/contexts/__tests__/AgentChatRuntimeContext.test.ts
@@ -14,6 +14,17 @@ describe("shouldRetainChatRuntime", () => {
     ).toBe(true);
   });
 
+  it("retains the active session before Relay metadata is cached", () => {
+    expect(
+      shouldRetainChatRuntime({
+        sessionId: "session-a",
+        activeSessionId: "session-a",
+        liveSessionIds: new Set(),
+        status: "ready",
+      })
+    ).toBe(true);
+  });
+
   it("retains inactive sessions while a response is in flight", () => {
     expect(
       shouldRetainChatRuntime({
@@ -23,18 +34,9 @@ describe("shouldRetainChatRuntime", () => {
         status: "streaming",
       })
     ).toBe(true);
-
-    expect(
-      shouldRetainChatRuntime({
-        sessionId: "session-a",
-        activeSessionId: "session-b",
-        liveSessionIds: new Set(["session-a", "session-b"]),
-        status: "submitted",
-      })
-    ).toBe(true);
   });
 
-  it("evicts inactive idle sessions that still exist in the store", () => {
+  it("evicts inactive idle sessions for Relay rehydration", () => {
     expect(
       shouldRetainChatRuntime({
         sessionId: "session-a",
@@ -45,7 +47,7 @@ describe("shouldRetainChatRuntime", () => {
     ).toBe(false);
   });
 
-  it("retains inactive ready sessions while tool output is pending", () => {
+  it("retains inactive sessions with pending tool output", () => {
     expect(
       shouldRetainChatRuntime({
         sessionId: "session-a",
@@ -61,7 +63,7 @@ describe("shouldRetainChatRuntime", () => {
     expect(
       shouldRetainChatRuntime({
         sessionId: "session-a",
-        activeSessionId: "session-a",
+        activeSessionId: "session-b",
         liveSessionIds: new Set(["session-b"]),
         status: "streaming",
       })

--- a/app/src/store/__tests__/agentStore.test.ts
+++ b/app/src/store/__tests__/agentStore.test.ts
@@ -162,15 +162,6 @@ describe("agentStore", () => {
     });
   });
 
-  describe("setSessionMessages", () => {
-    it("no-ops for unknown session", () => {
-      const store = createAgentStore();
-      const before = store.getState();
-      store.getState().setSessionMessages("nonexistent", []);
-      expect(store.getState().sessionMap).toBe(before.sessionMap);
-    });
-  });
-
   describe("session retention", () => {
     it("retains prior sessions when creating a new session", () => {
       const store = createAgentStore();
@@ -187,13 +178,12 @@ describe("agentStore", () => {
   });
 
   describe("cacheSession", () => {
-    it("adds a server-loaded transcript to the runtime cache", () => {
+    it("adds server-loaded metadata to the runtime cache", () => {
       const store = createAgentStore();
       store.getState().cacheSession({
         clientKey: "remote",
         id: "remote-node-id",
         title: "remote session",
-        messages: [{ id: "m1", role: "user", parts: [] }],
         context: [],
         modelConfig: store.getState().defaultModelConfig,
         createdAt: 1,
@@ -203,26 +193,20 @@ describe("agentStore", () => {
       expect(state.sessions).toEqual(["remote"]);
       expect(state.sessionMap["remote"]).toMatchObject({
         title: "remote session",
-        messages: [{ id: "m1", role: "user", parts: [] }],
         createdAt: 1,
       });
       expect(state.activeSessionId).toBeNull();
     });
 
-    it("preserves live messages while backfilling a server title", () => {
+    it("preserves local metadata while backfilling a server title", () => {
       const store = createAgentStore();
       const localSessionId = store.getState().createSession();
-      store
-        .getState()
-        .setSessionMessages(localSessionId, [
-          { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] },
-        ]);
+      store.getState().addSessionContext(localSessionId, "span:123");
 
       store.getState().cacheSession({
         clientKey: localSessionId,
         id: "local-node-id",
         title: "server title",
-        messages: [],
         context: [],
         modelConfig: store.getState().defaultModelConfig,
         createdAt: 1,
@@ -231,136 +215,8 @@ describe("agentStore", () => {
       const state = store.getState();
       expect(state.sessions).toEqual([localSessionId]);
       const localSession = state.sessionMap[localSessionId];
-      expect(localSession?.messages).toHaveLength(1);
       expect(localSession?.title).toBe("server title");
-    });
-  });
-
-  describe("forkSession", () => {
-    it("creates a new active session retaining the source session", () => {
-      const store = createAgentStore();
-      const sourceId = store.getState().createSession();
-      const messages = [{ id: "user-1", role: "user" as const, parts: [] }];
-
-      const forkId = store.getState().forkSession({
-        sourceSessionId: sourceId,
-        messages,
-      });
-
-      expect(forkId).not.toBeNull();
-      const state = store.getState();
-      expect(state.activeSessionId).toBe(forkId);
-      // Source session is preserved alongside the fork.
-      expect(state.sessionMap[sourceId]).toBeDefined();
-      expect(state.sessionMap[forkId!].messages).toEqual(messages);
-    });
-
-    it("copies the source session's model config and context", () => {
-      const store = createAgentStore();
-      const sourceId = store.getState().createSession();
-      store
-        .getState()
-        .updateSessionModelConfig(sourceId, { modelName: "gpt-4o" });
-      store.getState().addSessionContext(sourceId, "span:123");
-
-      const forkId = store.getState().forkSession({
-        sourceSessionId: sourceId,
-        messages: [],
-      });
-
-      const forked = store.getState().sessionMap[forkId!];
-      expect(forked.modelConfig.modelName).toBe("gpt-4o");
-      expect(forked.context).toEqual(["span:123"]);
-    });
-
-    it("stages restored input as the forked session draft", () => {
-      const store = createAgentStore();
-      const sourceId = store.getState().createSession();
-
-      const forkId = store.getState().forkSession({
-        sourceSessionId: sourceId,
-        messages: [],
-        restoredInput: "edit me",
-      });
-
-      expect(store.getState().draftInputBySessionId[forkId!]).toBe("edit me");
-    });
-
-    it("prefixes the source title with (branch)", () => {
-      const store = createAgentStore();
-      const sourceId = store.getState().createSession();
-      store.getState().updateSessionTitle(sourceId, "Debugging traces");
-
-      const forkId = store.getState().forkSession({
-        sourceSessionId: sourceId,
-        messages: [],
-      });
-
-      expect(store.getState().sessionMap[forkId!].title).toBe(
-        "(branch) Debugging traces"
-      );
-    });
-
-    it("derives the fork title from the first user message when the source is untitled", () => {
-      const store = createAgentStore();
-      const sourceId = store.getState().createSession();
-
-      const forkId = store.getState().forkSession({
-        sourceSessionId: sourceId,
-        messages: [
-          {
-            id: "user-1",
-            role: "user" as const,
-            parts: [{ type: "text" as const, text: "How do I trace OpenAI?" }],
-          },
-        ],
-      });
-
-      // The source session still has the messages too (fork copies them), but
-      // here we assert the fork derives its own label from its messages.
-      store.getState().setSessionMessages(sourceId, [
-        {
-          id: "user-1",
-          role: "user",
-          parts: [{ type: "text", text: "How do I trace OpenAI?" }],
-        },
-      ]);
-      const refork = store.getState().forkSession({
-        sourceSessionId: sourceId,
-        messages: [],
-      });
-      expect(store.getState().sessionMap[refork!].title).toBe(
-        "(branch) How do I trace OpenAI?"
-      );
-      expect(forkId).not.toBeNull();
-    });
-
-    it("does not stack the (branch) prefix when branching from a branch", () => {
-      const store = createAgentStore();
-      const sourceId = store.getState().createSession();
-      store.getState().updateSessionTitle(sourceId, "(branch) Original");
-
-      const forkId = store.getState().forkSession({
-        sourceSessionId: sourceId,
-        messages: [],
-      });
-
-      expect(store.getState().sessionMap[forkId!].title).toBe(
-        "(branch) Original"
-      );
-    });
-
-    it("returns null and no-ops for an unknown source session", () => {
-      const store = createAgentStore();
-      const before = store.getState().sessions;
-
-      const forkId = store.getState().forkSession({
-        sourceSessionId: "missing",
-        messages: [],
-      });
-
-      expect(forkId).toBeNull();
-      expect(store.getState().sessions).toBe(before);
+      expect(localSession?.context).toEqual(["span:123"]);
     });
   });
 

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -1,9 +1,8 @@
-import { isTextUIPart, type ChatStatus } from "ai";
+import type { ChatStatus } from "ai";
 import type { StateCreator } from "zustand";
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
-import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import {
   agentContextKey,
   type AgentContext,
@@ -123,8 +122,7 @@ export type PendingAgentMessage = {
 };
 
 /**
- * An agent conversation session containing messages, context references,
- * and its own model configuration (initially cloned from the default).
+ * App-local metadata for an agent conversation session.
  */
 export type AgentSession = {
   /** Stable client-side key used to identify the session in React. */
@@ -133,8 +131,6 @@ export type AgentSession = {
   id: string | null;
   /** Brief human-readable title for the conversation. */
   title: string;
-  /** Messages in AI SDK UIMessage format. */
-  messages: AgentUIMessage[];
   /** Contextual references (e.g. trace IDs, span IDs) attached to the session. */
   context: string[];
   /** Model configuration scoped to this session. */
@@ -171,42 +167,6 @@ const DEFAULT_AGENT_OBSERVABILITY_SETTINGS: AgentObservabilitySettings = {
 const DEFAULT_AGENT_PERMISSIONS: AgentPermissions = {
   edits: "manual",
 };
-
-/** Prefix applied to a branched session's title to denote its origin. */
-const FORK_TITLE_PREFIX = "(branch) ";
-
-/** Max length for a derived (non-LLM) fork title before truncation. */
-const FORK_TITLE_MAX_LENGTH = 50;
-
-/**
- * Builds the title for a session branched from `source`. Reuses the source's
- * LLM-generated title when available, otherwise derives a short label from
- * its first user message, then prefixes it with `(branch)`. Seeding a non-empty
- * title here also prevents the async summarizer from overwriting it.
- */
-function buildForkTitle(source: AgentSession): string {
-  let base = source.title.trim();
-  if (!base) {
-    const firstUserMessage = source.messages.find(
-      (message) => message.role === "user"
-    );
-    const text = firstUserMessage?.parts
-      .filter(isTextUIPart)
-      .map((part) => part.text)
-      .join(" ")
-      .trim();
-    base = text
-      ? text.length > FORK_TITLE_MAX_LENGTH
-        ? `${text.slice(0, FORK_TITLE_MAX_LENGTH)}...`
-        : text
-      : "";
-  }
-  // Avoid stacking "(branch) (branch) ..." when branching from a branch.
-  if (base.startsWith(FORK_TITLE_PREFIX)) {
-    return base;
-  }
-  return base ? `${FORK_TITLE_PREFIX}${base}` : FORK_TITLE_PREFIX.trim();
-}
 
 export function getCurrentTraceConsentSettings(
   agentsConfig: AgentServerConfig
@@ -313,11 +273,6 @@ export interface AgentState extends AgentProps {
   setFabPlacement: (placement: AgentFabPlacement) => void;
   createSession: () => string;
   deleteSession: (sessionId: string) => void;
-  forkSession: (params: {
-    sourceSessionId: string;
-    messages: AgentUIMessage[];
-    restoredInput?: string | null;
-  }) => string | null;
   setActiveSession: (sessionId: string | null) => void;
   updateSessionTitle: (sessionId: string, title: string) => void;
   updateSessionModelConfig: (
@@ -326,11 +281,8 @@ export interface AgentState extends AgentProps {
   ) => void;
   addSessionContext: (sessionId: string, context: string) => void;
   removeSessionContext: (sessionId: string, context: string) => void;
-  setSessionMessages: (sessionId: string, messages: AgentUIMessage[]) => void;
   setSessionPersisted: (clientKey: string, id: string) => void;
-  /**
-   * Adds a server-loaded transcript to the app-local runtime cache.
-   */
+  /** Adds server-loaded session metadata to the app-local cache. */
   cacheSession: (session: AgentSession) => void;
   setDefaultModelConfig: (config: ModelConfig) => void;
   setObservability: (patch: Partial<AgentObservabilitySettings>) => void;
@@ -676,7 +628,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
             clientKey: sessionId,
             id: null,
             title: "",
-            messages: [],
             context: [],
             modelConfig: { ...state.defaultModelConfig },
             createdAt: Date.now(),
@@ -691,40 +642,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         { type: "createSession" }
       );
       return sessionId;
-    },
-    forkSession: ({ sourceSessionId, messages, restoredInput }) => {
-      const sessionId = generateUUID();
-      let created = false;
-      set(
-        (state) => {
-          const source = state.sessionMap[sourceSessionId];
-          if (!source) return state;
-          created = true;
-          const session: AgentSession = {
-            clientKey: sessionId,
-            id: null,
-            title: buildForkTitle(source),
-            messages,
-            // Carry over the source session's context and model so the fork
-            // continues the same conversation under the same configuration.
-            context: [...source.context],
-            modelConfig: { ...source.modelConfig },
-            createdAt: Date.now(),
-          };
-          const draftInputBySessionId = restoredInput
-            ? { ...state.draftInputBySessionId, [sessionId]: restoredInput }
-            : state.draftInputBySessionId;
-          return {
-            sessions: [...state.sessions, sessionId],
-            sessionMap: { ...state.sessionMap, [sessionId]: session },
-            activeSessionId: sessionId,
-            draftInputBySessionId,
-          };
-        },
-        false,
-        { type: "forkSession" }
-      );
-      return created ? sessionId : null;
     },
     deleteSession: (sessionId) => {
       set(
@@ -847,22 +764,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         { type: "removeSessionContext" }
       );
     },
-    setSessionMessages: (sessionId, messages) => {
-      set(
-        (state) => {
-          const session = state.sessionMap[sessionId];
-          if (!session) return state;
-          return {
-            sessionMap: {
-              ...state.sessionMap,
-              [sessionId]: { ...session, messages },
-            },
-          };
-        },
-        false,
-        { type: "setSessionMessages" }
-      );
-    },
     setSessionPersisted: (clientKey, id) => {
       set(
         (state) => {
@@ -894,10 +795,6 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
                     ...session,
                     ...existing,
                     title: existing.title || session.title,
-                    messages:
-                      existing.messages.length > 0
-                        ? existing.messages
-                        : session.messages,
                   }
                 : session,
             },

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1548,6 +1548,114 @@ export interface components {
             data: components["schemas"]["DatasetLabel"];
         };
         /**
+         * AgentChatRegenerateMessage
+         * @description Regenerate a persisted assistant response.
+         */
+        AgentChatRegenerateMessage: {
+            /**
+             * Ingesttraces
+             * @default false
+             */
+            ingestTraces?: boolean;
+            /**
+             * Exportremotetraces
+             * @default false
+             */
+            exportRemoteTraces?: boolean;
+            /**
+             * Attachuserid
+             * @description When true and the request is authenticated as a PhoenixUser, attaches the user's email as the OpenInference ``user.id`` span attribute on all traced work for this request.
+             * @default false
+             */
+            attachUserId?: boolean;
+            /** Contexts */
+            contexts?: components["schemas"]["ChatContext"][];
+            /** Agentsessionid */
+            agentSessionId?: string | null;
+            /**
+             * Editpermission
+             * @default manual
+             * @enum {string}
+             */
+            editPermission?: "manual" | "bypass";
+            /**
+             * Requestedskills
+             * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
+             */
+            requestedSkills?: string[];
+            /** Model */
+            model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
+            turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            trigger: "regenerate-message";
+            /** Id */
+            id: string;
+            /** Messageid */
+            messageId?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * AgentChatRequest
+         * @description Incremental request for a database-backed assistant session.
+         */
+        AgentChatRequest: components["schemas"]["AgentChatSubmitMessage"] | components["schemas"]["AgentChatRegenerateMessage"];
+        /**
+         * AgentChatSubmitMessage
+         * @description Submit one new user message or one assistant tool-response update.
+         */
+        AgentChatSubmitMessage: {
+            /**
+             * Ingesttraces
+             * @default false
+             */
+            ingestTraces?: boolean;
+            /**
+             * Exportremotetraces
+             * @default false
+             */
+            exportRemoteTraces?: boolean;
+            /**
+             * Attachuserid
+             * @description When true and the request is authenticated as a PhoenixUser, attaches the user's email as the OpenInference ``user.id`` span attribute on all traced work for this request.
+             * @default false
+             */
+            attachUserId?: boolean;
+            /** Contexts */
+            contexts?: components["schemas"]["ChatContext"][];
+            /** Agentsessionid */
+            agentSessionId?: string | null;
+            /**
+             * Editpermission
+             * @default manual
+             * @enum {string}
+             */
+            editPermission?: "manual" | "bypass";
+            /**
+             * Requestedskills
+             * @description Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored.
+             */
+            requestedSkills?: string[];
+            /** Model */
+            model: components["schemas"]["CustomProviderModelSelection"] | components["schemas"]["BuiltInProviderModelSelection"];
+            turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            trigger: "submit-message";
+            /** Id */
+            id: string;
+            message: components["schemas"]["PhoenixUIMessage"];
+            /** Parentmessageid */
+            parentMessageId?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * AgentSpanContext
          * @description Span the user has selected.
          *
@@ -1785,7 +1893,7 @@ export interface components {
             /** Id */
             id: string;
             /** Messages */
-            messages: components["schemas"]["PhoenixUIMessage"][];
+            messages: components["schemas"]["UIMessage"][];
             /** Messageid */
             messageId?: string | null;
             /**
@@ -1843,7 +1951,7 @@ export interface components {
             /** Id */
             id: string;
             /** Messages */
-            messages: components["schemas"]["PhoenixUIMessage"][];
+            messages: components["schemas"]["UIMessage"][];
             /**
              * Ingesttraces
              * @default false
@@ -5473,6 +5581,23 @@ export interface components {
              * Format: date-time
              */
             startedAt: string;
+        };
+        /**
+         * UIMessage
+         * @description A message as displayed in the UI by Vercel AI Elements.
+         */
+        UIMessage: {
+            /** Id */
+            id: string;
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "system" | "user" | "assistant";
+            /** Metadata */
+            metadata?: unknown | null;
+            /** Parts */
+            parts: (components["schemas"]["TextUIPart"] | components["schemas"]["ReasoningUIPart"] | components["schemas"]["ToolInputStreamingPart"] | components["schemas"]["ToolInputAvailablePart"] | components["schemas"]["ToolOutputAvailablePart"] | components["schemas"]["ToolOutputErrorPart"] | components["schemas"]["ToolApprovalRequestedPart"] | components["schemas"]["ToolApprovalRespondedPart"] | components["schemas"]["ToolOutputDeniedPart"] | components["schemas"]["DynamicToolInputStreamingPart"] | components["schemas"]["DynamicToolInputAvailablePart"] | components["schemas"]["DynamicToolOutputAvailablePart"] | components["schemas"]["DynamicToolOutputErrorPart"] | components["schemas"]["DynamicToolApprovalRequestedPart"] | components["schemas"]["DynamicToolApprovalRespondedPart"] | components["schemas"]["DynamicToolOutputDeniedPart"] | components["schemas"]["SourceUrlUIPart"] | components["schemas"]["SourceDocumentUIPart"] | components["schemas"]["FileUIPart"] | components["schemas"]["DataUIPart"] | components["schemas"]["StepStartUIPart"])[];
         };
         /** UpdateAnnotationConfigResponseBody */
         UpdateAnnotationConfigResponseBody: {
@@ -10385,7 +10510,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ChatRequest"];
+                "application/json": components["schemas"]["AgentChatRequest"];
             };
         };
         responses: {

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1566,6 +1566,37 @@ class TraceData(TypedDict):
     spans: NotRequired[Sequence[TraceSpanData]]
 
 
+class UIMessage(TypedDict):
+    id: str
+    role: Literal["system", "user", "assistant"]
+    parts: Sequence[
+        Union[
+            TextUIPart,
+            ReasoningUIPart,
+            ToolInputStreamingPart,
+            ToolInputAvailablePart,
+            ToolOutputAvailablePart,
+            ToolOutputErrorPart,
+            ToolApprovalRequestedPart,
+            ToolApprovalRespondedPart,
+            ToolOutputDeniedPart,
+            DynamicToolInputStreamingPart,
+            DynamicToolInputAvailablePart,
+            DynamicToolOutputAvailablePart,
+            DynamicToolOutputErrorPart,
+            DynamicToolApprovalRequestedPart,
+            DynamicToolApprovalRespondedPart,
+            DynamicToolOutputDeniedPart,
+            SourceUrlUIPart,
+            SourceDocumentUIPart,
+            FileUIPart,
+            DataUIPart,
+            StepStartUIPart,
+        ]
+    ]
+    metadata: NotRequired[Any]
+
+
 class UpdateAnnotationConfigResponseBody(TypedDict):
     data: Union[CategoricalAnnotationConfig, ContinuousAnnotationConfig, FreeformAnnotationConfig]
 
@@ -1591,6 +1622,75 @@ class AssistantMessageMetadata(TypedDict):
     trace: NotRequired[AssistantMessageMetadataTraceIds]
     turnTraceContext: NotRequired[TurnTraceContext]
     usage: NotRequired[AssistantMessageMetadataUsage]
+
+
+class ChatRegenerateMessage(TypedDict):
+    id: str
+    messages: Sequence[UIMessage]
+    model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
+    trigger: Literal["regenerate-message"]
+    messageId: NotRequired[str]
+    ingestTraces: NotRequired[bool]
+    exportRemoteTraces: NotRequired[bool]
+    attachUserId: NotRequired[bool]
+    contexts: NotRequired[
+        Sequence[
+            Union[
+                AppContext,
+                ProjectContext,
+                TraceContext,
+                SessionContext,
+                PromptContext,
+                PromptVersionContext,
+                AgentSpanContext,
+                PlaygroundContext,
+                CodeEvaluatorContext,
+                LlmEvaluatorContext,
+                DatasetContext,
+                GraphQLContext,
+                WebAccessContext,
+                SubagentsContext,
+            ]
+        ]
+    ]
+    agentSessionId: NotRequired[str]
+    editPermission: NotRequired[Literal["manual", "bypass"]]
+    requestedSkills: NotRequired[Sequence[str]]
+    turnTraceContext: NotRequired[TurnTraceContext]
+
+
+class ChatSubmitMessage(TypedDict):
+    id: str
+    messages: Sequence[UIMessage]
+    model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
+    trigger: Literal["submit-message"]
+    ingestTraces: NotRequired[bool]
+    exportRemoteTraces: NotRequired[bool]
+    attachUserId: NotRequired[bool]
+    contexts: NotRequired[
+        Sequence[
+            Union[
+                AppContext,
+                ProjectContext,
+                TraceContext,
+                SessionContext,
+                PromptContext,
+                PromptVersionContext,
+                AgentSpanContext,
+                PlaygroundContext,
+                CodeEvaluatorContext,
+                LlmEvaluatorContext,
+                DatasetContext,
+                GraphQLContext,
+                WebAccessContext,
+                SubagentsContext,
+            ]
+        ]
+    ]
+    agentSessionId: NotRequired[str]
+    editPermission: NotRequired[Literal["manual", "bypass"]]
+    requestedSkills: NotRequired[Sequence[str]]
+    turnTraceContext: NotRequired[TurnTraceContext]
 
 
 class CreateAnnotationConfigResponseBody(TypedDict):
@@ -1667,46 +1767,44 @@ class PromptMessage(TypedDict):
     ]
 
 
-class ChatRegenerateMessage(TypedDict):
-    id: str
-    messages: Sequence[PhoenixUIMessage]
+class AgentChatRegenerateMessage(TypedDict):
     model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
+    id: str
+    ingestTraces: NotRequired[bool]
+    exportRemoteTraces: NotRequired[bool]
+    attachUserId: NotRequired[bool]
+    contexts: NotRequired[
+        Sequence[
+            Union[
+                AppContext,
+                ProjectContext,
+                TraceContext,
+                SessionContext,
+                PromptContext,
+                PromptVersionContext,
+                AgentSpanContext,
+                PlaygroundContext,
+                CodeEvaluatorContext,
+                LlmEvaluatorContext,
+                DatasetContext,
+                GraphQLContext,
+                WebAccessContext,
+                SubagentsContext,
+            ]
+        ]
+    ]
+    agentSessionId: NotRequired[str]
+    editPermission: NotRequired[Literal["manual", "bypass"]]
+    requestedSkills: NotRequired[Sequence[str]]
+    turnTraceContext: NotRequired[TurnTraceContext]
     trigger: Literal["regenerate-message"]
     messageId: NotRequired[str]
-    ingestTraces: NotRequired[bool]
-    exportRemoteTraces: NotRequired[bool]
-    attachUserId: NotRequired[bool]
-    contexts: NotRequired[
-        Sequence[
-            Union[
-                AppContext,
-                ProjectContext,
-                TraceContext,
-                SessionContext,
-                PromptContext,
-                PromptVersionContext,
-                AgentSpanContext,
-                PlaygroundContext,
-                CodeEvaluatorContext,
-                LlmEvaluatorContext,
-                DatasetContext,
-                GraphQLContext,
-                WebAccessContext,
-                SubagentsContext,
-            ]
-        ]
-    ]
-    agentSessionId: NotRequired[str]
-    editPermission: NotRequired[Literal["manual", "bypass"]]
-    requestedSkills: NotRequired[Sequence[str]]
-    turnTraceContext: NotRequired[TurnTraceContext]
 
 
-class ChatSubmitMessage(TypedDict):
-    id: str
-    messages: Sequence[PhoenixUIMessage]
+class AgentChatSubmitMessage(TypedDict):
     model: Union[CustomProviderModelSelection, BuiltInProviderModelSelection]
-    trigger: Literal["submit-message"]
+    id: str
+    message: PhoenixUIMessage
     ingestTraces: NotRequired[bool]
     exportRemoteTraces: NotRequired[bool]
     attachUserId: NotRequired[bool]
@@ -1734,6 +1832,8 @@ class ChatSubmitMessage(TypedDict):
     editPermission: NotRequired[Literal["manual", "bypass"]]
     requestedSkills: NotRequired[Sequence[str]]
     turnTraceContext: NotRequired[TurnTraceContext]
+    trigger: Literal["submit-message"]
+    parentMessageId: NotRequired[str]
 
 
 class PromptChatTemplate(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -7582,7 +7582,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChatRequest"
+                "$ref": "#/components/schemas/AgentChatRequest"
               }
             }
           }
@@ -7671,6 +7671,253 @@
           "data"
         ],
         "title": "AddDatasetLabelToDatasetResponseBody"
+      },
+      "AgentChatRegenerateMessage": {
+        "properties": {
+          "ingestTraces": {
+            "type": "boolean",
+            "title": "Ingesttraces",
+            "default": false
+          },
+          "exportRemoteTraces": {
+            "type": "boolean",
+            "title": "Exportremotetraces",
+            "default": false
+          },
+          "attachUserId": {
+            "type": "boolean",
+            "title": "Attachuserid",
+            "description": "When true and the request is authenticated as a PhoenixUser, attaches the user's email as the OpenInference ``user.id`` span attribute on all traced work for this request.",
+            "default": false
+          },
+          "contexts": {
+            "items": {
+              "$ref": "#/components/schemas/ChatContext"
+            },
+            "type": "array",
+            "title": "Contexts"
+          },
+          "agentSessionId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agentsessionid"
+          },
+          "editPermission": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "bypass"
+            ],
+            "title": "Editpermission",
+            "default": "manual"
+          },
+          "requestedSkills": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Requestedskills",
+            "description": "Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored."
+          },
+          "model": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CustomProviderModelSelection"
+              },
+              {
+                "$ref": "#/components/schemas/BuiltInProviderModelSelection"
+              }
+            ],
+            "title": "Model",
+            "discriminator": {
+              "propertyName": "providerType",
+              "mapping": {
+                "builtin": "#/components/schemas/BuiltInProviderModelSelection",
+                "custom": "#/components/schemas/CustomProviderModelSelection"
+              }
+            }
+          },
+          "turnTraceContext": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TurnTraceContext"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "trigger": {
+            "type": "string",
+            "const": "regenerate-message",
+            "title": "Trigger"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "messageId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Messageid"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "model",
+          "trigger",
+          "id"
+        ],
+        "title": "AgentChatRegenerateMessage",
+        "description": "Regenerate a persisted assistant response."
+      },
+      "AgentChatRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AgentChatSubmitMessage"
+          },
+          {
+            "$ref": "#/components/schemas/AgentChatRegenerateMessage"
+          }
+        ],
+        "title": "AgentChatRequest",
+        "description": "Incremental request for a database-backed assistant session.",
+        "discriminator": {
+          "propertyName": "trigger",
+          "mapping": {
+            "regenerate-message": "#/components/schemas/AgentChatRegenerateMessage",
+            "submit-message": "#/components/schemas/AgentChatSubmitMessage"
+          }
+        }
+      },
+      "AgentChatSubmitMessage": {
+        "properties": {
+          "ingestTraces": {
+            "type": "boolean",
+            "title": "Ingesttraces",
+            "default": false
+          },
+          "exportRemoteTraces": {
+            "type": "boolean",
+            "title": "Exportremotetraces",
+            "default": false
+          },
+          "attachUserId": {
+            "type": "boolean",
+            "title": "Attachuserid",
+            "description": "When true and the request is authenticated as a PhoenixUser, attaches the user's email as the OpenInference ``user.id`` span attribute on all traced work for this request.",
+            "default": false
+          },
+          "contexts": {
+            "items": {
+              "$ref": "#/components/schemas/ChatContext"
+            },
+            "type": "array",
+            "title": "Contexts"
+          },
+          "agentSessionId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agentsessionid"
+          },
+          "editPermission": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "bypass"
+            ],
+            "title": "Editpermission",
+            "default": "manual"
+          },
+          "requestedSkills": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Requestedskills",
+            "description": "Skills the user explicitly requested via the prompt's slash-command affordance. The server force-loads each available skill by injecting a synthetic load_skill tool call/result at the tail of the message history. Unknown or context-unavailable names are ignored."
+          },
+          "model": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CustomProviderModelSelection"
+              },
+              {
+                "$ref": "#/components/schemas/BuiltInProviderModelSelection"
+              }
+            ],
+            "title": "Model",
+            "discriminator": {
+              "propertyName": "providerType",
+              "mapping": {
+                "builtin": "#/components/schemas/BuiltInProviderModelSelection",
+                "custom": "#/components/schemas/CustomProviderModelSelection"
+              }
+            }
+          },
+          "turnTraceContext": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TurnTraceContext"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "trigger": {
+            "type": "string",
+            "const": "submit-message",
+            "title": "Trigger",
+            "default": "submit-message"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "message": {
+            "$ref": "#/components/schemas/PhoenixUIMessage"
+          },
+          "parentMessageId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parentmessageid"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "model",
+          "id",
+          "message"
+        ],
+        "title": "AgentChatSubmitMessage",
+        "description": "Submit one new user message or one assistant tool-response update."
       },
       "AgentSpanContext": {
         "properties": {
@@ -8323,7 +8570,7 @@
           },
           "messages": {
             "items": {
-              "$ref": "#/components/schemas/PhoenixUIMessage"
+              "$ref": "#/components/schemas/UIMessage"
             },
             "type": "array",
             "title": "Messages"
@@ -8463,7 +8710,7 @@
           },
           "messages": {
             "items": {
-              "$ref": "#/components/schemas/PhoenixUIMessage"
+              "$ref": "#/components/schemas/UIMessage"
             },
             "type": "array",
             "title": "Messages"
@@ -17184,6 +17431,112 @@
           "startedAt"
         ],
         "title": "TurnTraceContext"
+      },
+      "UIMessage": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "system",
+              "user",
+              "assistant"
+            ],
+            "title": "Role"
+          },
+          "metadata": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "parts": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/TextUIPart"
+                },
+                {
+                  "$ref": "#/components/schemas/ReasoningUIPart"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolInputStreamingPart"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolInputAvailablePart"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolOutputAvailablePart"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolOutputErrorPart"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolApprovalRequestedPart"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolApprovalRespondedPart"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolOutputDeniedPart"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicToolInputStreamingPart"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicToolInputAvailablePart"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicToolOutputAvailablePart"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicToolOutputErrorPart"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicToolApprovalRequestedPart"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicToolApprovalRespondedPart"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicToolOutputDeniedPart"
+                },
+                {
+                  "$ref": "#/components/schemas/SourceUrlUIPart"
+                },
+                {
+                  "$ref": "#/components/schemas/SourceDocumentUIPart"
+                },
+                {
+                  "$ref": "#/components/schemas/FileUIPart"
+                },
+                {
+                  "$ref": "#/components/schemas/DataUIPart"
+                },
+                {
+                  "$ref": "#/components/schemas/StepStartUIPart"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Parts"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "role",
+          "parts"
+        ],
+        "title": "UIMessage",
+        "description": "A message as displayed in the UI by Vercel AI Elements."
       },
       "UpdateAnnotationConfigResponseBody": {
         "properties": {

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -1,16 +1,18 @@
 """Mutations for persisted assistant chat sessions."""
 
+from datetime import datetime, timezone
+
 import strawberry
-from sqlalchemy import delete, select
+from sqlalchemy import Select, delete, select
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
 from phoenix.db import models
-from phoenix.server.api.auth import IsNotReadOnly
+from phoenix.server.api.auth import IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, NotFound
 from phoenix.server.api.queries import Query
-from phoenix.server.api.types.AgentSession import AgentSession
+from phoenix.server.api.types.AgentSession import AgentSession, to_gql_agent_session
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 
 
@@ -19,10 +21,66 @@ class DeleteAgentSessionInput:
     id: GlobalID
 
 
+@strawberry.input
+class TruncateAgentSessionInput:
+    id: GlobalID
+    last_message_id: str | None
+
+
+@strawberry.input
+class ForkAgentSessionInput:
+    source_session_id: GlobalID
+    last_message_id: str | None
+
+
 @strawberry.type
 class DeleteAgentSessionMutationPayload:
     deleted_agent_session_id: GlobalID
     query: Query
+
+
+@strawberry.type
+class AgentSessionMutationPayload:
+    agent_session: AgentSession
+    query: Query
+
+
+def _decode_agent_session_id(id: GlobalID) -> int:
+    try:
+        return from_global_id_with_expected_type(id, models.AgentSession.__name__)
+    except ValueError as exc:
+        raise BadRequest(str(exc)) from exc
+
+
+def _owner_qualified_session_stmt(
+    *,
+    agent_session_rowid: int,
+    viewer_id: int | None,
+) -> Select[tuple[models.AgentSession]]:
+    stmt = select(models.AgentSession).where(models.AgentSession.id == agent_session_rowid)
+    if viewer_id is not None:
+        stmt = stmt.where(models.AgentSession.user_id == viewer_id)
+    return stmt
+
+
+def _retained_message_count(
+    *,
+    messages: list[models.AgentSessionMessage],
+    last_message_id: str | None,
+) -> int:
+    if last_message_id is None:
+        return 0
+    for index, message in enumerate(messages):
+        if message.message.id == last_message_id:
+            return index + 1
+    raise BadRequest(f"Message '{last_message_id}' was not found in the agent session")
+
+
+def _fork_title(title: str) -> str:
+    title = title.strip()
+    if title.startswith("(branch)"):
+        return title
+    return f"(branch) {title}".rstrip()
 
 
 @strawberry.type
@@ -34,18 +92,11 @@ class AgentSessionMutationMixin:
         input: DeleteAgentSessionInput,
     ) -> DeleteAgentSessionMutationPayload:
         """Delete a persisted session along with its snapshot."""
-        try:
-            agent_session_rowid = from_global_id_with_expected_type(
-                input.id,
-                models.AgentSession.__name__,
-            )
-        except ValueError as exc:
-            raise BadRequest(str(exc)) from exc
-        lookup_stmt = select(models.AgentSession.id).where(
-            models.AgentSession.id == agent_session_rowid
-        )
-        if (viewer_id := info.context.user_id) is not None:
-            lookup_stmt = lookup_stmt.where(models.AgentSession.user_id == viewer_id)
+        agent_session_rowid = _decode_agent_session_id(input.id)
+        lookup_stmt = _owner_qualified_session_stmt(
+            agent_session_rowid=agent_session_rowid,
+            viewer_id=info.context.user_id,
+        ).with_only_columns(models.AgentSession.id)
         async with info.context.db() as session:
             agent_session_id = await session.scalar(lookup_stmt)
             if agent_session_id is not None:
@@ -56,5 +107,98 @@ class AgentSessionMutationMixin:
             raise NotFound(f"No agent session found for ID '{input.id}'")
         return DeleteAgentSessionMutationPayload(
             deleted_agent_session_id=GlobalID(AgentSession.__name__, str(agent_session_id)),
+            query=Query(),
+        )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def truncate_agent_session(
+        self,
+        info: Info[Context, None],
+        input: TruncateAgentSessionInput,
+    ) -> AgentSessionMutationPayload:
+        """Delete transcript messages after the selected retained message."""
+        agent_session_rowid = _decode_agent_session_id(input.id)
+        async with info.context.db() as session:
+            agent_session = await session.scalar(
+                _owner_qualified_session_stmt(
+                    agent_session_rowid=agent_session_rowid,
+                    viewer_id=info.context.user_id,
+                )
+            )
+            if agent_session is None:
+                raise NotFound(f"No agent session found for ID '{input.id}'")
+            messages = list(
+                await session.scalars(
+                    select(models.AgentSessionMessage)
+                    .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
+                    .order_by(models.AgentSessionMessage.position)
+                )
+            )
+            retained_count = _retained_message_count(
+                messages=messages,
+                last_message_id=input.last_message_id,
+            )
+            if retained_count < len(messages):
+                await session.execute(
+                    delete(models.AgentSessionMessage).where(
+                        models.AgentSessionMessage.agent_session_id == agent_session_rowid,
+                        models.AgentSessionMessage.position >= retained_count,
+                    )
+                )
+                await session.execute(
+                    delete(models.AgentSessionSnapshot).where(
+                        models.AgentSessionSnapshot.agent_session_id == agent_session_rowid
+                    )
+                )
+                agent_session.updated_at = datetime.now(timezone.utc)
+        return AgentSessionMutationPayload(
+            agent_session=to_gql_agent_session(agent_session),
+            query=Query(),
+        )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def fork_agent_session(
+        self,
+        info: Info[Context, None],
+        input: ForkAgentSessionInput,
+    ) -> AgentSessionMutationPayload:
+        """Create a new session from a selected persisted transcript prefix."""
+        source_session_rowid = _decode_agent_session_id(input.source_session_id)
+        async with info.context.db() as session:
+            source_session = await session.scalar(
+                _owner_qualified_session_stmt(
+                    agent_session_rowid=source_session_rowid,
+                    viewer_id=info.context.user_id,
+                )
+            )
+            if source_session is None:
+                raise NotFound(f"No agent session found for ID '{input.source_session_id}'")
+            source_messages = list(
+                await session.scalars(
+                    select(models.AgentSessionMessage)
+                    .where(models.AgentSessionMessage.agent_session_id == source_session_rowid)
+                    .order_by(models.AgentSessionMessage.position)
+                )
+            )
+            retained_count = _retained_message_count(
+                messages=source_messages,
+                last_message_id=input.last_message_id,
+            )
+            forked_session = models.AgentSession(
+                user_id=source_session.user_id,
+                title=_fork_title(source_session.title),
+            )
+            session.add(forked_session)
+            await session.flush()
+            session.add_all(
+                models.AgentSessionMessage(
+                    agent_session_id=forked_session.id,
+                    position=position,
+                    message=source_message.message,
+                )
+                for position, source_message in enumerate(source_messages[:retained_count])
+            )
+        return AgentSessionMutationPayload(
+            agent_session=to_gql_agent_session(forked_session),
             query=Query(),
         )

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -1,6 +1,7 @@
 """Mutations for persisted assistant chat sessions."""
 
 from datetime import datetime, timezone
+from uuid import uuid4
 
 import strawberry
 from sqlalchemy import Select, delete, select
@@ -185,6 +186,8 @@ class AgentSessionMutationMixin:
                 last_message_id=input.last_message_id,
             )
             forked_session = models.AgentSession(
+                project_session_id=str(uuid4()),
+                project_name=source_session.project_name,
                 user_id=source_session.user_id,
                 title=_fork_title(source_session.title),
             )

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -455,23 +455,26 @@ def _build_assistant_message_metadata(
     turn_trace_context: TurnTraceContext | None,
     session_id: str,
     usage: RunUsage,
+    include_trace: bool = True,
 ) -> AssistantMessageMetadata:
     """Build the metadata payload attached to the turn's assistant message."""
-    trace_ids = (
-        AssistantMessageMetadataTraceIds(
-            trace_id=turn_trace_context.trace_id,
-            root_span_id=turn_trace_context.root_span_id,
-        )
-        if turn_trace_context is not None
-        else (
+    trace_ids = None
+    if include_trace:
+        trace_ids = (
             AssistantMessageMetadataTraceIds(
-                trace_id=format_trace_id(span_context.trace_id),
-                root_span_id=format_span_id(span_context.span_id),
+                trace_id=turn_trace_context.trace_id,
+                root_span_id=turn_trace_context.root_span_id,
             )
-            if span_context is not None
-            else None
+            if turn_trace_context is not None
+            else (
+                AssistantMessageMetadataTraceIds(
+                    trace_id=format_trace_id(span_context.trace_id),
+                    root_span_id=format_span_id(span_context.span_id),
+                )
+                if span_context is not None
+                else None
+            )
         )
-    )
     return AssistantMessageMetadata(
         session_id=session_id,
         trace=trace_ids,
@@ -486,6 +489,7 @@ def _build_message_metadata_chunk(
     turn_trace_context: TurnTraceContext | None,
     session_id: str,
     usage: RunUsage,
+    include_trace: bool = True,
 ) -> MessageMetadataChunk:
     """Build the `MessageMetadataChunk` emitted at the end of an agent turn."""
     return MessageMetadataChunk(
@@ -494,6 +498,7 @@ def _build_message_metadata_chunk(
             session_id=session_id,
             turn_trace_context=turn_trace_context,
             usage=usage,
+            include_trace=include_trace,
         )
     )
 
@@ -1964,6 +1969,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 turn_trace_context=resolved_turn_trace_context,
                 session_id=otel_session_id,
                 usage=result.usage,
+                include_trace=ingest_traces,
             )
 
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -271,6 +271,7 @@ class _ChatMessageMixin(_ObservabilityMixin):
 
     model_config = ConfigDict(
         protected_namespaces=(),  # allow ``model`` field; pydantic reserves ``model_*``
+        extra="allow",
     )
 
     contexts: list[ChatContext] = Field(default_factory=list)
@@ -285,7 +286,6 @@ class _ChatMessageMixin(_ObservabilityMixin):
             "Unknown or context-unavailable names are ignored."
         ),
     )
-    messages: list[PhoenixUIMessage]
     model: AgentModelSelection
     turn_trace_context: TurnTraceContext | None = None
 
@@ -309,18 +309,57 @@ class ChatRequest(
     """Discriminated union of chat request payloads."""
 
 
+class AgentChatSubmitMessage(_ChatMessageMixin):
+    """Submit one new user message or one assistant tool-response update."""
+
+    trigger: Literal["submit-message"] = "submit-message"
+    id: str
+    message: PhoenixUIMessage
+    parent_message_id: str | None = None
+
+
+class AgentChatRegenerateMessage(_ChatMessageMixin):
+    """Regenerate a persisted assistant response."""
+
+    trigger: Literal["regenerate-message"]
+    id: str
+    message_id: str | None = None
+
+
+class AgentChatRequest(
+    RootModel[
+        Annotated[
+            AgentChatSubmitMessage | AgentChatRegenerateMessage,
+            Field(discriminator="trigger"),
+        ]
+    ]
+):
+    """Incremental request for a database-backed assistant session."""
+
+
 _PydanticAIRequestDataAdapter: TypeAdapter[PydanticAIRequestData] = TypeAdapter(
     PydanticAIRequestData
 )
 
 
 def _to_pydantic_ai_request_data(
-    request_data: ChatSubmitMessage | ChatRegenerateMessage,
+    request_data: (
+        ChatSubmitMessage
+        | ChatRegenerateMessage
+        | AgentChatSubmitMessage
+        | AgentChatRegenerateMessage
+    ),
+    *,
+    messages: Sequence[PhoenixUIMessage] | None = None,
 ) -> PydanticAIRequestData:
     """Validate vendored wire types into pydantic-ai's runtime request classes."""
-    return _PydanticAIRequestDataAdapter.validate_python(
-        request_data.model_dump(mode="json", by_alias=True, exclude_none=True)
-    )
+    data = request_data.model_dump(mode="json", by_alias=True, exclude_none=True)
+    if messages is not None:
+        data["messages"] = [
+            message.model_dump(mode="json", by_alias=True, exclude_none=True)
+            for message in messages
+        ]
+    return _PydanticAIRequestDataAdapter.validate_python(data)
 
 
 logger = logging.getLogger(__name__)
@@ -1204,6 +1243,101 @@ async def _load_agent_session(
     return loaded_agent_session
 
 
+async def _load_agent_session_messages(
+    session: AsyncSession,
+    *,
+    agent_session_rowid: int,
+) -> list[PhoenixUIMessage]:
+    return list(
+        await session.scalars(
+            select(models.AgentSessionMessage.message)
+            .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
+            .order_by(models.AgentSessionMessage.position)
+        )
+    )
+
+
+def _hydrate_agent_session_messages(
+    *,
+    persisted_messages: Sequence[PhoenixUIMessage],
+    request_data: AgentChatSubmitMessage | AgentChatRegenerateMessage,
+) -> list[PhoenixUIMessage]:
+    messages = list(persisted_messages)
+    if isinstance(request_data, AgentChatSubmitMessage):
+        message = request_data.message
+        if message.role == "user":
+            if request_data.parent_message_id is not None:
+                for index, persisted_message in enumerate(messages):
+                    if persisted_message.id == request_data.parent_message_id:
+                        return [*messages[: index + 1], message]
+                if (
+                    messages
+                    and messages[-1].role == "assistant"
+                    and messages[-1].id == "subagent-message"
+                ):
+                    # Assistant IDs persisted before server-issued stream IDs
+                    # cannot be matched to their browser-generated counterparts.
+                    return [*messages, message]
+                raise HTTPException(status_code=400, detail="Parent message not found in session")
+            return [*messages, message]
+        if message.role != "assistant":
+            raise HTTPException(
+                status_code=400, detail="Only user messages and tool responses are accepted"
+            )
+        if not messages or messages[-1].role != "assistant" or messages[-1].id != message.id:
+            raise HTTPException(
+                status_code=400,
+                detail="A tool response must update the latest assistant message",
+            )
+        persisted_assistant = messages[-1]
+        persisted_part_indices_by_tool_call_id = {
+            tool_call_id: index
+            for index, part in enumerate(persisted_assistant.parts)
+            if (tool_call_id := getattr(part, "tool_call_id", None)) is not None
+        }
+        merged_parts = list(persisted_assistant.parts)
+        allowed_states = {
+            "approval-responded",
+            "output-available",
+            "output-denied",
+            "output-error",
+        }
+        for tool_response in message.parts:
+            tool_call_id = getattr(tool_response, "tool_call_id", None)
+            state = getattr(tool_response, "state", None)
+            part_index = persisted_part_indices_by_tool_call_id.get(tool_call_id)
+            if tool_call_id is None or state not in allowed_states or part_index is None:
+                raise HTTPException(status_code=400, detail="Invalid tool response")
+            persisted_part = merged_parts[part_index]
+            if (
+                getattr(persisted_part, "type", None) != getattr(tool_response, "type", None)
+                or getattr(persisted_part, "input", None) != getattr(tool_response, "input", None)
+                or getattr(persisted_part, "tool_name", None)
+                != getattr(tool_response, "tool_name", None)
+            ):
+                raise HTTPException(
+                    status_code=400, detail="Tool response does not match the session"
+                )
+            merged_parts[part_index] = tool_response
+        if not message.parts:
+            raise HTTPException(status_code=400, detail="At least one tool response is required")
+        merged_assistant = persisted_assistant.model_copy(update={"parts": merged_parts})
+        return [*messages[:-1], merged_assistant]
+
+    if not messages:
+        raise HTTPException(status_code=400, detail="Cannot regenerate an empty session")
+    if request_data.message_id is None:
+        if messages[-1].role == "assistant":
+            messages.pop()
+        return messages
+    for index, message in enumerate(messages):
+        if message.id != request_data.message_id:
+            continue
+        end = index if message.role == "assistant" else index + 1
+        return messages[:end]
+    raise HTTPException(status_code=400, detail="Regeneration message not found in session")
+
+
 async def _update_agent_session(
     session: AsyncSession,
     *,
@@ -1354,6 +1488,23 @@ async def _build_session_transcript(
             session_id,
         )
         return list(request_messages)
+    if (
+        request_messages
+        and request_messages[-1].role == "assistant"
+        and request_messages[-1].id == persisted_assistant_message.id
+    ):
+        previous_assistant_message = request_messages[-1]
+        continued_assistant_message = previous_assistant_message.model_copy(
+            update={
+                "metadata": persisted_assistant_message.metadata
+                or previous_assistant_message.metadata,
+                "parts": [
+                    *previous_assistant_message.parts,
+                    *persisted_assistant_message.parts,
+                ],
+            }
+        )
+        return [*request_messages[:-1], continued_assistant_message]
     return [*request_messages, persisted_assistant_message]
 
 
@@ -1506,15 +1657,14 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
     async def chat(
         agent_id: str,
         request: Request,
-        request_body: ChatRequest,
+        request_body: AgentChatRequest,
     ) -> Response:
         if agent_id != _ASSISTANT_AGENT_ID:
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
         if not request.app.state.system_settings.agent_assistant_enabled.enabled:
             raise HTTPException(status_code=403, detail="Agents are disabled")
         body = request_body.root
-        if not body.messages:
-            raise HTTPException(status_code=400, detail="At least one message is required")
+        incoming_message = body.message if isinstance(body, AgentChatSubmitMessage) else None
         request_received_at = datetime.now(timezone.utc)
         attach_user_id = _resolve_attach_user_id(body.attach_user_id)
         recording = request.app.state.system_settings.agent_trace_recording
@@ -1527,7 +1677,10 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         configured_project_name = get_env_phoenix_agents_assistant_project_name()
 
         resolved_contexts = resolve_contexts(body.contexts)
-        if (browser_clock := _resolve_browser_clock(body.messages)) is not None:
+        if (
+            incoming_message is not None
+            and (browser_clock := _resolve_browser_clock([incoming_message])) is not None
+        ):
             resolved_contexts.app = browser_clock
         user = request.user if "user" in request.scope else None
         phoenix_user = user if isinstance(user, PhoenixUser) else None
@@ -1545,19 +1698,35 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         try:
             async with request.app.state.db() as session:
                 if body.agent_session_id is None:
+                    if incoming_message is None:
+                        raise HTTPException(
+                            status_code=400,
+                            detail="Regeneration requires a persisted session",
+                        )
                     agent_session = await _create_agent_session(
                         session,
                         otel_session_id=str(uuid4()),
                         user_id=request_user_id,
-                        messages=body.messages,
+                        messages=[incoming_message],
                         project_name=configured_project_name,
                     )
+                    messages = [incoming_message]
                 else:
                     agent_session = await _load_agent_session(
                         session,
                         agent_session_id=body.agent_session_id,
                         user_id=request_user_id,
                     )
+                    persisted_messages = await _load_agent_session_messages(
+                        session,
+                        agent_session_rowid=agent_session.id,
+                    )
+                    messages = _hydrate_agent_session_messages(
+                        persisted_messages=persisted_messages,
+                        request_data=body,
+                    )
+                if (browser_clock := _resolve_browser_clock(messages)) is not None:
+                    resolved_contexts.app = browser_clock
                 project_name = agent_session.project_name
                 tracer = (
                     Tracer(
@@ -1708,13 +1877,13 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
         if body.requested_skills:
             available_skills = get_skills_for_contexts(resolved_contexts)
             forced_skills = resolve_requested_skills(
-                messages=body.messages,
+                messages=messages,
                 requested_skill_names=body.requested_skills,
                 available_skills=available_skills,
             )
             if forced_skills:
-                body.messages = inject_requested_skills(
-                    messages=body.messages,
+                messages = inject_requested_skills(
+                    messages=messages,
                     requested_skill_names=body.requested_skills,
                     available_skills=available_skills,
                     load_skill_template=agent_prompts.load_skill,
@@ -1722,8 +1891,13 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 )
         adapter: VercelAIAdapter[AgentDependencies, AgentOutput] = VercelAIAdapter(
             agent=agent,
-            run_input=_to_pydantic_ai_request_data(body),
+            run_input=_to_pydantic_ai_request_data(body, messages=messages),
             accept=request.headers.get("accept"),
+            server_message_id=(
+                incoming_message.id
+                if incoming_message is not None and incoming_message.role == "assistant"
+                else str(uuid4())
+            ),
         )
         deps = AgentDependencies(
             contexts=resolved_contexts,
@@ -1801,7 +1975,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     _synthesize_client_tool_spans(
                         tracer=tracer,
                         turn_ids=turn_ids,
-                        messages=body.messages,
+                        messages=messages,
                         received_at=request_received_at,
                         session_id=otel_session_id,
                     )
@@ -1897,7 +2071,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         agent_session_rowid=agent_session_rowid,
                         user_id=request_user_id,
                         messages=await _build_session_transcript(
-                            request_messages=body.messages,
+                            request_messages=messages,
                             message_chunks=emitted_message_chunks,
                             session_id=otel_session_id,
                         ),
@@ -1915,7 +2089,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                             tracer=tracer,
                             turn_ids=turn_ids,
                             session_id=otel_session_id,
-                            input_text=_get_last_user_text(body.messages),
+                            input_text=_get_last_user_text(messages),
                             output_text=turn_final_output_text,
                             error_message=(
                                 None

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -378,6 +378,26 @@ def test_turn_trace_context_is_clamped_and_used_for_metadata() -> None:
     assert metadata.trace.root_span_id == turn_trace_context.root_span_id
 
 
+def test_message_metadata_omits_local_trace_link_when_not_ingested() -> None:
+    turn_trace_context = TurnTraceContext(
+        trace_id="1" * 32,
+        root_span_id="2" * 16,
+        started_at=datetime(2026, 7, 10, 12, tzinfo=timezone.utc),
+    )
+
+    metadata = _build_message_metadata_chunk(
+        span_context=None,
+        turn_trace_context=turn_trace_context,
+        session_id="session-1",
+        usage=RunUsage(),
+        include_trace=False,
+    ).message_metadata
+
+    assert metadata is not None
+    assert metadata.trace is None
+    assert metadata.turn_trace_context == turn_trace_context
+
+
 def test_zero_turn_ids_are_replaced() -> None:
     now = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
     turn_ids = _resolve_turn_trace_ids(
@@ -772,6 +792,7 @@ def _build_backend_trace(
 
 async def test_chat_stream_metadata_uses_turn_trace_context(
     db: DbSessionFactory,
+    app: FastAPI,
     httpx_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -783,6 +804,7 @@ async def test_chat_stream_metadata_uses_turn_trace_context(
         return TestModel(call_tools=[])
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
+    await _enable_local_trace_recording(app)
     session_id = "11111111-1111-4111-8111-111111111111"
 
     response = await httpx_client.post(
@@ -795,6 +817,7 @@ async def test_chat_stream_metadata_uses_turn_trace_context(
                 "rootSpanId": root_span_id,
                 "startedAt": datetime.now(timezone.utc).isoformat(),
             },
+            ingestTraces=True,
         ),
     )
     assert response.status_code == 200
@@ -816,6 +839,10 @@ async def test_chat_stream_metadata_uses_turn_trace_context(
         agent_session_rowid = await session.scalar(select(models.AgentSession.id))
         assert agent_session_rowid is not None
         stored_messages = await _load_session_messages(session, agent_session_rowid)
+        assert (
+            await session.scalar(select(models.Trace.id).where(models.Trace.trace_id == trace_id))
+            is not None
+        )
     assistant_messages = [message for message in stored_messages if message["role"] == "assistant"]
     assert assistant_messages
     assert assistant_messages[-1]["metadata"]["trace"] == {
@@ -1209,11 +1236,30 @@ async def test_resumed_chat_turn_keeps_original_trace_project(
     )
     assert second_response.status_code == 200
 
+    second_metadata_chunks = [
+        chunk["messageMetadata"]
+        for chunk in _stream_chunks(second_response.text)
+        if chunk.get("type") == "message-metadata" and "sessionId" in chunk["messageMetadata"]
+    ]
+    assert len(second_metadata_chunks) == 1
+    assert second_metadata_chunks[0]["trace"] == {
+        "traceId": second_trace_id,
+        "rootSpanId": "b" * 16,
+    }
+
     assert tracer_project_names == [original_project_name, original_project_name]
     async with db() as session:
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
         assert agent_session.project_name == original_project_name
+        stored_messages = await _load_session_messages(session, agent_session.id)
+        assistant_messages = [
+            message for message in stored_messages if message["role"] == "assistant"
+        ]
+        assert assistant_messages[-1]["metadata"]["trace"] == {
+            "traceId": second_trace_id,
+            "rootSpanId": "b" * 16,
+        }
         traces = (
             await session.scalars(
                 select(models.Trace).where(

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -47,6 +47,7 @@ from phoenix.server.agents.data_stream_protocol import (
 from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
 from phoenix.server.api.routers.agents import (
     _build_message_metadata_chunk,
+    _build_session_transcript,
     _emit_turn_root_span,
     _get_span_context,
     _persist_db_traces,
@@ -84,7 +85,7 @@ def _chat_body(
         "trigger": "submit-message",
         "id": session_id,
         "agentSessionId": agent_session_id,
-        "messages": messages,
+        **({"message": messages[-1]} if messages else {}),
         "model": {
             "providerType": "builtin",
             "provider": "OPENAI",
@@ -256,6 +257,8 @@ async def test_chat_turn_persists_session_transcript(
     assistant_messages = [message for message in messages if message["role"] == "assistant"]
     assert assistant_messages
     assert assistant_messages[-1] == await _accumulate_streamed_assistant_message(chunks)
+    start_chunks = [chunk for chunk in chunks if chunk.get("type") == "start"]
+    assert start_chunks[0]["messageId"] == assistant_messages[-1]["id"]
     metadata = assistant_messages[-1]["metadata"]
     assert metadata["sessionId"] == persisted_session_id
     assert metadata["usage"]["tokens"]["total"] > 0
@@ -269,10 +272,8 @@ async def test_chat_turn_persists_session_transcript(
         json={
             **body,
             "agentSessionId": agent_session_id,
-            "messages": [
-                *messages,
-                _user_message("And experiments?", message_id="msg-user-2"),
-            ],
+            "message": _user_message("And experiments?", message_id="msg-user-2"),
+            "parentMessageId": messages[-1]["id"],
         },
     )
     assert second_response.status_code == 200
@@ -292,6 +293,44 @@ async def test_chat_turn_persists_session_transcript(
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
         assert agent_session.title == "a"
+        resumed_messages = await _load_session_messages(session, agent_session.id)
+        assert resumed_messages[: len(messages)] == messages
+        assert resumed_messages[len(messages)]["id"] == "msg-user-2"
+
+
+async def test_build_session_transcript_continues_existing_assistant_message() -> None:
+    assistant_message = PhoenixUIMessage.model_validate(
+        {
+            "id": "assistant-1",
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool-read_prompt",
+                    "toolCallId": "call-1",
+                    "state": "output-available",
+                    "input": {"id": "prompt-1"},
+                    "output": {"name": "Prompt"},
+                }
+            ],
+        }
+    )
+    chunks: list[BaseChunk] = [
+        StartChunk(message_id=assistant_message.id),
+        TextStartChunk(id="text-1"),
+        TextDeltaChunk(id="text-1", delta="Done"),
+        TextEndChunk(id="text-1"),
+    ]
+
+    transcript = await _build_session_transcript(
+        request_messages=[assistant_message],
+        message_chunks=chunks,
+        session_id="session-1",
+    )
+
+    assert len(transcript) == 1
+    assert transcript[0].id == assistant_message.id
+    assert transcript[0].parts[0] == assistant_message.parts[0]
+    assert transcript[0].parts[1].type == "text"
 
 
 def test_message_metadata_can_use_propagated_root_span_context() -> None:
@@ -833,7 +872,7 @@ async def test_failed_summary_leaves_session_untitled_until_a_later_turn(
         _chat_url(),
         json=_chat_body(
             session_id,
-            [*stored_messages, _user_message("second question", message_id="msg-user-2")],
+            [_user_message("second question", message_id="msg-user-2")],
             agent_session_id=agent_session_id,
         ),
     )
@@ -899,7 +938,7 @@ async def test_bash_shell_state_persists_across_chat_turns(
         _chat_url(),
         json=_chat_body(
             session_id,
-            [*stored_messages, _user_message("thanks", message_id="msg-user-2")],
+            [_user_message("thanks", message_id="msg-user-2")],
             agent_session_id=agent_session_id,
         ),
     )
@@ -915,7 +954,7 @@ async def test_bash_shell_state_persists_across_chat_turns(
         _chat_url(),
         json=_chat_body(
             session_id,
-            [*stored_messages, _user_message("read it back", message_id="msg-user-3")],
+            [_user_message("read it back", message_id="msg-user-3")],
             agent_session_id=agent_session_id,
         ),
     )

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -37,6 +37,7 @@ from pydantic_ai.ui.vercel_ai.response_types import (
 from sqlalchemy import func, select
 from sqlalchemy.exc import SAWarning
 from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.relay import GlobalID
 
 from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
@@ -246,6 +247,10 @@ async def test_chat_turn_persists_session_transcript(
         assert agent_session.user_id is None
         assert UUID(agent_session.project_session_id).version == 4
         assert agent_session.project_name == get_env_phoenix_agents_assistant_project_name()
+        relay_session_id = GlobalID.from_id(agent_session_id)
+        assert relay_session_id.type_name == models.AgentSession.__name__
+        assert int(relay_session_id.node_id) == agent_session.id
+        assert agent_session_id != agent_session.project_session_id
         # The in-stream summary is persisted as the session title.
         assert agent_session.title == "a"
         messages = await _load_session_messages(session, agent_session.id)

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -824,16 +824,15 @@ async def test_chat_stream_metadata_uses_turn_trace_context(
     }
 
 
-async def test_chat_turn_without_messages_returns_bad_request(
+async def test_chat_turn_without_message_fails_validation(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
 ) -> None:
-    """An empty message history is rejected without persisting a session."""
+    """A submission without its incremental message persists no session."""
     session_id = "22222222-2222-4222-8222-222222222222"
 
     response = await httpx_client.post(_chat_url(), json=_chat_body(session_id, []))
-    assert response.status_code == 400
-    assert response.text == "At least one message is required"
+    assert response.status_code == 422
 
     async with db() as session:
         assert (await session.scalars(select(models.AgentSession))).all() == []

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -16,6 +16,62 @@ _DELETE_MUTATION = """
   }
 """
 
+_TRUNCATE_MUTATION = """
+  mutation ($id: ID!, $lastMessageId: String) {
+    truncateAgentSession(input: { id: $id, lastMessageId: $lastMessageId }) {
+      agentSession {
+        id
+        messages
+      }
+    }
+  }
+"""
+
+_FORK_MUTATION = """
+  mutation ($sourceSessionId: ID!, $lastMessageId: String) {
+    forkAgentSession(
+      input: {
+        sourceSessionId: $sourceSessionId
+        lastMessageId: $lastMessageId
+      }
+    ) {
+      agentSession {
+        id
+        title
+        messages
+      }
+    }
+  }
+"""
+
+
+async def _create_session_with_transcript(db: DbSessionFactory) -> tuple[int, str]:
+    async with db() as session:
+        agent_session = models.AgentSession(user_id=None, title="Original")
+        session.add(agent_session)
+        await session.flush()
+        messages = [
+            PhoenixUIMessage(id="user-1", role="user", parts=[]),
+            PhoenixUIMessage(id="assistant-1", role="assistant", parts=[]),
+            PhoenixUIMessage(id="user-2", role="user", parts=[]),
+            PhoenixUIMessage(id="assistant-2", role="assistant", parts=[]),
+        ]
+        session.add_all(
+            models.AgentSessionMessage(
+                agent_session_id=agent_session.id,
+                position=position,
+                message=message,
+            )
+            for position, message in enumerate(messages)
+        )
+        session.add(
+            models.AgentSessionSnapshot(
+                agent_session_id=agent_session.id,
+                bashkit_snapshot=b"shell-state",
+            )
+        )
+        return agent_session.id, str(GlobalID("AgentSession", str(agent_session.id)))
+
 
 async def test_delete_agent_session_cascades_snapshot(
     db: DbSessionFactory,
@@ -70,3 +126,90 @@ async def test_delete_agent_session_not_found(
     )
     assert response.errors
     assert "No agent session found" in response.errors[0].message
+
+
+async def test_truncate_agent_session_persists_prefix_and_deletes_snapshot(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    agent_session_rowid, agent_session_id = await _create_session_with_transcript(db)
+
+    response = await gql_client.execute(
+        query=_TRUNCATE_MUTATION,
+        variables={"id": agent_session_id, "lastMessageId": "assistant-1"},
+    )
+
+    assert response.data and not response.errors
+    messages = response.data["truncateAgentSession"]["agentSession"]["messages"]
+    assert [message["id"] for message in messages] == ["user-1", "assistant-1"]
+    async with db() as session:
+        stored_messages = list(
+            await session.scalars(
+                select(models.AgentSessionMessage)
+                .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
+                .order_by(models.AgentSessionMessage.position)
+            )
+        )
+        assert [message.message.id for message in stored_messages] == [
+            "user-1",
+            "assistant-1",
+        ]
+        assert await session.scalar(select(models.AgentSessionSnapshot)) is None
+
+
+async def test_truncate_agent_session_to_empty_transcript(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    _, agent_session_id = await _create_session_with_transcript(db)
+
+    response = await gql_client.execute(
+        query=_TRUNCATE_MUTATION,
+        variables={"id": agent_session_id, "lastMessageId": None},
+    )
+
+    assert response.data and not response.errors
+    assert response.data["truncateAgentSession"]["agentSession"]["messages"] == []
+
+
+async def test_fork_agent_session_copies_prefix_without_snapshot(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    source_session_rowid, source_session_id = await _create_session_with_transcript(db)
+
+    response = await gql_client.execute(
+        query=_FORK_MUTATION,
+        variables={
+            "sourceSessionId": source_session_id,
+            "lastMessageId": "assistant-1",
+        },
+    )
+
+    assert response.data and not response.errors
+    forked_session = response.data["forkAgentSession"]["agentSession"]
+    assert forked_session["title"] == "(branch) Original"
+    assert [message["id"] for message in forked_session["messages"]] == [
+        "user-1",
+        "assistant-1",
+    ]
+    forked_session_rowid = int(GlobalID.from_id(forked_session["id"]).node_id)
+    async with db() as session:
+        source_message_count = len(
+            list(
+                await session.scalars(
+                    select(models.AgentSessionMessage).where(
+                        models.AgentSessionMessage.agent_session_id == source_session_rowid
+                    )
+                )
+            )
+        )
+        assert source_message_count == 4
+        assert (
+            await session.scalar(
+                select(models.AgentSessionSnapshot).where(
+                    models.AgentSessionSnapshot.agent_session_id == forked_session_rowid
+                )
+            )
+            is None
+        )

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -47,7 +47,12 @@ _FORK_MUTATION = """
 
 async def _create_session_with_transcript(db: DbSessionFactory) -> tuple[int, str]:
     async with db() as session:
-        agent_session = models.AgentSession(user_id=None, title="Original")
+        agent_session = models.AgentSession(
+            project_session_id="11111111-1111-4111-8111-111111111111",
+            project_name="assistant_agent",
+            user_id=None,
+            title="Original",
+        )
         session.add(agent_session)
         await session.flush()
         messages = [

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -21,7 +21,10 @@ from phoenix.server.agents.types import (
     SandboxAvailability,
 )
 from phoenix.server.api.routers.agents import (
+    AgentChatRegenerateMessage,
+    AgentChatSubmitMessage,
     _create_agent_session,
+    _hydrate_agent_session_messages,
     _interleave_agent_and_subagent_message_chunks,
     _load_agent_session,
     _load_phoenix_user_email,
@@ -49,7 +52,8 @@ class TestAgentSessionPersistence:
         self,
         db: DbSessionFactory,
     ) -> None:
-        messages = [PhoenixUIMessage(id="message-1", role="user", parts=[])]
+        message = PhoenixUIMessage(id="message-1", role="user", parts=[])
+        messages = [message]
         async with db() as session:
             created = await _create_agent_session(
                 session,
@@ -62,6 +66,12 @@ class TestAgentSessionPersistence:
             assert created.project_session_id == "11111111-1111-4111-8111-111111111111"
             created_rowid = created.id
             created_project_session_id = created.project_session_id
+            persisted_message = await session.scalar(
+                select(models.AgentSessionMessage.message).where(
+                    models.AgentSessionMessage.agent_session_id == created_rowid
+                )
+            )
+            assert persisted_message == message
 
         async with db() as session:
             loaded = await _load_agent_session(
@@ -120,6 +130,120 @@ class TestAgentSessionPersistence:
             session.add(second)
             await session.flush()
             assert second.id > first_rowid
+
+    def test_hydrates_user_message_from_persisted_transcript(self) -> None:
+        persisted = [PhoenixUIMessage(id="user-1", role="user", parts=[])]
+        next_message = PhoenixUIMessage(id="user-2", role="user", parts=[])
+        request = AgentChatSubmitMessage(
+            id="client-session",
+            message=next_message,
+            model={
+                "providerType": "builtin",
+                "provider": "OPENAI",
+                "modelName": "gpt-test",
+            },
+        )
+
+        assert _hydrate_agent_session_messages(
+            persisted_messages=persisted,
+            request_data=request,
+        ) == [*persisted, next_message]
+
+    def test_tool_response_updates_latest_persisted_assistant_message(self) -> None:
+        user_message = PhoenixUIMessage(id="user-1", role="user", parts=[])
+        pending_assistant = PhoenixUIMessage.model_validate(
+            {
+                "id": "assistant-1",
+                "role": "assistant",
+                "parts": [
+                    {
+                        "type": "tool-read_prompt",
+                        "toolCallId": "call-1",
+                        "state": "input-available",
+                        "input": {"id": "prompt-1"},
+                    }
+                ],
+            }
+        )
+        resolved_assistant = PhoenixUIMessage.model_validate(
+            {
+                "id": "assistant-1",
+                "role": "assistant",
+                "parts": [
+                    {
+                        "type": "tool-read_prompt",
+                        "toolCallId": "call-1",
+                        "state": "output-available",
+                        "input": {"id": "prompt-1"},
+                        "output": {"name": "Prompt"},
+                    }
+                ],
+            }
+        )
+        request = AgentChatSubmitMessage(
+            id="client-session",
+            message=resolved_assistant,
+            model={
+                "providerType": "builtin",
+                "provider": "OPENAI",
+                "modelName": "gpt-test",
+            },
+        )
+
+        assert _hydrate_agent_session_messages(
+            persisted_messages=[user_message, pending_assistant],
+            request_data=request,
+        ) == [user_message, resolved_assistant]
+
+    def test_user_message_selects_persisted_parent_after_rewind(self) -> None:
+        messages = [
+            PhoenixUIMessage(id="user-1", role="user", parts=[]),
+            PhoenixUIMessage(id="assistant-1", role="assistant", parts=[]),
+            PhoenixUIMessage(id="user-2", role="user", parts=[]),
+            PhoenixUIMessage(id="assistant-2", role="assistant", parts=[]),
+        ]
+        next_message = PhoenixUIMessage(id="user-3", role="user", parts=[])
+        request = AgentChatSubmitMessage(
+            id="client-session",
+            message=next_message,
+            parentMessageId="assistant-1",
+            model={
+                "providerType": "builtin",
+                "provider": "OPENAI",
+                "modelName": "gpt-test",
+            },
+        )
+
+        assert _hydrate_agent_session_messages(
+            persisted_messages=messages,
+            request_data=request,
+        ) == [*messages[:2], next_message]
+
+    def test_regeneration_selects_persisted_prefix(self) -> None:
+        messages = [
+            PhoenixUIMessage(id="user-1", role="user", parts=[]),
+            PhoenixUIMessage(id="assistant-1", role="assistant", parts=[]),
+            PhoenixUIMessage(id="user-2", role="user", parts=[]),
+            PhoenixUIMessage(id="assistant-2", role="assistant", parts=[]),
+        ]
+        request = AgentChatRegenerateMessage(
+            trigger="regenerate-message",
+            id="client-session",
+            messageId="user-1",
+            model={
+                "providerType": "builtin",
+                "provider": "OPENAI",
+                "modelName": "gpt-test",
+            },
+        )
+
+        assert (
+            _hydrate_agent_session_messages(
+                persisted_messages=messages,
+                request_data=request,
+            )
+            == messages[:1]
+        )
 
 
 class TestPersistDbTracesAndEmitEvent:


### PR DESCRIPTION
## Summary
- Make persisted agent-session messages authoritative and send only incremental user/tool updates from the browser.
- Add durable undo and branch mutations, including transcript-prefix and snapshot handling.
- Keep the thinking indicator stable across early stream states.

This enables smaller chat requests, reload-safe transcript recovery, and server-backed conversation editing and branching.

## Testing
- Focused Python and frontend tests
- Python and TypeScript type checks
- GraphQL permission checks