### PR TITLE
fix(phoenix-otel): warn when add_span_processor replaces the default Phoenix exporter

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -307,16 +307,17 @@ class TracerProvider(_TracerProvider):
         self._default_processor = span_processor
 
     def _shutdown_default_processor(self) -> None:
-        default_processor = self._default_processor
-        if default_processor is not None:
-            default_processor.shutdown()
-            with self._active_span_processor._lock:
-                self._active_span_processor._span_processors = tuple(
-                    processor
-                    for processor in self._active_span_processor._span_processors
-                    if processor is not default_processor
-                )
+        with self._active_span_processor._lock:
+            default_processor = self._default_processor
+            if default_processor is None:
+                return
+            self._active_span_processor._span_processors = tuple(
+                processor
+                for processor in self._active_span_processor._span_processors
+                if processor is not default_processor
+            )
             self._default_processor = None
+        default_processor.shutdown()
 
     def _tracing_details(self) -> str:
         project = self.resource.attributes.get(PROJECT_NAME)

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -175,8 +175,7 @@ def register(
         span_processor = BatchSpanProcessor(endpoint=endpoint, headers=headers, protocol=protocol)
     else:
         span_processor = SimpleSpanProcessor(endpoint=endpoint, headers=headers, protocol=protocol)
-    tracer_provider.add_span_processor(span_processor)
-    tracer_provider._default_processor = True
+    tracer_provider._set_default_processor(span_processor)
 
     if set_global_tracer_provider:
         trace_api.set_tracer_provider(tracer_provider)
@@ -286,14 +285,34 @@ class TracerProvider(_TracerProvider):
         """
         Registers a new `SpanProcessor` for this `TracerProvider`.
 
-        If this `TracerProvider` has a default processor, it will be removed.
+        If this `TracerProvider` has a default processor, it will be removed
+        (and a warning emitted). Pass `replace_default_processor=False` to keep
+        the default processor alongside the newly added one.
         """
 
         if self._default_processor and replace_default_processor:
+            warnings.warn(
+                "The default span processor (the Phoenix exporter configured at "
+                "construction) is being replaced by the newly added span processor. "
+                "Spans will no longer be exported by the default processor. Pass "
+                "`replace_default_processor=False` to keep it alongside the new one.",
+                stacklevel=2,
+            )
+            self._shutdown_default_processor()
+        return super().add_span_processor(*args, **kwargs)
+
+    def _set_default_processor(self, span_processor: SpanProcessor) -> None:
+        # Internal setup path (e.g. `register`): replacing the default here is the
+        # intended configuration step, so it happens without a warning.
+        self._shutdown_default_processor()
+        super().add_span_processor(span_processor)
+        self._default_processor = True
+
+    def _shutdown_default_processor(self) -> None:
+        if self._default_processor:
             self._active_span_processor.shutdown()
             self._active_span_processor._span_processors = tuple()  # remove default processors
             self._default_processor = False
-        return super().add_span_processor(*args, **kwargs)
 
     def _tracing_details(self) -> str:
         project = self.resource.attributes.get(PROJECT_NAME)

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -263,19 +263,17 @@ class TracerProvider(_TracerProvider):
         validated_protocol = OTLPTransportProtocol(protocol)
         use_http = validated_protocol == OTLPTransportProtocol.HTTP_PROTOBUF
         parsed_url, endpoint = _normalized_endpoint(endpoint, use_http=use_http)
-        self._default_processor = False
+        self._default_processor: Optional[SpanProcessor] = None
 
         if (
             _maybe_http_endpoint(parsed_url)
             or validated_protocol == OTLPTransportProtocol.HTTP_PROTOBUF
         ):
             http_exporter: SpanExporter = HTTPSpanExporter(endpoint=endpoint)
-            self.add_span_processor(SimpleSpanProcessor(span_exporter=http_exporter))
-            self._default_processor = True
+            self._set_default_processor(SimpleSpanProcessor(span_exporter=http_exporter))
         elif _maybe_grpc_endpoint(parsed_url) or validated_protocol == OTLPTransportProtocol.GRPC:
             grpc_exporter: SpanExporter = GRPCSpanExporter(endpoint=endpoint)
-            self.add_span_processor(SimpleSpanProcessor(span_exporter=grpc_exporter))
-            self._default_processor = True
+            self._set_default_processor(SimpleSpanProcessor(span_exporter=grpc_exporter))
         if verbose:
             print(self._tracing_details())
 
@@ -290,7 +288,7 @@ class TracerProvider(_TracerProvider):
         the default processor alongside the newly added one.
         """
 
-        if self._default_processor and replace_default_processor:
+        if self._default_processor is not None and replace_default_processor:
             warnings.warn(
                 "The default span processor (the Phoenix exporter configured at "
                 "construction) is being replaced by the newly added span processor. "
@@ -306,13 +304,19 @@ class TracerProvider(_TracerProvider):
         # intended configuration step, so it happens without a warning.
         self._shutdown_default_processor()
         super().add_span_processor(span_processor)
-        self._default_processor = True
+        self._default_processor = span_processor
 
     def _shutdown_default_processor(self) -> None:
-        if self._default_processor:
-            self._active_span_processor.shutdown()
-            self._active_span_processor._span_processors = tuple()  # remove default processors
-            self._default_processor = False
+        default_processor = self._default_processor
+        if default_processor is not None:
+            default_processor.shutdown()
+            with self._active_span_processor._lock:
+                self._active_span_processor._span_processors = tuple(
+                    processor
+                    for processor in self._active_span_processor._span_processors
+                    if processor is not default_processor
+                )
+            self._default_processor = None
 
     def _tracing_details(self) -> str:
         project = self.resource.attributes.get(PROJECT_NAME)
@@ -377,7 +381,7 @@ class TracerProvider(_TracerProvider):
             f"|  Transport: {transport}\n"
             f"|  Transport Headers: {headers}\n"
             "|  \n"
-            f"{configuration_msg if self._default_processor else ''}"
+            f"{configuration_msg if self._default_processor is not None else ''}"
             f"{span_processor_warning if using_simple_processor else ''}"
         )
         return details_msg

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -401,6 +401,19 @@ class TestTracerProvider:
         assert processors == (first_custom_processor, second_custom_processor)
         first_custom_processor.shutdown.assert_not_called()
 
+    def test_add_span_processor_removes_default_before_shutdown(self) -> None:
+        tracer_provider = TracerProvider(verbose=False)
+        default_processor = tracer_provider._default_processor
+        assert default_processor is not None
+
+        def assert_default_is_inactive() -> None:
+            assert default_processor not in tracer_provider._active_span_processor._span_processors
+            assert tracer_provider._default_processor is None
+
+        with patch.object(default_processor, "shutdown", side_effect=assert_default_is_inactive):
+            with pytest.warns(UserWarning, match="default span processor"):
+                tracer_provider.add_span_processor(Mock(spec=_SimpleSpanProcessor))
+
     def test_register_does_not_warn_on_default_processor_setup(self) -> None:
         # `register` replaces the provider's construction-time default internally as its
         # intended configuration step — that path must stay silent.

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from pathlib import Path
 from typing import Any, Generator, Optional
 from unittest.mock import MagicMock, Mock, patch
@@ -363,7 +364,8 @@ class TestTracerProvider:
         assert tracer_provider._default_processor
 
         custom_processor = Mock(spec=_SimpleSpanProcessor)
-        tracer_provider.add_span_processor(custom_processor)
+        with pytest.warns(UserWarning, match="default span processor"):
+            tracer_provider.add_span_processor(custom_processor)
 
         assert not tracer_provider._default_processor
         # The default processor should have been removed
@@ -376,11 +378,21 @@ class TestTracerProvider:
         initial_count = len(tracer_provider._active_span_processor._span_processors)
 
         custom_processor = Mock(spec=_SimpleSpanProcessor)
-        tracer_provider.add_span_processor(custom_processor, replace_default_processor=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # keeping the default must NOT warn
+            tracer_provider.add_span_processor(custom_processor, replace_default_processor=False)
 
         assert tracer_provider._default_processor
         # Both processors should be present
         assert len(tracer_provider._active_span_processor._span_processors) == initial_count + 1
+
+    def test_register_does_not_warn_on_default_processor_setup(self) -> None:
+        # `register` replaces the provider's construction-time default internally as its
+        # intended configuration step — that path must stay silent.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            tracer_provider = register(set_global_tracer_provider=False, verbose=False)
+        assert tracer_provider._default_processor
 
     @patch("builtins.print")
     def test_tracer_provider_verbose(self, mock_print: Any) -> None:

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -386,6 +386,21 @@ class TestTracerProvider:
         # Both processors should be present
         assert len(tracer_provider._active_span_processor._span_processors) == initial_count + 1
 
+    def test_add_span_processor_replaces_only_default(self) -> None:
+        tracer_provider = TracerProvider(verbose=False)
+        default_processor = tracer_provider._active_span_processor._span_processors[0]
+        first_custom_processor = Mock(spec=_SimpleSpanProcessor)
+        tracer_provider.add_span_processor(first_custom_processor, replace_default_processor=False)
+
+        second_custom_processor = Mock(spec=_SimpleSpanProcessor)
+        with pytest.warns(UserWarning, match="default span processor"):
+            tracer_provider.add_span_processor(second_custom_processor)
+
+        processors = tracer_provider._active_span_processor._span_processors
+        assert default_processor not in processors
+        assert processors == (first_custom_processor, second_custom_processor)
+        first_custom_processor.shutdown.assert_not_called()
+
     def test_register_does_not_warn_on_default_processor_setup(self) -> None:
         # `register` replaces the provider's construction-time default internally as its
         # intended configuration step — that path must stay silent.


### PR DESCRIPTION
## Summary

`TracerProvider.add_span_processor` removes the default span processor (and with it the configured Phoenix exporter) unless `replace_default_processor=False` is passed. The behavior is documented in the docstring, but nothing signals it at runtime — adding a second processor (e.g. to mirror spans to a second collector) silently stops the Phoenix export, which makes for a confusing debugging session: spans keep being created, flushes succeed, and the Phoenix project just goes quiet.

## Changes

- Emit a `UserWarning` when a user-initiated `add_span_processor` call replaces the default processor, pointing to `replace_default_processor=False`.
- Keep `register()`'s internal default-processor setup silent by routing it through a private `_set_default_processor` helper — plain `register()` emits no new warnings.
- Tests: tightened the two existing replacement tests to assert the new warning, and added a test asserting `register()` stays silent.

No change to replacement semantics, flags, or the public API.

## Testing

- `pytest packages/phoenix-otel/tests/test_otel.py` — 55 passed.
- Manually verified: plain `register()` → no warning; `add_span_processor(p)` on a registered provider → exactly one warning, replacement behavior unchanged; `add_span_processor(p, replace_default_processor=False)` → no warning, both processors active.