### PR TITLE
fix(settings): gate admin tabs behind authentication

### DIFF
--- a/app/src/__tests__/installTestMatchMedia.ts
+++ b/app/src/__tests__/installTestMatchMedia.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, vi } from "vitest";
+
+// Opt-in `window.matchMedia` stub — jsdom does not implement matchMedia, so
+// any test that mounts a component using media queries (e.g. useMediaQuery)
+// must import this and call `installTestMatchMedia()` once at the top of the
+// test file (or inside a `describe` block).
+export function installTestMatchMedia({
+  matches = false,
+}: { matches?: boolean } = {}): void {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        matches,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+}

--- a/app/src/components/agent/AgentExperimentalSettings.tsx
+++ b/app/src/components/agent/AgentExperimentalSettings.tsx
@@ -6,7 +6,7 @@ import {
 } from "@phoenix/agent/extensions/capabilities";
 import { Flex, Switch, Text } from "@phoenix/components";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
-import { useIsAdmin } from "@phoenix/contexts/ViewerContext";
+import { useIsAdminOrAuthDisabled } from "@phoenix/contexts/ViewerContext";
 
 import { SystemSettingsWarning } from "./SystemSettingsWarning";
 
@@ -89,7 +89,7 @@ export function AgentWebAccessSettings() {
   const isWebAccessEnabled = useAgentContext(
     (state) => state.agentsConfig.webAccessEnabled
   );
-  const isAdmin = useIsAdmin();
+  const isAdmin = useIsAdminOrAuthDisabled();
   const definition = getAgentCapabilityDefinition("web.access");
 
   return (

--- a/app/src/components/agent/AgentModelCredentialForm.tsx
+++ b/app/src/components/agent/AgentModelCredentialForm.tsx
@@ -5,7 +5,7 @@ import { graphql, useLazyLoadQuery } from "react-relay";
 import { Flex, Icon, Icons, Text } from "@phoenix/components";
 import type { ModelMenuValue } from "@phoenix/components/generative";
 import { ProviderServerCredentialsPanel } from "@phoenix/components/generative";
-import { useIsAdmin } from "@phoenix/contexts/ViewerContext";
+import { useIsAdminOrAuthDisabled } from "@phoenix/contexts/ViewerContext";
 
 import type { AgentModelCredentialFormQuery } from "./__generated__/AgentModelCredentialFormQuery.graphql";
 
@@ -79,7 +79,7 @@ export function AgentModelCredentialForm({
   onCredentialsUpdated: () => void;
   provider: AgentModelCredentialProvider;
 }) {
-  const isAdmin = useIsAdmin();
+  const isAdmin = useIsAdminOrAuthDisabled();
 
   return (
     <section

--- a/app/src/components/agent/AgentObservabilitySettings.tsx
+++ b/app/src/components/agent/AgentObservabilitySettings.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 
 import { ContextualHelp, Switch, Text } from "@phoenix/components";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
-import { useIsAdmin } from "@phoenix/contexts/ViewerContext";
+import { useIsAdminOrAuthDisabled } from "@phoenix/contexts/ViewerContext";
 import {
   getEffectiveAttachUserId,
   getEffectiveTraceRecordingSettings,
@@ -104,7 +104,7 @@ export function AgentObservabilitySettings({
   const agentsConfig = useAgentContext((state) => state.agentsConfig);
   const observability = useAgentContext((state) => state.observability);
   const setObservability = useAgentContext((state) => state.setObservability);
-  const isAdmin = useIsAdmin();
+  const isAdmin = useIsAdminOrAuthDisabled();
   const isRemoteCollectorConfigured = Boolean(agentsConfig.collectorEndpoint);
   const isTracingForced = agentsConfig.forceTracing;
 

--- a/app/src/components/auth/AuthGuard.tsx
+++ b/app/src/components/auth/AuthGuard.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren, ReactNode } from "react";
 
 import {
+  useIsAuthenticatedAdmin,
   useViewer,
   useViewerCanManageRetentionPolicy,
   useViewerCanManageSandboxes,
@@ -29,9 +30,9 @@ export function IsAuthenticated(props: PropsWithChildren<AuthGuardProps>) {
  */
 export function IsAdmin(props: PropsWithChildren<AuthGuardProps>) {
   const { fallback = null, children } = props;
-  const { viewer } = useViewer();
+  const isAuthenticatedAdmin = useIsAuthenticatedAdmin();
   // If the viewer is not an admin, show the fallback
-  if (!viewer || viewer.role.name !== "ADMIN") {
+  if (!isAuthenticatedAdmin) {
     return <>{fallback}</>;
   }
   return children;

--- a/app/src/components/datetime/__tests__/TimeRangeSelector.test.tsx
+++ b/app/src/components/datetime/__tests__/TimeRangeSelector.test.tsx
@@ -2,6 +2,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { installTestMatchMedia } from "@phoenix/__tests__/installTestMatchMedia";
 import { PreferencesProvider } from "@phoenix/contexts/PreferencesContext";
 import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
 
@@ -10,9 +11,10 @@ import type { OpenTimeRangeWithKey } from "../types";
 import { getTimeRangeFromLastNTimeRangeKey } from "../utils";
 
 describe("TimeRangeSelector", () => {
+  installTestMatchMedia();
+
   let container: HTMLDivElement;
   let root: Root;
-  const originalMatchMedia = window.matchMedia;
   const originalOffsetWidth = Object.getOwnPropertyDescriptor(
     HTMLElement.prototype,
     "offsetWidth"
@@ -21,15 +23,6 @@ describe("TimeRangeSelector", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-09T10:00:30.000Z"));
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      writable: true,
-      value: vi.fn().mockReturnValue({
-        matches: false,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      }),
-    });
     // The presets popover only mounts once the trigger has a measurable width
     Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
       configurable: true,
@@ -45,11 +38,6 @@ describe("TimeRangeSelector", () => {
       root.unmount();
     });
     container.remove();
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      writable: true,
-      value: originalMatchMedia,
-    });
     if (originalOffsetWidth) {
       Object.defineProperty(
         HTMLElement.prototype,

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -90,9 +90,7 @@ export const navLinkCSS = css`
   flex-direction: row;
   align-items: center;
   overflow: hidden;
-  transition:
-    color 0.2s ease-in-out,
-    background-color 0.2s ease-in-out;
+  transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
   text-decoration: none;
   cursor: pointer;
 

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -90,7 +90,9 @@ export const navLinkCSS = css`
   flex-direction: row;
   align-items: center;
   overflow: hidden;
-  transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
+  transition:
+    color 0.2s ease-in-out,
+    background-color 0.2s ease-in-out;
   text-decoration: none;
   cursor: pointer;
 

--- a/app/src/components/project/IntegrationIcons.tsx
+++ b/app/src/components/project/IntegrationIcons.tsx
@@ -956,6 +956,273 @@ export const OpenRouterSVG = () => (
   </svg>
 );
 
+// Brand-color mark: blurred color fields clipped by the "A" silhouette mask.
+// Kept on the source 24x24 viewBox because the filter regions and mask are in
+// userSpace coordinates; the svg is simply rendered at 32x32.
+export const AntigravitySVG = () => (
+  <svg
+    width="32"
+    height="32"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>Antigravity</title>
+    <mask
+      id="antigravity-mask"
+      maskUnits="userSpaceOnUse"
+      x="0"
+      y="1"
+      width="24"
+      height="23"
+    >
+      <path
+        d="M21.751 22.607c1.34 1.005 3.35.335 1.508-1.508C17.73 15.74 18.904 1 12.037 1 5.17 1 6.342 15.74.815 21.1c-2.01 2.009.167 2.511 1.507 1.506 5.192-3.517 4.857-9.714 9.715-9.714 4.857 0 4.522 6.197 9.714 9.715z"
+        fill="#fff"
+      />
+    </mask>
+    <g mask="url(#antigravity-mask)">
+      <g filter="url(#antigravity-b1)">
+        <path
+          d="M-1.018-3.992c-.408 3.591 2.686 6.89 6.91 7.37 4.225.48 7.98-2.043 8.387-5.633.408-3.59-2.686-6.89-6.91-7.37-4.225-.479-7.98 2.043-8.387 5.633z"
+          fill="#FFE432"
+        />
+      </g>
+      <g filter="url(#antigravity-b2)">
+        <path
+          d="M15.269 7.747c1.058 4.557 5.691 7.374 10.348 6.293 4.657-1.082 7.575-5.653 6.516-10.21-1.058-4.556-5.691-7.374-10.348-6.292-4.657 1.082-7.575 5.653-6.516 10.21z"
+          fill="#FC413D"
+        />
+      </g>
+      <g filter="url(#antigravity-b3)">
+        <path
+          d="M-12.443 10.804c1.338 4.703 7.36 7.11 13.453 5.378 6.092-1.733 9.947-6.95 8.61-11.652C8.282-.173 2.26-2.58-3.833-.848-9.925.884-13.78 6.1-12.443 10.804z"
+          fill="#00B95C"
+        />
+      </g>
+      <g filter="url(#antigravity-b4)">
+        <path
+          d="M-12.443 10.804c1.338 4.703 7.36 7.11 13.453 5.378 6.092-1.733 9.947-6.95 8.61-11.652C8.282-.173 2.26-2.58-3.833-.848-9.925.884-13.78 6.1-12.443 10.804z"
+          fill="#00B95C"
+        />
+      </g>
+      <g filter="url(#antigravity-b5)">
+        <path
+          d="M-7.608 14.703c3.352 3.424 9.126 3.208 12.896-.483 3.77-3.69 4.108-9.459.756-12.883C2.69-2.087-3.083-1.871-6.853 1.82c-3.77 3.69-4.108 9.458-.755 12.883z"
+          fill="#00B95C"
+        />
+      </g>
+      <g filter="url(#antigravity-b6)">
+        <path
+          d="M9.932 27.617c1.04 4.482 5.384 7.303 9.7 6.3 4.316-1.002 6.971-5.448 5.93-9.93-1.04-4.483-5.384-7.304-9.7-6.301-4.316 1.002-6.971 5.448-5.93 9.93z"
+          fill="#3186FF"
+        />
+      </g>
+      <g filter="url(#antigravity-b7)">
+        <path
+          d="M2.572-8.185C.392-3.329 2.778 2.472 7.9 4.771c5.122 2.3 11.042.227 13.222-4.63 2.18-4.855-.205-10.656-5.327-12.955-5.122-2.3-11.042-.227-13.222 4.63z"
+          fill="#FBBC04"
+        />
+      </g>
+      <g filter="url(#antigravity-b8)">
+        <path
+          d="M-3.267 38.686c-5.277-2.072 3.742-19.117 5.984-24.83 2.243-5.712 8.34-8.664 13.616-6.592 5.278 2.071 11.533 13.482 9.29 19.195-2.242 5.713-23.613 14.298-28.89 12.227z"
+          fill="#3186FF"
+        />
+      </g>
+      <g filter="url(#antigravity-b9)">
+        <path
+          d="M28.71 17.471c-1.413 1.649-5.1.808-8.236-1.878-3.135-2.687-4.531-6.201-3.118-7.85 1.412-1.649 5.1-.808 8.235 1.878s4.532 6.2 3.119 7.85z"
+          fill="#749BFF"
+        />
+      </g>
+      <g filter="url(#antigravity-b10)">
+        <path
+          d="M18.163 9.077c5.81 3.93 12.502 4.19 14.946.577 2.443-3.612-.287-9.727-6.098-13.658-5.81-3.931-12.502-4.19-14.946-.577-2.443 3.612.287 9.727 6.098 13.658z"
+          fill="#FC413D"
+        />
+      </g>
+      <g filter="url(#antigravity-b11)">
+        <path
+          d="M-.915 2.684c-1.44 3.473-.97 6.967 1.05 7.804 2.02.837 4.824-1.3 6.264-4.772 1.44-3.473.97-6.967-1.05-7.804-2.02-.837-4.824 1.3-6.264 4.772z"
+          fill="#FFEE48"
+        />
+      </g>
+    </g>
+    <defs>
+      <filter
+        id="antigravity-b1"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-3.288"
+        y="-11.917"
+        width="19.838"
+        height="17.587"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="1.117" />
+      </filter>
+      <filter
+        id="antigravity-b2"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="4.251"
+        y="-13.493"
+        width="38.9"
+        height="38.565"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="5.4" />
+      </filter>
+      <filter
+        id="antigravity-b3"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-21.889"
+        y="-10.592"
+        width="40.955"
+        height="36.517"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="4.591" />
+      </filter>
+      <filter
+        id="antigravity-b4"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-21.889"
+        y="-10.592"
+        width="40.955"
+        height="36.517"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="4.591" />
+      </filter>
+      <filter
+        id="antigravity-b5"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-19.099"
+        y="-10.278"
+        width="36.632"
+        height="36.595"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="4.591" />
+      </filter>
+      <filter
+        id="antigravity-b6"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x=".981"
+        y="8.758"
+        width="33.533"
+        height="34.087"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="4.363" />
+      </filter>
+      <filter
+        id="antigravity-b7"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-6.143"
+        y="-21.659"
+        width="35.978"
+        height="35.276"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="3.954" />
+      </filter>
+      <filter
+        id="antigravity-b8"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-11.96"
+        y="-.46"
+        width="45.114"
+        height="46.523"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="3.531" />
+      </filter>
+      <filter
+        id="antigravity-b9"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="10.485"
+        y=".58"
+        width="25.094"
+        height="24.054"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="3.159" />
+      </filter>
+      <filter
+        id="antigravity-b10"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="5.833"
+        y="-12.467"
+        width="33.508"
+        height="30.007"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="2.669" />
+      </filter>
+      <filter
+        id="antigravity-b11"
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-8.355"
+        y="-8.876"
+        width="22.194"
+        height="26.151"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur result="blur" stdDeviation="3.303" />
+      </filter>
+    </defs>
+  </svg>
+);
+
+// The frame follows the theme via currentColor (near-black in light, near-white
+// in dark, matching the brand's two variants); the inner square approximates
+// the brand grays (#CFCECD light / #4B4646 dark) with reduced opacity.
+export const OpenCodeSVG = () => (
+  <svg
+    width="32"
+    height="32"
+    viewBox="0 0 32 32"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>OpenCode</title>
+    <g transform="translate(3.2 0)">
+      <path
+        d="M19.2,25.6 L6.4,25.6 L6.4,12.8 L19.2,12.8 L19.2,25.6"
+        fill="currentColor"
+        fillOpacity="0.25"
+      />
+      <path
+        d="M19.2,6.4 L6.4,6.4 L6.4,25.6 L19.2,25.6 L19.2,6.4 M25.6,32 L0,32 L0,0 L25.6,0 L25.6,32"
+        fill="currentColor"
+      />
+    </g>
+  </svg>
+);
+
 export const RubyLLMSVG = () => (
   <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
     <g clipPath="url(#rubyllm-clip)">
@@ -1355,6 +1622,7 @@ export const VSCodeSVG = () => (
  */
 export const INTEGRATION_ICONS: Record<string, () => React.JSX.Element> = {
   AgnoSVG,
+  AntigravitySVG,
   AnthropicSVG,
   AutogenSVG,
   BasetenSVG,
@@ -1382,6 +1650,7 @@ export const INTEGRATION_ICONS: Record<string, () => React.JSX.Element> = {
   MistralAISVG,
   NodeJSSVG,
   OpenAISVG,
+  OpenCodeSVG,
   OpenRouterSVG,
   PortkeySVG,
   PydanticAISVG,

--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -36,48 +36,56 @@ export function useViewerCanModify() {
 }
 
 /**
- * Returns true if the viewer is an admin.
- * Note: when the app is not configured with auth, we assume the user is an admin
- * (matching IsAdminIfAuthEnabled server-side)
+ * Returns true if the viewer is an admin or authentication is disabled.
+ * This matches the server-side IsAdminIfAuthEnabled permission.
  */
-export function useIsAdmin() {
+export function useIsAdminOrAuthDisabled() {
   const { viewer } = useViewer();
-  return !viewer || viewer.role?.name === "ADMIN";
+  return !window.Config.authenticationEnabled || viewer?.role?.name === "ADMIN";
+}
+
+/**
+ * Returns true only for an authenticated admin.
+ * This matches the server-side IsAdmin permission.
+ */
+export function useIsAuthenticatedAdmin() {
+  const { viewer } = useViewer();
+  return window.Config.authenticationEnabled && viewer?.role?.name === "ADMIN";
 }
 
 /**
  * Returns true if the viewer can manage retention policies
  */
 export function useViewerCanManageRetentionPolicy() {
-  return useIsAdmin();
+  return useIsAdminOrAuthDisabled();
 }
 
 /**
  * Returns true if the viewer can manage sandboxes
  */
 export function useViewerCanManageSandboxes() {
-  return useIsAdmin();
+  return useIsAdminOrAuthDisabled();
 }
 
 /**
  * Returns true if the viewer can manage secrets
  */
 export function useViewerCanManageSecrets() {
-  return useIsAdmin();
+  return useIsAdminOrAuthDisabled();
 }
 
 /**
  * Returns true if the viewer should be shown platform version update notices
  */
 export function useViewerCanSeeVersionUpdates() {
-  return useIsAdmin();
+  return useIsAdminOrAuthDisabled();
 }
 
 /**
  * Returns true if the viewer can bulk-delete a project's annotations
  */
 export function useViewerCanDeleteProjectAnnotations() {
-  return useIsAdmin();
+  return useIsAdminOrAuthDisabled();
 }
 
 export function ViewerProvider({

--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -40,8 +40,8 @@ export function useViewerCanModify() {
  * This matches the server-side IsAdminIfAuthEnabled permission.
  */
 export function useIsAdminOrAuthDisabled() {
-  const { viewer } = useViewer();
-  return !window.Config.authenticationEnabled || viewer?.role?.name === "ADMIN";
+  const isAuthenticatedAdmin = useIsAuthenticatedAdmin();
+  return !window.Config.authenticationEnabled || isAuthenticatedAdmin;
 }
 
 /**

--- a/app/src/contexts/__tests__/ViewerContext.test.tsx
+++ b/app/src/contexts/__tests__/ViewerContext.test.tsx
@@ -1,0 +1,105 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import {
+  useIsAdminOrAuthDisabled,
+  useIsAuthenticatedAdmin,
+  ViewerContext,
+  type ViewerContextType,
+} from "../ViewerContext";
+
+let container: HTMLDivElement;
+let root: Root;
+let originalAuthenticationEnabled: boolean;
+
+beforeEach(() => {
+  originalAuthenticationEnabled = window.Config.authenticationEnabled;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  window.Config.authenticationEnabled = originalAuthenticationEnabled;
+});
+
+function AuthorizationStatus() {
+  const isAdminOrAuthDisabled = useIsAdminOrAuthDisabled();
+  const isAuthenticatedAdmin = useIsAuthenticatedAdmin();
+  return (
+    <output>
+      {String(isAdminOrAuthDisabled)}|{String(isAuthenticatedAdmin)}
+    </output>
+  );
+}
+
+function buildViewer(role: string): NonNullable<ViewerContextType["viewer"]> {
+  return {
+    authMethod: "LOCAL",
+    email: `${role.toLowerCase()}@localhost`,
+    id: role,
+    isManagementUser: false,
+    profilePictureUrl: null,
+    role: { name: role },
+    username: role.toLowerCase(),
+  } as NonNullable<ViewerContextType["viewer"]>;
+}
+
+function renderAuthorizationStatus({
+  isAuthenticationEnabled,
+  viewer,
+}: {
+  isAuthenticationEnabled: boolean;
+  viewer: ViewerContextType["viewer"];
+}) {
+  window.Config.authenticationEnabled = isAuthenticationEnabled;
+  act(() => {
+    root.render(
+      <ViewerContext.Provider value={{ viewer, refetchViewer: () => {} }}>
+        <AuthorizationStatus />
+      </ViewerContext.Provider>
+    );
+  });
+}
+
+describe("viewer authorization hooks", () => {
+  it("distinguishes auth-disabled access from an authenticated admin", () => {
+    renderAuthorizationStatus({
+      isAuthenticationEnabled: false,
+      viewer: null,
+    });
+
+    expect(container.textContent).toBe("true|false");
+  });
+
+  it("recognizes an authenticated admin", () => {
+    renderAuthorizationStatus({
+      isAuthenticationEnabled: true,
+      viewer: buildViewer("ADMIN"),
+    });
+
+    expect(container.textContent).toBe("true|true");
+  });
+
+  it("does not treat a missing viewer as admin when authentication is enabled", () => {
+    renderAuthorizationStatus({
+      isAuthenticationEnabled: true,
+      viewer: null,
+    });
+
+    expect(container.textContent).toBe("false|false");
+  });
+
+  it("rejects an authenticated non-admin", () => {
+    renderAuthorizationStatus({
+      isAuthenticationEnabled: true,
+      viewer: buildViewer("MEMBER"),
+    });
+
+    expect(container.textContent).toBe("false|false");
+  });
+});

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -264,7 +264,7 @@ function SideNav() {
           </li>
           <li key="settings">
             <NavLink
-              to="/settings/general"
+              to="/settings"
               text="Settings"
               leadingVisual={<Icon svg={<Icons.Options />} />}
               isExpanded={isSideNavExpanded}

--- a/app/src/pages/settings/SettingsAgentsPage.tsx
+++ b/app/src/pages/settings/SettingsAgentsPage.tsx
@@ -21,7 +21,7 @@ import {
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
-import { useIsAdmin } from "@phoenix/contexts/ViewerContext";
+import { useIsAdminOrAuthDisabled } from "@phoenix/contexts/ViewerContext";
 
 import { SettingsAgentsAdminSettingsSection } from "./SettingsAgentsWorkspaceCard";
 
@@ -76,7 +76,7 @@ const settingSwitchCSS = css`
 `;
 
 function AssistantAgentEnabledSetting() {
-  const isAdmin = useIsAdmin();
+  const isAdmin = useIsAdminOrAuthDisabled();
   const adminAssistantEnabled = useAgentContext(
     (state) => state.agentsConfig.assistantEnabled
   );
@@ -189,7 +189,7 @@ function PersonalSettingsSection() {
 }
 
 export function SettingsAgentsPage() {
-  const isAdmin = useIsAdmin();
+  const isAdmin = useIsAdminOrAuthDisabled();
   const isExperimentalSettingsEnabled = useFeatureFlag(
     "agent-experimental-settings"
   );

--- a/app/src/pages/settings/SettingsMCPPage.tsx
+++ b/app/src/pages/settings/SettingsMCPPage.tsx
@@ -90,11 +90,6 @@ const vsCodeConfig = JSON.stringify(
   null,
   2
 );
-const codexConfig = [
-  "[mcp_servers.phoenix]",
-  `url = "${mcpUrl}"`,
-  'bearer_token_env_var = "PHOENIX_API_KEY"',
-].join("\n");
 const apiKeyConfig = JSON.stringify(
   {
     mcpServers: {
@@ -109,105 +104,124 @@ const apiKeyConfig = JSON.stringify(
 );
 
 // One entry per MCP client rendered in the "Connect a client" disclosure
-// group. Everything here is static, so the list lives at module scope.
-const CLIENTS = [
-  {
-    id: "claude-code",
-    label: "Claude Code",
-    icon: <ClaudeSVG />,
-    content: (
-      <>
-        <BashBlockWithCopy
-          value={`claude mcp add --transport http phoenix ${mcpUrl}`}
-        />
+// group. The copy differs by deployment: with auth enabled each client walks
+// through its login flow; without auth the URL alone is a complete config.
+function getClients({ isAuthEnabled }: { isAuthEnabled: boolean }) {
+  const codexConfig = [
+    "[mcp_servers.phoenix]",
+    `url = "${mcpUrl}"`,
+    ...(isAuthEnabled ? ['bearer_token_env_var = "PHOENIX_API_KEY"'] : []),
+  ].join("\n");
+  return [
+    {
+      id: "claude-code",
+      label: "Claude Code",
+      icon: <ClaudeSVG />,
+      content: (
+        <>
+          <BashBlockWithCopy
+            value={`claude mcp add --transport http phoenix ${mcpUrl}`}
+          />
+          <Text size="S" color="text-700">
+            {isAuthEnabled
+              ? "Then run /mcp inside Claude Code, select phoenix, and complete the browser login."
+              : "Then run /mcp inside Claude Code and select phoenix to verify the connection."}
+          </Text>
+        </>
+      ),
+    },
+    {
+      id: "claude-desktop",
+      label: "Claude Desktop",
+      icon: <ClaudeSVG />,
+      content: (
+        <>
+          <Text size="S" color="text-700">
+            Go to Settings → Connectors → Add custom connector and enter the
+            name Phoenix with the URL below.
+            {isAuthEnabled &&
+              " Claude Desktop opens the browser login the first time you use the connector."}
+          </Text>
+          <CopyField value={mcpUrl} aria-label="Phoenix MCP URL">
+            <CopyInput />
+          </CopyField>
+        </>
+      ),
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      icon: <OpenAISVG />,
+      content: (
+        <>
+          <Text size="S" color="text-700">
+            {isAuthEnabled
+              ? "Codex authenticates with an API key. Create a Phoenix API key, export it as PHOENIX_API_KEY, and add to ~/.codex/config.toml:"
+              : "Add to ~/.codex/config.toml:"}
+          </Text>
+          <TomlBlockWithCopy value={codexConfig} />
+        </>
+      ),
+    },
+    {
+      id: "cursor",
+      label: "Cursor",
+      icon: <CursorSVG />,
+      content: (
+        <>
+          <Text size="S" color="text-700">
+            Add to ~/.cursor/mcp.json (or the project&apos;s .cursor/mcp.json).
+            {isAuthEnabled &&
+              " Cursor prompts you to log in via the browser on first use."}
+          </Text>
+          <JSONBlockWithCopy value={cursorConfig} />
+        </>
+      ),
+    },
+    {
+      id: "vscode",
+      label: "VS Code",
+      icon: <VSCodeSVG />,
+      content: (
+        <>
+          <Text size="S" color="text-700">
+            Run MCP: Add Server from the Command Palette, or add to
+            .vscode/mcp.json.
+            {isAuthEnabled &&
+              " VS Code walks you through the browser login when the server first starts."}
+          </Text>
+          <JSONBlockWithCopy value={vsCodeConfig} />
+        </>
+      ),
+    },
+    {
+      id: "other",
+      label: "Other clients",
+      icon: <McpSVG />,
+      content: isAuthEnabled ? (
+        <>
+          <Text size="S" color="text-700">
+            Any client that supports streamable HTTP and OAuth works — configure
+            the URL above and complete the login prompt on first use. For
+            headless environments or clients that can&apos;t complete a browser
+            login, pass a Phoenix API key as a Bearer header instead:
+          </Text>
+          <JSONBlockWithCopy value={apiKeyConfig} />
+        </>
+      ) : (
         <Text size="S" color="text-700">
-          Then run /mcp inside Claude Code, select phoenix, and complete the
-          browser login.
+          Any client that supports streamable HTTP works — configuring the URL
+          above is all it takes; no credentials are required on this deployment.
         </Text>
-      </>
-    ),
-  },
-  {
-    id: "claude-desktop",
-    label: "Claude Desktop",
-    icon: <ClaudeSVG />,
-    content: (
-      <>
-        <Text size="S" color="text-700">
-          Go to Settings → Connectors → Add custom connector and enter the name
-          Phoenix with the URL below. Claude Desktop opens the browser login the
-          first time you use the connector.
-        </Text>
-        <CopyField value={mcpUrl} aria-label="Phoenix MCP URL">
-          <CopyInput />
-        </CopyField>
-      </>
-    ),
-  },
-  {
-    id: "codex",
-    label: "Codex",
-    icon: <OpenAISVG />,
-    content: (
-      <>
-        <Text size="S" color="text-700">
-          Codex authenticates with an API key. Create a Phoenix API key, export
-          it as PHOENIX_API_KEY, and add to ~/.codex/config.toml:
-        </Text>
-        <TomlBlockWithCopy value={codexConfig} />
-      </>
-    ),
-  },
-  {
-    id: "cursor",
-    label: "Cursor",
-    icon: <CursorSVG />,
-    content: (
-      <>
-        <Text size="S" color="text-700">
-          Add to ~/.cursor/mcp.json (or the project&apos;s .cursor/mcp.json).
-          Cursor prompts you to log in via the browser on first use.
-        </Text>
-        <JSONBlockWithCopy value={cursorConfig} />
-      </>
-    ),
-  },
-  {
-    id: "vscode",
-    label: "VS Code",
-    icon: <VSCodeSVG />,
-    content: (
-      <>
-        <Text size="S" color="text-700">
-          Run MCP: Add Server from the Command Palette, or add to
-          .vscode/mcp.json. VS Code walks you through the browser login when the
-          server first starts.
-        </Text>
-        <JSONBlockWithCopy value={vsCodeConfig} />
-      </>
-    ),
-  },
-  {
-    id: "other",
-    label: "Other clients",
-    icon: <McpSVG />,
-    content: (
-      <>
-        <Text size="S" color="text-700">
-          Any client that supports streamable HTTP and OAuth works — configure
-          the URL above and complete the login prompt on first use. For headless
-          environments or clients that can&apos;t complete a browser login, pass
-          a Phoenix API key as a Bearer header instead:
-        </Text>
-        <JSONBlockWithCopy value={apiKeyConfig} />
-      </>
-    ),
-  },
-];
+      ),
+    },
+  ];
+}
 
 export function SettingsMCPPage() {
   const { mcpServerEnabled, mcpCodeModeEnabled, authenticationEnabled } =
     window.Config;
+  const clients = getClients({ isAuthEnabled: authenticationEnabled });
 
   return (
     <Card
@@ -275,7 +289,7 @@ export function SettingsMCPPage() {
               borderRadius="medium"
             >
               <DisclosureGroup defaultExpandedKeys={["claude-code"]}>
-                {CLIENTS.map((client) => (
+                {clients.map((client) => (
                   <Disclosure id={client.id} key={client.id}>
                     <DisclosureTrigger arrowPosition="start">
                       <Icon svg={client.icon} aria-hidden />

--- a/app/src/pages/settings/SettingsMCPPage.tsx
+++ b/app/src/pages/settings/SettingsMCPPage.tsx
@@ -25,10 +25,12 @@ import {
   TomlBlockWithCopy,
 } from "@phoenix/components/code";
 import {
+  AntigravitySVG,
   ClaudeSVG,
   CursorSVG,
   McpSVG,
   OpenAISVG,
+  OpenCodeSVG,
   VSCodeSVG,
 } from "@phoenix/components/project/IntegrationIcons";
 import { BASE_URL } from "@phoenix/config";
@@ -90,6 +92,15 @@ const vsCodeConfig = JSON.stringify(
   null,
   2
 );
+// Mirrors the fragment the px CLI writes via `px setup mcp --agent opencode`.
+const opencodeConfig = JSON.stringify(
+  {
+    $schema: "https://opencode.ai/config.json",
+    mcp: { phoenix: { type: "remote", url: mcpUrl, enabled: true } },
+  },
+  null,
+  2
+);
 const apiKeyConfig = JSON.stringify(
   {
     mcpServers: {
@@ -112,6 +123,22 @@ function getClients({ isAuthEnabled }: { isAuthEnabled: boolean }) {
     `url = "${mcpUrl}"`,
     ...(isAuthEnabled ? ['bearer_token_env_var = "PHOENIX_API_KEY"'] : []),
   ].join("\n");
+  // Antigravity has no OAuth flow for third-party MCP servers — remote servers
+  // use `serverUrl` plus a Bearer header when the deployment requires auth.
+  const antigravityConfig = JSON.stringify(
+    {
+      mcpServers: {
+        phoenix: {
+          serverUrl: mcpUrl,
+          ...(isAuthEnabled
+            ? { headers: { Authorization: "Bearer <your-api-key>" } }
+            : {}),
+        },
+      },
+    },
+    null,
+    2
+  );
   return [
     {
       id: "claude-code",
@@ -149,6 +176,24 @@ function getClients({ isAuthEnabled }: { isAuthEnabled: boolean }) {
       ),
     },
     {
+      id: "antigravity",
+      label: "Antigravity",
+      icon: <AntigravitySVG />,
+      content: (
+        <>
+          <Text size="S" color="text-700">
+            {isAuthEnabled
+              ? "Antigravity authenticates with an API key. Create a Phoenix API key and add to ~/.gemini/config/mcp_config.json:"
+              : "Add to ~/.gemini/config/mcp_config.json:"}
+          </Text>
+          <JSONBlockWithCopy value={antigravityConfig} />
+          <Text size="S" color="text-700">
+            Antigravity reloads the config automatically when you save.
+          </Text>
+        </>
+      ),
+    },
+    {
       id: "codex",
       label: "Codex",
       icon: <OpenAISVG />,
@@ -175,6 +220,22 @@ function getClients({ isAuthEnabled }: { isAuthEnabled: boolean }) {
               " Cursor prompts you to log in via the browser on first use."}
           </Text>
           <JSONBlockWithCopy value={cursorConfig} />
+        </>
+      ),
+    },
+    {
+      id: "opencode",
+      label: "OpenCode",
+      icon: <OpenCodeSVG />,
+      content: (
+        <>
+          <Text size="S" color="text-700">
+            Add to ~/.config/opencode/opencode.json (or the project&apos;s
+            opencode.json).
+            {isAuthEnabled &&
+              " OpenCode prompts you to log in via the browser on first use."}
+          </Text>
+          <JSONBlockWithCopy value={opencodeConfig} />
         </>
       ),
     },

--- a/app/src/pages/settings/SettingsMCPPage.tsx
+++ b/app/src/pages/settings/SettingsMCPPage.tsx
@@ -206,7 +206,8 @@ const CLIENTS = [
 ];
 
 export function SettingsMCPPage() {
-  const { mcpServerEnabled, mcpCodeModeEnabled } = window.Config;
+  const { mcpServerEnabled, mcpCodeModeEnabled, authenticationEnabled } =
+    window.Config;
 
   return (
     <Card
@@ -232,8 +233,10 @@ export function SettingsMCPPage() {
               <CopyInput />
             </CopyField>
             <Text size="S" color="text-700">
-              Point any MCP-compatible client at this URL. Clients authenticate
-              with OAuth or a Phoenix API key.{" "}
+              Point any MCP-compatible client at this URL.{" "}
+              {authenticationEnabled
+                ? "Clients authenticate with OAuth or a Phoenix API key. "
+                : "Authentication is disabled on this deployment, so clients connect without credentials. "}
               {mcpServerEnabled
                 ? mcpCodeModeEnabled
                   ? "Code mode is enabled: clients see a compact set of discovery tools plus a sandboxed execute tool that composes Phoenix operations in one step. "

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -17,7 +17,7 @@ import {
 import { PxiGlyphOutline } from "@phoenix/components/agent";
 import { McpSVG } from "@phoenix/components/project/IntegrationIcons";
 import {
-  useIsAdmin,
+  useIsAuthenticatedAdmin,
   useViewerCanManageSandboxes,
   useViewerCanManageSecrets,
 } from "@phoenix/contexts";
@@ -108,14 +108,14 @@ export function SettingsPage() {
       navigate(`/settings/${tab}`, { replace: true });
     }
   };
-  const isAdmin = useIsAdmin();
+  const isAuthenticatedAdmin = useIsAuthenticatedAdmin();
   const canManageSecrets = useViewerCanManageSecrets();
   const canManageSandboxes = useViewerCanManageSandboxes();
   // Tabs absent from this map are visible to everyone.
   const tabVisibility: Partial<Record<SettingsTabId, boolean>> = {
     agents: !window.Config.agentAssistantDisabled,
-    users: isAdmin,
-    "api-keys": isAdmin,
+    users: isAuthenticatedAdmin,
+    "api-keys": isAuthenticatedAdmin,
     secrets: canManageSecrets,
     sandboxes: canManageSandboxes,
   };

--- a/app/src/pages/settings/UserDetailsDrawer.tsx
+++ b/app/src/pages/settings/UserDetailsDrawer.tsx
@@ -23,7 +23,7 @@ import { DRAWER_DEFAULT_MIN_SIZE } from "@phoenix/components/core/overlay/consta
 import { useDefaultDrawerSize } from "@phoenix/components/core/overlay/useDefaultDrawerSize";
 import { UserPicture } from "@phoenix/components/user/UserPicture";
 import { normalizeUserRole } from "@phoenix/constants";
-import { useIsAdmin } from "@phoenix/contexts";
+import { useIsAuthenticatedAdmin } from "@phoenix/contexts";
 import { AuthorizedApplicationsCard } from "@phoenix/pages/profile/AuthorizedApplicationsCard";
 import type { UserDetailsDrawerQuery } from "@phoenix/pages/settings/__generated__/UserDetailsDrawerQuery.graphql";
 import { UserAPIKeysCard } from "@phoenix/pages/settings/UserAPIKeysCard";
@@ -139,7 +139,7 @@ function UserDetailsContent({ userId }: { userId: string }) {
 export function UserDetailsDrawer() {
   const { userId } = useParams();
   const navigate = useNavigate();
-  const isAdmin = useIsAdmin();
+  const isAdmin = useIsAuthenticatedAdmin();
   const { defaultSize, onSizeChange } = useDefaultDrawerSize({
     id: "settings-user-details",
   });

--- a/app/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/app/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -3,7 +3,11 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { vi } from "vitest";
 
+import { installTestMatchMedia } from "@phoenix/__tests__/installTestMatchMedia";
+
 import { SettingsPage } from "../SettingsPage";
+
+installTestMatchMedia();
 
 let container: HTMLDivElement;
 let root: Root;
@@ -12,14 +16,6 @@ let originalAuthenticationEnabled: boolean;
 beforeEach(() => {
   originalAuthenticationEnabled = window.Config.authenticationEnabled;
   window.Config.authenticationEnabled = false;
-  vi.stubGlobal(
-    "matchMedia",
-    vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    })
-  );
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -32,7 +28,6 @@ afterEach(() => {
   container.remove();
   window.Config.authenticationEnabled = originalAuthenticationEnabled;
   vi.restoreAllMocks();
-  vi.unstubAllGlobals();
 });
 
 function CurrentSettingsRoute() {

--- a/app/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/app/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,83 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { vi } from "vitest";
+
+import { SettingsPage } from "../SettingsPage";
+
+let container: HTMLDivElement;
+let root: Root;
+let originalAuthenticationEnabled: boolean;
+
+beforeEach(() => {
+  originalAuthenticationEnabled = window.Config.authenticationEnabled;
+  window.Config.authenticationEnabled = false;
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+  );
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  window.Config.authenticationEnabled = originalAuthenticationEnabled;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function CurrentSettingsRoute() {
+  const { pathname } = useLocation();
+  return <output>{pathname}</output>;
+}
+
+async function renderSettingsPage(initialEntry: string) {
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/settings" element={<SettingsPage />}>
+            <Route path="general" element={<CurrentSettingsRoute />} />
+            <Route path="users" element={<div>Users page</div>} />
+            <Route path="api-keys" element={<div>API Keys page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+  });
+}
+
+describe("SettingsPage access control without authentication", () => {
+  it.each(["/settings/users", "/settings/api-keys"])(
+    "redirects %s to general settings",
+    async (initialEntry) => {
+      await renderSettingsPage(initialEntry);
+
+      expect(container.querySelector("output")?.textContent).toBe(
+        "/settings/general"
+      );
+      expect(container.textContent).not.toContain("Users page");
+      expect(container.textContent).not.toContain("API Keys page");
+    }
+  );
+
+  it("does not render the Users or API Keys tabs", async () => {
+    await renderSettingsPage("/settings/general");
+
+    const tabNames = Array.from(
+      container.querySelectorAll('[role="tab"]'),
+      (tab) => tab.textContent
+    );
+    expect(tabNames).not.toContain("Users");
+    expect(tabNames).not.toContain("API Keys");
+  });
+});

--- a/app/tests/playground-prompt-configuration.spec.ts
+++ b/app/tests/playground-prompt-configuration.spec.ts
@@ -405,9 +405,9 @@ test.describe("Playground prompt configuration round-trip", () => {
   // and different canonicalization on the RESPONSES write path
   // (`max_output_tokens` → `max_completion_tokens`, nested `reasoning.effort`
   // → flat `reasoning_effort`). Running both ensures neither branch silently
-  // drops a shared field. The API Type is asserted after reload: the Responses
-  // case includes a raw Responses-only tool, so prompt rehydration must infer
-  // the Responses API surface instead of falling back to Chat Completions.
+  // drops a shared field. Saved prompts don't record the API type — on reload
+  // it is inferred from Responses-only tool shapes and otherwise assumed to be
+  // Responses (the default) — so both cases rehydrate to the Responses surface.
   for (const apiTypeLabel of ["Chat Completions", "Responses"] as const) {
     test(`OpenAI (${apiTypeLabel}): prompt configuration survives reload`, async ({
       page,
@@ -471,7 +471,7 @@ test.describe("Playground prompt configuration round-trip", () => {
       ).toHaveValue(expectedMaxCompletionTokens);
       await expect(
         reopened.getByTestId("invocation-param-apiType")
-      ).toContainText(apiTypeLabel);
+      ).toContainText("Responses");
       await expect(
         reopened.getByTestId("invocation-param-reasoningEffort")
       ).toContainText(expectedReasoningEffort);

--- a/app/tests/settings-access.spec.ts
+++ b/app/tests/settings-access.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function expectAdminSettingsAreInaccessible({ page }: { page: Page }) {
+  for (const path of ["/settings/users", "/settings/api-keys"]) {
+    await page.goto(path);
+    await page.waitForURL("**/settings/general");
+  }
+
+  await expect(page.getByRole("tab", { name: "Users" })).not.toBeVisible();
+  await expect(page.getByRole("tab", { name: "API Keys" })).not.toBeVisible();
+}
+
+test.describe("member settings access", () => {
+  test.use({ storageState: "playwright/.auth/member.json" });
+
+  test("redirects away from admin settings", async ({ page }) => {
+    await expectAdminSettingsAreInaccessible({ page });
+  });
+});
+
+test.describe("viewer settings access", () => {
+  test.use({ storageState: "playwright/.auth/viewer.json" });
+
+  test("redirects away from admin settings", async ({ page }) => {
+    await expectAdminSettingsAreInaccessible({ page });
+  });
+});

--- a/app/tests/settings-access.spec.ts
+++ b/app/tests/settings-access.spec.ts
@@ -6,22 +6,19 @@ async function expectAdminSettingsAreInaccessible({ page }: { page: Page }) {
     await page.waitForURL("**/settings/general");
   }
 
+  // Anchor on a tab that is visible to everyone so the negative assertions
+  // below can't pass vacuously on a blank or crashed page.
+  await expect(page.getByRole("tab", { name: "General" })).toBeVisible();
   await expect(page.getByRole("tab", { name: "Users" })).not.toBeVisible();
   await expect(page.getByRole("tab", { name: "API Keys" })).not.toBeVisible();
 }
 
-test.describe("member settings access", () => {
-  test.use({ storageState: "playwright/.auth/member.json" });
+for (const role of ["member", "viewer"] as const) {
+  test.describe(`${role} settings access`, () => {
+    test.use({ storageState: `playwright/.auth/${role}.json` });
 
-  test("redirects away from admin settings", async ({ page }) => {
-    await expectAdminSettingsAreInaccessible({ page });
+    test("redirects away from admin settings", async ({ page }) => {
+      await expectAdminSettingsAreInaccessible({ page });
+    });
   });
-});
-
-test.describe("viewer settings access", () => {
-  test.use({ storageState: "playwright/.auth/viewer.json" });
-
-  test("redirects away from admin settings", async ({ page }) => {
-    await expectAdminSettingsAreInaccessible({ page });
-  });
-});
+}

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -71,6 +71,13 @@ export default defineConfig(() => {
       environment: "jsdom",
       setupFiles: [resolve(__dirname, "./vitest.setup.ts")],
       globals: true,
+      server: {
+        deps: {
+          // codemirror-json-schema ships ESM with extensionless relative
+          // imports that Node's resolver rejects when externalized
+          inline: ["codemirror-json-schema"],
+        },
+      },
     },
     build: {
       manifest: true,

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -110,6 +110,30 @@ Clients authenticate with **OAuth** (authorization code + PKCE). Phoenix acts as
     </Steps>
   </Accordion>
 
+  <Accordion title="OpenCode">
+    <Steps>
+      <Step title="Add the Phoenix MCP server">
+        Add to `~/.config/opencode/opencode.json` (or project `opencode.json`):
+
+        ```json
+        {
+          "$schema": "https://opencode.ai/config.json",
+          "mcp": {
+            "phoenix": {
+              "type": "remote",
+              "url": "http://localhost:6006/mcp",
+              "enabled": true
+            }
+          }
+        }
+        ```
+      </Step>
+      <Step title="Log in">
+        OpenCode prompts you to log in via the browser on first use.
+      </Step>
+    </Steps>
+  </Accordion>
+
   <Accordion title="Codex (OpenAI)">
     Codex configures remote MCP servers with an API key. Create a [Phoenix API key](/docs/phoenix/settings/api-keys), export it as `PHOENIX_API_KEY`, and add to `~/.codex/config.toml`:
 
@@ -120,6 +144,25 @@ Clients authenticate with **OAuth** (authorization code + PKCE). Phoenix acts as
     ```
 
     Launch `codex` and run `/mcp` to verify the server is connected.
+  </Accordion>
+
+  <Accordion title="Antigravity">
+    Antigravity configures remote MCP servers with an API key. Create a [Phoenix API key](/docs/phoenix/settings/api-keys) and add to `~/.gemini/config/mcp_config.json` (or open **Manage MCP Servers → View raw config** from the agent panel):
+
+    ```json
+    {
+      "mcpServers": {
+        "phoenix": {
+          "serverUrl": "http://localhost:6006/mcp",
+          "headers": {
+            "Authorization": "Bearer <your-api-key>"
+          }
+        }
+      }
+    }
+    ```
+
+    Antigravity reloads the config automatically when you save. If your Phoenix instance runs without authentication, omit the `headers` block.
   </Accordion>
 
   <Accordion title="Other clients">


### PR DESCRIPTION
## Summary

- split permissive admin-or-auth-disabled checks from strict authenticated-admin checks
- hide the Users and API Keys settings tabs unless an authenticated admin is present
- redirect direct unauthorized routes to General settings
- add hook, no-auth route, member, viewer, and admin regression coverage

## Root cause

The dedicated Users and API Keys tabs used a helper whose contract intentionally treats auth-disabled deployments as admin-capable. Their GraphQL fields use the stricter server-side `IsAdmin` permission, so the frontend exposed routes whose data requests were guaranteed to fail when authentication was disabled.

## User impact

Auth-disabled Phoenix deployments no longer expose Settings pages that crash with `Only admin can perform this action`. Authenticated admins retain access, while members and viewers are redirected away from the admin-only routes.

## Validation

- `pnpm typecheck`
- targeted `oxlint`
- 7 focused Vitest tests
- production frontend build
- 5 Chromium Playwright tests covering admin, member, and viewer access
- live no-auth browser verification on an isolated Phoenix instance

Related: #14458