### PR TITLE
feat(auth): add scope and audience columns to api_keys

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -445,6 +445,8 @@ CREATE TABLE public.api_keys (
     description VARCHAR,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     expires_at TIMESTAMP WITH TIME ZONE,
+    scopes JSONB,
+    audience JSONB,
     CONSTRAINT pk_api_keys PRIMARY KEY (id),
     CONSTRAINT fk_api_keys_user_id_users FOREIGN KEY
         (user_id)

--- a/src/phoenix/db/migrations/versions/132d988c5bef_add_oauth2_authorization_server_tables.py
+++ b/src/phoenix/db/migrations/versions/132d988c5bef_add_oauth2_authorization_server_tables.py
@@ -202,8 +202,22 @@ def upgrade() -> None:
         batch_op.alter_column("user_id", existing_type=_Integer, nullable=False)
         batch_op.alter_column("refresh_token_id", existing_type=_Integer, nullable=False)
 
+    with op.batch_alter_table(
+        "api_keys",
+        table_kwargs={"sqlite_autoincrement": True},
+    ) as batch_op:
+        batch_op.add_column(sa.Column("scopes", JSON_, nullable=True))
+        batch_op.add_column(sa.Column("audience", JSON_, nullable=True))
+
 
 def downgrade() -> None:
+    with op.batch_alter_table(
+        "api_keys",
+        table_kwargs={"sqlite_autoincrement": True},
+    ) as batch_op:
+        batch_op.drop_column("audience")
+        batch_op.drop_column("scopes")
+
     with op.batch_alter_table(
         "access_tokens",
         table_kwargs={"sqlite_autoincrement": True},

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2443,6 +2443,8 @@ class ApiKey(HasId):
     description: Mapped[Optional[str]]
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True, index=True)
+    scopes: Mapped[Optional[list[str]]] = mapped_column(JSON_, nullable=True)
+    audience: Mapped[Optional[list[str]]] = mapped_column(JSON_, nullable=True)
     __table_args__ = (dict(sqlite_autoincrement=True),)
 
 


### PR DESCRIPTION
## Summary

Adds nullable `scopes` and `audience` JSON columns to the `api_keys` table, mirroring the columns the OAuth2 authorization-server branch already adds to `access_tokens` and `refresh_tokens`.

The columns are added inside the existing unreleased `132d988c5bef` migration rather than a new revision, since that migration ships for the first time with the OAuth2 branch. The `ApiKey` ORM model and the generated `postgresql_schema.sql` DDL snapshot are updated to match.

These columns are schema-only for now — nothing populates or reads them on API keys yet.

## Testing

Ran the full alembic cycle against a scratch SQLite database: upgrade to head adds both columns, downgrade below `132d988c5bef` removes them, re-upgrade succeeds, and the table's `AUTOINCREMENT` is preserved throughout.

Stacked on `feat/oauth2-authorization-server-cli-login`.