### PR TITLE
feat(cli): persist PXI agent chat sessions

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -62,6 +62,19 @@ export PHOENIX_API_KEY=your-api-key  # if auth is enabled
 
 Always use `--format raw --no-progress` when piping to `jq`.
 
+### `pxi` — terminal agent chat
+
+`pxi` opens an interactive Phoenix agent session. With Phoenix 18.0.0 and
+newer it uses the persisted `/agents/server/chat` protocol, captures the
+server-assigned session ID, and resumes that session on later turns. It falls
+back automatically to the legacy session-path route for older servers or when
+server-version detection fails. Pass `--no-progress` to suppress the startup
+protocol and fallback notices.
+
+```bash
+pxi --endpoint http://localhost:6006 --provider OPENAI --model gpt-5.4
+```
+
 ### `px setup` — onboarding
 
 `px setup` connects the app in the current directory to a Phoenix deployment

--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -25,8 +25,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || github.event.before }}
         run: |
-          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
-            schemas/openapi.json > head.json
+          cp schemas/openapi.json head.json
           if [ -z "$BASE_REF" ]; then
             echo "::error::Could not determine base ref for OpenAPI schema comparison"
             exit 1
@@ -34,8 +33,7 @@ jobs:
           git checkout "$BASE_REF"
       - name: Snapshot base schema
         run: |
-          jq '.paths |= with_entries(select(.key | startswith("/agent") | not))' \
-            schemas/openapi.json > base.json
+          cp schemas/openapi.json base.json
       - uses: docker://openapitools/openapi-diff@sha256:82291446e5554742d9c0725d7b315d18e93958c5526f9a663e8885227bdd6cb6 # latest
         with:
           args: --fail-on-incompatible base.json head.json

--- a/.github/workflows/typescript-packages-CI.yml
+++ b/.github/workflows/typescript-packages-CI.yml
@@ -56,6 +56,10 @@ jobs:
       - name: Install Dependencies
         working-directory: ./js
         run: pnpm install --frozen-lockfile -r
+      - name: OpenAPI Client Codegen
+        run: |
+          make codegen-ts-client
+          git diff --exit-code
       - name: Build
         working-directory: ./js
         run: |

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/overview.mdx
@@ -36,7 +36,7 @@ That gives the agent version-matched docs plus the exact implementation and gene
 
 | Import | Purpose |
 |--------|---------|
-| `@arizeai/phoenix-client` | `createClient`, generated OpenAPI types, config helpers |
+| `@arizeai/phoenix-client` | `createClient`, generated OpenAPI types, config and server-version helpers |
 | `@arizeai/phoenix-client/prompts` | Prompt CRUD plus `toSDK` conversion |
 | `@arizeai/phoenix-client/datasets` | Dataset creation and retrieval |
 | `@arizeai/phoenix-client/experiments` | Experiment execution and lifecycle |
@@ -149,6 +149,28 @@ const prompt = await client.GET("/v1/prompts/{prompt_identifier}/latest", {
 ```
 
 The root export exposes generated API types: `pathsV1`, `componentsV1`, `operationsV1`, `Types`, and `PhoenixClient`.
+
+### Server Version Guards
+
+Use `client.getServerVersion()` when a client feature depends on a server-side
+capability. The root package also exports `SemanticVersion`,
+`parseSemanticVersion`, and `satisfiesMinVersion` for typed version checks.
+
+```ts
+import {
+  createClient,
+  satisfiesMinVersion,
+  type SemanticVersion,
+} from "@arizeai/phoenix-client";
+
+const client = createClient();
+const version = await client.getServerVersion();
+const minimumVersion: SemanticVersion = [18, 0, 0];
+
+if (!satisfiesMinVersion({ version, minVersion: minimumVersion })) {
+  throw new Error("This feature requires Phoenix 18.0.0 or newer.");
+}
+```
 
 Prefer this layer when:
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -127,6 +127,11 @@ pxi --endpoint http://localhost:6006 --provider OPENAI --model gpt-5.4
 npx -y @arizeai/phoenix-cli pxi                              # run without installing
 ```
 
+PXI uses persisted, resumable server sessions with Phoenix 18.0.0 and newer.
+It automatically falls back to the legacy chat protocol for older servers or
+when server-version detection is unavailable. The selected protocol is printed
+at startup; pass `--no-progress` to suppress protocol notices.
+
 Inside the chat, `/help`, `/clear`, and `/exit` are handled locally. See the
 [PXI documentation](https://arize.com/docs/phoenix/pxi) for the full flag and
 slash-command reference, model setup, and privacy controls.

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -637,6 +637,7 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
   );
   const [status, setStatus] = useState<PxiStatus>("idle");
   const [error, setError] = useState<string | null>(null);
+  const [sessionTitle, setSessionTitle] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const streamingAssistantMessageRef = useRef<PxiMessage | null>(null);
   const chatClient = useMemo(
@@ -732,6 +733,7 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
           streamingAssistantMessageRef.current = assistantMessage;
           setMessages([...nextMessages, assistantMessage]);
         },
+        onSessionTitle: setSessionTitle,
       })
       .then((assistantMessage) => {
         if (abortController.signal.aborted) {
@@ -867,7 +869,7 @@ export function PxiApp({ options, client, initialMessages = [] }: PxiAppProps) {
       <PxiBanner />
       <Text dimColor>
         endpoint: {options.config.endpoint} | model: {getModelLabel(options)} |
-        session: {options.sessionId}
+        session: {sessionTitle ?? options.sessionId}
       </Text>
       <Box marginTop={1} flexDirection="column">
         <Transcript

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -1,3 +1,4 @@
+import type { pathsV1 } from "@arizeai/phoenix-client";
 import {
   DefaultChatTransport,
   readUIMessageStream,
@@ -5,15 +6,21 @@ import {
 } from "ai";
 
 import type { PhoenixConfig } from "../config";
+import { writeProgress } from "../io";
 import { formatPxiRuntimeError } from "./preflight";
 import type {
   PxiChatClient,
+  PxiChatRoute,
   PxiChatRequest,
   PxiContext,
   PxiMessage,
   PxiRuntimeOptions,
+  PxiSessionMetadata,
   PxiTransport,
 } from "./types";
+
+const AGENT_CHAT_PATH_TEMPLATE =
+  "/agents/{agent_id}/chat" satisfies keyof pathsV1;
 
 /**
  * Chat client for the Phoenix server-agent endpoint.
@@ -65,6 +72,12 @@ export function buildServerAgentChatUrl({
   return `${trimTrailingSlash(endpoint)}/agents/server/sessions/${encodeURIComponent(
     sessionId
   )}/chat`;
+}
+
+/** Build the persisted server-agent chat URL from the generated OpenAPI path. */
+export function buildAgentChatUrl({ endpoint }: { endpoint: string }): string {
+  const path = AGENT_CHAT_PATH_TEMPLATE.replace("{agent_id}", "server");
+  return `${trimTrailingSlash(endpoint)}${path}`;
 }
 
 /**
@@ -131,12 +144,15 @@ export function buildPxiContexts({
 export function buildPxiChatRequest({
   messages,
   options,
+  agentSessionId,
 }: {
   messages: PxiMessage[];
   options: PxiRuntimeOptions;
+  agentSessionId?: string;
 }): PxiChatRequest {
   return {
     id: options.sessionId,
+    ...(agentSessionId ? { agentSessionId } : {}),
     messages,
     trigger: "submit-message",
     ingestTraces: options.ingestTraces,
@@ -158,26 +174,67 @@ export function buildPxiChatRequest({
  * so per-request context (like the current time) stays fresh. Throws if no
  * endpoint is configured. `fetch` is injectable for testing.
  */
+type PxiChatSessionState = {
+  chatRoute: PxiChatRoute;
+  agentSessionId?: string;
+  title?: string;
+};
+
 export function createServerAgentTransport({
   options,
-  fetch,
+  sessionState = { chatRoute: options.chatRoute },
+  fetch: fetchImpl = globalThis.fetch,
 }: {
   options: PxiRuntimeOptions;
+  sessionState?: PxiChatSessionState;
   fetch?: typeof globalThis.fetch;
 }): PxiTransport {
   if (!options.config.endpoint) {
     throw new Error("Phoenix endpoint not configured.");
   }
 
+  const persistedUrl = buildAgentChatUrl({
+    endpoint: options.config.endpoint,
+  });
+  const legacyUrl = buildServerAgentChatUrl({
+    endpoint: options.config.endpoint,
+    sessionId: options.sessionId,
+  });
+
+  const fetchWithLegacyFallback: typeof globalThis.fetch = async (
+    _input,
+    init
+  ) => {
+    const requestUrl =
+      sessionState.chatRoute === "persisted" ? persistedUrl : legacyUrl;
+    const response = await fetchImpl(requestUrl, init);
+    const shouldRetryLegacy =
+      sessionState.chatRoute === "persisted" &&
+      (response.status === 404 || response.status === 405);
+    if (!shouldRetryLegacy) {
+      return response;
+    }
+    sessionState.chatRoute = "legacy";
+    writeProgress({
+      message: `PXI persisted chat route returned HTTP ${response.status}; retrying with the legacy protocol.`,
+      noProgress: options.noProgress,
+    });
+    return fetchImpl(legacyUrl, init);
+  };
+
   return new DefaultChatTransport<PxiMessage>({
-    api: buildServerAgentChatUrl({
-      endpoint: options.config.endpoint,
-      sessionId: options.sessionId,
-    }),
+    api: sessionState.chatRoute === "persisted" ? persistedUrl : legacyUrl,
     headers: buildPxiHeaders({ config: options.config }),
-    fetch,
+    fetch: fetchWithLegacyFallback,
     prepareSendMessagesRequest: ({ messages }) => ({
-      body: buildPxiChatRequest({ messages, options }),
+      body: buildPxiChatRequest({
+        messages,
+        options,
+        agentSessionId:
+          sessionState.chatRoute === "persisted"
+            ? sessionState.agentSessionId
+            : undefined,
+      }),
     }),
   });
 }
@@ -203,6 +260,70 @@ export async function streamAssistantMessage({
   return finalMessage;
 }
 
+function parseSessionMetadata({
+  chunk,
+}: {
+  chunk: UIMessageChunk;
+}): PxiSessionMetadata | null {
+  if (chunk.type !== "data-session-created") {
+    return null;
+  }
+  const data = chunk.data;
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    !("id" in data) ||
+    !("title" in data) ||
+    !("createdAt" in data) ||
+    !("updatedAt" in data) ||
+    typeof data.id !== "string" ||
+    typeof data.title !== "string" ||
+    typeof data.createdAt !== "string" ||
+    typeof data.updatedAt !== "string"
+  ) {
+    return null;
+  }
+  return {
+    id: data.id,
+    title: data.title,
+    createdAt: data.createdAt,
+    updatedAt: data.updatedAt,
+  };
+}
+
+function captureSessionChunks({
+  stream,
+  sessionState,
+  onSessionTitle,
+}: {
+  stream: ReadableStream<UIMessageChunk>;
+  sessionState: PxiChatSessionState;
+  onSessionTitle?: (title: string) => void;
+}): ReadableStream<UIMessageChunk> {
+  return stream.pipeThrough(
+    new TransformStream<UIMessageChunk, UIMessageChunk>({
+      transform(chunk, controller) {
+        const sessionMetadata = parseSessionMetadata({ chunk });
+        if (sessionMetadata !== null) {
+          sessionState.agentSessionId = sessionMetadata.id;
+          if (sessionMetadata.title) {
+            sessionState.title = sessionMetadata.title;
+            onSessionTitle?.(sessionMetadata.title);
+          }
+        } else if (
+          chunk.type === "data-session-summary" &&
+          typeof chunk.data === "string" &&
+          chunk.data
+        ) {
+          sessionState.title = chunk.data;
+          onSessionTitle?.(chunk.data);
+        }
+        controller.enqueue(chunk);
+      },
+    })
+  );
+}
+
 /**
  * Create the {@link PxiChatClient} the UI talks to. It sends the conversation
  * over the transport, streams the assistant reply back, and on failure wraps
@@ -212,22 +333,39 @@ export async function streamAssistantMessage({
  */
 export function createPxiChatClient({
   options,
-  transport = createServerAgentTransport({ options }),
+  transport,
+  fetch,
 }: {
   options: PxiRuntimeOptions;
   transport?: PxiTransport;
+  fetch?: typeof globalThis.fetch;
 }): PxiChatClient {
+  const sessionState: PxiChatSessionState = { chatRoute: options.chatRoute };
+  const resolvedTransport =
+    transport ?? createServerAgentTransport({ options, sessionState, fetch });
   return {
-    async sendMessage({ messages, abortSignal, onAssistantMessage }) {
+    async sendMessage({
+      messages,
+      abortSignal,
+      onAssistantMessage,
+      onSessionTitle,
+    }) {
       try {
-        const stream = await transport.sendMessages({
+        const stream = await resolvedTransport.sendMessages({
           trigger: "submit-message",
           chatId: options.sessionId,
           messageId: undefined,
           messages,
           abortSignal,
         });
-        return await streamAssistantMessage({ stream, onAssistantMessage });
+        return await streamAssistantMessage({
+          stream: captureSessionChunks({
+            stream,
+            sessionState,
+            onSessionTitle,
+          }),
+          onAssistantMessage,
+        });
       } catch (error) {
         throw formatPxiRuntimeError({
           error,

--- a/js/packages/phoenix-cli/src/pxi/index.tsx
+++ b/js/packages/phoenix-cli/src/pxi/index.tsx
@@ -4,10 +4,10 @@ import { render } from "ink";
 import React from "react";
 
 import { getExitCodeForError } from "../exitCodes";
-import { writeError } from "../io";
+import { writeError, writeProgress } from "../io";
 import { PxiApp } from "./App";
 import { parsePxiRuntimeOptions } from "./options";
-import { runPxiModelPreflight } from "./preflight";
+import { runPxiStartupPreflight } from "./preflight";
 
 /**
  * Entry point for the `pxi` command.
@@ -23,8 +23,12 @@ export async function main({
 }: {
   argv?: string[];
 } = {}): Promise<void> {
-  const options = await parsePxiRuntimeOptions({ argv });
-  await runPxiModelPreflight({ options });
+  const unresolvedOptions = await parsePxiRuntimeOptions({ argv });
+  const options = await runPxiStartupPreflight({ options: unresolvedOptions });
+  writeProgress({
+    message: `PXI chat protocol: ${options.chatRoute}`,
+    noProgress: options.noProgress,
+  });
   // Ink's kitty-keyboard "auto" detection writes a `CSI ? u` capability query to
   // stdout from its constructor, before it switches the terminal into raw mode.
   // On a TTY still in canonical mode the terminal echoes its reply (`ESC[?0u`)

--- a/js/packages/phoenix-cli/src/pxi/options.ts
+++ b/js/packages/phoenix-cli/src/pxi/options.ts
@@ -134,6 +134,8 @@ type RawPxiOptions = {
    * @example true
    */
   attachUserId?: boolean;
+  /** `--no-progress`: suppress protocol selection and fallback notices. */
+  noProgress?: boolean;
 };
 
 /** Input to {@link resolvePxiRuntimeOptions}. */
@@ -252,6 +254,8 @@ export function resolvePxiRuntimeOptions({
     ingestTraces: Boolean(cliOptions.ingestTraces),
     exportRemoteTraces: Boolean(cliOptions.exportRemoteTraces),
     attachUserId: Boolean(cliOptions.attachUserId),
+    chatRoute: "legacy",
+    noProgress: Boolean(cliOptions.noProgress),
   };
 }
 
@@ -296,6 +300,7 @@ export function createPxiProgram(): Command {
       "--attach-user-id",
       "Attach the authenticated Phoenix user to PXI traces"
     )
+    .option("--no-progress", "Suppress PXI protocol progress notices")
     .addHelpText(
       "after",
       `

--- a/js/packages/phoenix-cli/src/pxi/preflight.ts
+++ b/js/packages/phoenix-cli/src/pxi/preflight.ts
@@ -1,7 +1,36 @@
+import {
+  satisfiesMinVersion,
+  type PhoenixClient,
+  type SemanticVersion,
+} from "@arizeai/phoenix-client";
+
+import { createPhoenixClient } from "../client";
 import { buildGraphqlRequest } from "../commands/api";
 import type { PhoenixConfig } from "../config";
 import { InvalidArgumentError } from "../exitCodes";
-import type { ModelSelection, PxiRuntimeOptions } from "./types";
+import type { ModelSelection, PxiChatRoute, PxiRuntimeOptions } from "./types";
+
+/** First Phoenix release containing persisted `POST /agents/server/chat`. */
+export const MIN_SERVER_VERSION_FOR_AGENT_CHAT: SemanticVersion = [18, 0, 0];
+
+/** Select the persisted protocol when the connected server advertises support. */
+export async function resolvePxiChatRoute({
+  client,
+}: {
+  client: Pick<PhoenixClient, "getServerVersion">;
+}): Promise<PxiChatRoute> {
+  try {
+    const version = await client.getServerVersion();
+    return satisfiesMinVersion({
+      version,
+      minVersion: MIN_SERVER_VERSION_FOR_AGENT_CHAT,
+    })
+      ? "persisted"
+      : "legacy";
+  } catch {
+    return "legacy";
+  }
+}
 
 /**
  * Pre-launch validation of the selected model.
@@ -390,6 +419,23 @@ export async function runPxiModelPreflight({
     data,
     modelSelection: options.modelSelection,
   });
+}
+
+/** Resolve the chat protocol and validate the selected model before rendering PXI. */
+export async function runPxiStartupPreflight({
+  options,
+  fetchImpl = globalThis.fetch,
+}: {
+  options: PxiRuntimeOptions;
+  fetchImpl?: typeof globalThis.fetch;
+}): Promise<PxiRuntimeOptions> {
+  const client = createPhoenixClient({
+    config: options.config,
+    fetch: fetchImpl,
+  });
+  const chatRoute = await resolvePxiChatRoute({ client });
+  await runPxiModelPreflight({ options, fetchImpl });
+  return { ...options, chatRoute };
 }
 
 /**

--- a/js/packages/phoenix-cli/src/pxi/types.ts
+++ b/js/packages/phoenix-cli/src/pxi/types.ts
@@ -102,9 +102,21 @@ export type PxiContext =
  */
 export type PxiEditPermission = "manual" | "bypass";
 
+/** Which server chat protocol PXI uses for this session. */
+export type PxiChatRoute = "persisted" | "legacy";
+
+/** Persisted session metadata delivered as a transient stream chunk. */
+export type PxiSessionMetadata = {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 /** The request body POSTed to the Phoenix server-agent chat endpoint. */
 export type PxiChatRequest = {
   id: string;
+  agentSessionId?: string;
   messages: PxiMessage[];
   trigger: "submit-message";
   ingestTraces: boolean;
@@ -133,6 +145,8 @@ export type PxiRuntimeOptions = {
   ingestTraces: boolean;
   exportRemoteTraces: boolean;
   attachUserId: boolean;
+  chatRoute: PxiChatRoute;
+  noProgress: boolean;
 };
 
 /**
@@ -147,6 +161,7 @@ export type PxiChatClient = {
     messages: PxiMessage[];
     abortSignal?: AbortSignal;
     onAssistantMessage: (message: PxiMessage) => void;
+    onSessionTitle?: (title: string) => void;
   }) => Promise<PxiMessage | null>;
 };
 

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -2,6 +2,7 @@ import type { UIMessageChunk } from "ai";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAgentChatUrl,
   buildPxiChatRequest,
   buildPxiHeaders,
   buildServerAgentChatUrl,
@@ -41,6 +42,19 @@ function createChunkStream(
       controller.close();
     },
   });
+}
+
+function createSseResponse(chunks: UIMessageChunk[]): Response {
+  return new Response(
+    `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`,
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "x-vercel-ai-ui-message-stream": "v1",
+      },
+    }
+  );
 }
 
 describe("PXI client", () => {
@@ -126,6 +140,108 @@ describe("PXI client", () => {
     ).toBe(
       "http://localhost:6006/agents/server/sessions/session%20with%20spaces/chat"
     );
+  });
+
+  it("builds the persisted server-agent chat URL", () => {
+    expect(buildAgentChatUrl({ endpoint: "http://localhost:6006/" })).toBe(
+      "http://localhost:6006/agents/server/chat"
+    );
+  });
+
+  it("includes a persisted session id only after one is assigned", () => {
+    const options = createRuntimeOptions();
+    const firstRequest = buildPxiChatRequest({
+      messages: [userMessage("first")],
+      options,
+    });
+    const resumedRequest = buildPxiChatRequest({
+      messages: [userMessage("second")],
+      options,
+      agentSessionId: "QWdlbnRTZXNzaW9uOjE=",
+    });
+
+    expect(firstRequest).not.toHaveProperty("agentSessionId");
+    expect(resumedRequest.agentSessionId).toBe("QWdlbnRTZXNzaW9uOjE=");
+  });
+
+  it("captures transient session chunks and resumes the next turn", async () => {
+    const options = createRuntimeOptions();
+    options.chatRoute = "persisted";
+    const requestBodies: unknown[] = [];
+    const fetchImpl: typeof globalThis.fetch = async (_input, init) => {
+      requestBodies.push(JSON.parse(String(init?.body)));
+      return createSseResponse([
+        { type: "start", messageId: "assistant-1" },
+        {
+          type: "data-session-created",
+          data: {
+            id: "QWdlbnRTZXNzaW9uOjE=",
+            title: "",
+            createdAt: "2026-07-16T12:00:00Z",
+            updatedAt: "2026-07-16T12:00:00Z",
+          },
+          transient: true,
+        },
+        {
+          type: "data-session-summary",
+          data: "Project investigation",
+          transient: true,
+        },
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "Done" },
+        { type: "text-end", id: "text-1" },
+        { type: "finish", finishReason: "stop" },
+      ]);
+    };
+    const titles: string[] = [];
+    const client = createPxiChatClient({ options, fetch: fetchImpl });
+
+    await client.sendMessage({
+      messages: [userMessage("first")],
+      onAssistantMessage: () => undefined,
+      onSessionTitle: (title) => titles.push(title),
+    });
+    await client.sendMessage({
+      messages: [userMessage("second")],
+      onAssistantMessage: () => undefined,
+      onSessionTitle: (title) => titles.push(title),
+    });
+
+    expect(requestBodies[0]).not.toHaveProperty("agentSessionId");
+    expect(requestBodies[1]).toMatchObject({
+      agentSessionId: "QWdlbnRTZXNzaW9uOjE=",
+    });
+    expect(titles).toContain("Project investigation");
+  });
+
+  it("retries a missing persisted route once with the legacy URL", async () => {
+    const options = createRuntimeOptions({ noProgress: true });
+    options.chatRoute = "persisted";
+    const requestUrls: string[] = [];
+    const fetchImpl: typeof globalThis.fetch = async (input) => {
+      requestUrls.push(String(input));
+      if (requestUrls.length === 1) {
+        return new Response("Not found", { status: 404 });
+      }
+      return createSseResponse([
+        { type: "start", messageId: "assistant-1" },
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "Done" },
+        { type: "text-end", id: "text-1" },
+        { type: "finish", finishReason: "stop" },
+      ]);
+    };
+    const client = createPxiChatClient({ options, fetch: fetchImpl });
+
+    await client.sendMessage({
+      messages: [userMessage("hello")],
+      onAssistantMessage: () => undefined,
+    });
+
+    expect(requestUrls).toEqual([
+      "http://localhost:6006/agents/server/chat",
+      "http://localhost:6006/agents/server/sessions/session-1/chat",
+    ]);
   });
 
   it("streams assistant text updates", async () => {

--- a/js/packages/phoenix-cli/test/pxiOptions.test.ts
+++ b/js/packages/phoenix-cli/test/pxiOptions.test.ts
@@ -41,6 +41,7 @@ describe("PXI options", () => {
     expect(help).toContain("--enable-web-access");
     expect(help).toContain("--custom-provider-id");
     expect(help).toContain("--skip-model-preflight");
+    expect(help).toContain("--no-progress");
   });
 
   it("defaults to the browser PXI model", () => {
@@ -93,6 +94,7 @@ describe("PXI options", () => {
 
     expect(options.config.project).toBeUndefined();
     expect(options.sessionId).toBe("session-1");
+    expect(options.chatRoute).toBe("legacy");
   });
 
   it("defaults model preflight to enabled", () => {

--- a/js/packages/phoenix-cli/test/pxiPreflight.test.ts
+++ b/js/packages/phoenix-cli/test/pxiPreflight.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { resolvePxiRuntimeOptions } from "../src/pxi/options";
-import { runPxiModelPreflight } from "../src/pxi/preflight";
+import {
+  MIN_SERVER_VERSION_FOR_AGENT_CHAT,
+  resolvePxiChatRoute,
+  runPxiModelPreflight,
+  runPxiStartupPreflight,
+} from "../src/pxi/preflight";
 
 type FetchCall = {
   url: string;
@@ -100,6 +105,56 @@ function createFetch({
 }
 
 describe("PXI model preflight", () => {
+  it("selects persisted chat for a supported server", async () => {
+    const route = await resolvePxiChatRoute({
+      client: { getServerVersion: async () => [18, 0, 0] },
+    });
+
+    expect(MIN_SERVER_VERSION_FOR_AGENT_CHAT).toEqual([18, 0, 0]);
+    expect(route).toBe("persisted");
+  });
+
+  it("selects legacy chat for an older server", async () => {
+    const route = await resolvePxiChatRoute({
+      client: { getServerVersion: async () => [17, 14, 0] },
+    });
+
+    expect(route).toBe("legacy");
+  });
+
+  it("selects legacy chat when server version detection fails", async () => {
+    const route = await resolvePxiChatRoute({
+      client: {
+        getServerVersion: async () => {
+          throw new Error("version endpoint unavailable");
+        },
+      },
+    });
+
+    expect(route).toBe("legacy");
+  });
+
+  it("returns startup options with the resolved chat protocol", async () => {
+    const options = createRuntimeOptions();
+    const fetchImpl: typeof globalThis.fetch = async (input) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.endsWith("/arize_phoenix_version")) {
+        return new Response("18.0.0");
+      }
+      return new Response(JSON.stringify({ data: createPreflightData() }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const resolvedOptions = await runPxiStartupPreflight({
+      options,
+      fetchImpl,
+    });
+
+    expect(options.chatRoute).toBe("legacy");
+    expect(resolvedOptions.chatRoute).toBe("persisted");
+  });
+
   it("uses configured endpoint, API key, and custom headers", async () => {
     const options = createRuntimeOptions({ apiKey: "secret" });
     options.config.headers = { "X-Phoenix": "pxi" };

--- a/js/packages/phoenix-client/src/client.ts
+++ b/js/packages/phoenix-client/src/client.ts
@@ -142,9 +142,11 @@ export const createClient = (
         const headers = mergedOptions.headers
           ? { ...(mergedOptions.headers as Record<string, string>) }
           : {};
-        const resp = await fetch(`${baseUrl}/arize_phoenix_version`, {
+        const fetchImpl = mergedOptions.fetch ?? globalThis.fetch;
+        const request = new Request(`${baseUrl}/arize_phoenix_version`, {
           headers,
         });
+        const resp = await fetchImpl(request);
         if (resp.ok) {
           const text = await resp.text();
           const parsed = parseSemanticVersion(text);

--- a/js/packages/phoenix-client/src/index.ts
+++ b/js/packages/phoenix-client/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./client";
 export * from "./errors";
+export type { SemanticVersion } from "./types/semver";
+export { parseSemanticVersion, satisfiesMinVersion } from "./utils/semverUtils";

--- a/js/packages/phoenix-client/test/client.test.ts
+++ b/js/packages/phoenix-client/test/client.test.ts
@@ -30,3 +30,24 @@ describe("non-2xx responses", () => {
     expect((error as HttpError).message).toContain("401 Unauthorized");
   });
 });
+
+describe("server version", () => {
+  it("uses the configured transport for version detection", async () => {
+    const requestedUrls: string[] = [];
+    const client = createClient({
+      getEnvironmentOptions: () => ({}),
+      options: {
+        baseUrl: "https://phoenix.example.com",
+        fetch: async (request) => {
+          requestedUrls.push(request.url);
+          return new Response("18.0.0");
+        },
+      },
+    });
+
+    await expect(client.getServerVersion()).resolves.toEqual([18, 0, 0]);
+    expect(requestedUrls).toEqual([
+      "https://phoenix.example.com/arize_phoenix_version",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- move PXI to persisted server-agent sessions on Phoenix 18.0.0 and newer
- retain version-based and HTTP 404/405 fallback to the legacy protocol
- capture transient session identity and title chunks across turns
- export Phoenix client semantic-version helpers and honor configured fetch for version checks
- strengthen OpenAPI compatibility and TypeScript client codegen freshness checks
- update CLI and packaged TypeScript client documentation

## Verification

- Phoenix client tests: 456 passed; 1 skipped
- Phoenix CLI tests: 707 passed
- TypeScript typecheck, formatting, and package builds passed
- lint passed with two existing control-regex warnings
- Phoenix client package dry-run includes synchronized docs
- generated TypeScript OpenAPI client is clean

## Stack

1. #14468 adds the persisted server-agent route and database support
2. This PR targets #14468