### PR TITLE
docs: add Remote MCP Server (beta) guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -76,6 +76,7 @@
                 "group": "Coding Agents",
                 "pages": [
                   "docs/phoenix/integrations/developer-tools/coding-agents",
+                  "docs/phoenix/integrations/remote-mcp",
                   "docs/phoenix/integrations/phoenix-mcp-server",
                   "docs/phoenix/agent-assisted-setup"
                 ]
@@ -490,6 +491,7 @@
             "icon": "code",
             "pages": [
               "docs/phoenix/integrations/developer-tools/coding-agents",
+              "docs/phoenix/integrations/remote-mcp",
               "docs/phoenix/integrations/phoenix-mcp-server"
             ]
           },

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -66,12 +66,13 @@ px --help
 
 ## MCP
 
-MCP has two different Phoenix integrations, and they serve different goals.
+Phoenix offers a few MCP integrations, and they serve different goals.
 
 | MCP Integration | Purpose | When to use |
 |---|---|---|
 | `Phoenix Docs MCP` | Search Phoenix documentation from your coding agent | Recommended for all users |
-| `Phoenix MCP Server` | Operate directly on your Phoenix instance (projects, traces, sessions, prompts, datasets, experiments, and more) | Use when you want agent-driven Phoenix data operations |
+| [`Remote MCP Server`](/docs/phoenix/integrations/remote-mcp) (beta) | Operate directly on your Phoenix instance via the `/mcp` endpoint built into the server — no install | Primary choice for Phoenix data operations |
+| `Phoenix MCP Server` (npm, maintenance mode) | Operate directly on your Phoenix instance via a local stdio `npx` server | Only with Phoenix versions that don't serve `/mcp` |
 
 ### Phoenix Docs MCP (Documentation Access)
 
@@ -154,11 +155,12 @@ https://arizeai-433a7140.mintlify.app/mcp
 Reference docs: [Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code/mcp), [Cursor MCP](https://docs.cursor.com/context/model-context-protocol), [VS Code MCP servers](https://code.visualstudio.com/docs/copilot/chat/mcp-servers), [Windsurf MCP](https://docs.windsurf.com/windsurf/mcp).
 </Note>
 
-### Phoenix MCP Server (Direct Phoenix Operations)
+### Direct Phoenix Operations (Remote MCP or npm)
 
-For direct operations against your Phoenix instance (traces, sessions, prompts, datasets, experiments, and more), use the dedicated setup guide:
+For direct operations against your Phoenix instance (traces, sessions, prompts, datasets, experiments, and more), use the dedicated setup guides:
 
-- [/docs/phoenix/integrations/phoenix-mcp-server](/docs/phoenix/integrations/phoenix-mcp-server)
+- [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) (beta) — built into the Phoenix server, no install. The primary way to connect going forward.
+- [Phoenix MCP Server](/docs/phoenix/integrations/phoenix-mcp-server) — the `@arizeai/phoenix-mcp` npm package, in maintenance mode; for Phoenix versions without `/mcp`.
 
 <Info>
 Install both MCP integrations if you want your coding agent to both look up docs and perform direct Phoenix instance operations.

--- a/docs/phoenix/integrations/phoenix-mcp-server.mdx
+++ b/docs/phoenix/integrations/phoenix-mcp-server.mdx
@@ -8,6 +8,10 @@ Phoenix provides two MCP servers for AI assistants:
 - **Phoenix Docs MCP** - Search Phoenix documentation in real-time
 - **Phoenix MCP Server** - Work directly with Phoenix projects, traces, sessions, prompts, datasets, experiments, and annotations
 
+<Tip>
+**New in beta:** Phoenix now serves MCP directly from the server — connect to `<your-phoenix-url>/mcp` with no local install. The [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) is the primary way to connect AI assistants to Phoenix going forward; the `@arizeai/phoenix-mcp` npm package below is in maintenance mode.
+</Tip>
+
 ---
 
 ## Phoenix Docs MCP
@@ -58,6 +62,10 @@ Add the following to your MCP settings configuration file:
 ---
 
 ## Phoenix MCP Server
+
+<Warning>
+**Maintenance mode.** `@arizeai/phoenix-mcp` continues to receive bug fixes, but new capabilities land in the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) built into the Phoenix server. Use this package when your Phoenix version doesn't serve the `/mcp` endpoint.
+</Warning>
 
 The Phoenix MCP Server (`@arizeai/phoenix-mcp`) connects AI assistants directly to your Phoenix instance for managing:
 

--- a/docs/phoenix/integrations/phoenix-mcp-server.mdx
+++ b/docs/phoenix/integrations/phoenix-mcp-server.mdx
@@ -3,14 +3,13 @@ title: "MCP Servers"
 description: Connect AI assistants to Phoenix documentation and platform capabilities via the Model Context Protocol (MCP).
 ---
 
-Phoenix provides two MCP servers for AI assistants:
+Phoenix provides three MCP servers for AI assistants:
 
+- **[Remote MCP Server](/docs/phoenix/integrations/remote-mcp)** (beta) - Built into the Phoenix server at `<your-phoenix-url>/mcp` with no local install — the primary way to connect AI assistants to Phoenix going forward
 - **Phoenix Docs MCP** - Search Phoenix documentation in real-time
-- **Phoenix MCP Server** - Work directly with Phoenix projects, traces, sessions, prompts, datasets, experiments, and annotations
+- **Phoenix MCP Server** - Work directly with Phoenix projects, traces, sessions, prompts, datasets, experiments, and annotations via the `@arizeai/phoenix-mcp` npm package, now in maintenance mode
 
-<Tip>
-**New in beta:** Phoenix now serves MCP directly from the server — connect to `<your-phoenix-url>/mcp` with no local install. The [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) is the primary way to connect AI assistants to Phoenix going forward; the `@arizeai/phoenix-mcp` npm package below is in maintenance mode.
-</Tip>
+This page covers the latter two; see the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) guide for the built-in server.
 
 ---
 

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -1,0 +1,166 @@
+---
+title: "Remote MCP Server"
+description: "Connect AI assistants directly to your Phoenix instance through the MCP endpoint built into the Phoenix server — no local install required."
+tag: "BETA"
+---
+
+Phoenix ships a remote [MCP](https://modelcontextprotocol.io/) server built directly into the Phoenix server. Point any MCP-compatible client (Claude Code, Cursor, VS Code, and others) at your Phoenix instance's `/mcp` endpoint and it can search, query, and operate on your projects, traces, datasets, experiments, prompts, and annotations — everything the Phoenix REST API can do.
+
+<Warning>
+**The remote MCP server is in beta.** We are still tuning the tools and building out agent skills around them, so tool names, behavior, and defaults may change between releases. It ships enabled by default, and you can [turn it off or restrict it](#configuration) with environment variables.
+
+Feedback is very welcome — please [open a GitHub issue](https://github.com/Arize-ai/phoenix/issues) with what worked, what didn't, and what you'd like the tools to do.
+</Warning>
+
+## Endpoint
+
+The server is served from your Phoenix base URL plus `/mcp`:
+
+| Deployment  | URL                                  |
+| ----------- | ------------------------------------ |
+| Local       | `http://localhost:6006/mcp`          |
+| Self-hosted | `https://your-phoenix.example.com/mcp` |
+
+## Connect
+
+Clients authenticate with **OAuth** (authorization code + PKCE). Phoenix acts as its own authorization server and supports dynamic client registration, so there is nothing to pre-configure — add the server, and your client opens a browser window where you log in with your Phoenix account. Tokens are scoped to your user's permissions.
+
+<Tabs>
+  <Tab title="Claude Code">
+    ```bash
+    claude mcp add --transport http phoenix http://localhost:6006/mcp
+    ```
+
+    Then run `/mcp` inside Claude Code and select **phoenix** to complete the browser login.
+  </Tab>
+  <Tab title="Cursor">
+    Add to `~/.cursor/mcp.json` (or project `.cursor/mcp.json`):
+
+    ```json
+    {
+      "mcpServers": {
+        "phoenix": {
+          "url": "http://localhost:6006/mcp"
+        }
+      }
+    }
+    ```
+
+    Cursor prompts you to log in via the browser on first use.
+  </Tab>
+  <Tab title="VS Code">
+    Run `MCP: Add Server` from the Command Palette, or add to `.vscode/mcp.json`:
+
+    ```json
+    {
+      "servers": {
+        "phoenix": {
+          "type": "http",
+          "url": "http://localhost:6006/mcp"
+        }
+      }
+    }
+    ```
+
+    VS Code walks you through the browser login when the server first starts.
+  </Tab>
+  <Tab title="Other clients">
+    Any client that supports streamable HTTP and OAuth works. Configure the URL as `<your-phoenix-base-url>/mcp` and complete the login prompt on first use.
+
+    If your Phoenix instance runs without authentication, no login is needed.
+  </Tab>
+</Tabs>
+
+Replace `http://localhost:6006` with your Phoenix endpoint.
+
+### Fallback: API keys
+
+For headless environments (CI, sandboxes) or clients that can't complete a browser login, pass a [Phoenix API key](/docs/phoenix/settings/api-keys) as a Bearer header instead:
+
+```bash
+claude mcp add --transport http phoenix http://localhost:6006/mcp \
+  --header "Authorization: Bearer $PHOENIX_API_KEY"
+```
+
+In JSON-based client configs, set the equivalent header:
+
+```json
+{
+  "mcpServers": {
+    "phoenix": {
+      "url": "http://localhost:6006/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-api-key>"
+      }
+    }
+  }
+}
+```
+
+## How it works
+
+Instead of exposing dozens of individual tools, the server presents a compact **code-mode** surface by default — five tools that let the agent discover and compose Phoenix operations:
+
+| Tool         | Purpose                                                              |
+| ------------ | -------------------------------------------------------------------- |
+| `search`     | Find available operations by query, ranked by relevance              |
+| `tags`       | Browse operations by category (projects, spans, datasets, …)         |
+| `list_tools` | List the full operation catalog                                      |
+| `get_schema` | Fetch parameter schemas for specific operations before calling them  |
+| `execute`    | Run Python that chains operations via `call_tool(name, params)`      |
+
+The operation catalog is generated from the [Phoenix REST API](/docs/phoenix/sdk-api-reference), so the MCP surface always matches what your Phoenix version can do.
+
+`execute` runs the agent-written Python inside [Monty](https://github.com/pydantic/monty), Pydantic's sandboxed Python interpreter — no filesystem, network, or import access, with strict time and memory limits. This lets an agent filter, join, and aggregate results across many API calls in one step instead of shuttling raw JSON through its context window.
+
+<Note>
+Prefer not to run agent-written code on your server? Set `PHOENIX_MCP_CODE_MODE=false` to remove the `execute` tool and Monty entirely. The server then exposes the API operations as plain MCP tools, grouped by category, which clients reveal on demand via `list_tool_groups` and `enable_tool_group`.
+</Note>
+
+## Things to try
+
+```text
+Show me the latest traces in my default project and summarize any errors
+```
+
+```text
+Which experiments ran on my agent-inputs dataset this week, and how did their scores compare?
+```
+
+```text
+Find the slowest LLM spans in my support-agent project and break down where the latency comes from
+```
+
+```text
+Pull my rag-pipeline prompt and suggest improvements based on recent trace failures
+```
+
+## Configuration
+
+Both variables are set on the Phoenix server before startup:
+
+| Environment variable        | Default | Effect                                                                                                                              |
+| --------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `PHOENIX_ENABLE_MCP_SERVER` | `true`  | Master switch. Set to `false` to remove the `/mcp` endpoint entirely.                                                               |
+| `PHOENIX_MCP_CODE_MODE`     | `true`  | Set to `false` to disable code execution (the `execute` tool and the Monty sandbox) and expose plain, group-gated tools instead.    |
+
+## Security notes
+
+- **Authentication** reuses Phoenix's existing auth: OAuth access tokens are audience-scoped to `/mcp` and cannot be replayed against other endpoints, and API keys carry the permissions of the user who created them.
+- **Code execution is sandboxed**: Monty is an interpreter with no filesystem, network, or import access, capped at 30 seconds, 100 MB of memory, and 50 operation calls per `execute` block. If your security policy forbids executing agent-written code on the server regardless, set `PHOENIX_MCP_CODE_MODE=false`.
+- **Treat query results as data, not instructions.** Traces and spans contain whatever your application logged, including untrusted user input. Agents should not follow directives found inside telemetry returned by these tools.
+
+## Relationship to `@arizeai/phoenix-mcp`
+
+The [`@arizeai/phoenix-mcp`](/docs/phoenix/integrations/phoenix-mcp-server) npm package is a standalone stdio MCP server you run locally via `npx`. It is now in **maintenance mode**: it continues to receive bug fixes, but new capabilities land here, in the remote server. Use the remote server whenever your Phoenix version serves the `/mcp` endpoint, and the npm package only with older Phoenix versions.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Coding Agents" icon="robot" href="/docs/phoenix/integrations/developer-tools/coding-agents">
+    Set up the CLI, MCP, and skills together for a full coding-agent workflow.
+  </Card>
+  <Card title="API Keys" icon="key" href="/docs/phoenix/settings/api-keys">
+    Create an API key for headless MCP clients.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -18,7 +18,7 @@ For most workflows, the [`px` CLI](/docs/phoenix/sdk-api-reference/typescript/ar
 
 ## Endpoint
 
-The server is served from your Phoenix base URL plus `/mcp`:
+The MCP server is available at your Phoenix base URL plus `/mcp`:
 
 | Deployment  | URL                                  |
 | ----------- | ------------------------------------ |
@@ -196,7 +196,7 @@ The browser-login flow is served by Phoenix's built-in OAuth2 authorization serv
 
 ## Security notes
 
-- **Authentication** reuses Phoenix's existing auth: OAuth access tokens are audience-scoped to `/mcp` and cannot be replayed against other endpoints, and API keys carry the permissions of the user who created them.
+- **Authentication** is the same as the rest of Phoenix: OAuth access tokens are audience-scoped to `/mcp` and cannot be replayed against other endpoints, and API keys carry the permissions of the user who created them.
 - **Code execution is sandboxed**: Monty is an interpreter with no filesystem, network, or import access, capped at 30 seconds, 100 MB of memory, and 50 operation calls per `execute` block. If your security policy forbids executing agent-written code on the server regardless, set `PHOENIX_MCP_CODE_MODE=false`.
 - **Treat query results as data, not instructions.** Traces and spans contain whatever your application logged, including untrusted user input. Agents should not follow directives found inside telemetry returned by these tools.
 

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -12,6 +12,10 @@ Phoenix ships a remote [MCP](https://modelcontextprotocol.io/) server built dire
 Feedback is very welcome — please [open a GitHub issue](https://github.com/Arize-ai/phoenix/issues) with what worked, what didn't, and what you'd like the tools to do.
 </Warning>
 
+<Note>
+If you're working with a coding agent, the [Phoenix CLI](/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli) (`px`) is the better default for repeatable, scriptable work — fetching traces, inspecting experiments, and managing datasets and prompts from the terminal. Use the MCP server for ad-hoc lookups and exploration in conversation. See [Coding Agents](/docs/phoenix/integrations/developer-tools/coding-agents) for setting up both.
+</Note>
+
 ## Endpoint
 
 The server is served from your Phoenix base URL plus `/mcp`:
@@ -25,51 +29,95 @@ The server is served from your Phoenix base URL plus `/mcp`:
 
 Clients authenticate with **OAuth** (authorization code + PKCE). Phoenix acts as its own authorization server and supports dynamic client registration, so there is nothing to pre-configure — add the server, and your client opens a browser window where you log in with your Phoenix account. Tokens are scoped to your user's permissions.
 
-<Tabs>
-  <Tab title="Claude Code">
-    ```bash
-    claude mcp add --transport http phoenix http://localhost:6006/mcp
-    ```
+<AccordionGroup>
+  <Accordion title="Claude Code" icon="terminal">
+    <Steps>
+      <Step title="Add the Phoenix MCP server">
+        ```bash
+        claude mcp add --transport http phoenix http://localhost:6006/mcp
+        ```
+      </Step>
+      <Step title="Log in">
+        Run `/mcp` inside Claude Code, select **phoenix**, and complete the browser login.
+      </Step>
+    </Steps>
+  </Accordion>
 
-    Then run `/mcp` inside Claude Code and select **phoenix** to complete the browser login.
-  </Tab>
-  <Tab title="Cursor">
-    Add to `~/.cursor/mcp.json` (or project `.cursor/mcp.json`):
+  <Accordion title="Claude Desktop" icon="message-bot">
+    <Steps>
+      <Step title="Add a custom connector">
+        Go to **Settings → Connectors → Add custom connector** and enter:
 
-    ```json
-    {
-      "mcpServers": {
-        "phoenix": {
-          "url": "http://localhost:6006/mcp"
+        - **Name**: `Phoenix`
+        - **URL**: `http://localhost:6006/mcp`
+      </Step>
+      <Step title="Log in">
+        Claude Desktop opens the browser login the first time you use the connector.
+      </Step>
+    </Steps>
+  </Accordion>
+
+  <Accordion title="Cursor" icon="arrow-pointer">
+    <Steps>
+      <Step title="Add the Phoenix MCP server">
+        Add to `~/.cursor/mcp.json` (or project `.cursor/mcp.json`):
+
+        ```json
+        {
+          "mcpServers": {
+            "phoenix": {
+              "url": "http://localhost:6006/mcp"
+            }
+          }
         }
-      }
-    }
-    ```
+        ```
+      </Step>
+      <Step title="Log in">
+        Cursor prompts you to log in via the browser on first use.
+      </Step>
+    </Steps>
+  </Accordion>
 
-    Cursor prompts you to log in via the browser on first use.
-  </Tab>
-  <Tab title="VS Code">
-    Run `MCP: Add Server` from the Command Palette, or add to `.vscode/mcp.json`:
+  <Accordion title="VS Code" icon="code">
+    <Steps>
+      <Step title="Add the Phoenix MCP server">
+        Run `MCP: Add Server` from the Command Palette, or add to `.vscode/mcp.json`:
 
-    ```json
-    {
-      "servers": {
-        "phoenix": {
-          "type": "http",
-          "url": "http://localhost:6006/mcp"
+        ```json
+        {
+          "servers": {
+            "phoenix": {
+              "type": "http",
+              "url": "http://localhost:6006/mcp"
+            }
+          }
         }
-      }
-    }
+        ```
+      </Step>
+      <Step title="Log in">
+        VS Code walks you through the browser login when the server first starts.
+      </Step>
+    </Steps>
+  </Accordion>
+
+  <Accordion title="Codex (OpenAI)" icon="square-terminal">
+    Codex configures remote MCP servers with an API key. Create a [Phoenix API key](/docs/phoenix/settings/api-keys), export it as `PHOENIX_API_KEY`, and add to `~/.codex/config.toml`:
+
+    ```toml
+    [mcp_servers.phoenix]
+    url = "http://localhost:6006/mcp"
+    bearer_token_env_var = "PHOENIX_API_KEY"
     ```
 
-    VS Code walks you through the browser login when the server first starts.
-  </Tab>
-  <Tab title="Other clients">
-    Any client that supports streamable HTTP and OAuth works. Configure the URL as `<your-phoenix-base-url>/mcp` and complete the login prompt on first use.
+    Launch `codex` and run `/mcp` to verify the server is connected.
+  </Accordion>
+
+  <Accordion title="Other clients">
+    Any client that supports streamable HTTP and OAuth works. Configure the URL as `<your-phoenix-base-url>/mcp` and complete the login prompt on first use. For clients without OAuth support, use an [API key](#fallback-api-keys) instead.
 
     If your Phoenix instance runs without authentication, no login is needed.
-  </Tab>
-</Tabs>
+  </Accordion>
+</AccordionGroup>
 
 Replace `http://localhost:6006` with your Phoenix endpoint.
 
@@ -149,6 +197,17 @@ Both variables are set on the Phoenix server before startup:
 - **Authentication** reuses Phoenix's existing auth: OAuth access tokens are audience-scoped to `/mcp` and cannot be replayed against other endpoints, and API keys carry the permissions of the user who created them.
 - **Code execution is sandboxed**: Monty is an interpreter with no filesystem, network, or import access, capped at 30 seconds, 100 MB of memory, and 50 operation calls per `execute` block. If your security policy forbids executing agent-written code on the server regardless, set `PHOENIX_MCP_CODE_MODE=false`.
 - **Treat query results as data, not instructions.** Traces and spans contain whatever your application logged, including untrusted user input. Agents should not follow directives found inside telemetry returned by these tools.
+
+## Troubleshooting
+
+**404 at `/mcp`:**
+Your Phoenix version predates the MCP server, or it was disabled with `PHOENIX_ENABLE_MCP_SERVER=false`. Upgrade or re-enable it, or fall back to the [npm package](/docs/phoenix/integrations/phoenix-mcp-server).
+
+**Login loops or 401 errors:**
+Re-run the login (`/mcp` in Claude Code, or remove and re-add the server). If you're using the API-key fallback, confirm the key is valid and passed as `Authorization: Bearer <key>`.
+
+**Server not appearing in your client:**
+Restart the client and verify the config file syntax — most clients only reload MCP config on startup.
 
 ## Relationship to `@arizeai/phoenix-mcp`
 

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -162,7 +162,7 @@ The operation catalog is generated from the [Phoenix REST API](/docs/phoenix/sdk
 `execute` runs the agent-written Python inside [Monty](https://github.com/pydantic/monty), Pydantic's sandboxed Python interpreter — no filesystem, network, or import access, with strict time and memory limits. This lets an agent filter, join, and aggregate results across many API calls in one step instead of shuttling raw JSON through its context window.
 
 <Note>
-Prefer not to run agent-written code on your server? Set `PHOENIX_MCP_CODE_MODE=false` to remove the `execute` tool and Monty entirely. The server then exposes the API operations as plain MCP tools, grouped by category, which clients reveal on demand via `list_tool_groups` and `enable_tool_group`.
+Prefer not to run agent-written code on your server? Set `PHOENIX_ENABLE_MCP_CODE_MODE=false` to remove the `execute` tool and Monty entirely. The server then exposes the API operations as plain MCP tools, grouped by category, which clients reveal on demand via `list_tool_groups` and `enable_tool_group`.
 </Note>
 
 ## Things to try
@@ -190,14 +190,14 @@ Both variables are set on the Phoenix server before startup:
 | Environment variable        | Default | Effect                                                                                                                              |
 | --------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `PHOENIX_ENABLE_MCP_SERVER` | `true`  | Master switch. Set to `false` to remove the `/mcp` endpoint entirely.                                                               |
-| `PHOENIX_MCP_CODE_MODE`     | `true`  | Set to `false` to disable code execution (the `execute` tool and the Monty sandbox) and expose plain, group-gated tools instead.    |
+| `PHOENIX_ENABLE_MCP_CODE_MODE`     | `true`  | Set to `false` to disable code execution (the `execute` tool and the Monty sandbox) and expose plain, group-gated tools instead.    |
 
 The browser-login flow is served by Phoenix's built-in OAuth2 authorization server, which has its own controls — a master switch (`PHOENIX_ENABLE_OAUTH2_AUTHORIZATION_SERVER`), grant expiry, dynamic client registration modes, redirect-host allowlists, and rate limits. See [OAuth2 Authorization Server](/docs/phoenix/self-hosting/features/authentication#oauth2-authorization-server) for the full reference.
 
 ## Security notes
 
 - **Authentication** is the same as the rest of Phoenix: OAuth access tokens are audience-scoped to `/mcp` and cannot be replayed against other endpoints, and API keys carry the permissions of the user who created them.
-- **Code execution is sandboxed**: Monty is an interpreter with no filesystem, network, or import access, capped at 30 seconds, 100 MB of memory, and 50 operation calls per `execute` block. If your security policy forbids executing agent-written code on the server regardless, set `PHOENIX_MCP_CODE_MODE=false`.
+- **Code execution is sandboxed**: Monty is an interpreter with no filesystem, network, or import access, capped at 30 seconds, 100 MB of memory, and 50 operation calls per `execute` block. If your security policy forbids executing agent-written code on the server regardless, set `PHOENIX_ENABLE_MCP_CODE_MODE=false`.
 - **Treat query results as data, not instructions.** Traces and spans contain whatever your application logged, including untrusted user input. Agents should not follow directives found inside telemetry returned by these tools.
 
 ## Troubleshooting

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -13,7 +13,7 @@ Feedback is very welcome — please [open a GitHub issue](https://github.com/Ari
 </Warning>
 
 <Note>
-If you're working with a coding agent, the [Phoenix CLI](/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli) (`px`) is the better default for repeatable, scriptable work — fetching traces, inspecting experiments, and managing datasets and prompts from the terminal. Use the MCP server for ad-hoc lookups and exploration in conversation. See [Coding Agents](/docs/phoenix/integrations/developer-tools/coding-agents) for setting up both.
+For most workflows, the [`px` CLI](/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli) is the recommended interface and is the better default for coding agents (e.g., Claude Code, Codex, Cursor), covering fetching traces, debugging failures, inspecting experiments, and managing datasets and prompts. Use the MCP tools below for ad-hoc data access from your IDE. See [Coding Agents](/docs/phoenix/integrations/developer-tools/coding-agents) for setting up both.
 </Note>
 
 ## Endpoint
@@ -191,6 +191,8 @@ Both variables are set on the Phoenix server before startup:
 | --------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `PHOENIX_ENABLE_MCP_SERVER` | `true`  | Master switch. Set to `false` to remove the `/mcp` endpoint entirely.                                                               |
 | `PHOENIX_MCP_CODE_MODE`     | `true`  | Set to `false` to disable code execution (the `execute` tool and the Monty sandbox) and expose plain, group-gated tools instead.    |
+
+The browser-login flow is served by Phoenix's built-in OAuth2 authorization server, which has its own controls — a master switch (`PHOENIX_ENABLE_OAUTH2_AUTHORIZATION_SERVER`), grant expiry, dynamic client registration modes, redirect-host allowlists, and rate limits. See [OAuth2 Authorization Server](/docs/phoenix/self-hosting/features/authentication#oauth2-authorization-server) for the full reference.
 
 ## Security notes
 

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -228,7 +228,8 @@
 ### Developer Tools
 
 - [Coding Agents](https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents): Claude Code, Cursor, and AI coding assistant integration
-- [Phoenix MCP Server](https://arize.com/docs/phoenix/integrations/phoenix-mcp-server): Connect AI assistants to Phoenix via Model Context Protocol
+- [Remote MCP Server](https://arize.com/docs/phoenix/integrations/remote-mcp): Connect MCP clients to the /mcp endpoint built into the Phoenix server (beta)
+- [Phoenix MCP Server](https://arize.com/docs/phoenix/integrations/phoenix-mcp-server): Connect AI assistants to Phoenix via the @arizeai/phoenix-mcp npm package (maintenance mode)
 
 ### LLM Providers
 

--- a/docs/phoenix/sdk-api-reference/typescript/mcp-server.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/mcp-server.mdx
@@ -14,6 +14,10 @@ description: MCP server implementation for Arize Phoenix providing unified inter
   Github
 </Card>
 
+<Warning>
+**Maintenance mode.** This stdio-based package continues to receive bug fixes, but new capabilities land in the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) built into the Phoenix server, which is the primary way to connect MCP clients to Phoenix. Use this package with Phoenix versions that don't serve the `/mcp` endpoint.
+</Warning>
+
 Phoenix MCP Server is an implementation of the Model Context Protocol for the Arize Phoenix platform. It provides a unified interface to Phoenix's capabilities.
 
 You can use Phoenix MCP Server for:

--- a/docs/phoenix/self-hosting/configuration.mdx
+++ b/docs/phoenix/self-hosting/configuration.mdx
@@ -85,6 +85,10 @@ The following environment variables will control how your phoenix server runs.
 
 * **PHOENIX\_ALLOWED\_PROVIDERS:** A comma-separated, case-insensitive list of model provider names to display in the playground UI. When unset, all providers are shown. Set to `NONE` to hide all providers. Unrecognized provider names will cause a startup error. Supported values: `OPENAI`, `ANTHROPIC`, `AZURE_OPENAI`, `GOOGLE`, `DEEPSEEK`, `XAI`, `OLLAMA`, `AWS`, `CEREBRAS`, `FIREWORKS`, `GROQ`, `MOONSHOT`, `PERPLEXITY`, `TOGETHER`. Example: `PHOENIX_ALLOWED_PROVIDERS=OPENAI,ANTHROPIC`. Available since version 13.13.0.
 
+* **PHOENIX\_ENABLE\_MCP\_SERVER:** Whether to mount the built-in [remote MCP server](/docs/phoenix/integrations/remote-mcp) (currently in beta) at `/mcp`. Defaults to `true`. Set to `false` to remove the endpoint entirely.
+
+* **PHOENIX\_MCP\_CODE\_MODE:** Whether the built-in MCP server presents its code-mode tool surface, including an `execute` tool that runs agent-written Python in a sandboxed interpreter. Defaults to `true`. Set to `false` to disable code execution and expose plain, group-gated tools instead. Has no effect unless the MCP server is enabled. See [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) for details.
+
 * **PHOENIX\_ALLOWED\_SANDBOX\_PROVIDERS:** A comma-separated, case-insensitive list of code-execution sandbox providers that Phoenix is permitted to use. When unset, all providers are allowed. Set to `NONE` to disable every sandbox provider. Unrecognized provider names will cause a startup error. Supported values: `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, `MODAL`. Example: `PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO`. See [Sandbox Backends](self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) for details.
 
 ### Logging

--- a/docs/phoenix/self-hosting/configuration.mdx
+++ b/docs/phoenix/self-hosting/configuration.mdx
@@ -87,7 +87,7 @@ The following environment variables will control how your phoenix server runs.
 
 * **PHOENIX\_ENABLE\_MCP\_SERVER:** Whether to mount the built-in [remote MCP server](/docs/phoenix/integrations/remote-mcp) (currently in beta) at `/mcp`. Defaults to `true`. Set to `false` to remove the endpoint entirely.
 
-* **PHOENIX\_MCP\_CODE\_MODE:** Whether the built-in MCP server presents its code-mode tool surface, including an `execute` tool that runs agent-written Python in a sandboxed interpreter. Defaults to `true`. Set to `false` to disable code execution and expose plain, group-gated tools instead. Has no effect unless the MCP server is enabled. See [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) for details.
+* **PHOENIX\_ENABLE\_MCP\_CODE\_MODE:** Whether the built-in MCP server presents its code-mode tool surface, including an `execute` tool that runs agent-written Python in a sandboxed interpreter. Defaults to `true`. Set to `false` to disable code execution and expose plain, group-gated tools instead. Has no effect unless the MCP server is enabled. See [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) for details.
 
 * **PHOENIX\_ENABLE\_OAUTH2\_AUTHORIZATION\_SERVER:** Whether Phoenix serves its built-in OAuth2 authorization server, which lets MCP clients and the Phoenix CLI log in interactively via the browser. Defaults to `true`. Has no effect unless authentication is enabled. See [OAuth2 Authorization Server](/docs/phoenix/self-hosting/features/authentication#oauth2-authorization-server) for the full set of `PHOENIX_OAUTH2_*` tuning variables (grant expiry, dynamic client registration, redirect host allowlists, and rate limits).
 

--- a/docs/phoenix/self-hosting/configuration.mdx
+++ b/docs/phoenix/self-hosting/configuration.mdx
@@ -89,6 +89,8 @@ The following environment variables will control how your phoenix server runs.
 
 * **PHOENIX\_MCP\_CODE\_MODE:** Whether the built-in MCP server presents its code-mode tool surface, including an `execute` tool that runs agent-written Python in a sandboxed interpreter. Defaults to `true`. Set to `false` to disable code execution and expose plain, group-gated tools instead. Has no effect unless the MCP server is enabled. See [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) for details.
 
+* **PHOENIX\_ENABLE\_OAUTH2\_AUTHORIZATION\_SERVER:** Whether Phoenix serves its built-in OAuth2 authorization server, which lets MCP clients and the Phoenix CLI log in interactively via the browser. Defaults to `true`. Has no effect unless authentication is enabled. See [OAuth2 Authorization Server](/docs/phoenix/self-hosting/features/authentication#oauth2-authorization-server) for the full set of `PHOENIX_OAUTH2_*` tuning variables (grant expiry, dynamic client registration, redirect host allowlists, and rate limits).
+
 * **PHOENIX\_ALLOWED\_SANDBOX\_PROVIDERS:** A comma-separated, case-insensitive list of code-execution sandbox providers that Phoenix is permitted to use. When unset, all providers are allowed. Set to `NONE` to disable every sandbox provider. Unrecognized provider names will cause a startup error. Supported values: `WASM`, `DENO`, `E2B`, `DAYTONA`, `VERCEL`, `MODAL`. Example: `PHOENIX_ALLOWED_SANDBOX_PROVIDERS=WASM,DENO`. See [Sandbox Backends](self-hosting/features/sandbox-runtimes#restricting-which-providers-are-allowed) for details.
 
 ### Logging

--- a/docs/phoenix/self-hosting/features/authentication.mdx
+++ b/docs/phoenix/self-hosting/features/authentication.mdx
@@ -218,9 +218,29 @@ Phoenix serves two discovery endpoints so AI agents can learn how to authenticat
 - `GET /auth.md` — a human- and agent-readable Markdown guide describing this deployment's auth model. When authentication is disabled it states that all endpoints are public; when enabled it directs the caller to create an API key under **Settings → API Keys** and send an `Authorization: Bearer <token>` header. It follows the [auth.md convention](https://workos.com/auth-md/docs/apps).
 - `GET /.well-known/oauth-protected-resource` — [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected Resource Metadata (JSON), advertising the resource, that bearer tokens are sent in the header, and a link to `/auth.md`.
 
-When authentication is enabled, `401 Unauthorized` responses include a `WWW-Authenticate` header pointing at the Protected Resource Metadata endpoint, giving agents a stable entry point for discovering how to authenticate.
+When authentication is enabled, `401 Unauthorized` responses include a `WWW-Authenticate` header pointing at the Protected Resource Metadata endpoint, giving agents a stable entry point for discovering how to authenticate. When the [OAuth2 authorization server](#oauth2-authorization-server) is enabled, the metadata also advertises it, so OAuth-capable clients (such as MCP clients) can log in interactively; other clients are provisioned out of band with [API keys](#api-keys), and access is always governed by the role of the user the credential belongs to.
 
-Phoenix issues its own credentials and does **not** implement OAuth token exchange, OAuth scopes, or the agent registration protocol (`/agent/identity`). Credentials are provisioned out of band as [API keys](#api-keys) or access tokens, and access is governed by the role of the user the credential belongs to.
+## OAuth2 Authorization Server
+
+When authentication is enabled, Phoenix also acts as its own **OAuth2 authorization server** so that interactive clients — MCP clients like Claude Code and Cursor connecting to the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp), and the Phoenix CLI — can log in through the browser instead of handling long-lived API keys. The flow is standard authorization code with PKCE: clients register via [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) dynamic client registration, discover endpoints via [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414) server metadata, and a token is minted only after a logged-in user approves the consent page. Tokens are audience-bound to the resource they were minted for and carry the permissions of the approving user.
+
+<Note>
+Don't confuse this with [Configuring OAuth2 Identity Providers](#configuring-oauth2-identity-providers) below, where Phoenix is the *client* logging your users in against Google, Okta, etc. (`PHOENIX_OAUTH2_<IDP>_*` variables). Here Phoenix is the *server*, issuing its own tokens to MCP and CLI clients.
+</Note>
+
+Registration alone grants no authority: an authorization code is delivered only to the exact registered redirect URI, PKCE binds the exchange to the flow's initiator, and nothing is issued without a logged-in user's consent. The defaults are designed to work out of the box with MCP clients in the wild; the variables below let you tighten or disable the surface.
+
+| Variable | Description |
+|---|---|
+| **PHOENIX\_ENABLE\_OAUTH2\_AUTHORIZATION\_SERVER** | Whether Phoenix serves the built-in authorization server. Defaults to `true`. When `false`, the `/oauth2/*` endpoints and the RFC 8414 discovery document respond 404, and the protected-resource metadata stops advertising an authorization server. Previously minted access tokens remain valid until they expire, but grants can no longer be refreshed. API keys and browser login are unaffected. Has no effect unless authentication is enabled. |
+| **PHOENIX\_OAUTH2\_GRANT\_EXPIRY\_DAYS** | How long, in days, an OAuth2 grant lives. Refresh-token rotation never extends a token's life past its grant's expiry, so this is the hard ceiling on how long a consent lasts before the user must log in again. Defaults to `90`. |
+| **PHOENIX\_OAUTH2\_DYNAMIC\_CLIENT\_REGISTRATION** | Which redirect URI mechanisms public clients may register. One of `enabled`, `local_only`, `disabled`. Defaults to `enabled` — MCP clients in the wild (e.g., Cursor) register HTTPS redirect URIs alongside loopback and private-use-scheme ones, and rejecting HTTPS breaks those clients out of the box. Set to `local_only` to accept only loopback and private-use-scheme redirects, or `disabled` to turn off dynamic registration entirely. |
+| **PHOENIX\_OAUTH2\_ALLOWED\_REDIRECT\_HOSTS** | A comma-separated list of hosts allowed as HTTPS redirect targets for dynamic client registration, e.g. `PHOENIX_OAUTH2_ALLOWED_REDIRECT_HOSTS=cursor.com,example.com`. When unset, all HTTPS redirect hosts are accepted while dynamic client registration is `enabled`. Use this to keep browser-based clients working while pinning exactly which services may receive authorization codes. |
+| **PHOENIX\_OAUTH2\_CONSENT\_ORIGIN\_CHECK** | Origin-header enforcement on consent-page decisions, a defense against cross-site consent forgery. One of `strict`, `off`. Defaults to `strict`. Only relax this if a reverse proxy strips the `Origin` header and consent approvals fail. |
+| **PHOENIX\_OAUTH2\_DCR\_RATE\_LIMIT\_PER\_HOUR** | Maximum dynamic client registrations accepted per IP address each hour. Defaults to `10`. |
+| **PHOENIX\_OAUTH2\_DCR\_MAX\_UNCONSUMED\_PER\_IP\_PER\_DAY** | Maximum registered-but-never-used (no grant created) dynamic clients retained per IP address each day. Defaults to `50`. |
+| **PHOENIX\_OAUTH2\_DCR\_ZERO\_GRANT\_TTL\_DAYS** | Days before abandoned dynamic clients that never created a grant are cleaned up. Defaults to `7`. |
+| **PHOENIX\_OAUTH2\_DCR\_DEAD\_GRANT\_TTL\_DAYS** | Days before dynamic clients whose grants are all inactive are cleaned up. Defaults to `30`. |
 
 ## Password Recovery
 


### PR DESCRIPTION
## Summary

Documents the new MCP server built into the Phoenix server at `/mcp`, and repositions the stdio-based `@arizeai/phoenix-mcp` npm package as maintenance mode.

### New page: `docs/phoenix/integrations/remote-mcp.mdx`

A single concise guide (informed by a review of LangSmith, Braintrust, Logfire, and Langfuse MCP docs) covering:

- **Beta notice** up top — tools and skills are still being tuned, things may change, feedback welcome via GitHub issues
- **PKCE OAuth onboarding** as the primary connect path (Claude Code, Cursor, VS Code, generic), with API-key Bearer auth as a headless/CI fallback
- **Code-mode tool surface** — `search`, `tags`, `list_tools`, `get_schema`, `execute`, with the catalog generated from the `/v1` REST API
- **Monty-sandboxed code execution** and its limits (30s / 100 MB / 50 calls per block)
- **Kill switches**: `PHOENIX_ENABLE_MCP_SERVER=false` removes `/mcp`; `PHOENIX_MCP_CODE_MODE=false` disables code execution
- Example prompts and security notes (audience-scoped tokens, treat telemetry as data not instructions)

### Maintenance-mode repositioning

- `integrations/phoenix-mcp-server.mdx` and `sdk-api-reference/typescript/mcp-server.mdx` now carry maintenance-mode warnings pointing to the remote server as the primary integration
- Coding Agents comparison table updated accordingly

### Discoverability

- Nav entries (Get Started → Coding Agents, Integrations → Developer Tools) with a `BETA` sidebar tag
- `llms.txt` index entry
- Both env vars added to the self-hosting configuration reference

## Test plan

- [x] `docs.json` parses as valid JSON
- [x] phoenix-cli llms.txt parser tests pass (25/25)
- [x] All internal links verified against existing pages

Only touches docs (plus two nav lines in `docs.json`).