### PR TITLE
docs: rewrite agent-assisted setup around px setup; MCP docs updates

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -79,17 +79,18 @@
                   "docs/phoenix/agent-assisted-setup"
                 ]
               },
+              {
+                "group": "MCP",
+                "pages": [
+                  "docs/phoenix/integrations/mcp",
+                  "docs/phoenix/integrations/remote-mcp",
+                  "docs/phoenix/integrations/docs-mcp",
+                  "docs/phoenix/integrations/phoenix-mcp-server"
+                ]
+              },
               "docs/phoenix/end-to-end-features-notebook",
               "docs/phoenix/phoenix-demo",
               "docs/phoenix/pxi"
-            ]
-          },
-          {
-            "group": "MCP",
-            "icon": "plug",
-            "pages": [
-              "docs/phoenix/integrations/phoenix-mcp-server",
-              "docs/phoenix/integrations/remote-mcp"
             ]
           },
           {
@@ -503,8 +504,10 @@
             "group": "MCP",
             "icon": "plug",
             "pages": [
-              "docs/phoenix/integrations/phoenix-mcp-server",
-              "docs/phoenix/integrations/remote-mcp"
+              "docs/phoenix/integrations/mcp",
+              "docs/phoenix/integrations/remote-mcp",
+              "docs/phoenix/integrations/docs-mcp",
+              "docs/phoenix/integrations/phoenix-mcp-server"
             ]
           },
           {

--- a/docs/phoenix/agent-assisted-setup.mdx
+++ b/docs/phoenix/agent-assisted-setup.mdx
@@ -1,119 +1,80 @@
 ---
-title: "Agent-Assisted Tracing"
+title: "Agent-Assisted Setup"
 description: >-
-  Use a coding agent to automatically add Phoenix tracing to your application.
+  Connect your app to Phoenix and get traces flowing with a single command —
+  `px setup` hands the instrumentation to your coding agent and waits until a
+  real trace arrives.
 ---
 
-# Agent-Assisted Tracing
+# Agent-Assisted Setup
 
-The fastest way to add Phoenix tracing to your application. Paste a single URL into your coding agent and it handles everything — dependency installation, instrumentation, and configuration.
+The fastest way to add Phoenix tracing to your application. Run one command from your app's root and Phoenix walks you through connecting, hands the instrumentation to your coding agent, and confirms a real trace arrived.
 
 <Tip>
-**Get started — paste this into your coding agent:**
+**Get started — run this from your app's root directory:**
+```bash
+npx -y @arizeai/phoenix-cli setup
 ```
-Follow the instructions from https://raw.githubusercontent.com/Arize-ai/phoenix/main/docs/PROMPT.md and ask me questions as needed.
-```
+Already have the CLI installed (`npm install -g @arizeai/phoenix-cli`)? Just run `px setup`.
 </Tip>
 
-### How it works
+## What `px setup` does
 
-1. **Paste the URL** into any coding agent (Claude Code, Cursor, Windsurf, Copilot, etc.)
-2. **The agent analyzes** your codebase — detects language, LLM providers, and frameworks
-3. **The agent proposes** an instrumentation plan based on your stack
-4. **You approve**, and the agent implements tracing with the right integrations
+`px setup` runs an interactive flow:
+
+1. **Checks git safety** — warns on a dirty tree so agent edits stay separate from your own work.
+2. **Establishes the connection** — asks where your Phoenix instance is running, handles auth, and writes a gitignored `.env.phoenix` file.
+3. **Hands off instrumentation** — passes an instrumentation task to a coding agent (Claude Code, Codex, Cursor, or OpenCode), which detects your language, LLM providers, and frameworks, then adds tracing.
+4. **Verifies traces** — waits until the Phoenix API confirms a real trace arrived, so "done" means traces are actually flowing.
+5. **Sets up tooling** — optionally points `px` at the new project and installs Phoenix [skills](/docs/phoenix/integrations/developer-tools/coding-agents#skills) so your agent can query what you captured.
 
 <Info>
 **Supported stacks:** Python, TypeScript/JavaScript, and Java — covering 30+ LLM providers, frameworks, and platforms. See the [full integration list](/docs/phoenix/integrations).
 </Info>
 
-### What the agent does
+## Re-run individual steps
 
-- **Phase 1 (Analysis):** Scans imports and dependency files to detect your LLM provider and framework, then proposes an instrumentation plan. No code changes.
-- **Phase 2 (Implementation):** Installs dependencies, creates a centralized instrumentation module, and configures OpenTelemetry to send traces to Phoenix.
+The connection questions only need answering once. Re-run a single slice on a repo that's already registered:
 
----
+```bash
+px setup instrument   # Instrument and verify traces again (any supported agent)
+px setup skills        # Install the coding-agent skills alone
+```
 
-## Alternative: MCP and Skills
+## Non-interactive use (CI or agents)
 
-For persistent documentation access, direct Phoenix instance operations, and reusable agent skills beyond the initial tracing setup, see the [Coding Agents](/docs/phoenix/integrations/developer-tools/coding-agents) guide.
+Pass flags instead of answering prompts:
 
-<CardGroup cols={3}>
-  <Card title="CLI" icon="terminal" href="/docs/phoenix/integrations/developer-tools/coding-agents#cli">
-    Terminal access to traces, experiments, datasets, and prompts.
+```bash
+# Connection only — write .env.phoenix, no source changes
+px setup --no-input --endpoint http://localhost:6006 --project my-app
+
+# Instrument too — requires --agent when there's no TTY to choose one
+px setup --no-input --instrument --agent claude --yolo --format raw
+```
+
+See the [CLI reference](/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli#px-setup) for the full list of flags.
+
+## Validate your setup
+
+`px setup` verifies traces automatically. To confirm manually:
+
+1. Run your application and trigger at least one LLM call.
+2. Open the Phoenix UI (local: http://localhost:6006, or your Phoenix Cloud URL).
+3. Open the **Traces** view and verify traces appear under your project.
+
+If no traces appear, check the [Troubleshooting FAQ](/docs/phoenix/tracing/concepts-tracing/faqs-tracing).
+
+## Alternatives
+
+<CardGroup cols={2}>
+  <Card title="Paste a prompt instead" icon="clipboard">
+    No CLI? Paste this into any coding agent:
+    ```text
+    Follow the instructions from https://raw.githubusercontent.com/Arize-ai/phoenix/main/docs/PROMPT.md and ask me questions as needed.
+    ```
   </Card>
-  <Card title="MCP" icon="plug" href="/docs/phoenix/integrations/developer-tools/coding-agents#mcp">
-    In-editor Phoenix documentation lookup and direct Phoenix instance operations.
-  </Card>
-  <Card title="Skills" icon="wand-magic-sparkles" href="/docs/phoenix/integrations/developer-tools/coding-agents#skills">
-    Reusable instructions so agents apply Phoenix best practices consistently.
+  <Card title="Coding Agents guide" icon="robot" href="/docs/phoenix/integrations/developer-tools/coding-agents">
+    CLI, MCP, and skills for ongoing agent workflows beyond initial setup.
   </Card>
 </CardGroup>
-
----
-
-## IDE-Specific Instructions
-
-<Tabs>
-  <Tab title="Claude Code">
-    In your Claude Code session, paste the PROMPT.md URL and ask the agent to follow the instructions.
-
-    For richer ongoing integration, add the Phoenix MCP server:
-    ```bash
-    claude mcp add --transport http phoenix-docs https://arizeai-433a7140.mintlify.app/mcp
-    ```
-  </Tab>
-  <Tab title="Cursor">
-    Open Cursor's AI chat panel. Paste the PROMPT.md URL and instruct the agent to add Phoenix tracing.
-
-    For richer ongoing integration, add to `.cursor/mcp.json`:
-    ```json
-    {
-      "mcpServers": {
-        "phoenix-docs": {
-          "url": "https://arizeai-433a7140.mintlify.app/mcp"
-        }
-      }
-    }
-    ```
-  </Tab>
-  <Tab title="VS Code (Copilot)">
-    Open the Copilot chat panel. Paste the PROMPT.md URL and ask it to follow the instructions.
-
-    For richer ongoing integration, add to `.vscode/mcp.json`:
-    ```json
-    {
-      "servers": {
-        "phoenix-docs": {
-          "url": "https://arizeai-433a7140.mintlify.app/mcp"
-        }
-      }
-    }
-    ```
-  </Tab>
-  <Tab title="Windsurf">
-    Open the Cascade panel. Paste the PROMPT.md URL and ask the agent to add Phoenix tracing.
-
-    For richer ongoing integration, add to `~/.codeium/windsurf/mcp_config.json`:
-    ```json
-    {
-      "mcpServers": {
-        "phoenix-docs": {
-          "serverUrl": "https://arizeai-433a7140.mintlify.app/mcp"
-        }
-      }
-    }
-    ```
-  </Tab>
-</Tabs>
-
----
-
-## Validate Your Setup
-
-After the agent finishes:
-
-1. Run your application and trigger at least one LLM call
-2. Open Phoenix UI (local: http://localhost:6006, or your Phoenix Cloud URL)
-3. Navigate to the **Traces** view and verify traces appear under your project
-
-If no traces appear, check the [Troubleshooting FAQ](/docs/phoenix/resources/frequently-asked-questions).

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -50,8 +50,8 @@ Integrate Phoenix with AI coding assistants to debug and analyze your LLM applic
   <Card title="Coding Agents" icon="terminal" href="/docs/phoenix/integrations/developer-tools/coding-agents">
     Install Phoenix debugging skills and CLI for Claude Code, Cursor, and other AI coding assistants.
   </Card>
-  <Card title="Phoenix MCP Server" icon="plug" href="/docs/phoenix/integrations/phoenix-mcp-server">
-    Connect AI assistants directly to your Phoenix instance via the Model Context Protocol.
+  <Card title="MCP Servers" icon="plug" href="/docs/phoenix/integrations/mcp">
+    Connect AI assistants to your Phoenix data and docs via the Model Context Protocol.
   </Card>
 </CardGroup>
 

--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -252,7 +252,7 @@ This means your agent can look up accurate API signatures, implementations, and 
   <Card title="Retrieve Traces via CLI" icon="download" href="/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/retrieve-traces-via-cli">
     Detailed guide for fetching traces from Phoenix.
   </Card>
-  <Card title="Phoenix MCP Server" icon="plug" href="/docs/phoenix/integrations/phoenix-mcp-server">
-    Interact with projects, traces, sessions, prompts, datasets, and experiments via the Phoenix MCP Server.
+  <Card title="MCP Servers" icon="plug" href="/docs/phoenix/integrations/mcp">
+    Interact with projects, traces, sessions, prompts, datasets, and experiments via the Phoenix MCP servers.
   </Card>
 </CardGroup>

--- a/docs/phoenix/integrations/docs-mcp.mdx
+++ b/docs/phoenix/integrations/docs-mcp.mdx
@@ -1,0 +1,91 @@
+---
+title: "Phoenix Docs MCP"
+description: "Let AI assistants search and retrieve the Phoenix documentation in real time over MCP."
+---
+
+The Phoenix Docs MCP server lets AI assistants search and retrieve Phoenix documentation in real time. It's complementary to the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) — run it alongside a data server so your assistant can answer questions from the docs as well as your Phoenix instance.
+
+**Server URL:**
+
+```
+https://arizeai-433a7140.mintlify.app/mcp
+```
+
+Point your client at the server URL above. No authentication is required.
+
+<AccordionGroup>
+  <Accordion title="Claude Code">
+    <Steps>
+      <Step title="Add the Phoenix Docs MCP server">
+        ```bash
+        claude mcp add --transport http phoenix-docs https://arizeai-433a7140.mintlify.app/mcp
+        ```
+
+        Add `--scope user` to make it available in all projects instead of the current directory only.
+      </Step>
+    </Steps>
+  </Accordion>
+
+  <Accordion title="Claude Desktop">
+    <Steps>
+      <Step title="Add a custom connector">
+        Go to **Settings → Connectors → Add custom connector** and enter:
+
+        - **Name**: `Phoenix Docs`
+        - **URL**: `https://arizeai-433a7140.mintlify.app/mcp`
+      </Step>
+    </Steps>
+  </Accordion>
+
+  <Accordion title="Cursor">
+    <Steps>
+      <Step title="Add the Phoenix Docs MCP server">
+        Add to `~/.cursor/mcp.json` (or project `.cursor/mcp.json`):
+
+        ```json
+        {
+          "mcpServers": {
+            "phoenix-docs": {
+              "url": "https://arizeai-433a7140.mintlify.app/mcp"
+            }
+          }
+        }
+        ```
+      </Step>
+    </Steps>
+  </Accordion>
+
+  <Accordion title="VS Code">
+    <Steps>
+      <Step title="Add the Phoenix Docs MCP server">
+        Run `MCP: Add Server` from the Command Palette, or add to `.vscode/mcp.json`:
+
+        ```json
+        {
+          "servers": {
+            "phoenix-docs": {
+              "type": "http",
+              "url": "https://arizeai-433a7140.mintlify.app/mcp"
+            }
+          }
+        }
+        ```
+      </Step>
+    </Steps>
+  </Accordion>
+
+  <Accordion title="Other clients">
+    Any client that supports streamable HTTP works. Configure the URL as `https://arizeai-433a7140.mintlify.app/mcp` — no authentication is required.
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Remote MCP Server" icon="database" href="/docs/phoenix/integrations/remote-mcp">
+    Connect assistants to your Phoenix data — traces, datasets, experiments, and prompts.
+  </Card>
+  <Card title="MCP Overview" icon="plug" href="/docs/phoenix/integrations/mcp">
+    Compare the Phoenix MCP servers and pick the right one.
+  </Card>
+</CardGroup>

--- a/docs/phoenix/integrations/mcp.mdx
+++ b/docs/phoenix/integrations/mcp.mdx
@@ -1,0 +1,28 @@
+---
+title: "MCP Servers"
+sidebarTitle: "MCP Overview"
+description: Connect AI assistants to Phoenix — your data and your docs — over the Model Context Protocol (MCP).
+---
+
+Phoenix speaks [MCP](https://modelcontextprotocol.io/), so you can wire assistants like Claude Code, Cursor, and VS Code into Phoenix. There are two things you might want your assistant to do — pick the server that matches, or run both.
+
+<CardGroup cols={2}>
+  <Card title="Work with your Phoenix data" icon="database" href="/docs/phoenix/integrations/remote-mcp">
+    **Remote MCP Server** — query and operate on your projects, traces, sessions, datasets, experiments, prompts, and annotations. Built into the Phoenix server at `/mcp`; nothing to install.
+
+    **Recommended** · beta
+  </Card>
+  <Card title="Search the Phoenix docs" icon="book" href="/docs/phoenix/integrations/docs-mcp">
+    **Phoenix Docs MCP** — let your assistant answer questions from the Phoenix documentation in real time. A hosted URL you point your client at.
+  </Card>
+</CardGroup>
+
+The two are complementary. Run the **Docs MCP** alongside the **Remote MCP Server** to give your assistant both your live Phoenix data and the documentation.
+
+<Note>
+For most coding-agent workflows, the [`px` CLI](/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli) is the recommended interface — fetching traces, debugging failures, inspecting experiments, and managing datasets and prompts. Use the MCP servers for ad-hoc data access from your IDE. See [Coding Agents](/docs/phoenix/integrations/developer-tools/coding-agents) for setting them up together.
+</Note>
+
+## Older Phoenix versions
+
+If your Phoenix version doesn't yet serve the built-in `/mcp` endpoint, use the [`@arizeai/phoenix-mcp` npm package](/docs/phoenix/integrations/phoenix-mcp-server) — a local stdio server that connects to the same Phoenix data. It's in **maintenance mode**: it still receives bug fixes, but new capabilities land in the Remote MCP Server. Prefer the Remote MCP Server whenever your Phoenix version serves `/mcp`.

--- a/docs/phoenix/integrations/model-context-protocol.mdx
+++ b/docs/phoenix/integrations/model-context-protocol.mdx
@@ -8,7 +8,7 @@ description: Anthropic's Model Context Protocol is a standard for connecting AI 
 
 <Columns cols={2}>
   <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/0e65210e-image.jpeg">
-    [**Phoenix MCP Server**](/docs/phoenix/integrations/phoenix-mcp-server)
+    [**Phoenix MCP Servers**](/docs/phoenix/integrations/mcp)
   </Card>
   <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/b97976e8-image.jpeg">
     [**MCP Tracing**](/docs/phoenix/integrations/python/mcp-tracing)

--- a/docs/phoenix/integrations/phoenix-mcp-server.mdx
+++ b/docs/phoenix/integrations/phoenix-mcp-server.mdx
@@ -1,116 +1,15 @@
 ---
-title: "MCP Servers"
-sidebarTitle: "MCP Overview"
-description: Connect AI assistants to Phoenix documentation and platform capabilities via the Model Context Protocol (MCP).
+title: "Phoenix MCP Server"
+sidebarTitle: "Phoenix MCP Server (npm)"
+description: "The @arizeai/phoenix-mcp local stdio server. In maintenance mode — use the Remote MCP Server on Phoenix versions that serve /mcp."
+tag: "Maintenance"
 ---
-
-Phoenix offers MCP servers for two different jobs: **working with your Phoenix data** (traces,
-datasets, prompts, experiments) and **searching the Phoenix documentation**. Three servers cover
-those jobs — pick by what you want your assistant to do:
-
-| Server | Use it for | How it runs | Status |
-| ------ | ---------- | ----------- | ------ |
-| **[Remote MCP Server](/docs/phoenix/integrations/remote-mcp)** | Your Phoenix data — projects, traces, sessions, prompts, datasets, experiments, annotations | Built into the Phoenix server at `<your-phoenix-url>/mcp`; nothing to install | **Recommended** (beta) |
-| **Phoenix MCP Server** (`@arizeai/phoenix-mcp`) | The same Phoenix data, for Phoenix versions that don't yet serve `/mcp` | Local stdio process launched with `npx` | Maintenance mode |
-| **Phoenix Docs MCP** | Searching the Phoenix documentation in real time | Hosted URL you point your client at | Stable |
-
-**Which one?**
-
-- **To work with your Phoenix data**, use the **[Remote MCP Server](/docs/phoenix/integrations/remote-mcp)** — it's the built-in `/mcp` endpoint and where all new capabilities land. Only fall back to the **Phoenix MCP Server** npm package (below) if your Phoenix version predates that endpoint.
-- **To let your assistant answer questions from the docs**, add the **Phoenix Docs MCP** (below). It's complementary — run it alongside either data server.
-
-This page covers the **Phoenix Docs MCP** and the **Phoenix MCP Server** npm package. For the
-recommended built-in server, see the dedicated [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) guide.
-
----
-
-## Phoenix Docs MCP
-
-The Phoenix Docs MCP server allows AI assistants to search and retrieve Phoenix documentation in real-time.
-
-**Server URL:**
-
-```
-https://arizeai-433a7140.mintlify.app/mcp
-```
-
-Point your client at the server URL above. No authentication is required.
-
-<AccordionGroup>
-  <Accordion title="Claude Code">
-    <Steps>
-      <Step title="Add the Phoenix Docs MCP server">
-        ```bash
-        claude mcp add --transport http phoenix-docs https://arizeai-433a7140.mintlify.app/mcp
-        ```
-
-        Add `--scope user` to make it available in all projects instead of the current directory only.
-      </Step>
-    </Steps>
-  </Accordion>
-
-  <Accordion title="Claude Desktop">
-    <Steps>
-      <Step title="Add a custom connector">
-        Go to **Settings → Connectors → Add custom connector** and enter:
-
-        - **Name**: `Phoenix Docs`
-        - **URL**: `https://arizeai-433a7140.mintlify.app/mcp`
-      </Step>
-    </Steps>
-  </Accordion>
-
-  <Accordion title="Cursor">
-    <Steps>
-      <Step title="Add the Phoenix Docs MCP server">
-        Add to `~/.cursor/mcp.json` (or project `.cursor/mcp.json`):
-
-        ```json
-        {
-          "mcpServers": {
-            "phoenix-docs": {
-              "url": "https://arizeai-433a7140.mintlify.app/mcp"
-            }
-          }
-        }
-        ```
-      </Step>
-    </Steps>
-  </Accordion>
-
-  <Accordion title="VS Code">
-    <Steps>
-      <Step title="Add the Phoenix Docs MCP server">
-        Run `MCP: Add Server` from the Command Palette, or add to `.vscode/mcp.json`:
-
-        ```json
-        {
-          "servers": {
-            "phoenix-docs": {
-              "type": "http",
-              "url": "https://arizeai-433a7140.mintlify.app/mcp"
-            }
-          }
-        }
-        ```
-      </Step>
-    </Steps>
-  </Accordion>
-
-  <Accordion title="Other clients">
-    Any client that supports streamable HTTP works. Configure the URL as `https://arizeai-433a7140.mintlify.app/mcp` — no authentication is required.
-  </Accordion>
-</AccordionGroup>
-
----
-
-## Phoenix MCP Server
 
 <Warning>
-**Maintenance mode.** `@arizeai/phoenix-mcp` continues to receive bug fixes, but new capabilities land in the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) built into the Phoenix server. Use this package when your Phoenix version doesn't serve the `/mcp` endpoint.
+**Maintenance mode.** `@arizeai/phoenix-mcp` continues to receive bug fixes, but new capabilities land in the [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) built into the Phoenix server. Reach for this package only when your Phoenix version doesn't serve the `/mcp` endpoint. New to Phoenix MCP? Start with the [MCP Overview](/docs/phoenix/integrations/mcp).
 </Warning>
 
-The Phoenix MCP Server (`@arizeai/phoenix-mcp`) connects AI assistants directly to your Phoenix instance for managing:
+The Phoenix MCP Server (`@arizeai/phoenix-mcp`) is a local stdio server, launched with `npx`, that connects AI assistants directly to your Phoenix instance for managing:
 
 * **Projects, Traces, and Spans**: Explore recent traces, inspect spans, and analyze annotations
 * **Sessions**: Review conversation flows and session annotations
@@ -119,7 +18,7 @@ The Phoenix MCP Server (`@arizeai/phoenix-mcp`) connects AI assistants directly 
 * **Datasets**: Explore datasets and synthesize new examples
 * **Experiments**: Pull experiment results and visualize them with the help of an LLM
 
-### Connecting the Phoenix MCP Server
+## Connecting the Phoenix MCP Server
 
 The package runs as a local stdio process. In every client, pass your Phoenix endpoint with
 `--baseUrl` and an [API key](/docs/phoenix/settings/api-keys) with `--apiKey` (for Phoenix Cloud,
@@ -200,7 +99,7 @@ The package runs as a local stdio process. In every client, pass your Phoenix en
   </Accordion>
 </AccordionGroup>
 
-### Using the Phoenix MCP Server
+## Using the Phoenix MCP Server
 
 The MCP server can be used to interact with projects, traces, spans, sessions, annotation configs, prompts, experiments, and datasets. It can retrieve operational data, inspect prompt and experiment artifacts, and perform the existing prompt and dataset write flows.
 
@@ -220,9 +119,8 @@ Some good questions to try:
 
 7. `Visualize the results of my jailbreak dataset experiments in Phoenix`
 
-### Hoping to see additional functionality?
+## Hoping to see additional functionality?
 
 `@arizeai/phoenix-mcp` is [open-source](https://github.com/Arize-ai/phoenix)! Issues and PRs welcome.
 
-<Card horizontal icon="github" href="https://github.com/Arize-ai/phoenix/tree/main/js/packages/phoenix-mcp" title="Not found
-" description="phoenix-mcp package repository" />
+<Card horizontal icon="github" href="https://github.com/Arize-ai/phoenix/tree/main/js/packages/phoenix-mcp" title="phoenix-mcp" description="phoenix-mcp package repository" />

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -228,7 +228,9 @@
 ### Developer Tools
 
 - [Coding Agents](https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents): Claude Code, Cursor, and AI coding assistant integration
-- [Remote MCP Server](https://arize.com/docs/phoenix/integrations/remote-mcp): Connect MCP clients to the /mcp endpoint built into the Phoenix server (beta)
+- [MCP Overview](https://arize.com/docs/phoenix/integrations/mcp): Compare the Phoenix MCP servers and pick one for your data or docs
+- [Remote MCP Server](https://arize.com/docs/phoenix/integrations/remote-mcp): Connect MCP clients to the /mcp endpoint built into the Phoenix server (beta, recommended)
+- [Phoenix Docs MCP](https://arize.com/docs/phoenix/integrations/docs-mcp): Let AI assistants search and retrieve the Phoenix documentation in real time
 - [Phoenix MCP Server](https://arize.com/docs/phoenix/integrations/phoenix-mcp-server): Connect AI assistants to Phoenix via the @arizeai/phoenix-mcp npm package (maintenance mode)
 
 ### LLM Providers


### PR DESCRIPTION
## Summary

- Rewrites `docs/phoenix/agent-assisted-setup.mdx` around the `px setup` command instead of the old paste-a-PROMPT.md-URL flow. Documents the real interactive flow (git-safety check → connection + gitignored `.env.phoenix` → agent hand-off → trace verification → tooling installs), the `px setup instrument` / `px setup skills` subcommands, and non-interactive `--no-input` usage. Links the CLI reference as source-of-truth for flags rather than duplicating the table.
- MCP docs updates across `docs.json`, `integrations.mdx`, `coding-agents.mdx`, `model-context-protocol.mdx`, `phoenix-mcp-server.mdx`, and `llms.txt`, plus new `docs-mcp.mdx` and `mcp.mdx` pages.

## Notes

- Slug for agent-assisted-setup is unchanged, so existing links from the get-started tracing pages and `docs.json` keep working.