### PR TITLE
feat(online-eval): session evaluation sweep and evaluation-delay API

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1010,7 +1010,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1036,7 +1036,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -2705,27 +2705,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Create an LLM project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Update an LLM project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Create a CODE project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
@@ -3285,12 +3285,12 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Evaluation grain. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   evaluationTarget: EvaluationTarget!
 
   """
-  Seconds of inactivity before a SESSION evaluation. Null uses the default of 300 seconds.
+  Seconds a SESSION must stay quiet before work is scheduled. Values must be at least 10 seconds. Null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
   inputMapping: EvaluatorInputMapping!
@@ -5173,7 +5173,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  SESSION evaluation delay in seconds. Omit to preserve the current setting or use null to restore the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }
@@ -5192,7 +5192,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  SESSION evaluation delay in seconds. Omit to preserve the current setting or use null to restore the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1010,7 +1010,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1036,7 +1036,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -2705,27 +2705,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Create an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Update an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Create a CODE project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
@@ -3285,12 +3285,20 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   evaluationTarget: EvaluationTarget!
 
+  """Whether this project evaluator is currently eligible for scheduling."""
+  schedulabilityStatus: ProjectEvaluatorSchedulabilityStatus!
+
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New criteria store the current default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Machine-readable reason the project evaluator is not schedulable, or null when it is schedulable.
+  """
+  schedulabilityReason: ProjectEvaluatorSchedulabilityReason
+
+  """
+  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New criteria store the current default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it. A later change to SESSION uses the stored value, but the target cannot change after evaluation work exists for this project evaluator.
   """
   evaluationDelaySeconds: Int!
   inputMapping: EvaluatorInputMapping!
@@ -3330,6 +3338,18 @@ enum ProjectEvaluatorFilterColumn {
 type ProjectEvaluatorMutationPayload {
   evaluator: ProjectEvaluator!
   query: Query!
+}
+
+enum ProjectEvaluatorSchedulabilityReason {
+  DISABLED
+  TRACE_TARGET_UNSUPPORTED
+  SESSION_FILTER_UNSUPPORTED
+  SESSION_SAMPLING_UNSUPPORTED
+}
+
+enum ProjectEvaluatorSchedulabilityStatus {
+  SCHEDULABLE
+  NOT_SCHEDULABLE
 }
 
 """The filter key and value for project connections"""
@@ -5173,7 +5193,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int
 }
@@ -5192,7 +5212,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int
 }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1010,7 +1010,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1036,7 +1036,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -2705,27 +2705,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Create an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Update an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Create a CODE project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
@@ -3285,12 +3285,12 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  Evaluation grain. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   evaluationTarget: EvaluationTarget!
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. Values must be at least 10 seconds. Null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. Null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
   inputMapping: EvaluatorInputMapping!
@@ -5173,7 +5173,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }
@@ -5192,7 +5192,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -5178,6 +5178,8 @@ input UpdateProjectCodeEvaluatorInput {
   projectEvaluatorId: ID!
   name: Identifier!
   samplingRate: Float!
+
+  """The evaluation target is fixed at project evaluator creation."""
   evaluationTarget: EvaluationTarget!
   filterCondition: String!
   evaluatorInputMapping: EvaluatorInputMappingInput
@@ -5205,6 +5207,8 @@ input UpdateProjectLLMEvaluatorInput {
   outputConfigs: [AnnotationConfigInput!]!
   inputMapping: EvaluatorInputMappingInput!
   samplingRate: Float!
+
+  """The evaluation target is fixed at project evaluator creation."""
   evaluationTarget: EvaluationTarget!
   filterCondition: String!
   enabled: Boolean

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1010,7 +1010,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -1036,7 +1036,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -3290,9 +3290,9 @@ type ProjectEvaluator implements Node {
   evaluationTarget: EvaluationTarget!
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. Null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New criteria store the current default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
-  evaluationDelaySeconds: Int
+  evaluationDelaySeconds: Int!
   inputMapping: EvaluatorInputMapping!
   enabled: Boolean!
   createdAt: DateTime!
@@ -5173,7 +5173,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }
@@ -5192,7 +5192,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -83,6 +83,11 @@ input AddProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput = null
   filterCondition: String! = ""
   enabled: Boolean! = true
+
+  """
+  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  """
+  evaluationDelaySeconds: Int = null
 }
 
 input AddSpansToDatasetInput {
@@ -1003,6 +1008,11 @@ input CreateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput = null
   filterCondition: String! = ""
   enabled: Boolean! = true
+
+  """
+  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  """
+  evaluationDelaySeconds: Int = null
 }
 
 input CreateProjectInput {
@@ -1024,6 +1034,11 @@ input CreateProjectLLMEvaluatorInput {
   promptVersionId: ID
   filterCondition: String! = ""
   enabled: Boolean! = true
+
+  """
+  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  """
+  evaluationDelaySeconds: Int = null
 }
 
 input CreateProjectSessionAnnotationInput {
@@ -2690,27 +2705,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Create an LLM project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Update an LLM project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Create a CODE project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
@@ -3270,9 +3285,14 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  SPAN is currently executable; TRACE and SESSION are stored but remain inactive until their runtimes are available.
+  SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   evaluationTarget: EvaluationTarget!
+
+  """
+  Seconds of inactivity before a SESSION evaluation. Null uses the default of 300 seconds.
+  """
+  evaluationDelaySeconds: Int
   inputMapping: EvaluatorInputMapping!
   enabled: Boolean!
   createdAt: DateTime!
@@ -5151,6 +5171,11 @@ input UpdateProjectCodeEvaluatorInput {
   Project-specific CODE input mapping patch. Omit to preserve the current setting, use null to inherit the evaluator input mapping, or provide an object to override it.
   """
   inputMapping: EvaluatorInputMappingInput
+
+  """
+  SESSION evaluation delay in seconds. Omit to preserve the current setting or use null to restore the default delay.
+  """
+  evaluationDelaySeconds: Int
 }
 
 input UpdateProjectLLMEvaluatorInput {
@@ -5165,6 +5190,11 @@ input UpdateProjectLLMEvaluatorInput {
   enabled: Boolean
   description: String
   promptVersionId: ID
+
+  """
+  SESSION evaluation delay in seconds. Omit to preserve the current setting or use null to restore the default delay.
+  """
+  evaluationDelaySeconds: Int
 }
 
 input UpdateSandboxConfigInput {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -882,7 +882,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -908,7 +908,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -3013,9 +3013,9 @@ type ProjectEvaluator implements Node {
   evaluationTarget: EvaluationTarget!
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. Null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New criteria store the current default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
-  evaluationDelaySeconds: Int
+  evaluationDelaySeconds: Int!
   inputMapping: EvaluatorInputMapping!
   enabled: Boolean!
   createdAt: DateTime!
@@ -4836,7 +4836,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }
@@ -4855,7 +4855,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -882,7 +882,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -908,7 +908,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -2515,27 +2515,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Create an LLM project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Update an LLM project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Create a CODE project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
   deleteProjectEvaluators(input: DeleteProjectEvaluatorsInput!): DeleteProjectEvaluatorsPayload!
@@ -3008,12 +3008,12 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
+  Evaluation grain. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
   """
   evaluationTarget: EvaluationTarget!
 
   """
-  Seconds of inactivity before a SESSION evaluation. Null uses the default of 300 seconds.
+  Seconds a SESSION must stay quiet before work is scheduled. Values must be at least 10 seconds. Null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
   inputMapping: EvaluatorInputMapping!
@@ -4836,7 +4836,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  SESSION evaluation delay in seconds. Omit to preserve the current setting or use null to restore the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }
@@ -4855,7 +4855,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  SESSION evaluation delay in seconds. Omit to preserve the current setting or use null to restore the default delay.
+  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -882,7 +882,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -908,7 +908,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -2515,27 +2515,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Create an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Update an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Create a CODE project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
   deleteProjectEvaluators(input: DeleteProjectEvaluatorsInput!): DeleteProjectEvaluatorsPayload!
@@ -3008,12 +3008,12 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  Evaluation grain. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling are evaluated once: work is scheduled after the session first stays quiet for the evaluation delay, and execution begins when a consumer claims it. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not yet scheduled.
+  SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
   """
   evaluationTarget: EvaluationTarget!
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. Values must be at least 10 seconds. Null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. Null uses the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
   inputMapping: EvaluatorInputMapping!
@@ -4836,7 +4836,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }
@@ -4855,7 +4855,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  Seconds a SESSION must stay quiet before work is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to restore the default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
   """
   evaluationDelaySeconds: Int
 }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -85,7 +85,7 @@ input AddProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -882,7 +882,7 @@ input CreateProjectCodeEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -908,7 +908,7 @@ input CreateProjectLLMEvaluatorInput {
   enabled: Boolean! = true
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds. Omit or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int = null
 }
@@ -2515,27 +2515,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Create an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Update an LLM project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Create a CODE project evaluator. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
   deleteProjectEvaluators(input: DeleteProjectEvaluatorsInput!): DeleteProjectEvaluatorsPayload!
@@ -3008,12 +3008,20 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled.
+  SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling rate of 1 are evaluated once per session: evaluation is scheduled after the session first stays quiet for the evaluation delay, then runs asynchronously. Later activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation delay without using it. The target can change only until evaluation work exists for the project evaluator.
   """
   evaluationTarget: EvaluationTarget!
 
+  """Whether this project evaluator is currently eligible for scheduling."""
+  schedulabilityStatus: ProjectEvaluatorSchedulabilityStatus!
+
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New criteria store the current default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Machine-readable reason the project evaluator is not schedulable, or null when it is schedulable.
+  """
+  schedulabilityReason: ProjectEvaluatorSchedulabilityReason
+
+  """
+  Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at least 10 seconds. New criteria store the current default of 300 seconds when no value is provided. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it. A later change to SESSION uses the stored value, but the target cannot change after evaluation work exists for this project evaluator.
   """
   evaluationDelaySeconds: Int!
   inputMapping: EvaluatorInputMapping!
@@ -3043,6 +3051,18 @@ type ProjectEvaluatorEdge {
 type ProjectEvaluatorMutationPayload {
   evaluator: ProjectEvaluator!
   query: Query!
+}
+
+enum ProjectEvaluatorSchedulabilityReason {
+  DISABLED
+  TRACE_TARGET_UNSUPPORTED
+  SESSION_FILTER_UNSUPPORTED
+  SESSION_SAMPLING_UNSUPPORTED
+}
+
+enum ProjectEvaluatorSchedulabilityStatus {
+  SCHEDULABLE
+  NOT_SCHEDULABLE
 }
 
 """The filter key and value for project connections"""
@@ -4836,7 +4856,7 @@ input UpdateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int
 }
@@ -4855,7 +4875,7 @@ input UpdateProjectLLMEvaluatorInput {
   promptVersionId: ID
 
   """
-  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation.
+  Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is 10 seconds; omit to preserve the current setting or use null to store the current default of 300 seconds. A session is evaluated only once, and later activity does not schedule another evaluation. Non-SESSION targets preserve this value without using it.
   """
   evaluationDelaySeconds: Int
 }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -83,6 +83,11 @@ input AddProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput = null
   filterCondition: String! = ""
   enabled: Boolean! = true
+
+  """
+  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  """
+  evaluationDelaySeconds: Int = null
 }
 
 input AddSpansToDatasetInput {
@@ -875,6 +880,11 @@ input CreateProjectCodeEvaluatorInput {
   inputMapping: EvaluatorInputMappingInput = null
   filterCondition: String! = ""
   enabled: Boolean! = true
+
+  """
+  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  """
+  evaluationDelaySeconds: Int = null
 }
 
 input CreateProjectInput {
@@ -896,6 +906,11 @@ input CreateProjectLLMEvaluatorInput {
   promptVersionId: ID
   filterCondition: String! = ""
   enabled: Boolean! = true
+
+  """
+  Seconds of inactivity before a SESSION evaluation. Null uses the default delay.
+  """
+  evaluationDelaySeconds: Int = null
 }
 
 input CreateProjectSessionAnnotationInput {
@@ -2500,27 +2515,27 @@ type Mutation {
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
 
   """
-  Create an LLM project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Create an LLM project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update an LLM project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Update an LLM project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Create a CODE project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Create a CODE project evaluator. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
   deleteProjectEvaluators(input: DeleteProjectEvaluatorsInput!): DeleteProjectEvaluatorsPayload!
@@ -2993,9 +3008,14 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  SPAN is currently executable; TRACE and SESSION are stored but remain inactive until their runtimes are available.
+  SPAN evaluators run on matching spans; unfiltered SESSION evaluators with full sampling run after their evaluation delay. TRACE evaluators are stored but not scheduled.
   """
   evaluationTarget: EvaluationTarget!
+
+  """
+  Seconds of inactivity before a SESSION evaluation. Null uses the default of 300 seconds.
+  """
+  evaluationDelaySeconds: Int
   inputMapping: EvaluatorInputMapping!
   enabled: Boolean!
   createdAt: DateTime!
@@ -4814,6 +4834,11 @@ input UpdateProjectCodeEvaluatorInput {
   Project-specific CODE input mapping patch. Omit to preserve the current setting, use null to inherit the evaluator input mapping, or provide an object to override it.
   """
   inputMapping: EvaluatorInputMappingInput
+
+  """
+  SESSION evaluation delay in seconds. Omit to preserve the current setting or use null to restore the default delay.
+  """
+  evaluationDelaySeconds: Int
 }
 
 input UpdateProjectLLMEvaluatorInput {
@@ -4828,6 +4853,11 @@ input UpdateProjectLLMEvaluatorInput {
   enabled: Boolean!
   description: String = null
   promptVersionId: ID
+
+  """
+  SESSION evaluation delay in seconds. Omit to preserve the current setting or use null to restore the default delay.
+  """
+  evaluationDelaySeconds: Int
 }
 
 input UpdateSandboxConfigInput {

--- a/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/EditProjectEvaluatorSlideover.tsx
@@ -453,6 +453,7 @@ function EditLlmProjectEvaluatorContent({
                 onScopeChange={setScope}
                 onFilterValidityChange={setIsFilterValid}
                 showAnnotationTemplate
+                isTargetDisabled
               />
             }
           />

--- a/app/src/pages/project/evaluators/ProjectCodeEvaluatorDialogContent.tsx
+++ b/app/src/pages/project/evaluators/ProjectCodeEvaluatorDialogContent.tsx
@@ -79,6 +79,7 @@ export const ProjectCodeEvaluatorDialogContent = ({
           codeEvaluatorId={inlineCode ? undefined : evaluatorId}
           inlineCode={inlineCode}
           requiredVariables={requiredVariables}
+          isTargetDisabled={mode === "update"}
         />
       }
     />

--- a/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorScopePanel.tsx
@@ -143,6 +143,7 @@ export const ProjectEvaluatorScopePanel = ({
   inlineCode,
   requiredVariables,
   showAnnotationTemplate = false,
+  isTargetDisabled = false,
 }: {
   projectId: string;
   scope: ProjectEvaluatorScope;
@@ -152,6 +153,7 @@ export const ProjectEvaluatorScopePanel = ({
   inlineCode?: ProjectEvaluatorInlineCode;
   requiredVariables?: string[];
   showAnnotationTemplate?: boolean;
+  isTargetDisabled?: boolean;
 }) => {
   const [timeWindow, setTimeWindow] = useState(() => makeTimeWindow("7d"));
   return (
@@ -170,6 +172,7 @@ export const ProjectEvaluatorScopePanel = ({
           onFilterValidityChange={onFilterValidityChange}
           timeWindow={timeWindow}
           onTimeWindowChange={setTimeWindow}
+          isTargetDisabled={isTargetDisabled}
         />
         <Flex direction="column" gap="size-25">
           <Heading level={2}>Matching spans</Heading>
@@ -279,6 +282,7 @@ function ScopeEditorCard({
   onFilterValidityChange,
   timeWindow,
   onTimeWindowChange,
+  isTargetDisabled,
 }: {
   projectId: string;
   scope: ProjectEvaluatorScope;
@@ -286,6 +290,7 @@ function ScopeEditorCard({
   onFilterValidityChange?: (isValid: boolean) => void;
   timeWindow: TimeWindow;
   onTimeWindowChange: (timeWindow: TimeWindow) => void;
+  isTargetDisabled: boolean;
 }) {
   // Only validated conditions are lifted into `scope`.
   const [filterConditionDraft, setFilterConditionDraft] = useState(
@@ -306,6 +311,7 @@ function ScopeEditorCard({
           <ProjectEvaluatorTargetField
             value={scope.targetType}
             onChange={(targetType) => onScopeChange({ ...scope, targetType })}
+            isDisabled={isTargetDisabled}
           />
           <Flex direction="column" gap="size-50">
             <Text size="XS" weight="heavy" color="text-700">

--- a/app/src/pages/project/evaluators/ProjectEvaluatorTargetField.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorTargetField.tsx
@@ -12,9 +12,11 @@ import {
 export const ProjectEvaluatorTargetField = ({
   value,
   onChange,
+  isDisabled = false,
 }: {
   value: ProjectEvaluatorTarget;
   onChange: (target: ProjectEvaluatorTarget) => void;
+  isDisabled?: boolean;
 }) => {
   return (
     <Flex direction="column" gap="size-50" flex="none">
@@ -31,7 +33,7 @@ export const ProjectEvaluatorTargetField = ({
           }
         }}
       >
-        <ToggleButton id="span" aria-label="Span">
+        <ToggleButton id="span" aria-label="Span" isDisabled={isDisabled}>
           Span
         </ToggleButton>
         <ToggleButton id="session" aria-label="Session" isDisabled>

--- a/app/src/pages/project/evaluators/__generated__/CreateProjectCodeEvaluatorDialogContentMutation.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/CreateProjectCodeEvaluatorDialogContentMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<21262d692fd155ee05133cb4b3115f6d>>
+ * @generated SignedSource<<4fa7ac065b8ecaf4af19496123a1a51c>>
  * @lightSyntaxTransform
  */
 
@@ -15,6 +15,7 @@ export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type CreateProjectCodeEvaluatorInput = {
   description?: string | null;
   enabled?: boolean;
+  evaluationDelaySeconds?: number | null;
   evaluationTarget: EvaluationTarget;
   evaluatorInputMapping: EvaluatorInputMappingInput;
   filterCondition?: string;

--- a/app/src/pages/project/evaluators/__generated__/CreateProjectEvaluatorSlideoverAddCodeMutation.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/CreateProjectEvaluatorSlideoverAddCodeMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3846d339b24501be0bf0d13b23edaf82>>
+ * @generated SignedSource<<c61f314c168553ea85f73721a691c124>>
  * @lightSyntaxTransform
  */
 
@@ -12,6 +12,7 @@ export type EvaluationTarget = "SESSION" | "SPAN" | "TRACE";
 export type EvaluatorKind = "BUILTIN" | "CODE" | "LLM";
 export type AddProjectCodeEvaluatorInput = {
   enabled?: boolean;
+  evaluationDelaySeconds?: number | null;
   evaluationTarget: EvaluationTarget;
   evaluatorId: string;
   filterCondition?: string;

--- a/app/src/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverUpdateCodeMutation.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverUpdateCodeMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<34c99ef2501f0d91da6080c86a968f60>>
+ * @generated SignedSource<<ebc43678fb6acda558960c1a74bb99f2>>
  * @lightSyntaxTransform
  */
 
@@ -13,6 +13,7 @@ export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type UpdateProjectCodeEvaluatorInput = {
   description?: string | null;
   enabled?: boolean | null;
+  evaluationDelaySeconds?: number | null;
   evaluationTarget: EvaluationTarget;
   evaluatorInputMapping?: EvaluatorInputMappingInput | null;
   filterCondition: string;

--- a/app/src/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverUpdateLlmMutation.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/EditProjectEvaluatorSlideoverUpdateLlmMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f2c1941226debc1a9f7f80ace39b9454>>
+ * @generated SignedSource<<16612b354ce6f6eef3d7b47753bbfc6e>>
  * @lightSyntaxTransform
  */
 
@@ -20,6 +20,7 @@ export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type UpdateProjectLLMEvaluatorInput = {
   description?: string | null;
   enabled?: boolean | null;
+  evaluationDelaySeconds?: number | null;
   evaluationTarget: EvaluationTarget;
   filterCondition: string;
   inputMapping: EvaluatorInputMappingInput;

--- a/app/src/pages/project/evaluators/__generated__/createProjectLlmEvaluatorMutation.graphql.ts
+++ b/app/src/pages/project/evaluators/__generated__/createProjectLlmEvaluatorMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0fe3db0edf55e4328fdc05ee01f2a9c5>>
+ * @generated SignedSource<<5cf82ac324a6de8ed2334b9067078c9e>>
  * @lightSyntaxTransform
  */
 
@@ -21,6 +21,7 @@ export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type CreateProjectLLMEvaluatorInput = {
   description?: string | null;
   enabled?: boolean;
+  evaluationDelaySeconds?: number | null;
   evaluationTarget: EvaluationTarget;
   filterCondition?: string;
   inputMapping: EvaluatorInputMappingInput;

--- a/internal_docs/specs/online-evals.md
+++ b/internal_docs/specs/online-evals.md
@@ -220,6 +220,12 @@ Design questions include:
 
 Project evaluators run after ingestion. They must never delay or fail ingestion.
 
+The live path uses project-evaluator creation as its boundary: an artifact's latest activity must
+be at or after the criterion's `created_at`. Older quiet artifacts belong to backfill. Disabling
+and later re-enabling a criterion deliberately retains that creation boundary, so activity after
+creation can still become eligible. If re-enablement should reset the live boundary, that requires
+a dedicated enablement timestamp and is future work rather than an inference from `enabled`.
+
 ### Spans
 
 Spans are eligible as soon as they are stored. When a matching span is ingested, the project

--- a/internal_docs/specs/online-evals.md
+++ b/internal_docs/specs/online-evals.md
@@ -254,12 +254,17 @@ Example: after an agent trace finishes, score whether the user got a correct ans
 Sessions are open-ended and can resume. The likely readiness mechanism is an idle timeout: a
 session is treated as ready for evaluation after no new activity arrives for some configured
 duration. This is only a pragmatic proxy for "complete" — e.g. sessions idle for a day may be
-considered done, even though that is not strictly true. If the session resumes and later goes idle
-again, it can be evaluated again. The visible session annotation reflects the latest evaluation.
+considered done, even though that is not strictly true.
 
-Re-evaluation **overrides** rather than stacks: if a session was judged "incomplete" and later
-completes, the newer judgment should replace the earlier one (see [Output](#output) for override-key
-requirements). Run history still preserves prior evaluations for audit.
+v1 evaluates each session once, when its first quiet period elapses. Later activity does not
+schedule another evaluation. This deliberate initial limitation is tracked in
+[#14903](https://github.com/Arize-ai/phoenix/issues/14903), which owns result identity, re-entry and
+frequency, recovery after permanent failure, and staleness detection for in-flight evaluation.
+
+When re-evaluation lands, it should **override** rather than stack: if a session was judged
+"incomplete" and later completes, the newer judgment should replace the earlier one (see
+[Output](#output) for override-key requirements). Run history should still preserve prior
+evaluations for audit.
 
 Example: after a support chat ends, assess whether the agent stayed coherent and moved toward
 resolution.
@@ -288,10 +293,10 @@ database, so some evaluation happens in Python, which makes them open-endedly ex
 not need to solve all levels at launch; a subset is still useful, and we can carve out room for
 the rest.
 
-Session filtering is the hardest: there is no obvious filter vocabulary for a session yet (it may
-come down to consistent metadata on root spans), and it is unclear whether a condition should
-apply to *any* or *all* of the session's spans. v1 should either define a small set of session
-filter options or omit session filters until that exists.
+The session filter DSL shipped in [#14101](https://github.com/Arize-ai/phoenix/pull/14101), closing
+[#14041](https://github.com/Arize-ai/phoenix/issues/14041). SESSION online-evaluation criteria do
+not consume it yet: filtered or sampled SESSION criteria are accepted but not scheduled.
+[#14038](https://github.com/Arize-ai/phoenix/issues/14038) owns the sampling half.
 
 Changing a filter affects only future artifacts; it does not backfill or re-run past data.
 

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -34,7 +34,8 @@ CREATE TABLE public.eval_work_cursors (
     CONSTRAINT pk_eval_work_cursors PRIMARY KEY (id),
     CONSTRAINT uq_eval_work_cursors_evaluation_target_consumer_group
         UNIQUE (evaluation_target, consumer_group),
-    CHECK (((evaluation_target)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_eval_work_cursors_`valid_evaluation_target`"
+        CHECK (((evaluation_target)::text = ANY ((ARRAY[
             'SPAN'::character varying,
             'TRACE'::character varying,
             'SESSION'::character varying
@@ -1201,12 +1202,11 @@ CREATE TABLE public.agent_sessions (
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_agent_sessions PRIMARY KEY (id),
     CONSTRAINT fk_agent_sessions_custom_provider_id_generative_model_c_af13
-        FOREIGN KEY
-        (custom_provider_id)
+        FOREIGN KEY (custom_provider_id)
         REFERENCES public.generative_model_custom_providers (id)
         ON DELETE SET NULL,
-    CONSTRAINT fk_agent_sessions_user_id_users FOREIGN KEY
-        (user_id)
+    CONSTRAINT fk_agent_sessions_user_id_users
+        FOREIGN KEY (user_id)
         REFERENCES public.users (id)
         ON DELETE CASCADE
 );
@@ -1234,10 +1234,9 @@ CREATE TABLE public.agent_session_messages (
     CONSTRAINT pk_agent_session_messages PRIMARY KEY (id),
     CONSTRAINT uq_agent_session_messages_message_id
         UNIQUE (message_id),
-    CHECK (((message_id)::text ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'::text)),
+    CONSTRAINT "ck_agent_session_messages_`valid_message_id`" CHECK (((message_id)::text ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'::text)),
     CONSTRAINT fk_agent_session_messages_agent_session_id_agent_sessions
-        FOREIGN KEY
-        (agent_session_id)
+        FOREIGN KEY (agent_session_id)
         REFERENCES public.agent_sessions (id)
         ON DELETE CASCADE
 );
@@ -1260,8 +1259,7 @@ CREATE TABLE public.agent_session_snapshots (
     CONSTRAINT uq_agent_session_snapshots_agent_session_id
         UNIQUE (agent_session_id),
     CONSTRAINT fk_agent_session_snapshots_agent_session_id_agent_sessions
-        FOREIGN KEY
-        (agent_session_id)
+        FOREIGN KEY (agent_session_id)
         REFERENCES public.agent_sessions (id)
         ON DELETE CASCADE
 );
@@ -1367,21 +1365,20 @@ CREATE TABLE public.project_evaluator_criteria (
     CONSTRAINT pk_project_evaluator_criteria PRIMARY KEY (id),
     CONSTRAINT uq_project_evaluator_criteria_project_id_name
         UNIQUE (project_id, name),
-    CHECK ((evaluation_delay_seconds >= 10)),
-    CHECK (((evaluation_target)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_project_evaluator_criteria_`valid_evaluation_delay_seconds`" CHECK ((evaluation_delay_seconds >= 10)),
+    CONSTRAINT "ck_project_evaluator_criteria_`valid_evaluation_target`"
+        CHECK (((evaluation_target)::text = ANY ((ARRAY[
             'SPAN'::character varying,
             'TRACE'::character varying,
             'SESSION'::character varying
         ])::text[]))),
-    CHECK ((((0.0)::double precision <= sampling_rate) AND (sampling_rate <= (1.0)::double precision))),
+    CONSTRAINT "ck_project_evaluator_criteria_`valid_sampling_rate`" CHECK ((((0.0)::double precision <= sampling_rate) AND (sampling_rate <= (1.0)::double precision))),
     CONSTRAINT fk_project_evaluator_criteria_evaluator_id_evaluators
-        FOREIGN KEY
-        (evaluator_id)
+        FOREIGN KEY (evaluator_id)
         REFERENCES public.evaluators (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_project_evaluator_criteria_project_id_projects
-        FOREIGN KEY
-        (project_id)
+        FOREIGN KEY (project_id)
         REFERENCES public.projects (id)
         ON DELETE CASCADE
 );
@@ -1410,7 +1407,8 @@ CREATE TABLE public.eval_session_work_units (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_eval_session_work_units PRIMARY KEY (id),
-    CHECK (((status)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_eval_session_work_units_`valid_eval_work_status`"
+        CHECK (((status)::text = ANY ((ARRAY[
             'PENDING'::character varying,
             'RUNNING'::character varying,
             'DONE'::character varying,
@@ -1418,18 +1416,15 @@ CREATE TABLE public.eval_session_work_units (
             'EXPIRED'::character varying
         ])::text[]))),
     CONSTRAINT fk_eval_session_work_units_criteria_id_project_evaluato_744c
-        FOREIGN KEY
-        (criteria_id)
+        FOREIGN KEY (criteria_id)
         REFERENCES public.project_evaluator_criteria (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_eval_session_work_units_evaluator_id_evaluators
-        FOREIGN KEY
-        (evaluator_id)
+        FOREIGN KEY (evaluator_id)
         REFERENCES public.evaluators (id)
         ON DELETE CASCADE,
     CONSTRAINT fk_eval_session_work_units_project_session_rowid_projec_ed73
-        FOREIGN KEY
-        (project_session_rowid)
+        FOREIGN KEY (project_session_rowid)
         REFERENCES public.project_sessions (id)
         ON DELETE CASCADE
 );
@@ -1467,7 +1462,8 @@ CREATE TABLE public.eval_work_units (
     CONSTRAINT pk_eval_work_units PRIMARY KEY (id),
     CONSTRAINT uq_eval_work_units_span_rowid_evaluator_id_config_fingerprint
         UNIQUE (span_rowid, evaluator_id, config_fingerprint),
-    CHECK (((status)::text = ANY ((ARRAY[
+    CONSTRAINT "ck_eval_work_units_`valid_eval_work_status`"
+        CHECK (((status)::text = ANY ((ARRAY[
             'PENDING'::character varying,
             'RUNNING'::character varying,
             'DONE'::character varying,
@@ -1475,16 +1471,15 @@ CREATE TABLE public.eval_work_units (
             'EXPIRED'::character varying
         ])::text[]))),
     CONSTRAINT fk_eval_work_units_criteria_id_project_evaluator_criteria
-        FOREIGN KEY
-        (criteria_id)
+        FOREIGN KEY (criteria_id)
         REFERENCES public.project_evaluator_criteria (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_eval_work_units_evaluator_id_evaluators FOREIGN KEY
-        (evaluator_id)
+    CONSTRAINT fk_eval_work_units_evaluator_id_evaluators
+        FOREIGN KEY (evaluator_id)
         REFERENCES public.evaluators (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_eval_work_units_span_rowid_spans FOREIGN KEY
-        (span_rowid)
+    CONSTRAINT fk_eval_work_units_span_rowid_spans
+        FOREIGN KEY (span_rowid)
         REFERENCES public.spans (id)
         ON DELETE CASCADE
 );

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -164,6 +164,7 @@ CREATE TABLE public.project_sessions (
     start_time TIMESTAMP WITH TIME ZONE NOT NULL,
     end_time TIMESTAMP WITH TIME ZONE NOT NULL,
     last_span_ingested_at TIMESTAMP WITH TIME ZONE,
+    content_complete BOOLEAN NOT NULL DEFAULT true,
     CONSTRAINT pk_project_sessions PRIMARY KEY (id),
     CONSTRAINT uq_project_sessions_session_id
         UNIQUE (session_id),
@@ -1342,6 +1343,7 @@ CREATE TABLE public.project_evaluator_criteria (
     filter_condition VARCHAR NOT NULL DEFAULT ''::character varying,
     sampling_rate DOUBLE PRECISION NOT NULL,
     evaluation_target VARCHAR NOT NULL,
+    evaluation_delay_seconds INTEGER NOT NULL DEFAULT 300,
     input_mapping JSONB,
     enabled BOOLEAN NOT NULL DEFAULT true,
     work_materialized_at TIMESTAMP WITH TIME ZONE,
@@ -1350,6 +1352,7 @@ CREATE TABLE public.project_evaluator_criteria (
     CONSTRAINT pk_project_evaluator_criteria PRIMARY KEY (id),
     CONSTRAINT uq_project_evaluator_criteria_project_id_name
         UNIQUE (project_id, name),
+    CHECK ((evaluation_delay_seconds >= 10)),
     CHECK (((evaluation_target)::text = ANY ((ARRAY[
             'SPAN'::character varying,
             'TRACE'::character varying,
@@ -1372,6 +1375,62 @@ CREATE INDEX ix_project_evaluator_criteria_evaluator_id ON public.project_evalua
     USING btree (evaluator_id);
 CREATE INDEX ix_project_evaluator_criteria_project_id ON public.project_evaluator_criteria
     USING btree (project_id);
+
+
+-- Table: eval_session_work_units
+-- ------------------------------
+CREATE TABLE public.eval_session_work_units (
+    id bigserial NOT NULL,
+    project_session_rowid BIGINT NOT NULL,
+    evaluator_id BIGINT NOT NULL,
+    criteria_id BIGINT NOT NULL,
+    config_fingerprint VARCHAR NOT NULL,
+    evaluated_through TIMESTAMP WITH TIME ZONE NOT NULL,
+    status VARCHAR NOT NULL DEFAULT 'PENDING'::character varying,
+    claimed_at TIMESTAMP WITH TIME ZONE,
+    claimed_by VARCHAR,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    error VARCHAR,
+    cooldown_until TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT pk_eval_session_work_units PRIMARY KEY (id),
+    CHECK (((status)::text = ANY ((ARRAY[
+            'PENDING'::character varying,
+            'RUNNING'::character varying,
+            'DONE'::character varying,
+            'ERROR'::character varying,
+            'EXPIRED'::character varying
+        ])::text[]))),
+    CONSTRAINT fk_eval_session_work_units_criteria_id_project_evaluato_744c
+        FOREIGN KEY
+        (criteria_id)
+        REFERENCES public.project_evaluator_criteria (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_eval_session_work_units_evaluator_id_evaluators
+        FOREIGN KEY
+        (evaluator_id)
+        REFERENCES public.evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_eval_session_work_units_project_session_rowid_projec_ed73
+        FOREIGN KEY
+        (project_session_rowid)
+        REFERENCES public.project_sessions (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_eval_session_work_units_claimable ON public.eval_session_work_units
+    USING btree (status, id) WHERE ((status)::text <> ALL ((ARRAY['DONE'::character varying, 'EXPIRED'::character varying])::text[]));
+CREATE INDEX ix_eval_session_work_units_criteria_id ON public.eval_session_work_units
+    USING btree (criteria_id);
+CREATE INDEX ix_eval_session_work_units_error_attempts ON public.eval_session_work_units
+    USING btree (attempts) WHERE ((status)::text = 'ERROR'::text);
+CREATE INDEX ix_eval_session_work_units_evaluator_id ON public.eval_session_work_units
+    USING btree (evaluator_id);
+CREATE INDEX ix_eval_session_work_units_terminal ON public.eval_session_work_units
+    USING btree (updated_at) WHERE ((status)::text = ANY ((ARRAY['DONE'::character varying, 'EXPIRED'::character varying])::text[]));
+CREATE UNIQUE INDEX uq_eval_session_work_units_live_key ON public.eval_session_work_units
+    USING btree (project_session_rowid, evaluator_id, config_fingerprint) WHERE (((status)::text = ANY ((ARRAY['PENDING'::character varying, 'RUNNING'::character varying])::text[])) OR (((status)::text = 'ERROR'::text) AND (attempts < 3)));
 
 
 -- Table: eval_work_units

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -42,6 +42,21 @@ CREATE TABLE public.eval_work_cursors (
 );
 
 
+-- Table: eval_work_leases
+-- -----------------------
+CREATE TABLE public.eval_work_leases (
+    id bigserial NOT NULL,
+    name VARCHAR NOT NULL,
+    holder VARCHAR,
+    heartbeat_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT pk_eval_work_leases PRIMARY KEY (id),
+    CONSTRAINT uq_eval_work_leases_name
+        UNIQUE (name)
+);
+
+
 -- Table: generative_models
 -- ------------------------
 CREATE TABLE public.generative_models (

--- a/scripts/ddl/sqlite_schema.sql
+++ b/scripts/ddl/sqlite_schema.sql
@@ -17,6 +17,41 @@ CREATE TABLE annotation_configs (
 );
 
 
+-- Table: eval_work_cursors
+-- ------------------------
+CREATE TABLE eval_work_cursors (
+    id INTEGER NOT NULL,
+    evaluation_target VARCHAR NOT NULL
+        CONSTRAINT "ck_eval_work_cursors_`valid_evaluation_target`"
+        CHECK (evaluation_target IN ('SPAN', 'TRACE', 'SESSION')),
+    consumer_group VARCHAR NOT NULL,
+    produced_through_id INTEGER DEFAULT '0' NOT NULL,
+    observed_high_water_id INTEGER,
+    observed_at TIMESTAMP,
+    claimed_at TIMESTAMP,
+    claimed_by VARCHAR,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_eval_work_cursors PRIMARY KEY (id),
+    CONSTRAINT uq_eval_work_cursors_evaluation_target_consumer_group
+        UNIQUE (evaluation_target, consumer_group)
+);
+
+
+-- Table: eval_work_leases
+-- -----------------------
+CREATE TABLE eval_work_leases (
+    id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    holder VARCHAR,
+    heartbeat_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_eval_work_leases PRIMARY KEY (id),
+    CONSTRAINT uq_eval_work_leases_name UNIQUE (name)
+);
+
+
 -- Table: generative_models
 -- ------------------------
 CREATE TABLE generative_models (
@@ -136,6 +171,8 @@ CREATE TABLE project_sessions (
     project_id INTEGER NOT NULL,
     start_time TIMESTAMP NOT NULL,
     end_time TIMESTAMP NOT NULL,
+    last_span_ingested_at TIMESTAMP,
+    content_complete BOOLEAN DEFAULT true NOT NULL,
     CONSTRAINT pk_project_sessions PRIMARY KEY (id),
     CONSTRAINT uq_project_sessions_session_id UNIQUE (session_id),
     CONSTRAINT fk_project_sessions_project_id_projects
@@ -146,6 +183,9 @@ CREATE TABLE project_sessions (
 
 CREATE INDEX ix_project_sessions_project_id_end_time ON project_sessions
     (project_id, end_time DESC);
+CREATE INDEX ix_project_sessions_project_id_last_span_ingested_at ON project_sessions
+    (project_id, last_span_ingested_at)
+    WHERE last_span_ingested_at IS NOT NULL;
 CREATE INDEX ix_project_sessions_project_id_start_time ON project_sessions
     (project_id, start_time DESC);
 
@@ -283,7 +323,6 @@ CREATE TABLE spans (
 
 CREATE INDEX ix_cumulative_llm_token_count_total ON spans
     ((cumulative_llm_token_count_prompt + cumulative_llm_token_count_completion));
-CREATE INDEX ix_latency ON spans ((end_time - start_time));
 CREATE INDEX ix_spans_parent_id ON spans (parent_id);
 CREATE INDEX ix_spans_session_id ON spans (JSON_EXTRACT(attributes, '$."session"."id"'))
     WHERE JSON_EXTRACT(attributes, '$."session"."id"') IS NOT NULL;
@@ -744,6 +783,7 @@ CREATE TABLE dataset_evaluators (
 
 CREATE INDEX ix_dataset_evaluators_evaluator_id ON dataset_evaluators (evaluator_id);
 CREATE INDEX ix_dataset_evaluators_project_id ON dataset_evaluators (project_id);
+CREATE INDEX ix_dataset_evaluators_user_id ON dataset_evaluators (user_id);
 
 
 -- Table: experiments
@@ -1067,6 +1107,84 @@ CREATE TABLE generative_model_custom_providers (
         ON DELETE SET NULL
 );
 
+CREATE INDEX ix_generative_model_custom_providers_user_id ON generative_model_custom_providers
+    (user_id);
+
+
+-- Table: agent_sessions
+-- ---------------------
+CREATE TABLE agent_sessions (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    project_name VARCHAR NOT NULL,
+    user_id INTEGER,
+    title VARCHAR NOT NULL,
+    model_provider VARCHAR NOT NULL,
+    model_name VARCHAR NOT NULL,
+    custom_provider_id INTEGER,
+    is_ephemeral BOOLEAN NOT NULL,
+    heartbeat_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT fk_agent_sessions_custom_provider_id_generative_model_custom_providers
+        FOREIGN KEY (custom_provider_id)
+        REFERENCES generative_model_custom_providers (id)
+        ON DELETE SET NULL,
+    CONSTRAINT fk_agent_sessions_user_id_users
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_sessions_custom_provider_id ON agent_sessions
+    (custom_provider_id);
+CREATE INDEX ix_agent_sessions_ephemeral_updated_at ON agent_sessions (updated_at)
+    WHERE is_ephemeral IS TRUE;
+CREATE INDEX ix_agent_sessions_updated_at_id ON agent_sessions (updated_at, id);
+CREATE INDEX ix_agent_sessions_user_id_updated_at ON agent_sessions
+    (user_id, updated_at DESC);
+
+
+-- Table: agent_session_messages
+-- -----------------------------
+CREATE TABLE agent_session_messages (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    agent_session_id INTEGER NOT NULL,
+    message JSONB NOT NULL,
+    message_id VARCHAR NOT NULL GENERATED ALWAYS AS (JSON_EXTRACT(message, '$."id"')) STORED,
+    is_compaction_message BOOLEAN NOT NULL GENERATED ALWAYS AS (coalesce(JSON_EXTRACT(message, '$."metadata"."phoenix"."isCompactionMessage"'), 0)) STORED,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT uq_agent_session_messages_message_id UNIQUE (message_id),
+    CONSTRAINT "ck_agent_session_messages_`valid_message_id`"
+        CHECK (message_id GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'),
+    CONSTRAINT fk_agent_session_messages_agent_session_id_agent_sessions
+        FOREIGN KEY (agent_session_id)
+        REFERENCES agent_sessions (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_session_messages_agent_session_id_id ON agent_session_messages
+    (agent_session_id, id);
+CREATE INDEX ix_agent_session_messages_compaction ON agent_session_messages
+    (agent_session_id, id DESC)
+    WHERE is_compaction_message;
+
+
+-- Table: agent_session_snapshots
+-- ------------------------------
+CREATE TABLE agent_session_snapshots (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    agent_session_id INTEGER NOT NULL,
+    bashkit_snapshot BLOB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT uq_agent_session_snapshots_agent_session_id UNIQUE (agent_session_id),
+    CONSTRAINT fk_agent_session_snapshots_agent_session_id_agent_sessions
+        FOREIGN KEY (agent_session_id)
+        REFERENCES agent_sessions (id)
+        ON DELETE CASCADE
+);
+
 
 -- Table: oauth2_authorization_codes
 -- ---------------------------------
@@ -1140,6 +1258,142 @@ CREATE TABLE password_reset_tokens (
 
 CREATE INDEX ix_password_reset_tokens_expires_at ON password_reset_tokens (expires_at);
 CREATE UNIQUE INDEX ix_password_reset_tokens_user_id ON password_reset_tokens (user_id);
+
+
+-- Table: project_evaluator_criteria
+-- ---------------------------------
+CREATE TABLE project_evaluator_criteria (
+    id INTEGER NOT NULL,
+    project_id INTEGER NOT NULL,
+    evaluator_id INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    filter_condition VARCHAR DEFAULT '' NOT NULL,
+    sampling_rate FLOAT NOT NULL
+        CONSTRAINT "ck_project_evaluator_criteria_`valid_sampling_rate`"
+        CHECK (0.0 <= sampling_rate AND sampling_rate <= 1.0),
+    evaluation_target VARCHAR NOT NULL
+        CONSTRAINT "ck_project_evaluator_criteria_`valid_evaluation_target`"
+        CHECK (evaluation_target IN ('SPAN', 'TRACE', 'SESSION')),
+    evaluation_delay_seconds INTEGER DEFAULT '300' NOT NULL
+        CONSTRAINT "ck_project_evaluator_criteria_`valid_evaluation_delay_seconds`"
+        CHECK (evaluation_delay_seconds >= 10),
+    input_mapping JSONB,
+    enabled BOOLEAN DEFAULT true NOT NULL,
+    work_materialized_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_project_evaluator_criteria PRIMARY KEY (id),
+    CONSTRAINT uq_project_evaluator_criteria_project_id_name UNIQUE (project_id, name),
+    CONSTRAINT fk_project_evaluator_criteria_evaluator_id_evaluators
+        FOREIGN KEY (evaluator_id)
+        REFERENCES evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_project_evaluator_criteria_project_id_projects
+        FOREIGN KEY (project_id)
+        REFERENCES projects (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_project_evaluator_criteria_evaluator_id ON project_evaluator_criteria
+    (evaluator_id);
+CREATE INDEX ix_project_evaluator_criteria_project_id ON project_evaluator_criteria
+    (project_id);
+
+
+-- Table: eval_session_work_units
+-- ------------------------------
+CREATE TABLE eval_session_work_units (
+    id INTEGER NOT NULL,
+    project_session_rowid INTEGER NOT NULL,
+    evaluator_id INTEGER NOT NULL,
+    criteria_id INTEGER NOT NULL,
+    config_fingerprint VARCHAR NOT NULL,
+    evaluated_through TIMESTAMP NOT NULL,
+    status VARCHAR DEFAULT 'PENDING' NOT NULL
+        CONSTRAINT "ck_eval_session_work_units_`valid_eval_work_status`"
+        CHECK (status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')),
+    claimed_at TIMESTAMP,
+    claimed_by VARCHAR,
+    attempts INTEGER DEFAULT '0' NOT NULL,
+    error VARCHAR,
+    cooldown_until TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_eval_session_work_units PRIMARY KEY (id),
+    CONSTRAINT fk_eval_session_work_units_criteria_id_project_evaluator_criteria
+        FOREIGN KEY (criteria_id)
+        REFERENCES project_evaluator_criteria (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_eval_session_work_units_evaluator_id_evaluators
+        FOREIGN KEY (evaluator_id)
+        REFERENCES evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_eval_session_work_units_project_session_rowid_project_sessions
+        FOREIGN KEY (project_session_rowid)
+        REFERENCES project_sessions (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_eval_session_work_units_claimable ON eval_session_work_units
+    (status, id)
+    WHERE status NOT IN ('DONE', 'EXPIRED');
+CREATE INDEX ix_eval_session_work_units_criteria_id ON eval_session_work_units
+    (criteria_id);
+CREATE INDEX ix_eval_session_work_units_error_attempts ON eval_session_work_units
+    (attempts)
+    WHERE status = 'ERROR';
+CREATE INDEX ix_eval_session_work_units_evaluator_id ON eval_session_work_units
+    (evaluator_id);
+CREATE INDEX ix_eval_session_work_units_terminal ON eval_session_work_units (updated_at)
+    WHERE status IN ('DONE', 'EXPIRED');
+CREATE UNIQUE INDEX uq_eval_session_work_units_live_key ON eval_session_work_units
+    (project_session_rowid, evaluator_id, config_fingerprint)
+    WHERE status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3;
+
+
+-- Table: eval_work_units
+-- ----------------------
+CREATE TABLE eval_work_units (
+    id INTEGER NOT NULL,
+    span_rowid INTEGER NOT NULL,
+    evaluator_id INTEGER NOT NULL,
+    criteria_id INTEGER NOT NULL,
+    config_fingerprint VARCHAR NOT NULL,
+    status VARCHAR DEFAULT 'PENDING' NOT NULL
+        CONSTRAINT "ck_eval_work_units_`valid_eval_work_status`"
+        CHECK (status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')),
+    claimed_at TIMESTAMP,
+    claimed_by VARCHAR,
+    attempts INTEGER DEFAULT '0' NOT NULL,
+    error VARCHAR,
+    cooldown_until TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_eval_work_units PRIMARY KEY (id),
+    CONSTRAINT uq_eval_work_units_span_rowid_evaluator_id_config_fingerprint
+        UNIQUE (span_rowid, evaluator_id, config_fingerprint),
+    CONSTRAINT fk_eval_work_units_criteria_id_project_evaluator_criteria
+        FOREIGN KEY (criteria_id)
+        REFERENCES project_evaluator_criteria (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_eval_work_units_evaluator_id_evaluators
+        FOREIGN KEY (evaluator_id)
+        REFERENCES evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_eval_work_units_span_rowid_spans
+        FOREIGN KEY (span_rowid)
+        REFERENCES spans (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_eval_work_units_claimable ON eval_work_units (status, id)
+    WHERE status NOT IN ('DONE', 'EXPIRED');
+CREATE INDEX ix_eval_work_units_criteria_id ON eval_work_units (criteria_id);
+CREATE INDEX ix_eval_work_units_error_attempts ON eval_work_units (attempts)
+    WHERE status = 'ERROR';
+CREATE INDEX ix_eval_work_units_evaluator_id ON eval_work_units (evaluator_id);
+CREATE INDEX ix_eval_work_units_terminal ON eval_work_units (updated_at)
+    WHERE status IN ('DONE', 'EXPIRED');
 
 
 -- Table: project_session_annotations
@@ -1259,6 +1513,11 @@ CREATE TABLE experiment_prompt_tasks (
         REFERENCES experiment_jobs (type, id)
         ON DELETE CASCADE
 );
+
+CREATE INDEX ix_experiment_prompt_tasks_custom_provider_id ON experiment_prompt_tasks
+    (custom_provider_id);
+CREATE INDEX ix_experiment_prompt_tasks_prompt_version_id ON experiment_prompt_tasks
+    (prompt_version_id);
 
 
 -- Table: prompt_version_tags
@@ -1498,6 +1757,8 @@ CREATE TABLE secrets (
         REFERENCES users (id)
         ON DELETE SET NULL
 );
+
+CREATE INDEX ix_secrets_user_id ON secrets (user_id);
 
 
 -- Table: span_annotations

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -385,6 +385,11 @@ ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING = "PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING"
 The outstanding work-unit count above which the online-eval producer stops materializing
 new work units: PENDING + RUNNING + retryable ERROR (non-terminal work). Defaults to 10000.
 """
+ENV_PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING = "PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING"
+"""
+The outstanding session work-unit count above which the session sweeper stops materializing
+new work units: PENDING + RUNNING + retryable ERROR (non-terminal work). Defaults to 10000.
+"""
 ENV_PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE = "PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE"
 """
 The maximum number of work units an online-eval consumer claims per tick. Together with
@@ -3489,6 +3494,22 @@ def get_env_online_eval_max_outstanding() -> int:
     if max_outstanding <= 0:
         raise ValueError(
             f"Invalid value for environment variable {ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING}: "
+            f"{max_outstanding}. Value must be a positive integer."
+        )
+    return max_outstanding
+
+
+def get_env_online_eval_max_session_outstanding() -> int:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING environment variable.
+
+    Counts PENDING + RUNNING + retryable ERROR (non-terminal work).
+    """
+    max_outstanding = _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING, 10_000)
+    if max_outstanding <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING}: "
             f"{max_outstanding}. Value must be a positive integer."
         )
     return max_outstanding

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -334,6 +334,12 @@ ENV_PHOENIX_ONLINE_EVAL_ENABLED = "PHOENIX_ONLINE_EVAL_ENABLED"
 """
 Whether to run the online-eval producer and consumer daemons. Defaults to false.
 """
+ENV_PHOENIX_ONLINE_EVAL_SESSION_SWEEP_ENABLED = "PHOENIX_ONLINE_EVAL_SESSION_SWEEP_ENABLED"
+"""
+Whether to also run the session evaluation sweeper, which requires the online-eval
+daemons. Nothing executes the session work it creates yet, so enabling it only fills
+the outstanding-work budget. Defaults to false.
+"""
 ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS = "PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS"
 """
 How long an observed span high-water id must age before the online-eval producer scans up
@@ -3388,6 +3394,13 @@ def get_env_online_eval_enabled() -> bool:
     Gets the value of the PHOENIX_ONLINE_EVAL_ENABLED environment variable.
     """
     return _bool_val(ENV_PHOENIX_ONLINE_EVAL_ENABLED, False)
+
+
+def get_env_online_eval_session_sweep_enabled() -> bool:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_SESSION_SWEEP_ENABLED environment variable.
+    """
+    return _bool_val(ENV_PHOENIX_ONLINE_EVAL_SESSION_SWEEP_ENABLED, False)
 
 
 def get_env_online_eval_frontier_lag_seconds() -> float:

--- a/src/phoenix/db/eval_work.py
+++ b/src/phoenix/db/eval_work.py
@@ -1,0 +1,25 @@
+"""Retry budget for online-eval work units, and the index predicate derived from it.
+
+This module has no Phoenix imports so the schema (``models``), the queries
+(``online_eval``), and the migrations can all read the same values.
+"""
+
+from __future__ import annotations
+
+# Retry budget for a work unit before its ERROR state becomes terminal. The producer
+# excludes attempt-exhausted rows from reaping and backstop re-materialization using
+# this value, and the consumer-side coordinator stops reclaiming ERROR rows at it —
+# the two sides drifting apart either resurrects dead work or strands retryable work.
+MAX_ATTEMPTS = 3
+
+
+def live_eval_work_index_predicate() -> str:
+    """SQL text selecting work units that still hold their dedup key.
+
+    Postgres matches ``ON CONFLICT ... WHERE`` to a partial index by predicate
+    equivalence, so the sweeper's conflict target, the model's index, and the
+    migration that creates it must all spell this the same way. Changing
+    ``MAX_ATTEMPTS`` changes the DDL: existing deployments need a new migration
+    that rebuilds the index.
+    """
+    return f"status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < {MAX_ATTEMPTS}"

--- a/src/phoenix/db/eval_work.py
+++ b/src/phoenix/db/eval_work.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 # the two sides drifting apart either resurrects dead work or strands retryable work.
 MAX_ATTEMPTS = 3
 
+# Stamped on session work units retired because their session lost content. Like the
+# subsystem's other error markers it is read by operators and matched in tests, so it
+# is spelled once here rather than at the deletion path that writes it.
+SESSION_CONTENT_INCOMPLETE_ERROR = "session content incomplete"
+
 
 def live_eval_work_index_predicate() -> str:
     """SQL text selecting work units that still hold their dedup key.

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -31,6 +31,7 @@ from typing_extensions import assert_never
 
 from phoenix.config import PLAYGROUND_PROJECT_NAME, get_env_database_schema
 from phoenix.db import models
+from phoenix.db.eval_work import SESSION_CONTENT_INCOMPLETE_ERROR
 
 
 class SupportedSQLDialect(Enum):
@@ -605,6 +606,48 @@ def get_ancestor_span_rowids(parent_id: str) -> Select[tuple[int]]:
     return select(ancestors.c.id)
 
 
+async def delete_traces(
+    session: AsyncSession,
+    trace_filter: sa.ColumnElement[bool],
+) -> None:
+    """Delete the traces matching this filter, standing down the evaluations of every
+    session that loses content.
+
+    Deleting traces is what makes a session's evaluation wrong, so the delete and the
+    stand-down belong to one function rather than to five callers who each have to
+    remember. Route new trace deletions through here.
+    """
+    affected_session_rowids = (
+        sa.select(models.Trace.project_session_rowid)
+        .where(trace_filter, models.Trace.project_session_rowid.is_not(None))
+        .distinct()
+    )
+    await mark_session_content_incomplete(session, affected_session_rowids)
+    await session.execute(sa.delete(models.Trace).where(trace_filter))
+
+
+async def delete_spans(
+    session: AsyncSession,
+    span_filter: sa.ColumnElement[bool],
+) -> None:
+    """Delete the spans matching this filter, standing down the evaluations of every
+    session that loses content.
+
+    Removing a span changes what the session contains whether or not its trace survives,
+    so span deletion stands down the same way trace deletion does. See `delete_traces`.
+    """
+    affected_session_rowids = (
+        sa.select(models.Trace.project_session_rowid)
+        .where(
+            models.Trace.id.in_(sa.select(models.Span.trace_rowid).where(span_filter)),
+            models.Trace.project_session_rowid.is_not(None),
+        )
+        .distinct()
+    )
+    await mark_session_content_incomplete(session, affected_session_rowids)
+    await session.execute(sa.delete(models.Span).where(span_filter))
+
+
 async def mark_session_content_incomplete(
     session: AsyncSession,
     project_session_rowids: Union[Iterable[int], InElementRole],
@@ -614,7 +657,8 @@ async def mark_session_content_incomplete(
     A session evaluation scores the session as a whole, so once part of it is gone the
     score describes content that no longer exists. Session scheduling is evaluate-once,
     which makes a wrong score permanent — every path that destroys session content must
-    call this before or with the delete.
+    call this before or with the delete. `delete_traces` and `delete_spans` are how
+    deletion paths get that for free.
     """
     await session.execute(
         sa.update(models.ProjectSession)
@@ -632,7 +676,7 @@ async def mark_session_content_incomplete(
             claimed_at=None,
             claimed_by=None,
             cooldown_until=None,
-            error="session content incomplete",
+            error=SESSION_CONTENT_INCOMPLETE_ERROR,
         )
     )
 

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -716,7 +716,8 @@ async def mark_session_content_incomplete(
     )
     await session.execute(
         sa.delete(models.ProjectSessionAnnotation).where(
-            models.ProjectSessionAnnotation.project_session_id.in_(session_rowids)
+            models.ProjectSessionAnnotation.project_session_id.in_(session_rowids),
+            models.ProjectSessionAnnotation.identifier.startswith("online:"),
         )
     )
 

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -606,6 +606,9 @@ def get_ancestor_span_rowids(parent_id: str) -> Select[tuple[int]]:
     return select(ancestors.c.id)
 
 
+_SESSION_CONTENT_DELETE_BATCH_SIZE = 1_000
+
+
 async def delete_traces(
     session: AsyncSession,
     trace_filter: sa.ColumnElement[bool],
@@ -617,13 +620,24 @@ async def delete_traces(
     stand-down belong to one function rather than to five callers who each have to
     remember. Route new trace deletions through here.
     """
-    affected_session_rowids = (
-        sa.select(models.Trace.project_session_rowid)
-        .where(trace_filter, models.Trace.project_session_rowid.is_not(None))
-        .distinct()
-    )
-    await mark_session_content_incomplete(session, affected_session_rowids)
-    await session.execute(sa.delete(models.Trace).where(trace_filter))
+    while trace_rowids := tuple(
+        await session.scalars(
+            sa.select(models.Trace.id)
+            .where(trace_filter)
+            .order_by(models.Trace.id)
+            .limit(_SESSION_CONTENT_DELETE_BATCH_SIZE)
+        )
+    ):
+        affected_session_rowids = (
+            sa.select(models.Trace.project_session_rowid)
+            .where(
+                models.Trace.id.in_(trace_rowids),
+                models.Trace.project_session_rowid.is_not(None),
+            )
+            .distinct()
+        )
+        await mark_session_content_incomplete(session, affected_session_rowids)
+        await session.execute(sa.delete(models.Trace).where(models.Trace.id.in_(trace_rowids)))
 
 
 async def delete_spans(
@@ -636,16 +650,26 @@ async def delete_spans(
     Removing a span changes what the session contains whether or not its trace survives,
     so span deletion stands down the same way trace deletion does. See `delete_traces`.
     """
-    affected_session_rowids = (
-        sa.select(models.Trace.project_session_rowid)
-        .where(
-            models.Trace.id.in_(sa.select(models.Span.trace_rowid).where(span_filter)),
-            models.Trace.project_session_rowid.is_not(None),
+    while span_rowids := tuple(
+        await session.scalars(
+            sa.select(models.Span.id)
+            .where(span_filter)
+            .order_by(models.Span.id)
+            .limit(_SESSION_CONTENT_DELETE_BATCH_SIZE)
         )
-        .distinct()
-    )
-    await mark_session_content_incomplete(session, affected_session_rowids)
-    await session.execute(sa.delete(models.Span).where(span_filter))
+    ):
+        affected_session_rowids = (
+            sa.select(models.Trace.project_session_rowid)
+            .where(
+                models.Trace.id.in_(
+                    sa.select(models.Span.trace_rowid).where(models.Span.id.in_(span_rowids))
+                ),
+                models.Trace.project_session_rowid.is_not(None),
+            )
+            .distinct()
+        )
+        await mark_session_content_incomplete(session, affected_session_rowids)
+        await session.execute(sa.delete(models.Span).where(models.Span.id.in_(span_rowids)))
 
 
 async def mark_session_content_incomplete(
@@ -660,15 +684,26 @@ async def mark_session_content_incomplete(
     call this before or with the delete. `delete_traces` and `delete_spans` are how
     deletion paths get that for free.
     """
+    session_rowids_stmt = (
+        sa.select(models.ProjectSession.id)
+        .where(models.ProjectSession.id.in_(project_session_rowids))
+        .order_by(models.ProjectSession.id)
+    )
+    if SupportedSQLDialect(session.bind.dialect.name) is SupportedSQLDialect.POSTGRESQL:
+        session_rowids_stmt = session_rowids_stmt.with_for_update()
+    session_rowids = tuple(await session.scalars(session_rowids_stmt))
+    if not session_rowids:
+        return
+
     await session.execute(
         sa.update(models.ProjectSession)
-        .where(models.ProjectSession.id.in_(project_session_rowids))
+        .where(models.ProjectSession.id.in_(session_rowids))
         .values(content_complete=False)
     )
     await session.execute(
         sa.update(models.EvalSessionWorkUnit)
         .where(
-            models.EvalSessionWorkUnit.project_session_rowid.in_(project_session_rowids),
+            models.EvalSessionWorkUnit.project_session_rowid.in_(session_rowids),
             models.EvalSessionWorkUnit.status.in_(("PENDING", "RUNNING", "ERROR")),
         )
         .values(
@@ -677,6 +712,11 @@ async def mark_session_content_incomplete(
             claimed_by=None,
             cooldown_until=None,
             error=SESSION_CONTENT_INCOMPLETE_ERROR,
+        )
+    )
+    await session.execute(
+        sa.delete(models.ProjectSessionAnnotation).where(
+            models.ProjectSessionAnnotation.project_session_id.in_(session_rowids)
         )
     )
 

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -605,6 +605,38 @@ def get_ancestor_span_rowids(parent_id: str) -> Select[tuple[int]]:
     return select(ancestors.c.id)
 
 
+async def mark_session_content_incomplete(
+    session: AsyncSession,
+    project_session_rowids: Union[Iterable[int], InElementRole],
+) -> None:
+    """Record that content was removed from these sessions, and stand down their evals.
+
+    A session evaluation scores the session as a whole, so once part of it is gone the
+    score describes content that no longer exists. Session scheduling is evaluate-once,
+    which makes a wrong score permanent — every path that destroys session content must
+    call this before or with the delete.
+    """
+    await session.execute(
+        sa.update(models.ProjectSession)
+        .where(models.ProjectSession.id.in_(project_session_rowids))
+        .values(content_complete=False)
+    )
+    await session.execute(
+        sa.update(models.EvalSessionWorkUnit)
+        .where(
+            models.EvalSessionWorkUnit.project_session_rowid.in_(project_session_rowids),
+            models.EvalSessionWorkUnit.status.in_(("PENDING", "RUNNING", "ERROR")),
+        )
+        .values(
+            status="EXPIRED",
+            claimed_at=None,
+            claimed_by=None,
+            cooldown_until=None,
+            error="session content incomplete",
+        )
+    )
+
+
 def truncate_name(name: str, max_len: int = 63) -> str:
     # https://github.com/sqlalchemy/sqlalchemy/blob/e263825e3c5060bf4f47eed0e833c6660a31658e/lib/sqlalchemy/sql/compiler.py#L7844-L7845
     if len(name) > max_len:

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -137,6 +137,16 @@ def upgrade() -> None:
             ),
             nullable=False,
         ),
+        sa.Column(
+            "evaluation_delay_seconds",
+            sa.Integer(),
+            sa.CheckConstraint(
+                "evaluation_delay_seconds >= 10",
+                name="valid_evaluation_delay_seconds",
+            ),
+            nullable=False,
+            server_default="300",
+        ),
         sa.Column("input_mapping", JSON_, nullable=True),
         sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
         sa.Column("work_materialized_at", sa.TIMESTAMP(timezone=True), nullable=True),

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -150,6 +150,15 @@ def upgrade() -> None:
             nullable=True,
         ),
     )
+    op.add_column(
+        "project_sessions",
+        sa.Column(
+            "content_complete",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
     op.create_index(
         "ix_project_sessions_project_id_last_span_ingested_at",
         "project_sessions",
@@ -360,9 +369,17 @@ def upgrade() -> None:
         "eval_work_units",
         ["criteria_id"],
     )
+    _create_session_work_units_table()
 
 
 def downgrade() -> None:
+    op.drop_index("ix_eval_session_work_units_criteria_id", table_name="eval_session_work_units")
+    op.drop_index("ix_eval_session_work_units_evaluator_id", table_name="eval_session_work_units")
+    op.drop_index("ix_eval_session_work_units_error_attempts", table_name="eval_session_work_units")
+    op.drop_index("ix_eval_session_work_units_terminal", table_name="eval_session_work_units")
+    op.drop_index("ix_eval_session_work_units_claimable", table_name="eval_session_work_units")
+    op.drop_table("eval_session_work_units")
+
     op.drop_index("ix_eval_work_units_criteria_id", table_name="eval_work_units")
     op.drop_index("ix_eval_work_units_evaluator_id", table_name="eval_work_units")
     op.drop_index("ix_eval_work_units_error_attempts", table_name="eval_work_units")
@@ -382,4 +399,5 @@ def downgrade() -> None:
         "ix_project_sessions_project_id_last_span_ingested_at",
         table_name="project_sessions",
     )
+    op.drop_column("project_sessions", "content_complete")
     op.drop_column("project_sessions", "last_span_ingested_at")

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -38,6 +38,106 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _create_session_work_units_table() -> None:
+    op.create_table(
+        "eval_session_work_units",
+        sa.Column("id", _Integer, primary_key=True),
+        sa.Column(
+            "project_session_rowid",
+            _Integer,
+            sa.ForeignKey("project_sessions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "evaluator_id",
+            _Integer,
+            sa.ForeignKey("evaluators.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "criteria_id",
+            _Integer,
+            sa.ForeignKey("project_evaluator_criteria.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("config_fingerprint", sa.String(), nullable=False),
+        sa.Column(
+            "evaluated_through",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.String(),
+            sa.CheckConstraint(
+                "status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')",
+                name="valid_eval_work_status",
+            ),
+            nullable=False,
+            server_default="PENDING",
+        ),
+        sa.Column("claimed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("claimed_by", sa.String(), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error", sa.String(), nullable=True),
+        sa.Column("cooldown_until", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "uq_eval_session_work_units_live_key",
+        "eval_session_work_units",
+        ["project_session_rowid", "evaluator_id", "config_fingerprint"],
+        unique=True,
+        postgresql_where=sa.text(
+            "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
+        ),
+        sqlite_where=sa.text(
+            "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
+        ),
+    )
+    op.create_index(
+        "ix_eval_session_work_units_claimable",
+        "eval_session_work_units",
+        ["status", "id"],
+        postgresql_where=sa.text("status NOT IN ('DONE', 'EXPIRED')"),
+        sqlite_where=sa.text("status NOT IN ('DONE', 'EXPIRED')"),
+    )
+    op.create_index(
+        "ix_eval_session_work_units_terminal",
+        "eval_session_work_units",
+        ["updated_at"],
+        postgresql_where=sa.text("status IN ('DONE', 'EXPIRED')"),
+        sqlite_where=sa.text("status IN ('DONE', 'EXPIRED')"),
+    )
+    op.create_index(
+        "ix_eval_session_work_units_error_attempts",
+        "eval_session_work_units",
+        ["attempts"],
+        postgresql_where=sa.text("status = 'ERROR'"),
+        sqlite_where=sa.text("status = 'ERROR'"),
+    )
+    op.create_index(
+        "ix_eval_session_work_units_evaluator_id",
+        "eval_session_work_units",
+        ["evaluator_id"],
+    )
+    op.create_index(
+        "ix_eval_session_work_units_criteria_id",
+        "eval_session_work_units",
+        ["criteria_id"],
+    )
+
 def upgrade() -> None:
     # project_sessions carries raw-expression DESC indexes, so add_column/drop_column are used
     # bare here: batch mode would rebuild the table by reflection and silently recreate those

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -138,6 +138,7 @@ def _create_session_work_units_table() -> None:
         ["criteria_id"],
     )
 
+
 def upgrade() -> None:
     # project_sessions carries raw-expression DESC indexes, so add_column/drop_column are used
     # bare here: batch mode would rebuild the table by reflection and silently recreate those

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -207,6 +207,30 @@ def upgrade() -> None:
         sa.UniqueConstraint("evaluation_target", "consumer_group"),
     )
     op.create_table(
+        "eval_work_leases",
+        sa.Column(
+            "id",
+            _Integer,
+            primary_key=True,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("holder", sa.String(), nullable=True),
+        sa.Column("heartbeat_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_table(
         "project_evaluator_criteria",
         sa.Column(
             "id",
@@ -392,6 +416,7 @@ def downgrade() -> None:
         "ix_project_evaluator_criteria_project_id", table_name="project_evaluator_criteria"
     )
     op.drop_table("project_evaluator_criteria")
+    op.drop_table("eval_work_leases")
     op.drop_table("eval_work_cursors")
 
     op.drop_index(

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -14,6 +14,8 @@ from sqlalchemy import JSON
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.compiler import compiles
 
+from phoenix.db.eval_work import live_eval_work_index_predicate
+
 _Integer = sa.Integer().with_variant(
     sa.BigInteger(),
     "postgresql",
@@ -99,12 +101,8 @@ def _create_session_work_units_table() -> None:
         "eval_session_work_units",
         ["project_session_rowid", "evaluator_id", "config_fingerprint"],
         unique=True,
-        postgresql_where=sa.text(
-            "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
-        ),
-        sqlite_where=sa.text(
-            "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
-        ),
+        postgresql_where=sa.text(live_eval_work_index_predicate()),
+        sqlite_where=sa.text(live_eval_work_index_predicate()),
     )
     op.create_index(
         "ix_eval_session_work_units_claimable",

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -93,10 +93,17 @@ def _create_session_work_units_table() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint(
-            "project_session_rowid",
-            "evaluator_id",
-            "config_fingerprint",
+    )
+    op.create_index(
+        "uq_eval_session_work_units_live_key",
+        "eval_session_work_units",
+        ["project_session_rowid", "evaluator_id", "config_fingerprint"],
+        unique=True,
+        postgresql_where=sa.text(
+            "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
+        ),
+        sqlite_where=sa.text(
+            "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
         ),
     )
     op.create_index(

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -234,6 +234,16 @@ def upgrade() -> None:
             ),
             nullable=False,
         ),
+        sa.Column(
+            "evaluation_delay_seconds",
+            sa.Integer(),
+            sa.CheckConstraint(
+                "evaluation_delay_seconds >= 10",
+                name="valid_evaluation_delay_seconds",
+            ),
+            nullable=False,
+            server_default="300",
+        ),
         sa.Column("input_mapping", JSON_, nullable=True),
         sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
         sa.Column(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3571,8 +3571,11 @@ class AgentSessionSnapshot(HasId):
 
 
 class ProjectEvaluatorCriteria(HasId):
-    """Attaches an evaluator to a project for online evaluation: which spans to
-    match, how they are sampled, and the annotation name results are written under."""
+    """Attaches an evaluator to a project for online evaluation: which spans or
+    sessions to match, how they are sampled, and the annotation name results are
+    written under. evaluation_target picks which of the two this row governs, and
+    the fields that apply differ with it — sampling and filter_condition shape span
+    selection, evaluation_delay_seconds shapes session selection."""
 
     __tablename__ = "project_evaluator_criteria"
     project_id: Mapped[int] = mapped_column(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3718,3 +3718,79 @@ class EvalWorkUnit(HasId):
             sqlite_where=text("status = 'ERROR'"),
         ),
     )
+
+
+class EvalSessionWorkUnit(HasId):
+    __tablename__ = "eval_session_work_units"
+    project_session_rowid: Mapped[int] = mapped_column(
+        ForeignKey("project_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    evaluator_id: Mapped[int] = mapped_column(
+        ForeignKey("evaluators.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    criteria_id: Mapped[int] = mapped_column(
+        ForeignKey("project_evaluator_criteria.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    config_fingerprint: Mapped[str] = mapped_column(String, nullable=False)
+    evaluated_through: Mapped[datetime] = mapped_column(UtcTimeStamp, nullable=False)
+    status: Mapped[EvalWorkStatus] = mapped_column(
+        CheckConstraint(
+            "status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')",
+            name="valid_eval_work_status",
+        ),
+        default="PENDING",
+        server_default="PENDING",
+    )
+    claimed_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+    claimed_by: Mapped[Optional[str]] = mapped_column(String)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    error: Mapped[Optional[str]] = mapped_column(String)
+    cooldown_until: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
+
+    project_session: Mapped["ProjectSession"] = relationship("ProjectSession")
+    evaluator: Mapped["Evaluator"] = relationship("Evaluator")
+    criteria: Mapped["ProjectEvaluatorCriteria"] = relationship("ProjectEvaluatorCriteria")
+
+    __table_args__ = (
+        Index(
+            "uq_eval_session_work_units_live_key",
+            "project_session_rowid",
+            "evaluator_id",
+            "config_fingerprint",
+            unique=True,
+            postgresql_where=text(
+                "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
+            ),
+            sqlite_where=text(
+                "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
+            ),
+        ),
+        Index(
+            "ix_eval_session_work_units_claimable",
+            "status",
+            "id",
+            postgresql_where=text("status NOT IN ('DONE', 'EXPIRED')"),
+            sqlite_where=text("status NOT IN ('DONE', 'EXPIRED')"),
+        ),
+        Index(
+            "ix_eval_session_work_units_terminal",
+            "updated_at",
+            postgresql_where=text("status IN ('DONE', 'EXPIRED')"),
+            sqlite_where=text("status IN ('DONE', 'EXPIRED')"),
+        ),
+        Index(
+            "ix_eval_session_work_units_error_attempts",
+            "attempts",
+            postgresql_where=text("status = 'ERROR'"),
+            sqlite_where=text("status = 'ERROR'"),
+        ),
+    )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3630,10 +3630,33 @@ class ProjectEvaluatorCriteria(HasId):
     __table_args__ = (UniqueConstraint("project_id", "name"),)
 
 
+class EvalWorkLease(HasId):
+    """A named single-holder lease for a materializer that has no position to keep.
+
+    The session sweeper decides what to materialize from session state rather than from
+    the span arrival log, so it needs mutual exclusion and nothing else. A lease is
+    held while heartbeat_at stays fresh; once it goes stale another holder may take it.
+    """
+
+    __tablename__ = "eval_work_leases"
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    holder: Mapped[Optional[str]] = mapped_column(String)
+    heartbeat_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (UniqueConstraint("name"),)
+
+
 class EvalWorkCursor(HasId):
-    """Producer lease and position in the span arrival log, one row per
-    (evaluation_target, consumer_group). For each target, produced_through_id is a Span.id
-    position in the shared arrival log rather than a target-specific entity id."""
+    """SPAN producer lease and position in the span arrival log, one row per
+    (evaluation_target, consumer_group). produced_through_id, observed_high_water_id and
+    observed_at are Span.id positions in that log, so only targets materialized by
+    scanning it keep a row here — targets that materialize from entity state take a
+    plain EvalWorkLease instead."""
 
     __tablename__ = "eval_work_cursors"
     evaluation_target: Mapped[EvaluationTarget] = mapped_column(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3585,6 +3585,15 @@ class ProjectEvaluatorCriteria(HasId):
         ),
         nullable=False,
     )
+    evaluation_delay_seconds: Mapped[int] = mapped_column(
+        Integer,
+        CheckConstraint(
+            "evaluation_delay_seconds >= 10",
+            name="valid_evaluation_delay_seconds",
+        ),
+        nullable=False,
+        server_default="300",
+    )
     input_mapping: Mapped[Optional[InputMapping]] = mapped_column(
         _OptionalInputMapping, nullable=True
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -811,6 +811,11 @@ class ProjectSession(HasId):
         UtcTimeStamp,
         nullable=True,
     )
+    content_complete: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("true"),
+    )
     traces: Mapped[list["Trace"]] = relationship(
         "Trace",
         back_populates="project_session",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -54,6 +54,7 @@ from typing_extensions import Self, TypeAlias
 
 from phoenix.config import get_env_database_schema
 from phoenix.datetime_utils import normalize_datetime
+from phoenix.db.eval_work import live_eval_work_index_predicate
 from phoenix.db.types.annotation_configs import (
     AnnotationConfig as AnnotationConfigModel,
 )
@@ -3772,12 +3773,8 @@ class EvalSessionWorkUnit(HasId):
             "evaluator_id",
             "config_fingerprint",
             unique=True,
-            postgresql_where=text(
-                "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
-            ),
-            sqlite_where=text(
-                "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
-            ),
+            postgresql_where=text(live_eval_work_index_predicate()),
+            sqlite_where=text(live_eval_work_index_predicate()),
         ),
         Index(
             "ix_eval_session_work_units_claimable",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -812,6 +812,9 @@ class ProjectSession(HasId):
         UtcTimeStamp,
         nullable=True,
     )
+    # Deliberately one-way: once content is destroyed, nothing sets this back to true.
+    # Re-admitting a trimmed session would need a design for what its earlier
+    # evaluations mean, which does not exist yet.
     content_complete: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3466,10 +3466,18 @@ class EvalSessionWorkUnit(HasId):
     criteria: Mapped["ProjectEvaluatorCriteria"] = relationship("ProjectEvaluatorCriteria")
 
     __table_args__ = (
-        UniqueConstraint(
+        Index(
+            "uq_eval_session_work_units_live_key",
             "project_session_rowid",
             "evaluator_id",
             "config_fingerprint",
+            unique=True,
+            postgresql_where=text(
+                "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
+            ),
+            sqlite_where=text(
+                "status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3"
+            ),
         ),
         Index(
             "ix_eval_session_work_units_claimable",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3294,6 +3294,15 @@ class ProjectEvaluatorCriteria(HasId):
         ),
         nullable=False,
     )
+    evaluation_delay_seconds: Mapped[int] = mapped_column(
+        Integer,
+        CheckConstraint(
+            "evaluation_delay_seconds >= 10",
+            name="valid_evaluation_delay_seconds",
+        ),
+        nullable=False,
+        server_default="300",
+    )
     input_mapping: Mapped[Optional[InputMapping]] = mapped_column(
         _OptionalInputMapping, nullable=True
     )

--- a/src/phoenix/db/types/trace_retention.py
+++ b/src/phoenix/db/types/trace_retention.py
@@ -12,6 +12,46 @@ from sqlalchemy.sql.roles import InElementRole
 from phoenix.utilities import hour_of_week
 
 
+async def _delete_matching_traces(
+    session: AsyncSession,
+    project_rowids: Union[Iterable[int], InElementRole],
+    trace_filter: sa.ColumnElement[bool],
+) -> None:
+    from phoenix.db.models import EvalSessionWorkUnit, ProjectSession, Trace
+
+    candidate_trace_ids = (
+        sa.select(Trace.id).where(Trace.project_rowid.in_(project_rowids)).where(trace_filter)
+    )
+    affected_session_ids = (
+        sa.select(Trace.project_session_rowid)
+        .where(
+            Trace.id.in_(candidate_trace_ids),
+            Trace.project_session_rowid.is_not(None),
+        )
+        .distinct()
+    )
+    await session.execute(
+        sa.update(ProjectSession)
+        .where(ProjectSession.id.in_(affected_session_ids))
+        .values(content_complete=False)
+    )
+    await session.execute(
+        sa.update(EvalSessionWorkUnit)
+        .where(
+            EvalSessionWorkUnit.project_session_rowid.in_(affected_session_ids),
+            EvalSessionWorkUnit.status.in_(("PENDING", "RUNNING", "ERROR")),
+        )
+        .values(
+            status="EXPIRED",
+            claimed_at=None,
+            claimed_by=None,
+            cooldown_until=None,
+            error="session content incomplete",
+        )
+    )
+    await session.execute(sa.delete(Trace).where(Trace.id.in_(candidate_trace_ids)))
+
+
 class _MaxDays(BaseModel):
     max_days: Annotated[float, Field(ge=0)]
 
@@ -61,13 +101,7 @@ class MaxDaysRule(_MaxDays, BaseModel):
     ) -> set[int]:
         if self.max_days <= 0:
             return set()
-        from phoenix.db.models import Trace
-
-        await session.execute(
-            sa.delete(Trace)
-            .where(Trace.project_rowid.in_(project_rowids))
-            .where(self.max_days_filter)
-        )
+        await _delete_matching_traces(session, project_rowids, self.max_days_filter)
         # Intentionally returns an empty set: the affected project ids only feed
         # CacheForDataLoaders invalidation, which is None on every backend except SQLite.
         # Collecting them via RETURNING buffered the full result set in memory (OOM on large
@@ -89,12 +123,10 @@ class MaxCountRule(_MaxCount, BaseModel):
     ) -> set[int]:
         if self.max_count <= 0:
             return set()
-        from phoenix.db.models import Trace
-
-        await session.execute(
-            sa.delete(Trace)
-            .where(Trace.project_rowid.in_(project_rowids))
-            .where(self.max_count_filter(project_rowids))
+        await _delete_matching_traces(
+            session,
+            project_rowids,
+            self.max_count_filter(project_rowids),
         )
         # Empty set by design; see MaxDaysRule.delete_traces for why (avoids #13906 OOM).
         return set()
@@ -113,12 +145,10 @@ class MaxDaysOrCountRule(_MaxDays, _MaxCount, BaseModel):
     ) -> set[int]:
         if self.max_days <= 0 and self.max_count <= 0:
             return set()
-        from phoenix.db.models import Trace
-
-        await session.execute(
-            sa.delete(Trace)
-            .where(Trace.project_rowid.in_(project_rowids))
-            .where(sa.or_(self.max_days_filter, self.max_count_filter(project_rowids)))
+        await _delete_matching_traces(
+            session,
+            project_rowids,
+            sa.or_(self.max_days_filter, self.max_count_filter(project_rowids)),
         )
         # Empty set by design; see MaxDaysRule.delete_traces for why (avoids #13906 OOM).
         return set()

--- a/src/phoenix/db/types/trace_retention.py
+++ b/src/phoenix/db/types/trace_retention.py
@@ -17,7 +17,8 @@ async def _delete_matching_traces(
     project_rowids: Union[Iterable[int], InElementRole],
     trace_filter: sa.ColumnElement[bool],
 ) -> None:
-    from phoenix.db.models import EvalSessionWorkUnit, ProjectSession, Trace
+    from phoenix.db.helpers import mark_session_content_incomplete
+    from phoenix.db.models import Trace
 
     candidate_trace_ids = (
         sa.select(Trace.id).where(Trace.project_rowid.in_(project_rowids)).where(trace_filter)
@@ -30,25 +31,7 @@ async def _delete_matching_traces(
         )
         .distinct()
     )
-    await session.execute(
-        sa.update(ProjectSession)
-        .where(ProjectSession.id.in_(affected_session_ids))
-        .values(content_complete=False)
-    )
-    await session.execute(
-        sa.update(EvalSessionWorkUnit)
-        .where(
-            EvalSessionWorkUnit.project_session_rowid.in_(affected_session_ids),
-            EvalSessionWorkUnit.status.in_(("PENDING", "RUNNING", "ERROR")),
-        )
-        .values(
-            status="EXPIRED",
-            claimed_at=None,
-            claimed_by=None,
-            cooldown_until=None,
-            error="session content incomplete",
-        )
-    )
+    await mark_session_content_incomplete(session, affected_session_ids)
     await session.execute(sa.delete(Trace).where(Trace.id.in_(candidate_trace_ids)))
 
 

--- a/src/phoenix/db/types/trace_retention.py
+++ b/src/phoenix/db/types/trace_retention.py
@@ -17,22 +17,13 @@ async def _delete_matching_traces(
     project_rowids: Union[Iterable[int], InElementRole],
     trace_filter: sa.ColumnElement[bool],
 ) -> None:
-    from phoenix.db.helpers import mark_session_content_incomplete
+    from phoenix.db.helpers import delete_traces
     from phoenix.db.models import Trace
 
     candidate_trace_ids = (
         sa.select(Trace.id).where(Trace.project_rowid.in_(project_rowids)).where(trace_filter)
     )
-    affected_session_ids = (
-        sa.select(Trace.project_session_rowid)
-        .where(
-            Trace.id.in_(candidate_trace_ids),
-            Trace.project_session_rowid.is_not(None),
-        )
-        .distinct()
-    )
-    await mark_session_content_incomplete(session, affected_session_ids)
-    await session.execute(sa.delete(Trace).where(Trace.id.in_(candidate_trace_ids)))
+    await delete_traces(session, Trace.id.in_(candidate_trace_ids))
 
 
 class _MaxDays(BaseModel):

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -62,8 +62,19 @@ from phoenix.server.api.types.SandboxConfig import (
     SandboxConfig,
 )
 from phoenix.server.bearer_auth import PhoenixUser
-from phoenix.server.online_eval.session_policy import MINIMUM_EVALUATION_DELAY_SECONDS
+from phoenix.server.online_eval.session_policy import (
+    DEFAULT_SESSION_EVALUATION_DELAY_SECONDS,
+    MINIMUM_EVALUATION_DELAY_SECONDS,
+)
 from phoenix.trace.dsl.filter import validate_span_filter_condition
+
+_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
+    "SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling "
+    "are evaluated once: work is scheduled after the session first stays quiet for the "
+    "evaluation delay, and execution begins when a consumer claims it. Later activity does not "
+    "schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators "
+    "are stored but not yet scheduled."
+)
 
 
 def _output_config_input_to_pydantic(input: AnnotationConfigInput) -> OutputConfigType:
@@ -433,7 +444,10 @@ class CreateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -454,8 +468,11 @@ class UpdateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "SESSION evaluation delay in seconds. Omit to preserve the current setting or use "
-            "null to restore the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
+            f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
+            "seconds. A session is evaluated only once, and later activity does not schedule "
+            "another evaluation."
         ),
     )
 
@@ -479,7 +496,10 @@ class AddProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -508,7 +528,10 @@ class CreateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -536,8 +559,11 @@ class UpdateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "SESSION evaluation delay in seconds. Omit to preserve the current setting or use "
-            "null to restore the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
+            f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
+            "seconds. A session is evaluated only once, and later activity does not schedule "
+            "another evaluation."
         ),
     )
 
@@ -609,11 +635,7 @@ class CreateCodeEvaluatorVersionPayload:
 class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
-        description=(
-            "Create an LLM project evaluator. SPAN evaluators run on matching spans; "
-            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
-            "TRACE evaluators are stored but not scheduled."
-        ),
+        description=f"Create an LLM project evaluator. {_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}",
     )  # type: ignore
     async def create_project_llm_evaluator(
         self, info: Info[Context, None], input: CreateProjectLLMEvaluatorInput
@@ -719,11 +741,7 @@ class EvaluatorMutationMixin:
 
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
-        description=(
-            "Update an LLM project evaluator. SPAN evaluators run on matching spans; "
-            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
-            "TRACE evaluators are stored but not scheduled."
-        ),
+        description=f"Update an LLM project evaluator. {_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}",
     )  # type: ignore
     async def update_project_llm_evaluator(
         self, info: Info[Context, None], input: UpdateProjectLLMEvaluatorInput
@@ -853,9 +871,8 @@ class EvaluatorMutationMixin:
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
             "Bind an existing CODE evaluator to a project. The evaluator's configuration is "
-            "shared with every project and dataset it is bound to. SPAN evaluators run on "
-            "matching spans; unfiltered SESSION evaluators with full sampling run after their "
-            "evaluation delay. TRACE evaluators are stored but not scheduled."
+            "shared with every project and dataset it is bound to. "
+            f"{_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}"
         ),
     )  # type: ignore
     async def add_project_code_evaluator(
@@ -910,11 +927,7 @@ class EvaluatorMutationMixin:
 
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
-        description=(
-            "Create a CODE project evaluator. SPAN evaluators run on matching spans; "
-            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
-            "TRACE evaluators are stored but not scheduled."
-        ),
+        description=f"Create a CODE project evaluator. {_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}",
     )  # type: ignore
     async def create_project_code_evaluator(
         self, info: Info[Context, None], input: CreateProjectCodeEvaluatorInput
@@ -1000,9 +1013,8 @@ class EvaluatorMutationMixin:
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
             "Update a CODE project evaluator. Editing changes the underlying evaluator, which "
-            "applies to every project and dataset it is bound to. SPAN evaluators run on matching "
-            "spans; unfiltered SESSION evaluators with full sampling run after their evaluation "
-            "delay. TRACE evaluators are stored but not scheduled."
+            "applies to every project and dataset it is bound to. "
+            f"{_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}"
         ),
     )  # type: ignore
     async def update_project_code_evaluator(

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -69,11 +69,11 @@ from phoenix.server.online_eval.session_policy import (
 from phoenix.trace.dsl.filter import validate_span_filter_condition
 
 _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
-    "SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling "
-    "are evaluated once: work is scheduled after the session first stays quiet for the "
-    "evaluation delay, and execution begins when a consumer claims it. Later activity does not "
-    "schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators "
-    "are stored but not yet scheduled."
+    "SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling "
+    "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
+    "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
+    "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
+    "evaluators are stored but not scheduled."
 )
 
 
@@ -444,7 +444,7 @@ class CreateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
             "once, and later activity does not schedule another evaluation."
@@ -468,7 +468,7 @@ class UpdateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
             f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
             "seconds. A session is evaluated only once, and later activity does not schedule "
@@ -496,7 +496,7 @@ class AddProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
             "once, and later activity does not schedule another evaluation."
@@ -528,7 +528,7 @@ class CreateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
             "once, and later activity does not schedule another evaluation."
@@ -559,7 +559,7 @@ class UpdateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
             f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
             "seconds. A session is evaluated only once, and later activity does not schedule "

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -62,6 +62,7 @@ from phoenix.server.api.types.SandboxConfig import (
     SandboxConfig,
 )
 from phoenix.server.bearer_auth import PhoenixUser
+from phoenix.server.online_eval.session_policy import MINIMUM_EVALUATION_DELAY_SECONDS
 from phoenix.trace.dsl.filter import validate_span_filter_condition
 
 
@@ -263,6 +264,18 @@ def _validate_project_evaluator_sampling_rate(sampling_rate: float) -> None:
         raise BadRequest("samplingRate must be between 0.0 and 1.0")
 
 
+def _validate_project_evaluator_evaluation_delay(
+    evaluation_delay_seconds: Optional[int],
+) -> None:
+    if (
+        evaluation_delay_seconds is not None
+        and evaluation_delay_seconds < MINIMUM_EVALUATION_DELAY_SECONDS
+    ):
+        raise BadRequest(
+            f"evaluationDelaySeconds must be at least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds"
+        )
+
+
 async def _garbage_collect_evaluators(
     session: AsyncSession,
     *,
@@ -417,6 +430,12 @@ class CreateProjectLLMEvaluatorInput:
     prompt_version_id: Optional[GlobalID] = UNSET
     filter_condition: str = ""
     enabled: bool = True
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=None,
+        description=(
+            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+        ),
+    )
 
 
 @strawberry.input
@@ -432,6 +451,13 @@ class UpdateProjectLLMEvaluatorInput:
     enabled: bool
     description: Optional[str] = None
     prompt_version_id: Optional[GlobalID] = UNSET
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=UNSET,
+        description=(
+            "SESSION evaluation delay in seconds. Omit to preserve the current setting or use "
+            "null to restore the default delay."
+        ),
+    )
 
 
 @strawberry.input
@@ -450,6 +476,12 @@ class AddProjectCodeEvaluatorInput:
     )
     filter_condition: str = ""
     enabled: bool = True
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=None,
+        description=(
+            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+        ),
+    )
 
 
 @strawberry.input
@@ -473,6 +505,12 @@ class CreateProjectCodeEvaluatorInput:
     )
     filter_condition: str = ""
     enabled: bool = True
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=None,
+        description=(
+            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+        ),
+    )
 
 
 @strawberry.input
@@ -493,6 +531,13 @@ class UpdateProjectCodeEvaluatorInput:
         description=(
             "Project-specific CODE input mapping patch. Omit to preserve the current setting, "
             "use null to inherit the evaluator input mapping, or provide an object to override it."
+        ),
+    )
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=UNSET,
+        description=(
+            "SESSION evaluation delay in seconds. Omit to preserve the current setting or use "
+            "null to restore the default delay."
         ),
     )
 
@@ -565,8 +610,9 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
-            "Create an LLM project evaluator. SPAN is executable; TRACE and SESSION "
-            "are stored but inactive until their runtimes are available."
+            "Create an LLM project evaluator. SPAN evaluators run on matching spans; "
+            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
+            "TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def create_project_llm_evaluator(
@@ -578,6 +624,7 @@ class EvaluatorMutationMixin:
             raise BadRequest(f"Invalid project id: {input.project_id}")
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -657,6 +704,7 @@ class EvaluatorMutationMixin:
                     sampling_rate=input.sampling_rate,
                     evaluation_target=input.evaluation_target.value,
                     input_mapping=input.input_mapping.to_orm(),
+                    evaluation_delay_seconds=input.evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -672,8 +720,9 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
-            "Update an LLM project evaluator. SPAN is executable; TRACE and SESSION "
-            "are stored but inactive until their runtimes are available."
+            "Update an LLM project evaluator. SPAN evaluators run on matching spans; "
+            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
+            "TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def update_project_llm_evaluator(
@@ -687,6 +736,8 @@ class EvaluatorMutationMixin:
             raise BadRequest(f"Invalid project evaluator id: {input.project_evaluator_id}")
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        if input.evaluation_delay_seconds is not UNSET:
+            _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -786,6 +837,8 @@ class EvaluatorMutationMixin:
                 criteria.sampling_rate = input.sampling_rate
                 criteria.evaluation_target = input.evaluation_target.value
                 criteria.input_mapping = input.input_mapping.to_orm()
+                if input.evaluation_delay_seconds is not UNSET:
+                    criteria.evaluation_delay_seconds = input.evaluation_delay_seconds
                 criteria.enabled = input.enabled
                 await session.flush()
         except (PostgreSQLIntegrityError, SQLiteIntegrityError):
@@ -800,8 +853,9 @@ class EvaluatorMutationMixin:
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
             "Bind an existing CODE evaluator to a project. The evaluator's configuration is "
-            "shared with every project and dataset it is bound to. SPAN is executable; TRACE "
-            "and SESSION are stored but inactive until their runtimes are available."
+            "shared with every project and dataset it is bound to. SPAN evaluators run on "
+            "matching spans; unfiltered SESSION evaluators with full sampling run after their "
+            "evaluation delay. TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def add_project_code_evaluator(
@@ -823,6 +877,7 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
 
         try:
             async with info.context.db() as session:
@@ -840,6 +895,7 @@ class EvaluatorMutationMixin:
                     input_mapping=(
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     ),
+                    evaluation_delay_seconds=input.evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -855,8 +911,9 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
-            "Create a CODE project evaluator. SPAN is executable; TRACE and SESSION "
-            "are stored but inactive until their runtimes are available."
+            "Create a CODE project evaluator. SPAN evaluators run on matching spans; "
+            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
+            "TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def create_project_code_evaluator(
@@ -869,6 +926,7 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         _raise_on_uninferable_evaluate_signature(input.source_code, input.language)
         if input.output_configs is not None:
             try:
@@ -925,6 +983,7 @@ class EvaluatorMutationMixin:
                     input_mapping=(
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     ),
+                    evaluation_delay_seconds=input.evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -941,8 +1000,9 @@ class EvaluatorMutationMixin:
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
             "Update a CODE project evaluator. Editing changes the underlying evaluator, which "
-            "applies to every project and dataset it is bound to. SPAN is executable; TRACE and "
-            "SESSION are stored but inactive until their runtimes are available."
+            "applies to every project and dataset it is bound to. SPAN evaluators run on matching "
+            "spans; unfiltered SESSION evaluators with full sampling run after their evaluation "
+            "delay. TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def update_project_code_evaluator(
@@ -957,6 +1017,8 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        if input.evaluation_delay_seconds is not UNSET:
+            _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         if input.source_code is not UNSET and input.source_code is None:
             raise BadRequest("source_code cannot be set to null")
         if input.output_configs is None:
@@ -1041,6 +1103,8 @@ class EvaluatorMutationMixin:
                     criteria.input_mapping = (
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     )
+                if input.evaluation_delay_seconds is not UNSET:
+                    criteria.evaluation_delay_seconds = input.evaluation_delay_seconds
                 criteria.enabled = input.enabled
                 await session.flush()
         except (PostgreSQLIntegrityError, SQLiteIntegrityError):

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -85,7 +85,9 @@ _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
     "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
     "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
     "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
-    "evaluators are stored but not scheduled."
+    "evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation "
+    "delay without using it. The target can change only until evaluation work exists for the "
+    "project evaluator."
 )
 
 
@@ -525,7 +527,8 @@ class CreateProjectLLMEvaluatorInput:
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation."
+            "evaluated only once, and later activity does not schedule another evaluation. "
+            "Non-SESSION targets preserve this value without using it."
         ),
     )
 
@@ -550,7 +553,8 @@ class UpdateProjectLLMEvaluatorInput:
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
             f"or use null to store the current default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            "once, and later activity does not schedule another evaluation. Non-SESSION targets "
+            "preserve this value without using it."
         ),
     )
 
@@ -577,7 +581,8 @@ class AddProjectCodeEvaluatorInput:
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation."
+            "evaluated only once, and later activity does not schedule another evaluation. "
+            "Non-SESSION targets preserve this value without using it."
         ),
     )
 
@@ -609,7 +614,8 @@ class CreateProjectCodeEvaluatorInput:
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation."
+            "evaluated only once, and later activity does not schedule another evaluation. "
+            "Non-SESSION targets preserve this value without using it."
         ),
     )
 
@@ -641,7 +647,8 @@ class UpdateProjectCodeEvaluatorInput:
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
             f"or use null to store the current default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            "once, and later activity does not schedule another evaluation. Non-SESSION targets "
+            "preserve this value without using it."
         ),
     )
 

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -5,7 +5,7 @@ from typing import Optional, cast
 import strawberry
 from fastapi import Request
 from pydantic import ValidationError
-from sqlalchemy import and_, delete, select, true
+from sqlalchemy import and_, delete, or_, select, true
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -342,6 +342,32 @@ def _materialize_project_evaluator_evaluation_delay(
         if evaluation_delay_seconds is None
         else evaluation_delay_seconds
     )
+
+
+async def _validate_project_evaluator_target_update(
+    session: AsyncSession,
+    criteria: models.ProjectEvaluatorCriteria,
+    evaluation_target: EvaluationTarget,
+) -> None:
+    if criteria.evaluation_target == evaluation_target.value:
+        return
+    work_exists = await session.scalar(
+        select(
+            or_(
+                select(models.EvalWorkUnit.id)
+                .where(models.EvalWorkUnit.criteria_id == criteria.id)
+                .exists(),
+                select(models.EvalSessionWorkUnit.id)
+                .where(models.EvalSessionWorkUnit.criteria_id == criteria.id)
+                .exists(),
+            )
+        )
+    )
+    if work_exists:
+        raise BadRequest(
+            "evaluationTarget cannot be changed after evaluation work has been created "
+            "for this project evaluator"
+        )
 
 
 async def _garbage_collect_evaluators(
@@ -849,6 +875,11 @@ class EvaluatorMutationMixin:
                 if pair is None:
                     raise NotFound(f"LLM project evaluator not found: {input.project_evaluator_id}")
                 criteria, evaluator = pair
+                await _validate_project_evaluator_target_update(
+                    session,
+                    criteria,
+                    input.evaluation_target,
+                )
                 shared_evaluator_changed = False
                 if criteria.name != name:
                     evaluator.name = await _generate_unique_evaluator_name(session, name)
@@ -1209,6 +1240,11 @@ class EvaluatorMutationMixin:
                         f"CODE project evaluator not found: {input.project_evaluator_id}"
                     )
                 criteria, evaluator = pair
+                await _validate_project_evaluator_target_update(
+                    session,
+                    criteria,
+                    input.evaluation_target,
+                )
                 shared_evaluator_changed = False
                 if criteria.name != name:
                     evaluator.name = await _generate_unique_evaluator_name(session, name)

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -5,7 +5,7 @@ from typing import Optional, cast
 import strawberry
 from fastapi import Request
 from pydantic import ValidationError
-from sqlalchemy import and_, delete, or_, select, true
+from sqlalchemy import and_, delete, select, true
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -346,30 +346,13 @@ def _materialize_project_evaluator_evaluation_delay(
     )
 
 
-async def _validate_project_evaluator_target_update(
-    session: AsyncSession,
+def _validate_project_evaluator_target_update(
     criteria: models.ProjectEvaluatorCriteria,
     evaluation_target: EvaluationTarget,
 ) -> None:
     if criteria.evaluation_target == evaluation_target.value:
         return
-    work_exists = await session.scalar(
-        select(
-            or_(
-                select(models.EvalWorkUnit.id)
-                .where(models.EvalWorkUnit.criteria_id == criteria.id)
-                .exists(),
-                select(models.EvalSessionWorkUnit.id)
-                .where(models.EvalSessionWorkUnit.criteria_id == criteria.id)
-                .exists(),
-            )
-        )
-    )
-    if work_exists:
-        raise BadRequest(
-            "evaluationTarget cannot be changed after evaluation work has been created "
-            "for this project evaluator"
-        )
+    raise BadRequest("evaluationTarget is fixed at project evaluator creation")
 
 
 async def _garbage_collect_evaluators(
@@ -541,7 +524,9 @@ class UpdateProjectLLMEvaluatorInput:
     output_configs: list[AnnotationConfigInput]
     input_mapping: EvaluatorInputMappingInput
     sampling_rate: float
-    evaluation_target: EvaluationTarget
+    evaluation_target: EvaluationTarget = strawberry.field(
+        description="The evaluation target is fixed at project evaluator creation."
+    )
     filter_condition: str
     enabled: Optional[bool] = UNSET
     description: Optional[str] = UNSET
@@ -625,7 +610,9 @@ class UpdateProjectCodeEvaluatorInput:
     project_evaluator_id: GlobalID
     name: Identifier
     sampling_rate: float
-    evaluation_target: EvaluationTarget
+    evaluation_target: EvaluationTarget = strawberry.field(
+        description="The evaluation target is fixed at project evaluator creation."
+    )
     filter_condition: str
     evaluator_input_mapping: Optional[EvaluatorInputMappingInput] = UNSET
     enabled: Optional[bool] = UNSET
@@ -882,8 +869,7 @@ class EvaluatorMutationMixin:
                 if pair is None:
                     raise NotFound(f"LLM project evaluator not found: {input.project_evaluator_id}")
                 criteria, evaluator = pair
-                await _validate_project_evaluator_target_update(
-                    session,
+                _validate_project_evaluator_target_update(
                     criteria,
                     input.evaluation_target,
                 )
@@ -1247,8 +1233,7 @@ class EvaluatorMutationMixin:
                         f"CODE project evaluator not found: {input.project_evaluator_id}"
                     )
                 criteria, evaluator = pair
-                await _validate_project_evaluator_target_update(
-                    session,
+                _validate_project_evaluator_target_update(
                     criteria,
                     input.evaluation_target,
                 )

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -327,9 +327,9 @@ def _validate_project_evaluator_sampling_rate(sampling_rate: float) -> None:
         raise BadRequest("samplingRate must be between 0.0 and 1.0")
 
 
-def _validate_project_evaluator_evaluation_delay(
+def _materialize_project_evaluator_evaluation_delay(
     evaluation_delay_seconds: Optional[int],
-) -> None:
+) -> int:
     if (
         evaluation_delay_seconds is not None
         and evaluation_delay_seconds < MINIMUM_EVALUATION_DELAY_SECONDS
@@ -337,6 +337,11 @@ def _validate_project_evaluator_evaluation_delay(
         raise BadRequest(
             f"evaluationDelaySeconds must be at least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds"
         )
+    return (
+        DEFAULT_SESSION_EVALUATION_DELAY_SECONDS
+        if evaluation_delay_seconds is None
+        else evaluation_delay_seconds
+    )
 
 
 async def _garbage_collect_evaluators(
@@ -492,9 +497,9 @@ class CreateProjectLLMEvaluatorInput:
         default=None,
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
+            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
+            "evaluated only once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -517,9 +522,9 @@ class UpdateProjectLLMEvaluatorInput:
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
-            f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
-            "seconds. A session is evaluated only once, and later activity does not schedule "
-            "another evaluation."
+            f"or use null to store the current default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -544,9 +549,9 @@ class AddProjectCodeEvaluatorInput:
         default=None,
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
+            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
+            "evaluated only once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -576,9 +581,9 @@ class CreateProjectCodeEvaluatorInput:
         default=None,
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
+            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
+            "evaluated only once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -608,9 +613,9 @@ class UpdateProjectCodeEvaluatorInput:
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
-            f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
-            "seconds. A session is evaluated only once, and later activity does not schedule "
-            "another evaluation."
+            f"or use null to store the current default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -699,7 +704,9 @@ class EvaluatorMutationMixin:
             raise BadRequest(f"Invalid project id: {input.project_id}")
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
-        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+        evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
+            input.evaluation_delay_seconds
+        )
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -779,7 +786,7 @@ class EvaluatorMutationMixin:
                     sampling_rate=input.sampling_rate,
                     evaluation_target=input.evaluation_target.value,
                     input_mapping=input.input_mapping.to_orm(),
-                    evaluation_delay_seconds=input.evaluation_delay_seconds,
+                    evaluation_delay_seconds=evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -810,7 +817,7 @@ class EvaluatorMutationMixin:
         if input.enabled is None:
             raise BadRequest("enabled cannot be set to null")
         if input.evaluation_delay_seconds is not UNSET:
-            _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+            _materialize_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -928,7 +935,11 @@ class EvaluatorMutationMixin:
                 criteria.evaluation_target = input.evaluation_target.value
                 criteria.input_mapping = input.input_mapping.to_orm()
                 if input.evaluation_delay_seconds is not UNSET:
-                    criteria.evaluation_delay_seconds = input.evaluation_delay_seconds
+                    criteria.evaluation_delay_seconds = (
+                        _materialize_project_evaluator_evaluation_delay(
+                            input.evaluation_delay_seconds
+                        )
+                    )
                 if input.enabled is not UNSET:
                     assert input.enabled is not None
                     criteria.enabled = input.enabled
@@ -968,7 +979,9 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
-        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+        evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
+            input.evaluation_delay_seconds
+        )
 
         try:
             async with info.context.db() as session:
@@ -986,7 +999,7 @@ class EvaluatorMutationMixin:
                     input_mapping=(
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     ),
-                    evaluation_delay_seconds=input.evaluation_delay_seconds,
+                    evaluation_delay_seconds=evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -1013,7 +1026,9 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
-        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+        evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
+            input.evaluation_delay_seconds
+        )
         _raise_on_uninferable_evaluate_signature(input.source_code, input.language)
         if input.output_configs is not None:
             try:
@@ -1076,7 +1091,7 @@ class EvaluatorMutationMixin:
                     input_mapping=(
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     ),
-                    evaluation_delay_seconds=input.evaluation_delay_seconds,
+                    evaluation_delay_seconds=evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -1114,7 +1129,7 @@ class EvaluatorMutationMixin:
         if input.enabled is None:
             raise BadRequest("enabled cannot be set to null")
         if input.evaluation_delay_seconds is not UNSET:
-            _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+            _materialize_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         if input.source_code is not UNSET and input.source_code is None:
             raise BadRequest("source_code cannot be set to null")
         if input.output_configs is None:
@@ -1257,7 +1272,11 @@ class EvaluatorMutationMixin:
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     )
                 if input.evaluation_delay_seconds is not UNSET:
-                    criteria.evaluation_delay_seconds = input.evaluation_delay_seconds
+                    criteria.evaluation_delay_seconds = (
+                        _materialize_project_evaluator_evaluation_delay(
+                            input.evaluation_delay_seconds
+                        )
+                    )
                 if input.enabled is not UNSET:
                     assert input.enabled is not None
                     criteria.enabled = input.enabled

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -65,7 +65,10 @@ from phoenix.server.api.types.SandboxConfig import (
     SandboxConfig,
 )
 from phoenix.server.bearer_auth import PhoenixUser
-from phoenix.server.online_eval.session_policy import MINIMUM_EVALUATION_DELAY_SECONDS
+from phoenix.server.online_eval.session_policy import (
+    DEFAULT_SESSION_EVALUATION_DELAY_SECONDS,
+    MINIMUM_EVALUATION_DELAY_SECONDS,
+)
 from phoenix.server.sandbox import SANDBOX_ADAPTERS
 from phoenix.server.sandbox.types import SandboxRuntimeContext, SandboxValidationUnavailable
 from phoenix.server.types import DbSessionFactory
@@ -76,6 +79,14 @@ _EVALUATOR_KIND_BY_TYPENAME: dict[str, EvaluatorKind] = {
     CodeEvaluator.__name__: "CODE",
     BuiltInEvaluator.__name__: "BUILTIN",
 }
+
+_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
+    "SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling "
+    "are evaluated once: work is scheduled after the session first stays quiet for the "
+    "evaluation delay, and execution begins when a consumer claims it. Later activity does not "
+    "schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators "
+    "are stored but not yet scheduled."
+)
 
 
 def _output_config_input_to_pydantic(input: AnnotationConfigInput) -> OutputConfigType:
@@ -480,7 +491,10 @@ class CreateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -501,8 +515,11 @@ class UpdateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "SESSION evaluation delay in seconds. Omit to preserve the current setting or use "
-            "null to restore the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
+            f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
+            "seconds. A session is evaluated only once, and later activity does not schedule "
+            "another evaluation."
         ),
     )
 
@@ -526,7 +543,10 @@ class AddProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -555,7 +575,10 @@ class CreateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -583,8 +606,11 @@ class UpdateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "SESSION evaluation delay in seconds. Omit to preserve the current setting or use "
-            "null to restore the default delay."
+            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
+            f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
+            "seconds. A session is evaluated only once, and later activity does not schedule "
+            "another evaluation."
         ),
     )
 
@@ -662,11 +688,7 @@ class CreateCodeEvaluatorVersionPayload:
 class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
-        description=(
-            "Create an LLM project evaluator. SPAN evaluators run on matching spans; "
-            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
-            "TRACE evaluators are stored but not scheduled."
-        ),
+        description=f"Create an LLM project evaluator. {_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}",
     )  # type: ignore
     async def create_project_llm_evaluator(
         self, info: Info[Context, None], input: CreateProjectLLMEvaluatorInput
@@ -772,11 +794,7 @@ class EvaluatorMutationMixin:
 
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
-        description=(
-            "Update an LLM project evaluator. SPAN evaluators run on matching spans; "
-            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
-            "TRACE evaluators are stored but not scheduled."
-        ),
+        description=f"Update an LLM project evaluator. {_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}",
     )  # type: ignore
     async def update_project_llm_evaluator(
         self, info: Info[Context, None], input: UpdateProjectLLMEvaluatorInput
@@ -927,9 +945,8 @@ class EvaluatorMutationMixin:
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
             "Bind an existing CODE evaluator to a project. The evaluator's configuration is "
-            "shared with every project and dataset it is bound to. SPAN evaluators run on "
-            "matching spans; unfiltered SESSION evaluators with full sampling run after their "
-            "evaluation delay. TRACE evaluators are stored but not scheduled."
+            "shared with every project and dataset it is bound to. "
+            f"{_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}"
         ),
     )  # type: ignore
     async def add_project_code_evaluator(
@@ -984,11 +1001,7 @@ class EvaluatorMutationMixin:
 
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
-        description=(
-            "Create a CODE project evaluator. SPAN evaluators run on matching spans; "
-            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
-            "TRACE evaluators are stored but not scheduled."
-        ),
+        description=f"Create a CODE project evaluator. {_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}",
     )  # type: ignore
     async def create_project_code_evaluator(
         self, info: Info[Context, None], input: CreateProjectCodeEvaluatorInput
@@ -1080,9 +1093,8 @@ class EvaluatorMutationMixin:
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
             "Update a CODE project evaluator. Editing changes the underlying evaluator, which "
-            "applies to every project and dataset it is bound to. SPAN evaluators run on matching "
-            "spans; unfiltered SESSION evaluators with full sampling run after their evaluation "
-            "delay. TRACE evaluators are stored but not scheduled."
+            "applies to every project and dataset it is bound to. "
+            f"{_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION}"
         ),
     )  # type: ignore
     async def update_project_code_evaluator(

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -81,11 +81,11 @@ _EVALUATOR_KIND_BY_TYPENAME: dict[str, EvaluatorKind] = {
 }
 
 _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
-    "SPAN evaluators run on matching spans. Unfiltered SESSION evaluators with full sampling "
-    "are evaluated once: work is scheduled after the session first stays quiet for the "
-    "evaluation delay, and execution begins when a consumer claims it. Later activity does not "
-    "schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE evaluators "
-    "are stored but not yet scheduled."
+    "SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling "
+    "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
+    "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
+    "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
+    "evaluators are stored but not scheduled."
 )
 
 
@@ -491,7 +491,7 @@ class CreateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
             "once, and later activity does not schedule another evaluation."
@@ -515,7 +515,7 @@ class UpdateProjectLLMEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
             f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
             "seconds. A session is evaluated only once, and later activity does not schedule "
@@ -543,7 +543,7 @@ class AddProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
             "once, and later activity does not schedule another evaluation."
@@ -575,7 +575,7 @@ class CreateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=None,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
             "once, and later activity does not schedule another evaluation."
@@ -606,7 +606,7 @@ class UpdateProjectCodeEvaluatorInput:
     evaluation_delay_seconds: Optional[int] = strawberry.field(
         default=UNSET,
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. The minimum is "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
             f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
             "seconds. A session is evaluated only once, and later activity does not schedule "

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -65,6 +65,7 @@ from phoenix.server.api.types.SandboxConfig import (
     SandboxConfig,
 )
 from phoenix.server.bearer_auth import PhoenixUser
+from phoenix.server.online_eval.session_policy import MINIMUM_EVALUATION_DELAY_SECONDS
 from phoenix.server.sandbox import SANDBOX_ADAPTERS
 from phoenix.server.sandbox.types import SandboxRuntimeContext, SandboxValidationUnavailable
 from phoenix.server.types import DbSessionFactory
@@ -315,6 +316,18 @@ def _validate_project_evaluator_sampling_rate(sampling_rate: float) -> None:
         raise BadRequest("samplingRate must be between 0.0 and 1.0")
 
 
+def _validate_project_evaluator_evaluation_delay(
+    evaluation_delay_seconds: Optional[int],
+) -> None:
+    if (
+        evaluation_delay_seconds is not None
+        and evaluation_delay_seconds < MINIMUM_EVALUATION_DELAY_SECONDS
+    ):
+        raise BadRequest(
+            f"evaluationDelaySeconds must be at least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds"
+        )
+
+
 async def _garbage_collect_evaluators(
     session: AsyncSession,
     *,
@@ -464,6 +477,12 @@ class CreateProjectLLMEvaluatorInput:
     prompt_version_id: Optional[GlobalID] = UNSET
     filter_condition: str = ""
     enabled: bool = True
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=None,
+        description=(
+            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+        ),
+    )
 
 
 @strawberry.input
@@ -479,6 +498,13 @@ class UpdateProjectLLMEvaluatorInput:
     enabled: Optional[bool] = UNSET
     description: Optional[str] = UNSET
     prompt_version_id: Optional[GlobalID] = UNSET
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=UNSET,
+        description=(
+            "SESSION evaluation delay in seconds. Omit to preserve the current setting or use "
+            "null to restore the default delay."
+        ),
+    )
 
 
 @strawberry.input
@@ -497,6 +523,12 @@ class AddProjectCodeEvaluatorInput:
     )
     filter_condition: str = ""
     enabled: bool = True
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=None,
+        description=(
+            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+        ),
+    )
 
 
 @strawberry.input
@@ -520,6 +552,12 @@ class CreateProjectCodeEvaluatorInput:
     )
     filter_condition: str = ""
     enabled: bool = True
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=None,
+        description=(
+            "Seconds of inactivity before a SESSION evaluation. Null uses the default delay."
+        ),
+    )
 
 
 @strawberry.input
@@ -540,6 +578,13 @@ class UpdateProjectCodeEvaluatorInput:
         description=(
             "Project-specific CODE input mapping patch. Omit to preserve the current setting, "
             "use null to inherit the evaluator input mapping, or provide an object to override it."
+        ),
+    )
+    evaluation_delay_seconds: Optional[int] = strawberry.field(
+        default=UNSET,
+        description=(
+            "SESSION evaluation delay in seconds. Omit to preserve the current setting or use "
+            "null to restore the default delay."
         ),
     )
 
@@ -618,8 +663,9 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
-            "Create an LLM project evaluator. SPAN is executable; TRACE and SESSION "
-            "are stored but inactive until their runtimes are available."
+            "Create an LLM project evaluator. SPAN evaluators run on matching spans; "
+            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
+            "TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def create_project_llm_evaluator(
@@ -631,6 +677,7 @@ class EvaluatorMutationMixin:
             raise BadRequest(f"Invalid project id: {input.project_id}")
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -710,6 +757,7 @@ class EvaluatorMutationMixin:
                     sampling_rate=input.sampling_rate,
                     evaluation_target=input.evaluation_target.value,
                     input_mapping=input.input_mapping.to_orm(),
+                    evaluation_delay_seconds=input.evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -725,8 +773,9 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
-            "Update an LLM project evaluator. SPAN is executable; TRACE and SESSION "
-            "are stored but inactive until their runtimes are available."
+            "Update an LLM project evaluator. SPAN evaluators run on matching spans; "
+            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
+            "TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def update_project_llm_evaluator(
@@ -742,6 +791,8 @@ class EvaluatorMutationMixin:
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         if input.enabled is None:
             raise BadRequest("enabled cannot be set to null")
+        if input.evaluation_delay_seconds is not UNSET:
+            _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -858,6 +909,8 @@ class EvaluatorMutationMixin:
                 criteria.sampling_rate = input.sampling_rate
                 criteria.evaluation_target = input.evaluation_target.value
                 criteria.input_mapping = input.input_mapping.to_orm()
+                if input.evaluation_delay_seconds is not UNSET:
+                    criteria.evaluation_delay_seconds = input.evaluation_delay_seconds
                 if input.enabled is not UNSET:
                     assert input.enabled is not None
                     criteria.enabled = input.enabled
@@ -874,8 +927,9 @@ class EvaluatorMutationMixin:
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
             "Bind an existing CODE evaluator to a project. The evaluator's configuration is "
-            "shared with every project and dataset it is bound to. SPAN is executable; TRACE "
-            "and SESSION are stored but inactive until their runtimes are available."
+            "shared with every project and dataset it is bound to. SPAN evaluators run on "
+            "matching spans; unfiltered SESSION evaluators with full sampling run after their "
+            "evaluation delay. TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def add_project_code_evaluator(
@@ -897,6 +951,7 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
 
         try:
             async with info.context.db() as session:
@@ -914,6 +969,7 @@ class EvaluatorMutationMixin:
                     input_mapping=(
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     ),
+                    evaluation_delay_seconds=input.evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -929,8 +985,9 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
-            "Create a CODE project evaluator. SPAN is executable; TRACE and SESSION "
-            "are stored but inactive until their runtimes are available."
+            "Create a CODE project evaluator. SPAN evaluators run on matching spans; "
+            "unfiltered SESSION evaluators with full sampling run after their evaluation delay. "
+            "TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def create_project_code_evaluator(
@@ -943,6 +1000,7 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         _raise_on_uninferable_evaluate_signature(input.source_code, input.language)
         if input.output_configs is not None:
             try:
@@ -1005,6 +1063,7 @@ class EvaluatorMutationMixin:
                     input_mapping=(
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     ),
+                    evaluation_delay_seconds=input.evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -1021,8 +1080,9 @@ class EvaluatorMutationMixin:
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
             "Update a CODE project evaluator. Editing changes the underlying evaluator, which "
-            "applies to every project and dataset it is bound to. SPAN is executable; TRACE and "
-            "SESSION are stored but inactive until their runtimes are available."
+            "applies to every project and dataset it is bound to. SPAN evaluators run on matching "
+            "spans; unfiltered SESSION evaluators with full sampling run after their evaluation "
+            "delay. TRACE evaluators are stored but not scheduled."
         ),
     )  # type: ignore
     async def update_project_code_evaluator(
@@ -1041,6 +1101,8 @@ class EvaluatorMutationMixin:
             raise BadRequest("evaluator_input_mapping cannot be set to null")
         if input.enabled is None:
             raise BadRequest("enabled cannot be set to null")
+        if input.evaluation_delay_seconds is not UNSET:
+            _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         if input.source_code is not UNSET and input.source_code is None:
             raise BadRequest("source_code cannot be set to null")
         if input.output_configs is None:
@@ -1182,6 +1244,8 @@ class EvaluatorMutationMixin:
                     criteria.input_mapping = (
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     )
+                if input.evaluation_delay_seconds is not UNSET:
+                    criteria.evaluation_delay_seconds = input.evaluation_delay_seconds
                 if input.enabled is not UNSET:
                     assert input.enabled is not None
                     criteria.enabled = input.enabled

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -5,7 +5,7 @@ from typing import Optional, cast
 import strawberry
 from fastapi import Request
 from pydantic import ValidationError
-from sqlalchemy import delete, select
+from sqlalchemy import delete, or_, select
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -290,6 +290,32 @@ def _materialize_project_evaluator_evaluation_delay(
         if evaluation_delay_seconds is None
         else evaluation_delay_seconds
     )
+
+
+async def _validate_project_evaluator_target_update(
+    session: AsyncSession,
+    criteria: models.ProjectEvaluatorCriteria,
+    evaluation_target: EvaluationTarget,
+) -> None:
+    if criteria.evaluation_target == evaluation_target.value:
+        return
+    work_exists = await session.scalar(
+        select(
+            or_(
+                select(models.EvalWorkUnit.id)
+                .where(models.EvalWorkUnit.criteria_id == criteria.id)
+                .exists(),
+                select(models.EvalSessionWorkUnit.id)
+                .where(models.EvalSessionWorkUnit.criteria_id == criteria.id)
+                .exists(),
+            )
+        )
+    )
+    if work_exists:
+        raise BadRequest(
+            "evaluationTarget cannot be changed after evaluation work has been created "
+            "for this project evaluator"
+        )
 
 
 async def _garbage_collect_evaluators(
@@ -794,6 +820,11 @@ class EvaluatorMutationMixin:
                 if pair is None:
                     raise NotFound(f"LLM project evaluator not found: {input.project_evaluator_id}")
                 criteria, evaluator = pair
+                await _validate_project_evaluator_target_update(
+                    session,
+                    criteria,
+                    input.evaluation_target,
+                )
                 if criteria.name != name:
                     evaluator.name = await _generate_unique_evaluator_name(session, name)
 
@@ -1079,6 +1110,11 @@ class EvaluatorMutationMixin:
                         f"CODE project evaluator not found: {input.project_evaluator_id}"
                     )
                 criteria, evaluator = pair
+                await _validate_project_evaluator_target_update(
+                    session,
+                    criteria,
+                    input.evaluation_target,
+                )
                 if criteria.name != name:
                     evaluator.name = await _generate_unique_evaluator_name(session, name)
                 evaluator.description = input.description

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -275,9 +275,9 @@ def _validate_project_evaluator_sampling_rate(sampling_rate: float) -> None:
         raise BadRequest("samplingRate must be between 0.0 and 1.0")
 
 
-def _validate_project_evaluator_evaluation_delay(
+def _materialize_project_evaluator_evaluation_delay(
     evaluation_delay_seconds: Optional[int],
-) -> None:
+) -> int:
     if (
         evaluation_delay_seconds is not None
         and evaluation_delay_seconds < MINIMUM_EVALUATION_DELAY_SECONDS
@@ -285,6 +285,11 @@ def _validate_project_evaluator_evaluation_delay(
         raise BadRequest(
             f"evaluationDelaySeconds must be at least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds"
         )
+    return (
+        DEFAULT_SESSION_EVALUATION_DELAY_SECONDS
+        if evaluation_delay_seconds is None
+        else evaluation_delay_seconds
+    )
 
 
 async def _garbage_collect_evaluators(
@@ -445,9 +450,9 @@ class CreateProjectLLMEvaluatorInput:
         default=None,
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
+            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
+            "evaluated only once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -470,9 +475,9 @@ class UpdateProjectLLMEvaluatorInput:
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
-            f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
-            "seconds. A session is evaluated only once, and later activity does not schedule "
-            "another evaluation."
+            f"or use null to store the current default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -497,9 +502,9 @@ class AddProjectCodeEvaluatorInput:
         default=None,
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
+            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
+            "evaluated only once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -529,9 +534,9 @@ class CreateProjectCodeEvaluatorInput:
         default=None,
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
-            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
+            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
+            "evaluated only once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -561,9 +566,9 @@ class UpdateProjectCodeEvaluatorInput:
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
-            f"or use null to restore the default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} "
-            "seconds. A session is evaluated only once, and later activity does not schedule "
-            "another evaluation."
+            f"or use null to store the current default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         ),
     )
 
@@ -646,7 +651,9 @@ class EvaluatorMutationMixin:
             raise BadRequest(f"Invalid project id: {input.project_id}")
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
-        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+        evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
+            input.evaluation_delay_seconds
+        )
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -726,7 +733,7 @@ class EvaluatorMutationMixin:
                     sampling_rate=input.sampling_rate,
                     evaluation_target=input.evaluation_target.value,
                     input_mapping=input.input_mapping.to_orm(),
-                    evaluation_delay_seconds=input.evaluation_delay_seconds,
+                    evaluation_delay_seconds=evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -755,7 +762,7 @@ class EvaluatorMutationMixin:
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         if input.evaluation_delay_seconds is not UNSET:
-            _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+            _materialize_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         try:
             name = IdentifierModel.model_validate(input.name)
             prompt_version = input.prompt_version.to_orm_prompt_version(None)
@@ -856,7 +863,11 @@ class EvaluatorMutationMixin:
                 criteria.evaluation_target = input.evaluation_target.value
                 criteria.input_mapping = input.input_mapping.to_orm()
                 if input.evaluation_delay_seconds is not UNSET:
-                    criteria.evaluation_delay_seconds = input.evaluation_delay_seconds
+                    criteria.evaluation_delay_seconds = (
+                        _materialize_project_evaluator_evaluation_delay(
+                            input.evaluation_delay_seconds
+                        )
+                    )
                 criteria.enabled = input.enabled
                 await session.flush()
         except (PostgreSQLIntegrityError, SQLiteIntegrityError):
@@ -894,7 +905,9 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
-        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+        evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
+            input.evaluation_delay_seconds
+        )
 
         try:
             async with info.context.db() as session:
@@ -912,7 +925,7 @@ class EvaluatorMutationMixin:
                     input_mapping=(
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     ),
-                    evaluation_delay_seconds=input.evaluation_delay_seconds,
+                    evaluation_delay_seconds=evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -939,7 +952,9 @@ class EvaluatorMutationMixin:
             raise BadRequest(str(error))
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
-        _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+        evaluation_delay_seconds = _materialize_project_evaluator_evaluation_delay(
+            input.evaluation_delay_seconds
+        )
         _raise_on_uninferable_evaluate_signature(input.source_code, input.language)
         if input.output_configs is not None:
             try:
@@ -996,7 +1011,7 @@ class EvaluatorMutationMixin:
                     input_mapping=(
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     ),
-                    evaluation_delay_seconds=input.evaluation_delay_seconds,
+                    evaluation_delay_seconds=evaluation_delay_seconds,
                     enabled=input.enabled,
                 )
                 session.add(criteria)
@@ -1030,7 +1045,7 @@ class EvaluatorMutationMixin:
         _validate_project_evaluator_filter(input.filter_condition)
         _validate_project_evaluator_sampling_rate(input.sampling_rate)
         if input.evaluation_delay_seconds is not UNSET:
-            _validate_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
+            _materialize_project_evaluator_evaluation_delay(input.evaluation_delay_seconds)
         if input.source_code is not UNSET and input.source_code is None:
             raise BadRequest("source_code cannot be set to null")
         if input.output_configs is None:
@@ -1116,7 +1131,11 @@ class EvaluatorMutationMixin:
                         input.input_mapping.to_orm() if input.input_mapping is not None else None
                     )
                 if input.evaluation_delay_seconds is not UNSET:
-                    criteria.evaluation_delay_seconds = input.evaluation_delay_seconds
+                    criteria.evaluation_delay_seconds = (
+                        _materialize_project_evaluator_evaluation_delay(
+                            input.evaluation_delay_seconds
+                        )
+                    )
                 criteria.enabled = input.enabled
                 await session.flush()
         except (PostgreSQLIntegrityError, SQLiteIntegrityError):

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -73,7 +73,9 @@ _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
     "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
     "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
     "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
-    "evaluators are stored but not scheduled."
+    "evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation "
+    "delay without using it. The target can change only until evaluation work exists for the "
+    "project evaluator."
 )
 
 
@@ -478,7 +480,8 @@ class CreateProjectLLMEvaluatorInput:
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation."
+            "evaluated only once, and later activity does not schedule another evaluation. "
+            "Non-SESSION targets preserve this value without using it."
         ),
     )
 
@@ -503,7 +506,8 @@ class UpdateProjectLLMEvaluatorInput:
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
             f"or use null to store the current default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            "once, and later activity does not schedule another evaluation. Non-SESSION targets "
+            "preserve this value without using it."
         ),
     )
 
@@ -530,7 +534,8 @@ class AddProjectCodeEvaluatorInput:
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation."
+            "evaluated only once, and later activity does not schedule another evaluation. "
+            "Non-SESSION targets preserve this value without using it."
         ),
     )
 
@@ -562,7 +567,8 @@ class CreateProjectCodeEvaluatorInput:
             "Seconds a SESSION must stay quiet before evaluation is scheduled. The minimum is "
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Omit or use null to store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is "
-            "evaluated only once, and later activity does not schedule another evaluation."
+            "evaluated only once, and later activity does not schedule another evaluation. "
+            "Non-SESSION targets preserve this value without using it."
         ),
     )
 
@@ -594,7 +600,8 @@ class UpdateProjectCodeEvaluatorInput:
             f"{MINIMUM_EVALUATION_DELAY_SECONDS} seconds; omit to preserve the current setting "
             f"or use null to store the current default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            "once, and later activity does not schedule another evaluation. Non-SESSION targets "
+            "preserve this value without using it."
         ),
     )
 

--- a/src/phoenix/server/api/mutations/project_mutations.py
+++ b/src/phoenix/server/api/mutations/project_mutations.py
@@ -9,6 +9,7 @@ from strawberry.types import Info
 
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
+from phoenix.db.helpers import mark_session_content_incomplete
 from phoenix.server.api.auth import IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, Conflict
@@ -93,6 +94,7 @@ class ProjectMutationMixin:
             stmt = delete(models.ProjectSession)
             for i in range(0, len(session_ids_to_delete), chunk_size):
                 chunk = session_ids_to_delete[i : i + chunk_size]
+                await mark_session_content_incomplete(session, chunk)
                 await session.execute(
                     stmt.where(
                         and_(

--- a/src/phoenix/server/api/mutations/project_mutations.py
+++ b/src/phoenix/server/api/mutations/project_mutations.py
@@ -9,7 +9,7 @@ from strawberry.types import Info
 
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
-from phoenix.db.helpers import mark_session_content_incomplete
+from phoenix.db.helpers import delete_traces, mark_session_content_incomplete
 from phoenix.server.api.auth import IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, Conflict
@@ -77,23 +77,28 @@ class ProjectMutationMixin:
         project_id = from_global_id_with_expected_type(
             global_id=input.id, expected_type_name="Project"
         )
-        delete_statement = (
-            delete(models.Trace)
-            .where(models.Trace.project_rowid == project_id)
-            .returning(models.Trace.project_session_rowid)
-        )
+        trace_filter = models.Trace.project_rowid == project_id
         if input.end_time:
-            delete_statement = delete_statement.where(models.Trace.start_time < input.end_time)
+            trace_filter = and_(trace_filter, models.Trace.start_time < input.end_time)
         async with info.context.db() as session:
-            deleted_trace_project_session_ids = await session.scalars(delete_statement)
             session_ids_to_delete = [
-                id_ for id_ in set(deleted_trace_project_session_ids) if id_ is not None
+                id_
+                for id_ in await session.scalars(
+                    select(models.Trace.project_session_rowid)
+                    .where(trace_filter, models.Trace.project_session_rowid.is_not(None))
+                    .distinct()
+                )
+                if id_ is not None
             ]
+            await delete_traces(session, trace_filter)
             # Process deletions in chunks of 10000 to avoid PostgreSQL argument limit
             chunk_size = 10000
             stmt = delete(models.ProjectSession)
             for i in range(0, len(session_ids_to_delete), chunk_size):
                 chunk = session_ids_to_delete[i : i + chunk_size]
+                # Belt and braces: delete_traces already stood these sessions down, and
+                # the CASCADE on EvalSessionWorkUnit.project_session_rowid removes their
+                # work rows with the session anyway.
                 await mark_session_content_incomplete(session, chunk)
                 await session.execute(
                     stmt.where(

--- a/src/phoenix/server/api/mutations/trace_mutations.py
+++ b/src/phoenix/server/api/mutations/trace_mutations.py
@@ -1,12 +1,11 @@
 import strawberry
 from sqlalchemy import and_, delete, not_, select, update
-from sqlalchemy.orm import load_only
 from sqlalchemy.sql import literal
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
 from phoenix.db import models
-from phoenix.db.helpers import mark_session_content_incomplete
+from phoenix.db.helpers import delete_traces
 from phoenix.server.api.auth import IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest
@@ -35,29 +34,20 @@ class TraceMutationMixin:
             raise BadRequest(str(error))
         async with info.context.db() as session:
             traces = (
-                await session.scalars(
-                    delete(models.Trace)
-                    .where(models.Trace.id.in_(trace_rowids))
-                    .returning(models.Trace)
-                    .options(
-                        load_only(models.Trace.project_rowid, models.Trace.project_session_rowid)
+                await session.execute(
+                    select(models.Trace.project_rowid, models.Trace.project_session_rowid).where(
+                        models.Trace.id.in_(trace_rowids)
                     )
                 )
             ).all()
             if len(traces) < len(trace_rowids):
-                await session.rollback()
                 raise BadRequest("Invalid trace IDs provided")
-            project_ids = tuple(set(trace.project_rowid for trace in traces))
+            project_ids = tuple(set(project_rowid for project_rowid, _ in traces))
             if len(project_ids) > 1:
-                await session.rollback()
                 raise BadRequest("Cannot delete traces from multiple projects")
-            session_ids = set(
-                session_id
-                for trace in traces
-                if (session_id := trace.project_session_rowid) is not None
-            )
+            session_ids = set(session_id for _, session_id in traces if session_id is not None)
+            await delete_traces(session, models.Trace.id.in_(trace_rowids))
             if session_ids:
-                await mark_session_content_incomplete(session, session_ids)
                 await session.execute(
                     delete(models.ProjectSession).where(
                         and_(

--- a/src/phoenix/server/api/mutations/trace_mutations.py
+++ b/src/phoenix/server/api/mutations/trace_mutations.py
@@ -6,6 +6,7 @@ from strawberry.relay import GlobalID
 from strawberry.types import Info
 
 from phoenix.db import models
+from phoenix.db.helpers import mark_session_content_incomplete
 from phoenix.server.api.auth import IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest
@@ -56,6 +57,7 @@ class TraceMutationMixin:
                 if (session_id := trace.project_session_rowid) is not None
             )
             if session_ids:
+                await mark_session_content_incomplete(session, session_ids)
                 await session.execute(
                     delete(models.ProjectSession).where(
                         and_(

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -19,7 +19,11 @@ from strawberry.relay import GlobalID
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.datetime_utils import is_timezone_aware, normalize_datetime
 from phoenix.db import models
-from phoenix.db.helpers import SupportedSQLDialect, get_ancestor_span_rowids
+from phoenix.db.helpers import (
+    SupportedSQLDialect,
+    get_ancestor_span_rowids,
+    mark_session_content_incomplete,
+)
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.utils import df_to_bytes
@@ -1570,6 +1574,16 @@ async def delete_span(
                 status_code=404,
                 detail=error_detail,
             )
+
+        # Removing a span changes what the session contains, whether or not the trace
+        # survives it, so the session's evaluations stand down either way.
+        project_session_rowid = await session.scalar(
+            select(models.Trace.project_session_rowid).where(
+                models.Trace.id == target_span.trace_rowid
+            )
+        )
+        if project_session_rowid is not None:
+            await mark_session_content_incomplete(session, [project_session_rowid])
 
         # Store values needed for later operations
         trace_rowid = target_span.trace_rowid

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -21,8 +21,8 @@ from phoenix.datetime_utils import is_timezone_aware, normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import (
     SupportedSQLDialect,
+    delete_spans,
     get_ancestor_span_rowids,
-    mark_session_content_incomplete,
 )
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
 from phoenix.server.api.helpers.annotations import get_note_identifier
@@ -1564,10 +1564,7 @@ async def delete_span(
             predicate = models.Span.span_id == span_identifier
             error_detail = f"Span with span_id '{span_identifier}' not found"
 
-        # Delete the span and return its data in one operation
-        target_span = await session.scalar(
-            sa.delete(models.Span).where(predicate).returning(models.Span)
-        )
+        target_span = await session.scalar(select(models.Span).where(predicate))
 
         if target_span is None:
             raise HTTPException(
@@ -1575,15 +1572,7 @@ async def delete_span(
                 detail=error_detail,
             )
 
-        # Removing a span changes what the session contains, whether or not the trace
-        # survives it, so the session's evaluations stand down either way.
-        project_session_rowid = await session.scalar(
-            select(models.Trace.project_session_rowid).where(
-                models.Trace.id == target_span.trace_rowid
-            )
-        )
-        if project_session_rowid is not None:
-            await mark_session_content_incomplete(session, [project_session_rowid])
+        await delete_spans(session, models.Span.id == target_span.id)
 
         # Store values needed for later operations
         trace_rowid = target_span.trace_rowid

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -20,7 +20,11 @@ from strawberry.relay import GlobalID
 
 from phoenix.datetime_utils import normalize_datetime
 from phoenix.db import models
-from phoenix.db.helpers import SupportedSQLDialect, token_counts_by_trace
+from phoenix.db.helpers import (
+    SupportedSQLDialect,
+    mark_session_content_incomplete,
+    token_counts_by_trace,
+)
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.v1.annotations import TraceAnnotationData
@@ -623,7 +627,7 @@ async def delete_trace(
             delete_stmt = (
                 delete(models.Trace)
                 .where(models.Trace.id == trace_rowid)
-                .returning(models.Trace.project_rowid)
+                .returning(models.Trace.project_rowid, models.Trace.project_session_rowid)
             )
             error_detail = f"Trace with relay ID '{trace_identifier}' not found"
         except Exception:
@@ -631,17 +635,21 @@ async def delete_trace(
             delete_stmt = (
                 delete(models.Trace)
                 .where(models.Trace.trace_id == trace_identifier)
-                .returning(models.Trace.project_rowid)
+                .returning(models.Trace.project_rowid, models.Trace.project_session_rowid)
             )
             error_detail = f"Trace with trace_id '{trace_identifier}' not found"
 
-        project_id = await session.scalar(delete_stmt)
+        deleted = (await session.execute(delete_stmt)).first()
 
-        if project_id is None:
+        if deleted is None:
             raise HTTPException(
                 status_code=404,
                 detail=error_detail,
             )
+
+        project_id, project_session_rowid = deleted
+        if project_session_rowid is not None:
+            await mark_session_content_incomplete(session, [project_session_rowid])
 
     # Trigger cache invalidation event
     request.state.event_queue.put(SpanDeleteEvent((project_id,)))

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -11,7 +11,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceResponse,
 )
 from pydantic import BeforeValidator, Field
-from sqlalchemy import delete, insert, or_, select
+from sqlalchemy import insert, or_, select
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import State
 from starlette.requests import Request
@@ -22,7 +22,7 @@ from phoenix.datetime_utils import normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import (
     SupportedSQLDialect,
-    mark_session_content_incomplete,
+    delete_traces,
     token_counts_by_trace,
 )
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
@@ -623,33 +623,23 @@ async def delete_trace(
                 GlobalID.from_id(trace_identifier),
                 "Trace",
             )
-            # Delete by database rowid
-            delete_stmt = (
-                delete(models.Trace)
-                .where(models.Trace.id == trace_rowid)
-                .returning(models.Trace.project_rowid, models.Trace.project_session_rowid)
-            )
+            # Address by database rowid
+            trace_filter = models.Trace.id == trace_rowid
             error_detail = f"Trace with relay ID '{trace_identifier}' not found"
         except Exception:
-            # Delete by OpenTelemetry trace_id
-            delete_stmt = (
-                delete(models.Trace)
-                .where(models.Trace.trace_id == trace_identifier)
-                .returning(models.Trace.project_rowid, models.Trace.project_session_rowid)
-            )
+            # Address by OpenTelemetry trace_id
+            trace_filter = models.Trace.trace_id == trace_identifier
             error_detail = f"Trace with trace_id '{trace_identifier}' not found"
 
-        deleted = (await session.execute(delete_stmt)).first()
+        project_id = await session.scalar(select(models.Trace.project_rowid).where(trace_filter))
 
-        if deleted is None:
+        if project_id is None:
             raise HTTPException(
                 status_code=404,
                 detail=error_detail,
             )
 
-        project_id, project_session_rowid = deleted
-        if project_session_rowid is not None:
-            await mark_session_content_incomplete(session, [project_session_rowid])
+        await delete_traces(session, trace_filter)
 
     # Trigger cache invalidation event
     request.state.event_queue.put(SpanDeleteEvent((project_id,)))

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -36,6 +36,9 @@ from phoenix.server.api.types.pagination import (
     connection_from_list,
 )
 from phoenix.server.api.types.SandboxConfig import Language
+from phoenix.server.online_eval.session_policy import (
+    DEFAULT_SESSION_EVALUATION_DELAY_SECONDS,
+)
 
 if TYPE_CHECKING:
     from .Dataset import Dataset
@@ -1130,13 +1133,23 @@ class ProjectEvaluator(Node):
 
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
-            "SPAN is currently executable; TRACE and SESSION are "
-            "stored but remain inactive until their runtimes are available."
+            "SPAN evaluators run on matching spans; unfiltered SESSION "
+            "evaluators with full sampling run after their evaluation delay. TRACE evaluators "
+            "are stored but not scheduled."
         )
     )
     async def evaluation_target(self, info: Info[Context, None]) -> EvaluationTarget:
         record = await self._get_record(info)
         return EvaluationTarget(record.evaluation_target)
+
+    @strawberry.field(  # type: ignore[untyped-decorator]
+        description=(
+            "Seconds of inactivity before a SESSION evaluation. Null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds."
+        )
+    )
+    async def evaluation_delay_seconds(self, info: Info[Context, None]) -> Optional[int]:
+        return (await self._get_record(info)).evaluation_delay_seconds
 
     @strawberry.field
     async def input_mapping(self, info: Info[Context, None]) -> EvaluatorInputMapping:

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -38,6 +38,7 @@ from phoenix.server.api.types.pagination import (
 from phoenix.server.api.types.SandboxConfig import Language
 from phoenix.server.online_eval.session_policy import (
     DEFAULT_SESSION_EVALUATION_DELAY_SECONDS,
+    MINIMUM_EVALUATION_DELAY_SECONDS,
 )
 
 if TYPE_CHECKING:
@@ -48,6 +49,14 @@ if TYPE_CHECKING:
     from .PromptVersionTag import PromptVersionTag
     from .SandboxConfig import SandboxConfig
     from .User import User
+
+_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
+    "Evaluation grain. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators "
+    "with full sampling are evaluated once: work is scheduled after the session first stays "
+    "quiet for the evaluation delay, and execution begins when a consumer claims it. Later "
+    "activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and "
+    "TRACE evaluators are stored but not yet scheduled."
+)
 
 
 @strawberry.enum
@@ -1132,11 +1141,7 @@ class ProjectEvaluator(Node):
         return (await self._get_record(info)).sampling_rate
 
     @strawberry.field(  # type: ignore[untyped-decorator]
-        description=(
-            "SPAN evaluators run on matching spans; unfiltered SESSION "
-            "evaluators with full sampling run after their evaluation delay. TRACE evaluators "
-            "are stored but not scheduled."
-        )
+        description=_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION
     )
     async def evaluation_target(self, info: Info[Context, None]) -> EvaluationTarget:
         record = await self._get_record(info)
@@ -1144,8 +1149,10 @@ class ProjectEvaluator(Node):
 
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
-            "Seconds of inactivity before a SESSION evaluation. Null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds."
+            "Seconds a SESSION must stay quiet before work is scheduled. Values must be at "
+            f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         )
     )
     async def evaluation_delay_seconds(self, info: Info[Context, None]) -> Optional[int]:

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -51,11 +51,11 @@ if TYPE_CHECKING:
     from .User import User
 
 _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
-    "Evaluation grain. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators "
-    "with full sampling are evaluated once: work is scheduled after the session first stays "
-    "quiet for the evaluation delay, and execution begins when a consumer claims it. Later "
-    "activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and "
-    "TRACE evaluators are stored but not yet scheduled."
+    "SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling "
+    "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
+    "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
+    "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
+    "evaluators are stored but not scheduled."
 )
 
 
@@ -1149,7 +1149,7 @@ class ProjectEvaluator(Node):
 
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. Values must be at "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at "
             f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Null uses the default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
             "once, and later activity does not schedule another evaluation."

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -56,7 +56,9 @@ _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
     "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
     "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
     "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
-    "evaluators are stored but not scheduled."
+    "evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation "
+    "delay without using it. The target can change only until evaluation work exists for the "
+    "project evaluator."
 )
 
 
@@ -72,6 +74,48 @@ class EvaluationTarget(Enum):
     SPAN = "SPAN"
     TRACE = "TRACE"
     SESSION = "SESSION"
+
+
+@strawberry.enum
+class ProjectEvaluatorSchedulabilityStatus(Enum):
+    SCHEDULABLE = "SCHEDULABLE"
+    NOT_SCHEDULABLE = "NOT_SCHEDULABLE"
+
+
+@strawberry.enum
+class ProjectEvaluatorSchedulabilityReason(Enum):
+    DISABLED = "DISABLED"
+    TRACE_TARGET_UNSUPPORTED = "TRACE_TARGET_UNSUPPORTED"
+    SESSION_FILTER_UNSUPPORTED = "SESSION_FILTER_UNSUPPORTED"
+    SESSION_SAMPLING_UNSUPPORTED = "SESSION_SAMPLING_UNSUPPORTED"
+
+
+def _project_evaluator_schedulability(
+    record: models.ProjectEvaluatorCriteria,
+) -> tuple[ProjectEvaluatorSchedulabilityStatus, Optional[ProjectEvaluatorSchedulabilityReason]]:
+    if not record.enabled:
+        return (
+            ProjectEvaluatorSchedulabilityStatus.NOT_SCHEDULABLE,
+            ProjectEvaluatorSchedulabilityReason.DISABLED,
+        )
+    if record.evaluation_target == "SPAN":
+        return ProjectEvaluatorSchedulabilityStatus.SCHEDULABLE, None
+    if record.evaluation_target == "TRACE":
+        return (
+            ProjectEvaluatorSchedulabilityStatus.NOT_SCHEDULABLE,
+            ProjectEvaluatorSchedulabilityReason.TRACE_TARGET_UNSUPPORTED,
+        )
+    if record.filter_condition:
+        return (
+            ProjectEvaluatorSchedulabilityStatus.NOT_SCHEDULABLE,
+            ProjectEvaluatorSchedulabilityReason.SESSION_FILTER_UNSUPPORTED,
+        )
+    if record.sampling_rate != 1.0:
+        return (
+            ProjectEvaluatorSchedulabilityStatus.NOT_SCHEDULABLE,
+            ProjectEvaluatorSchedulabilityReason.SESSION_SAMPLING_UNSUPPORTED,
+        )
+    return ProjectEvaluatorSchedulabilityStatus.SCHEDULABLE, None
 
 
 @strawberry.type
@@ -1153,13 +1197,38 @@ class ProjectEvaluator(Node):
         record = await self._get_record(info)
         return EvaluationTarget(record.evaluation_target)
 
+    @strawberry.field(
+        description="Whether this project evaluator is currently eligible for scheduling."
+    )
+    async def schedulability_status(
+        self,
+        info: Info[Context, None],
+    ) -> ProjectEvaluatorSchedulabilityStatus:
+        status, _ = _project_evaluator_schedulability(await self._get_record(info))
+        return status
+
+    @strawberry.field(
+        description=(
+            "Machine-readable reason the project evaluator is not schedulable, or null when "
+            "it is schedulable."
+        )
+    )
+    async def schedulability_reason(
+        self,
+        info: Info[Context, None],
+    ) -> Optional[ProjectEvaluatorSchedulabilityReason]:
+        _, reason = _project_evaluator_schedulability(await self._get_record(info))
+        return reason
+
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at "
             f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. New criteria store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds when no value is "
             "provided. A session is evaluated only once, and later activity does not schedule "
-            "another evaluation."
+            "another evaluation. Non-SESSION targets preserve this value without using it. A "
+            "later change to SESSION uses the stored value, but the target cannot change after "
+            "evaluation work exists for this project evaluator."
         )
     )
     async def evaluation_delay_seconds(self, info: Info[Context, None]) -> int:

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -52,11 +52,11 @@ if TYPE_CHECKING:
     from .User import User
 
 _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
-    "Evaluation grain. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators "
-    "with full sampling are evaluated once: work is scheduled after the session first stays "
-    "quiet for the evaluation delay, and execution begins when a consumer claims it. Later "
-    "activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and "
-    "TRACE evaluators are stored but not yet scheduled."
+    "SPAN evaluators run on matching spans. SESSION evaluators with no filter and a sampling "
+    "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
+    "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
+    "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
+    "evaluators are stored but not scheduled."
 )
 
 
@@ -1155,7 +1155,7 @@ class ProjectEvaluator(Node):
 
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
-            "Seconds a SESSION must stay quiet before work is scheduled. Values must be at "
+            "Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at "
             f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Null uses the default of "
             f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
             "once, and later activity does not schedule another evaluation."

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -37,6 +37,9 @@ from phoenix.server.api.types.pagination import (
     connection_from_list,
 )
 from phoenix.server.api.types.SandboxConfig import Language
+from phoenix.server.online_eval.session_policy import (
+    DEFAULT_SESSION_EVALUATION_DELAY_SECONDS,
+)
 
 if TYPE_CHECKING:
     from .Dataset import Dataset
@@ -1136,13 +1139,23 @@ class ProjectEvaluator(Node):
 
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
-            "SPAN is currently executable; TRACE and SESSION are "
-            "stored but remain inactive until their runtimes are available."
+            "SPAN evaluators run on matching spans; unfiltered SESSION "
+            "evaluators with full sampling run after their evaluation delay. TRACE evaluators "
+            "are stored but not scheduled."
         )
     )
     async def evaluation_target(self, info: Info[Context, None]) -> EvaluationTarget:
         record = await self._get_record(info)
         return EvaluationTarget(record.evaluation_target)
+
+    @strawberry.field(  # type: ignore[untyped-decorator]
+        description=(
+            "Seconds of inactivity before a SESSION evaluation. Null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds."
+        )
+    )
+    async def evaluation_delay_seconds(self, info: Info[Context, None]) -> Optional[int]:
+        return (await self._get_record(info)).evaluation_delay_seconds
 
     @strawberry.field
     async def input_mapping(self, info: Info[Context, None]) -> EvaluatorInputMapping:

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -1197,7 +1197,7 @@ class ProjectEvaluator(Node):
         record = await self._get_record(info)
         return EvaluationTarget(record.evaluation_target)
 
-    @strawberry.field(
+    @strawberry.field(  # type: ignore[untyped-decorator]
         description="Whether this project evaluator is currently eligible for scheduling."
     )
     async def schedulability_status(
@@ -1207,7 +1207,7 @@ class ProjectEvaluator(Node):
         status, _ = _project_evaluator_schedulability(await self._get_record(info))
         return status
 
-    @strawberry.field(
+    @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
             "Machine-readable reason the project evaluator is not schedulable, or null when "
             "it is schedulable."

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -39,6 +39,7 @@ from phoenix.server.api.types.pagination import (
 from phoenix.server.api.types.SandboxConfig import Language
 from phoenix.server.online_eval.session_policy import (
     DEFAULT_SESSION_EVALUATION_DELAY_SECONDS,
+    MINIMUM_EVALUATION_DELAY_SECONDS,
 )
 
 if TYPE_CHECKING:
@@ -49,6 +50,14 @@ if TYPE_CHECKING:
     from .PromptVersionTag import PromptVersionTag
     from .SandboxConfig import SandboxConfig
     from .User import User
+
+_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
+    "Evaluation grain. SPAN evaluators run on matching spans. Unfiltered SESSION evaluators "
+    "with full sampling are evaluated once: work is scheduled after the session first stays "
+    "quiet for the evaluation delay, and execution begins when a consumer claims it. Later "
+    "activity does not schedule another evaluation. Filtered or sampled SESSION evaluators and "
+    "TRACE evaluators are stored but not yet scheduled."
+)
 
 
 @strawberry.enum
@@ -1138,11 +1147,7 @@ class ProjectEvaluator(Node):
         return (await self._get_record(info)).sampling_rate
 
     @strawberry.field(  # type: ignore[untyped-decorator]
-        description=(
-            "SPAN evaluators run on matching spans; unfiltered SESSION "
-            "evaluators with full sampling run after their evaluation delay. TRACE evaluators "
-            "are stored but not scheduled."
-        )
+        description=_PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION
     )
     async def evaluation_target(self, info: Info[Context, None]) -> EvaluationTarget:
         record = await self._get_record(info)
@@ -1150,8 +1155,10 @@ class ProjectEvaluator(Node):
 
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
-            "Seconds of inactivity before a SESSION evaluation. Null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds."
+            "Seconds a SESSION must stay quiet before work is scheduled. Values must be at "
+            f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Null uses the default of "
+            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
+            "once, and later activity does not schedule another evaluation."
         )
     )
     async def evaluation_delay_seconds(self, info: Info[Context, None]) -> Optional[int]:

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -1156,12 +1156,13 @@ class ProjectEvaluator(Node):
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at "
-            f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. New criteria store the current "
+            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds when no value is "
+            "provided. A session is evaluated only once, and later activity does not schedule "
+            "another evaluation."
         )
     )
-    async def evaluation_delay_seconds(self, info: Info[Context, None]) -> Optional[int]:
+    async def evaluation_delay_seconds(self, info: Info[Context, None]) -> int:
         return (await self._get_record(info)).evaluation_delay_seconds
 
     @strawberry.field

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -1150,12 +1150,13 @@ class ProjectEvaluator(Node):
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at "
-            f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. Null uses the default of "
-            f"{DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds. A session is evaluated only "
-            "once, and later activity does not schedule another evaluation."
+            f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. New criteria store the current "
+            f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds when no value is "
+            "provided. A session is evaluated only once, and later activity does not schedule "
+            "another evaluation."
         )
     )
-    async def evaluation_delay_seconds(self, info: Info[Context, None]) -> Optional[int]:
+    async def evaluation_delay_seconds(self, info: Info[Context, None]) -> int:
         return (await self._get_record(info)).evaluation_delay_seconds
 
     @strawberry.field

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -1191,7 +1191,7 @@ class ProjectEvaluator(Node):
         record = await self._get_record(info)
         return EvaluationTarget(record.evaluation_target)
 
-    @strawberry.field(
+    @strawberry.field(  # type: ignore[untyped-decorator]
         description="Whether this project evaluator is currently eligible for scheduling."
     )
     async def schedulability_status(
@@ -1201,7 +1201,7 @@ class ProjectEvaluator(Node):
         status, _ = _project_evaluator_schedulability(await self._get_record(info))
         return status
 
-    @strawberry.field(
+    @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
             "Machine-readable reason the project evaluator is not schedulable, or null when "
             "it is schedulable."

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -55,7 +55,9 @@ _PROJECT_EVALUATOR_SCHEDULING_DESCRIPTION = (
     "rate of 1 are evaluated once per session: evaluation is scheduled after the session "
     "first stays quiet for the evaluation delay, then runs asynchronously. Later activity "
     "does not schedule another evaluation. Filtered or sampled SESSION evaluators and TRACE "
-    "evaluators are stored but not scheduled."
+    "evaluators are stored but not scheduled. Non-SESSION targets preserve the evaluation "
+    "delay without using it. The target can change only until evaluation work exists for the "
+    "project evaluator."
 )
 
 
@@ -71,6 +73,48 @@ class EvaluationTarget(Enum):
     SPAN = "SPAN"
     TRACE = "TRACE"
     SESSION = "SESSION"
+
+
+@strawberry.enum
+class ProjectEvaluatorSchedulabilityStatus(Enum):
+    SCHEDULABLE = "SCHEDULABLE"
+    NOT_SCHEDULABLE = "NOT_SCHEDULABLE"
+
+
+@strawberry.enum
+class ProjectEvaluatorSchedulabilityReason(Enum):
+    DISABLED = "DISABLED"
+    TRACE_TARGET_UNSUPPORTED = "TRACE_TARGET_UNSUPPORTED"
+    SESSION_FILTER_UNSUPPORTED = "SESSION_FILTER_UNSUPPORTED"
+    SESSION_SAMPLING_UNSUPPORTED = "SESSION_SAMPLING_UNSUPPORTED"
+
+
+def _project_evaluator_schedulability(
+    record: models.ProjectEvaluatorCriteria,
+) -> tuple[ProjectEvaluatorSchedulabilityStatus, Optional[ProjectEvaluatorSchedulabilityReason]]:
+    if not record.enabled:
+        return (
+            ProjectEvaluatorSchedulabilityStatus.NOT_SCHEDULABLE,
+            ProjectEvaluatorSchedulabilityReason.DISABLED,
+        )
+    if record.evaluation_target == "SPAN":
+        return ProjectEvaluatorSchedulabilityStatus.SCHEDULABLE, None
+    if record.evaluation_target == "TRACE":
+        return (
+            ProjectEvaluatorSchedulabilityStatus.NOT_SCHEDULABLE,
+            ProjectEvaluatorSchedulabilityReason.TRACE_TARGET_UNSUPPORTED,
+        )
+    if record.filter_condition:
+        return (
+            ProjectEvaluatorSchedulabilityStatus.NOT_SCHEDULABLE,
+            ProjectEvaluatorSchedulabilityReason.SESSION_FILTER_UNSUPPORTED,
+        )
+    if record.sampling_rate != 1.0:
+        return (
+            ProjectEvaluatorSchedulabilityStatus.NOT_SCHEDULABLE,
+            ProjectEvaluatorSchedulabilityReason.SESSION_SAMPLING_UNSUPPORTED,
+        )
+    return ProjectEvaluatorSchedulabilityStatus.SCHEDULABLE, None
 
 
 @strawberry.type
@@ -1147,13 +1191,38 @@ class ProjectEvaluator(Node):
         record = await self._get_record(info)
         return EvaluationTarget(record.evaluation_target)
 
+    @strawberry.field(
+        description="Whether this project evaluator is currently eligible for scheduling."
+    )
+    async def schedulability_status(
+        self,
+        info: Info[Context, None],
+    ) -> ProjectEvaluatorSchedulabilityStatus:
+        status, _ = _project_evaluator_schedulability(await self._get_record(info))
+        return status
+
+    @strawberry.field(
+        description=(
+            "Machine-readable reason the project evaluator is not schedulable, or null when "
+            "it is schedulable."
+        )
+    )
+    async def schedulability_reason(
+        self,
+        info: Info[Context, None],
+    ) -> Optional[ProjectEvaluatorSchedulabilityReason]:
+        _, reason = _project_evaluator_schedulability(await self._get_record(info))
+        return reason
+
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
             "Seconds a SESSION must stay quiet before evaluation is scheduled. Values must be at "
             f"least {MINIMUM_EVALUATION_DELAY_SECONDS} seconds. New criteria store the current "
             f"default of {DEFAULT_SESSION_EVALUATION_DELAY_SECONDS} seconds when no value is "
             "provided. A session is evaluated only once, and later activity does not schedule "
-            "another evaluation."
+            "another evaluation. Non-SESSION targets preserve this value without using it. A "
+            "later change to SESSION uses the stored value, but the target cannot change after "
+            "evaluation work exists for this project evaluator."
         )
     )
     async def evaluation_delay_seconds(self, info: Info[Context, None]) -> int:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -84,6 +84,7 @@ from phoenix.config import (
     get_env_online_eval_enabled,
     get_env_online_eval_max_outstanding,
     get_env_online_eval_pending_ttl_seconds,
+    get_env_online_eval_session_sweep_enabled,
     get_env_phoenix_agents_disable_bash,
     get_env_port,
     get_env_support_email,
@@ -1109,7 +1110,8 @@ def create_app(
             tick_interval_seconds=tick_interval_seconds,
             claim_batch_size=claim_batch_size,
         )
-        online_eval_session_sweeper = SessionEvalSweeper(db)
+        if get_env_online_eval_session_sweep_enabled():
+            online_eval_session_sweeper = SessionEvalSweeper(db)
     graphql_schema = build_graphql_schema(graphql_schema_extensions)
     graphql_router = create_graphql_router(
         db=db,

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -147,6 +147,7 @@ from phoenix.server.oauth2 import OAuth2Clients
 from phoenix.server.oauth2_authorization_server import public_origin
 from phoenix.server.online_eval.consumer import OnlineEvalConsumer
 from phoenix.server.online_eval.producer import OnlineEvalProducer
+from phoenix.server.online_eval.session_sweeper import SessionEvalSweeper
 from phoenix.server.prometheus import SPAN_QUEUE_REJECTIONS
 from phoenix.server.redaction import Redactor, current_redactor
 from phoenix.server.retention import TraceDataSweeper
@@ -643,6 +644,7 @@ def _lifespan(
     sandbox_runtime: SandboxRuntimeContext,
     online_eval_producer: Optional[OnlineEvalProducer] = None,
     online_eval_consumer: Optional[OnlineEvalConsumer] = None,
+    online_eval_session_sweeper: Optional[SessionEvalSweeper] = None,
     token_store: Optional[TokenStore] = None,
     tracer_provider: Optional["TracerProvider"] = None,
     enable_prometheus: bool = False,
@@ -709,6 +711,8 @@ def _lifespan(
                 await stack.enter_async_context(online_eval_consumer)
             if online_eval_producer is not None:
                 await stack.enter_async_context(online_eval_producer)
+            if online_eval_session_sweeper is not None:
+                await stack.enter_async_context(online_eval_session_sweeper)
             if docs_mcp_server is not None:
                 # The docs MCP server connects to an external host during
                 # startup. Never let its initialization (which can hang until a
@@ -1073,6 +1077,7 @@ def create_app(
     )
     online_eval_producer: Optional[OnlineEvalProducer] = None
     online_eval_consumer: Optional[OnlineEvalConsumer] = None
+    online_eval_session_sweeper: Optional[SessionEvalSweeper] = None
     if get_env_online_eval_enabled() and not read_only:
         claim_batch_size = get_env_online_eval_claim_batch_size()
         tick_interval_seconds = get_env_online_eval_consumer_tick_interval_seconds()
@@ -1104,6 +1109,7 @@ def create_app(
             tick_interval_seconds=tick_interval_seconds,
             claim_batch_size=claim_batch_size,
         )
+        online_eval_session_sweeper = SessionEvalSweeper(db)
     graphql_schema = build_graphql_schema(graphql_schema_extensions)
     graphql_router = create_graphql_router(
         db=db,
@@ -1157,6 +1163,7 @@ def create_app(
             sandbox_runtime=sandbox_runtime,
             online_eval_producer=online_eval_producer,
             online_eval_consumer=online_eval_consumer,
+            online_eval_session_sweeper=online_eval_session_sweeper,
             grpc_interceptors=grpc_interceptors,
             token_store=token_store,
             tracer_provider=tracer_provider,
@@ -1363,6 +1370,7 @@ def create_app(
     app.state.sandbox_runtime = sandbox_runtime
     app.state.online_eval_producer = online_eval_producer
     app.state.online_eval_consumer = online_eval_consumer
+    app.state.online_eval_session_sweeper = online_eval_session_sweeper
     app.state.graphql_schema = graphql_schema
     app.state.build_graphql_context = _get_build_graphql_context_function(
         db=db,

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -140,6 +140,7 @@ from phoenix.server.oauth2 import OAuth2Clients
 from phoenix.server.oauth2_authorization_server import public_origin
 from phoenix.server.online_eval.consumer import OnlineEvalConsumer
 from phoenix.server.online_eval.producer import OnlineEvalProducer
+from phoenix.server.online_eval.session_sweeper import SessionEvalSweeper
 from phoenix.server.prometheus import SPAN_QUEUE_REJECTIONS
 from phoenix.server.redaction import Redactor, current_redactor
 from phoenix.server.retention import TraceDataSweeper
@@ -636,6 +637,7 @@ def _lifespan(
     sandbox_session_manager: SandboxSessionManager,
     online_eval_producer: Optional[OnlineEvalProducer] = None,
     online_eval_consumer: Optional[OnlineEvalConsumer] = None,
+    online_eval_session_sweeper: Optional[SessionEvalSweeper] = None,
     token_store: Optional[TokenStore] = None,
     tracer_provider: Optional["TracerProvider"] = None,
     enable_prometheus: bool = False,
@@ -701,6 +703,8 @@ def _lifespan(
                 await stack.enter_async_context(online_eval_consumer)
             if online_eval_producer is not None:
                 await stack.enter_async_context(online_eval_producer)
+            if online_eval_session_sweeper is not None:
+                await stack.enter_async_context(online_eval_session_sweeper)
             if docs_mcp_server is not None:
                 # The docs MCP server connects to an external host during
                 # startup. Never let its initialization (which can hang until a
@@ -1045,6 +1049,7 @@ def create_app(
     )
     online_eval_producer: Optional[OnlineEvalProducer] = None
     online_eval_consumer: Optional[OnlineEvalConsumer] = None
+    online_eval_session_sweeper: Optional[SessionEvalSweeper] = None
     if get_env_online_eval_enabled() and not read_only:
         claim_batch_size = get_env_online_eval_claim_batch_size()
         tick_interval_seconds = get_env_online_eval_consumer_tick_interval_seconds()
@@ -1076,6 +1081,7 @@ def create_app(
             tick_interval_seconds=tick_interval_seconds,
             claim_batch_size=claim_batch_size,
         )
+        online_eval_session_sweeper = SessionEvalSweeper(db)
     graphql_schema = build_graphql_schema(graphql_schema_extensions)
     graphql_router = create_graphql_router(
         db=db,
@@ -1126,6 +1132,7 @@ def create_app(
             sandbox_session_manager=sandbox_session_manager,
             online_eval_producer=online_eval_producer,
             online_eval_consumer=online_eval_consumer,
+            online_eval_session_sweeper=online_eval_session_sweeper,
             grpc_interceptors=grpc_interceptors,
             token_store=token_store,
             tracer_provider=tracer_provider,
@@ -1322,6 +1329,7 @@ def create_app(
     app.state.sandbox_session_manager = sandbox_session_manager
     app.state.online_eval_producer = online_eval_producer
     app.state.online_eval_consumer = online_eval_consumer
+    app.state.online_eval_session_sweeper = online_eval_session_sweeper
     app.state.graphql_schema = graphql_schema
     app.state.build_graphql_context = _get_build_graphql_context_function(
         db=db,

--- a/src/phoenix/server/online_eval/derivation.py
+++ b/src/phoenix/server/online_eval/derivation.py
@@ -2,7 +2,7 @@
 backstop all compute config fingerprints, annotation identifiers, and sampling keys
 through this module — an independent recipe that drifts from these re-materializes the
 work backlog (fingerprint mismatch) or breaks annotation idempotency (identifier
-mismatch). It also holds the shared work-unit retry budget (``MAX_ATTEMPTS``), which
+mismatch). It also re-exports the shared work-unit retry budget (``MAX_ATTEMPTS``), which
 the producer's reaper/backstop and the consumer's claim predicate must agree on. All
 functions are pure; version resolution and any DB access happen in callers.
 """
@@ -15,14 +15,10 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any
 
+from phoenix.db.eval_work import MAX_ATTEMPTS as MAX_ATTEMPTS
+
 _IDENTIFIER_PREFIX = "online:"
 _IDENTIFIER_FINGERPRINT_CHARS = 16
-
-# Retry budget for a work unit before its ERROR state becomes terminal. The producer
-# excludes attempt-exhausted rows from reaping and backstop re-materialization using
-# this value, and the consumer-side coordinator stops reclaiming ERROR rows at it —
-# the two sides drifting apart either resurrects dead work or strands retryable work.
-MAX_ATTEMPTS = 3
 
 
 @dataclass(frozen=True)

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -48,6 +48,7 @@ from phoenix.server.online_eval.derivation import (
     config_fingerprint,
     sample_key,
 )
+from phoenix.server.online_eval.session_policy import session_criteria_is_schedulable
 from phoenix.server.types import DaemonTask, DbSessionFactory
 from phoenix.trace.dsl.filter import SpanFilter
 

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -48,7 +48,6 @@ from phoenix.server.online_eval.derivation import (
     config_fingerprint,
     sample_key,
 )
-from phoenix.server.online_eval.session_policy import session_criteria_is_schedulable
 from phoenix.server.types import DaemonTask, DbSessionFactory
 from phoenix.trace.dsl.filter import SpanFilter
 

--- a/src/phoenix/server/online_eval/session_policy.py
+++ b/src/phoenix/server/online_eval/session_policy.py
@@ -1,0 +1,11 @@
+from phoenix.db import models
+
+DEFAULT_SESSION_EVALUATION_DELAY_SECONDS = 300
+MINIMUM_EVALUATION_DELAY_SECONDS = 10
+
+
+def effective_session_evaluation_delay_seconds(
+    criteria: models.ProjectEvaluatorCriteria,
+) -> int:
+    delay = criteria.evaluation_delay_seconds
+    return DEFAULT_SESSION_EVALUATION_DELAY_SECONDS if delay is None else delay

--- a/src/phoenix/server/online_eval/session_policy.py
+++ b/src/phoenix/server/online_eval/session_policy.py
@@ -1,11 +1,27 @@
-from phoenix.db import models
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import and_
+from sqlalchemy.sql.elements import ColumnElement
+
+if TYPE_CHECKING:
+    from phoenix.db import models
 
 DEFAULT_SESSION_EVALUATION_DELAY_SECONDS = 300
 MINIMUM_EVALUATION_DELAY_SECONDS = 10
 
 
 def effective_session_evaluation_delay_seconds(
-    criteria: models.ProjectEvaluatorCriteria,
+    delay_seconds: Optional[int],
 ) -> int:
-    delay = criteria.evaluation_delay_seconds
-    return DEFAULT_SESSION_EVALUATION_DELAY_SECONDS if delay is None else delay
+    return DEFAULT_SESSION_EVALUATION_DELAY_SECONDS if delay_seconds is None else delay_seconds
+
+
+def session_criteria_is_schedulable(
+    criteria: type["models.ProjectEvaluatorCriteria"],
+) -> ColumnElement[bool]:
+    return and_(
+        criteria.enabled,
+        criteria.evaluation_target == "SESSION",
+        criteria.filter_condition == "",
+        criteria.sampling_rate == 1.0,
+    )

--- a/src/phoenix/server/online_eval/session_policy.py
+++ b/src/phoenix/server/online_eval/session_policy.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from sqlalchemy import and_
 from sqlalchemy.sql.elements import ColumnElement
@@ -8,12 +8,6 @@ if TYPE_CHECKING:
 
 DEFAULT_SESSION_EVALUATION_DELAY_SECONDS = 300
 MINIMUM_EVALUATION_DELAY_SECONDS = 10
-
-
-def effective_session_evaluation_delay_seconds(
-    delay_seconds: Optional[int],
-) -> int:
-    return DEFAULT_SESSION_EVALUATION_DELAY_SECONDS if delay_seconds is None else delay_seconds
 
 
 def session_criteria_is_schedulable(

--- a/src/phoenix/server/online_eval/session_policy.py
+++ b/src/phoenix/server/online_eval/session_policy.py
@@ -13,6 +13,7 @@ MINIMUM_EVALUATION_DELAY_SECONDS = 10
 def session_criteria_is_schedulable(
     criteria: type["models.ProjectEvaluatorCriteria"],
 ) -> ColumnElement[bool]:
+    # Session filters shipped in #14101 (#14041); #14038 owns sampling integration.
     return and_(
         criteria.enabled,
         criteria.evaluation_target == "SESSION",

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -1,0 +1,282 @@
+"""Materialize session evaluation work after session activity becomes old enough."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from secrets import token_hex
+from typing import Optional
+
+from sqlalchemy import delete, func, or_, select, type_coerce, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import with_polymorphic
+
+from phoenix.db import models
+from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.server.online_eval.derivation import config_fingerprint
+from phoenix.server.online_eval.producer import resolve_criteria
+from phoenix.server.online_eval.session_policy import (
+    effective_session_evaluation_delay_seconds,
+)
+from phoenix.server.types import DaemonTask, DbSessionFactory
+
+logger = logging.getLogger(__name__)
+
+SESSION_SWEEP_LEASE_TTL_SECONDS = 90.0
+SESSION_SWEEP_INTERVAL_SECONDS = 10.0
+
+_CONSUMER_GROUP = "default"
+_GENERATION = 0
+_MAX_ACTIVITY_ROWS_PER_TICK = 1000
+_SESSION_WORK_UNIQUE_BY = (
+    "project_session_rowid",
+    "evaluator_id",
+    "config_fingerprint",
+    "generation",
+)
+
+
+@dataclass(frozen=True)
+class _SessionCriteria:
+    criteria_id: int
+    project_id: int
+    evaluator_id: int
+    fingerprint: Optional[str]
+    delay_seconds: int
+
+
+class SessionEvalSweeper(DaemonTask):
+    """Create pending generation-0 work for eligible project sessions."""
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        consumer_group: str = _CONSUMER_GROUP,
+        tick_interval_seconds: float = SESSION_SWEEP_INTERVAL_SECONDS,
+    ) -> None:
+        super().__init__()
+        self._db = db
+        self._consumer_group = consumer_group
+        self._tick_interval_seconds = tick_interval_seconds
+        self._sweeper_id = f"session-sweeper-{token_hex(8)}"
+        self._lease_held = False
+
+    async def _run(self) -> None:
+        try:
+            while self._running:
+                try:
+                    await self._tick()
+                except Exception:
+                    logger.exception("Session evaluation sweep failed")
+                await asyncio.sleep(self._tick_interval_seconds)
+        finally:
+            await self._release_lease()
+
+    async def _tick(self) -> None:
+        for _ in range(2):
+            async with self._db() as session:
+                database_now = await self._database_now(session)
+                cursor_id = await session.scalar(
+                    update(models.EvalWorkCursor)
+                    .where(
+                        models.EvalWorkCursor.evaluation_target == "SESSION",
+                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        or_(
+                            models.EvalWorkCursor.claimed_by.is_(None),
+                            models.EvalWorkCursor.claimed_by == self._sweeper_id,
+                            models.EvalWorkCursor.claimed_at
+                            < database_now - timedelta(seconds=SESSION_SWEEP_LEASE_TTL_SECONDS),
+                        ),
+                    )
+                    .values(claimed_by=self._sweeper_id, claimed_at=database_now)
+                    .returning(models.EvalWorkCursor.id)
+                )
+                if cursor_id is None:
+                    row_exists = await session.scalar(
+                        select(models.EvalWorkCursor.id).where(
+                            models.EvalWorkCursor.evaluation_target == "SESSION",
+                            models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        )
+                    )
+                    if row_exists is not None:
+                        self._lease_held = False
+                        return
+                    await session.execute(
+                        insert_on_conflict(
+                            {
+                                "evaluation_target": "SESSION",
+                                "consumer_group": self._consumer_group,
+                                "produced_through_id": 0,
+                            },
+                            table=models.EvalWorkCursor,
+                            dialect=self._db.dialect,
+                            unique_by=("evaluation_target", "consumer_group"),
+                            on_conflict=OnConflict.DO_NOTHING,
+                        )
+                    )
+                    continue
+
+                self._lease_held = True
+                await self._sweep(session, database_now)
+                renewed_at = await self._database_now(session)
+                renewed = await session.scalar(
+                    update(models.EvalWorkCursor)
+                    .where(
+                        models.EvalWorkCursor.id == cursor_id,
+                        models.EvalWorkCursor.claimed_by == self._sweeper_id,
+                    )
+                    .values(claimed_at=renewed_at)
+                    .returning(models.EvalWorkCursor.id)
+                )
+                if renewed is None:
+                    await session.rollback()
+                    self._lease_held = False
+                    logger.warning("Session evaluation sweeper lost its lease")
+                return
+
+    async def _database_now(self, session: AsyncSession) -> datetime:
+        database_now = await session.scalar(select(type_coerce(func.now(), models.UtcTimeStamp())))
+        if database_now is None:
+            raise RuntimeError("Database did not return its current time")
+        return database_now
+
+    async def _load_criteria(self, session: AsyncSession) -> list[_SessionCriteria]:
+        polymorphic_evaluator = with_polymorphic(
+            models.Evaluator,
+            [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+        )
+        rows = (
+            await session.execute(
+                select(models.ProjectEvaluatorCriteria, polymorphic_evaluator)
+                .join(
+                    polymorphic_evaluator,
+                    models.ProjectEvaluatorCriteria.evaluator_id == polymorphic_evaluator.id,
+                )
+                .where(
+                    models.ProjectEvaluatorCriteria.enabled,
+                    models.ProjectEvaluatorCriteria.evaluation_target == "SESSION",
+                    models.ProjectEvaluatorCriteria.filter_condition == "",
+                    models.ProjectEvaluatorCriteria.sampling_rate == 1.0,
+                )
+            )
+        ).all()
+        criteria_rows: list[_SessionCriteria] = []
+        for criteria, evaluator in rows:
+            resolved = await resolve_criteria(session, criteria, evaluator)
+            criteria_rows.append(
+                _SessionCriteria(
+                    criteria_id=criteria.id,
+                    project_id=criteria.project_id,
+                    evaluator_id=criteria.evaluator_id,
+                    fingerprint=None if resolved is None else config_fingerprint(resolved),
+                    delay_seconds=effective_session_evaluation_delay_seconds(criteria),
+                )
+            )
+        return criteria_rows
+
+    async def _sweep(self, session: AsyncSession, database_now: datetime) -> None:
+        criteria_by_project: defaultdict[int, list[_SessionCriteria]] = defaultdict(list)
+        for criteria in await self._load_criteria(session):
+            criteria_by_project[criteria.project_id].append(criteria)
+
+        activity_rows = (
+            await session.execute(
+                select(models.EvalSessionActivity, models.ProjectSession.project_id)
+                .join(
+                    models.ProjectSession,
+                    models.EvalSessionActivity.project_session_rowid == models.ProjectSession.id,
+                )
+                .order_by(models.EvalSessionActivity.id)
+                .limit(_MAX_ACTIVITY_ROWS_PER_TICK)
+            )
+        ).all()
+        if not activity_rows:
+            return
+
+        project_session_ids = [activity.project_session_rowid for activity, _ in activity_rows]
+        existing_work_keys = {
+            tuple(row)
+            for row in await session.execute(
+                select(
+                    models.EvalSessionWorkUnit.project_session_rowid,
+                    models.EvalSessionWorkUnit.evaluator_id,
+                    models.EvalSessionWorkUnit.config_fingerprint,
+                    models.EvalSessionWorkUnit.generation,
+                ).where(
+                    models.EvalSessionWorkUnit.project_session_rowid.in_(project_session_ids),
+                    models.EvalSessionWorkUnit.generation == _GENERATION,
+                )
+            )
+        }
+
+        work_records: list[dict[str, object]] = []
+        resolved_activity_ids: list[int] = []
+        for activity, project_id in activity_rows:
+            activity_resolved = True
+            for criteria in criteria_by_project[project_id]:
+                if criteria.fingerprint is None:
+                    activity_resolved = False
+                    continue
+                key = (
+                    activity.project_session_rowid,
+                    criteria.evaluator_id,
+                    criteria.fingerprint,
+                    _GENERATION,
+                )
+                # Reopened sessions are not re-evaluated; the original annotation stands.
+                if key in existing_work_keys:
+                    continue
+                if activity.observed_at > database_now - timedelta(seconds=criteria.delay_seconds):
+                    activity_resolved = False
+                    continue
+                work_records.append(
+                    {
+                        "project_session_rowid": activity.project_session_rowid,
+                        "evaluator_id": criteria.evaluator_id,
+                        "criteria_id": criteria.criteria_id,
+                        "config_fingerprint": criteria.fingerprint,
+                        "generation": _GENERATION,
+                    }
+                )
+                existing_work_keys.add(key)
+            if activity_resolved:
+                resolved_activity_ids.append(activity.id)
+
+        if work_records:
+            await session.execute(
+                insert_on_conflict(
+                    *work_records,
+                    table=models.EvalSessionWorkUnit,
+                    dialect=self._db.dialect,
+                    unique_by=_SESSION_WORK_UNIQUE_BY,
+                    on_conflict=OnConflict.DO_NOTHING,
+                )
+            )
+        if resolved_activity_ids:
+            await session.execute(
+                delete(models.EvalSessionActivity).where(
+                    models.EvalSessionActivity.id.in_(resolved_activity_ids)
+                )
+            )
+
+    async def _release_lease(self) -> None:
+        if not self._lease_held:
+            return
+        self._lease_held = False
+        try:
+            async with self._db() as session:
+                await session.execute(
+                    update(models.EvalWorkCursor)
+                    .where(
+                        models.EvalWorkCursor.evaluation_target == "SESSION",
+                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.claimed_by == self._sweeper_id,
+                    )
+                    .values(claimed_by=None, claimed_at=None)
+                )
+        except Exception:
+            logger.exception("Failed to release session evaluation sweep lease")

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -262,7 +262,6 @@ class SessionEvalSweeper(DaemonTask):
                     criteria.fingerprint,
                     _GENERATION,
                 )
-                # Reopened sessions are not re-evaluated; the original annotation stands.
                 if key in existing_work_keys:
                     continue
                 if activity.observed_at > database_now - timedelta(seconds=criteria.delay_seconds):

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -190,7 +190,7 @@ class SessionEvalSweeper(DaemonTask):
                     models.ProjectSession,
                     models.EvalSessionActivity.project_session_rowid == models.ProjectSession.id,
                 )
-                .order_by(models.EvalSessionActivity.id)
+                .order_by(models.EvalSessionActivity.observed_at)
                 .limit(_MAX_ACTIVITY_ROWS_PER_TICK)
             )
         ).all()

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from secrets import token_hex
 from typing import Optional
 
-from sqlalchemy import delete, func, or_, select, type_coerce, update
+from sqlalchemy import and_, delete, func, or_, select, type_coerce, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_polymorphic
 
@@ -20,6 +20,7 @@ from phoenix.server.online_eval.derivation import config_fingerprint
 from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.online_eval.session_policy import (
     effective_session_evaluation_delay_seconds,
+    session_criteria_is_schedulable,
 )
 from phoenix.server.types import DaemonTask, DbSessionFactory
 
@@ -44,7 +45,7 @@ class _SessionCriteria:
     criteria_id: int
     project_id: int
     evaluator_id: int
-    fingerprint: Optional[str]
+    fingerprint: str
     delay_seconds: int
 
 
@@ -77,6 +78,14 @@ class SessionEvalSweeper(DaemonTask):
             await self._release_lease()
 
     async def _tick(self) -> None:
+        cursor_id = await self._acquire_cursor()
+        if cursor_id is None:
+            return
+        if not await self._materialize_and_renew(cursor_id):
+            self._lease_held = False
+            logger.warning("Session evaluation sweeper lost its lease")
+
+    async def _acquire_cursor(self) -> Optional[int]:
         for _ in range(2):
             async with self._db() as session:
                 database_now = await self._database_now(session)
@@ -95,48 +104,51 @@ class SessionEvalSweeper(DaemonTask):
                     .values(claimed_by=self._sweeper_id, claimed_at=database_now)
                     .returning(models.EvalWorkCursor.id)
                 )
-                if cursor_id is None:
-                    row_exists = await session.scalar(
-                        select(models.EvalWorkCursor.id).where(
-                            models.EvalWorkCursor.evaluation_target == "SESSION",
-                            models.EvalWorkCursor.consumer_group == self._consumer_group,
-                        )
-                    )
-                    if row_exists is not None:
-                        self._lease_held = False
-                        return
-                    await session.execute(
-                        insert_on_conflict(
-                            {
-                                "evaluation_target": "SESSION",
-                                "consumer_group": self._consumer_group,
-                                "produced_through_id": 0,
-                            },
-                            table=models.EvalWorkCursor,
-                            dialect=self._db.dialect,
-                            unique_by=("evaluation_target", "consumer_group"),
-                            on_conflict=OnConflict.DO_NOTHING,
-                        )
-                    )
-                    continue
-
+            if cursor_id is not None:
                 self._lease_held = True
-                await self._sweep(session, database_now)
-                renewed_at = await self._database_now(session)
-                renewed = await session.scalar(
-                    update(models.EvalWorkCursor)
-                    .where(
-                        models.EvalWorkCursor.id == cursor_id,
-                        models.EvalWorkCursor.claimed_by == self._sweeper_id,
+                return cursor_id
+            async with self._db() as session:
+                row_exists = await session.scalar(
+                    select(models.EvalWorkCursor.id).where(
+                        models.EvalWorkCursor.evaluation_target == "SESSION",
+                        models.EvalWorkCursor.consumer_group == self._consumer_group,
                     )
-                    .values(claimed_at=renewed_at)
-                    .returning(models.EvalWorkCursor.id)
                 )
-                if renewed is None:
-                    await session.rollback()
-                    self._lease_held = False
-                    logger.warning("Session evaluation sweeper lost its lease")
-                return
+                if row_exists is not None:
+                    break
+                await session.execute(
+                    insert_on_conflict(
+                        {
+                            "evaluation_target": "SESSION",
+                            "consumer_group": self._consumer_group,
+                            "produced_through_id": 0,
+                        },
+                        table=models.EvalWorkCursor,
+                        dialect=self._db.dialect,
+                        unique_by=("evaluation_target", "consumer_group"),
+                        on_conflict=OnConflict.DO_NOTHING,
+                    )
+                )
+        self._lease_held = False
+        return None
+
+    async def _materialize_and_renew(self, cursor_id: int) -> bool:
+        async with self._db() as session:
+            database_now = await self._database_now(session)
+            await self._sweep(session, database_now)
+            renewed_at = await self._database_now(session)
+            renewed = await session.scalar(
+                update(models.EvalWorkCursor)
+                .where(
+                    models.EvalWorkCursor.id == cursor_id,
+                    models.EvalWorkCursor.claimed_by == self._sweeper_id,
+                )
+                .values(claimed_at=renewed_at)
+                .returning(models.EvalWorkCursor.id)
+            )
+            if renewed is None:
+                await session.rollback()
+        return renewed is not None
 
     async def _database_now(self, session: AsyncSession) -> datetime:
         database_now = await session.scalar(select(type_coerce(func.now(), models.UtcTimeStamp())))
@@ -157,23 +169,28 @@ class SessionEvalSweeper(DaemonTask):
                     models.ProjectEvaluatorCriteria.evaluator_id == polymorphic_evaluator.id,
                 )
                 .where(
-                    models.ProjectEvaluatorCriteria.enabled,
-                    models.ProjectEvaluatorCriteria.evaluation_target == "SESSION",
-                    models.ProjectEvaluatorCriteria.filter_condition == "",
-                    models.ProjectEvaluatorCriteria.sampling_rate == 1.0,
+                    session_criteria_is_schedulable(models.ProjectEvaluatorCriteria),
                 )
             )
         ).all()
         criteria_rows: list[_SessionCriteria] = []
         for criteria, evaluator in rows:
             resolved = await resolve_criteria(session, criteria, evaluator)
+            if resolved is None:
+                logger.warning(
+                    f"Skipping criteria {criteria.id}: "
+                    f"no resolvable version for evaluator {evaluator.id}"
+                )
+                continue
             criteria_rows.append(
                 _SessionCriteria(
                     criteria_id=criteria.id,
                     project_id=criteria.project_id,
                     evaluator_id=criteria.evaluator_id,
-                    fingerprint=None if resolved is None else config_fingerprint(resolved),
-                    delay_seconds=effective_session_evaluation_delay_seconds(criteria),
+                    fingerprint=config_fingerprint(resolved),
+                    delay_seconds=effective_session_evaluation_delay_seconds(
+                        criteria.evaluation_delay_seconds
+                    ),
                 )
             )
         return criteria_rows
@@ -183,15 +200,36 @@ class SessionEvalSweeper(DaemonTask):
         for criteria in await self._load_criteria(session):
             criteria_by_project[criteria.project_id].append(criteria)
 
+        activity_stmt = select(
+            models.EvalSessionActivity,
+            models.ProjectSession.project_id,
+        ).join(
+            models.ProjectSession,
+            models.EvalSessionActivity.project_session_rowid == models.ProjectSession.id,
+        )
+        if criteria_by_project:
+            due_for_project = [
+                and_(
+                    models.ProjectSession.project_id == project_id,
+                    models.EvalSessionActivity.observed_at
+                    <= database_now
+                    - timedelta(
+                        seconds=min(criteria.delay_seconds for criteria in project_criteria)
+                    ),
+                )
+                for project_id, project_criteria in criteria_by_project.items()
+            ]
+            activity_stmt = activity_stmt.where(
+                or_(
+                    models.ProjectSession.project_id.not_in(criteria_by_project),
+                    *due_for_project,
+                )
+            )
         activity_rows = (
             await session.execute(
-                select(models.EvalSessionActivity, models.ProjectSession.project_id)
-                .join(
-                    models.ProjectSession,
-                    models.EvalSessionActivity.project_session_rowid == models.ProjectSession.id,
+                activity_stmt.order_by(models.EvalSessionActivity.observed_at).limit(
+                    _MAX_ACTIVITY_ROWS_PER_TICK
                 )
-                .order_by(models.EvalSessionActivity.observed_at)
-                .limit(_MAX_ACTIVITY_ROWS_PER_TICK)
             )
         ).all()
         if not activity_rows:
@@ -218,9 +256,6 @@ class SessionEvalSweeper(DaemonTask):
         for activity, project_id in activity_rows:
             activity_resolved = True
             for criteria in criteria_by_project[project_id]:
-                if criteria.fingerprint is None:
-                    activity_resolved = False
-                    continue
                 key = (
                     activity.project_session_rowid,
                     criteria.evaluator_id,

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -401,7 +401,12 @@ class SessionEvalSweeper(DaemonTask):
         return renewed is not None
 
     async def _database_now(self, session: AsyncSession) -> datetime:
-        database_now = await session.scalar(select(type_coerce(func.now(), models.UtcTimeStamp())))
+        clock = (
+            func.statement_timestamp()
+            if self._db.dialect is SupportedSQLDialect.POSTGRESQL
+            else func.now()
+        )
+        database_now = await session.scalar(select(type_coerce(clock, models.UtcTimeStamp())))
         if database_now is None:
             raise RuntimeError("Database did not return its current time")
         return database_now

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -87,9 +87,13 @@ class _SessionCriteria:
     evaluator_id: int
     fingerprint: str
     delay_seconds: int
+    created_at: datetime
 
 
-def _criteria_relation(criteria: Sequence[_SessionCriteria]) -> Subquery:
+def _criteria_relation(
+    criteria: Sequence[_SessionCriteria],
+    dialect: SupportedSQLDialect,
+) -> Subquery:
     """Return a portable inline relation for resolved session criteria."""
     rows = []
     parameters: dict[str, Any] = {}
@@ -100,16 +104,23 @@ def _criteria_relation(criteria: Sequence[_SessionCriteria]) -> Subquery:
             f"sc{index}_evaluator_id": criterion.evaluator_id,
             f"sc{index}_config_fingerprint": criterion.fingerprint,
             f"sc{index}_delay_seconds": criterion.delay_seconds,
+            f"sc{index}_created_at": criterion.created_at,
         }
         parameters.update(row_parameters)
         placeholders = [f":{name}" for name in row_parameters]
         if index == 0:
+            created_at_type = (
+                "TIMESTAMP WITH TIME ZONE"
+                if dialect is SupportedSQLDialect.POSTGRESQL
+                else "TEXT"
+            )
             placeholders = [
                 f"CAST({placeholders[0]} AS INTEGER)",
                 f"CAST({placeholders[1]} AS INTEGER)",
                 f"CAST({placeholders[2]} AS INTEGER)",
                 f"CAST({placeholders[3]} AS VARCHAR)",
                 f"CAST({placeholders[4]} AS INTEGER)",
+                f"CAST({placeholders[5]} AS {created_at_type})",
             ]
         rows.append(f"({', '.join(placeholders)})")
     statement = text(
@@ -118,7 +129,8 @@ def _criteria_relation(criteria: Sequence[_SessionCriteria]) -> Subquery:
         "sc.column2 AS project_id, "
         "sc.column3 AS evaluator_id, "
         "sc.column4 AS config_fingerprint, "
-        "sc.column5 AS delay_seconds "
+        "sc.column5 AS delay_seconds, "
+        "sc.column6 AS created_at "
         f"FROM (VALUES {', '.join(rows)}) AS sc"
     )
     return (
@@ -129,6 +141,7 @@ def _criteria_relation(criteria: Sequence[_SessionCriteria]) -> Subquery:
             column("evaluator_id", Integer),
             column("config_fingerprint", String),
             column("delay_seconds", Integer),
+            column("created_at", models.UtcTimeStamp()),
         )
         .subquery("sweep_criteria")
     )
@@ -222,6 +235,7 @@ def _eligible_pairs_statement(
         .where(
             models.ProjectSession.content_complete.is_(True),
             models.ProjectSession.last_span_ingested_at.is_not(None),
+            models.ProjectSession.last_span_ingested_at >= criteria_relation.c.created_at,
             due_at <= current_time,
             ~successful_result_exists,
             ~_live_work_exists(criteria_relation),
@@ -449,6 +463,7 @@ class SessionEvalSweeper(DaemonTask):
                     evaluator_id=criteria.evaluator_id,
                     fingerprint=config_fingerprint(resolved),
                     delay_seconds=criteria.evaluation_delay_seconds,
+                    created_at=criteria.created_at,
                 )
             )
         return criteria_rows
@@ -480,7 +495,7 @@ class SessionEvalSweeper(DaemonTask):
     ) -> tuple[int, Optional[int]]:
         if not criteria:
             return 0, 0 if self._publish_metrics else None
-        criteria_relation = _criteria_relation(criteria)
+        criteria_relation = _criteria_relation(criteria, self._db.dialect)
         relation = _eligible_pairs_statement(
             criteria_relation,
             database_now,

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -65,6 +65,10 @@ _SESSION_WORK_INSERT_FIXED_PARAMETERS = 16
 _SESSION_WORK_INSERT_BATCH_SIZE = (
     _MAX_SESSION_WORK_INSERT_PARAMETERS - _SESSION_WORK_INSERT_FIXED_PARAMETERS
 )
+# Only work terminated within this window feeds the watermark-lag gauge; the table has
+# no retention, so an unbounded aggregate would scan more rows on every tick forever.
+_WATERMARK_LAG_WINDOW_SECONDS = 86_400.0
+
 _LIVE_WORK_INDEX_PREDICATE = text(live_eval_work_index_predicate())
 
 _SESSION_WORK_INSERT_COLUMNS = (
@@ -340,7 +344,7 @@ class SessionEvalSweeper(DaemonTask):
             limit=min(work_budget, _MAX_ELIGIBLE_PAIRS_PER_TICK),
         )
         if self._publish_metrics:
-            await self._publish_eligibility_metrics(session, eligible_pair_count)
+            await self._publish_eligibility_metrics(session, database_now, eligible_pair_count)
         if not eligible_pairs:
             return 0
 
@@ -470,34 +474,38 @@ class SessionEvalSweeper(DaemonTask):
     async def _publish_eligibility_metrics(
         self,
         session: AsyncSession,
+        database_now: datetime,
         eligible_pair_count: int,
     ) -> None:
         ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG.set(eligible_pair_count)
-        watermark_rows = (
-            await session.execute(
-                select(
-                    models.ProjectSession.last_span_ingested_at,
-                    models.EvalSessionWorkUnit.evaluated_through,
-                )
-                .join(
-                    models.EvalSessionWorkUnit,
-                    models.EvalSessionWorkUnit.project_session_rowid == models.ProjectSession.id,
-                )
-                .where(
-                    models.EvalSessionWorkUnit.status == "DONE",
-                    models.ProjectSession.last_span_ingested_at.is_not(None),
-                )
+        if self._db.dialect is SupportedSQLDialect.SQLITE:
+            lag_seconds = (
+                cast(func.julianday(models.ProjectSession.last_span_ingested_at), Float)
+                - cast(func.julianday(models.EvalSessionWorkUnit.evaluated_through), Float)
+            ) * 86_400
+        else:
+            lag_seconds = func.extract(
+                "epoch",
+                models.ProjectSession.last_span_ingested_at
+                - models.EvalSessionWorkUnit.evaluated_through,
             )
-        ).all()
-        watermark_lag_seconds = max(
-            (
-                max((last_span_ingested_at - evaluated_through).total_seconds(), 0.0)
-                for last_span_ingested_at, evaluated_through in watermark_rows
-                if last_span_ingested_at is not None
-            ),
-            default=0.0,
+        watermark_lag_seconds = await session.scalar(
+            select(func.max(lag_seconds))
+            .select_from(models.EvalSessionWorkUnit)
+            .join(
+                models.ProjectSession,
+                models.EvalSessionWorkUnit.project_session_rowid == models.ProjectSession.id,
+            )
+            .where(
+                models.EvalSessionWorkUnit.status == "DONE",
+                models.EvalSessionWorkUnit.updated_at
+                >= database_now - timedelta(seconds=_WATERMARK_LAG_WINDOW_SECONDS),
+                models.ProjectSession.last_span_ingested_at.is_not(None),
+            )
         )
-        ONLINE_EVAL_SESSION_RESULT_WATERMARK_LAG_SECONDS.set(watermark_lag_seconds)
+        ONLINE_EVAL_SESSION_RESULT_WATERMARK_LAG_SECONDS.set(
+            max(float(watermark_lag_seconds or 0.0), 0.0)
+        )
 
     async def _admission_budget(self, session: AsyncSession) -> int:
         outstanding = (

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -370,12 +370,13 @@ class SessionEvalSweeper(DaemonTask):
             )
             if self._db.dialect is SupportedSQLDialect.SQLITE:
                 due_at = (
-                    cast(func.julianday(models.ProjectSession.last_span_seen_at), Float) * 86_400
+                    cast(func.julianday(models.ProjectSession.last_span_ingested_at), Float)
+                    * 86_400
                     + criterion.delay_seconds
                 )
             else:
                 due_at = (
-                    func.extract("epoch", models.ProjectSession.last_span_seen_at)
+                    func.extract("epoch", models.ProjectSession.last_span_ingested_at)
                     + criterion.delay_seconds
                 )
             statements.append(
@@ -384,18 +385,19 @@ class SessionEvalSweeper(DaemonTask):
                     literal(criterion.evaluator_id).label("evaluator_id"),
                     literal(criterion.criteria_id).label("criteria_id"),
                     literal(criterion.fingerprint).label("config_fingerprint"),
-                    models.ProjectSession.last_span_seen_at.label("evaluated_through"),
+                    models.ProjectSession.last_span_ingested_at.label("evaluated_through"),
                     due_at.label("effective_due_time"),
                 ).where(
                     models.ProjectSession.project_id == criterion.project_id,
                     models.ProjectSession.content_complete.is_(True),
-                    models.ProjectSession.last_span_seen_at
+                    models.ProjectSession.last_span_ingested_at.is_not(None),
+                    models.ProjectSession.last_span_ingested_at
                     <= database_now - timedelta(seconds=criterion.delay_seconds),
                     ~successful_result_exists,
                     ~live_work_exists,
                     or_(
                         successful_watermark.is_(None),
-                        successful_watermark < models.ProjectSession.last_span_seen_at,
+                        successful_watermark < models.ProjectSession.last_span_ingested_at,
                     ),
                 )
             )
@@ -437,20 +439,24 @@ class SessionEvalSweeper(DaemonTask):
         watermark_rows = (
             await session.execute(
                 select(
-                    models.ProjectSession.last_span_seen_at,
+                    models.ProjectSession.last_span_ingested_at,
                     models.EvalSessionWorkUnit.evaluated_through,
                 )
                 .join(
                     models.EvalSessionWorkUnit,
                     models.EvalSessionWorkUnit.project_session_rowid == models.ProjectSession.id,
                 )
-                .where(models.EvalSessionWorkUnit.status == "DONE")
+                .where(
+                    models.EvalSessionWorkUnit.status == "DONE",
+                    models.ProjectSession.last_span_ingested_at.is_not(None),
+                )
             )
         ).all()
         watermark_lag_seconds = max(
             (
-                max((last_span_seen_at - evaluated_through).total_seconds(), 0.0)
-                for last_span_seen_at, evaluated_through in watermark_rows
+                max((last_span_ingested_at - evaluated_through).total_seconds(), 0.0)
+                for last_span_ingested_at, evaluated_through in watermark_rows
+                if last_span_ingested_at is not None
             ),
             default=0.0,
         )

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from secrets import token_hex
 from typing import Optional, Sequence
 
 from sqlalchemy import (
+    ColumnElement,
     Float,
     Insert,
     and_,
@@ -32,6 +34,7 @@ from typing_extensions import assert_never
 
 from phoenix.config import get_env_enable_prometheus, get_env_online_eval_max_session_outstanding
 from phoenix.db import models
+from phoenix.db.eval_work import live_eval_work_index_predicate
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerprint
@@ -56,41 +59,21 @@ SESSION_SWEEP_INTERVAL_SECONDS = 10.0
 _CONSUMER_GROUP = "default"
 _MAX_ELIGIBLE_PAIRS_PER_TICK = 1000
 _MAX_SESSION_WORK_INSERT_PARAMETERS = 30_000
-_SESSION_WORK_INSERT_PARAMETERS_PER_ROW = 7
+# One bind parameter per candidate session id, plus the handful of per-criterion
+# literals the whole statement shares.
+_SESSION_WORK_INSERT_FIXED_PARAMETERS = 16
 _SESSION_WORK_INSERT_BATCH_SIZE = (
-    _MAX_SESSION_WORK_INSERT_PARAMETERS // _SESSION_WORK_INSERT_PARAMETERS_PER_ROW
+    _MAX_SESSION_WORK_INSERT_PARAMETERS - _SESSION_WORK_INSERT_FIXED_PARAMETERS
 )
+_LIVE_WORK_INDEX_PREDICATE = text(live_eval_work_index_predicate())
 
-
-def _session_work_insert_statement(
-    work_records: Sequence[dict[str, object]],
-    dialect: SupportedSQLDialect,
-) -> Insert:
-    index_elements = (
-        models.EvalSessionWorkUnit.project_session_rowid,
-        models.EvalSessionWorkUnit.evaluator_id,
-        models.EvalSessionWorkUnit.config_fingerprint,
-    )
-    live_work = text("status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3")
-    if dialect is SupportedSQLDialect.POSTGRESQL:
-        return (
-            insert_postgresql(models.EvalSessionWorkUnit)
-            .values(work_records)
-            .on_conflict_do_nothing(
-                index_elements=index_elements,
-                index_where=live_work,
-            )
-        )
-    if dialect is SupportedSQLDialect.SQLITE:
-        return (
-            insert_sqlite(models.EvalSessionWorkUnit)
-            .values(work_records)
-            .on_conflict_do_nothing(
-                index_elements=index_elements,
-                index_where=live_work,
-            )
-        )
-    assert_never(dialect)
+_SESSION_WORK_INSERT_COLUMNS = (
+    "project_session_rowid",
+    "evaluator_id",
+    "criteria_id",
+    "config_fingerprint",
+    "evaluated_through",
+)
 
 
 @dataclass(frozen=True)
@@ -105,10 +88,79 @@ class _SessionCriteria:
 @dataclass(frozen=True)
 class _EligiblePair:
     project_session_rowid: int
-    evaluator_id: int
     criteria_id: int
-    config_fingerprint: str
-    evaluated_through: datetime
+
+
+def _live_work_exists(criterion: _SessionCriteria) -> ColumnElement[bool]:
+    """Whether the session still holds a live dedup key for this criterion."""
+    live_work = aliased(models.EvalSessionWorkUnit)
+    return (
+        select(1)
+        .select_from(live_work)
+        .where(
+            live_work.project_session_rowid == models.ProjectSession.id,
+            live_work.evaluator_id == criterion.evaluator_id,
+            live_work.config_fingerprint == criterion.fingerprint,
+            or_(
+                live_work.status.in_(("PENDING", "RUNNING")),
+                and_(
+                    live_work.status == "ERROR",
+                    live_work.attempts < MAX_ATTEMPTS,
+                ),
+            ),
+        )
+        .correlate(models.ProjectSession)
+        .exists()
+    )
+
+
+def _session_work_insert_statement(
+    criterion: _SessionCriteria,
+    project_session_rowids: Sequence[int],
+    dialect: SupportedSQLDialect,
+) -> Insert:
+    """Materialize work for one criterion, re-deriving eligibility at write time.
+
+    The completeness and no-live-work guards belong to the writing statement, not to
+    the SELECT that picked the candidates: under READ COMMITTED a session can be marked
+    incomplete, or acquire live work, in the gap between the two.
+    """
+    index_elements = (
+        models.EvalSessionWorkUnit.project_session_rowid,
+        models.EvalSessionWorkUnit.evaluator_id,
+        models.EvalSessionWorkUnit.config_fingerprint,
+    )
+    candidates = select(
+        models.ProjectSession.id,
+        literal(criterion.evaluator_id),
+        literal(criterion.criteria_id),
+        literal(criterion.fingerprint),
+        models.ProjectSession.last_span_ingested_at,
+    ).where(
+        models.ProjectSession.id.in_(project_session_rowids),
+        models.ProjectSession.content_complete.is_(True),
+        models.ProjectSession.last_span_ingested_at.is_not(None),
+        ~_live_work_exists(criterion),
+    )
+    if dialect is SupportedSQLDialect.POSTGRESQL:
+        return (
+            insert_postgresql(models.EvalSessionWorkUnit)
+            .from_select(list(_SESSION_WORK_INSERT_COLUMNS), candidates)
+            .on_conflict_do_nothing(
+                index_elements=index_elements,
+                index_where=_LIVE_WORK_INDEX_PREDICATE,
+            )
+        )
+    if dialect is SupportedSQLDialect.SQLITE:
+        return (
+            insert_sqlite(models.EvalSessionWorkUnit)
+            .from_select(list(_SESSION_WORK_INSERT_COLUMNS), candidates)
+            .on_conflict_do_nothing(
+                index_elements=index_elements,
+                index_where=_LIVE_WORK_INDEX_PREDICATE,
+            )
+        )
+    assert_never(dialect)
 
 
 class SessionEvalSweeper(DaemonTask):
@@ -279,6 +331,8 @@ class SessionEvalSweeper(DaemonTask):
     async def _sweep(self, session: AsyncSession, database_now: datetime) -> int:
         criteria = await self._load_criteria(session)
         work_budget = await self._admission_budget(session)
+        if work_budget == 0:
+            return 0
         eligible_pairs, eligible_pair_count = await self._load_eligible_pairs(
             session,
             database_now,
@@ -287,26 +341,22 @@ class SessionEvalSweeper(DaemonTask):
         )
         if self._publish_metrics:
             await self._publish_eligibility_metrics(session, eligible_pair_count)
-        if work_budget == 0 or not eligible_pairs:
+        if not eligible_pairs:
             return 0
 
-        work_records = [
-            {
-                "project_session_rowid": pair.project_session_rowid,
-                "evaluator_id": pair.evaluator_id,
-                "criteria_id": pair.criteria_id,
-                "config_fingerprint": pair.config_fingerprint,
-                "evaluated_through": pair.evaluated_through,
-            }
-            for pair in eligible_pairs
-        ]
+        criteria_by_id = {criterion.criteria_id: criterion for criterion in criteria}
+        rowids_by_criteria: defaultdict[int, list[int]] = defaultdict(list)
+        for pair in eligible_pairs:
+            rowids_by_criteria[pair.criteria_id].append(pair.project_session_rowid)
 
         inserted_count = 0
-        if work_records:
-            for start in range(0, len(work_records), _SESSION_WORK_INSERT_BATCH_SIZE):
+        for criteria_id, rowids in rowids_by_criteria.items():
+            criterion = criteria_by_id[criteria_id]
+            for start in range(0, len(rowids), _SESSION_WORK_INSERT_BATCH_SIZE):
                 result = await session.execute(
                     _session_work_insert_statement(
-                        work_records[start : start + _SESSION_WORK_INSERT_BATCH_SIZE],
+                        criterion,
+                        rowids[start : start + _SESSION_WORK_INSERT_BATCH_SIZE],
                         self._db.dialect,
                     )
                 )
@@ -325,15 +375,25 @@ class SessionEvalSweeper(DaemonTask):
             return [], 0
         statements = []
         for criterion in criteria:
-            live_work = aliased(models.EvalSessionWorkUnit)
             successful_work = aliased(models.EvalSessionWorkUnit)
-            successful_watermark = (
-                select(func.max(successful_work.evaluated_through))
+            terminal_work = aliased(models.EvalSessionWorkUnit)
+            # How far session content was already carried by work that will never run
+            # again — a completed evaluation, an expired one, or one that exhausted its
+            # retries. Without new content past that mark there is nothing to re-evaluate,
+            # and materializing anyway loops a failing session forever.
+            terminal_watermark = (
+                select(func.max(terminal_work.evaluated_through))
                 .where(
-                    successful_work.project_session_rowid == models.ProjectSession.id,
-                    successful_work.evaluator_id == criterion.evaluator_id,
-                    successful_work.config_fingerprint == criterion.fingerprint,
-                    successful_work.status == "DONE",
+                    terminal_work.project_session_rowid == models.ProjectSession.id,
+                    terminal_work.evaluator_id == criterion.evaluator_id,
+                    terminal_work.config_fingerprint == criterion.fingerprint,
+                    or_(
+                        terminal_work.status.in_(("DONE", "EXPIRED")),
+                        and_(
+                            terminal_work.status == "ERROR",
+                            terminal_work.attempts >= MAX_ATTEMPTS,
+                        ),
+                    ),
                 )
                 .correlate(models.ProjectSession)
                 .scalar_subquery()
@@ -350,24 +410,7 @@ class SessionEvalSweeper(DaemonTask):
                 .correlate(models.ProjectSession)
                 .exists()
             )
-            live_work_exists = (
-                select(1)
-                .select_from(live_work)
-                .where(
-                    live_work.project_session_rowid == models.ProjectSession.id,
-                    live_work.evaluator_id == criterion.evaluator_id,
-                    live_work.config_fingerprint == criterion.fingerprint,
-                    or_(
-                        live_work.status.in_(("PENDING", "RUNNING")),
-                        and_(
-                            live_work.status == "ERROR",
-                            live_work.attempts < MAX_ATTEMPTS,
-                        ),
-                    ),
-                )
-                .correlate(models.ProjectSession)
-                .exists()
-            )
+            live_work_exists = _live_work_exists(criterion)
             if self._db.dialect is SupportedSQLDialect.SQLITE:
                 due_at = (
                     cast(func.julianday(models.ProjectSession.last_span_ingested_at), Float)
@@ -382,10 +425,7 @@ class SessionEvalSweeper(DaemonTask):
             statements.append(
                 select(
                     models.ProjectSession.id.label("project_session_rowid"),
-                    literal(criterion.evaluator_id).label("evaluator_id"),
                     literal(criterion.criteria_id).label("criteria_id"),
-                    literal(criterion.fingerprint).label("config_fingerprint"),
-                    models.ProjectSession.last_span_ingested_at.label("evaluated_through"),
                     due_at.label("effective_due_time"),
                 ).where(
                     models.ProjectSession.project_id == criterion.project_id,
@@ -396,8 +436,8 @@ class SessionEvalSweeper(DaemonTask):
                     ~successful_result_exists,
                     ~live_work_exists,
                     or_(
-                        successful_watermark.is_(None),
-                        successful_watermark < models.ProjectSession.last_span_ingested_at,
+                        terminal_watermark.is_(None),
+                        terminal_watermark < models.ProjectSession.last_span_ingested_at,
                     ),
                 )
             )
@@ -421,10 +461,7 @@ class SessionEvalSweeper(DaemonTask):
         pairs = [
             _EligiblePair(
                 project_session_rowid=row.project_session_rowid,
-                evaluator_id=row.evaluator_id,
                 criteria_id=row.criteria_id,
-                config_fingerprint=row.config_fingerprint,
-                evaluated_through=row.evaluated_through,
             )
             for row in rows
         ]

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -14,13 +15,22 @@ from sqlalchemy import Insert, and_, delete, func, or_, select, type_coerce, upd
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_polymorphic
 
-from phoenix.config import get_env_online_eval_max_session_outstanding
+from phoenix.config import get_env_enable_prometheus, get_env_online_eval_max_session_outstanding
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerprint
 from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.online_eval.session_policy import session_criteria_is_schedulable
+from phoenix.server.prometheus import (
+    ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG,
+    ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS,
+    ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS,
+    ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS,
+    ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS,
+    ONLINE_EVAL_SESSION_SWEEP_FAILURES,
+    ONLINE_EVAL_SESSION_SWEEP_SUCCESSES,
+)
 from phoenix.server.types import DaemonTask, DbSessionFactory
 
 logger = logging.getLogger(__name__)
@@ -79,6 +89,7 @@ class SessionEvalSweeper(DaemonTask):
         self._consumer_group = consumer_group
         self._tick_interval_seconds = tick_interval_seconds
         self._max_outstanding = get_env_online_eval_max_session_outstanding()
+        self._publish_metrics = get_env_enable_prometheus()
         self._sweeper_id = f"session-sweeper-{token_hex(8)}"
         self._lease_held = False
 
@@ -149,21 +160,40 @@ class SessionEvalSweeper(DaemonTask):
         return None
 
     async def _materialize_and_renew(self, cursor_id: int) -> bool:
-        async with self._db() as session:
-            database_now = await self._database_now(session)
-            await self._sweep(session, database_now)
-            renewed_at = await self._database_now(session)
-            renewed = await session.scalar(
-                update(models.EvalWorkCursor)
-                .where(
-                    models.EvalWorkCursor.id == cursor_id,
-                    models.EvalWorkCursor.claimed_by == self._sweeper_id,
+        started_at = time.monotonic()
+        if self._publish_metrics:
+            ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS.inc()
+        materialized_work_count = 0
+        renewed: Optional[int] = None
+        try:
+            async with self._db() as session:
+                database_now = await self._database_now(session)
+                materialized_work_count = await self._sweep(session, database_now)
+                renewed_at = await self._database_now(session)
+                renewed = await session.scalar(
+                    update(models.EvalWorkCursor)
+                    .where(
+                        models.EvalWorkCursor.id == cursor_id,
+                        models.EvalWorkCursor.claimed_by == self._sweeper_id,
+                    )
+                    .values(claimed_at=renewed_at)
+                    .returning(models.EvalWorkCursor.id)
                 )
-                .values(claimed_at=renewed_at)
-                .returning(models.EvalWorkCursor.id)
-            )
+                if renewed is None:
+                    await session.rollback()
+        except Exception:
+            if self._publish_metrics:
+                ONLINE_EVAL_SESSION_SWEEP_FAILURES.inc()
+            raise
+        finally:
+            if self._publish_metrics:
+                ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS.observe(time.monotonic() - started_at)
+        if self._publish_metrics:
             if renewed is None:
-                await session.rollback()
+                ONLINE_EVAL_SESSION_SWEEP_FAILURES.inc()
+            else:
+                ONLINE_EVAL_SESSION_SWEEP_SUCCESSES.inc()
+                ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS.inc(materialized_work_count)
         return renewed is not None
 
     async def _database_now(self, session: AsyncSession) -> datetime:
@@ -209,14 +239,17 @@ class SessionEvalSweeper(DaemonTask):
             )
         return criteria_rows
 
-    async def _sweep(self, session: AsyncSession, database_now: datetime) -> None:
+    async def _sweep(self, session: AsyncSession, database_now: datetime) -> int:
         criteria_by_project: defaultdict[int, list[_SessionCriteria]] = defaultdict(list)
         for criteria in await self._load_criteria(session):
             criteria_by_project[criteria.project_id].append(criteria)
 
+        if self._publish_metrics:
+            await self._publish_activity_metrics(session, database_now)
+
         work_budget = await self._admission_budget(session)
         if work_budget == 0:
-            return
+            return 0
 
         activity_stmt = select(
             models.EvalSessionActivity,
@@ -251,7 +284,7 @@ class SessionEvalSweeper(DaemonTask):
             )
         ).all()
         if not activity_rows:
-            return
+            return 0
 
         project_session_ids = [activity.project_session_rowid for activity, _ in activity_rows]
         existing_work_keys = {
@@ -311,6 +344,28 @@ class SessionEvalSweeper(DaemonTask):
                     models.EvalSessionActivity.id.in_(resolved_activity_ids)
                 )
             )
+        return len(work_records)
+
+    async def _publish_activity_metrics(
+        self,
+        session: AsyncSession,
+        database_now: datetime,
+    ) -> None:
+        activity_count, oldest_observed_at = (
+            await session.execute(
+                select(
+                    func.count(models.EvalSessionActivity.id),
+                    func.min(models.EvalSessionActivity.observed_at),
+                )
+            )
+        ).one()
+        ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG.set(activity_count)
+        oldest_age_seconds = (
+            max((database_now - oldest_observed_at).total_seconds(), 0.0)
+            if oldest_observed_at is not None
+            else 0.0
+        )
+        ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS.set(oldest_age_seconds)
 
     async def _admission_budget(self, session: AsyncSession) -> int:
         outstanding = (

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -18,10 +18,7 @@ from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.online_eval.derivation import config_fingerprint
 from phoenix.server.online_eval.producer import resolve_criteria
-from phoenix.server.online_eval.session_policy import (
-    effective_session_evaluation_delay_seconds,
-    session_criteria_is_schedulable,
-)
+from phoenix.server.online_eval.session_policy import session_criteria_is_schedulable
 from phoenix.server.types import DaemonTask, DbSessionFactory
 
 logger = logging.getLogger(__name__)
@@ -30,13 +27,11 @@ SESSION_SWEEP_LEASE_TTL_SECONDS = 90.0
 SESSION_SWEEP_INTERVAL_SECONDS = 10.0
 
 _CONSUMER_GROUP = "default"
-_GENERATION = 0
 _MAX_ACTIVITY_ROWS_PER_TICK = 1000
 _SESSION_WORK_UNIQUE_BY = (
     "project_session_rowid",
     "evaluator_id",
     "config_fingerprint",
-    "generation",
 )
 
 
@@ -50,7 +45,7 @@ class _SessionCriteria:
 
 
 class SessionEvalSweeper(DaemonTask):
-    """Create pending generation-0 work for eligible project sessions."""
+    """Create pending work for eligible project sessions."""
 
     def __init__(
         self,
@@ -188,9 +183,7 @@ class SessionEvalSweeper(DaemonTask):
                     project_id=criteria.project_id,
                     evaluator_id=criteria.evaluator_id,
                     fingerprint=config_fingerprint(resolved),
-                    delay_seconds=effective_session_evaluation_delay_seconds(
-                        criteria.evaluation_delay_seconds
-                    ),
+                    delay_seconds=criteria.evaluation_delay_seconds,
                 )
             )
         return criteria_rows
@@ -243,10 +236,8 @@ class SessionEvalSweeper(DaemonTask):
                     models.EvalSessionWorkUnit.project_session_rowid,
                     models.EvalSessionWorkUnit.evaluator_id,
                     models.EvalSessionWorkUnit.config_fingerprint,
-                    models.EvalSessionWorkUnit.generation,
                 ).where(
                     models.EvalSessionWorkUnit.project_session_rowid.in_(project_session_ids),
-                    models.EvalSessionWorkUnit.generation == _GENERATION,
                 )
             )
         }
@@ -260,7 +251,6 @@ class SessionEvalSweeper(DaemonTask):
                     activity.project_session_rowid,
                     criteria.evaluator_id,
                     criteria.fingerprint,
-                    _GENERATION,
                 )
                 if key in existing_work_keys:
                     continue
@@ -273,7 +263,6 @@ class SessionEvalSweeper(DaemonTask):
                         "evaluator_id": criteria.evaluator_id,
                         "criteria_id": criteria.criteria_id,
                         "config_fingerprint": criteria.fingerprint,
-                        "generation": _GENERATION,
                     }
                 )
                 existing_work_keys.add(key)

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -5,15 +5,30 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from secrets import token_hex
 from typing import Optional, Sequence
 
-from sqlalchemy import Insert, and_, delete, func, or_, select, type_coerce, update
+from sqlalchemy import (
+    Float,
+    Insert,
+    and_,
+    cast,
+    func,
+    literal,
+    or_,
+    select,
+    text,
+    type_coerce,
+    union_all,
+    update,
+)
+from sqlalchemy.dialects.postgresql import insert as insert_postgresql
+from sqlalchemy.dialects.sqlite import insert as insert_sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import with_polymorphic
+from sqlalchemy.orm import aliased, with_polymorphic
+from typing_extensions import assert_never
 
 from phoenix.config import get_env_enable_prometheus, get_env_online_eval_max_session_outstanding
 from phoenix.db import models
@@ -23,9 +38,9 @@ from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerpri
 from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.online_eval.session_policy import session_criteria_is_schedulable
 from phoenix.server.prometheus import (
-    ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG,
-    ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS,
+    ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG,
     ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS,
+    ONLINE_EVAL_SESSION_RESULT_WATERMARK_LAG_SECONDS,
     ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS,
     ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS,
     ONLINE_EVAL_SESSION_SWEEP_FAILURES,
@@ -39,16 +54,11 @@ SESSION_SWEEP_LEASE_TTL_SECONDS = 90.0
 SESSION_SWEEP_INTERVAL_SECONDS = 10.0
 
 _CONSUMER_GROUP = "default"
-_MAX_ACTIVITY_ROWS_PER_TICK = 1000
+_MAX_ELIGIBLE_PAIRS_PER_TICK = 1000
 _MAX_SESSION_WORK_INSERT_PARAMETERS = 30_000
-_SESSION_WORK_INSERT_PARAMETERS_PER_ROW = 6
+_SESSION_WORK_INSERT_PARAMETERS_PER_ROW = 7
 _SESSION_WORK_INSERT_BATCH_SIZE = (
     _MAX_SESSION_WORK_INSERT_PARAMETERS // _SESSION_WORK_INSERT_PARAMETERS_PER_ROW
-)
-_SESSION_WORK_UNIQUE_BY = (
-    "project_session_rowid",
-    "evaluator_id",
-    "config_fingerprint",
 )
 
 
@@ -56,13 +66,31 @@ def _session_work_insert_statement(
     work_records: Sequence[dict[str, object]],
     dialect: SupportedSQLDialect,
 ) -> Insert:
-    return insert_on_conflict(
-        *work_records,
-        table=models.EvalSessionWorkUnit,
-        dialect=dialect,
-        unique_by=_SESSION_WORK_UNIQUE_BY,
-        on_conflict=OnConflict.DO_NOTHING,
+    index_elements = (
+        models.EvalSessionWorkUnit.project_session_rowid,
+        models.EvalSessionWorkUnit.evaluator_id,
+        models.EvalSessionWorkUnit.config_fingerprint,
     )
+    live_work = text("status IN ('PENDING', 'RUNNING') OR status = 'ERROR' AND attempts < 3")
+    if dialect is SupportedSQLDialect.POSTGRESQL:
+        return (
+            insert_postgresql(models.EvalSessionWorkUnit)
+            .values(work_records)
+            .on_conflict_do_nothing(
+                index_elements=index_elements,
+                index_where=live_work,
+            )
+        )
+    if dialect is SupportedSQLDialect.SQLITE:
+        return (
+            insert_sqlite(models.EvalSessionWorkUnit)
+            .values(work_records)
+            .on_conflict_do_nothing(
+                index_elements=index_elements,
+                index_where=live_work,
+            )
+        )
+    assert_never(dialect)
 
 
 @dataclass(frozen=True)
@@ -72,6 +100,15 @@ class _SessionCriteria:
     evaluator_id: int
     fingerprint: str
     delay_seconds: int
+
+
+@dataclass(frozen=True)
+class _EligiblePair:
+    project_session_rowid: int
+    evaluator_id: int
+    criteria_id: int
+    config_fingerprint: str
+    evaluated_through: datetime
 
 
 class SessionEvalSweeper(DaemonTask):
@@ -240,132 +277,184 @@ class SessionEvalSweeper(DaemonTask):
         return criteria_rows
 
     async def _sweep(self, session: AsyncSession, database_now: datetime) -> int:
-        criteria_by_project: defaultdict[int, list[_SessionCriteria]] = defaultdict(list)
-        for criteria in await self._load_criteria(session):
-            criteria_by_project[criteria.project_id].append(criteria)
-
-        if self._publish_metrics:
-            await self._publish_activity_metrics(session, database_now)
-
+        criteria = await self._load_criteria(session)
         work_budget = await self._admission_budget(session)
-        if work_budget == 0:
-            return 0
-
-        activity_stmt = select(
-            models.EvalSessionActivity,
-            models.ProjectSession.project_id,
-        ).join(
-            models.ProjectSession,
-            models.EvalSessionActivity.project_session_rowid == models.ProjectSession.id,
+        eligible_pairs, eligible_pair_count = await self._load_eligible_pairs(
+            session,
+            database_now,
+            criteria,
+            limit=min(work_budget, _MAX_ELIGIBLE_PAIRS_PER_TICK),
         )
-        if criteria_by_project:
-            due_for_project = [
-                and_(
-                    models.ProjectSession.project_id == project_id,
-                    models.EvalSessionActivity.observed_at
-                    <= database_now
-                    - timedelta(
-                        seconds=min(criteria.delay_seconds for criteria in project_criteria)
-                    ),
-                )
-                for project_id, project_criteria in criteria_by_project.items()
-            ]
-            activity_stmt = activity_stmt.where(
-                or_(
-                    models.ProjectSession.project_id.not_in(criteria_by_project),
-                    *due_for_project,
-                )
-            )
-        activity_rows = (
-            await session.execute(
-                activity_stmt.order_by(models.EvalSessionActivity.observed_at).limit(
-                    _MAX_ACTIVITY_ROWS_PER_TICK
-                )
-            )
-        ).all()
-        if not activity_rows:
+        if self._publish_metrics:
+            await self._publish_eligibility_metrics(session, eligible_pair_count)
+        if work_budget == 0 or not eligible_pairs:
             return 0
 
-        project_session_ids = [activity.project_session_rowid for activity, _ in activity_rows]
-        existing_work_keys = {
-            tuple(row)
-            for row in await session.execute(
-                select(
-                    models.EvalSessionWorkUnit.project_session_rowid,
-                    models.EvalSessionWorkUnit.evaluator_id,
-                    models.EvalSessionWorkUnit.config_fingerprint,
-                ).where(
-                    models.EvalSessionWorkUnit.project_session_rowid.in_(project_session_ids),
-                )
-            )
-        }
+        work_records = [
+            {
+                "project_session_rowid": pair.project_session_rowid,
+                "evaluator_id": pair.evaluator_id,
+                "criteria_id": pair.criteria_id,
+                "config_fingerprint": pair.config_fingerprint,
+                "evaluated_through": pair.evaluated_through,
+            }
+            for pair in eligible_pairs
+        ]
 
-        work_records: list[dict[str, object]] = []
-        resolved_activity_ids: list[int] = []
-        for activity, project_id in activity_rows:
-            activity_resolved = True
-            for criteria in criteria_by_project[project_id]:
-                key = (
-                    activity.project_session_rowid,
-                    criteria.evaluator_id,
-                    criteria.fingerprint,
-                )
-                if key in existing_work_keys:
-                    continue
-                if activity.observed_at > database_now - timedelta(seconds=criteria.delay_seconds):
-                    activity_resolved = False
-                    continue
-                if len(work_records) >= work_budget:
-                    activity_resolved = False
-                    continue
-                work_records.append(
-                    {
-                        "project_session_rowid": activity.project_session_rowid,
-                        "evaluator_id": criteria.evaluator_id,
-                        "criteria_id": criteria.criteria_id,
-                        "config_fingerprint": criteria.fingerprint,
-                    }
-                )
-                existing_work_keys.add(key)
-            if activity_resolved:
-                resolved_activity_ids.append(activity.id)
-
+        inserted_count = 0
         if work_records:
             for start in range(0, len(work_records), _SESSION_WORK_INSERT_BATCH_SIZE):
-                await session.execute(
+                result = await session.execute(
                     _session_work_insert_statement(
                         work_records[start : start + _SESSION_WORK_INSERT_BATCH_SIZE],
                         self._db.dialect,
                     )
                 )
-        if resolved_activity_ids:
-            await session.execute(
-                delete(models.EvalSessionActivity).where(
-                    models.EvalSessionActivity.id.in_(resolved_activity_ids)
-                )
-            )
-        return len(work_records)
+                inserted_count += result.rowcount  # type: ignore[attr-defined]
+        return inserted_count
 
-    async def _publish_activity_metrics(
+    async def _load_eligible_pairs(
         self,
         session: AsyncSession,
         database_now: datetime,
-    ) -> None:
-        activity_count, oldest_observed_at = (
-            await session.execute(
+        criteria: Sequence[_SessionCriteria],
+        *,
+        limit: int,
+    ) -> tuple[list[_EligiblePair], int]:
+        if not criteria:
+            return [], 0
+        statements = []
+        for criterion in criteria:
+            live_work = aliased(models.EvalSessionWorkUnit)
+            successful_work = aliased(models.EvalSessionWorkUnit)
+            successful_watermark = (
+                select(func.max(successful_work.evaluated_through))
+                .where(
+                    successful_work.project_session_rowid == models.ProjectSession.id,
+                    successful_work.evaluator_id == criterion.evaluator_id,
+                    successful_work.config_fingerprint == criterion.fingerprint,
+                    successful_work.status == "DONE",
+                )
+                .correlate(models.ProjectSession)
+                .scalar_subquery()
+            )
+            successful_result_exists = (
+                select(1)
+                .select_from(successful_work)
+                .where(
+                    successful_work.project_session_rowid == models.ProjectSession.id,
+                    successful_work.evaluator_id == criterion.evaluator_id,
+                    successful_work.config_fingerprint == criterion.fingerprint,
+                    successful_work.status == "DONE",
+                )
+                .correlate(models.ProjectSession)
+                .exists()
+            )
+            live_work_exists = (
+                select(1)
+                .select_from(live_work)
+                .where(
+                    live_work.project_session_rowid == models.ProjectSession.id,
+                    live_work.evaluator_id == criterion.evaluator_id,
+                    live_work.config_fingerprint == criterion.fingerprint,
+                    or_(
+                        live_work.status.in_(("PENDING", "RUNNING")),
+                        and_(
+                            live_work.status == "ERROR",
+                            live_work.attempts < MAX_ATTEMPTS,
+                        ),
+                    ),
+                )
+                .correlate(models.ProjectSession)
+                .exists()
+            )
+            if self._db.dialect is SupportedSQLDialect.SQLITE:
+                due_at = (
+                    cast(func.julianday(models.ProjectSession.last_activity_at), Float) * 86_400
+                    + criterion.delay_seconds
+                )
+            else:
+                due_at = (
+                    func.extract("epoch", models.ProjectSession.last_activity_at)
+                    + criterion.delay_seconds
+                )
+            statements.append(
                 select(
-                    func.count(models.EvalSessionActivity.id),
-                    func.min(models.EvalSessionActivity.observed_at),
+                    models.ProjectSession.id.label("project_session_rowid"),
+                    literal(criterion.evaluator_id).label("evaluator_id"),
+                    literal(criterion.criteria_id).label("criteria_id"),
+                    literal(criterion.fingerprint).label("config_fingerprint"),
+                    models.ProjectSession.last_activity_at.label("evaluated_through"),
+                    due_at.label("effective_due_time"),
+                ).where(
+                    models.ProjectSession.project_id == criterion.project_id,
+                    models.ProjectSession.content_complete.is_(True),
+                    models.ProjectSession.last_activity_at
+                    <= database_now - timedelta(seconds=criterion.delay_seconds),
+                    ~successful_result_exists,
+                    ~live_work_exists,
+                    or_(
+                        successful_watermark.is_(None),
+                        successful_watermark < models.ProjectSession.last_activity_at,
+                    ),
                 )
             )
-        ).one()
-        ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG.set(activity_count)
-        oldest_age_seconds = (
-            max((database_now - oldest_observed_at).total_seconds(), 0.0)
-            if oldest_observed_at is not None
-            else 0.0
+        relation = union_all(*statements).subquery()
+        eligible_pair_count = (
+            await session.scalar(select(func.count()).select_from(relation))
+        ) or 0
+        if limit == 0:
+            return [], eligible_pair_count
+        rows = (
+            await session.execute(
+                select(relation)
+                .order_by(
+                    relation.c.effective_due_time,
+                    relation.c.project_session_rowid,
+                    relation.c.criteria_id,
+                )
+                .limit(limit)
+            )
+        ).all()
+        pairs = [
+            _EligiblePair(
+                project_session_rowid=row.project_session_rowid,
+                evaluator_id=row.evaluator_id,
+                criteria_id=row.criteria_id,
+                config_fingerprint=row.config_fingerprint,
+                evaluated_through=row.evaluated_through,
+            )
+            for row in rows
+        ]
+        return pairs, eligible_pair_count
+
+    async def _publish_eligibility_metrics(
+        self,
+        session: AsyncSession,
+        eligible_pair_count: int,
+    ) -> None:
+        ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG.set(eligible_pair_count)
+        watermark_rows = (
+            await session.execute(
+                select(
+                    models.ProjectSession.last_activity_at,
+                    models.EvalSessionWorkUnit.evaluated_through,
+                )
+                .join(
+                    models.EvalSessionWorkUnit,
+                    models.EvalSessionWorkUnit.project_session_rowid == models.ProjectSession.id,
+                )
+                .where(models.EvalSessionWorkUnit.status == "DONE")
+            )
+        ).all()
+        watermark_lag_seconds = max(
+            (
+                max((last_activity_at - evaluated_through).total_seconds(), 0.0)
+                for last_activity_at, evaluated_through in watermark_rows
+            ),
+            default=0.0,
         )
-        ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS.set(oldest_age_seconds)
+        ONLINE_EVAL_SESSION_RESULT_WATERMARK_LAG_SECONDS.set(watermark_lag_seconds)
 
     async def _admission_budget(self, session: AsyncSession) -> int:
         outstanding = (

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -8,13 +8,14 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from secrets import token_hex
-from typing import Optional
+from typing import Optional, Sequence
 
-from sqlalchemy import and_, delete, func, or_, select, type_coerce, update
+from sqlalchemy import Insert, and_, delete, func, or_, select, type_coerce, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_polymorphic
 
 from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.online_eval.derivation import config_fingerprint
 from phoenix.server.online_eval.producer import resolve_criteria
@@ -28,11 +29,29 @@ SESSION_SWEEP_INTERVAL_SECONDS = 10.0
 
 _CONSUMER_GROUP = "default"
 _MAX_ACTIVITY_ROWS_PER_TICK = 1000
+_MAX_SESSION_WORK_INSERT_PARAMETERS = 30_000
+_SESSION_WORK_INSERT_PARAMETERS_PER_ROW = 6
+_SESSION_WORK_INSERT_BATCH_SIZE = (
+    _MAX_SESSION_WORK_INSERT_PARAMETERS // _SESSION_WORK_INSERT_PARAMETERS_PER_ROW
+)
 _SESSION_WORK_UNIQUE_BY = (
     "project_session_rowid",
     "evaluator_id",
     "config_fingerprint",
 )
+
+
+def _session_work_insert_statement(
+    work_records: Sequence[dict[str, object]],
+    dialect: SupportedSQLDialect,
+) -> Insert:
+    return insert_on_conflict(
+        *work_records,
+        table=models.EvalSessionWorkUnit,
+        dialect=dialect,
+        unique_by=_SESSION_WORK_UNIQUE_BY,
+        on_conflict=OnConflict.DO_NOTHING,
+    )
 
 
 @dataclass(frozen=True)
@@ -270,15 +289,13 @@ class SessionEvalSweeper(DaemonTask):
                 resolved_activity_ids.append(activity.id)
 
         if work_records:
-            await session.execute(
-                insert_on_conflict(
-                    *work_records,
-                    table=models.EvalSessionWorkUnit,
-                    dialect=self._db.dialect,
-                    unique_by=_SESSION_WORK_UNIQUE_BY,
-                    on_conflict=OnConflict.DO_NOTHING,
+            for start in range(0, len(work_records), _SESSION_WORK_INSERT_BATCH_SIZE):
+                await session.execute(
+                    _session_work_insert_statement(
+                        work_records[start : start + _SESSION_WORK_INSERT_BATCH_SIZE],
+                        self._db.dialect,
+                    )
                 )
-            )
         if resolved_activity_ids:
             await session.execute(
                 delete(models.EvalSessionActivity).where(

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -44,7 +44,7 @@ from phoenix.db.eval_work import live_eval_work_index_predicate
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerprint
-from phoenix.server.online_eval.producer import resolve_criteria
+from phoenix.server.online_eval.producer import resolve_criteria_bulk
 from phoenix.server.online_eval.session_policy import session_criteria_is_schedulable
 from phoenix.server.prometheus import (
     ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG,
@@ -423,9 +423,14 @@ class SessionEvalSweeper(DaemonTask):
                 )
             )
         ).all()
+        criteria_evaluators = [(criteria, evaluator) for criteria, evaluator in rows]
         criteria_rows: list[_SessionCriteria] = []
-        for criteria, evaluator in rows:
-            resolved = await resolve_criteria(session, criteria, evaluator)
+        resolved_rows = await resolve_criteria_bulk(session, criteria_evaluators)
+        for (criteria, evaluator), resolved in zip(
+            criteria_evaluators,
+            resolved_rows,
+            strict=True,
+        ):
             if resolved is None:
                 logger.warning(
                     f"Skipping criteria {criteria.id}: "
@@ -445,10 +450,10 @@ class SessionEvalSweeper(DaemonTask):
 
     async def _sweep(self, session: AsyncSession, database_now: datetime) -> tuple[int, int]:
         """Materialize this tick's work, returning (work created, pairs found eligible)."""
-        criteria = await self._load_criteria(session)
         work_budget = await self._admission_budget(session)
         if work_budget == 0:
             return 0, 0
+        criteria = await self._load_criteria(session)
         return await self._load_eligible_pairs(
             session,
             database_now,

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -370,12 +370,12 @@ class SessionEvalSweeper(DaemonTask):
             )
             if self._db.dialect is SupportedSQLDialect.SQLITE:
                 due_at = (
-                    cast(func.julianday(models.ProjectSession.last_activity_at), Float) * 86_400
+                    cast(func.julianday(models.ProjectSession.last_span_seen_at), Float) * 86_400
                     + criterion.delay_seconds
                 )
             else:
                 due_at = (
-                    func.extract("epoch", models.ProjectSession.last_activity_at)
+                    func.extract("epoch", models.ProjectSession.last_span_seen_at)
                     + criterion.delay_seconds
                 )
             statements.append(
@@ -384,18 +384,18 @@ class SessionEvalSweeper(DaemonTask):
                     literal(criterion.evaluator_id).label("evaluator_id"),
                     literal(criterion.criteria_id).label("criteria_id"),
                     literal(criterion.fingerprint).label("config_fingerprint"),
-                    models.ProjectSession.last_activity_at.label("evaluated_through"),
+                    models.ProjectSession.last_span_seen_at.label("evaluated_through"),
                     due_at.label("effective_due_time"),
                 ).where(
                     models.ProjectSession.project_id == criterion.project_id,
                     models.ProjectSession.content_complete.is_(True),
-                    models.ProjectSession.last_activity_at
+                    models.ProjectSession.last_span_seen_at
                     <= database_now - timedelta(seconds=criterion.delay_seconds),
                     ~successful_result_exists,
                     ~live_work_exists,
                     or_(
                         successful_watermark.is_(None),
-                        successful_watermark < models.ProjectSession.last_activity_at,
+                        successful_watermark < models.ProjectSession.last_span_seen_at,
                     ),
                 )
             )
@@ -437,7 +437,7 @@ class SessionEvalSweeper(DaemonTask):
         watermark_rows = (
             await session.execute(
                 select(
-                    models.ProjectSession.last_activity_at,
+                    models.ProjectSession.last_span_seen_at,
                     models.EvalSessionWorkUnit.evaluated_through,
                 )
                 .join(
@@ -449,8 +449,8 @@ class SessionEvalSweeper(DaemonTask):
         ).all()
         watermark_lag_seconds = max(
             (
-                max((last_activity_at - evaluated_through).total_seconds(), 0.0)
-                for last_activity_at, evaluated_through in watermark_rows
+                max((last_span_seen_at - evaluated_through).total_seconds(), 0.0)
+                for last_span_seen_at, evaluated_through in watermark_rows
             ),
             default=0.0,
         )

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -14,10 +14,11 @@ from sqlalchemy import Insert, and_, delete, func, or_, select, type_coerce, upd
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_polymorphic
 
+from phoenix.config import get_env_online_eval_max_session_outstanding
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
-from phoenix.server.online_eval.derivation import config_fingerprint
+from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerprint
 from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.online_eval.session_policy import session_criteria_is_schedulable
 from phoenix.server.types import DaemonTask, DbSessionFactory
@@ -77,6 +78,7 @@ class SessionEvalSweeper(DaemonTask):
         self._db = db
         self._consumer_group = consumer_group
         self._tick_interval_seconds = tick_interval_seconds
+        self._max_outstanding = get_env_online_eval_max_session_outstanding()
         self._sweeper_id = f"session-sweeper-{token_hex(8)}"
         self._lease_held = False
 
@@ -212,6 +214,10 @@ class SessionEvalSweeper(DaemonTask):
         for criteria in await self._load_criteria(session):
             criteria_by_project[criteria.project_id].append(criteria)
 
+        work_budget = await self._admission_budget(session)
+        if work_budget == 0:
+            return
+
         activity_stmt = select(
             models.EvalSessionActivity,
             models.ProjectSession.project_id,
@@ -276,6 +282,9 @@ class SessionEvalSweeper(DaemonTask):
                 if activity.observed_at > database_now - timedelta(seconds=criteria.delay_seconds):
                     activity_resolved = False
                     continue
+                if len(work_records) >= work_budget:
+                    activity_resolved = False
+                    continue
                 work_records.append(
                     {
                         "project_session_rowid": activity.project_session_rowid,
@@ -302,6 +311,32 @@ class SessionEvalSweeper(DaemonTask):
                     models.EvalSessionActivity.id.in_(resolved_activity_ids)
                 )
             )
+
+    async def _admission_budget(self, session: AsyncSession) -> int:
+        outstanding = (
+            select(1)
+            .select_from(models.EvalSessionWorkUnit)
+            .where(
+                or_(
+                    models.EvalSessionWorkUnit.status.in_(("PENDING", "RUNNING")),
+                    and_(
+                        models.EvalSessionWorkUnit.status == "ERROR",
+                        models.EvalSessionWorkUnit.attempts < MAX_ATTEMPTS,
+                    ),
+                )
+            )
+            .limit(self._max_outstanding)
+            .subquery()
+        )
+        outstanding_count = await session.scalar(select(func.count()).select_from(outstanding)) or 0
+        budget = max(0, self._max_outstanding - outstanding_count)
+        if budget == 0:
+            logger.warning(
+                f"Session evaluation admission gate closed: "
+                f"{outstanding_count} outstanding work units reached "
+                f"{self._max_outstanding}"
+            )
+        return budget
 
     async def _release_lease(self) -> None:
         if not self._lease_held:

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -516,6 +516,28 @@ class SessionEvalSweeper(DaemonTask):
         )
         locked_project_session_rowids: Optional[Sequence[int]] = None
         if self._db.dialect is SupportedSQLDialect.POSTGRESQL:
+            page_criteria_ids = tuple(
+                dict.fromkeys(await session.scalars(select(eligible_page.c.criteria_id)))
+            )
+            if not page_criteria_ids:
+                return 0, eligible_pair_count
+            page_criteria_ids_parameter = bindparam(
+                "page_criteria_ids",
+                page_criteria_ids,
+                type_=ARRAY(Integer),
+            )
+            locked_criteria_ids = tuple(
+                await session.scalars(
+                    select(models.ProjectEvaluatorCriteria.id)
+                    .where(
+                        models.ProjectEvaluatorCriteria.id == any_(page_criteria_ids_parameter),
+                    )
+                    .order_by(models.ProjectEvaluatorCriteria.id)
+                    .with_for_update()
+                )
+            )
+            if len(locked_criteria_ids) != len(page_criteria_ids):
+                return 0, eligible_pair_count
             page_ids = tuple(
                 dict.fromkeys(await session.scalars(select(eligible_page.c.project_session_rowid)))
             )

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -5,31 +5,34 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from secrets import token_hex
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 from sqlalchemy import (
     ColumnElement,
     Float,
     Insert,
+    Integer,
+    String,
     and_,
     cast,
+    column,
     func,
     literal,
     or_,
     select,
     text,
     type_coerce,
-    union_all,
     update,
 )
 from sqlalchemy.dialects.postgresql import insert as insert_postgresql
 from sqlalchemy.dialects.sqlite import insert as insert_sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, with_polymorphic
+from sqlalchemy.sql import Select
+from sqlalchemy.sql.selectable import Subquery
 from typing_extensions import assert_never
 
 from phoenix.config import get_env_enable_prometheus, get_env_online_eval_max_session_outstanding
@@ -59,13 +62,6 @@ SESSION_SWEEP_INTERVAL_SECONDS = 10.0
 _CONSUMER_GROUP = "default"
 _SESSION_SWEEP_LEASE_NAME = "session-sweep"
 _MAX_ELIGIBLE_PAIRS_PER_TICK = 1000
-_MAX_SESSION_WORK_INSERT_PARAMETERS = 30_000
-# One bind parameter per candidate session id, plus the handful of per-criterion
-# literals the whole statement shares.
-_SESSION_WORK_INSERT_FIXED_PARAMETERS = 16
-_SESSION_WORK_INSERT_BATCH_SIZE = (
-    _MAX_SESSION_WORK_INSERT_PARAMETERS - _SESSION_WORK_INSERT_FIXED_PARAMETERS
-)
 # Only work terminated within this window feeds the watermark-lag gauge; the table has
 # no retention, so an unbounded aggregate would scan more rows on every tick forever.
 _WATERMARK_LAG_WINDOW_SECONDS = 86_400.0
@@ -90,13 +86,52 @@ class _SessionCriteria:
     delay_seconds: int
 
 
-@dataclass(frozen=True)
-class _EligiblePair:
-    project_session_rowid: int
-    criteria_id: int
+def _criteria_relation(criteria: Sequence[_SessionCriteria]) -> Subquery:
+    """Return a portable inline relation for resolved session criteria."""
+    rows = []
+    parameters: dict[str, Any] = {}
+    for index, criterion in enumerate(criteria):
+        row_parameters = {
+            f"sc{index}_criteria_id": criterion.criteria_id,
+            f"sc{index}_project_id": criterion.project_id,
+            f"sc{index}_evaluator_id": criterion.evaluator_id,
+            f"sc{index}_config_fingerprint": criterion.fingerprint,
+            f"sc{index}_delay_seconds": criterion.delay_seconds,
+        }
+        parameters.update(row_parameters)
+        placeholders = [f":{name}" for name in row_parameters]
+        if index == 0:
+            placeholders = [
+                f"CAST({placeholders[0]} AS INTEGER)",
+                f"CAST({placeholders[1]} AS INTEGER)",
+                f"CAST({placeholders[2]} AS INTEGER)",
+                f"CAST({placeholders[3]} AS VARCHAR)",
+                f"CAST({placeholders[4]} AS INTEGER)",
+            ]
+        rows.append(f"({', '.join(placeholders)})")
+    statement = text(
+        "SELECT "
+        "sc.column1 AS criteria_id, "
+        "sc.column2 AS project_id, "
+        "sc.column3 AS evaluator_id, "
+        "sc.column4 AS config_fingerprint, "
+        "sc.column5 AS delay_seconds "
+        f"FROM (VALUES {', '.join(rows)}) AS sc"
+    )
+    return (
+        statement.bindparams(**parameters)
+        .columns(
+            column("criteria_id", Integer),
+            column("project_id", Integer),
+            column("evaluator_id", Integer),
+            column("config_fingerprint", String),
+            column("delay_seconds", Integer),
+        )
+        .subquery("sweep_criteria")
+    )
 
 
-def _live_work_exists(criterion: _SessionCriteria) -> ColumnElement[bool]:
+def _live_work_exists(criteria_relation: Subquery) -> ColumnElement[bool]:
     """Whether the session still holds a live dedup key for this criterion."""
     live_work = aliased(models.EvalSessionWorkUnit)
     return (
@@ -104,8 +139,8 @@ def _live_work_exists(criterion: _SessionCriteria) -> ColumnElement[bool]:
         .select_from(live_work)
         .where(
             live_work.project_session_rowid == models.ProjectSession.id,
-            live_work.evaluator_id == criterion.evaluator_id,
-            live_work.config_fingerprint == criterion.fingerprint,
+            live_work.evaluator_id == criteria_relation.c.evaluator_id,
+            live_work.config_fingerprint == criteria_relation.c.config_fingerprint,
             or_(
                 live_work.status.in_(("PENDING", "RUNNING")),
                 and_(
@@ -114,39 +149,104 @@ def _live_work_exists(criterion: _SessionCriteria) -> ColumnElement[bool]:
                 ),
             ),
         )
-        .correlate(models.ProjectSession)
+        .correlate(models.ProjectSession, criteria_relation)
         .exists()
     )
 
 
+def _eligible_pairs_statement(
+    criteria_relation: Subquery,
+    database_now: datetime,
+    dialect: SupportedSQLDialect,
+) -> Select[Any]:
+    successful_work = aliased(models.EvalSessionWorkUnit)
+    terminal_work = aliased(models.EvalSessionWorkUnit)
+    terminal_watermark = (
+        select(func.max(terminal_work.evaluated_through))
+        .where(
+            terminal_work.project_session_rowid == models.ProjectSession.id,
+            terminal_work.evaluator_id == criteria_relation.c.evaluator_id,
+            terminal_work.config_fingerprint == criteria_relation.c.config_fingerprint,
+            or_(
+                terminal_work.status.in_(("DONE", "EXPIRED")),
+                and_(
+                    terminal_work.status == "ERROR",
+                    terminal_work.attempts >= MAX_ATTEMPTS,
+                ),
+            ),
+        )
+        .correlate(models.ProjectSession, criteria_relation)
+        .scalar_subquery()
+    )
+    successful_result_exists = (
+        select(1)
+        .select_from(successful_work)
+        .where(
+            successful_work.project_session_rowid == models.ProjectSession.id,
+            successful_work.evaluator_id == criteria_relation.c.evaluator_id,
+            successful_work.config_fingerprint == criteria_relation.c.config_fingerprint,
+            successful_work.status == "DONE",
+        )
+        .correlate(models.ProjectSession, criteria_relation)
+        .exists()
+    )
+    if dialect is SupportedSQLDialect.SQLITE:
+        due_at = (
+            cast(func.julianday(models.ProjectSession.last_span_ingested_at), Float) * 86_400
+            + criteria_relation.c.delay_seconds
+        )
+        current_time = cast(func.julianday(database_now), Float) * 86_400
+    else:
+        due_at = (
+            func.extract("epoch", models.ProjectSession.last_span_ingested_at)
+            + criteria_relation.c.delay_seconds
+        )
+        current_time = func.extract("epoch", literal(database_now))
+    return (
+        select(
+            models.ProjectSession.id.label("project_session_rowid"),
+            criteria_relation.c.criteria_id,
+            criteria_relation.c.evaluator_id,
+            criteria_relation.c.config_fingerprint,
+            models.ProjectSession.last_span_ingested_at.label("evaluated_through"),
+            due_at.label("effective_due_time"),
+        )
+        .select_from(models.ProjectSession)
+        .join(
+            criteria_relation,
+            models.ProjectSession.project_id == criteria_relation.c.project_id,
+        )
+        .where(
+            models.ProjectSession.content_complete.is_(True),
+            models.ProjectSession.last_span_ingested_at.is_not(None),
+            due_at <= current_time,
+            ~successful_result_exists,
+            ~_live_work_exists(criteria_relation),
+            or_(
+                terminal_watermark.is_(None),
+                terminal_watermark < models.ProjectSession.last_span_ingested_at,
+            ),
+        )
+    )
+
+
 def _session_work_insert_statement(
-    criterion: _SessionCriteria,
-    project_session_rowids: Sequence[int],
+    eligible_pairs: Subquery,
     dialect: SupportedSQLDialect,
 ) -> Insert:
-    """Materialize work for one criterion, re-deriving eligibility at write time.
-
-    The completeness and no-live-work guards belong to the writing statement, not to
-    the SELECT that picked the candidates: under READ COMMITTED a session can be marked
-    incomplete, or acquire live work, in the gap between the two.
-    """
+    """Materialize the globally ordered eligibility page in one statement."""
     index_elements = (
         models.EvalSessionWorkUnit.project_session_rowid,
         models.EvalSessionWorkUnit.evaluator_id,
         models.EvalSessionWorkUnit.config_fingerprint,
     )
     candidates = select(
-        models.ProjectSession.id,
-        literal(criterion.evaluator_id),
-        literal(criterion.criteria_id),
-        literal(criterion.fingerprint),
-        models.ProjectSession.last_span_ingested_at,
-    ).where(
-        models.ProjectSession.id.in_(project_session_rowids),
-        models.ProjectSession.content_complete.is_(True),
-        models.ProjectSession.last_span_ingested_at.is_not(None),
-        ~_live_work_exists(criterion),
-    )
+        eligible_pairs.c.project_session_rowid,
+        eligible_pairs.c.evaluator_id,
+        eligible_pairs.c.criteria_id,
+        eligible_pairs.c.config_fingerprint,
+        eligible_pairs.c.evaluated_through,
+    ).where(literal(True))
     if dialect is SupportedSQLDialect.POSTGRESQL:
         return (
             insert_postgresql(models.EvalSessionWorkUnit)
@@ -155,6 +255,7 @@ def _session_work_insert_statement(
                 index_elements=index_elements,
                 index_where=_LIVE_WORK_INDEX_PREDICATE,
             )
+            .returning(models.EvalSessionWorkUnit.criteria_id)
         )
     if dialect is SupportedSQLDialect.SQLITE:
         return (
@@ -164,6 +265,7 @@ def _session_work_insert_statement(
                 index_elements=index_elements,
                 index_where=_LIVE_WORK_INDEX_PREDICATE,
             )
+            .returning(models.EvalSessionWorkUnit.criteria_id)
         )
     assert_never(dialect)
 
@@ -338,33 +440,12 @@ class SessionEvalSweeper(DaemonTask):
         work_budget = await self._admission_budget(session)
         if work_budget == 0:
             return 0, 0
-        eligible_pairs, eligible_pair_count = await self._load_eligible_pairs(
+        return await self._load_eligible_pairs(
             session,
             database_now,
             criteria,
             limit=min(work_budget, _MAX_ELIGIBLE_PAIRS_PER_TICK),
         )
-        if not eligible_pairs:
-            return 0, eligible_pair_count
-
-        criteria_by_id = {criterion.criteria_id: criterion for criterion in criteria}
-        rowids_by_criteria: defaultdict[int, list[int]] = defaultdict(list)
-        for pair in eligible_pairs:
-            rowids_by_criteria[pair.criteria_id].append(pair.project_session_rowid)
-
-        inserted_count = 0
-        for criteria_id, rowids in rowids_by_criteria.items():
-            criterion = criteria_by_id[criteria_id]
-            for start in range(0, len(rowids), _SESSION_WORK_INSERT_BATCH_SIZE):
-                result = await session.execute(
-                    _session_work_insert_statement(
-                        criterion,
-                        rowids[start : start + _SESSION_WORK_INSERT_BATCH_SIZE],
-                        self._db.dialect,
-                    )
-                )
-                inserted_count += result.rowcount  # type: ignore[attr-defined]
-        return inserted_count, eligible_pair_count
 
     async def _load_eligible_pairs(
         self,
@@ -373,102 +454,36 @@ class SessionEvalSweeper(DaemonTask):
         criteria: Sequence[_SessionCriteria],
         *,
         limit: int,
-    ) -> tuple[list[_EligiblePair], int]:
+    ) -> tuple[int, int]:
         if not criteria:
-            return [], 0
-        statements = []
-        for criterion in criteria:
-            successful_work = aliased(models.EvalSessionWorkUnit)
-            terminal_work = aliased(models.EvalSessionWorkUnit)
-            # How far session content was already carried by work that will never run
-            # again — a completed evaluation, an expired one, or one that exhausted its
-            # retries. Without new content past that mark there is nothing to re-evaluate,
-            # and materializing anyway loops a failing session forever.
-            terminal_watermark = (
-                select(func.max(terminal_work.evaluated_through))
-                .where(
-                    terminal_work.project_session_rowid == models.ProjectSession.id,
-                    terminal_work.evaluator_id == criterion.evaluator_id,
-                    terminal_work.config_fingerprint == criterion.fingerprint,
-                    or_(
-                        terminal_work.status.in_(("DONE", "EXPIRED")),
-                        and_(
-                            terminal_work.status == "ERROR",
-                            terminal_work.attempts >= MAX_ATTEMPTS,
-                        ),
-                    ),
-                )
-                .correlate(models.ProjectSession)
-                .scalar_subquery()
-            )
-            successful_result_exists = (
-                select(1)
-                .select_from(successful_work)
-                .where(
-                    successful_work.project_session_rowid == models.ProjectSession.id,
-                    successful_work.evaluator_id == criterion.evaluator_id,
-                    successful_work.config_fingerprint == criterion.fingerprint,
-                    successful_work.status == "DONE",
-                )
-                .correlate(models.ProjectSession)
-                .exists()
-            )
-            live_work_exists = _live_work_exists(criterion)
-            if self._db.dialect is SupportedSQLDialect.SQLITE:
-                due_at = (
-                    cast(func.julianday(models.ProjectSession.last_span_ingested_at), Float)
-                    * 86_400
-                    + criterion.delay_seconds
-                )
-            else:
-                due_at = (
-                    func.extract("epoch", models.ProjectSession.last_span_ingested_at)
-                    + criterion.delay_seconds
-                )
-            statements.append(
-                select(
-                    models.ProjectSession.id.label("project_session_rowid"),
-                    literal(criterion.criteria_id).label("criteria_id"),
-                    due_at.label("effective_due_time"),
-                ).where(
-                    models.ProjectSession.project_id == criterion.project_id,
-                    models.ProjectSession.content_complete.is_(True),
-                    models.ProjectSession.last_span_ingested_at.is_not(None),
-                    models.ProjectSession.last_span_ingested_at
-                    <= database_now - timedelta(seconds=criterion.delay_seconds),
-                    ~successful_result_exists,
-                    ~live_work_exists,
-                    or_(
-                        terminal_watermark.is_(None),
-                        terminal_watermark < models.ProjectSession.last_span_ingested_at,
-                    ),
-                )
-            )
-        relation = union_all(*statements).subquery()
+            return 0, 0
+        criteria_relation = _criteria_relation(criteria)
+        relation = _eligible_pairs_statement(
+            criteria_relation,
+            database_now,
+            self._db.dialect,
+        ).subquery("eligible_pairs")
         eligible_pair_count = (
             await session.scalar(select(func.count()).select_from(relation))
         ) or 0
-        if limit == 0:
-            return [], eligible_pair_count
-        rows = (
-            await session.execute(
-                select(relation)
-                .order_by(
-                    relation.c.effective_due_time,
-                    relation.c.project_session_rowid,
-                    relation.c.criteria_id,
+        eligible_page = (
+            select(relation)
+            .order_by(
+                relation.c.effective_due_time,
+                relation.c.project_session_rowid,
+                relation.c.criteria_id,
+            )
+            .limit(limit)
+            .subquery("eligible_pair_page")
+        )
+        inserted_count = len(
+            (
+                await session.scalars(
+                    _session_work_insert_statement(eligible_page, self._db.dialect)
                 )
-                .limit(limit)
-            )
-        ).all()
-        pairs = [
-            _EligiblePair(
-                project_session_rowid=row.project_session_rowid,
-                criteria_id=row.criteria_id,
-            )
-            for row in rows
-        ]
-        return pairs, eligible_pair_count
+            ).all()
+        )
+        return inserted_count, eligible_pair_count
 
     async def _publish_eligibility_metrics(self, eligible_pair_count: int) -> None:
         """Publish the sweep's observation gauges from a session of its own.

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -253,11 +253,14 @@ class SessionEvalSweeper(DaemonTask):
         if self._publish_metrics:
             ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS.inc()
         materialized_work_count = 0
+        eligible_pair_count = 0
         renewed: Optional[int] = None
         try:
             async with self._db() as session:
                 database_now = await self._database_now(session)
-                materialized_work_count = await self._sweep(session, database_now)
+                materialized_work_count, eligible_pair_count = await self._sweep(
+                    session, database_now
+                )
                 renewed_at = await self._database_now(session)
                 renewed = await session.scalar(
                     update(models.EvalWorkLease)
@@ -283,6 +286,7 @@ class SessionEvalSweeper(DaemonTask):
             else:
                 ONLINE_EVAL_SESSION_SWEEP_SUCCESSES.inc()
                 ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS.inc(materialized_work_count)
+                await self._publish_eligibility_metrics(eligible_pair_count)
         return renewed is not None
 
     async def _database_now(self, session: AsyncSession) -> datetime:
@@ -328,21 +332,20 @@ class SessionEvalSweeper(DaemonTask):
             )
         return criteria_rows
 
-    async def _sweep(self, session: AsyncSession, database_now: datetime) -> int:
+    async def _sweep(self, session: AsyncSession, database_now: datetime) -> tuple[int, int]:
+        """Materialize this tick's work, returning (work created, pairs found eligible)."""
         criteria = await self._load_criteria(session)
         work_budget = await self._admission_budget(session)
         if work_budget == 0:
-            return 0
+            return 0, 0
         eligible_pairs, eligible_pair_count = await self._load_eligible_pairs(
             session,
             database_now,
             criteria,
             limit=min(work_budget, _MAX_ELIGIBLE_PAIRS_PER_TICK),
         )
-        if self._publish_metrics:
-            await self._publish_eligibility_metrics(session, database_now, eligible_pair_count)
         if not eligible_pairs:
-            return 0
+            return 0, eligible_pair_count
 
         criteria_by_id = {criterion.criteria_id: criterion for criterion in criteria}
         rowids_by_criteria: defaultdict[int, list[int]] = defaultdict(list)
@@ -361,7 +364,7 @@ class SessionEvalSweeper(DaemonTask):
                     )
                 )
                 inserted_count += result.rowcount  # type: ignore[attr-defined]
-        return inserted_count
+        return inserted_count, eligible_pair_count
 
     async def _load_eligible_pairs(
         self,
@@ -467,13 +470,26 @@ class SessionEvalSweeper(DaemonTask):
         ]
         return pairs, eligible_pair_count
 
-    async def _publish_eligibility_metrics(
+    async def _publish_eligibility_metrics(self, eligible_pair_count: int) -> None:
+        """Publish the sweep's observation gauges from a session of its own.
+
+        Reporting is not materialization: this runs after the work has been committed
+        and the lease renewed, over its own read session, so a failing aggregate costs
+        a stale gauge rather than the sweep that already succeeded.
+        """
+        ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG.set(eligible_pair_count)
+        try:
+            async with self._db.read() as session:
+                database_now = await self._database_now(session)
+                await self._publish_watermark_lag(session, database_now)
+        except Exception:
+            logger.exception("Failed to publish session evaluation watermark lag")
+
+    async def _publish_watermark_lag(
         self,
         session: AsyncSession,
         database_now: datetime,
-        eligible_pair_count: int,
     ) -> None:
-        ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG.set(eligible_pair_count)
         if self._db.dialect is SupportedSQLDialect.SQLITE:
             lag_seconds = (
                 cast(func.julianday(models.ProjectSession.last_span_ingested_at), Float)

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -17,6 +17,8 @@ from sqlalchemy import (
     Integer,
     String,
     and_,
+    any_,
+    bindparam,
     cast,
     column,
     func,
@@ -27,6 +29,7 @@ from sqlalchemy import (
     type_coerce,
     update,
 )
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import insert as insert_postgresql
 from sqlalchemy.dialects.sqlite import insert as insert_sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -233,8 +236,10 @@ def _eligible_pairs_statement(
 def _session_work_insert_statement(
     eligible_pairs: Subquery,
     dialect: SupportedSQLDialect,
+    *,
+    project_session_rowids: Optional[Sequence[int]] = None,
 ) -> Insert:
-    """Materialize the globally ordered eligibility page in one statement."""
+    """Insert work from a globally ordered page whose PostgreSQL sessions are locked."""
     index_elements = (
         models.EvalSessionWorkUnit.project_session_rowid,
         models.EvalSessionWorkUnit.evaluator_id,
@@ -247,6 +252,10 @@ def _session_work_insert_statement(
         eligible_pairs.c.config_fingerprint,
         eligible_pairs.c.evaluated_through,
     ).where(literal(True))
+    if project_session_rowids is not None:
+        candidates = candidates.where(
+            eligible_pairs.c.project_session_rowid.in_(project_session_rowids)
+        )
     if dialect is SupportedSQLDialect.POSTGRESQL:
         return (
             insert_postgresql(models.EvalSessionWorkUnit)
@@ -476,10 +485,39 @@ class SessionEvalSweeper(DaemonTask):
             .limit(limit)
             .subquery("eligible_pair_page")
         )
+        locked_project_session_rowids: Optional[Sequence[int]] = None
+        if self._db.dialect is SupportedSQLDialect.POSTGRESQL:
+            page_ids = tuple(
+                dict.fromkeys(await session.scalars(select(eligible_page.c.project_session_rowid)))
+            )
+            if not page_ids:
+                return 0, eligible_pair_count
+            page_ids_parameter = bindparam(
+                "page_ids",
+                page_ids,
+                type_=ARRAY(Integer),
+            )
+            locked_project_session_rowids = tuple(
+                await session.scalars(
+                    select(models.ProjectSession.id)
+                    .where(
+                        models.ProjectSession.id == any_(page_ids_parameter),
+                        models.ProjectSession.content_complete.is_(True),
+                    )
+                    .order_by(models.ProjectSession.id)
+                    .with_for_update()
+                )
+            )
+            if not locked_project_session_rowids:
+                return 0, eligible_pair_count
         inserted_count = len(
             (
                 await session.scalars(
-                    _session_work_insert_statement(eligible_page, self._db.dialect)
+                    _session_work_insert_statement(
+                        eligible_page,
+                        self._db.dialect,
+                        project_session_rowids=locked_project_session_rowids,
+                    )
                 )
             ).all()
         )

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -364,7 +364,7 @@ class SessionEvalSweeper(DaemonTask):
         if self._publish_metrics:
             ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS.inc()
         materialized_work_count = 0
-        eligible_pair_count = 0
+        eligible_pair_count: Optional[int] = None
         renewed: Optional[int] = None
         try:
             async with self._db() as session:
@@ -453,11 +453,15 @@ class SessionEvalSweeper(DaemonTask):
             )
         return criteria_rows
 
-    async def _sweep(self, session: AsyncSession, database_now: datetime) -> tuple[int, int]:
+    async def _sweep(
+        self,
+        session: AsyncSession,
+        database_now: datetime,
+    ) -> tuple[int, Optional[int]]:
         """Materialize this tick's work, returning (work created, pairs found eligible)."""
         work_budget = await self._admission_budget(session)
         if work_budget == 0:
-            return 0, 0
+            return 0, None
         criteria = await self._load_criteria(session)
         return await self._load_eligible_pairs(
             session,
@@ -473,18 +477,20 @@ class SessionEvalSweeper(DaemonTask):
         criteria: Sequence[_SessionCriteria],
         *,
         limit: int,
-    ) -> tuple[int, int]:
+    ) -> tuple[int, Optional[int]]:
         if not criteria:
-            return 0, 0
+            return 0, 0 if self._publish_metrics else None
         criteria_relation = _criteria_relation(criteria)
         relation = _eligible_pairs_statement(
             criteria_relation,
             database_now,
             self._db.dialect,
         ).subquery("eligible_pairs")
-        eligible_pair_count = (
-            await session.scalar(select(func.count()).select_from(relation))
-        ) or 0
+        eligible_pair_count = None
+        if self._publish_metrics:
+            eligible_pair_count = (
+                await session.scalar(select(func.count()).select_from(relation))
+            ) or 0
         eligible_page = (
             select(relation)
             .order_by(
@@ -533,14 +539,15 @@ class SessionEvalSweeper(DaemonTask):
         )
         return inserted_count, eligible_pair_count
 
-    async def _publish_eligibility_metrics(self, eligible_pair_count: int) -> None:
+    async def _publish_eligibility_metrics(self, eligible_pair_count: Optional[int]) -> None:
         """Publish the sweep's observation gauges from a session of its own.
 
         Reporting is not materialization: this runs after the work has been committed
         and the lease renewed, over its own read session, so a failing aggregate costs
         a stale gauge rather than the sweep that already succeeded.
         """
-        ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG.set(eligible_pair_count)
+        if eligible_pair_count is not None:
+            ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG.set(eligible_pair_count)
         try:
             async with self._db.read() as session:
                 database_now = await self._database_now(session)

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -57,6 +57,7 @@ SESSION_SWEEP_LEASE_TTL_SECONDS = 90.0
 SESSION_SWEEP_INTERVAL_SECONDS = 10.0
 
 _CONSUMER_GROUP = "default"
+_SESSION_SWEEP_LEASE_NAME = "session-sweep"
 _MAX_ELIGIBLE_PAIRS_PER_TICK = 1000
 _MAX_SESSION_WORK_INSERT_PARAMETERS = 30_000
 # One bind parameter per candidate session id, plus the handful of per-criterion
@@ -184,6 +185,7 @@ class SessionEvalSweeper(DaemonTask):
         self._max_outstanding = get_env_online_eval_max_session_outstanding()
         self._publish_metrics = get_env_enable_prometheus()
         self._sweeper_id = f"session-sweeper-{token_hex(8)}"
+        self._lease_name = f"{_SESSION_SWEEP_LEASE_NAME}:{consumer_group}"
         self._lease_held = False
 
     async def _run(self) -> None:
@@ -198,61 +200,55 @@ class SessionEvalSweeper(DaemonTask):
             await self._release_lease()
 
     async def _tick(self) -> None:
-        cursor_id = await self._acquire_cursor()
-        if cursor_id is None:
+        lease_id = await self._acquire_lease()
+        if lease_id is None:
             return
-        if not await self._materialize_and_renew(cursor_id):
+        if not await self._materialize_and_renew(lease_id):
             self._lease_held = False
             logger.warning("Session evaluation sweeper lost its lease")
 
-    async def _acquire_cursor(self) -> Optional[int]:
+    async def _acquire_lease(self) -> Optional[int]:
         for _ in range(2):
             async with self._db() as session:
                 database_now = await self._database_now(session)
-                cursor_id = await session.scalar(
-                    update(models.EvalWorkCursor)
+                lease_id = await session.scalar(
+                    update(models.EvalWorkLease)
                     .where(
-                        models.EvalWorkCursor.evaluation_target == "SESSION",
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkLease.name == self._lease_name,
                         or_(
-                            models.EvalWorkCursor.claimed_by.is_(None),
-                            models.EvalWorkCursor.claimed_by == self._sweeper_id,
-                            models.EvalWorkCursor.claimed_at
+                            models.EvalWorkLease.holder.is_(None),
+                            models.EvalWorkLease.holder == self._sweeper_id,
+                            models.EvalWorkLease.heartbeat_at
                             < database_now - timedelta(seconds=SESSION_SWEEP_LEASE_TTL_SECONDS),
                         ),
                     )
-                    .values(claimed_by=self._sweeper_id, claimed_at=database_now)
-                    .returning(models.EvalWorkCursor.id)
+                    .values(holder=self._sweeper_id, heartbeat_at=database_now)
+                    .returning(models.EvalWorkLease.id)
                 )
-            if cursor_id is not None:
+            if lease_id is not None:
                 self._lease_held = True
-                return cursor_id
+                return lease_id
             async with self._db() as session:
                 row_exists = await session.scalar(
-                    select(models.EvalWorkCursor.id).where(
-                        models.EvalWorkCursor.evaluation_target == "SESSION",
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    select(models.EvalWorkLease.id).where(
+                        models.EvalWorkLease.name == self._lease_name
                     )
                 )
                 if row_exists is not None:
                     break
                 await session.execute(
                     insert_on_conflict(
-                        {
-                            "evaluation_target": "SESSION",
-                            "consumer_group": self._consumer_group,
-                            "produced_through_id": 0,
-                        },
-                        table=models.EvalWorkCursor,
+                        {"name": self._lease_name},
+                        table=models.EvalWorkLease,
                         dialect=self._db.dialect,
-                        unique_by=("evaluation_target", "consumer_group"),
+                        unique_by=("name",),
                         on_conflict=OnConflict.DO_NOTHING,
                     )
                 )
         self._lease_held = False
         return None
 
-    async def _materialize_and_renew(self, cursor_id: int) -> bool:
+    async def _materialize_and_renew(self, lease_id: int) -> bool:
         started_at = time.monotonic()
         if self._publish_metrics:
             ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS.inc()
@@ -264,13 +260,13 @@ class SessionEvalSweeper(DaemonTask):
                 materialized_work_count = await self._sweep(session, database_now)
                 renewed_at = await self._database_now(session)
                 renewed = await session.scalar(
-                    update(models.EvalWorkCursor)
+                    update(models.EvalWorkLease)
                     .where(
-                        models.EvalWorkCursor.id == cursor_id,
-                        models.EvalWorkCursor.claimed_by == self._sweeper_id,
+                        models.EvalWorkLease.id == lease_id,
+                        models.EvalWorkLease.holder == self._sweeper_id,
                     )
-                    .values(claimed_at=renewed_at)
-                    .returning(models.EvalWorkCursor.id)
+                    .values(heartbeat_at=renewed_at)
+                    .returning(models.EvalWorkLease.id)
                 )
                 if renewed is None:
                     await session.rollback()
@@ -540,13 +536,12 @@ class SessionEvalSweeper(DaemonTask):
         try:
             async with self._db() as session:
                 await session.execute(
-                    update(models.EvalWorkCursor)
+                    update(models.EvalWorkLease)
                     .where(
-                        models.EvalWorkCursor.evaluation_target == "SESSION",
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
-                        models.EvalWorkCursor.claimed_by == self._sweeper_id,
+                        models.EvalWorkLease.name == self._lease_name,
+                        models.EvalWorkLease.holder == self._sweeper_id,
                     )
-                    .values(claimed_by=None, claimed_at=None)
+                    .values(holder=None, heartbeat_at=None)
                 )
         except Exception:
             logger.exception("Failed to release session evaluation sweep lease")

--- a/src/phoenix/server/online_eval/session_sweeper.py
+++ b/src/phoenix/server/online_eval/session_sweeper.py
@@ -110,9 +110,7 @@ def _criteria_relation(
         placeholders = [f":{name}" for name in row_parameters]
         if index == 0:
             created_at_type = (
-                "TIMESTAMP WITH TIME ZONE"
-                if dialect is SupportedSQLDialect.POSTGRESQL
-                else "TEXT"
+                "TIMESTAMP WITH TIME ZONE" if dialect is SupportedSQLDialect.POSTGRESQL else "TEXT"
             )
             placeholders = [
                 f"CAST({placeholders[0]} AS INTEGER)",

--- a/src/phoenix/server/prometheus.py
+++ b/src/phoenix/server/prometheus.py
@@ -180,6 +180,41 @@ ONLINE_EVAL_INGEST_SPANS_PER_SECOND = Gauge(
     documentation="Span ingest rate derived from successive online-eval cursor "
     "high-water observations",
 )
+ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG = Gauge(
+    namespace="phoenix",
+    name="online_eval_session_activity_backlog",
+    documentation="Current number of session activity rows awaiting a sweep",
+)
+ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS = Gauge(
+    namespace="phoenix",
+    name="online_eval_session_activity_oldest_age_seconds",
+    documentation="Age in seconds of the oldest session activity row (0 when empty)",
+)
+ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS = Counter(
+    namespace="phoenix",
+    name="online_eval_session_sweep_attempts_total",
+    documentation="Total number of session evaluation sweep attempts",
+)
+ONLINE_EVAL_SESSION_SWEEP_SUCCESSES = Counter(
+    namespace="phoenix",
+    name="online_eval_session_sweep_successes_total",
+    documentation="Total number of committed session evaluation sweeps",
+)
+ONLINE_EVAL_SESSION_SWEEP_FAILURES = Counter(
+    namespace="phoenix",
+    name="online_eval_session_sweep_failures_total",
+    documentation="Total number of failed or rolled-back session evaluation sweeps",
+)
+ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS = Histogram(
+    namespace="phoenix",
+    name="online_eval_session_sweep_duration_seconds",
+    documentation="Session evaluation sweep duration in seconds",
+)
+ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS = Counter(
+    namespace="phoenix",
+    name="online_eval_session_materialized_work_units_total",
+    documentation="Total number of session evaluation work units materialized",
+)
 
 
 def _join_paths(prefix: str, path: str) -> str:

--- a/src/phoenix/server/prometheus.py
+++ b/src/phoenix/server/prometheus.py
@@ -180,15 +180,15 @@ ONLINE_EVAL_INGEST_SPANS_PER_SECOND = Gauge(
     documentation="Span ingest rate derived from successive online-eval cursor "
     "high-water observations",
 )
-ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG = Gauge(
+ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG = Gauge(
     namespace="phoenix",
-    name="online_eval_session_activity_backlog",
-    documentation="Current number of session activity rows awaiting a sweep",
+    name="online_eval_session_eligible_pair_backlog",
+    documentation="Current number of session and evaluator pairs eligible for work",
 )
-ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS = Gauge(
+ONLINE_EVAL_SESSION_RESULT_WATERMARK_LAG_SECONDS = Gauge(
     namespace="phoenix",
-    name="online_eval_session_activity_oldest_age_seconds",
-    documentation="Age in seconds of the oldest session activity row (0 when empty)",
+    name="online_eval_session_result_watermark_lag_seconds",
+    documentation="Largest gap between session activity and a successful result watermark",
 )
 ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS = Counter(
     namespace="phoenix",

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -166,6 +166,7 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
             "filter_condition",
             "sampling_rate",
             "evaluation_target",
+            "evaluation_delay_seconds",
             "input_mapping",
             "enabled",
             "work_materialized_at",
@@ -183,6 +184,7 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
             "fk_project_evaluator_criteria_evaluator_id_evaluators",
             "ck_project_evaluator_criteria_`valid_sampling_rate`",
             "ck_project_evaluator_criteria_`valid_evaluation_target`",
+            "ck_project_evaluator_criteria_`valid_evaluation_delay_seconds`",
         }
         if db_backend == "postgresql":
             index_names.update(

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -264,6 +264,69 @@ class TestEvalWorkUnits(_OnlineEvalSchemaTest):
         )
 
 
+class TestEvalSessionWorkUnits(_OnlineEvalSchemaTest):
+    table_name = "eval_session_work_units"
+
+    @override
+    @classmethod
+    def _get_upgraded_schema_info(cls, db_backend: _DBBackend) -> _TableSchemaInfo:
+        index_names = {
+            "ix_eval_session_work_units_claimable",
+            "ix_eval_session_work_units_evaluator_id",
+            "ix_eval_session_work_units_criteria_id",
+            "ix_eval_session_work_units_error_attempts",
+            "ix_eval_session_work_units_terminal",
+            "uq_eval_session_work_units_live_key",
+        }
+        constraint_names = {
+            "pk_eval_session_work_units",
+            _constraint_name(
+                "fk_eval_session_work_units_project_session_rowid_project_sessions",
+                db_backend,
+            ),
+            _constraint_name(
+                "fk_eval_session_work_units_evaluator_id_evaluators",
+                db_backend,
+            ),
+            _constraint_name(
+                "fk_eval_session_work_units_criteria_id_project_evaluator_criteria",
+                db_backend,
+            ),
+            "ck_eval_session_work_units_`valid_eval_work_status`",
+        }
+        if db_backend == "postgresql":
+            index_names.add("pk_eval_session_work_units")
+        elif db_backend == "sqlite":
+            index_names.add("sqlite_autoindex_eval_session_work_units_1")
+        else:
+            assert_never(db_backend)
+        return _TableSchemaInfo(
+            table_name=cls.table_name,
+            column_names=frozenset(
+                {
+                    "id",
+                    "project_session_rowid",
+                    "evaluator_id",
+                    "criteria_id",
+                    "config_fingerprint",
+                    "evaluated_through",
+                    "status",
+                    "claimed_at",
+                    "claimed_by",
+                    "attempts",
+                    "error",
+                    "cooldown_until",
+                    "created_at",
+                    "updated_at",
+                }
+            ),
+            index_names=frozenset(index_names),
+            constraint_names=frozenset(constraint_names),
+            nullable_column_names=frozenset(
+                {"claimed_at", "claimed_by", "error", "cooldown_until"}
+            ),
+        )
+
 async def test_project_session_liveness_schema(
     _engine: AsyncEngine,
     _alembic_config: Config,

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -152,6 +152,40 @@ class TestEvalWorkCursors(_OnlineEvalSchemaTest):
         )
 
 
+class TestEvalWorkLeases(_OnlineEvalSchemaTest):
+    table_name = "eval_work_leases"
+
+    @override
+    @classmethod
+    def _get_upgraded_schema_info(cls, db_backend: _DBBackend) -> Optional[_TableSchemaInfo]:
+        column_names = {
+            "id",
+            "name",
+            "holder",
+            "heartbeat_at",
+            "created_at",
+            "updated_at",
+        }
+        index_names: set[str] = set()
+        constraint_names = {
+            "pk_eval_work_leases",
+            "uq_eval_work_leases_name",
+        }
+        if db_backend == "postgresql":
+            index_names.update({"pk_eval_work_leases", "uq_eval_work_leases_name"})
+        elif db_backend == "sqlite":
+            index_names.update({"sqlite_autoindex_eval_work_leases_1"})
+        else:
+            assert_never(db_backend)
+        return _TableSchemaInfo(
+            table_name=cls.table_name,
+            column_names=frozenset(column_names),
+            index_names=frozenset(index_names),
+            constraint_names=frozenset(constraint_names),
+            nullable_column_names=frozenset(["holder", "heartbeat_at"]),
+        )
+
+
 class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
     table_name = "project_evaluator_criteria"
 

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -327,6 +327,7 @@ class TestEvalSessionWorkUnits(_OnlineEvalSchemaTest):
             ),
         )
 
+
 async def test_project_session_liveness_schema(
     _engine: AsyncEngine,
     _alembic_config: Config,
@@ -405,12 +406,16 @@ async def test_project_session_liveness_schema(
     before = await _run_async(_engine, _get)
     assert before is not None
     assert "last_span_ingested_at" not in before["column_names"]
+    assert "content_complete" not in before["column_names"]
     await _run_async(_engine, _seed)
 
     await _up(_engine, _alembic_config, _UP, _schema)
     after = await _run_async(_engine, _get)
     assert after is not None
-    assert after["column_names"] == before["column_names"] | {"last_span_ingested_at"}
+    assert after["column_names"] == before["column_names"] | {
+        "last_span_ingested_at",
+        "content_complete",
+    }
     assert after["index_names"] == before["index_names"] | {
         "ix_project_sessions_project_id_last_span_ingested_at"
     }

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -121,6 +121,7 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
             "filter_condition",
             "sampling_rate",
             "evaluation_target",
+            "evaluation_delay_seconds",
             "input_mapping",
             "enabled",
             "created_at",
@@ -137,6 +138,7 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
             "fk_project_evaluator_criteria_evaluator_id_evaluators",
             "ck_project_evaluator_criteria_`valid_sampling_rate`",
             "ck_project_evaluator_criteria_`valid_evaluation_target`",
+            "ck_project_evaluator_criteria_`valid_evaluation_delay_seconds`",
         }
         if db_backend == "postgresql":
             index_names.update(

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -224,20 +224,16 @@ class TestEvalSessionWorkUnits(_OnlineEvalSchemaTest):
     @override
     @classmethod
     def _get_upgraded_schema_info(cls, db_backend: _DBBackend) -> _TableSchemaInfo:
-        unique_name = _constraint_name(
-            "uq_eval_session_work_units_project_session_rowid_evaluator_id_config_fingerprint",
-            db_backend,
-        )
         index_names = {
             "ix_eval_session_work_units_claimable",
             "ix_eval_session_work_units_evaluator_id",
             "ix_eval_session_work_units_criteria_id",
             "ix_eval_session_work_units_error_attempts",
             "ix_eval_session_work_units_terminal",
+            "uq_eval_session_work_units_live_key",
         }
         constraint_names = {
             "pk_eval_session_work_units",
-            unique_name,
             _constraint_name(
                 "fk_eval_session_work_units_project_session_rowid_project_sessions",
                 db_backend,
@@ -253,7 +249,7 @@ class TestEvalSessionWorkUnits(_OnlineEvalSchemaTest):
             "ck_eval_session_work_units_`valid_eval_work_status`",
         }
         if db_backend == "postgresql":
-            index_names.update({"pk_eval_session_work_units", unique_name})
+            index_names.add("pk_eval_session_work_units")
         elif db_backend == "sqlite":
             index_names.add("sqlite_autoindex_eval_session_work_units_1")
         else:

--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -188,6 +188,48 @@ async def _add_project_session(
     return project_session
 
 
+async def _add_live_session_work_unit(
+    session: AsyncSession,
+    project_session: models.ProjectSession,
+) -> models.EvalSessionWorkUnit:
+    """Seed a claimed session evaluation, so a deleter's stand-down is observable."""
+    from phoenix.db.types.identifier import Identifier
+
+    now = datetime.now(timezone.utc)
+    evaluator = models.BuiltinEvaluator(
+        name=Identifier(root=f"eval-{token_hex(4)}"),
+        kind="BUILTIN",
+        key=token_hex(8),
+        input_schema={},
+        output_configs=[],
+    )
+    session.add(evaluator)
+    await session.flush()
+    criteria = models.ProjectEvaluatorCriteria(
+        project_id=project_session.project_id,
+        evaluator_id=evaluator.id,
+        name=Identifier(root=f"criteria-{token_hex(4)}"),
+        filter_condition="",
+        sampling_rate=1.0,
+        evaluation_target="SESSION",
+    )
+    session.add(criteria)
+    await session.flush()
+    work_unit = models.EvalSessionWorkUnit(
+        project_session_rowid=project_session.id,
+        evaluator_id=evaluator.id,
+        criteria_id=criteria.id,
+        config_fingerprint=token_hex(8),
+        evaluated_through=now,
+        status="RUNNING",
+        claimed_at=now,
+        claimed_by="consumer",
+    )
+    session.add(work_unit)
+    await session.flush()
+    return work_unit
+
+
 _ExperimentGlobalId: TypeAlias = str
 _DatasetExampleGlobalId: TypeAlias = str
 _DatasetExampleRevisionGlobalId: TypeAlias = str

--- a/tests/unit/db/test_eval_work_coordination.py
+++ b/tests/unit/db/test_eval_work_coordination.py
@@ -216,7 +216,7 @@ async def test_session_liveness_and_work_accounting(db: DbSessionFactory) -> Non
     async with db() as session:
         fetched_session = await session.get(models.ProjectSession, project_session_id)
         assert fetched_session is not None
-        assert fetched_session.last_span_seen_at is not None
+        assert fetched_session.last_span_ingested_at is None
         assert fetched_session.content_complete is True
 
         work_unit = await session.scalar(

--- a/tests/unit/db/test_eval_work_coordination.py
+++ b/tests/unit/db/test_eval_work_coordination.py
@@ -194,6 +194,7 @@ async def test_project_evaluator_criteria_defaults_and_relationships(
         assert fetched.name.root.startswith("criteria-")
         assert fetched.filter_condition == ""
         assert fetched.evaluation_target == "SPAN"
+        assert fetched.evaluation_delay_seconds == 300
         assert fetched.input_mapping is None
         assert fetched.sampling_rate == 1.0
         assert fetched.evaluator.id == evaluator_id

--- a/tests/unit/db/test_eval_work_coordination.py
+++ b/tests/unit/db/test_eval_work_coordination.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from secrets import token_hex
 
 import pytest
@@ -11,7 +12,7 @@ from phoenix.db.types.evaluators import InputMapping
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.types import DbSessionFactory
 
-from .._helpers import _add_project, _add_span, _add_trace
+from .._helpers import _add_project, _add_project_session, _add_span, _add_trace
 
 _INTEGRITY_ERRORS = (SQLAlchemyIntegrityError, SQLiteIntegrityError)
 
@@ -173,6 +174,65 @@ async def test_eval_work_unit_accepts_expired_status(db: DbSessionFactory) -> No
         )
         assert fetched is not None
         assert fetched.status == "EXPIRED"
+
+
+async def test_session_liveness_and_work_accounting(db: DbSessionFactory) -> None:
+    evaluated_through = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with db() as session:
+        project = await _add_project(session)
+        project_session = await _add_project_session(session, project)
+        project_session_id = project_session.id
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator.id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SESSION",
+        )
+        session.add(criteria)
+        await session.flush()
+        evaluator_id = evaluator.id
+        criteria_id = criteria.id
+        session.add(
+            models.EvalSessionWorkUnit(
+                project_session_rowid=project_session_id,
+                evaluator_id=evaluator_id,
+                criteria_id=criteria_id,
+                config_fingerprint="fp-session",
+                evaluated_through=evaluated_through,
+            )
+        )
+
+    async with db() as session:
+        fetched_session = await session.get(models.ProjectSession, project_session_id)
+        assert fetched_session is not None
+        assert fetched_session.last_span_seen_at is not None
+        assert fetched_session.content_complete is True
+
+        work_unit = await session.scalar(
+            select(models.EvalSessionWorkUnit).options(
+                selectinload(models.EvalSessionWorkUnit.project_session),
+                selectinload(models.EvalSessionWorkUnit.evaluator),
+                selectinload(models.EvalSessionWorkUnit.criteria),
+            )
+        )
+        assert work_unit is not None
+        assert work_unit.project_session.id == project_session_id
+        assert work_unit.evaluator.id == evaluator_id
+        assert work_unit.criteria.id == criteria_id
+        assert work_unit.evaluated_through == evaluated_through
+        assert work_unit.status == "PENDING"
+        assert work_unit.attempts == 0
 
 
 async def test_project_evaluator_criteria_defaults_and_relationships(

--- a/tests/unit/db/test_eval_work_coordination.py
+++ b/tests/unit/db/test_eval_work_coordination.py
@@ -254,6 +254,7 @@ async def test_project_evaluator_criteria_defaults_and_relationships(
         assert fetched.name.root.startswith("criteria-")
         assert fetched.filter_condition == ""
         assert fetched.evaluation_target == "SPAN"
+        assert fetched.evaluation_delay_seconds == 300
         assert fetched.input_mapping is None
         assert fetched.sampling_rate == 1.0
         assert fetched.evaluator.id == evaluator_id

--- a/tests/unit/db/types/test_trace_retention.py
+++ b/tests/unit/db/types/test_trace_retention.py
@@ -301,16 +301,26 @@ class TestTraceRetentionRuleMaxCount:
             session.add(work_unit)
             await session.flush()
             work_unit_id = work_unit.id
-            annotation = models.ProjectSessionAnnotation(
+            online_eval_annotation = models.ProjectSessionAnnotation(
+                project_session_id=project_session.id,
+                name=token_hex(4),
+                metadata_={},
+                annotator_kind="CODE",
+                identifier=f"online:{token_hex(8)}",
+                source="API",
+            )
+            human_annotation = models.ProjectSessionAnnotation(
                 project_session_id=project_session.id,
                 name=token_hex(4),
                 metadata_={},
                 annotator_kind="HUMAN",
+                identifier=f"human:{token_hex(8)}",
                 source="APP",
             )
-            session.add(annotation)
+            session.add_all((online_eval_annotation, human_annotation))
             await session.flush()
-            annotation_id = annotation.id
+            online_eval_annotation_id = online_eval_annotation.id
+            human_annotation_id = human_annotation.id
             session.add_all(
                 [
                     models.Trace(
@@ -338,7 +348,13 @@ class TestTraceRetentionRuleMaxCount:
             assert retained_session.content_complete is False
             assert retained_work.status == "EXPIRED"
             assert retained_work.claimed_by is None
-            assert await session.get(models.ProjectSessionAnnotation, annotation_id) is None
+            assert (
+                await session.get(models.ProjectSessionAnnotation, online_eval_annotation_id)
+                is None
+            )
+            assert (
+                await session.get(models.ProjectSessionAnnotation, human_annotation_id) is not None
+            )
             assert remaining_trace_count == 1
 
 

--- a/tests/unit/db/types/test_trace_retention.py
+++ b/tests/unit/db/types/test_trace_retention.py
@@ -439,8 +439,9 @@ async def test_trace_delete_stands_down_sessions_added_while_delete_waits(
             )
             == 0
         )
-        content_complete = dict(
-            (
+        content_complete = {
+            session_id: is_complete
+            for session_id, is_complete in (
                 await session.execute(
                     sa.select(
                         models.ProjectSession.id,
@@ -448,7 +449,7 @@ async def test_trace_delete_stands_down_sessions_added_while_delete_waits(
                     ).where(models.ProjectSession.id.in_((first_session_id, later_session_id)))
                 )
             ).all()
-        )
+        }
     assert content_complete == {first_session_id: False, later_session_id: False}
 
 

--- a/tests/unit/db/types/test_trace_retention.py
+++ b/tests/unit/db/types/test_trace_retention.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import defaultdict
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
@@ -10,8 +11,10 @@ import sqlalchemy as sa
 from faker import Faker
 from freezegun import freeze_time
 from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from phoenix.db import models
+from phoenix.db.helpers import delete_traces
 from phoenix.db.types.identifier import Identifier
 from phoenix.db.types.trace_retention import (
     MaxCountRule,
@@ -22,6 +25,7 @@ from phoenix.db.types.trace_retention import (
     _MaxDays,
     _time_of_next_run,
 )
+from phoenix.server.app import _db
 from phoenix.server.types import DbSessionFactory
 
 fake = Faker()
@@ -297,6 +301,16 @@ class TestTraceRetentionRuleMaxCount:
             session.add(work_unit)
             await session.flush()
             work_unit_id = work_unit.id
+            annotation = models.ProjectSessionAnnotation(
+                project_session_id=project_session.id,
+                name=token_hex(4),
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="APP",
+            )
+            session.add(annotation)
+            await session.flush()
+            annotation_id = annotation.id
             session.add_all(
                 [
                     models.Trace(
@@ -324,7 +338,98 @@ class TestTraceRetentionRuleMaxCount:
             assert retained_session.content_complete is False
             assert retained_work.status == "EXPIRED"
             assert retained_work.claimed_by is None
+            assert await session.get(models.ProjectSessionAnnotation, annotation_id) is None
             assert remaining_trace_count == 1
+
+
+@pytest.mark.postgres_only
+async def test_trace_delete_stands_down_sessions_added_while_delete_waits(
+    postgresql_engine: AsyncEngine,
+) -> None:
+    db = DbSessionFactory(db=_db(postgresql_engine), dialect="postgresql")
+    now = datetime.now(timezone.utc)
+    async with db() as session:
+        project = models.Project(name=token_hex(8))
+        session.add(project)
+        await session.flush()
+        first_session = models.ProjectSession(
+            session_id=token_hex(8),
+            project_id=project.id,
+            start_time=now,
+            end_time=now,
+        )
+        later_session = models.ProjectSession(
+            session_id=token_hex(8),
+            project_id=project.id,
+            start_time=now,
+            end_time=now,
+        )
+        session.add_all((first_session, later_session))
+        await session.flush()
+        first_trace = models.Trace(
+            project_rowid=project.id,
+            project_session_rowid=first_session.id,
+            trace_id=token_hex(16),
+            start_time=now,
+            end_time=now,
+        )
+        session.add(first_trace)
+        await session.flush()
+        project_id = project.id
+        first_trace_id = first_trace.id
+        first_session_id = first_session.id
+        later_session_id = later_session.id
+
+    async with db() as blocker:
+        assert await blocker.scalar(
+            sa.select(models.Trace.id)
+            .where(models.Trace.id == first_trace_id)
+            .with_for_update()
+        ) == first_trace_id
+
+        async def run_delete() -> None:
+            async with db() as session:
+                await delete_traces(
+                    session,
+                    models.Trace.project_rowid == project_id,
+                )
+
+        delete_task = asyncio.create_task(run_delete())
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(delete_task), timeout=0.1)
+
+        async with db() as session:
+            session.add(
+                models.Trace(
+                    project_rowid=project_id,
+                    project_session_rowid=later_session_id,
+                    trace_id=token_hex(16),
+                    start_time=now,
+                    end_time=now,
+                )
+            )
+
+    await delete_task
+
+    async with db() as session:
+        assert await session.scalar(
+            sa.select(sa.func.count(models.Trace.id)).where(
+                models.Trace.project_rowid == project_id
+            )
+        ) == 0
+        content_complete = dict(
+            (
+                await session.execute(
+                    sa.select(
+                        models.ProjectSession.id,
+                        models.ProjectSession.content_complete,
+                    ).where(
+                        models.ProjectSession.id.in_((first_session_id, later_session_id))
+                    )
+                )
+            ).all()
+        )
+    assert content_complete == {first_session_id: False, later_session_id: False}
 
 
 class TestTraceRetentionRuleMaxDaysOrCountRule:

--- a/tests/unit/db/types/test_trace_retention.py
+++ b/tests/unit/db/types/test_trace_retention.py
@@ -12,6 +12,7 @@ from freezegun import freeze_time
 from pydantic import ValidationError
 
 from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
 from phoenix.db.types.trace_retention import (
     MaxCountRule,
     MaxDaysOrCountRule,
@@ -244,6 +245,86 @@ class TestTraceRetentionRuleMaxCount:
         assert set(remaining_traces.all()) == set(
             chain.from_iterable(unaffected_projects.values())
         ), "Unaffected projects should retain all their traces"
+
+    async def test_marks_affected_session_content_incomplete(
+        self,
+        db: DbSessionFactory,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        async with db() as session:
+            project = models.Project(name=token_hex(8))
+            session.add(project)
+            await session.flush()
+            project_session = models.ProjectSession(
+                session_id=token_hex(8),
+                project_id=project.id,
+                start_time=now - timedelta(hours=1),
+                end_time=now,
+            )
+            session.add(project_session)
+            await session.flush()
+            project_id = project.id
+            project_session_id = project_session.id
+            evaluator = models.BuiltinEvaluator(
+                name=Identifier(root=f"eval-{token_hex(4)}"),
+                kind="BUILTIN",
+                key=token_hex(8),
+                input_schema={},
+                output_configs=[],
+            )
+            session.add(evaluator)
+            await session.flush()
+            criteria = models.ProjectEvaluatorCriteria(
+                project_id=project.id,
+                evaluator_id=evaluator.id,
+                name=Identifier(root=f"criteria-{token_hex(4)}"),
+                filter_condition="",
+                sampling_rate=1.0,
+                evaluation_target="SESSION",
+            )
+            session.add(criteria)
+            await session.flush()
+            work_unit = models.EvalSessionWorkUnit(
+                project_session_rowid=project_session.id,
+                evaluator_id=evaluator.id,
+                criteria_id=criteria.id,
+                config_fingerprint=token_hex(8),
+                evaluated_through=now,
+                status="RUNNING",
+                claimed_at=now,
+                claimed_by="consumer",
+            )
+            session.add(work_unit)
+            await session.flush()
+            work_unit_id = work_unit.id
+            session.add_all(
+                [
+                    models.Trace(
+                        project_rowid=project.id,
+                        project_session_rowid=project_session.id,
+                        trace_id=token_hex(16),
+                        start_time=now - timedelta(minutes=offset),
+                        end_time=now - timedelta(minutes=offset),
+                    )
+                    for offset in (0, 1)
+                ]
+            )
+
+        async with db() as session:
+            await MaxCountRule(max_count=1).delete_traces(session, [project_id])
+            retained_session = await session.get(models.ProjectSession, project_session_id)
+            assert retained_session is not None
+            retained_work = await session.get(models.EvalSessionWorkUnit, work_unit_id)
+            assert retained_work is not None
+            remaining_trace_count = await session.scalar(
+                sa.select(sa.func.count(models.Trace.id)).where(
+                    models.Trace.project_session_rowid == project_session_id
+                )
+            )
+            assert retained_session.content_complete is False
+            assert retained_work.status == "EXPIRED"
+            assert retained_work.claimed_by is None
+            assert remaining_trace_count == 1
 
 
 class TestTraceRetentionRuleMaxDaysOrCountRule:

--- a/tests/unit/db/types/test_trace_retention.py
+++ b/tests/unit/db/types/test_trace_retention.py
@@ -381,11 +381,14 @@ async def test_trace_delete_stands_down_sessions_added_while_delete_waits(
         later_session_id = later_session.id
 
     async with db() as blocker:
-        assert await blocker.scalar(
-            sa.select(models.Trace.id)
-            .where(models.Trace.id == first_trace_id)
-            .with_for_update()
-        ) == first_trace_id
+        assert (
+            await blocker.scalar(
+                sa.select(models.Trace.id)
+                .where(models.Trace.id == first_trace_id)
+                .with_for_update()
+            )
+            == first_trace_id
+        )
 
         async def run_delete() -> None:
             async with db() as session:
@@ -412,20 +415,21 @@ async def test_trace_delete_stands_down_sessions_added_while_delete_waits(
     await delete_task
 
     async with db() as session:
-        assert await session.scalar(
-            sa.select(sa.func.count(models.Trace.id)).where(
-                models.Trace.project_rowid == project_id
+        assert (
+            await session.scalar(
+                sa.select(sa.func.count(models.Trace.id)).where(
+                    models.Trace.project_rowid == project_id
+                )
             )
-        ) == 0
+            == 0
+        )
         content_complete = dict(
             (
                 await session.execute(
                     sa.select(
                         models.ProjectSession.id,
                         models.ProjectSession.content_complete,
-                    ).where(
-                        models.ProjectSession.id.in_((first_session_id, later_session_id))
-                    )
+                    ).where(models.ProjectSession.id.in_((first_session_id, later_session_id)))
                 )
             ).all()
         )

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -14,6 +14,7 @@ name
 filterCondition
 samplingRate
 evaluationTarget
+evaluationDelaySeconds
 enabled
 inputMapping { literalMapping pathMapping }
 evaluator {
@@ -137,6 +138,7 @@ def _code_add_input(
         "inputMapping": _mapping(context="override"),
         "filterCondition": "span_kind == 'LLM'",
         "enabled": False,
+        "evaluationDelaySeconds": 30,
     }
 
 
@@ -211,6 +213,7 @@ async def test_project_code_evaluator_crud_and_connection(
     assert create_result.data and not create_result.errors
     created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
     assert created["evaluationTarget"] == "SPAN"
+    assert created["evaluationDelaySeconds"] is None
     assert created["inputMapping"] == _mapping(output="value")
     assert created["evaluator"]["kind"] == "CODE"
 
@@ -234,6 +237,7 @@ async def test_project_code_evaluator_crud_and_connection(
                 "inputMapping": _mapping(context="override"),
                 "samplingRate": 0.25,
                 "evaluationTarget": "SESSION",
+                "evaluationDelaySeconds": 30,
                 "filterCondition": "span_kind == 'LLM'",
                 "enabled": False,
             }
@@ -243,6 +247,7 @@ async def test_project_code_evaluator_crud_and_connection(
     updated = update_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert updated["name"] == "updated-code"
     assert updated["evaluationTarget"] == "SESSION"
+    assert updated["evaluationDelaySeconds"] == 30
     assert updated["inputMapping"] == _mapping(context="override")
     assert updated["evaluator"]["name"] == "updated-code"
 
@@ -252,6 +257,7 @@ async def test_project_code_evaluator_crud_and_connection(
         assert criteria is not None
         assert criteria.input_mapping is not None
         assert criteria.input_mapping.literal_mapping == {"context": "override"}
+        assert criteria.evaluation_delay_seconds == 30
 
     omitted_result = await gql_client.execute(
         _UPDATE_CODE,
@@ -271,11 +277,13 @@ async def test_project_code_evaluator_crud_and_connection(
     assert omitted_result.data and not omitted_result.errors
     omitted = omitted_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert omitted["inputMapping"] == _mapping(context="override")
+    assert omitted["evaluationDelaySeconds"] == 30
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
         assert criteria.input_mapping is not None
         assert criteria.input_mapping.literal_mapping == {"context": "override"}
+        assert criteria.evaluation_delay_seconds == 30
 
     inherited_result = await gql_client.execute(
         _UPDATE_CODE,
@@ -288,6 +296,7 @@ async def test_project_code_evaluator_crud_and_connection(
                 "inputMapping": None,
                 "samplingRate": 1.0,
                 "evaluationTarget": "SPAN",
+                "evaluationDelaySeconds": None,
                 "filterCondition": "",
                 "enabled": True,
             }
@@ -296,10 +305,12 @@ async def test_project_code_evaluator_crud_and_connection(
     assert inherited_result.data and not inherited_result.errors
     inherited = inherited_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert inherited["inputMapping"] == _mapping(output="inherited")
+    assert inherited["evaluationDelaySeconds"] is None
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
         assert criteria.input_mapping is None
+        assert criteria.evaluation_delay_seconds is None
 
     delete_result = await gql_client.execute(
         _DELETE,
@@ -346,6 +357,7 @@ async def test_add_project_code_evaluator_binds_existing_core(
     assert attached["inputMapping"] == _mapping(context="override")
     assert attached["filterCondition"] == "span_kind == 'LLM'"
     assert attached["enabled"] is False
+    assert attached["evaluationDelaySeconds"] == 30
 
     project_result = await gql_client.execute(
         _PROJECT_EVALUATORS,
@@ -460,10 +472,12 @@ async def test_project_llm_evaluator_create_update_delete(
 ) -> None:
     project = await _add_project(db)
     create_input = _llm_input(project, name="llm-evaluator", text="Evaluate {{input}}")
+    create_input["evaluationDelaySeconds"] = 60
     create_result = await gql_client.execute(_CREATE_LLM, {"input": create_input})
     assert create_result.data and not create_result.errors
     created = create_result.data["createProjectLlmEvaluator"]["evaluator"]
     assert created["evaluationTarget"] == "TRACE"
+    assert created["evaluationDelaySeconds"] == 60
     assert created["evaluator"]["kind"] == "LLM"
 
     update_input = _llm_input(project, name="updated-llm", text="Updated {{input}}")
@@ -475,6 +489,23 @@ async def test_project_llm_evaluator_create_update_delete(
     updated = update_result.data["updateProjectLlmEvaluator"]["evaluator"]
     assert updated["evaluator"]["name"] == "updated-llm"
     assert updated["evaluationTarget"] == "SPAN"
+    assert updated["evaluationDelaySeconds"] == 60
+
+    clear_input = _llm_input(project, name="cleared-llm", text="Clear {{input}}")
+    clear_input.pop("projectId")
+    clear_input["projectEvaluatorId"] = created["id"]
+    clear_input["evaluationTarget"] = "SESSION"
+    clear_input["evaluationDelaySeconds"] = None
+    clear_result = await gql_client.execute(_UPDATE_LLM, {"input": clear_input})
+    assert clear_result.data and not clear_result.errors
+    cleared = clear_result.data["updateProjectLlmEvaluator"]["evaluator"]
+    assert cleared["evaluationDelaySeconds"] is None
+
+    criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.evaluation_delay_seconds is None
 
     delete_result = await gql_client.execute(
         _DELETE,
@@ -562,6 +593,75 @@ async def test_sampling_rate_rejected_at_project_evaluator_input_boundary(
     assert update_llm_result.errors
     assert update_llm_result.errors[0].message == error_message
     assert await _row_counts(db) == before
+
+
+async def test_evaluation_delay_rejected_before_project_evaluator_writes(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    error_message = "evaluationDelaySeconds must be at least 10 seconds"
+
+    create_code_input = _code_create_input(project, sandbox_config)
+    create_code_input["evaluationDelaySeconds"] = 9
+    before = await _row_counts(db)
+    create_code_result = await gql_client.execute(_CREATE_CODE, {"input": create_code_input})
+    assert create_code_result.errors
+    assert create_code_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+    create_llm_input = _llm_input(project, name="invalid-delay-llm", text="Evaluate {{input}}")
+    create_llm_input["evaluationDelaySeconds"] = 9
+    create_llm_result = await gql_client.execute(_CREATE_LLM, {"input": create_llm_input})
+    assert create_llm_result.errors
+    assert create_llm_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+    valid_code_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(project, sandbox_config)},
+    )
+    assert valid_code_result.data and not valid_code_result.errors
+    code_evaluator_id = valid_code_result.data["createProjectCodeEvaluator"]["evaluator"]["id"]
+    update_code_result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": code_evaluator_id,
+                "name": f"invalid-delay-code-{token_hex(4)}",
+                "evaluatorInputMapping": _mapping(output="value"),
+                "samplingRate": 1.0,
+                "evaluationTarget": "SESSION",
+                "evaluationDelaySeconds": 9,
+                "filterCondition": "",
+                "enabled": True,
+            }
+        },
+    )
+    assert update_code_result.errors
+    assert update_code_result.errors[0].message == error_message
+
+    valid_llm_input = _llm_input(project, name="valid-delay-llm", text="Evaluate {{input}}")
+    valid_llm_result = await gql_client.execute(_CREATE_LLM, {"input": valid_llm_input})
+    assert valid_llm_result.data and not valid_llm_result.errors
+    llm_evaluator_id = valid_llm_result.data["createProjectLlmEvaluator"]["evaluator"]["id"]
+    update_llm_input = _llm_input(project, name="invalid-delay-llm", text="Update {{input}}")
+    update_llm_input.pop("projectId")
+    update_llm_input["projectEvaluatorId"] = llm_evaluator_id
+    update_llm_input["evaluationDelaySeconds"] = 9
+    update_llm_result = await gql_client.execute(_UPDATE_LLM, {"input": update_llm_input})
+    assert update_llm_result.errors
+    assert update_llm_result.errors[0].message == error_message
+
+    async with db() as session:
+        code_criteria_id = int(GlobalID.from_id(code_evaluator_id).node_id)
+        llm_criteria_id = int(GlobalID.from_id(llm_evaluator_id).node_id)
+        code_criteria = await session.get(models.ProjectEvaluatorCriteria, code_criteria_id)
+        llm_criteria = await session.get(models.ProjectEvaluatorCriteria, llm_criteria_id)
+        assert code_criteria is not None and llm_criteria is not None
+        assert code_criteria.evaluation_delay_seconds is None
+        assert llm_criteria.evaluation_delay_seconds is None
 
 
 async def test_update_code_evaluator_rejects_explicit_null_source_code(

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -9,8 +9,6 @@ from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
-from ...._helpers import _add_span, _add_trace
-
 _PROJECT_EVALUATOR_FIELDS = """
 id
 name
@@ -271,7 +269,7 @@ async def test_project_code_evaluator_crud_and_connection(
                 "evaluatorInputMapping": _mapping(output="updated"),
                 "inputMapping": _mapping(context="override"),
                 "samplingRate": 0.25,
-                "evaluationTarget": "SESSION",
+                "evaluationTarget": "SPAN",
                 "evaluationDelaySeconds": 30,
                 "filterCondition": "span_kind == 'LLM'",
                 "enabled": False,
@@ -281,7 +279,7 @@ async def test_project_code_evaluator_crud_and_connection(
     assert update_result.data and not update_result.errors
     updated = update_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert updated["name"] == "updated-code"
-    assert updated["evaluationTarget"] == "SESSION"
+    assert updated["evaluationTarget"] == "SPAN"
     assert updated["evaluationDelaySeconds"] == 30
     assert updated["schedulabilityStatus"] == "NOT_SCHEDULABLE"
     assert updated["schedulabilityReason"] == "DISABLED"
@@ -320,7 +318,7 @@ async def test_project_code_evaluator_crud_and_connection(
                 "projectEvaluatorId": created["id"],
                 "name": "updated-code",
                 "samplingRate": 0.75,
-                "evaluationTarget": "TRACE",
+                "evaluationTarget": "SPAN",
                 "filterCondition": "",
             }
         },
@@ -558,19 +556,19 @@ async def test_project_llm_evaluator_create_update_delete(
     update_input.pop("projectId")
     update_input.pop("enabled")
     update_input["projectEvaluatorId"] = created["id"]
-    update_input["evaluationTarget"] = "SPAN"
+    update_input["evaluationTarget"] = "TRACE"
     update_result = await gql_client.execute(_UPDATE_LLM, {"input": update_input})
     assert update_result.data and not update_result.errors
     updated = update_result.data["updateProjectLlmEvaluator"]["evaluator"]
     assert updated["evaluator"]["name"] == "updated-llm"
-    assert updated["evaluationTarget"] == "SPAN"
+    assert updated["evaluationTarget"] == "TRACE"
     assert updated["enabled"] is False
     assert updated["evaluationDelaySeconds"] == 60
 
     clear_input = _llm_input(project, name="cleared-llm", text="Clear {{input}}")
     clear_input.pop("projectId")
     clear_input["projectEvaluatorId"] = created["id"]
-    clear_input["evaluationTarget"] = "SESSION"
+    clear_input["evaluationTarget"] = "TRACE"
     clear_input["evaluationDelaySeconds"] = None
     clear_result = await gql_client.execute(_UPDATE_LLM, {"input": clear_input})
     assert clear_result.data and not clear_result.errors
@@ -934,7 +932,7 @@ async def test_evaluation_delay_rejected_before_project_evaluator_writes(
         assert llm_criteria.evaluation_delay_seconds == 300
 
 
-async def test_evaluation_target_change_rejected_after_work_exists(
+async def test_evaluation_target_change_rejected_from_creation(
     gql_client: AsyncGraphQLClient,
     db: DbSessionFactory,
     sandbox_config: models.SandboxConfig,
@@ -945,21 +943,6 @@ async def test_evaluation_target_change_rejected_after_work_exists(
     assert create_result.data and not create_result.errors
     created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
     criteria_id = int(GlobalID.from_id(created["id"]).node_id)
-
-    async with db() as session:
-        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
-        project_record = await session.get(models.Project, project.id)
-        assert criteria is not None and project_record is not None
-        trace = await _add_trace(session, project_record)
-        span = await _add_span(session, trace)
-        session.add(
-            models.EvalWorkUnit(
-                span_rowid=span.id,
-                evaluator_id=criteria.evaluator_id,
-                criteria_id=criteria.id,
-                config_fingerprint="existing-work",
-            )
-        )
 
     update_result = await gql_client.execute(
         _UPDATE_CODE,
@@ -978,8 +961,7 @@ async def test_evaluation_target_change_rejected_after_work_exists(
 
     assert update_result.errors
     assert update_result.errors[0].message == (
-        "evaluationTarget cannot be changed after evaluation work has been created "
-        "for this project evaluator"
+        "evaluationTarget is fixed at project evaluator creation"
     )
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
@@ -1097,7 +1079,7 @@ async def test_update_rolls_back_code_version_and_state_on_late_name_conflict(
                 "evaluatorInputMapping": _mapping(changed="value"),
                 "inputMapping": _mapping(override="value"),
                 "samplingRate": 0.9,
-                "evaluationTarget": "TRACE",
+                "evaluationTarget": "SPAN",
                 "filterCondition": "span_kind == 'LLM'",
                 "enabled": False,
             }

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -18,6 +18,8 @@ filterCondition
 samplingRate
 evaluationTarget
 evaluationDelaySeconds
+schedulabilityStatus
+schedulabilityReason
 enabled
 inputMapping { literalMapping pathMapping }
 evaluator {
@@ -244,6 +246,8 @@ async def test_project_code_evaluator_crud_and_connection(
     created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
     assert created["evaluationTarget"] == "SPAN"
     assert created["evaluationDelaySeconds"] == 300
+    assert created["schedulabilityStatus"] == "SCHEDULABLE"
+    assert created["schedulabilityReason"] is None
     assert created["inputMapping"] == _mapping(output="value")
     assert created["evaluator"]["kind"] == "CODE"
 
@@ -279,6 +283,8 @@ async def test_project_code_evaluator_crud_and_connection(
     assert updated["name"] == "updated-code"
     assert updated["evaluationTarget"] == "SESSION"
     assert updated["evaluationDelaySeconds"] == 30
+    assert updated["schedulabilityStatus"] == "NOT_SCHEDULABLE"
+    assert updated["schedulabilityReason"] == "DISABLED"
     assert updated["inputMapping"] == _mapping(context="override")
     assert updated["evaluator"]["name"] == "updated-code"
 
@@ -324,6 +330,8 @@ async def test_project_code_evaluator_crud_and_connection(
     assert omitted["inputMapping"] == _mapping(context="override")
     assert omitted["enabled"] is False
     assert omitted["evaluationDelaySeconds"] == 30
+    assert omitted["schedulabilityStatus"] == "NOT_SCHEDULABLE"
+    assert omitted["schedulabilityReason"] == "TRACE_TARGET_UNSUPPORTED"
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
@@ -357,6 +365,8 @@ async def test_project_code_evaluator_crud_and_connection(
     inherited = inherited_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert inherited["inputMapping"] == _mapping(output="inherited")
     assert inherited["evaluationDelaySeconds"] == 300
+    assert inherited["schedulabilityStatus"] == "SCHEDULABLE"
+    assert inherited["schedulabilityReason"] is None
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -331,7 +331,7 @@ async def test_project_code_evaluator_crud_and_connection(
     assert omitted["enabled"] is False
     assert omitted["evaluationDelaySeconds"] == 30
     assert omitted["schedulabilityStatus"] == "NOT_SCHEDULABLE"
-    assert omitted["schedulabilityReason"] == "TRACE_TARGET_UNSUPPORTED"
+    assert omitted["schedulabilityReason"] == "DISABLED"
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -9,6 +9,8 @@ from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
+from ...._helpers import _add_span, _add_trace
+
 _PROJECT_EVALUATOR_FIELDS = """
 id
 name
@@ -920,6 +922,59 @@ async def test_evaluation_delay_rejected_before_project_evaluator_writes(
         assert code_criteria is not None and llm_criteria is not None
         assert code_criteria.evaluation_delay_seconds == 300
         assert llm_criteria.evaluation_delay_seconds == 300
+
+
+async def test_evaluation_target_change_rejected_after_work_exists(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    create_input = _code_create_input(project, sandbox_config)
+    create_result = await gql_client.execute(_CREATE_CODE, {"input": create_input})
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
+    criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        project_record = await session.get(models.Project, project.id)
+        assert criteria is not None and project_record is not None
+        trace = await _add_trace(session, project_record)
+        span = await _add_span(session, trace)
+        session.add(
+            models.EvalWorkUnit(
+                span_rowid=span.id,
+                evaluator_id=criteria.evaluator_id,
+                criteria_id=criteria.id,
+                config_fingerprint="existing-work",
+            )
+        )
+
+    update_result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": created["id"],
+                "name": created["name"],
+                "evaluatorInputMapping": _mapping(output="value"),
+                "samplingRate": 1.0,
+                "evaluationTarget": "SESSION",
+                "filterCondition": "",
+                "enabled": True,
+            }
+        },
+    )
+
+    assert update_result.errors
+    assert update_result.errors[0].message == (
+        "evaluationTarget cannot be changed after evaluation work has been created "
+        "for this project evaluator"
+    )
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.evaluation_target == "SPAN"
 
 
 async def test_update_code_evaluator_rejects_explicit_null_source_code(

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -241,7 +241,7 @@ async def test_project_code_evaluator_crud_and_connection(
     assert create_result.data and not create_result.errors
     created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
     assert created["evaluationTarget"] == "SPAN"
-    assert created["evaluationDelaySeconds"] is None
+    assert created["evaluationDelaySeconds"] == 300
     assert created["inputMapping"] == _mapping(output="value")
     assert created["evaluator"]["kind"] == "CODE"
 
@@ -354,12 +354,12 @@ async def test_project_code_evaluator_crud_and_connection(
     assert inherited_result.data and not inherited_result.errors
     inherited = inherited_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert inherited["inputMapping"] == _mapping(output="inherited")
-    assert inherited["evaluationDelaySeconds"] is None
+    assert inherited["evaluationDelaySeconds"] == 300
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
         assert criteria.input_mapping is None
-        assert criteria.evaluation_delay_seconds is None
+        assert criteria.evaluation_delay_seconds == 300
 
     delete_result = await gql_client.execute(
         _DELETE,
@@ -563,13 +563,13 @@ async def test_project_llm_evaluator_create_update_delete(
     clear_result = await gql_client.execute(_UPDATE_LLM, {"input": clear_input})
     assert clear_result.data and not clear_result.errors
     cleared = clear_result.data["updateProjectLlmEvaluator"]["evaluator"]
-    assert cleared["evaluationDelaySeconds"] is None
+    assert cleared["evaluationDelaySeconds"] == 300
 
     criteria_id = int(GlobalID.from_id(created["id"]).node_id)
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
-        assert criteria.evaluation_delay_seconds is None
+        assert criteria.evaluation_delay_seconds == 300
 
     delete_result = await gql_client.execute(
         _DELETE,
@@ -918,8 +918,8 @@ async def test_evaluation_delay_rejected_before_project_evaluator_writes(
         code_criteria = await session.get(models.ProjectEvaluatorCriteria, code_criteria_id)
         llm_criteria = await session.get(models.ProjectEvaluatorCriteria, llm_criteria_id)
         assert code_criteria is not None and llm_criteria is not None
-        assert code_criteria.evaluation_delay_seconds is None
-        assert llm_criteria.evaluation_delay_seconds is None
+        assert code_criteria.evaluation_delay_seconds == 300
+        assert llm_criteria.evaluation_delay_seconds == 300
 
 
 async def test_update_code_evaluator_rejects_explicit_null_source_code(

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -15,6 +15,7 @@ name
 filterCondition
 samplingRate
 evaluationTarget
+evaluationDelaySeconds
 enabled
 inputMapping { literalMapping pathMapping }
 evaluator {
@@ -165,6 +166,7 @@ def _code_add_input(
         "inputMapping": _mapping(context="override"),
         "filterCondition": "span_kind == 'LLM'",
         "enabled": False,
+        "evaluationDelaySeconds": 30,
     }
 
 
@@ -239,6 +241,7 @@ async def test_project_code_evaluator_crud_and_connection(
     assert create_result.data and not create_result.errors
     created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
     assert created["evaluationTarget"] == "SPAN"
+    assert created["evaluationDelaySeconds"] is None
     assert created["inputMapping"] == _mapping(output="value")
     assert created["evaluator"]["kind"] == "CODE"
 
@@ -263,6 +266,7 @@ async def test_project_code_evaluator_crud_and_connection(
                 "inputMapping": _mapping(context="override"),
                 "samplingRate": 0.25,
                 "evaluationTarget": "SESSION",
+                "evaluationDelaySeconds": 30,
                 "filterCondition": "span_kind == 'LLM'",
                 "enabled": False,
             }
@@ -272,6 +276,7 @@ async def test_project_code_evaluator_crud_and_connection(
     updated = update_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert updated["name"] == "updated-code"
     assert updated["evaluationTarget"] == "SESSION"
+    assert updated["evaluationDelaySeconds"] == 30
     assert updated["inputMapping"] == _mapping(context="override")
     assert updated["evaluator"]["name"] == "updated-code"
 
@@ -281,6 +286,7 @@ async def test_project_code_evaluator_crud_and_connection(
         assert criteria is not None
         assert criteria.input_mapping is not None
         assert criteria.input_mapping.literal_mapping == {"context": "override"}
+        assert criteria.evaluation_delay_seconds == 30
         evaluator = await session.get(models.CodeEvaluator, criteria.evaluator_id)
         assert evaluator is not None
         user_role_id = await session.scalar(select(models.UserRole.id).limit(1))
@@ -315,11 +321,13 @@ async def test_project_code_evaluator_crud_and_connection(
     omitted = omitted_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert omitted["inputMapping"] == _mapping(context="override")
     assert omitted["enabled"] is False
+    assert omitted["evaluationDelaySeconds"] == 30
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
         assert criteria.input_mapping is not None
         assert criteria.input_mapping.literal_mapping == {"context": "override"}
+        assert criteria.evaluation_delay_seconds == 30
         evaluator = await session.get(models.CodeEvaluator, criteria.evaluator_id)
         assert evaluator is not None
         assert evaluator.description == "updated"
@@ -337,6 +345,7 @@ async def test_project_code_evaluator_crud_and_connection(
                 "inputMapping": None,
                 "samplingRate": 1.0,
                 "evaluationTarget": "SPAN",
+                "evaluationDelaySeconds": None,
                 "filterCondition": "",
                 "enabled": True,
             }
@@ -345,10 +354,12 @@ async def test_project_code_evaluator_crud_and_connection(
     assert inherited_result.data and not inherited_result.errors
     inherited = inherited_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert inherited["inputMapping"] == _mapping(output="inherited")
+    assert inherited["evaluationDelaySeconds"] is None
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
         assert criteria.input_mapping is None
+        assert criteria.evaluation_delay_seconds is None
 
     delete_result = await gql_client.execute(
         _DELETE,
@@ -402,6 +413,7 @@ async def test_add_project_code_evaluator_binds_existing_core(
     assert attached["inputMapping"] == _mapping(context="override")
     assert attached["filterCondition"] == "span_kind == 'LLM'"
     assert attached["enabled"] is False
+    assert attached["evaluationDelaySeconds"] == 30
 
     project_result = await gql_client.execute(
         _PROJECT_EVALUATORS,
@@ -516,10 +528,12 @@ async def test_project_llm_evaluator_create_update_delete(
 ) -> None:
     project = await _add_project(db)
     create_input = _llm_input(project, name="llm-evaluator", text="Evaluate {{input}}")
+    create_input["evaluationDelaySeconds"] = 60
     create_result = await gql_client.execute(_CREATE_LLM, {"input": create_input})
     assert create_result.data and not create_result.errors
     created = create_result.data["createProjectLlmEvaluator"]["evaluator"]
     assert created["evaluationTarget"] == "TRACE"
+    assert created["evaluationDelaySeconds"] == 60
     assert created["evaluator"]["kind"] == "LLM"
 
     disable_result = await gql_client.execute(
@@ -539,6 +553,23 @@ async def test_project_llm_evaluator_create_update_delete(
     assert updated["evaluator"]["name"] == "updated-llm"
     assert updated["evaluationTarget"] == "SPAN"
     assert updated["enabled"] is False
+    assert updated["evaluationDelaySeconds"] == 60
+
+    clear_input = _llm_input(project, name="cleared-llm", text="Clear {{input}}")
+    clear_input.pop("projectId")
+    clear_input["projectEvaluatorId"] = created["id"]
+    clear_input["evaluationTarget"] = "SESSION"
+    clear_input["evaluationDelaySeconds"] = None
+    clear_result = await gql_client.execute(_UPDATE_LLM, {"input": clear_input})
+    assert clear_result.data and not clear_result.errors
+    cleared = clear_result.data["updateProjectLlmEvaluator"]["evaluator"]
+    assert cleared["evaluationDelaySeconds"] is None
+
+    criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.evaluation_delay_seconds is None
 
     delete_result = await gql_client.execute(
         _DELETE,
@@ -820,6 +851,75 @@ async def test_sampling_rate_rejected_at_project_evaluator_input_boundary(
     assert update_llm_result.errors
     assert update_llm_result.errors[0].message == error_message
     assert await _row_counts(db) == before
+
+
+async def test_evaluation_delay_rejected_before_project_evaluator_writes(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    error_message = "evaluationDelaySeconds must be at least 10 seconds"
+
+    create_code_input = _code_create_input(project, sandbox_config)
+    create_code_input["evaluationDelaySeconds"] = 9
+    before = await _row_counts(db)
+    create_code_result = await gql_client.execute(_CREATE_CODE, {"input": create_code_input})
+    assert create_code_result.errors
+    assert create_code_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+    create_llm_input = _llm_input(project, name="invalid-delay-llm", text="Evaluate {{input}}")
+    create_llm_input["evaluationDelaySeconds"] = 9
+    create_llm_result = await gql_client.execute(_CREATE_LLM, {"input": create_llm_input})
+    assert create_llm_result.errors
+    assert create_llm_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+    valid_code_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(project, sandbox_config)},
+    )
+    assert valid_code_result.data and not valid_code_result.errors
+    code_evaluator_id = valid_code_result.data["createProjectCodeEvaluator"]["evaluator"]["id"]
+    update_code_result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": code_evaluator_id,
+                "name": f"invalid-delay-code-{token_hex(4)}",
+                "evaluatorInputMapping": _mapping(output="value"),
+                "samplingRate": 1.0,
+                "evaluationTarget": "SESSION",
+                "evaluationDelaySeconds": 9,
+                "filterCondition": "",
+                "enabled": True,
+            }
+        },
+    )
+    assert update_code_result.errors
+    assert update_code_result.errors[0].message == error_message
+
+    valid_llm_input = _llm_input(project, name="valid-delay-llm", text="Evaluate {{input}}")
+    valid_llm_result = await gql_client.execute(_CREATE_LLM, {"input": valid_llm_input})
+    assert valid_llm_result.data and not valid_llm_result.errors
+    llm_evaluator_id = valid_llm_result.data["createProjectLlmEvaluator"]["evaluator"]["id"]
+    update_llm_input = _llm_input(project, name="invalid-delay-llm", text="Update {{input}}")
+    update_llm_input.pop("projectId")
+    update_llm_input["projectEvaluatorId"] = llm_evaluator_id
+    update_llm_input["evaluationDelaySeconds"] = 9
+    update_llm_result = await gql_client.execute(_UPDATE_LLM, {"input": update_llm_input})
+    assert update_llm_result.errors
+    assert update_llm_result.errors[0].message == error_message
+
+    async with db() as session:
+        code_criteria_id = int(GlobalID.from_id(code_evaluator_id).node_id)
+        llm_criteria_id = int(GlobalID.from_id(llm_evaluator_id).node_id)
+        code_criteria = await session.get(models.ProjectEvaluatorCriteria, code_criteria_id)
+        llm_criteria = await session.get(models.ProjectEvaluatorCriteria, llm_criteria_id)
+        assert code_criteria is not None and llm_criteria is not None
+        assert code_criteria.evaluation_delay_seconds is None
+        assert llm_criteria.evaluation_delay_seconds is None
 
 
 async def test_update_code_evaluator_rejects_explicit_null_source_code(

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -17,6 +17,8 @@ filterCondition
 samplingRate
 evaluationTarget
 evaluationDelaySeconds
+schedulabilityStatus
+schedulabilityReason
 enabled
 inputMapping { literalMapping pathMapping }
 evaluator {
@@ -216,6 +218,8 @@ async def test_project_code_evaluator_crud_and_connection(
     created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
     assert created["evaluationTarget"] == "SPAN"
     assert created["evaluationDelaySeconds"] == 300
+    assert created["schedulabilityStatus"] == "SCHEDULABLE"
+    assert created["schedulabilityReason"] is None
     assert created["inputMapping"] == _mapping(output="value")
     assert created["evaluator"]["kind"] == "CODE"
 
@@ -250,6 +254,8 @@ async def test_project_code_evaluator_crud_and_connection(
     assert updated["name"] == "updated-code"
     assert updated["evaluationTarget"] == "SESSION"
     assert updated["evaluationDelaySeconds"] == 30
+    assert updated["schedulabilityStatus"] == "NOT_SCHEDULABLE"
+    assert updated["schedulabilityReason"] == "DISABLED"
     assert updated["inputMapping"] == _mapping(context="override")
     assert updated["evaluator"]["name"] == "updated-code"
 
@@ -280,6 +286,8 @@ async def test_project_code_evaluator_crud_and_connection(
     omitted = omitted_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert omitted["inputMapping"] == _mapping(context="override")
     assert omitted["evaluationDelaySeconds"] == 30
+    assert omitted["schedulabilityStatus"] == "NOT_SCHEDULABLE"
+    assert omitted["schedulabilityReason"] == "TRACE_TARGET_UNSUPPORTED"
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
@@ -308,6 +316,8 @@ async def test_project_code_evaluator_crud_and_connection(
     inherited = inherited_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert inherited["inputMapping"] == _mapping(output="inherited")
     assert inherited["evaluationDelaySeconds"] == 300
+    assert inherited["schedulabilityStatus"] == "SCHEDULABLE"
+    assert inherited["schedulabilityReason"] is None
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -8,6 +8,8 @@ from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
+from ...._helpers import _add_span, _add_trace
+
 _PROJECT_EVALUATOR_FIELDS = """
 id
 name
@@ -662,6 +664,59 @@ async def test_evaluation_delay_rejected_before_project_evaluator_writes(
         assert code_criteria is not None and llm_criteria is not None
         assert code_criteria.evaluation_delay_seconds == 300
         assert llm_criteria.evaluation_delay_seconds == 300
+
+
+async def test_evaluation_target_change_rejected_after_work_exists(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    create_input = _code_create_input(project, sandbox_config)
+    create_result = await gql_client.execute(_CREATE_CODE, {"input": create_input})
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
+    criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        project_record = await session.get(models.Project, project.id)
+        assert criteria is not None and project_record is not None
+        trace = await _add_trace(session, project_record)
+        span = await _add_span(session, trace)
+        session.add(
+            models.EvalWorkUnit(
+                span_rowid=span.id,
+                evaluator_id=criteria.evaluator_id,
+                criteria_id=criteria.id,
+                config_fingerprint="existing-work",
+            )
+        )
+
+    update_result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": created["id"],
+                "name": created["name"],
+                "evaluatorInputMapping": _mapping(output="value"),
+                "samplingRate": 1.0,
+                "evaluationTarget": "SESSION",
+                "filterCondition": "",
+                "enabled": True,
+            }
+        },
+    )
+
+    assert update_result.errors
+    assert update_result.errors[0].message == (
+        "evaluationTarget cannot be changed after evaluation work has been created "
+        "for this project evaluator"
+    )
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.evaluation_target == "SPAN"
 
 
 async def test_update_code_evaluator_rejects_explicit_null_source_code(

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -213,7 +213,7 @@ async def test_project_code_evaluator_crud_and_connection(
     assert create_result.data and not create_result.errors
     created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
     assert created["evaluationTarget"] == "SPAN"
-    assert created["evaluationDelaySeconds"] is None
+    assert created["evaluationDelaySeconds"] == 300
     assert created["inputMapping"] == _mapping(output="value")
     assert created["evaluator"]["kind"] == "CODE"
 
@@ -305,12 +305,12 @@ async def test_project_code_evaluator_crud_and_connection(
     assert inherited_result.data and not inherited_result.errors
     inherited = inherited_result.data["updateProjectCodeEvaluator"]["evaluator"]
     assert inherited["inputMapping"] == _mapping(output="inherited")
-    assert inherited["evaluationDelaySeconds"] is None
+    assert inherited["evaluationDelaySeconds"] == 300
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
         assert criteria.input_mapping is None
-        assert criteria.evaluation_delay_seconds is None
+        assert criteria.evaluation_delay_seconds == 300
 
     delete_result = await gql_client.execute(
         _DELETE,
@@ -499,13 +499,13 @@ async def test_project_llm_evaluator_create_update_delete(
     clear_result = await gql_client.execute(_UPDATE_LLM, {"input": clear_input})
     assert clear_result.data and not clear_result.errors
     cleared = clear_result.data["updateProjectLlmEvaluator"]["evaluator"]
-    assert cleared["evaluationDelaySeconds"] is None
+    assert cleared["evaluationDelaySeconds"] == 300
 
     criteria_id = int(GlobalID.from_id(created["id"]).node_id)
     async with db() as session:
         criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert criteria is not None
-        assert criteria.evaluation_delay_seconds is None
+        assert criteria.evaluation_delay_seconds == 300
 
     delete_result = await gql_client.execute(
         _DELETE,
@@ -660,8 +660,8 @@ async def test_evaluation_delay_rejected_before_project_evaluator_writes(
         code_criteria = await session.get(models.ProjectEvaluatorCriteria, code_criteria_id)
         llm_criteria = await session.get(models.ProjectEvaluatorCriteria, llm_criteria_id)
         assert code_criteria is not None and llm_criteria is not None
-        assert code_criteria.evaluation_delay_seconds is None
-        assert llm_criteria.evaluation_delay_seconds is None
+        assert code_criteria.evaluation_delay_seconds == 300
+        assert llm_criteria.evaluation_delay_seconds == 300
 
 
 async def test_update_code_evaluator_rejects_explicit_null_source_code(

--- a/tests/unit/server/api/mutations/test_project_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_mutations.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timedelta, timezone
 from secrets import token_hex
 
+from sqlalchemy import select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
 
+from ...._helpers import _add_live_session_work_unit
 from ....graphql import AsyncGraphQLClient
 
 PATCH_PROJECT_MUTATION = """
@@ -198,6 +200,71 @@ class TestProjectMutations:
             assert await session.get(models.Trace, old_trace_id) is None
             assert await session.get(models.Trace, new_trace_id) is not None
             assert await session.get(models.ProjectSession, session_rowid) is not None
+
+    async def test_clear_project_leaves_no_live_session_evaluations(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        """Clearing a project destroys session content, so no evaluation of that content
+        may stay live — whether the session row itself survives the clear or not.
+        """
+        cutoff = datetime.now(timezone.utc)
+        async with db() as session:
+            project = models.Project(name=token_hex(8))
+            session.add(project)
+            await session.flush()
+            project_session = models.ProjectSession(
+                project_id=project.id,
+                session_id=token_hex(8),
+                start_time=cutoff - timedelta(hours=2),
+                end_time=cutoff + timedelta(hours=2),
+            )
+            session.add(project_session)
+            await session.flush()
+            for offset in (timedelta(hours=-1), timedelta(hours=1)):
+                session.add(
+                    models.Trace(
+                        project_rowid=project.id,
+                        trace_id=token_hex(16),
+                        start_time=cutoff + offset,
+                        end_time=cutoff + offset,
+                        project_session_rowid=project_session.id,
+                    )
+                )
+            await _add_live_session_work_unit(session, project_session)
+            project_id = project.id
+
+        result = await gql_client.execute(
+            query="""
+            mutation($input: ClearProjectInput!) {
+                clearProject(input: $input) {
+                    __typename
+                }
+            }
+            """,
+            variables={
+                "input": {
+                    "id": str(GlobalID("Project", str(project_id))),
+                    "endTime": cutoff.isoformat(),
+                }
+            },
+        )
+        assert not result.errors
+
+        async with db() as session:
+            statuses = list(
+                await session.scalars(
+                    select(models.EvalSessionWorkUnit.status)
+                    .join(
+                        models.ProjectSession,
+                        models.EvalSessionWorkUnit.project_session_rowid
+                        == models.ProjectSession.id,
+                    )
+                    .where(models.ProjectSession.project_id == project_id)
+                )
+            )
+        assert all(status == "EXPIRED" for status in statuses)
 
     async def test_create_project(
         self,

--- a/tests/unit/server/api/mutations/test_trace_mutations.py
+++ b/tests/unit/server/api/mutations/test_trace_mutations.py
@@ -6,6 +6,7 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _add_live_session_work_unit
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -67,6 +68,37 @@ class TestTraceMutationMixin:
                 )
             ).all()
             assert len(spans) == 0
+
+    async def test_deleting_a_trace_stands_down_the_surviving_sessions_evaluations(
+        self,
+        gql_client: AsyncGraphQLClient,
+        trace_ids_to_delete: tuple[int, ...],
+        db: DbSessionFactory,
+    ) -> None:
+        trace_id = trace_ids_to_delete[0]  # this trace belongs to a session with two traces
+
+        async with db() as session:
+            trace = await session.get(models.Trace, trace_id)
+            assert trace is not None
+            assert (session_id := trace.project_session_rowid) is not None
+            project_session = await session.get(models.ProjectSession, session_id)
+            assert project_session is not None
+            work_unit_id = (await _add_live_session_work_unit(session, project_session)).id
+
+        result = await gql_client.execute(
+            self.DELETE_TRACES_MUTATION,
+            variables={"traceIds": [str(GlobalID("Trace", str(trace_id)))]},
+        )
+        assert not result.errors
+
+        async with db() as session:
+            project_session = await session.get(models.ProjectSession, session_id)
+            assert project_session is not None
+            assert project_session.content_complete is False
+            work_unit = await session.get(models.EvalSessionWorkUnit, work_unit_id)
+            assert work_unit is not None
+            assert work_unit.status == "EXPIRED"
+            assert work_unit.error == "session content incomplete"
 
     async def test_deleting_all_traces_in_a_session_also_deletes_the_session(
         self,

--- a/tests/unit/server/api/mutations/test_trace_mutations.py
+++ b/tests/unit/server/api/mutations/test_trace_mutations.py
@@ -5,6 +5,7 @@ from sqlalchemy import func, insert, select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
+from phoenix.db.eval_work import SESSION_CONTENT_INCOMPLETE_ERROR
 from phoenix.server.types import DbSessionFactory
 from tests.unit._helpers import _add_live_session_work_unit
 from tests.unit.graphql import AsyncGraphQLClient
@@ -98,7 +99,7 @@ class TestTraceMutationMixin:
             work_unit = await session.get(models.EvalSessionWorkUnit, work_unit_id)
             assert work_unit is not None
             assert work_unit.status == "EXPIRED"
-            assert work_unit.error == "session content incomplete"
+            assert work_unit.error == SESSION_CONTENT_INCOMPLETE_ERROR
 
     async def test_deleting_all_traces_in_a_session_also_deletes_the_session(
         self,

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -10,6 +10,7 @@ from sqlalchemy import insert, select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
+from phoenix.db.eval_work import SESSION_CONTENT_INCOMPLETE_ERROR
 from phoenix.server.api.routers.v1.spans import (
     OtlpAnyValue,
     OtlpSpan,
@@ -416,7 +417,7 @@ async def test_delete_span_stands_down_the_sessions_evaluations(
         work_unit = await session.get(models.EvalSessionWorkUnit, work_unit_id)
         assert work_unit is not None
         assert work_unit.status == "EXPIRED"
-        assert work_unit.error == "session content incomplete"
+        assert work_unit.error == SESSION_CONTENT_INCOMPLETE_ERROR
 
 
 async def test_delete_span_with_global_id(

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -17,6 +17,13 @@ from phoenix.server.api.routers.v1.spans import (
     Span,
 )
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import (
+    _add_live_session_work_unit,
+    _add_project,
+    _add_project_session,
+    _add_span,
+    _add_trace,
+)
 
 
 @pytest.mark.parametrize("sync", [False, True])
@@ -380,6 +387,36 @@ async def test_delete_span_empty_trace_cleanup(
             select(models.Trace).where(models.Trace.project_rowid == project.id)
         )
         assert remaining_trace is None
+
+
+async def test_delete_span_stands_down_the_sessions_evaluations(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Deleting one span mutates session content without deleting a trace, so the
+    stand-down has to key off the span, not off trace deletion.
+    """
+    async with db() as session:
+        project = await _add_project(session)
+        project_session = await _add_project_session(session, project)
+        trace = await _add_trace(session, project, project_session)
+        span = await _add_span(session, trace)
+        await _add_span(session, trace)
+        work_unit_id = (await _add_live_session_work_unit(session, project_session)).id
+        project_session_id = project_session.id
+        span_id = span.span_id
+
+    response = await httpx_client.delete(f"v1/spans/{span_id}")
+    assert response.status_code == 204
+
+    async with db() as session:
+        remaining_session = await session.get(models.ProjectSession, project_session_id)
+        assert remaining_session is not None
+        assert remaining_session.content_complete is False
+        work_unit = await session.get(models.EvalSessionWorkUnit, work_unit_id)
+        assert work_unit is not None
+        assert work_unit.status == "EXPIRED"
+        assert work_unit.error == "session content incomplete"
 
 
 async def test_delete_span_with_global_id(

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -20,6 +20,13 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import (
+    _add_live_session_work_unit,
+    _add_project,
+    _add_project_session,
+    _add_span,
+    _add_trace,
+)
 
 
 @pytest.fixture
@@ -339,6 +346,33 @@ async def test_delete_trace_by_trace_id(
     async with db() as session:
         deleted_trace = await session.get(models.Trace, trace_row_id)
         assert deleted_trace is None, f"Trace {trace_row_id} should be deleted from database"
+
+
+async def test_delete_trace_stands_down_the_sessions_evaluations(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        project_session = await _add_project_session(session, project)
+        trace = await _add_trace(session, project, project_session)
+        await _add_span(session, trace)
+        await _add_trace(session, project, project_session)
+        work_unit_id = (await _add_live_session_work_unit(session, project_session)).id
+        project_session_id = project_session.id
+        trace_id = trace.trace_id
+
+    response = await httpx_client.delete(f"v1/traces/{trace_id}")
+    assert response.status_code == 204
+
+    async with db() as session:
+        remaining_session = await session.get(models.ProjectSession, project_session_id)
+        assert remaining_session is not None
+        assert remaining_session.content_complete is False
+        work_unit = await session.get(models.EvalSessionWorkUnit, work_unit_id)
+        assert work_unit is not None
+        assert work_unit.status == "EXPIRED"
+        assert work_unit.error == "session content incomplete"
 
 
 async def test_delete_trace_not_found(

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -19,6 +19,7 @@ from sqlalchemy import insert, select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
+from phoenix.db.eval_work import SESSION_CONTENT_INCOMPLETE_ERROR
 from phoenix.server.types import DbSessionFactory
 from tests.unit._helpers import (
     _add_live_session_work_unit,
@@ -372,7 +373,7 @@ async def test_delete_trace_stands_down_the_sessions_evaluations(
         work_unit = await session.get(models.EvalSessionWorkUnit, work_unit_id)
         assert work_unit is not None
         assert work_unit.status == "EXPIRED"
-        assert work_unit.error == "session content incomplete"
+        assert work_unit.error == SESSION_CONTENT_INCOMPLETE_ERROR
 
 
 async def test_delete_trace_not_found(

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -22,7 +22,11 @@ from phoenix.db.types.prompts import (
     PromptTemplateFormat,
     PromptTemplateType,
 )
-from phoenix.server.api.types.Evaluator import BuiltInEvaluator, DatasetEvaluator, LLMEvaluator
+from phoenix.server.api.types.Evaluator import (
+    BuiltInEvaluator,
+    DatasetEvaluator,
+    LLMEvaluator,
+)
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -201,6 +205,49 @@ class TestEvaluatorFields:
         )
         assert not resp.errors and resp.data
         assert resp.data["node"]["datasetEvaluators"] == []
+
+
+async def test_project_evaluator_evaluation_delay_seconds(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    async with db() as session:
+        project = models.Project(name=f"project-{token_hex(4)}")
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(f"evaluator-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add_all([project, evaluator])
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator.id,
+            name=Identifier(f"criteria-{token_hex(4)}"),
+            evaluation_target="SESSION",
+            sampling_rate=1.0,
+            evaluation_delay_seconds=45,
+        )
+        session.add(criteria)
+        await session.flush()
+        project_id = project.id
+
+    response = await gql_client.execute(
+        """query ($id: ID!) {
+            node(id: $id) {
+                ... on Project {
+                    evaluators { edges { node { evaluationDelaySeconds } } }
+                }
+            }
+        }""",
+        variables={"id": str(GlobalID("Project", str(project_id)))},
+    )
+
+    assert not response.errors and response.data
+    edges = response.data["node"]["evaluators"]["edges"]
+    assert [edge["node"]["evaluationDelaySeconds"] for edge in edges] == [45]
 
 
 class TestDatasetEvaluatorDescriptionFallback:

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -22,7 +22,11 @@ from phoenix.db.types.prompts import (
     PromptTemplateFormat,
     PromptTemplateType,
 )
-from phoenix.server.api.types.Evaluator import BuiltInEvaluator, DatasetEvaluator, LLMEvaluator
+from phoenix.server.api.types.Evaluator import (
+    BuiltInEvaluator,
+    DatasetEvaluator,
+    LLMEvaluator,
+)
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -270,6 +274,49 @@ class TestEvaluatorFields:
         )
         assert not resp.errors and resp.data
         assert resp.data["node"]["projects"]["edges"] == []
+
+
+async def test_project_evaluator_evaluation_delay_seconds(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    async with db() as session:
+        project = models.Project(name=f"project-{token_hex(4)}")
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(f"evaluator-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add_all([project, evaluator])
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator.id,
+            name=Identifier(f"criteria-{token_hex(4)}"),
+            evaluation_target="SESSION",
+            sampling_rate=1.0,
+            evaluation_delay_seconds=45,
+        )
+        session.add(criteria)
+        await session.flush()
+        project_id = project.id
+
+    response = await gql_client.execute(
+        """query ($id: ID!) {
+            node(id: $id) {
+                ... on Project {
+                    evaluators { edges { node { evaluationDelaySeconds } } }
+                }
+            }
+        }""",
+        variables={"id": str(GlobalID("Project", str(project_id)))},
+    )
+
+    assert not response.errors and response.data
+    edges = response.data["node"]["evaluators"]["edges"]
+    assert [edge["node"]["evaluationDelaySeconds"] for edge in edges] == [45]
 
 
 class TestDatasetEvaluatorDescriptionFallback:

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -276,7 +276,7 @@ class TestEvaluatorFields:
         assert resp.data["node"]["projects"]["edges"] == []
 
 
-async def test_project_evaluator_evaluation_delay_seconds(
+async def test_project_evaluator_scheduling_fields(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
@@ -296,6 +296,7 @@ async def test_project_evaluator_evaluation_delay_seconds(
             evaluator_id=evaluator.id,
             name=Identifier(f"criteria-{token_hex(4)}"),
             evaluation_target="SESSION",
+            filter_condition="span_kind == 'LLM'",
             sampling_rate=1.0,
             evaluation_delay_seconds=45,
         )
@@ -307,7 +308,15 @@ async def test_project_evaluator_evaluation_delay_seconds(
         """query ($id: ID!) {
             node(id: $id) {
                 ... on Project {
-                    evaluators { edges { node { evaluationDelaySeconds } } }
+                    evaluators {
+                        edges {
+                            node {
+                                evaluationDelaySeconds
+                                schedulabilityStatus
+                                schedulabilityReason
+                            }
+                        }
+                    }
                 }
             }
         }""",
@@ -317,6 +326,10 @@ async def test_project_evaluator_evaluation_delay_seconds(
     assert not response.errors and response.data
     edges = response.data["node"]["evaluators"]["edges"]
     assert [edge["node"]["evaluationDelaySeconds"] for edge in edges] == [45]
+    assert [edge["node"]["schedulabilityStatus"] for edge in edges] == ["NOT_SCHEDULABLE"]
+    assert [edge["node"]["schedulabilityReason"] for edge in edges] == [
+        "SESSION_FILTER_UNSUPPORTED"
+    ]
 
 
 class TestDatasetEvaluatorDescriptionFallback:

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -207,7 +207,7 @@ class TestEvaluatorFields:
         assert resp.data["node"]["datasetEvaluators"] == []
 
 
-async def test_project_evaluator_evaluation_delay_seconds(
+async def test_project_evaluator_scheduling_fields(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
@@ -227,6 +227,7 @@ async def test_project_evaluator_evaluation_delay_seconds(
             evaluator_id=evaluator.id,
             name=Identifier(f"criteria-{token_hex(4)}"),
             evaluation_target="SESSION",
+            filter_condition="span_kind == 'LLM'",
             sampling_rate=1.0,
             evaluation_delay_seconds=45,
         )
@@ -238,7 +239,15 @@ async def test_project_evaluator_evaluation_delay_seconds(
         """query ($id: ID!) {
             node(id: $id) {
                 ... on Project {
-                    evaluators { edges { node { evaluationDelaySeconds } } }
+                    evaluators {
+                        edges {
+                            node {
+                                evaluationDelaySeconds
+                                schedulabilityStatus
+                                schedulabilityReason
+                            }
+                        }
+                    }
                 }
             }
         }""",
@@ -248,6 +257,10 @@ async def test_project_evaluator_evaluation_delay_seconds(
     assert not response.errors and response.data
     edges = response.data["node"]["evaluators"]["edges"]
     assert [edge["node"]["evaluationDelaySeconds"] for edge in edges] == [45]
+    assert [edge["node"]["schedulabilityStatus"] for edge in edges] == ["NOT_SCHEDULABLE"]
+    assert [edge["node"]["schedulabilityReason"] for edge in edges] == [
+        "SESSION_FILTER_UNSUPPORTED"
+    ]
 
 
 class TestDatasetEvaluatorDescriptionFallback:

--- a/tests/unit/server/online_eval/test_app_wiring.py
+++ b/tests/unit/server/online_eval/test_app_wiring.py
@@ -18,6 +18,7 @@ from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.app import create_app
 from phoenix.server.online_eval.consumer import OnlineEvalConsumer
 from phoenix.server.online_eval.producer import OnlineEvalProducer
+from phoenix.server.online_eval.session_sweeper import SessionEvalSweeper
 from phoenix.server.types import DbSessionFactory
 from tests.unit.conftest import (
     TestBulkInserter,
@@ -43,6 +44,7 @@ async def test_online_eval_daemons_absent_by_default(db: DbSessionFactory) -> No
     app = _create_app(db)
     assert app.state.online_eval_producer is None
     assert app.state.online_eval_consumer is None
+    assert app.state.online_eval_session_sweeper is None
 
 
 async def test_online_eval_daemons_absent_in_read_only_mode(
@@ -53,6 +55,7 @@ async def test_online_eval_daemons_absent_in_read_only_mode(
     app = _create_app(db, read_only=True)
     assert app.state.online_eval_producer is None
     assert app.state.online_eval_consumer is None
+    assert app.state.online_eval_session_sweeper is None
 
 
 async def test_enabled_app_runs_seeded_criteria_end_to_end(
@@ -67,9 +70,13 @@ async def test_enabled_app_runs_seeded_criteria_end_to_end(
         app = _create_app(db)
         producer = app.state.online_eval_producer
         consumer = app.state.online_eval_consumer
+        session_sweeper = app.state.online_eval_session_sweeper
         assert isinstance(producer, OnlineEvalProducer)
         assert isinstance(consumer, OnlineEvalConsumer)
+        assert isinstance(session_sweeper, SessionEvalSweeper)
         await stack.enter_async_context(LifespanManager(app))
+        await producer.stop()
+        await session_sweeper.stop()
 
         async with db() as session:
             project = await _add_project(session)

--- a/tests/unit/server/online_eval/test_app_wiring.py
+++ b/tests/unit/server/online_eval/test_app_wiring.py
@@ -12,7 +12,10 @@ import pytest
 from asgi_lifespan import LifespanManager
 from sqlalchemy import select, update
 
-from phoenix.config import ENV_PHOENIX_ONLINE_EVAL_ENABLED
+from phoenix.config import (
+    ENV_PHOENIX_ONLINE_EVAL_ENABLED,
+    ENV_PHOENIX_ONLINE_EVAL_SESSION_SWEEP_ENABLED,
+)
 from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.app import create_app
@@ -51,6 +54,7 @@ async def test_online_eval_daemons_absent_in_read_only_mode(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_ENABLED, "true")
+    monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_SESSION_SWEEP_ENABLED, "true")
 
     app = _create_app(db, read_only=True)
     assert app.state.online_eval_producer is None
@@ -58,10 +62,24 @@ async def test_online_eval_daemons_absent_in_read_only_mode(
     assert app.state.online_eval_session_sweeper is None
 
 
+async def test_session_sweeper_needs_its_own_flag(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing executes session work units yet, so the sweeper stays off until it is
+    asked for explicitly — otherwise it fills the outstanding-work budget and wedges.
+    """
+    monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_ENABLED, "true")
+
+    app = _create_app(db)
+    assert isinstance(app.state.online_eval_producer, OnlineEvalProducer)
+    assert app.state.online_eval_session_sweeper is None
+
+
 async def test_enabled_app_runs_seeded_criteria_end_to_end(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_ENABLED, "true")
+    monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_SESSION_SWEEP_ENABLED, "true")
     _patch_playground_client(monkeypatch, _StubLLMClient())
 
     async with AsyncExitStack() as stack:

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from sqlalchemy import func, select, update
 
 from phoenix.db import models
+from phoenix.server.online_eval import session_sweeper
 from phoenix.server.online_eval.session_sweeper import (
     SESSION_SWEEP_LEASE_TTL_SECONDS,
     SessionEvalSweeper,
@@ -89,6 +91,31 @@ async def test_materializes_generation_zero_and_prunes_resolved_activity(
     assert unit.status == "PENDING"
     assert activity_count == 0
     assert cursor.claimed_by == sweeper._sweeper_id
+
+
+async def test_materializes_oldest_activity_beyond_id_order_limit(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(session_sweeper, "_MAX_ACTIVITY_ROWS_PER_TICK", 2)
+    for _ in range(3):
+        project_id, _, _ = await _add_session_activity(db, age_seconds=0)
+        await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    project_id, oldest_project_session_id, _ = await _add_session_activity(
+        db,
+        age_seconds=600,
+    )
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+
+    await SessionEvalSweeper(db)._tick()
+
+    async with db() as session:
+        project_session_ids = list(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit.project_session_rowid)
+            )
+        )
+    assert project_session_ids == [oldest_project_session_id]
 
 
 async def test_retains_activity_until_each_criteria_delay_elapses(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -111,9 +111,7 @@ async def test_materializes_oldest_activity_beyond_id_order_limit(
 
     async with db() as session:
         project_session_ids = list(
-            await session.scalars(
-                select(models.EvalSessionWorkUnit.project_session_rowid)
-            )
+            await session.scalars(select(models.EvalSessionWorkUnit.project_session_rowid))
         )
     assert project_session_ids == [oldest_project_session_id]
 

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -1,10 +1,14 @@
+import logging
 from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from phoenix.db import models
 from phoenix.server.online_eval import session_sweeper
+from phoenix.server.online_eval.derivation import ResolvedCriteria
+from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.online_eval.session_sweeper import (
     SESSION_SWEEP_LEASE_TTL_SECONDS,
     SessionEvalSweeper,
@@ -23,16 +27,22 @@ async def _add_session_activity(
     db: DbSessionFactory,
     *,
     age_seconds: float,
+    project_id: int | None = None,
 ) -> tuple[int, int, int]:
     async with db() as session:
-        project = await _add_project(session)
+        if project_id is None:
+            project = await _add_project(session)
+        else:
+            existing_project = await session.get(models.Project, project_id)
+            assert existing_project is not None
+            project = existing_project
         project_session = await _add_project_session(session, project)
         trace = await _add_trace(session, project, project_session)
         span = await _add_span(session, trace)
         session.add(
             models.EvalSessionActivity(
                 project_session_rowid=project_session.id,
-                last_seen_span_id=span.id,
+                last_seen_span_rowid=span.id,
                 observed_at=_now() - timedelta(seconds=age_seconds),
             )
         )
@@ -93,19 +103,29 @@ async def test_materializes_generation_zero_and_prunes_resolved_activity(
     assert cursor.claimed_by == sweeper._sweeper_id
 
 
-async def test_materializes_oldest_activity_beyond_id_order_limit(
+async def test_not_yet_due_activity_does_not_consume_scan_limit(
     db: DbSessionFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(session_sweeper, "_MAX_ACTIVITY_ROWS_PER_TICK", 2)
-    for _ in range(3):
-        project_id, _, _ = await _add_session_activity(db, age_seconds=0)
-        await _seed_criteria(db, project_id, evaluation_target="SESSION")
-    project_id, oldest_project_session_id, _ = await _add_session_activity(
+    long_delay_project_id, _, _ = await _add_session_activity(db, age_seconds=0)
+    _, long_delay_criteria_id = await _seed_criteria(
+        db,
+        long_delay_project_id,
+        evaluation_target="SESSION",
+    )
+    await _set_delay(db, long_delay_criteria_id, 600)
+    for _ in range(2):
+        await _add_session_activity(
+            db,
+            age_seconds=0,
+            project_id=long_delay_project_id,
+        )
+    due_project_id, due_project_session_id, _ = await _add_session_activity(
         db,
         age_seconds=600,
     )
-    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    await _seed_criteria(db, due_project_id, evaluation_target="SESSION")
 
     await SessionEvalSweeper(db)._tick()
 
@@ -113,7 +133,112 @@ async def test_materializes_oldest_activity_beyond_id_order_limit(
         project_session_ids = list(
             await session.scalars(select(models.EvalSessionWorkUnit.project_session_rowid))
         )
-    assert project_session_ids == [oldest_project_session_id]
+    assert project_session_ids == [due_project_session_id]
+
+
+async def test_lost_lease_rolls_back_sweep(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+    acquire_cursor = sweeper._acquire_cursor
+
+    async def acquire_then_lose_lease() -> int | None:
+        cursor_id = await acquire_cursor()
+        assert cursor_id is not None
+        async with db() as session:
+            await session.execute(
+                update(models.EvalWorkCursor)
+                .where(models.EvalWorkCursor.id == cursor_id)
+                .values(claimed_by="replacement-sweeper")
+            )
+        return cursor_id
+
+    monkeypatch.setattr(sweeper, "_acquire_cursor", acquire_then_lose_lease)
+    async with db() as session:
+        activity_before = (
+            await session.execute(
+                select(
+                    models.EvalSessionActivity.id,
+                    models.EvalSessionActivity.last_seen_span_rowid,
+                    models.EvalSessionActivity.observed_at,
+                ).where(models.EvalSessionActivity.project_session_rowid == project_session_id)
+            )
+        ).one()
+
+    with caplog.at_level(logging.WARNING, logger=session_sweeper.__name__):
+        await sweeper._tick()
+
+    async with db() as session:
+        work_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        )
+        activity_after = (
+            await session.execute(
+                select(
+                    models.EvalSessionActivity.id,
+                    models.EvalSessionActivity.last_seen_span_rowid,
+                    models.EvalSessionActivity.observed_at,
+                ).where(models.EvalSessionActivity.project_session_rowid == project_session_id)
+            )
+        ).one()
+    assert work_count == 0
+    assert activity_after == activity_before
+    assert "Session evaluation sweeper lost its lease" in caplog.text
+
+
+async def test_unresolvable_criteria_does_not_stall_project_sweep(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
+    _, resolvable_criteria_id = await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+    )
+    _, unresolvable_criteria_id = await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+    )
+
+    async def resolve_with_one_unresolvable(
+        session: AsyncSession,
+        criteria: models.ProjectEvaluatorCriteria,
+        evaluator: models.Evaluator,
+    ) -> ResolvedCriteria | None:
+        if criteria.id == unresolvable_criteria_id:
+            return None
+        return await resolve_criteria(session, criteria, evaluator)
+
+    monkeypatch.setattr(session_sweeper, "resolve_criteria", resolve_with_one_unresolvable)
+    with caplog.at_level(logging.WARNING, logger=session_sweeper.__name__):
+        await SessionEvalSweeper(db)._tick()
+
+    async with db() as session:
+        criteria_ids = list(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit.criteria_id).where(
+                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
+                )
+            )
+        )
+        activity_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionActivity)
+        )
+    assert criteria_ids == [resolvable_criteria_id]
+    assert activity_count == 0
+    messages = [
+        record.message
+        for record in caplog.records
+        if f"Skipping criteria {unresolvable_criteria_id}:" in record.message
+    ]
+    assert len(messages) == 1
 
 
 async def test_retains_activity_until_each_criteria_delay_elapses(
@@ -187,8 +312,8 @@ async def test_reopened_session_is_pruned_without_another_work_unit(
         session.add(
             models.EvalSessionActivity(
                 project_session_rowid=project_session_id,
-                last_seen_span_id=span_id,
-                observed_at=_now(),
+                last_seen_span_rowid=span_id,
+                observed_at=_now() - timedelta(seconds=600),
             )
         )
     await sweeper._tick()

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -1,0 +1,258 @@
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, select, update
+
+from phoenix.db import models
+from phoenix.server.online_eval.session_sweeper import (
+    SESSION_SWEEP_LEASE_TTL_SECONDS,
+    SessionEvalSweeper,
+)
+from phoenix.server.types import DbSessionFactory
+
+from ..._helpers import _add_project, _add_project_session, _add_span, _add_trace
+from .test_producer import _seed_criteria
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def _add_session_activity(
+    db: DbSessionFactory,
+    *,
+    age_seconds: float,
+) -> tuple[int, int, int]:
+    async with db() as session:
+        project = await _add_project(session)
+        project_session = await _add_project_session(session, project)
+        trace = await _add_trace(session, project, project_session)
+        span = await _add_span(session, trace)
+        session.add(
+            models.EvalSessionActivity(
+                project_session_rowid=project_session.id,
+                last_seen_span_id=span.id,
+                observed_at=_now() - timedelta(seconds=age_seconds),
+            )
+        )
+        await session.flush()
+        return project.id, project_session.id, span.id
+
+
+async def _set_delay(
+    db: DbSessionFactory,
+    criteria_id: int,
+    delay_seconds: int | None,
+) -> None:
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(evaluation_delay_seconds=delay_seconds)
+        )
+
+
+async def test_materializes_generation_zero_and_prunes_resolved_activity(
+    db: DbSessionFactory,
+) -> None:
+    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
+    evaluator_id, criteria_id = await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+    )
+
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+
+    async with db() as session:
+        unit = (
+            await session.scalars(
+                select(models.EvalSessionWorkUnit).where(
+                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
+                )
+            )
+        ).one()
+        activity_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionActivity)
+        )
+        cursor = (
+            await session.scalars(
+                select(models.EvalWorkCursor).where(
+                    models.EvalWorkCursor.evaluation_target == "SESSION",
+                    models.EvalWorkCursor.consumer_group == "default",
+                )
+            )
+        ).one()
+    assert unit.evaluator_id == evaluator_id
+    assert unit.criteria_id == criteria_id
+    assert unit.generation == 0
+    assert unit.status == "PENDING"
+    assert activity_count == 0
+    assert cursor.claimed_by == sweeper._sweeper_id
+
+
+async def test_retains_activity_until_each_criteria_delay_elapses(
+    db: DbSessionFactory,
+) -> None:
+    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=100)
+    _, short_delay_criteria_id = await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+    )
+    _, long_delay_criteria_id = await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+    )
+    await _set_delay(db, short_delay_criteria_id, 10)
+    await _set_delay(db, long_delay_criteria_id, 600)
+
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+
+    async with db() as session:
+        units = list(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit).where(
+                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
+                )
+            )
+        )
+        activity = await session.scalar(
+            select(models.EvalSessionActivity).where(
+                models.EvalSessionActivity.project_session_rowid == project_session_id
+            )
+        )
+    assert [unit.criteria_id for unit in units] == [short_delay_criteria_id]
+    assert activity is not None
+
+    async with db() as session:
+        await session.execute(
+            update(models.EvalSessionActivity)
+            .where(models.EvalSessionActivity.project_session_rowid == project_session_id)
+            .values(observed_at=_now() - timedelta(seconds=700))
+        )
+    await sweeper._tick()
+
+    async with db() as session:
+        criteria_ids = set(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit.criteria_id).where(
+                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
+                )
+            )
+        )
+        activity_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionActivity)
+        )
+    assert criteria_ids == {short_delay_criteria_id, long_delay_criteria_id}
+    assert activity_count == 0
+
+
+async def test_reopened_session_is_pruned_without_another_work_unit(
+    db: DbSessionFactory,
+) -> None:
+    project_id, project_session_id, span_id = await _add_session_activity(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+
+    async with db() as session:
+        session.add(
+            models.EvalSessionActivity(
+                project_session_rowid=project_session_id,
+                last_seen_span_id=span_id,
+                observed_at=_now(),
+            )
+        )
+    await sweeper._tick()
+
+    async with db() as session:
+        units = list(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit).where(
+                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
+                )
+            )
+        )
+        activity_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionActivity)
+        )
+    assert len(units) == 1
+    assert units[0].generation == 0
+    assert activity_count == 0
+
+
+async def test_trace_filtered_and_sampled_criteria_remain_unscheduled(
+    db: DbSessionFactory,
+) -> None:
+    project_id, _, _ = await _add_session_activity(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="TRACE")
+    await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+        filter_condition="span_kind == 'LLM'",
+    )
+    await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+        sampling_rate=0.5,
+    )
+
+    await SessionEvalSweeper(db)._tick()
+
+    async with db() as session:
+        session_work_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        )
+    assert session_work_count == 0
+
+
+async def test_live_session_lease_stands_down_and_stale_lease_is_reclaimed(
+    db: DbSessionFactory,
+) -> None:
+    project_id, _, _ = await _add_session_activity(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    async with db() as session:
+        session.add(
+            models.EvalWorkCursor(
+                evaluation_target="SESSION",
+                consumer_group="default",
+                produced_through_id=0,
+                claimed_by="other-sweeper",
+                claimed_at=_now(),
+            )
+        )
+
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+    async with db() as session:
+        work_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        )
+    assert work_count == 0
+
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkCursor)
+            .where(models.EvalWorkCursor.evaluation_target == "SESSION")
+            .values(claimed_at=_now() - timedelta(seconds=SESSION_SWEEP_LEASE_TTL_SECONDS + 1))
+        )
+    await sweeper._tick()
+
+    async with db() as session:
+        work_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        )
+        cursor = (
+            await session.scalars(
+                select(models.EvalWorkCursor).where(
+                    models.EvalWorkCursor.evaluation_target == "SESSION"
+                )
+            )
+        ).one()
+    assert work_count == 1
+    assert cursor.claimed_by == sweeper._sweeper_id

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -6,12 +6,11 @@ from unittest.mock import Mock
 
 import pytest
 from sqlalchemy import Table, func, select, update
-from sqlalchemy.dialects.postgresql import asyncpg
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from phoenix.db import models
 from phoenix.db.eval_work import live_eval_work_index_predicate
-from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.db.types.identifier import Identifier
 from phoenix.server.online_eval import session_sweeper
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, ResolvedCriteria
 from phoenix.server.online_eval.producer import resolve_criteria
@@ -27,15 +26,6 @@ from .test_producer import _seed_criteria
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
-
-
-_CRITERION = session_sweeper._SessionCriteria(
-    criteria_id=1,
-    project_id=1,
-    evaluator_id=1,
-    fingerprint="fingerprint",
-    delay_seconds=10,
-)
 
 
 def test_live_key_predicate_is_single_sourced_from_max_attempts() -> None:
@@ -61,61 +51,43 @@ def test_live_key_predicate_is_single_sourced_from_max_attempts() -> None:
     assert migration.live_eval_work_index_predicate is live_eval_work_index_predicate
 
 
-def test_session_work_insert_batch_stays_below_asyncpg_parameter_limit() -> None:
-    statement = session_sweeper._session_work_insert_statement(
-        _CRITERION,
-        list(range(session_sweeper._SESSION_WORK_INSERT_BATCH_SIZE)),
-        SupportedSQLDialect.POSTGRESQL,
-    )
-    compiled = statement.compile(dialect=asyncpg.dialect())  # type: ignore[no-untyped-call]
-
-    assert len(compiled.params) <= session_sweeper._MAX_SESSION_WORK_INSERT_PARAMETERS
-    assert len(compiled.params) < 32_767
-
-
 async def test_materialization_rechecks_eligibility_at_write_time(
     db: DbSessionFactory,
 ) -> None:
-    """The insert re-derives completeness and the live-key check, so a session that
-    turns ineligible after the eligibility SELECT does not get a work unit anyway.
-    """
-    project_id, project_session_id, _ = await _add_session_liveness(db, age_seconds=600)
-    evaluator_id, criteria_id = await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    project_id, project_session_id, last_span_ingested_at = await _add_session_liveness(
+        db,
+        age_seconds=600,
+    )
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
     sweeper = SessionEvalSweeper(db)
 
     async with db() as session:
         criterion = (await sweeper._load_criteria(session))[0]
+        database_now = await sweeper._database_now(session)
         await session.execute(
             update(models.ProjectSession)
             .where(models.ProjectSession.id == project_session_id)
-            .values(content_complete=False)
+            .values(last_span_ingested_at=database_now)
         )
-        await session.execute(
-            session_sweeper._session_work_insert_statement(
-                criterion,
-                [project_session_id],
-                db.dialect,
-            )
+        inserted_count, _ = await sweeper._load_eligible_pairs(
+            session,
+            database_now,
+            [criterion],
+            limit=1,
         )
-        assert (
-            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
-        )
+        assert inserted_count == 0
         await session.execute(
             update(models.ProjectSession)
             .where(models.ProjectSession.id == project_session_id)
-            .values(content_complete=True)
+            .values(last_span_ingested_at=last_span_ingested_at)
         )
-        await session.execute(
-            session_sweeper._session_work_insert_statement(
-                criterion,
-                [project_session_id],
-                db.dialect,
-            )
+        inserted_count, _ = await sweeper._load_eligible_pairs(
+            session,
+            database_now,
+            [criterion],
+            limit=1,
         )
-        units = list(await session.scalars(select(models.EvalSessionWorkUnit)))
-    assert len(units) == 1
-    assert units[0].evaluator_id == evaluator_id
-    assert units[0].criteria_id == criteria_id
+        assert inserted_count == 1
 
 
 async def _add_session_liveness(
@@ -191,19 +163,6 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
                 )
             )
         ).one()
-        await session.execute(
-            session_sweeper._session_work_insert_statement(
-                session_sweeper._SessionCriteria(
-                    criteria_id=criteria_id,
-                    project_id=project_id,
-                    evaluator_id=evaluator_id,
-                    fingerprint=unit.config_fingerprint,
-                    delay_seconds=300,
-                ),
-                [project_session_id],
-                db.dialect,
-            )
-        )
         live_work_count = await session.scalar(
             select(func.count()).select_from(models.EvalSessionWorkUnit)
         )
@@ -213,6 +172,33 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
     assert unit.status == "PENDING"
     assert lease.holder == sweeper._sweeper_id
     assert live_work_count == 1
+
+
+async def test_materializes_with_501_schedulable_criteria(
+    db: DbSessionFactory,
+) -> None:
+    project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
+    evaluator_id, _ = await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    async with db() as session:
+        session.add_all(
+            models.ProjectEvaluatorCriteria(
+                project_id=project_id,
+                evaluator_id=evaluator_id,
+                name=Identifier(root=f"bulk-criteria-{index}"),
+                filter_condition="",
+                sampling_rate=1.0,
+                evaluation_target="SESSION",
+            )
+            for index in range(500)
+        )
+
+    await SessionEvalSweeper(db)._tick()
+
+    async with db() as session:
+        work_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        )
+    assert work_count == 501
 
 
 async def test_session_with_null_liveness_is_never_eligible(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -248,6 +248,79 @@ async def test_materializes_with_501_schedulable_criteria(
 
 
 @pytest.mark.postgres_only
+async def test_materialization_waits_for_publication_criteria_lock_before_session_locks(
+    postgresql_engine: AsyncEngine,
+) -> None:
+    db = DbSessionFactory(db=_db(postgresql_engine), dialect="postgresql")
+    project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
+    _, second_session_id, _ = await _add_session_liveness(
+        db,
+        age_seconds=600,
+        project_id=project_id,
+    )
+    _, first_criteria_id = await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+    )
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+    materialization_started = asyncio.Event()
+    materialization_backend_pid: int | None = None
+
+    async def materialize() -> tuple[int, int]:
+        nonlocal materialization_backend_pid
+        async with db() as session:
+            materialization_backend_pid = await session.scalar(select(func.pg_backend_pid()))
+            assert materialization_backend_pid is not None
+            database_now = await sweeper._database_now(session)
+            materialization_started.set()
+            return await sweeper._sweep(session, database_now)
+
+    async with db() as publication_session:
+        publication_backend_pid = await publication_session.scalar(select(func.pg_backend_pid()))
+        assert publication_backend_pid is not None
+        assert (
+            await publication_session.scalar(
+                select(models.ProjectEvaluatorCriteria.id)
+                .where(models.ProjectEvaluatorCriteria.id == first_criteria_id)
+                .with_for_update()
+            )
+            == first_criteria_id
+        )
+        materialization = asyncio.create_task(materialize())
+        await materialization_started.wait()
+
+        async def wait_for_publication_to_block_materialization() -> Sequence[int]:
+            assert materialization_backend_pid is not None
+            while True:
+                async with db() as observer:
+                    blocking_pids = await observer.scalar(
+                        select(func.pg_blocking_pids(materialization_backend_pid))
+                    )
+                if blocking_pids:
+                    return blocking_pids
+                await asyncio.sleep(0)
+
+        blocking_pids = await asyncio.wait_for(
+            wait_for_publication_to_block_materialization(),
+            timeout=5,
+        )
+        assert publication_backend_pid in blocking_pids
+        assert (
+            await publication_session.scalar(
+                select(models.ProjectSession.id)
+                .where(models.ProjectSession.id == second_session_id)
+                .with_for_update(nowait=True)
+            )
+            == second_session_id
+        )
+
+    inserted_count, _ = await asyncio.wait_for(materialization, timeout=5)
+    assert inserted_count == 4
+
+
+@pytest.mark.postgres_only
 async def test_materialization_waits_for_retention_session_lock(
     postgresql_engine: AsyncEngine,
 ) -> None:

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone
+from importlib import import_module
 from unittest.mock import Mock
 
 import pytest
@@ -8,6 +9,7 @@ from sqlalchemy.dialects.postgresql import asyncpg
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from phoenix.db import models
+from phoenix.db.eval_work import live_eval_work_index_predicate
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.server.online_eval import session_sweeper
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, ResolvedCriteria
@@ -26,30 +28,92 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def test_session_work_insert_batch_stays_below_asyncpg_parameter_limit() -> None:
-    work_records = [
-        {
-            "project_session_rowid": index,
-            "evaluator_id": index,
-            "criteria_id": index,
-            "config_fingerprint": f"fingerprint-{index}",
-            "evaluated_through": _now(),
-        }
-        for index in range(session_sweeper._SESSION_WORK_INSERT_BATCH_SIZE)
-    ]
+_CRITERION = session_sweeper._SessionCriteria(
+    criteria_id=1,
+    project_id=1,
+    evaluator_id=1,
+    fingerprint="fingerprint",
+    delay_seconds=10,
+)
 
+
+def test_live_key_predicate_is_single_sourced_from_max_attempts() -> None:
+    """The sweeper's conflict target, the model's index, and the migration that creates
+    it must stay textually identical and must track ``MAX_ATTEMPTS``: Postgres matches
+    ``ON CONFLICT ... WHERE`` to a partial index by predicate equivalence.
+    """
+    migration = import_module(
+        "phoenix.db.migrations.versions.a7f1c3e9d2b4_add_online_eval_coordination"
+    )
+    predicate = live_eval_work_index_predicate()
+    live_key_index = next(
+        index
+        for index in models.EvalSessionWorkUnit.__table__.indexes
+        if index.name == "uq_eval_session_work_units_live_key"
+    )
+
+    assert f"attempts < {MAX_ATTEMPTS}" in predicate
+    assert str(live_key_index.dialect_options["postgresql"]["where"]) == predicate
+    assert str(live_key_index.dialect_options["sqlite"]["where"]) == predicate
+    assert str(session_sweeper._LIVE_WORK_INDEX_PREDICATE) == predicate
+    assert migration.live_eval_work_index_predicate is live_eval_work_index_predicate
+
+
+def test_session_work_insert_batch_stays_below_asyncpg_parameter_limit() -> None:
     statement = session_sweeper._session_work_insert_statement(
-        work_records,
+        _CRITERION,
+        list(range(session_sweeper._SESSION_WORK_INSERT_BATCH_SIZE)),
         SupportedSQLDialect.POSTGRESQL,
     )
     compiled = statement.compile(dialect=asyncpg.dialect())  # type: ignore[no-untyped-call]
 
-    assert len(compiled.params) == (
-        session_sweeper._SESSION_WORK_INSERT_BATCH_SIZE
-        * session_sweeper._SESSION_WORK_INSERT_PARAMETERS_PER_ROW
-    )
     assert len(compiled.params) <= session_sweeper._MAX_SESSION_WORK_INSERT_PARAMETERS
     assert len(compiled.params) < 32_767
+
+
+async def test_materialization_rechecks_eligibility_at_write_time(
+    db: DbSessionFactory,
+) -> None:
+    """The insert re-derives completeness and the live-key check, so a session that
+    turns ineligible after the eligibility SELECT does not get a work unit anyway.
+    """
+    project_id, project_session_id, _ = await _add_session_liveness(db, age_seconds=600)
+    evaluator_id, criteria_id = await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+
+    async with db() as session:
+        criterion = (await sweeper._load_criteria(session))[0]
+        await session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == project_session_id)
+            .values(content_complete=False)
+        )
+        await session.execute(
+            session_sweeper._session_work_insert_statement(
+                criterion,
+                [project_session_id],
+                db.dialect,
+            )
+        )
+        assert (
+            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
+        )
+        await session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == project_session_id)
+            .values(content_complete=True)
+        )
+        await session.execute(
+            session_sweeper._session_work_insert_statement(
+                criterion,
+                [project_session_id],
+                db.dialect,
+            )
+        )
+        units = list(await session.scalars(select(models.EvalSessionWorkUnit)))
+    assert len(units) == 1
+    assert units[0].evaluator_id == evaluator_id
+    assert units[0].criteria_id == criteria_id
 
 
 async def _add_session_liveness(
@@ -128,15 +192,14 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
         ).one()
         await session.execute(
             session_sweeper._session_work_insert_statement(
-                [
-                    {
-                        "project_session_rowid": project_session_id,
-                        "evaluator_id": evaluator_id,
-                        "criteria_id": criteria_id,
-                        "config_fingerprint": unit.config_fingerprint,
-                        "evaluated_through": last_span_ingested_at,
-                    }
-                ],
+                session_sweeper._SessionCriteria(
+                    criteria_id=criteria_id,
+                    project_id=project_id,
+                    evaluator_id=evaluator_id,
+                    fingerprint=unit.config_fingerprint,
+                    delay_seconds=300,
+                ),
+                [project_session_id],
                 db.dialect,
             )
         )
@@ -302,48 +365,64 @@ async def test_successful_work_closes_evaluate_once_key(
     assert units[0].status == "DONE"
 
 
-async def test_exhausted_error_and_expired_history_are_replaceable(
+async def _work_statuses(db: DbSessionFactory) -> list[str]:
+    async with db() as session:
+        return list(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit.status).order_by(models.EvalSessionWorkUnit.id)
+            )
+        )
+
+
+async def _advance_liveness(
+    db: DbSessionFactory,
+    project_session_id: int,
+    to: datetime,
+) -> None:
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == project_session_id)
+            .values(last_span_ingested_at=to)
+        )
+
+
+async def test_terminal_history_re_materializes_only_after_new_ingest(
     db: DbSessionFactory,
 ) -> None:
-    project_id, project_session_id, _ = await _add_session_liveness(db, age_seconds=600)
+    """Work that will never run again — exhausted ERROR, EXPIRED — carries the session
+    content it already covered in ``evaluated_through``. Replacing it without newer
+    content just repeats the same failure every tick.
+    """
+    project_id, project_session_id, last_span_ingested_at = await _add_session_liveness(
+        db,
+        age_seconds=600,
+    )
     await _seed_criteria(db, project_id, evaluation_target="SESSION")
     sweeper = SessionEvalSweeper(db)
     await sweeper._tick()
 
     async with db() as session:
-        first_id = await session.scalar(select(models.EvalSessionWorkUnit.id))
-        assert first_id is not None
         await session.execute(
-            update(models.EvalSessionWorkUnit)
-            .where(models.EvalSessionWorkUnit.id == first_id)
-            .values(status="ERROR", attempts=MAX_ATTEMPTS)
+            update(models.EvalSessionWorkUnit).values(status="ERROR", attempts=MAX_ATTEMPTS)
         )
     await sweeper._tick()
+    await sweeper._tick()
+    assert await _work_statuses(db) == ["ERROR"]
+
+    await _advance_liveness(db, project_session_id, last_span_ingested_at + timedelta(seconds=60))
+    await sweeper._tick()
+    await sweeper._tick()
+    assert await _work_statuses(db) == ["ERROR", "PENDING"]
 
     async with db() as session:
-        units = list(
-            await session.scalars(
-                select(models.EvalSessionWorkUnit)
-                .where(models.EvalSessionWorkUnit.project_session_rowid == project_session_id)
-                .order_by(models.EvalSessionWorkUnit.id)
-            )
-        )
-        assert len(units) == 2
-        assert units[0].status == "ERROR"
         await session.execute(
             update(models.EvalSessionWorkUnit)
-            .where(models.EvalSessionWorkUnit.id == units[1].id)
+            .where(models.EvalSessionWorkUnit.status == "PENDING")
             .values(status="EXPIRED")
         )
     await sweeper._tick()
-
-    async with db() as session:
-        statuses = list(
-            await session.scalars(
-                select(models.EvalSessionWorkUnit.status).order_by(models.EvalSessionWorkUnit.id)
-            )
-        )
-    assert statuses == ["ERROR", "EXPIRED", "PENDING"]
+    assert await _work_statuses(db) == ["ERROR", "EXPIRED"]
 
 
 async def test_incomplete_session_is_never_scheduled(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
@@ -6,11 +7,12 @@ from unittest.mock import Mock
 
 import pytest
 from sqlalchemy import Table, func, select, update
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from phoenix.db import models
 from phoenix.db.eval_work import live_eval_work_index_predicate
 from phoenix.db.types.identifier import Identifier
+from phoenix.server.app import _db
 from phoenix.server.online_eval import session_sweeper
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, ResolvedCriteria
 from phoenix.server.online_eval.producer import resolve_criteria
@@ -199,6 +201,39 @@ async def test_materializes_with_501_schedulable_criteria(
             select(func.count()).select_from(models.EvalSessionWorkUnit)
         )
     assert work_count == 501
+
+
+@pytest.mark.postgres_only
+async def test_materialization_waits_for_retention_session_lock(
+    postgresql_engine: AsyncEngine,
+) -> None:
+    db = DbSessionFactory(db=_db(postgresql_engine), dialect="postgresql")
+    project_id, project_session_id, _ = await _add_session_liveness(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+
+    async def materialize() -> tuple[int, int]:
+        async with db() as session:
+            database_now = await sweeper._database_now(session)
+            return await sweeper._sweep(session, database_now)
+
+    async with db() as retention_session:
+        await retention_session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == project_session_id)
+            .values(content_complete=False)
+        )
+        materialization = asyncio.create_task(materialize())
+        await asyncio.sleep(0.05)
+        assert not materialization.done()
+
+    inserted_count, _ = await asyncio.wait_for(materialization, timeout=5)
+    assert inserted_count == 0
+    async with db() as session:
+        work_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        )
+    assert work_count == 0
 
 
 async def test_session_with_null_liveness_is_never_eligible(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -42,7 +42,6 @@ async def _add_session_activity(
         session.add(
             models.EvalSessionActivity(
                 project_session_rowid=project_session.id,
-                last_seen_span_rowid=span.id,
                 observed_at=_now() - timedelta(seconds=age_seconds),
             )
         )
@@ -53,7 +52,7 @@ async def _add_session_activity(
 async def _set_delay(
     db: DbSessionFactory,
     criteria_id: int,
-    delay_seconds: int | None,
+    delay_seconds: int,
 ) -> None:
     async with db() as session:
         await session.execute(
@@ -63,7 +62,7 @@ async def _set_delay(
         )
 
 
-async def test_materializes_generation_zero_and_prunes_resolved_activity(
+async def test_materializes_work_and_prunes_resolved_activity(
     db: DbSessionFactory,
 ) -> None:
     project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
@@ -97,7 +96,6 @@ async def test_materializes_generation_zero_and_prunes_resolved_activity(
         ).one()
     assert unit.evaluator_id == evaluator_id
     assert unit.criteria_id == criteria_id
-    assert unit.generation == 0
     assert unit.status == "PENDING"
     assert activity_count == 0
     assert cursor.claimed_by == sweeper._sweeper_id
@@ -163,7 +161,6 @@ async def test_lost_lease_rolls_back_sweep(
             await session.execute(
                 select(
                     models.EvalSessionActivity.id,
-                    models.EvalSessionActivity.last_seen_span_rowid,
                     models.EvalSessionActivity.observed_at,
                 ).where(models.EvalSessionActivity.project_session_rowid == project_session_id)
             )
@@ -180,7 +177,6 @@ async def test_lost_lease_rolls_back_sweep(
             await session.execute(
                 select(
                     models.EvalSessionActivity.id,
-                    models.EvalSessionActivity.last_seen_span_rowid,
                     models.EvalSessionActivity.observed_at,
                 ).where(models.EvalSessionActivity.project_session_rowid == project_session_id)
             )
@@ -303,7 +299,7 @@ async def test_retains_activity_until_each_criteria_delay_elapses(
 async def test_reopened_session_is_pruned_without_another_work_unit(
     db: DbSessionFactory,
 ) -> None:
-    project_id, project_session_id, span_id = await _add_session_activity(db, age_seconds=600)
+    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
     await _seed_criteria(db, project_id, evaluation_target="SESSION")
     sweeper = SessionEvalSweeper(db)
     await sweeper._tick()
@@ -312,7 +308,6 @@ async def test_reopened_session_is_pruned_without_another_work_unit(
         session.add(
             models.EvalSessionActivity(
                 project_session_rowid=project_session_id,
-                last_seen_span_rowid=span_id,
                 observed_at=_now() - timedelta(seconds=600),
             )
         )
@@ -330,7 +325,6 @@ async def test_reopened_session_is_pruned_without_another_work_unit(
             select(func.count()).select_from(models.EvalSessionActivity)
         )
     assert len(units) == 1
-    assert units[0].generation == 0
     assert activity_count == 0
 
 

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -41,7 +41,7 @@ def test_session_work_insert_batch_stays_below_asyncpg_parameter_limit() -> None
         work_records,
         SupportedSQLDialect.POSTGRESQL,
     )
-    compiled = statement.compile(dialect=asyncpg.dialect())
+    compiled = statement.compile(dialect=asyncpg.dialect())  # type: ignore[no-untyped-call]
 
     assert len(compiled.params) == (
         session_sweeper._SESSION_WORK_INSERT_BATCH_SIZE

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -23,11 +23,35 @@ from phoenix.server.online_eval.session_sweeper import (
 from phoenix.server.types import DbSessionFactory
 
 from ..._helpers import _add_project, _add_project_session, _add_span, _add_trace
-from .test_producer import _seed_criteria
+from .test_producer import _seed_criteria as _seed_criteria_raw
 
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+async def _seed_criteria(
+    db: DbSessionFactory,
+    project_id: int,
+    *,
+    evaluation_target: str,
+    filter_condition: str = "",
+    sampling_rate: float = 1.0,
+) -> tuple[int, int]:
+    evaluator_id, criteria_id = await _seed_criteria_raw(
+        db,
+        project_id,
+        evaluation_target=evaluation_target,
+        filter_condition=filter_condition,
+        sampling_rate=sampling_rate,
+    )
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(created_at=_now() - timedelta(days=1))
+        )
+    return evaluator_id, criteria_id
 
 
 def test_live_key_predicate_is_single_sourced_from_max_attempts() -> None:
@@ -209,6 +233,7 @@ async def test_materializes_with_501_schedulable_criteria(
                 filter_condition="",
                 sampling_rate=1.0,
                 evaluation_target="SESSION",
+                created_at=_now() - timedelta(days=1),
             )
             for index in range(500)
         )
@@ -505,6 +530,103 @@ async def test_incomplete_session_is_never_scheduled(
     async with db() as session:
         count = await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit))
     assert count == 0
+
+
+async def test_quiet_session_predating_criterion_creation_is_not_live(
+    db: DbSessionFactory,
+) -> None:
+    project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
+    await _seed_criteria_raw(db, project_id, evaluation_target="SESSION")
+
+    await SessionEvalSweeper(db)._tick()
+
+    async with db() as session:
+        assert (
+            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
+        )
+
+
+async def test_reenabled_criterion_reaches_back_to_creation(
+    db: DbSessionFactory,
+) -> None:
+    project_id, project_session_id, activity_at = await _add_session_liveness(
+        db,
+        age_seconds=600,
+    )
+    _, criteria_id = await _seed_criteria_raw(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+    )
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(created_at=activity_at - timedelta(seconds=1), enabled=False)
+        )
+
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+    async with db() as session:
+        assert (
+            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
+        )
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(enabled=True)
+        )
+
+    await sweeper._tick()
+    async with db() as session:
+        scheduled_session_id = await session.scalar(
+            select(models.EvalSessionWorkUnit.project_session_rowid)
+        )
+    assert scheduled_session_id == project_session_id
+
+
+async def test_session_without_liveness_becomes_live_after_new_activity(
+    db: DbSessionFactory,
+) -> None:
+    project_id, project_session_id, resumed_at = await _add_session_liveness(
+        db,
+        age_seconds=600,
+    )
+    _, criteria_id = await _seed_criteria_raw(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+    )
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(created_at=resumed_at - timedelta(seconds=1))
+        )
+        await session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == project_session_id)
+            .values(last_span_ingested_at=None)
+        )
+
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+    async with db() as session:
+        assert (
+            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
+        )
+        await session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == project_session_id)
+            .values(last_span_ingested_at=resumed_at)
+        )
+
+    await sweeper._tick()
+    async with db() as session:
+        scheduled_session_id = await session.scalar(
+            select(models.EvalSessionWorkUnit.project_session_rowid)
+        )
+    assert scheduled_session_id == project_session_id
 
 
 async def test_outstanding_work_ceiling_defers_eligible_pair(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -1,10 +1,11 @@
 import logging
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
+from typing import cast
 from unittest.mock import Mock
 
 import pytest
-from sqlalchemy import func, select, update
+from sqlalchemy import Table, func, select, update
 from sqlalchemy.dialects.postgresql import asyncpg
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -46,9 +47,10 @@ def test_live_key_predicate_is_single_sourced_from_max_attempts() -> None:
         "phoenix.db.migrations.versions.a7f1c3e9d2b4_add_online_eval_coordination"
     )
     predicate = live_eval_work_index_predicate()
+    live_key_table = cast(Table, models.EvalSessionWorkUnit.__table__)
     live_key_index = next(
         index
-        for index in models.EvalSessionWorkUnit.__table__.indexes
+        for index in live_key_table.indexes
         if index.name == "uq_eval_session_work_units_live_key"
     )
 

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.server.online_eval import session_sweeper
-from phoenix.server.online_eval.derivation import ResolvedCriteria
+from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, ResolvedCriteria
 from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.online_eval.session_sweeper import (
     SESSION_SWEEP_LEASE_TTL_SECONDS,
@@ -33,6 +33,7 @@ def test_session_work_insert_batch_stays_below_asyncpg_parameter_limit() -> None
             "evaluator_id": index,
             "criteria_id": index,
             "config_fingerprint": f"fingerprint-{index}",
+            "evaluated_through": _now(),
         }
         for index in range(session_sweeper._SESSION_WORK_INSERT_BATCH_SIZE)
     ]
@@ -51,12 +52,14 @@ def test_session_work_insert_batch_stays_below_asyncpg_parameter_limit() -> None
     assert len(compiled.params) < 32_767
 
 
-async def _add_session_activity(
+async def _add_session_liveness(
     db: DbSessionFactory,
     *,
     age_seconds: float,
     project_id: int | None = None,
-) -> tuple[int, int, int]:
+    content_complete: bool = True,
+) -> tuple[int, int, datetime]:
+    last_activity_at = _now() - timedelta(seconds=age_seconds)
     async with db() as session:
         if project_id is None:
             project = await _add_project(session)
@@ -66,15 +69,16 @@ async def _add_session_activity(
             project = existing_project
         project_session = await _add_project_session(session, project)
         trace = await _add_trace(session, project, project_session)
-        span = await _add_span(session, trace)
-        session.add(
-            models.EvalSessionActivity(
-                project_session_rowid=project_session.id,
-                observed_at=_now() - timedelta(seconds=age_seconds),
+        await _add_span(session, trace)
+        await session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == project_session.id)
+            .values(
+                last_activity_at=last_activity_at,
+                content_complete=content_complete,
             )
         )
-        await session.flush()
-        return project.id, project_session.id, span.id
+        return project.id, project_session.id, last_activity_at
 
 
 async def _set_delay(
@@ -90,10 +94,13 @@ async def _set_delay(
         )
 
 
-async def test_materializes_work_and_prunes_resolved_activity(
+async def test_materializes_due_complete_session_with_activity_snapshot(
     db: DbSessionFactory,
 ) -> None:
-    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
+    project_id, project_session_id, last_activity_at = await _add_session_liveness(
+        db,
+        age_seconds=600,
+    )
     evaluator_id, criteria_id = await _seed_criteria(
         db,
         project_id,
@@ -111,9 +118,6 @@ async def test_materializes_work_and_prunes_resolved_activity(
                 )
             )
         ).one()
-        activity_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionActivity)
-        )
         cursor = (
             await session.scalars(
                 select(models.EvalWorkCursor).where(
@@ -122,44 +126,242 @@ async def test_materializes_work_and_prunes_resolved_activity(
                 )
             )
         ).one()
+        await session.execute(
+            session_sweeper._session_work_insert_statement(
+                [
+                    {
+                        "project_session_rowid": project_session_id,
+                        "evaluator_id": evaluator_id,
+                        "criteria_id": criteria_id,
+                        "config_fingerprint": unit.config_fingerprint,
+                        "evaluated_through": last_activity_at,
+                    }
+                ],
+                db.dialect,
+            )
+        )
+        live_work_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        )
     assert unit.evaluator_id == evaluator_id
     assert unit.criteria_id == criteria_id
+    assert unit.evaluated_through == last_activity_at
     assert unit.status == "PENDING"
-    assert activity_count == 0
     assert cursor.claimed_by == sweeper._sweeper_id
+    assert live_work_count == 1
 
 
-async def test_not_yet_due_activity_does_not_consume_scan_limit(
+async def test_retained_long_delay_pairs_do_not_block_later_due_pair(
     db: DbSessionFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(session_sweeper, "_MAX_ACTIVITY_ROWS_PER_TICK", 2)
-    long_delay_project_id, _, _ = await _add_session_activity(db, age_seconds=0)
-    _, long_delay_criteria_id = await _seed_criteria(
+    monkeypatch.setattr(session_sweeper, "_MAX_ELIGIBLE_PAIRS_PER_TICK", 2)
+    retained_project_id, retained_session_1, _ = await _add_session_liveness(
         db,
-        long_delay_project_id,
+        age_seconds=100,
+    )
+    _, retained_session_2, _ = await _add_session_liveness(
+        db,
+        age_seconds=100,
+        project_id=retained_project_id,
+    )
+    _, short_criteria_id = await _seed_criteria(
+        db,
+        retained_project_id,
         evaluation_target="SESSION",
     )
-    await _set_delay(db, long_delay_criteria_id, 600)
-    for _ in range(2):
-        await _add_session_activity(
-            db,
-            age_seconds=0,
-            project_id=long_delay_project_id,
+    _, long_criteria_id = await _seed_criteria(
+        db,
+        retained_project_id,
+        evaluation_target="SESSION",
+    )
+    await _set_delay(db, short_criteria_id, 10)
+    await _set_delay(db, long_criteria_id, 600)
+    due_project_id, due_session_id, _ = await _add_session_liveness(
+        db,
+        age_seconds=50,
+    )
+    due_criteria_id = (await _seed_criteria(db, due_project_id, evaluation_target="SESSION"))[1]
+    await _set_delay(db, due_criteria_id, 10)
+
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+    await sweeper._tick()
+
+    async with db() as session:
+        materialized_session_ids = set(
+            await session.scalars(select(models.EvalSessionWorkUnit.project_session_rowid))
         )
-    due_project_id, due_project_session_id, _ = await _add_session_activity(
+    assert materialized_session_ids == {
+        retained_session_1,
+        retained_session_2,
+        due_session_id,
+    }
+
+
+async def test_disabled_and_unresolved_criteria_preserve_future_eligibility(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disabled_project_id, disabled_session_id, _ = await _add_session_liveness(
         db,
         age_seconds=600,
     )
-    await _seed_criteria(db, due_project_id, evaluation_target="SESSION")
+    _, disabled_criteria_id = await _seed_criteria(
+        db,
+        disabled_project_id,
+        evaluation_target="SESSION",
+    )
+    unresolved_project_id, unresolved_session_id, _ = await _add_session_liveness(
+        db,
+        age_seconds=600,
+    )
+    _, unresolved_criteria_id = await _seed_criteria(
+        db,
+        unresolved_project_id,
+        evaluation_target="SESSION",
+    )
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == disabled_criteria_id)
+            .values(enabled=False)
+        )
+
+    async def unresolved(
+        session: AsyncSession,
+        criteria: models.ProjectEvaluatorCriteria,
+        evaluator: models.Evaluator,
+    ) -> ResolvedCriteria | None:
+        if criteria.id == unresolved_criteria_id:
+            return None
+        return await resolve_criteria(session, criteria, evaluator)
+
+    monkeypatch.setattr(session_sweeper, "resolve_criteria", unresolved)
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+    async with db() as session:
+        assert (
+            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
+        )
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == disabled_criteria_id)
+            .values(enabled=True)
+        )
+
+    monkeypatch.setattr(session_sweeper, "resolve_criteria", resolve_criteria)
+    await sweeper._tick()
+    async with db() as session:
+        session_ids = set(
+            await session.scalars(select(models.EvalSessionWorkUnit.project_session_rowid))
+        )
+    assert session_ids == {disabled_session_id, unresolved_session_id}
+
+
+async def test_successful_work_closes_evaluate_once_key(
+    db: DbSessionFactory,
+) -> None:
+    project_id, project_session_id, _ = await _add_session_liveness(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+    async with db() as session:
+        await session.execute(update(models.EvalSessionWorkUnit).values(status="DONE"))
+        await session.execute(
+            update(models.ProjectSession)
+            .where(models.ProjectSession.id == project_session_id)
+            .values(last_activity_at=_now() - timedelta(seconds=400))
+        )
+
+    await sweeper._tick()
+    async with db() as session:
+        units = list(await session.scalars(select(models.EvalSessionWorkUnit)))
+    assert len(units) == 1
+    assert units[0].status == "DONE"
+
+
+async def test_exhausted_error_and_expired_history_are_replaceable(
+    db: DbSessionFactory,
+) -> None:
+    project_id, project_session_id, _ = await _add_session_liveness(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+
+    async with db() as session:
+        first_id = await session.scalar(select(models.EvalSessionWorkUnit.id))
+        assert first_id is not None
+        await session.execute(
+            update(models.EvalSessionWorkUnit)
+            .where(models.EvalSessionWorkUnit.id == first_id)
+            .values(status="ERROR", attempts=MAX_ATTEMPTS)
+        )
+    await sweeper._tick()
+
+    async with db() as session:
+        units = list(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit)
+                .where(models.EvalSessionWorkUnit.project_session_rowid == project_session_id)
+                .order_by(models.EvalSessionWorkUnit.id)
+            )
+        )
+        assert len(units) == 2
+        assert units[0].status == "ERROR"
+        await session.execute(
+            update(models.EvalSessionWorkUnit)
+            .where(models.EvalSessionWorkUnit.id == units[1].id)
+            .values(status="EXPIRED")
+        )
+    await sweeper._tick()
+
+    async with db() as session:
+        statuses = list(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit.status).order_by(models.EvalSessionWorkUnit.id)
+            )
+        )
+    assert statuses == ["ERROR", "EXPIRED", "PENDING"]
+
+
+async def test_incomplete_session_is_never_scheduled(
+    db: DbSessionFactory,
+) -> None:
+    project_id, _, _ = await _add_session_liveness(
+        db,
+        age_seconds=600,
+        content_complete=False,
+    )
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
 
     await SessionEvalSweeper(db)._tick()
 
     async with db() as session:
-        project_session_ids = list(
-            await session.scalars(select(models.EvalSessionWorkUnit.project_session_rowid))
+        count = await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit))
+    assert count == 0
+
+
+async def test_outstanding_work_ceiling_defers_eligible_pair(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id, project_session_id, _ = await _add_session_liveness(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+    monkeypatch.setattr(sweeper, "_max_outstanding", 0)
+
+    await sweeper._tick()
+    async with db() as session:
+        assert (
+            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
         )
-    assert project_session_ids == [due_project_session_id]
+
+    monkeypatch.setattr(sweeper, "_max_outstanding", 1)
+    await sweeper._tick()
+    async with db() as session:
+        session_id = await session.scalar(select(models.EvalSessionWorkUnit.project_session_rowid))
+    assert session_id == project_session_id
 
 
 async def test_lost_lease_rolls_back_sweep(
@@ -167,7 +369,7 @@ async def test_lost_lease_rolls_back_sweep(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
+    project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
     await _seed_criteria(db, project_id, evaluation_target="SESSION")
     sweeper = SessionEvalSweeper(db)
     acquire_cursor = sweeper._acquire_cursor
@@ -184,16 +386,6 @@ async def test_lost_lease_rolls_back_sweep(
         return cursor_id
 
     monkeypatch.setattr(sweeper, "_acquire_cursor", acquire_then_lose_lease)
-    async with db() as session:
-        activity_before = (
-            await session.execute(
-                select(
-                    models.EvalSessionActivity.id,
-                    models.EvalSessionActivity.observed_at,
-                ).where(models.EvalSessionActivity.project_session_rowid == project_session_id)
-            )
-        ).one()
-
     with caplog.at_level(logging.WARNING, logger=session_sweeper.__name__):
         await sweeper._tick()
 
@@ -201,274 +393,14 @@ async def test_lost_lease_rolls_back_sweep(
         work_count = await session.scalar(
             select(func.count()).select_from(models.EvalSessionWorkUnit)
         )
-        activity_after = (
-            await session.execute(
-                select(
-                    models.EvalSessionActivity.id,
-                    models.EvalSessionActivity.observed_at,
-                ).where(models.EvalSessionActivity.project_session_rowid == project_session_id)
-            )
-        ).one()
     assert work_count == 0
-    assert activity_after == activity_before
     assert "Session evaluation sweeper lost its lease" in caplog.text
-
-
-async def test_unresolvable_criteria_does_not_stall_project_sweep(
-    db: DbSessionFactory,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
-    _, resolvable_criteria_id = await _seed_criteria(
-        db,
-        project_id,
-        evaluation_target="SESSION",
-    )
-    _, unresolvable_criteria_id = await _seed_criteria(
-        db,
-        project_id,
-        evaluation_target="SESSION",
-    )
-
-    async def resolve_with_one_unresolvable(
-        session: AsyncSession,
-        criteria: models.ProjectEvaluatorCriteria,
-        evaluator: models.Evaluator,
-    ) -> ResolvedCriteria | None:
-        if criteria.id == unresolvable_criteria_id:
-            return None
-        return await resolve_criteria(session, criteria, evaluator)
-
-    monkeypatch.setattr(session_sweeper, "resolve_criteria", resolve_with_one_unresolvable)
-    with caplog.at_level(logging.WARNING, logger=session_sweeper.__name__):
-        await SessionEvalSweeper(db)._tick()
-
-    async with db() as session:
-        criteria_ids = list(
-            await session.scalars(
-                select(models.EvalSessionWorkUnit.criteria_id).where(
-                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
-                )
-            )
-        )
-        activity_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionActivity)
-        )
-    assert criteria_ids == [resolvable_criteria_id]
-    assert activity_count == 0
-    messages = [
-        record.message
-        for record in caplog.records
-        if f"Skipping criteria {unresolvable_criteria_id}:" in record.message
-    ]
-    assert len(messages) == 1
-
-
-async def test_retains_activity_until_each_criteria_delay_elapses(
-    db: DbSessionFactory,
-) -> None:
-    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=100)
-    _, short_delay_criteria_id = await _seed_criteria(
-        db,
-        project_id,
-        evaluation_target="SESSION",
-    )
-    _, long_delay_criteria_id = await _seed_criteria(
-        db,
-        project_id,
-        evaluation_target="SESSION",
-    )
-    await _set_delay(db, short_delay_criteria_id, 10)
-    await _set_delay(db, long_delay_criteria_id, 600)
-
-    sweeper = SessionEvalSweeper(db)
-    await sweeper._tick()
-
-    async with db() as session:
-        units = list(
-            await session.scalars(
-                select(models.EvalSessionWorkUnit).where(
-                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
-                )
-            )
-        )
-        activity = await session.scalar(
-            select(models.EvalSessionActivity).where(
-                models.EvalSessionActivity.project_session_rowid == project_session_id
-            )
-        )
-    assert [unit.criteria_id for unit in units] == [short_delay_criteria_id]
-    assert activity is not None
-
-    async with db() as session:
-        await session.execute(
-            update(models.EvalSessionActivity)
-            .where(models.EvalSessionActivity.project_session_rowid == project_session_id)
-            .values(observed_at=_now() - timedelta(seconds=700))
-        )
-    await sweeper._tick()
-
-    async with db() as session:
-        criteria_ids = set(
-            await session.scalars(
-                select(models.EvalSessionWorkUnit.criteria_id).where(
-                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
-                )
-            )
-        )
-        activity_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionActivity)
-        )
-    assert criteria_ids == {short_delay_criteria_id, long_delay_criteria_id}
-    assert activity_count == 0
-
-
-async def test_outstanding_work_budget_retains_activity_until_capacity_is_available(
-    db: DbSessionFactory,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING", "1")
-    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
-    await _seed_criteria(db, project_id, evaluation_target="SESSION")
-    await _seed_criteria(db, project_id, evaluation_target="SESSION")
-
-    sweeper = SessionEvalSweeper(db)
-    await sweeper._tick()
-
-    async with db() as session:
-        work_units = list(await session.scalars(select(models.EvalSessionWorkUnit)))
-        activity_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionActivity)
-        )
-        assert len(work_units) == 1
-        assert activity_count == 1
-        work_units[0].status = "DONE"
-
-    await sweeper._tick()
-
-    async with db() as session:
-        work_units = list(
-            await session.scalars(
-                select(models.EvalSessionWorkUnit).where(
-                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
-                )
-            )
-        )
-        activity_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionActivity)
-        )
-    assert len(work_units) == 2
-    assert activity_count == 0
-
-
-async def test_sweep_metrics_cover_backlog_success_materialization_and_failure(
-    db: DbSessionFactory,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(session_sweeper, "get_env_enable_prometheus", lambda: True)
-    metric_names = (
-        "ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG",
-        "ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS",
-        "ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS",
-        "ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS",
-        "ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS",
-        "ONLINE_EVAL_SESSION_SWEEP_FAILURES",
-        "ONLINE_EVAL_SESSION_SWEEP_SUCCESSES",
-    )
-    metrics = {name: Mock() for name in metric_names}
-    for name, metric in metrics.items():
-        monkeypatch.setattr(session_sweeper, name, metric)
-
-    project_id, _, _ = await _add_session_activity(db, age_seconds=600)
-    await _seed_criteria(db, project_id, evaluation_target="SESSION")
-    sweeper = SessionEvalSweeper(db)
-    await sweeper._tick()
-
-    metrics["ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG"].set.assert_called_once_with(1)
-    oldest_age = metrics["ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS"].set.call_args.args[0]
-    assert oldest_age == pytest.approx(600, abs=1)
-    metrics["ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS"].inc.assert_called_once_with()
-    metrics["ONLINE_EVAL_SESSION_SWEEP_SUCCESSES"].inc.assert_called_once_with()
-    metrics["ONLINE_EVAL_SESSION_SWEEP_FAILURES"].inc.assert_not_called()
-    metrics["ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS"].observe.assert_called_once()
-    metrics["ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS"].inc.assert_called_once_with(1)
-
-    async def fail_sweep(session: AsyncSession, database_now: datetime) -> int:
-        raise RuntimeError("failed sweep")
-
-    monkeypatch.setattr(sweeper, "_sweep", fail_sweep)
-    with pytest.raises(RuntimeError, match="failed sweep"):
-        await sweeper._tick()
-
-    assert metrics["ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS"].inc.call_count == 2
-    metrics["ONLINE_EVAL_SESSION_SWEEP_FAILURES"].inc.assert_called_once_with()
-    assert metrics["ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS"].observe.call_count == 2
-
-
-async def test_reopened_session_is_pruned_without_another_work_unit(
-    db: DbSessionFactory,
-) -> None:
-    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
-    await _seed_criteria(db, project_id, evaluation_target="SESSION")
-    sweeper = SessionEvalSweeper(db)
-    await sweeper._tick()
-
-    async with db() as session:
-        session.add(
-            models.EvalSessionActivity(
-                project_session_rowid=project_session_id,
-                observed_at=_now() - timedelta(seconds=600),
-            )
-        )
-    await sweeper._tick()
-
-    async with db() as session:
-        units = list(
-            await session.scalars(
-                select(models.EvalSessionWorkUnit).where(
-                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
-                )
-            )
-        )
-        activity_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionActivity)
-        )
-    assert len(units) == 1
-    assert activity_count == 0
-
-
-async def test_trace_filtered_and_sampled_criteria_remain_unscheduled(
-    db: DbSessionFactory,
-) -> None:
-    project_id, _, _ = await _add_session_activity(db, age_seconds=600)
-    await _seed_criteria(db, project_id, evaluation_target="TRACE")
-    await _seed_criteria(
-        db,
-        project_id,
-        evaluation_target="SESSION",
-        filter_condition="span_kind == 'LLM'",
-    )
-    await _seed_criteria(
-        db,
-        project_id,
-        evaluation_target="SESSION",
-        sampling_rate=0.5,
-    )
-
-    await SessionEvalSweeper(db)._tick()
-
-    async with db() as session:
-        session_work_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionWorkUnit)
-        )
-    assert session_work_count == 0
 
 
 async def test_live_session_lease_stands_down_and_stale_lease_is_reclaimed(
     db: DbSessionFactory,
 ) -> None:
-    project_id, _, _ = await _add_session_activity(db, age_seconds=600)
+    project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
     await _seed_criteria(db, project_id, evaluation_target="SESSION")
     async with db() as session:
         session.add(
@@ -484,12 +416,9 @@ async def test_live_session_lease_stands_down_and_stale_lease_is_reclaimed(
     sweeper = SessionEvalSweeper(db)
     await sweeper._tick()
     async with db() as session:
-        work_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        assert (
+            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
         )
-    assert work_count == 0
-
-    async with db() as session:
         await session.execute(
             update(models.EvalWorkCursor)
             .where(models.EvalWorkCursor.evaluation_target == "SESSION")
@@ -498,15 +427,71 @@ async def test_live_session_lease_stands_down_and_stale_lease_is_reclaimed(
     await sweeper._tick()
 
     async with db() as session:
-        work_count = await session.scalar(
-            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        assert (
+            await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 1
         )
-        cursor = (
-            await session.scalars(
-                select(models.EvalWorkCursor).where(
-                    models.EvalWorkCursor.evaluation_target == "SESSION"
-                )
-            )
-        ).one()
-    assert work_count == 1
-    assert cursor.claimed_by == sweeper._sweeper_id
+
+
+async def test_trace_filtered_and_sampled_criteria_remain_unscheduled(
+    db: DbSessionFactory,
+) -> None:
+    project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="TRACE")
+    await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+        filter_condition="span_kind == 'LLM'",
+    )
+    await _seed_criteria(
+        db,
+        project_id,
+        evaluation_target="SESSION",
+        sampling_rate=0.5,
+    )
+
+    await SessionEvalSweeper(db)._tick()
+    async with db() as session:
+        count = await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit))
+    assert count == 0
+
+
+async def test_sweep_metrics_cover_eligibility_watermark_and_outcomes(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(session_sweeper, "get_env_enable_prometheus", lambda: True)
+    metric_names = (
+        "ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG",
+        "ONLINE_EVAL_SESSION_RESULT_WATERMARK_LAG_SECONDS",
+        "ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS",
+        "ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS",
+        "ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS",
+        "ONLINE_EVAL_SESSION_SWEEP_FAILURES",
+        "ONLINE_EVAL_SESSION_SWEEP_SUCCESSES",
+    )
+    metrics = {name: Mock() for name in metric_names}
+    for name, metric in metrics.items():
+        monkeypatch.setattr(session_sweeper, name, metric)
+
+    project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+
+    metrics["ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG"].set.assert_called_once_with(1)
+    metrics["ONLINE_EVAL_SESSION_RESULT_WATERMARK_LAG_SECONDS"].set.assert_called_once_with(0.0)
+    metrics["ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS"].inc.assert_called_once_with()
+    metrics["ONLINE_EVAL_SESSION_SWEEP_SUCCESSES"].inc.assert_called_once_with()
+    metrics["ONLINE_EVAL_SESSION_SWEEP_FAILURES"].inc.assert_not_called()
+    metrics["ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS"].inc.assert_called_once_with(1)
+
+    async def fail_sweep(session: AsyncSession, database_now: datetime) -> int:
+        raise RuntimeError("failed sweep")
+
+    monkeypatch.setattr(sweeper, "_sweep", fail_sweep)
+    with pytest.raises(RuntimeError, match="failed sweep"):
+        await sweeper._tick()
+
+    metrics["ONLINE_EVAL_SESSION_SWEEP_FAILURES"].inc.assert_called_once_with()
+    assert metrics["ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS"].observe.call_count == 2

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -3,9 +3,11 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import func, select, update
+from sqlalchemy.dialects.postgresql import asyncpg
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.server.online_eval import session_sweeper
 from phoenix.server.online_eval.derivation import ResolvedCriteria
 from phoenix.server.online_eval.producer import resolve_criteria
@@ -21,6 +23,31 @@ from .test_producer import _seed_criteria
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def test_session_work_insert_batch_stays_below_asyncpg_parameter_limit() -> None:
+    work_records = [
+        {
+            "project_session_rowid": index,
+            "evaluator_id": index,
+            "criteria_id": index,
+            "config_fingerprint": f"fingerprint-{index}",
+        }
+        for index in range(session_sweeper._SESSION_WORK_INSERT_BATCH_SIZE)
+    ]
+
+    statement = session_sweeper._session_work_insert_statement(
+        work_records,
+        SupportedSQLDialect.POSTGRESQL,
+    )
+    compiled = statement.compile(dialect=asyncpg.dialect())
+
+    assert len(compiled.params) == (
+        session_sweeper._SESSION_WORK_INSERT_BATCH_SIZE
+        * session_sweeper._SESSION_WORK_INSERT_PARAMETERS_PER_ROW
+    )
+    assert len(compiled.params) <= session_sweeper._MAX_SESSION_WORK_INSERT_PARAMETERS
+    assert len(compiled.params) < 32_767
 
 
 async def _add_session_activity(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
-from typing import cast
+from typing import Sequence, cast
 from unittest.mock import Mock
 
 import pytest
@@ -15,7 +15,7 @@ from phoenix.db.types.identifier import Identifier
 from phoenix.server.app import _db
 from phoenix.server.online_eval import session_sweeper
 from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, ResolvedCriteria
-from phoenix.server.online_eval.producer import resolve_criteria
+from phoenix.server.online_eval.producer import resolve_criteria_bulk
 from phoenix.server.online_eval.session_sweeper import (
     SESSION_SWEEP_LEASE_TTL_SECONDS,
     SessionEvalSweeper,
@@ -334,16 +334,23 @@ async def test_disabled_and_unresolved_criteria_preserve_future_eligibility(
             .values(enabled=False)
         )
 
+    resolution_calls = 0
+
     async def unresolved(
         session: AsyncSession,
-        criteria: models.ProjectEvaluatorCriteria,
-        evaluator: models.Evaluator,
-    ) -> ResolvedCriteria | None:
-        if criteria.id == unresolved_criteria_id:
-            return None
-        return await resolve_criteria(session, criteria, evaluator)
+        criteria_evaluators: Sequence[
+            tuple[models.ProjectEvaluatorCriteria, models.Evaluator]
+        ],
+    ) -> list[ResolvedCriteria | None]:
+        nonlocal resolution_calls
+        resolution_calls += 1
+        resolved = await resolve_criteria_bulk(session, criteria_evaluators)
+        return [
+            None if criteria.id == unresolved_criteria_id else result
+            for (criteria, _), result in zip(criteria_evaluators, resolved, strict=True)
+        ]
 
-    monkeypatch.setattr(session_sweeper, "resolve_criteria", unresolved)
+    monkeypatch.setattr(session_sweeper, "resolve_criteria_bulk", unresolved)
     sweeper = SessionEvalSweeper(db)
     await sweeper._tick()
     async with db() as session:
@@ -356,13 +363,30 @@ async def test_disabled_and_unresolved_criteria_preserve_future_eligibility(
             .values(enabled=True)
         )
 
-    monkeypatch.setattr(session_sweeper, "resolve_criteria", resolve_criteria)
+    assert resolution_calls == 1
+    monkeypatch.setattr(session_sweeper, "resolve_criteria_bulk", resolve_criteria_bulk)
     await sweeper._tick()
     async with db() as session:
         session_ids = set(
             await session.scalars(select(models.EvalSessionWorkUnit.project_session_rowid))
         )
     assert session_ids == {disabled_session_id, unresolved_session_id}
+
+
+async def test_closed_admission_gate_skips_criteria_resolution(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sweeper = SessionEvalSweeper(db)
+    sweeper._max_outstanding = 0
+
+    async def unexpected_resolution(*_: object) -> list[ResolvedCriteria | None]:
+        pytest.fail("criteria resolution must follow admission")
+
+    monkeypatch.setattr(session_sweeper, "resolve_criteria_bulk", unexpected_resolution)
+    async with db() as session:
+        database_now = await sweeper._database_now(session)
+        assert await sweeper._sweep(session, database_now) == (0, 0)
 
 
 async def test_successful_work_closes_evaluate_once_key(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -59,7 +59,7 @@ async def _add_session_liveness(
     project_id: int | None = None,
     content_complete: bool = True,
 ) -> tuple[int, int, datetime]:
-    last_activity_at = _now() - timedelta(seconds=age_seconds)
+    last_span_seen_at = _now() - timedelta(seconds=age_seconds)
     async with db() as session:
         if project_id is None:
             project = await _add_project(session)
@@ -74,11 +74,11 @@ async def _add_session_liveness(
             update(models.ProjectSession)
             .where(models.ProjectSession.id == project_session.id)
             .values(
-                last_activity_at=last_activity_at,
+                last_span_seen_at=last_span_seen_at,
                 content_complete=content_complete,
             )
         )
-        return project.id, project_session.id, last_activity_at
+        return project.id, project_session.id, last_span_seen_at
 
 
 async def _set_delay(
@@ -97,7 +97,7 @@ async def _set_delay(
 async def test_materializes_due_complete_session_with_activity_snapshot(
     db: DbSessionFactory,
 ) -> None:
-    project_id, project_session_id, last_activity_at = await _add_session_liveness(
+    project_id, project_session_id, last_span_seen_at = await _add_session_liveness(
         db,
         age_seconds=600,
     )
@@ -134,7 +134,7 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
                         "evaluator_id": evaluator_id,
                         "criteria_id": criteria_id,
                         "config_fingerprint": unit.config_fingerprint,
-                        "evaluated_through": last_activity_at,
+                        "evaluated_through": last_span_seen_at,
                     }
                 ],
                 db.dialect,
@@ -145,7 +145,7 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
         )
     assert unit.evaluator_id == evaluator_id
     assert unit.criteria_id == criteria_id
-    assert unit.evaluated_through == last_activity_at
+    assert unit.evaluated_through == last_span_seen_at
     assert unit.status == "PENDING"
     assert cursor.claimed_by == sweeper._sweeper_id
     assert live_work_count == 1
@@ -271,7 +271,7 @@ async def test_successful_work_closes_evaluate_once_key(
         await session.execute(
             update(models.ProjectSession)
             .where(models.ProjectSession.id == project_session_id)
-            .values(last_activity_at=_now() - timedelta(seconds=400))
+            .values(last_span_seen_at=_now() - timedelta(seconds=400))
         )
 
     await sweeper._tick()

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -89,13 +89,14 @@ async def test_materialization_rechecks_eligibility_at_write_time(
             .where(models.ProjectSession.id == project_session_id)
             .values(last_span_ingested_at=database_now)
         )
-        inserted_count, _ = await sweeper._load_eligible_pairs(
+        inserted_count, eligible_pair_count = await sweeper._load_eligible_pairs(
             session,
             database_now,
             [criterion],
             limit=1,
         )
         assert inserted_count == 0
+        assert eligible_pair_count is None
         await session.execute(
             update(models.ProjectSession)
             .where(models.ProjectSession.id == project_session_id)
@@ -404,7 +405,7 @@ async def test_closed_admission_gate_skips_criteria_resolution(
     monkeypatch.setattr(session_sweeper, "resolve_criteria_bulk", unexpected_resolution)
     async with db() as session:
         database_now = await sweeper._database_now(session)
-        assert await sweeper._sweep(session, database_now) == (0, 0)
+        assert await sweeper._sweep(session, database_now) == (0, None)
 
 
 async def test_successful_work_closes_evaluate_once_key(
@@ -648,6 +649,11 @@ async def test_sweep_metrics_cover_eligibility_watermark_and_outcomes(
     metrics["ONLINE_EVAL_SESSION_SWEEP_FAILURES"].inc.assert_not_called()
     metrics["ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS"].inc.assert_called_once_with(1)
 
+    sweeper._max_outstanding = 0
+    await sweeper._tick()
+    metrics["ONLINE_EVAL_SESSION_ELIGIBLE_PAIR_BACKLOG"].set.assert_called_once_with(1)
+    assert metrics["ONLINE_EVAL_SESSION_RESULT_WATERMARK_LAG_SECONDS"].set.call_count == 2
+
     async def fail_sweep(session: AsyncSession, database_now: datetime) -> int:
         raise RuntimeError("failed sweep")
 
@@ -656,4 +662,4 @@ async def test_sweep_metrics_cover_eligibility_watermark_and_outcomes(
         await sweeper._tick()
 
     metrics["ONLINE_EVAL_SESSION_SWEEP_FAILURES"].inc.assert_called_once_with()
-    assert metrics["ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS"].observe.call_count == 2
+    assert metrics["ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS"].observe.call_count == 3

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -59,7 +59,7 @@ async def _add_session_liveness(
     project_id: int | None = None,
     content_complete: bool = True,
 ) -> tuple[int, int, datetime]:
-    last_span_seen_at = _now() - timedelta(seconds=age_seconds)
+    last_span_ingested_at = _now() - timedelta(seconds=age_seconds)
     async with db() as session:
         if project_id is None:
             project = await _add_project(session)
@@ -74,11 +74,11 @@ async def _add_session_liveness(
             update(models.ProjectSession)
             .where(models.ProjectSession.id == project_session.id)
             .values(
-                last_span_seen_at=last_span_seen_at,
+                last_span_ingested_at=last_span_ingested_at,
                 content_complete=content_complete,
             )
         )
-        return project.id, project_session.id, last_span_seen_at
+        return project.id, project_session.id, last_span_ingested_at
 
 
 async def _set_delay(
@@ -97,7 +97,7 @@ async def _set_delay(
 async def test_materializes_due_complete_session_with_activity_snapshot(
     db: DbSessionFactory,
 ) -> None:
-    project_id, project_session_id, last_span_seen_at = await _add_session_liveness(
+    project_id, project_session_id, last_span_ingested_at = await _add_session_liveness(
         db,
         age_seconds=600,
     )
@@ -134,7 +134,7 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
                         "evaluator_id": evaluator_id,
                         "criteria_id": criteria_id,
                         "config_fingerprint": unit.config_fingerprint,
-                        "evaluated_through": last_span_seen_at,
+                        "evaluated_through": last_span_ingested_at,
                     }
                 ],
                 db.dialect,
@@ -145,10 +145,31 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
         )
     assert unit.evaluator_id == evaluator_id
     assert unit.criteria_id == criteria_id
-    assert unit.evaluated_through == last_span_seen_at
+    assert unit.evaluated_through == last_span_ingested_at
     assert unit.status == "PENDING"
     assert cursor.claimed_by == sweeper._sweeper_id
     assert live_work_count == 1
+
+
+async def test_session_with_null_liveness_is_never_eligible(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        project_session = await _add_project_session(session, project)
+        trace = await _add_trace(session, project, project_session)
+        await _add_span(session, trace)
+        project_id = project.id
+        assert project_session.last_span_ingested_at is None
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+
+    await SessionEvalSweeper(db)._tick()
+
+    async with db() as session:
+        work_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionWorkUnit)
+        )
+    assert work_count == 0
 
 
 async def test_retained_long_delay_pairs_do_not_block_later_due_pair(
@@ -271,7 +292,7 @@ async def test_successful_work_closes_evaluate_once_key(
         await session.execute(
             update(models.ProjectSession)
             .where(models.ProjectSession.id == project_session_id)
-            .values(last_span_seen_at=_now() - timedelta(seconds=400))
+            .values(last_span_ingested_at=_now() - timedelta(seconds=400))
         )
 
     await sweeper._tick()

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
 
 import pytest
 from sqlalchemy import func, select, update
@@ -359,6 +360,50 @@ async def test_outstanding_work_budget_retains_activity_until_capacity_is_availa
         )
     assert len(work_units) == 2
     assert activity_count == 0
+
+
+async def test_sweep_metrics_cover_backlog_success_materialization_and_failure(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(session_sweeper, "get_env_enable_prometheus", lambda: True)
+    metric_names = (
+        "ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG",
+        "ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS",
+        "ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS",
+        "ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS",
+        "ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS",
+        "ONLINE_EVAL_SESSION_SWEEP_FAILURES",
+        "ONLINE_EVAL_SESSION_SWEEP_SUCCESSES",
+    )
+    metrics = {name: Mock() for name in metric_names}
+    for name, metric in metrics.items():
+        monkeypatch.setattr(session_sweeper, name, metric)
+
+    project_id, _, _ = await _add_session_activity(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+
+    metrics["ONLINE_EVAL_SESSION_ACTIVITY_BACKLOG"].set.assert_called_once_with(1)
+    oldest_age = metrics["ONLINE_EVAL_SESSION_ACTIVITY_OLDEST_AGE_SECONDS"].set.call_args.args[0]
+    assert oldest_age == pytest.approx(600, abs=1)
+    metrics["ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS"].inc.assert_called_once_with()
+    metrics["ONLINE_EVAL_SESSION_SWEEP_SUCCESSES"].inc.assert_called_once_with()
+    metrics["ONLINE_EVAL_SESSION_SWEEP_FAILURES"].inc.assert_not_called()
+    metrics["ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS"].observe.assert_called_once()
+    metrics["ONLINE_EVAL_SESSION_MATERIALIZED_WORK_UNITS"].inc.assert_called_once_with(1)
+
+    async def fail_sweep(session: AsyncSession, database_now: datetime) -> int:
+        raise RuntimeError("failed sweep")
+
+    monkeypatch.setattr(sweeper, "_sweep", fail_sweep)
+    with pytest.raises(RuntimeError, match="failed sweep"):
+        await sweeper._tick()
+
+    assert metrics["ONLINE_EVAL_SESSION_SWEEP_ATTEMPTS"].inc.call_count == 2
+    metrics["ONLINE_EVAL_SESSION_SWEEP_FAILURES"].inc.assert_called_once_with()
+    assert metrics["ONLINE_EVAL_SESSION_SWEEP_DURATION_SECONDS"].observe.call_count == 2
 
 
 async def test_reopened_session_is_pruned_without_another_work_unit(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -184,11 +184,10 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
                 )
             )
         ).one()
-        cursor = (
+        lease = (
             await session.scalars(
-                select(models.EvalWorkCursor).where(
-                    models.EvalWorkCursor.evaluation_target == "SESSION",
-                    models.EvalWorkCursor.consumer_group == "default",
+                select(models.EvalWorkLease).where(
+                    models.EvalWorkLease.name == sweeper._lease_name,
                 )
             )
         ).one()
@@ -212,7 +211,7 @@ async def test_materializes_due_complete_session_with_activity_snapshot(
     assert unit.criteria_id == criteria_id
     assert unit.evaluated_through == last_span_ingested_at
     assert unit.status == "PENDING"
-    assert cursor.claimed_by == sweeper._sweeper_id
+    assert lease.holder == sweeper._sweeper_id
     assert live_work_count == 1
 
 
@@ -474,20 +473,20 @@ async def test_lost_lease_rolls_back_sweep(
     project_id, _, _ = await _add_session_liveness(db, age_seconds=600)
     await _seed_criteria(db, project_id, evaluation_target="SESSION")
     sweeper = SessionEvalSweeper(db)
-    acquire_cursor = sweeper._acquire_cursor
+    acquire_lease = sweeper._acquire_lease
 
     async def acquire_then_lose_lease() -> int | None:
-        cursor_id = await acquire_cursor()
-        assert cursor_id is not None
+        lease_id = await acquire_lease()
+        assert lease_id is not None
         async with db() as session:
             await session.execute(
-                update(models.EvalWorkCursor)
-                .where(models.EvalWorkCursor.id == cursor_id)
-                .values(claimed_by="replacement-sweeper")
+                update(models.EvalWorkLease)
+                .where(models.EvalWorkLease.id == lease_id)
+                .values(holder="replacement-sweeper")
             )
-        return cursor_id
+        return lease_id
 
-    monkeypatch.setattr(sweeper, "_acquire_cursor", acquire_then_lose_lease)
+    monkeypatch.setattr(sweeper, "_acquire_lease", acquire_then_lose_lease)
     with caplog.at_level(logging.WARNING, logger=session_sweeper.__name__):
         await sweeper._tick()
 
@@ -506,12 +505,10 @@ async def test_live_session_lease_stands_down_and_stale_lease_is_reclaimed(
     await _seed_criteria(db, project_id, evaluation_target="SESSION")
     async with db() as session:
         session.add(
-            models.EvalWorkCursor(
-                evaluation_target="SESSION",
-                consumer_group="default",
-                produced_through_id=0,
-                claimed_by="other-sweeper",
-                claimed_at=_now(),
+            models.EvalWorkLease(
+                name=f"{session_sweeper._SESSION_SWEEP_LEASE_NAME}:default",
+                holder="other-sweeper",
+                heartbeat_at=_now(),
             )
         )
 
@@ -522,9 +519,9 @@ async def test_live_session_lease_stands_down_and_stale_lease_is_reclaimed(
             await session.scalar(select(func.count()).select_from(models.EvalSessionWorkUnit)) == 0
         )
         await session.execute(
-            update(models.EvalWorkCursor)
-            .where(models.EvalWorkCursor.evaluation_target == "SESSION")
-            .values(claimed_at=_now() - timedelta(seconds=SESSION_SWEEP_LEASE_TTL_SECONDS + 1))
+            update(models.EvalWorkLease)
+            .where(models.EvalWorkLease.name == sweeper._lease_name)
+            .values(heartbeat_at=_now() - timedelta(seconds=SESSION_SWEEP_LEASE_TTL_SECONDS + 1))
         )
     await sweeper._tick()
 

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
 from typing import Sequence, cast
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from sqlalchemy import Table, func, select, update
@@ -51,6 +51,24 @@ def test_live_key_predicate_is_single_sourced_from_max_attempts() -> None:
     assert str(live_key_index.dialect_options["sqlite"]["where"]) == predicate
     assert str(session_sweeper._LIVE_WORK_INDEX_PREDICATE) == predicate
     assert migration.live_eval_work_index_predicate is live_eval_work_index_predicate
+
+
+@pytest.mark.parametrize(
+    "database_dialect,expected_clock",
+    [("sqlite", "now()"), ("postgresql", "statement_timestamp()")],
+)
+async def test_database_now_uses_statement_time(
+    database_dialect: str,
+    expected_clock: str,
+) -> None:
+    session = AsyncMock(spec=AsyncSession)
+    session.scalar.return_value = _now()
+    sweeper = SessionEvalSweeper(DbSessionFactory(db=Mock(), dialect=database_dialect))
+
+    await sweeper._database_now(session)
+
+    statement = session.scalar.await_args.args[0]
+    assert expected_clock in str(statement)
 
 
 async def test_materialization_rechecks_eligibility_at_write_time(

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -323,6 +323,44 @@ async def test_retains_activity_until_each_criteria_delay_elapses(
     assert activity_count == 0
 
 
+async def test_outstanding_work_budget_retains_activity_until_capacity_is_available(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING", "1")
+    project_id, project_session_id, _ = await _add_session_activity(db, age_seconds=600)
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+    await _seed_criteria(db, project_id, evaluation_target="SESSION")
+
+    sweeper = SessionEvalSweeper(db)
+    await sweeper._tick()
+
+    async with db() as session:
+        work_units = list(await session.scalars(select(models.EvalSessionWorkUnit)))
+        activity_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionActivity)
+        )
+        assert len(work_units) == 1
+        assert activity_count == 1
+        work_units[0].status = "DONE"
+
+    await sweeper._tick()
+
+    async with db() as session:
+        work_units = list(
+            await session.scalars(
+                select(models.EvalSessionWorkUnit).where(
+                    models.EvalSessionWorkUnit.project_session_rowid == project_session_id
+                )
+            )
+        )
+        activity_count = await session.scalar(
+            select(func.count()).select_from(models.EvalSessionActivity)
+        )
+    assert len(work_units) == 2
+    assert activity_count == 0
+
+
 async def test_reopened_session_is_pruned_without_another_work_unit(
     db: DbSessionFactory,
 ) -> None:

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -382,9 +382,7 @@ async def test_disabled_and_unresolved_criteria_preserve_future_eligibility(
 
     async def unresolved(
         session: AsyncSession,
-        criteria_evaluators: Sequence[
-            tuple[models.ProjectEvaluatorCriteria, models.Evaluator]
-        ],
+        criteria_evaluators: Sequence[tuple[models.ProjectEvaluatorCriteria, models.Evaluator]],
     ) -> list[ResolvedCriteria | None]:
         nonlocal resolution_calls
         resolution_calls += 1

--- a/tests/unit/server/online_eval/test_session_sweeper.py
+++ b/tests/unit/server/online_eval/test_session_sweeper.py
@@ -34,7 +34,7 @@ async def _seed_criteria(
     db: DbSessionFactory,
     project_id: int,
     *,
-    evaluation_target: str,
+    evaluation_target: models.EvaluationTarget,
     filter_condition: str = "",
     sampling_rate: float = 1.0,
 ) -> tuple[int, int]:
@@ -268,7 +268,7 @@ async def test_materialization_waits_for_publication_criteria_lock_before_sessio
     materialization_started = asyncio.Event()
     materialization_backend_pid: int | None = None
 
-    async def materialize() -> tuple[int, int]:
+    async def materialize() -> tuple[int, int | None]:
         nonlocal materialization_backend_pid
         async with db() as session:
             materialization_backend_pid = await session.scalar(select(func.pg_backend_pid()))
@@ -299,7 +299,7 @@ async def test_materialization_waits_for_publication_criteria_lock_before_sessio
                         select(func.pg_blocking_pids(materialization_backend_pid))
                     )
                 if blocking_pids:
-                    return blocking_pids
+                    return cast(Sequence[int], blocking_pids)
                 await asyncio.sleep(0)
 
         blocking_pids = await asyncio.wait_for(
@@ -329,7 +329,7 @@ async def test_materialization_waits_for_retention_session_lock(
     await _seed_criteria(db, project_id, evaluation_target="SESSION")
     sweeper = SessionEvalSweeper(db)
 
-    async def materialize() -> tuple[int, int]:
+    async def materialize() -> tuple[int, int | None]:
         async with db() as session:
             database_now = await sweeper._database_now(session)
             return await sweeper._sweep(session, database_now)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -169,6 +169,12 @@ class TestGetEnvOnlineEval:
                 1,
             ),
             (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_session_outstanding,
+                "1",
+                1,
+            ),
+            (
                 phoenix_config.ENV_PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE,
                 phoenix_config.get_env_online_eval_claim_batch_size,
                 "1",
@@ -203,6 +209,16 @@ class TestGetEnvOnlineEval:
             (
                 phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING,
                 phoenix_config.get_env_online_eval_max_outstanding,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_session_outstanding,
+                "0",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_SESSION_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_session_outstanding,
                 "-1",
             ),
         ],


### PR DESCRIPTION
## Summary

Adds session-level online-evaluation scheduling on top of the durable queue tables from #14460. Eligible SESSION criteria now materialize work from `ProjectSession.last_span_ingested_at` after the configured quiet delay, while `content_complete` prevents evaluation after retention or another delete has removed part of a session. Execution of the resulting work ships in #14501.

Stacked on #14460. Closes the remaining scope of #13978. As in #14460, **criteria** are rows of `project_evaluator_criteria`: a project's per-evaluator configuration for target, filter, sampling rate, input mapping, enabled state, and evaluation delay.

## Changes

**Session eligibility and evaluate-once contract**

- The new session sweeper considers enabled SESSION criteria with no filter and a sampling rate of 1. A session is eligible only when its content is complete, span-ingest liveness has been observed, its latest activity is at or after the criterion's creation time, and the configured delay has elapsed according to database time. Quiet sessions that predate criterion creation are left for backfill; disabling and re-enabling a criterion retains its original creation boundary.
- `evaluationDelaySeconds` defaults to 300 seconds and has a 10-second minimum. Create/add mutations store 300 when the field is omitted or null; update mutations preserve the stored value when omitted and reset it to 300 when null. Non-SESSION criteria retain the value without using it.
- v1 is evaluate-once per session, evaluator, and resolved configuration: a successful result closes that key, so later session activity does not schedule another evaluation. #14903 owns re-evaluation semantics. Live work is deduplicated, while terminal work that produced no result can be replaced only after newer ingestion advances the session watermark.

**Relational materialization and queue model**

- Resolved criteria are represented as one inline relation and joined directly to project sessions. Each tick selects a globally ordered due page and inserts it with one `INSERT ... SELECT ... RETURNING`, re-deriving eligibility at write time and suppressing live-key conflicts. Criteria resolution is batched, the session outstanding-work ceiling is checked before resolution, and the oldest due pairs are admitted first.
- `eval_work_leases` provides a lease without a scan cursor, and `eval_session_work_units` stores the session, evaluator, criteria, configuration fingerprint, ingest watermark, lifecycle state, retry state, and claim/retry indexes. Prometheus coverage includes sweep attempts/outcomes, materialized work, truthful eligible-pair backlog, and result-watermark lag.

**Concurrency and retention safety**

The daemon runs on every replica, but a database-time named lease admits one active sweeper and a failed lease renewal rolls its transaction back. On PostgreSQL, materialization acquires criteria row locks and then complete-candidate session locks, each in ascending ID order — the same criteria-then-session order publication uses — before inserting. Trace and span deletion freeze bounded primary-key batches, take the same ordered session locks, mark affected sessions permanently incomplete, expire live session work, remove the session annotations produced by online evaluation (human- and API-authored annotations are untouched), and then delete only the frozen content batch. SQLite relies on its single-writer transaction model.

**GraphQL and UI contracts**

- Project-evaluator create, add, update, and read surfaces expose `evaluationDelaySeconds`, plus schedulability status and a machine-readable refusal reason. Filtered or sampled SESSION criteria and TRACE criteria remain storable but are not scheduled.
- `evaluationTarget` is immutable from project-evaluator creation. Both LLM and CODE update mutations reject a different target, and edit forms disable the target control.
- Session scheduling remains opt-in through `PHOENIX_ONLINE_EVAL_SESSION_SWEEP_ENABLED`, with a separate configurable ceiling for outstanding session work.

## Testing

- Focused backend coverage at the tip: 533 passed, 221 skipped. Tests cover database-time delay gating, write-time eligibility rechecks, null and incomplete liveness, the creation boundary and re-enable behavior, evaluate-once closure, replacement after resultless terminal history, admission limits, lease takeover/loss, truthful metrics, and relational materialization with 501 schedulable criteria.
- PostgreSQL-only interleaving tests cover materialization waiting for a retention session lock, materialization taking the publication lock order (criteria before sessions), retention deleting sessions that become candidates while deletion is blocked, and retention sparing human-authored annotations while removing online-evaluation ones.
- GraphQL mutation/type coverage verifies create/read/update/reset delay semantics, minimum validation before writes, immutable targets, and schedulability reporting. Schema export, Relay generation, Python type-checking, Ruff, and formatting checks pass.
