### PR TITLE
chore: update phoenix version to 19.0.0 in kustomize and helm

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -42,13 +42,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 10.0.1
+version: 11.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "18.1.0"
+appVersion: "19.0.0"
 icon: https://phoenix.arize.com/wp-content/uploads/2025/04/logo-with-arize.svg
 maintainers:
   - name: arize

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # phoenix-helm
 
-![Version: 10.0.1](https://img.shields.io/badge/Version-10.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 18.1.0](https://img.shields.io/badge/AppVersion-18.1.0-informational?style=flat-square)
+![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 19.0.0](https://img.shields.io/badge/AppVersion-19.0.0-informational?style=flat-square)
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8e8e8b34-7900-43fa-a38f-1f070bd48c64&page=helm/README.md" />
 
@@ -126,7 +126,7 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for Phoenix container (Always, IfNotPresent, or Never) |
 | image.registry | string | `"docker.io"` | Docker image registry for Phoenix |
 | image.repository | string | `"arizephoenix/phoenix"` | Docker image repository for Phoenix |
-| image.tag | string | `"version-18.1.0-nonroot"` | Docker image tag/version to deploy |
+| image.tag | string | `"version-19.0.0-nonroot"` | Docker image tag/version to deploy |
 | ingress.annotations | object | `{}` | Annotations to add to the ingress resource |
 | ingress.apiPath | string | `"/"` | Path prefix for the Phoenix API |
 | ingress.enabled | bool | `true` | Enable ingress controller for external access |

--- a/helm/README.md
+++ b/helm/README.md
@@ -71,6 +71,12 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | auth.name | string | `"phoenix-secret"` | Name of the Kubernetes secret containing authentication credentials |
 | auth.oauth2.enabled | bool | `false` | Enable OAuth2/OIDC authentication |
 | auth.oauth2.providers | string | `nil` | List of OAuth2 identity providers to configure Each provider requires client_id, client_secret (unless token_endpoint_auth_method="none"), and oidc_config_url You can also define corresponding ENVs via auth.secrets[].valueFrom to use existing secrets ENVs: PHOENIX_OAUTH2_{{ $provider_upper }}_{{ setting }}, e.g. PHOENIX_OAUTH2_GOOGLE_CLIENT_SECRET |
+| auth.oauth2AuthorizationServer.allowedRedirectHosts | list | `[]` | List of HTTPS redirect hosts allowed for dynamically registered OAuth2 clients (PHOENIX_OAUTH2_ALLOWED_REDIRECT_HOSTS) When empty, all HTTPS redirect hosts are accepted while dynamicClientRegistration is "enabled"; set this to restrict HTTPS deliveries to specific hosts. Loopback redirect URIs are always allowed. Example: ["app.example.com"] |
+| auth.oauth2AuthorizationServer.consentOriginCheck | string | `"strict"` | Origin-header enforcement mode for the OAuth2 consent endpoint (PHOENIX_OAUTH2_CONSENT_ORIGIN_CHECK) Valid values: "strict" (reject consent decisions from untrusted origins) or "off" |
+| auth.oauth2AuthorizationServer.dcrRateLimitPerHour | int | `10` | Per-IP hourly rate limit for dynamic OAuth2 client registration (PHOENIX_OAUTH2_DCR_RATE_LIMIT_PER_HOUR) |
+| auth.oauth2AuthorizationServer.dynamicClientRegistration | string | `"enabled"` | Dynamic client registration mode (PHOENIX_OAUTH2_DYNAMIC_CLIENT_REGISTRATION) Valid values: "disabled", "local_only" (loopback redirect URIs only), or "enabled" |
+| auth.oauth2AuthorizationServer.enabled | bool | `true` | Serve the built-in OAuth2 authorization server (PHOENIX_ENABLE_OAUTH2_AUTHORIZATION_SERVER) |
+| auth.oauth2AuthorizationServer.grantExpiryDays | int | `90` | Expiry ceiling in days applied to newly minted OAuth2 grants (PHOENIX_OAUTH2_GRANT_EXPIRY_DAYS) |
 | auth.passwordResetTokenExpiryMinutes | int | `60` | Duration in minutes before password reset tokens expire (PHOENIX_PASSWORD_RESET_TOKEN_EXPIRY_MINUTES) |
 | auth.refreshTokenExpiryMinutes | int | `43200` | Duration in minutes before refresh tokens expire (PHOENIX_REFRESH_TOKEN_EXPIRY_MINUTES) |
 | auth.secret[0] | object | `{"key":"PHOENIX_SECRET","value":""}` | Environment variable name for the main Phoenix secret key used for encryption |
@@ -173,6 +179,8 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | server.allowExternalResources | bool | `true` | Allows calls to external resources, like Google Fonts in the web interface (PHOENIX_ALLOW_EXTERNAL_RESOURCES) Set to false in air-gapped environments to prevent external requests that can cause UI loading delays |
 | server.allowedProviders | string | `""` | Comma-separated list of model provider names to display in the playground UI (PHOENIX_ALLOWED_PROVIDERS) When unset, all providers are shown. Set to "NONE" to hide all providers. Supported values: OPENAI, ANTHROPIC, AZURE_OPENAI, GOOGLE, DEEPSEEK, XAI, OLLAMA, AWS, CEREBRAS, FIREWORKS, GROQ, MOONSHOT, PERPLEXITY, TOGETHER Example: "OPENAI,ANTHROPIC" |
 | server.annotations | object | `{}` | Annotations to add to the Phoenix service |
+| server.enableMcpCodeMode | bool | `true` | Enable code mode for the built-in MCP server, which exposes tools through a code-execution interface (PHOENIX_ENABLE_MCP_CODE_MODE) Only applies when the MCP server is enabled |
+| server.enableMcpServer | bool | `true` | Serve the built-in MCP server (PHOENIX_ENABLE_MCP_SERVER) |
 | server.enablePrometheus | bool | `false` | Enable Prometheus metrics endpoint on port 9090 |
 | server.grpcPort | int | `4317` | Port for OpenTelemetry gRPC collector (PHOENIX_GRPC_PORT) |
 | server.host | string | `"::"` | Host IP to bind Phoenix server (PHOENIX_HOST) |

--- a/helm/templates/phoenix/configmap.yaml
+++ b/helm/templates/phoenix/configmap.yaml
@@ -26,6 +26,16 @@ data:
   {{- if .Values.auth.admins }}
   PHOENIX_ADMINS: {{ .Values.auth.admins | quote }}
   {{- end }}
+
+  # OAuth2 Authorization Server Configuration
+  PHOENIX_ENABLE_OAUTH2_AUTHORIZATION_SERVER: {{ .Values.auth.oauth2AuthorizationServer.enabled | quote }}
+  PHOENIX_OAUTH2_GRANT_EXPIRY_DAYS: {{ .Values.auth.oauth2AuthorizationServer.grantExpiryDays | quote }}
+  PHOENIX_OAUTH2_CONSENT_ORIGIN_CHECK: {{ .Values.auth.oauth2AuthorizationServer.consentOriginCheck | quote }}
+  PHOENIX_OAUTH2_DYNAMIC_CLIENT_REGISTRATION: {{ .Values.auth.oauth2AuthorizationServer.dynamicClientRegistration | quote }}
+  {{- if .Values.auth.oauth2AuthorizationServer.allowedRedirectHosts }}
+  PHOENIX_OAUTH2_ALLOWED_REDIRECT_HOSTS: {{ join "," .Values.auth.oauth2AuthorizationServer.allowedRedirectHosts | quote }}
+  {{- end }}
+  PHOENIX_OAUTH2_DCR_RATE_LIMIT_PER_HOUR: {{ .Values.auth.oauth2AuthorizationServer.dcrRateLimitPerHour | quote }}
   
   # OAuth2/OIDC Identity Provider Configuration
   {{- if and .Values.auth.oauth2.enabled .Values.auth.oauth2.providers }}
@@ -129,6 +139,8 @@ data:
   {{- if .Values.server.allowedProviders }}
   PHOENIX_ALLOWED_PROVIDERS: {{ .Values.server.allowedProviders | quote }}
   {{- end }}
+  PHOENIX_ENABLE_MCP_SERVER: {{ .Values.server.enableMcpServer | quote }}
+  PHOENIX_ENABLE_MCP_CODE_MODE: {{ .Values.server.enableMcpCodeMode | quote }}
 
   # Database configuration
   {{- if .Values.database.url }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -179,6 +179,13 @@ server:
   # Example: "OPENAI,ANTHROPIC"
   allowedProviders: ""
 
+  # -- Serve the built-in MCP server (PHOENIX_ENABLE_MCP_SERVER)
+  enableMcpServer: true
+
+  # -- Enable code mode for the built-in MCP server, which exposes tools through a code-execution interface (PHOENIX_ENABLE_MCP_CODE_MODE)
+  # Only applies when the MCP server is enabled
+  enableMcpCodeMode: true
+
 # Service configuration
 service:
   # -- Service type for Phoenix service (ClusterIP, NodePort, LoadBalancer, or ExternalName)
@@ -609,6 +616,35 @@ auth:
       #   oidc_config_url: "https://auth.example.com/.well-known/openid-configuration"
       #   # Advanced: Some IDPs require credentials in POST body instead of Basic Auth
       #   token_endpoint_auth_method: "client_secret_post"
+
+  # OAuth2 Authorization Server Configuration
+  # Phoenix acts as an OAuth2 authorization server (with PKCE) so clients such as the
+  # Phoenix CLI (`px auth login`) can obtain tokens through a browser-based consent flow.
+  # This is distinct from auth.oauth2 above, which configures external identity providers
+  # that Phoenix authenticates against as a client.
+  oauth2AuthorizationServer:
+    # -- Serve the built-in OAuth2 authorization server (PHOENIX_ENABLE_OAUTH2_AUTHORIZATION_SERVER)
+    enabled: true
+
+    # -- Expiry ceiling in days applied to newly minted OAuth2 grants (PHOENIX_OAUTH2_GRANT_EXPIRY_DAYS)
+    grantExpiryDays: 90
+
+    # -- Origin-header enforcement mode for the OAuth2 consent endpoint (PHOENIX_OAUTH2_CONSENT_ORIGIN_CHECK)
+    # Valid values: "strict" (reject consent decisions from untrusted origins) or "off"
+    consentOriginCheck: "strict"
+
+    # -- Dynamic client registration mode (PHOENIX_OAUTH2_DYNAMIC_CLIENT_REGISTRATION)
+    # Valid values: "disabled", "local_only" (loopback redirect URIs only), or "enabled"
+    dynamicClientRegistration: "enabled"
+
+    # -- List of HTTPS redirect hosts allowed for dynamically registered OAuth2 clients (PHOENIX_OAUTH2_ALLOWED_REDIRECT_HOSTS)
+    # When empty, all HTTPS redirect hosts are accepted while dynamicClientRegistration is "enabled";
+    # set this to restrict HTTPS deliveries to specific hosts. Loopback redirect URIs are always allowed.
+    # Example: ["app.example.com"]
+    allowedRedirectHosts: []
+
+    # -- Per-IP hourly rate limit for dynamic OAuth2 client registration (PHOENIX_OAUTH2_DCR_RATE_LIMIT_PER_HOUR)
+    dcrRateLimitPerHour: 10
 
 # SMTP (email) settings
 smtp:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -703,7 +703,7 @@ image:
   repository: "arizephoenix/phoenix"
 
   # -- Docker image tag/version to deploy
-  tag: version-18.1.0-nonroot
+  tag: version-19.0.0-nonroot
 
 # -- Resource configuration
 resources:

--- a/kustomize/base/phoenix.yaml
+++ b/kustomize/base/phoenix.yaml
@@ -30,7 +30,7 @@ spec:
                         value: "6006"
                       - name: PHOENIX_SQL_DATABASE_URL
                         value: "postgresql://postgres:postgres123@postgres:5432/postgres"
-                  image: arizephoenix/phoenix:version-18.1.0
+                  image: arizephoenix/phoenix:version-19.0.0
                   name: phoenix
                   ports:
                       - containerPort: 6006


### PR DESCRIPTION
This PR updates the phoenix version in the kustomize template to version 19.0.0.

This change was automatically generated by the docker-build-release workflow.