### PR TITLE
feat(settings): vertical settings tabs, users/API-keys tabs, virtualized models table

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -28,12 +28,14 @@ import { SettingsAIProvidersPage } from "@phoenix/pages/settings/SettingsAIProvi
 import { settingsAIProvidersPageLoader } from "@phoenix/pages/settings/settingsAIProvidersPageLoader";
 import { SettingsAnnotationsPage } from "@phoenix/pages/settings/SettingsAnnotationsPage";
 import { settingsAnnotationsPageLoader } from "@phoenix/pages/settings/settingsAnnotationsPageLoader";
+import { SettingsAPIKeysPage } from "@phoenix/pages/settings/SettingsAPIKeysPage";
 import { SettingsDataPage } from "@phoenix/pages/settings/SettingsDataPage";
 import { SettingsGeneralPage } from "@phoenix/pages/settings/SettingsGeneralPage";
 import { settingsModelsLoader } from "@phoenix/pages/settings/settingsModelsLoader";
 import { SettingsModelsPage } from "@phoenix/pages/settings/SettingsModelsPage";
 import { SettingsSandboxesPage } from "@phoenix/pages/settings/SettingsSandboxesPage";
 import { settingsSandboxesPageLoader } from "@phoenix/pages/settings/settingsSandboxesPageLoader";
+import { SettingsUsersPage } from "@phoenix/pages/settings/SettingsUsersPage";
 
 import type {
   DatasetLoaderData,
@@ -739,7 +741,31 @@ export const appRouteObjects = createRoutesFromElements(
               agentRoute: {
                 label: "General Settings",
                 description:
-                  "Configure general Phoenix instance settings including hostname, platform version, database usage, users, system API keys, and the default project retention policy.",
+                  "Configure general Phoenix instance settings including hostname, platform version, database usage, and the default project retention policy.",
+              },
+            }}
+          />
+          <Route
+            path="users"
+            element={<SettingsUsersPage />}
+            handle={{
+              crumb: () => "Users",
+              agentRoute: {
+                label: "Users",
+                description:
+                  "Manage users and members: add or invite a user, change a user's role, reset a password, or delete a user.",
+              },
+            }}
+          />
+          <Route
+            path="api-keys"
+            element={<SettingsAPIKeysPage />}
+            handle={{
+              crumb: () => "API Keys",
+              agentRoute: {
+                label: "API Keys",
+                description:
+                  "Manage API keys: create system API keys and view or revoke system and user API keys for programmatic access.",
               },
             }}
           />

--- a/app/src/components/core/tabs/Tabs.tsx
+++ b/app/src/components/core/tabs/Tabs.tsx
@@ -113,11 +113,9 @@ const tabListCSS = css`
 
   // The sliding selection indicator. react-aria positions it over the
   // selected tab via translate and animates between tabs; only the
-  // orientation-specific edge placement is styled here.
+  // orientation-specific appearance is styled here.
   .react-aria-SelectionIndicator {
     position: absolute;
-    z-index: 1;
-    background: var(--tab-indicator-color, var(--global-color-primary));
     border-radius: var(--global-rounding-small);
     transition-property: translate, width, height;
     transition-duration: 250ms;
@@ -130,13 +128,25 @@ const tabListCSS = css`
 
   &[data-orientation="vertical"] {
     flex-direction: column;
-    border-inline-end: 1px solid var(--tab-border-color);
 
+    // Tighter vertical rhythm than the horizontal bar: shorter tabs and a
+    // slimmer pill inset so the rail reads as a compact list, not a stack of
+    // spaced-out buttons.
+    --tab-pill-inset: var(--global-dimension-size-25)
+      var(--global-dimension-size-50);
+    .react-aria-Tab {
+      padding: var(--global-dimension-size-100)
+        var(--global-dimension-static-size-200);
+    }
+
+    // The selected tab is marked with a filled pill behind its label (the
+    // same treatment as the side nav's active item) rather than an edge bar,
+    // which would float detached from the left-aligned labels. The pill is
+    // inset to match the hover pill so the two states share a shape.
     .react-aria-SelectionIndicator {
-      top: 0;
-      right: 0;
-      height: 100%;
-      width: 3px;
+      inset: var(--tab-pill-inset);
+      background: var(--global-color-primary-100);
+      z-index: -1;
     }
   }
 
@@ -195,6 +205,8 @@ const tabListCSS = css`
       bottom: 0;
       width: 100%;
       height: 3px;
+      background: var(--tab-indicator-color, var(--global-color-primary));
+      z-index: 1;
     }
 
     .react-aria-Tab {
@@ -280,11 +292,15 @@ const tabCSS = css`
   cursor: default;
   outline: none;
   position: relative;
+  // The hover pill and selection indicator sit at z-index -1; isolate the
+  // tab so they paint just behind its label instead of escaping to an outer
+  // stacking context and disappearing behind opaque page backgrounds.
+  isolation: isolate;
   color: var(--global-text-color-700);
   transition: color 150ms ease-out;
   forced-color-adjust: none;
   -webkit-tap-highlight-color: transparent;
-  font-weight: 600;
+  font-weight: 400;
   line-height: var(--global-line-height-s);
   font-size: var(--global-font-size-s);
 
@@ -294,7 +310,7 @@ const tabCSS = css`
   &:before {
     content: "";
     position: absolute;
-    inset: var(--global-dimension-size-50);
+    inset: var(--tab-pill-inset, var(--global-dimension-size-50));
     border-radius: var(--global-rounding-small);
     transition: background 150ms ease-out;
     z-index: -1;
@@ -314,7 +330,7 @@ const tabCSS = css`
   }
 
   &[data-hovered]:not([data-selected]):before {
-    background: var(--global-color-primary-100);
+    background: var(--global-color-primary-50);
   }
 
   &[data-disabled] {
@@ -325,7 +341,7 @@ const tabCSS = css`
   &[data-focus-visible]:after {
     content: "";
     position: absolute;
-    inset: var(--global-dimension-size-50);
+    inset: var(--tab-pill-inset, var(--global-dimension-size-50));
     border-radius: var(--global-rounding-small);
     border: 2px solid var(--focus-ring-color);
   }

--- a/app/src/components/core/tabs/Tabs.tsx
+++ b/app/src/components/core/tabs/Tabs.tsx
@@ -33,9 +33,15 @@ function useHorizontalOverflow() {
 
   const update = () => {
     const el = elementRef.current;
-    // The fade affordance only applies to horizontal tab lists; skip
-    // measuring vertical ones so they never report horizontal overflow.
-    if (!el || el.getAttribute("data-orientation") !== "horizontal") {
+    if (!el) {
+      return;
+    }
+    // The fade affordance only applies to horizontal tab lists; clear any
+    // overflow state left over from before an orientation flip so vertical
+    // lists never report horizontal overflow.
+    if (el.getAttribute("data-orientation") !== "horizontal") {
+      setHasOverflowAtStart(false);
+      setHasOverflowAtEnd(false);
       return;
     }
     const { scrollLeft, scrollWidth, clientWidth } = el;

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -14,3 +14,4 @@ export * from "./useLatestPhoenixVersion";
 export * from "./usePersistedState";
 export * from "./useOwnedPreloadedQuery";
 export * from "./useLabelFilterSearchParams";
+export * from "./useMediaQuery";

--- a/app/src/hooks/useMediaQuery.ts
+++ b/app/src/hooks/useMediaQuery.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Subscribes to a CSS media query and returns whether it currently matches.
+ * The component re-renders whenever the match state changes (e.g. on window
+ * resize across the query's breakpoint).
+ *
+ * @example
+ * const isLargeScreen = useMediaQuery("(min-width: 900px)");
+ */
+export function useMediaQuery(query: string): boolean {
+  const subscribe = (onStoreChange: () => void) => {
+    const mediaQueryList = window.matchMedia(query);
+    mediaQueryList.addEventListener("change", onStoreChange);
+    return () => mediaQueryList.removeEventListener("change", onStoreChange);
+  };
+  const getSnapshot = () => window.matchMedia(query).matches;
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/app/src/pages/settings/GlobalRetentionPolicyCard.tsx
+++ b/app/src/pages/settings/GlobalRetentionPolicyCard.tsx
@@ -131,7 +131,12 @@ export const GlobalRetentionPolicyCard = () => {
     <Card title="Default Project Retention Policy">
       {error && <Alert variant="danger">{error}</Alert>}
       <View padding="size-200">
-        <Flex direction="row" gap="size-200" justifyContent="space-between" wrap>
+        <Flex
+          direction="row"
+          gap="size-200"
+          justifyContent="space-between"
+          wrap
+        >
           <View paddingTop="size-100" flex="1 1 300px">
             <Text>
               The default retention policy for all projects that do not have

--- a/app/src/pages/settings/GlobalRetentionPolicyCard.tsx
+++ b/app/src/pages/settings/GlobalRetentionPolicyCard.tsx
@@ -131,8 +131,8 @@ export const GlobalRetentionPolicyCard = () => {
     <Card title="Default Project Retention Policy">
       {error && <Alert variant="danger">{error}</Alert>}
       <View padding="size-200">
-        <Flex direction="row" gap="size-200" justifyContent="space-between">
-          <View paddingTop="size-100">
+        <Flex direction="row" gap="size-200" justifyContent="space-between" wrap>
+          <View paddingTop="size-100" flex="1 1 300px">
             <Text>
               The default retention policy for all projects that do not have
               their own custom retention policy. Traces that are older than the
@@ -140,7 +140,7 @@ export const GlobalRetentionPolicyCard = () => {
               free up storage space.
             </Text>
           </View>
-          <View width="1000px">
+          <View flex="none">
             <Form onSubmit={handleSubmit(onSubmit)}>
               <Flex gap="size-100" direction="row" alignItems="center">
                 <Controller

--- a/app/src/pages/settings/ModelsTable.tsx
+++ b/app/src/pages/settings/ModelsTable.tsx
@@ -7,7 +7,8 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useMemo, useRef } from "react";
 import { Focusable } from "react-aria";
 import { graphql, useFragment } from "react-relay";
 
@@ -45,6 +46,10 @@ import { costFormatter } from "@phoenix/utils/numberFormatUtils";
 
 import { CloneModelButton } from "./CloneModelButton";
 import { DeleteModelButton } from "./DeleteModelButton";
+
+// Initial estimate only — rows are measured once rendered. Roughly a 30px
+// size-S icon button + 2 * 8px cell padding + 1px row border.
+const ESTIMATED_ROW_HEIGHT = 47;
 
 type ModelsTableGenerativeModel =
   ModelsTable_generativeModels$data["generativeModels"]["edges"][number]["generativeModel"];
@@ -173,7 +178,7 @@ export function ModelsTable({
       {
         header: "name",
         accessorKey: "name",
-        size: 300,
+        size: 200,
         cell: ({ row }) => {
           const model = row.original;
           return (
@@ -217,17 +222,16 @@ export function ModelsTable({
       {
         header: "match pattern",
         accessorKey: "namePattern",
+        size: 200,
         cell: ({ row }) => {
           const namePattern = row.original.namePattern;
           const provider = row.original.provider;
           const providerKey = row.original.providerKey;
           return (
             <Flex direction="row" gap="size-100" alignItems="center">
-              <span>
-                <Truncate maxWidth="100%" title={namePattern}>
-                  {namePattern}
-                </Truncate>
-              </span>
+              <Truncate maxWidth="100%" title={namePattern}>
+                {namePattern}
+              </Truncate>
               {provider && (
                 <TooltipTrigger delay={0}>
                   <Focusable>
@@ -381,6 +385,8 @@ export function ModelsTable({
         id: "actions",
         header: "",
         accessorKey: "id",
+        size: 120,
+        enableResizing: false,
         cell: ({ row }) => {
           const isCustomModel = row.original.kind === "CUSTOM";
           return (
@@ -440,6 +446,10 @@ export function ModelsTable({
   const table = useReactTable({
     columns,
     data: tableData,
+    defaultColumn: {
+      minSize: 100,
+    },
+    columnResizeMode: "onChange",
     state: {
       columnVisibility: {
         kind: false,
@@ -460,6 +470,28 @@ export function ModelsTable({
   const rows = table.getRowModel().rows;
   const isEmpty = rows.length === 0;
 
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line react-hooks-js/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => tableContainerRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    // Rows have fractional heights; the default integer offsetHeight
+    // accumulates enough error over hundreds of rows to clip the last one.
+    measureElement: (element) => element.getBoundingClientRect().height,
+    overscan: 5,
+  });
+  const virtualRows = virtualizer.getVirtualItems();
+  const totalHeight = virtualizer.getTotalSize();
+  // Spacer rows keep the scrollbar sized to the full row count while only the
+  // visible rows are mounted. Rows are not transformed so the pinned (sticky)
+  // name and actions columns keep working.
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? totalHeight - virtualRows[virtualRows.length - 1].end
+      : 0;
+
   if (isEmpty) {
     return (
       <Flex width="100%" justifyContent="center" alignItems="center">
@@ -470,13 +502,25 @@ export function ModelsTable({
 
   return (
     <div
+      ref={tableContainerRef}
       css={css`
-        flex: 1 1 auto;
+        // Fill the card body exactly so this div (the virtualizer's scroll
+        // element) is the one that scrolls, keeping the mounted rows in sync
+        // with the viewport.
+        height: 100%;
+        box-sizing: border-box;
         overflow: auto;
       `}
     >
       <table
-        css={tableCSS}
+        css={[
+          tableCSS,
+          // Fixed layout so long model names and match patterns truncate at
+          // their column size instead of stretching the column.
+          css`
+            table-layout: fixed;
+          `,
+        ]}
         style={{ width: table.getTotalSize(), minWidth: "100%" }}
       >
         <thead>
@@ -494,33 +538,46 @@ export function ModelsTable({
                   }}
                 >
                   {header.isPlaceholder ? null : (
-                    <div
-                      {...{
-                        className: header.column.getCanSort() ? "sort" : "",
-                        onClick: header.column.getToggleSortingHandler(),
-                        style: {
-                          textWrap: "nowrap",
-                          textAlign: header.column.columnDef.meta?.textAlign,
-                        },
-                      }}
-                    >
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
-                      {header.column.getIsSorted() ? (
-                        <Icon
-                          className="sort-icon"
-                          svg={
-                            header.column.getIsSorted() === "asc" ? (
-                              <Icons.CaretUpFilled />
-                            ) : (
-                              <Icons.CaretDownFilled />
-                            )
-                          }
+                    <>
+                      <div
+                        {...{
+                          className: header.column.getCanSort() ? "sort" : "",
+                          onClick: header.column.getToggleSortingHandler(),
+                          style: {
+                            textWrap: "nowrap",
+                            textAlign: header.column.columnDef.meta?.textAlign,
+                          },
+                        }}
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                        {header.column.getIsSorted() ? (
+                          <Icon
+                            className="sort-icon"
+                            svg={
+                              header.column.getIsSorted() === "asc" ? (
+                                <Icons.CaretUpFilled />
+                              ) : (
+                                <Icons.CaretDownFilled />
+                              )
+                            }
+                          />
+                        ) : null}
+                      </div>
+                      {header.column.getCanResize() && (
+                        <div
+                          {...{
+                            onMouseDown: header.getResizeHandler(),
+                            onTouchStart: header.getResizeHandler(),
+                            className: `resizer ${
+                              header.column.getIsResizing() ? "isResizing" : ""
+                            }`,
+                          }}
                         />
-                      ) : null}
-                    </div>
+                      )}
+                    </>
                   )}
                 </th>
               ))}
@@ -528,9 +585,22 @@ export function ModelsTable({
           ))}
         </thead>
         <tbody>
-          {rows.map((row) => {
+          {paddingTop > 0 && (
+            <tr>
+              <td
+                colSpan={table.getVisibleLeafColumns().length}
+                style={{ height: paddingTop, padding: 0, border: "none" }}
+              />
+            </tr>
+          )}
+          {virtualRows.map((virtualRow) => {
+            const row = rows[virtualRow.index];
             return (
-              <tr key={row.id}>
+              <tr
+                key={row.id}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+              >
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}
@@ -545,6 +615,14 @@ export function ModelsTable({
               </tr>
             );
           })}
+          {paddingBottom > 0 && (
+            <tr>
+              <td
+                colSpan={table.getVisibleLeafColumns().length}
+                style={{ height: paddingBottom, padding: 0, border: "none" }}
+              />
+            </tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/app/src/pages/settings/SettingsAPIKeysPage.tsx
+++ b/app/src/pages/settings/SettingsAPIKeysPage.tsx
@@ -1,0 +1,5 @@
+import { APIKeysCard } from "@phoenix/pages/settings/APIKeysCard";
+
+export function SettingsAPIKeysPage() {
+  return <APIKeysCard />;
+}

--- a/app/src/pages/settings/SettingsGeneralPage.tsx
+++ b/app/src/pages/settings/SettingsGeneralPage.tsx
@@ -24,9 +24,17 @@ import { UsersCard } from "@phoenix/pages/settings/UsersCard";
 
 const gridCSS = css`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  // minmax(0, 1fr) lets the columns shrink below their content's min-content
+  // width so a wide card can't blow the layout out past the viewport.
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: var(--global-dimension-size-200);
   width: 100%;
+
+  // Stack the side-by-side cards on narrow screens so they don't squeeze
+  // their contents.
+  @media (max-width: 700px) {
+    grid-template-columns: minmax(0, 1fr);
+  }
 `;
 
 const fullWidthCSS = css`

--- a/app/src/pages/settings/SettingsGeneralPage.tsx
+++ b/app/src/pages/settings/SettingsGeneralPage.tsx
@@ -11,16 +11,14 @@ import {
   Text,
   View,
 } from "@phoenix/components";
-import { CanManageRetentionPolicy, IsAdmin } from "@phoenix/components/auth";
+import { CanManageRetentionPolicy } from "@phoenix/components/auth";
 import { PlatformVersionStatus } from "@phoenix/components/nav";
 import { BASE_URL, VERSION } from "@phoenix/config";
 import type { settingsGeneralPageLoaderQuery } from "@phoenix/pages/settings/__generated__/settingsGeneralPageLoaderQuery.graphql";
-import { APIKeysCard } from "@phoenix/pages/settings/APIKeysCard";
 import { DBUsagePieChart } from "@phoenix/pages/settings/DBUsagePieChart";
 import { GlobalRetentionPolicyCard } from "@phoenix/pages/settings/GlobalRetentionPolicyCard";
 import type { settingsGeneralPageLoaderType } from "@phoenix/pages/settings/settingsGeneralPageLoader";
 import { settingsGeneralPageLoaderGQL } from "@phoenix/pages/settings/settingsGeneralPageLoader";
-import { UsersCard } from "@phoenix/pages/settings/UsersCard";
 
 const gridCSS = css`
   display: grid;
@@ -74,14 +72,6 @@ export function SettingsGeneralPage() {
           <DBUsagePieChart query={data} />
         </View>
       </Card>
-      <IsAdmin>
-        <div css={fullWidthCSS}>
-          <APIKeysCard />
-        </div>
-        <div css={fullWidthCSS}>
-          <UsersCard />
-        </div>
-      </IsAdmin>
       <CanManageRetentionPolicy>
         <div css={fullWidthCSS}>
           <GlobalRetentionPolicyCard />

--- a/app/src/pages/settings/SettingsModelsPage.tsx
+++ b/app/src/pages/settings/SettingsModelsPage.tsx
@@ -43,7 +43,7 @@ export function SettingsModelsPage() {
   );
 
   return (
-    <Flex direction="column" gap="size-200">
+    <Flex direction="column" gap="size-200" flex="1 1 auto" minHeight={0}>
       <Flex gap="size-200" alignItems="center" justifyContent="space-between">
         <DebouncedSearch
           aria-label="Search models"
@@ -80,6 +80,9 @@ export function SettingsModelsPage() {
       </Flex>
       <Card
         title="Models"
+        flex="1 1 auto"
+        minHeight={0}
+        scrollBody
         extra={
           <Flex direction="row" gap="size-200" alignItems="center">
             <Text color="text-500" size="S">

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -5,7 +5,11 @@ import { Collection } from "react-aria-components";
 import { Navigate, Outlet, useLocation, useNavigate } from "react-router";
 
 import { Loading, Tab, TabList, TabPanel, Tabs } from "@phoenix/components";
-import { useViewerCanManageSandboxes } from "@phoenix/contexts";
+import {
+  useIsAdmin,
+  useViewerCanManageSandboxes,
+  useViewerCanManageSecrets,
+} from "@phoenix/contexts";
 import { useMediaQuery } from "@phoenix/hooks";
 
 /**
@@ -16,32 +20,42 @@ import { useMediaQuery } from "@phoenix/hooks";
 const VERTICAL_TABS_MEDIA_QUERY = "(min-width: 900px)";
 
 const settingsPageCSS = css`
-  overflow-y: auto;
+  overflow: hidden;
   height: 100%;
-`;
-
-const settingsPageInnerCSS = css`
-  padding: var(--global-dimension-size-100);
-  max-width: 1300px;
-  box-sizing: border-box;
-  width: 100%;
-  margin-left: auto;
-  margin-right: auto;
 `;
 
 const settingsTabListCSS = css`
   &[data-orientation="vertical"] {
     flex: none;
-    width: var(--global-dimension-size-2000);
-    // Keep the rail in view while the settings content scrolls.
-    position: sticky;
-    top: 0;
-    align-self: flex-start;
+    width: var(--global-dimension-size-2400);
+    box-sizing: border-box;
+    // The rail scrolls on its own if the tab list ever outgrows the
+    // viewport; it never scrolls along with the content.
+    overflow-y: auto;
+    padding: var(--global-dimension-size-200) var(--global-dimension-size-100);
+  }
+  &[data-orientation="horizontal"] {
+    margin: 0 var(--global-dimension-size-200);
+  }
+`;
+
+// The panel is the scroll container and stretches to the viewport edge so
+// its scrollbar sits at the edge of the screen, not in the middle of the
+// page. Padding lives inside the scroll area, and the content is capped and
+// left-aligned against the rail.
+const settingsTabPanelCSS = css`
+  overflow-y: auto;
+  padding: var(--global-dimension-size-200) var(--global-dimension-size-300)
+    var(--global-dimension-size-300);
+  & > * {
+    max-width: 1200px;
   }
 `;
 
 const TABS: { id: string; label: string }[] = [
   { id: "general", label: "General" },
+  { id: "users", label: "Users" },
+  { id: "api-keys", label: "API Keys" },
   { id: "providers", label: "AI Providers" },
   { id: "sandboxes", label: "Sandboxes" },
   { id: "models", label: "Models" },
@@ -63,21 +77,18 @@ export function SettingsPage() {
       navigate(`/settings/${tab}`, { replace: true });
     }
   };
-  const isAgentAssistantEnabled = !window.Config.agentAssistantDisabled;
-  const canManageSecrets = useViewerCanManageSandboxes();
+  const isAdmin = useIsAdmin();
+  const canManageSecrets = useViewerCanManageSecrets();
   const canManageSandboxes = useViewerCanManageSandboxes();
-  const tabs = TABS.filter((tab) => {
-    if (tab.id === "agents" && !isAgentAssistantEnabled) {
-      return false;
-    }
-    if (tab.id === "secrets" && !canManageSecrets) {
-      return false;
-    }
-    if (tab.id === "sandboxes" && !canManageSandboxes) {
-      return false;
-    }
-    return true;
-  });
+  // Tabs absent from this map are visible to everyone.
+  const tabVisibility: Record<string, boolean> = {
+    agents: !window.Config.agentAssistantDisabled,
+    users: isAdmin,
+    "api-keys": isAdmin,
+    secrets: canManageSecrets,
+    sandboxes: canManageSandboxes,
+  };
+  const tabs = TABS.filter((tab) => tabVisibility[tab.id] ?? true);
   if (!tab) {
     return <Navigate to="/settings/general" replace />;
   }
@@ -86,27 +97,24 @@ export function SettingsPage() {
   }
   return (
     <main css={settingsPageCSS}>
-      <div css={settingsPageInnerCSS}>
-        <Tabs
-          selectedKey={tab}
-          onSelectionChange={onChangeTab}
-          orientation={isLargeScreen ? "vertical" : "horizontal"}
-        >
-          {/* TODO: filter sandboxes tab for non-admins */}
-          <TabList items={tabs} css={settingsTabListCSS} aria-label="Settings">
-            {(item) => <Tab id={item.id}>{item.label}</Tab>}
-          </TabList>
-          <Collection items={tabs}>
-            {(item) => (
-              <TabPanel id={item.id} padded>
-                <Suspense fallback={<Loading />}>
-                  <Outlet />
-                </Suspense>
-              </TabPanel>
-            )}
-          </Collection>
-        </Tabs>
-      </div>
+      <Tabs
+        selectedKey={tab}
+        onSelectionChange={onChangeTab}
+        orientation={isLargeScreen ? "vertical" : "horizontal"}
+      >
+        <TabList items={tabs} css={settingsTabListCSS} aria-label="Settings">
+          {(item) => <Tab id={item.id}>{item.label}</Tab>}
+        </TabList>
+        <Collection items={tabs}>
+          {(item) => (
+            <TabPanel id={item.id} css={settingsTabPanelCSS}>
+              <Suspense fallback={<Loading />}>
+                <Outlet />
+              </Suspense>
+            </TabPanel>
+          )}
+        </Collection>
+      </Tabs>
     </main>
   );
 }

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -1,11 +1,19 @@
 import { css } from "@emotion/react";
-import { Suspense, useCallback } from "react";
+import { Suspense } from "react";
 import type { Key } from "react-aria-components";
 import { Collection } from "react-aria-components";
 import { Navigate, Outlet, useLocation, useNavigate } from "react-router";
 
 import { Loading, Tab, TabList, TabPanel, Tabs } from "@phoenix/components";
 import { useViewerCanManageSandboxes } from "@phoenix/contexts";
+import { useMediaQuery } from "@phoenix/hooks";
+
+/**
+ * Below this width the vertical tab rail would squeeze the settings content
+ * (tables, cards) too much, so the tabs fall back to a horizontal,
+ * scrollable bar above the content.
+ */
+const VERTICAL_TABS_MEDIA_QUERY = "(min-width: 900px)";
 
 const settingsPageCSS = css`
   overflow-y: auto;
@@ -15,11 +23,21 @@ const settingsPageCSS = css`
 const settingsPageInnerCSS = css`
   padding: var(--global-dimension-size-100);
   max-width: 1300px;
-  min-width: 500px;
   box-sizing: border-box;
   width: 100%;
   margin-left: auto;
   margin-right: auto;
+`;
+
+const settingsTabListCSS = css`
+  &[data-orientation="vertical"] {
+    flex: none;
+    width: var(--global-dimension-size-2000);
+    // Keep the rail in view while the settings content scrolls.
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
+  }
 `;
 
 const TABS: { id: string; label: string }[] = [
@@ -38,15 +56,13 @@ const TABS: { id: string; label: string }[] = [
 export function SettingsPage() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
+  const isLargeScreen = useMediaQuery(VERTICAL_TABS_MEDIA_QUERY);
   const tab = pathname.split("/settings")[1].replace("/", "");
-  const onChangeTab = useCallback(
-    (tab: Key) => {
-      if (typeof tab === "string") {
-        navigate(`/settings/${tab}`, { replace: true });
-      }
-    },
-    [navigate]
-  );
+  const onChangeTab = (tab: Key) => {
+    if (typeof tab === "string") {
+      navigate(`/settings/${tab}`, { replace: true });
+    }
+  };
   const isAgentAssistantEnabled = !window.Config.agentAssistantDisabled;
   const canManageSecrets = useViewerCanManageSandboxes();
   const canManageSandboxes = useViewerCanManageSandboxes();
@@ -71,9 +87,13 @@ export function SettingsPage() {
   return (
     <main css={settingsPageCSS}>
       <div css={settingsPageInnerCSS}>
-        <Tabs selectedKey={tab} onSelectionChange={onChangeTab}>
+        <Tabs
+          selectedKey={tab}
+          onSelectionChange={onChangeTab}
+          orientation={isLargeScreen ? "vertical" : "horizontal"}
+        >
           {/* TODO: filter sandboxes tab for non-admins */}
-          <TabList items={tabs}>
+          <TabList items={tabs} css={settingsTabListCSS} aria-label="Settings">
             {(item) => <Tab id={item.id}>{item.label}</Tab>}
           </TabList>
           <Collection items={tabs}>

--- a/app/src/pages/settings/SettingsUsersPage.tsx
+++ b/app/src/pages/settings/SettingsUsersPage.tsx
@@ -1,0 +1,5 @@
+import { UsersCard } from "@phoenix/pages/settings/UsersCard";
+
+export function SettingsUsersPage() {
+  return <UsersCard />;
+}

--- a/app/tests/admin-access.ts
+++ b/app/tests/admin-access.ts
@@ -4,6 +4,8 @@ test("admin can create system api key", async ({ page }) => {
   const testKeyName = `System-${randomUUID()}`;
   await page.getByRole("link", { name: "Settings" }).click();
   await page.waitForURL("**/settings/general");
+  await page.getByRole("tab", { name: "API Keys" }).click();
+  await page.waitForURL("**/settings/api-keys");
   await page.getByRole("button", { name: "System Key", exact: true }).click();
   await page.getByTestId("modal").getByLabel("Name").fill(testKeyName);
   await page.getByRole("button", { name: "Create Key" }).click();

--- a/app/tests/auth.setup.ts
+++ b/app/tests/auth.setup.ts
@@ -89,8 +89,8 @@ setup(
       oldPassword: "admin",
       newPassword: "admin123",
     });
-    await page.goto(`${baseURL}/settings/general`);
-    await page.waitForURL("**/settings/general");
+    await page.goto(`${baseURL}/settings/users`);
+    await page.waitForURL("**/settings/users");
 
     // Add member user
     await page.getByRole("button", { name: "Add User" }).click();

--- a/app/tests/settings-tables.spec.ts
+++ b/app/tests/settings-tables.spec.ts
@@ -8,17 +8,20 @@ async function clickSortableHeaderAndExpect(
   await expect(header).toHaveAttribute("aria-sort", direction);
 }
 
-test.describe("Settings General Tables", () => {
-  test("users and api key tables support core interactions", async ({
-    page,
-  }) => {
-    await page.goto("/settings/general");
-    await page.waitForURL("**/settings/general");
+test.describe("Settings Tables", () => {
+  test("users table supports core interactions", async ({ page }) => {
+    await page.goto("/settings/users");
+    await page.waitForURL("**/settings/users");
 
     await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
 
     const userHeader = page.getByRole("columnheader", { name: "user" }).first();
     await clickSortableHeaderAndExpect(userHeader, "ascending");
+  });
+
+  test("api key tables support core interactions", async ({ page }) => {
+    await page.goto("/settings/api-keys");
+    await page.waitForURL("**/settings/api-keys");
 
     await page.getByRole("tab", { name: "User Keys" }).click();
     await expect(

--- a/app/tests/user-management.spec.ts
+++ b/app/tests/user-management.spec.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "crypto";
 import { expect, test } from "@playwright/test";
 test("can create a user", async ({ page }) => {
-  await page.goto("/settings/general");
-  await page.waitForURL("**/settings/general");
+  await page.goto("/settings/users");
+  await page.waitForURL("**/settings/users");
   await page.getByRole("button", { name: "Add User" }).click();
 
   const email = `member-${randomUUID()}@localhost.com`;
@@ -26,8 +26,8 @@ test("can create a user", async ({ page }) => {
 });
 
 test("can create a user with viewer role", async ({ page }) => {
-  await page.goto("/settings/general");
-  await page.waitForURL("**/settings/general");
+  await page.goto("/settings/users");
+  await page.waitForURL("**/settings/users");
   await page.getByRole("button", { name: "Add User" }).click();
 
   const email = `viewer-${randomUUID()}@localhost.com`;


### PR DESCRIPTION
The settings page has accumulated a dozen tabs, which crowds the horizontal tab bar. On screens 900px and wider the tabs now render as a vertical rail on the left of the content; below that width they fall back to the existing horizontal, scrollable tab bar so the page keeps working on smaller screens. On top of the new layout, this PR splits Users and API Keys out of General into their own tabs and virtualizes the models table.

## Changes

### Vertical settings tabs
- **`SettingsPage`**: switches the `Tabs` orientation between `vertical` and `horizontal` based on a `(min-width: 900px)` media query. The tab panel is now the scroll container (its scrollbar sits at the viewport edge) and the rail scrolls independently if it ever outgrows the viewport.
- **New `useMediaQuery` hook** (`app/src/hooks/useMediaQuery.ts`), backed by `useSyncExternalStore`, so the orientation flips live on resize.
- **`Tabs` primitive**: vertical tab lists mark the selected tab with a filled pill behind the label (matching the side nav's active item) instead of an edge bar; the horizontal-overflow fade state resets when the orientation flips.
- **`GlobalRetentionPolicyCard`**: replaced the hardcoded `width="1000px"` wrapper (which overflowed narrow screens) with a wrapping flex row.

### Users and API Keys tabs
- Users and API Keys move out of the General tab into dedicated admin-only tabs (`/settings/users`, `/settings/api-keys`) with their own routes and agent route metadata; General slims down to platform info, database usage, and retention policy.
- E2E specs that reached those tables through `/settings/general` (auth setup, user management, table interactions, admin access helper) now navigate to the new routes.

### Virtualized models table
- The built-in model registry has grown to hundreds of rows, all of which were mounted at once. The table body now renders through `@tanstack/react-virtual`: the models card fills the tab panel, the table container is the scroll viewport, and only visible rows (plus overscan) mount.
- Top/bottom spacer rows preserve scrollbar geometry instead of the usual `translateY` row transform so the sticky pinned name/actions columns keep working; rows are measured with `getBoundingClientRect` because their fractional heights accumulate enough integer-rounding error over hundreds of rows to clip the last one.

## Verified

- Typecheck, oxlint, and oxfmt pass.
- Playwright: auth setup, `user-management.spec.ts`, and `settings-tables.spec.ts` pass against the new routes (chromium).
- Drove the app: models table mounts ~16 rows instead of 265 while scrolling/sorting/searching stay correct, pinned columns stay sticky during horizontal scroll, and the last row lands fully visible at the bottom; General/Users/API Keys tabs render their expected cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sJ3atv95C1ZrfVdAc9TBT
