### PR TITLE
feat(cli): px setup mcp — register the Phoenix remote MCP server with a coding agent

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -111,6 +111,25 @@ px setup instrument --agent claude   # instrument + verify only
 px setup skills                      # install the Phoenix coding-agent skills
 ```
 
+### `px setup mcp` — register the remote MCP server
+
+Wire the Phoenix remote MCP server (`<endpoint>/mcp`) into a coding agent so it
+can query Phoenix data. The endpoint is inferred from `--endpoint`, the active
+profile, or `PHOENIX_HOST`. Bare command prompts for scope (global default) then
+agent; `--agent` skips both prompts.
+
+```bash
+px setup mcp --agent codex --no-input --format raw
+px setup mcp --agent claude --local            # write this repo's .mcp.json
+```
+
+Agents: `claude`, `codex`, `gemini`, `cursor`, `opencode`, `vscode`. Scope is
+`--global` (default) or `--local` (repo; Codex is global-only). Auth is OAuth by
+default (URL-only config, browser login on first use); pass `--header "Name:
+value"` (repeatable) for an API-key bearer fallback — for Codex a
+`Authorization: Bearer ${VAR}` header becomes `bearer_token_env_var`. `--format
+raw` prints `{"endpoint","url","serverName","agent","scope","auth","file?"}`.
+
 ## Quick Reference
 
 | Task | Files |

--- a/docs/phoenix/integrations/remote-mcp.mdx
+++ b/docs/phoenix/integrations/remote-mcp.mdx
@@ -29,6 +29,16 @@ The MCP server is available at your Phoenix base URL plus `/mcp`:
 
 Clients authenticate with **OAuth** (authorization code + PKCE). Phoenix acts as its own authorization server and supports dynamic client registration, so there is nothing to pre-configure — add the server, and your client opens a browser window where you log in with your Phoenix account. Tokens are scoped to your user's permissions.
 
+<Tip>
+  The [`px` CLI](/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli) automates the steps below for Claude Code, Codex, Gemini, Cursor, OpenCode, and VS Code — it infers your endpoint and writes each agent's config for you:
+
+  ```bash
+  px setup mcp --agent claude   # or codex, gemini, cursor, opencode, vscode
+  ```
+
+  Configure it by hand with the per-client steps below.
+</Tip>
+
 <AccordionGroup>
   <Accordion title="Claude Code">
     <Steps>

--- a/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
@@ -197,6 +197,7 @@ Re-run individual steps later with the subcommands:
 ```bash
 px setup instrument --agent codex   # Instrument and verify again
 px setup skills                     # Install coding-agent skills only
+px setup mcp --agent claude         # Register the Phoenix MCP server with an agent
 ```
 
 | Option | Description | Default |
@@ -210,6 +211,35 @@ px setup skills                     # Install coding-agent skills only
 | `--skills` / `--no-skills` | Whether to install Phoenix coding-agent skills | Prompted |
 | `--docs-mcp` / `--no-docs-mcp` | Connect the Phoenix docs MCP server to the agent instead of downloading docs | Prompted |
 | `--yolo` | Let the agent run without per-step confirmation | — |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+
+### `px setup mcp`
+
+Register the Phoenix **remote MCP server** (`<endpoint>/mcp`) with a coding agent, so it can search, query, and operate on your Phoenix data. The endpoint is inferred from `--endpoint`, the active profile, or `PHOENIX_HOST` — you never re-type it. See [Remote MCP Server](/docs/phoenix/integrations/remote-mcp) for what the server exposes.
+
+```bash
+px setup mcp                        # Pick scope + agent interactively
+px setup mcp --agent codex          # Configure one agent
+px setup mcp --agent claude --local # Write this repo's config (.mcp.json)
+```
+
+Where an agent ships an `mcp add` (Claude, Codex, Gemini, VS Code global) the CLI drives it; the rest get a merge into their config file (`~/.cursor/mcp.json`, `~/.config/opencode/opencode.json`, `.vscode/mcp.json`).
+
+Auth defaults to **OAuth** — the config is URL-only and the agent opens Phoenix's browser login on first use. For headless clients, pass an API-key bearer header with `--header`:
+
+```bash
+px setup mcp --agent codex --no-input --format raw
+px setup mcp --agent claude --header "Authorization: Bearer ${PHOENIX_API_KEY}"
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--agent <agent>` | Agent to configure: `claude`, `codex`, `gemini`, `cursor`, `opencode`, `vscode` | Prompted |
+| `--global` / `--local` | User-wide config, or this repo's (Codex is global-only) | `--global` |
+| `--endpoint <url>` | Phoenix base URL (skips inference) | Inferred |
+| `--profile <name>` | Profile to infer the endpoint from | Active profile |
+| `--header <header>` | `Name: value` header for the API-key fallback (repeatable) | OAuth (none) |
+| `--no-input` | Headless mode; requires `--agent` and defaults scope to global | — |
 | `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
 
 ### `px project list`

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -176,6 +176,34 @@ px setup instrument --agent codex   # instrument and verify again
 px setup skills                     # install coding-agent skills only
 ```
 
+#### `px setup mcp`
+
+Register the Phoenix **remote MCP server** (`<endpoint>/mcp`) with a coding
+agent, so the agent can search, query, and operate on your Phoenix data. The
+endpoint is inferred from `--endpoint`, the active profile, or `PHOENIX_HOST` —
+you never re-type it.
+
+```bash
+px setup mcp                        # pick scope (global default) + agent, interactively
+px setup mcp --agent codex          # configure one agent
+px setup mcp --agent claude --local # write this repo's config (.mcp.json)
+```
+
+Supported agents: `claude`, `codex`, `gemini`, `cursor`, `opencode`, `vscode`.
+Where an agent ships an `mcp add` (Claude, Codex, Gemini, VS Code global) the
+CLI drives it; the rest get a merge into their config file (`~/.cursor/mcp.json`,
+`~/.config/opencode/opencode.json`, `.vscode/mcp.json`). Scope is `--global`
+(user-wide, the default) or `--local` (this repo — Codex is global-only).
+
+Auth defaults to **OAuth**: the config is URL-only and the agent opens Phoenix's
+browser login on first use. For headless clients, pass an API-key bearer header
+with `--header` (repeatable):
+
+```bash
+px setup mcp --agent codex --no-input --format raw
+px setup mcp --agent claude --header "Authorization: Bearer \${PHOENIX_API_KEY}"
+```
+
 ---
 
 ### `px self update`

--- a/js/packages/phoenix-cli/src/commands/formatSetup.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSetup.ts
@@ -7,6 +7,7 @@
  */
 
 import * as COPY from "../setup/copy";
+import type { McpSetupReport } from "../setup/mcp/runSetupMcp";
 import type { SetupReport } from "../setup/runSetup";
 import type { ToolingResult } from "../setup/steps/installTooling";
 
@@ -115,6 +116,64 @@ export function formatSetupOutput({
   format = "pretty",
 }: FormatSetupOutputOptions): string {
   return renderJson(toSetupOutput(report), format) ?? headlessSummary(report);
+}
+
+// ---------------------------------------------------------------------------
+// `px setup mcp`
+// ---------------------------------------------------------------------------
+
+/** The flat JSON envelope for a `px setup mcp` run. */
+export interface McpSetupOutput {
+  /** Phoenix base URL (no trailing `/mcp`). */
+  endpoint: string;
+  /** Full MCP URL written into the agent config. */
+  url: string;
+  serverName: string;
+  agent: string;
+  scope: string;
+  /** `oauth` when URL-only, `header` when a bearer/custom header was written. */
+  auth: "oauth" | "header";
+  /** Config file written, for file-based agents. */
+  file?: string;
+}
+
+export function toMcpSetupOutput(report: McpSetupReport): McpSetupOutput {
+  return {
+    endpoint: report.endpoint,
+    url: report.url,
+    serverName: report.serverName,
+    agent: report.agent,
+    scope: report.scope,
+    auth: report.auth,
+    ...(report.file ? { file: report.file } : {}),
+  };
+}
+
+/** The pretty rendering — what a headless `px setup mcp` prints on stdout. */
+function mcpHeadlessSummary(report: McpSetupReport): string {
+  const lines = [
+    `Configured the "${report.serverName}" MCP server with ${report.agent} (${report.scope}).`,
+    `url: ${report.url}`,
+    `auth: ${report.auth}`,
+  ];
+  if (report.file) {
+    lines.push(`config: ${report.file}`);
+  }
+  return lines.join("\n");
+}
+
+export interface FormatMcpSetupOutputOptions {
+  report: McpSetupReport;
+  format?: OutputFormat;
+}
+
+export function formatMcpSetupOutput({
+  report,
+  format = "pretty",
+}: FormatMcpSetupOutputOptions): string {
+  return (
+    renderJson(toMcpSetupOutput(report), format) ?? mcpHeadlessSummary(report)
+  );
 }
 
 export interface FormatToolingOutputOptions {

--- a/js/packages/phoenix-cli/src/commands/formatSetup.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSetup.ts
@@ -122,34 +122,11 @@ export function formatSetupOutput({
 // `px setup mcp`
 // ---------------------------------------------------------------------------
 
-/** The flat JSON envelope for a `px setup mcp` run. */
-export interface McpSetupOutput {
-  /** Phoenix base URL (no trailing `/mcp`). */
-  endpoint: string;
-  /** Full MCP URL written into the agent config. */
-  url: string;
-  serverName: string;
-  agent: string;
-  scope: string;
-  /** `oauth` when URL-only, `header` when a bearer/custom header was written. */
-  auth: "oauth" | "header";
-  /** Config file written, for file-based agents. */
-  file?: string;
-}
-
-export function toMcpSetupOutput(report: McpSetupReport): McpSetupOutput {
-  return {
-    endpoint: report.endpoint,
-    url: report.url,
-    serverName: report.serverName,
-    agent: report.agent,
-    scope: report.scope,
-    auth: report.auth,
-    ...(report.file ? { file: report.file } : {}),
-  };
-}
-
-/** The pretty rendering — what a headless `px setup mcp` prints on stdout. */
+/**
+ * The pretty rendering — what a headless `px setup mcp` prints on stdout. The
+ * `json`/`raw` renderings serialize the {@link McpSetupReport} verbatim, so the
+ * report interface itself is the documented JSON envelope.
+ */
 function mcpHeadlessSummary(report: McpSetupReport): string {
   const lines = [
     `Configured the "${report.serverName}" MCP server with ${report.agent} (${report.scope}).`,
@@ -171,9 +148,7 @@ export function formatMcpSetupOutput({
   report,
   format = "pretty",
 }: FormatMcpSetupOutputOptions): string {
-  return (
-    renderJson(toMcpSetupOutput(report), format) ?? mcpHeadlessSummary(report)
-  );
+  return renderJson(report, format) ?? mcpHeadlessSummary(report);
 }
 
 export interface FormatToolingOutputOptions {

--- a/js/packages/phoenix-cli/src/commands/setup.ts
+++ b/js/packages/phoenix-cli/src/commands/setup.ts
@@ -43,6 +43,7 @@ import {
   formatToolingOutput,
   type OutputFormat,
 } from "./formatSetup";
+import { createSetupMcpCommand } from "./setupMcp";
 
 /**
  * Options for `px setup` and its subcommands. Every choice setup would prompt
@@ -443,6 +444,11 @@ Examples:
 
 export function createSetupCommand(): Command {
   const command = new Command("setup");
+  // The program enables positional options; `setup` must too, or it greedily
+  // consumes a subcommand's flags that share a name with its own (`--agent`,
+  // `--format`, `--no-input`), leaving `px setup mcp --agent codex` and
+  // `px setup instrument --agent claude` unable to see their agent.
+  command.enablePositionalOptions();
   command.description(
     "Interactive setup: connect this app to Phoenix and get traces flowing.\n" +
       "(A top-level command, unlike the CLI's usual noun-verb layout — onboarding is a flow, not a resource.)"
@@ -472,10 +478,12 @@ Examples:
 Subcommands:
   px setup instrument   Instrument and verify, without redoing the questions
   px setup skills       Install the coding-agent skills alone
+  px setup mcp          Register the Phoenix MCP server with a coding agent
 `
     );
 
   command.addCommand(createSetupInstrumentCommand());
   command.addCommand(createSetupSkillsCommand());
+  command.addCommand(createSetupMcpCommand());
   return command;
 }

--- a/js/packages/phoenix-cli/src/commands/setupMcp.ts
+++ b/js/packages/phoenix-cli/src/commands/setupMcp.ts
@@ -15,7 +15,7 @@
 
 import { Command } from "commander";
 
-import { resolveConfig } from "../config";
+import { DEFAULT_PHOENIX_ENDPOINT, resolveConfig } from "../config";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeOutput } from "../io";
 import { collectString } from "../optionParsers";
@@ -120,6 +120,7 @@ function toMcpInputs(options: SetupMcpCommandOptions): {
   headers: McpHeader[];
   endpointExplicit: boolean;
   headless: boolean;
+  format: OutputFormat;
 } {
   const format = options.format ?? "pretty";
   if (!OUTPUT_FORMATS.includes(format)) {
@@ -167,6 +168,7 @@ function toMcpInputs(options: SetupMcpCommandOptions): {
     headers,
     endpointExplicit: options.endpoint !== undefined,
     headless: options.input === false,
+    format,
   };
 }
 
@@ -218,8 +220,8 @@ function exitWithError(error: unknown, format: OutputFormat): never {
 }
 
 async function setupMcpHandler(options: SetupMcpCommandOptions): Promise<void> {
-  const format = options.format ?? "pretty";
   const parsed = toMcpInputs(options);
+  const format = parsed.format;
   const deps = buildDefaultDeps();
 
   // The endpoint is resolved the same way every command resolves it: flags
@@ -233,7 +235,9 @@ async function setupMcpHandler(options: SetupMcpCommandOptions): Promise<void> {
 
   try {
     const report = await runSetupMcp(deps, {
-      endpoint: config.endpoint ?? "http://localhost:6006",
+      // `resolveConfig` always fills `endpoint`; the fallback only satisfies
+      // the optional type, and uses the shared default so it can't drift.
+      endpoint: config.endpoint ?? DEFAULT_PHOENIX_ENDPOINT,
       endpointExplicit: parsed.endpointExplicit,
       agent: parsed.agent,
       scope: parsed.scope,

--- a/js/packages/phoenix-cli/src/commands/setupMcp.ts
+++ b/js/packages/phoenix-cli/src/commands/setupMcp.ts
@@ -1,16 +1,14 @@
 /**
  * `px setup mcp` — register the Phoenix remote MCP server (`<endpoint>/mcp`)
- * with a coding agent.
+ * with a coding agent. A subcommand of the `px setup` flow, like
+ * `px setup instrument`.
  *
- * A slice of the `px setup` flow (a deliberate non-noun-verb special, like
- * `px setup instrument`). The endpoint is inferred through `resolveConfig` —
- * the same flag → env → profile → default merge every `px` command uses — so
- * the user never re-types their Phoenix URL. Auth is OAuth by default (URL-only
- * config; the agent opens Phoenix's browser login on first use); `--header`
- * wires the API-key bearer fallback for headless clients.
+ * The endpoint is inferred through `resolveConfig` (the flag → env → profile →
+ * default merge every `px` command uses). Auth defaults to OAuth; `--header`
+ * adds the API-key bearer fallback for headless clients.
  *
- * All behavior lives behind `runSetupMcp` in `../setup/mcp/runSetupMcp.ts`;
- * this layer only parses flags, resolves the endpoint, and renders the report.
+ * This layer only parses flags, resolves the endpoint, and renders the report;
+ * the behavior lives in `runSetupMcp` (`../setup/mcp/runSetupMcp.ts`).
  */
 
 import { Command } from "commander";

--- a/js/packages/phoenix-cli/src/commands/setupMcp.ts
+++ b/js/packages/phoenix-cli/src/commands/setupMcp.ts
@@ -1,0 +1,295 @@
+/**
+ * `px setup mcp` — register the Phoenix remote MCP server (`<endpoint>/mcp`)
+ * with a coding agent.
+ *
+ * A slice of the `px setup` flow (a deliberate non-noun-verb special, like
+ * `px setup instrument`). The endpoint is inferred through `resolveConfig` —
+ * the same flag → env → profile → default merge every `px` command uses — so
+ * the user never re-types their Phoenix URL. Auth is OAuth by default (URL-only
+ * config; the agent opens Phoenix's browser login on first use); `--header`
+ * wires the API-key bearer fallback for headless clients.
+ *
+ * All behavior lives behind `runSetupMcp` in `../setup/mcp/runSetupMcp.ts`;
+ * this layer only parses flags, resolves the endpoint, and renders the report.
+ */
+
+import { Command } from "commander";
+
+import { resolveConfig } from "../config";
+import { ExitCode, getExitCodeForError } from "../exitCodes";
+import { writeOutput } from "../io";
+import { collectString } from "../optionParsers";
+import * as COPY from "../setup/copy";
+import { buildDefaultDeps } from "../setup/deps/buildDefaultDeps";
+import {
+  HeadlessInputError,
+  SetupCancelledError,
+  SetupFatalError,
+} from "../setup/errors";
+import {
+  MCP_AGENT_IDS,
+  type McpAgentId,
+  type McpHeader,
+  type McpScope,
+} from "../setup/mcp/agents";
+import { runSetupMcp } from "../setup/mcp/runSetupMcp";
+import { writeStructuredError } from "../structuredError";
+import { ENDPOINT_REQUIREMENT, isEndpointUrl } from "../validation/endpoint";
+import { formatMcpSetupOutput, type OutputFormat } from "./formatSetup";
+
+/** The typed mirror of the flags `px setup mcp` registers. */
+interface SetupMcpCommandOptions {
+  /**
+   * `--agent <agent>`: Coding agent to configure. Required headlessly (no
+   * prompt to fall back to); interactively, omitting it opens the agent picker.
+   *
+   * @example "codex"
+   */
+  agent?: string;
+  /**
+   * `--global`: Configure the server in the agent's user-wide config (the
+   * default when neither scope flag is passed headlessly).
+   *
+   * @example true
+   */
+  global?: boolean;
+  /**
+   * `--local`: Configure the server in this repo's config (requires a git
+   * repository). Codex has no repo-scoped config and stays global.
+   *
+   * @example true
+   */
+  local?: boolean;
+  /**
+   * `--endpoint <url>`: Phoenix base URL. Overrides the active profile and
+   * `PHOENIX_HOST`; when omitted the endpoint is inferred and (interactively)
+   * confirmable.
+   *
+   * @example "https://phoenix.example.com"
+   */
+  endpoint?: string;
+  /**
+   * `--profile <name>`: Named profile to infer the endpoint from.
+   *
+   * @example "prod"
+   */
+  profile?: string;
+  /**
+   * `--header <header>`: `Name: value` header to attach for the API-key bearer
+   * fallback (repeatable). Without it the config is URL-only (OAuth).
+   *
+   * @example ["Authorization: Bearer ${PHOENIX_API_KEY}"]
+   */
+  header?: string[];
+  /**
+   * `--no-input`: Headless mode. Reads inverted — Commander defaults it to
+   * `true` and sets `false` only when `--no-input` is passed. Headless requires
+   * `--agent` and defaults the scope to global.
+   *
+   * @example false // px setup mcp --agent codex --no-input
+   */
+  input?: boolean;
+  /**
+   * `--format <format>`: How the result is rendered — `pretty` (default),
+   * `json`, or `raw`.
+   *
+   * @example "raw"
+   */
+  format?: OutputFormat;
+}
+
+const OUTPUT_FORMATS: readonly OutputFormat[] = ["pretty", "json", "raw"];
+
+/** Parse `Name: value` into a header, or throw with the offending input. */
+function parseHeader(raw: string): McpHeader {
+  const index = raw.indexOf(":");
+  const name = index === -1 ? "" : raw.slice(0, index).trim();
+  const value = index === -1 ? "" : raw.slice(index + 1).trim();
+  if (!name || !value) {
+    throw new HeadlessInputError(
+      `Invalid --header "${raw}". Use the form "Name: value".`
+    );
+  }
+  return { name, value };
+}
+
+/** Reject bad flag values before any side effect runs. */
+function toMcpInputs(options: SetupMcpCommandOptions): {
+  agent?: McpAgentId;
+  scope?: McpScope;
+  headers: McpHeader[];
+  endpointExplicit: boolean;
+  headless: boolean;
+} {
+  const format = options.format ?? "pretty";
+  if (!OUTPUT_FORMATS.includes(format)) {
+    fail(
+      format,
+      `Invalid --format: ${options.format}.`,
+      "px setup mcp --format pretty|json|raw"
+    );
+  }
+  if (
+    options.agent !== undefined &&
+    !MCP_AGENT_IDS.includes(options.agent as McpAgentId)
+  ) {
+    fail(
+      format,
+      `Invalid --agent: ${options.agent}.`,
+      `px setup mcp --agent <${MCP_AGENT_IDS.join("|")}>`
+    );
+  }
+  if (options.global && options.local) {
+    fail(
+      format,
+      "Pass only one of --global or --local.",
+      "px setup mcp --global"
+    );
+  }
+  if (options.endpoint !== undefined && !isEndpointUrl(options.endpoint)) {
+    fail(format, `--endpoint ${ENDPOINT_REQUIREMENT}.`, undefined);
+  }
+
+  let headers: McpHeader[];
+  try {
+    headers = (options.header ?? []).map(parseHeader);
+  } catch (error) {
+    fail(
+      format,
+      error instanceof Error ? error.message : String(error),
+      `px setup mcp --header "Authorization: Bearer \${PHOENIX_API_KEY}"`
+    );
+  }
+
+  return {
+    agent: options.agent as McpAgentId | undefined,
+    scope: options.local ? "local" : options.global ? "global" : undefined,
+    headers,
+    endpointExplicit: options.endpoint !== undefined,
+    headless: options.input === false,
+  };
+}
+
+/** Emit a structured INVALID_ARGUMENT and exit — the one bad-flag exit path. */
+function fail(format: OutputFormat, message: string, hint?: string): never {
+  writeStructuredError({
+    format,
+    message,
+    code: "INVALID_ARGUMENT",
+    ...(hint ? { hint } : {}),
+  });
+  process.exit(ExitCode.INVALID_ARGUMENT);
+}
+
+/**
+ * The command's single failure funnel, so a cancelled prompt, a bad headless
+ * invocation, and a fatal install each keep their distinct exit code and give
+ * `--format json|raw` callers the same `{error, code, hint}` envelope as the
+ * rest of `px`.
+ */
+function exitWithError(error: unknown, format: OutputFormat): never {
+  if (error instanceof SetupCancelledError) {
+    writeStructuredError({
+      format,
+      message: COPY.CANCEL_OUTRO,
+      code: "CANCELLED",
+    });
+    process.exit(ExitCode.CANCELLED);
+  }
+  if (error instanceof HeadlessInputError) {
+    writeStructuredError({
+      format,
+      message: error.message,
+      code: "INVALID_ARGUMENT",
+    });
+    process.exit(ExitCode.INVALID_ARGUMENT);
+  }
+  if (error instanceof SetupFatalError) {
+    writeStructuredError({ format, message: error.message, code: "FAILURE" });
+    process.exit(ExitCode.FAILURE);
+  }
+  const exitCode = getExitCodeForError(error);
+  writeStructuredError({
+    format,
+    message: String(error),
+    code: exitCode === ExitCode.NETWORK_ERROR ? "NETWORK_ERROR" : "FAILURE",
+  });
+  process.exit(exitCode);
+}
+
+async function setupMcpHandler(options: SetupMcpCommandOptions): Promise<void> {
+  const format = options.format ?? "pretty";
+  const parsed = toMcpInputs(options);
+  const deps = buildDefaultDeps();
+
+  // The endpoint is resolved the same way every command resolves it: flags
+  // over the active profile, then env vars, then the built-in default.
+  const config = resolveConfig({
+    cliOptions: { endpoint: options.endpoint },
+    profileName: options.profile,
+  });
+  // `--no-input` OR a non-TTY stdin opts into headless, matching px convention.
+  const headless = parsed.headless || !deps.context.stdinIsTTY;
+
+  try {
+    const report = await runSetupMcp(deps, {
+      endpoint: config.endpoint ?? "http://localhost:6006",
+      endpointExplicit: parsed.endpointExplicit,
+      agent: parsed.agent,
+      scope: parsed.scope,
+      headers: parsed.headers,
+      headless,
+    });
+    // An interactive run already narrated the result through the prompter; only
+    // a headless run (or an explicit --format) needs the printed report.
+    if (headless || format !== "pretty") {
+      writeOutput({ message: formatMcpSetupOutput({ report, format }) });
+    }
+    process.exit(ExitCode.SUCCESS);
+  } catch (error) {
+    exitWithError(error, format);
+  }
+}
+
+export function createSetupMcpCommand(): Command {
+  const command = new Command("mcp");
+  command
+    .description(
+      "Register the Phoenix remote MCP server with a coding agent.\n" +
+        "The endpoint is inferred from --endpoint, the active profile, or PHOENIX_HOST."
+    )
+    .option(
+      "--agent <agent>",
+      `Coding agent to configure (${MCP_AGENT_IDS.join("|")})`
+    )
+    .option("--global", "Configure the agent's user-wide config (default)")
+    .option("--local", "Configure this repo's config (requires a git repo)")
+    .option("--endpoint <url>", "Phoenix base URL (skips inference)")
+    .option("--profile <name>", "Profile to infer the endpoint from")
+    .option(
+      "--header <header>",
+      'Header for the API-key fallback, "Name: value" (repeatable)',
+      collectString,
+      [] as string[]
+    )
+    .option("--no-input", "Headless mode: no prompts (requires --agent)")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .action(setupMcpHandler)
+    .addHelpText(
+      "after",
+      `
+Examples:
+  px setup mcp
+  px setup mcp --agent codex
+  px setup mcp --agent claude --local
+  px setup mcp --agent cursor --global --endpoint https://phoenix.example.com
+  px setup mcp --agent codex --no-input --format raw
+  px setup mcp --agent claude --header "Authorization: Bearer \${PHOENIX_API_KEY}"
+`
+    );
+  return command;
+}

--- a/js/packages/phoenix-cli/src/commands/setupMcp.ts
+++ b/js/packages/phoenix-cli/src/commands/setupMcp.ts
@@ -224,16 +224,19 @@ async function setupMcpHandler(options: SetupMcpCommandOptions): Promise<void> {
   const format = parsed.format;
   const deps = buildDefaultDeps();
 
-  // The endpoint is resolved the same way every command resolves it: flags
-  // over the active profile, then env vars, then the built-in default.
-  const config = resolveConfig({
-    cliOptions: { endpoint: options.endpoint },
-    profileName: options.profile,
-  });
-  // `--no-input` OR a non-TTY stdin opts into headless, matching px convention.
-  const headless = parsed.headless || !deps.context.stdinIsTTY;
-
   try {
+    // The endpoint is resolved the same way every command resolves it: flags
+    // over the active profile, then env vars, then the built-in default. A bad
+    // --profile (or an unreadable stored config) throws here, so it must run
+    // inside the funnel — otherwise --format json|raw would get a bare stderr
+    // line and the wrong exit code instead of the {error,code,hint} envelope.
+    const config = resolveConfig({
+      cliOptions: { endpoint: options.endpoint },
+      profileName: options.profile,
+    });
+    // `--no-input` OR a non-TTY stdin opts into headless, matching px convention.
+    const headless = parsed.headless || !deps.context.stdinIsTTY;
+
     const report = await runSetupMcp(deps, {
       // `resolveConfig` always fills `endpoint`; the fallback only satisfies
       // the optional type, and uses the shared default so it can't drift.

--- a/js/packages/phoenix-cli/src/setup/mcp/agents.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/agents.ts
@@ -2,19 +2,15 @@
  * The coding agents `px setup mcp` can register the Phoenix remote MCP server
  * with, and how each one is configured per scope.
  *
- * This is a separate registry from the instrumentation one in
- * `../agents/registry.ts`. That registry is launch-focused — it knows how to
- * *run* an agent to instrument a repo, and only covers the four agents that can
- * take that hand-off. MCP configuration is a different concern (no launch, two
- * scopes, six agents including VS Code and Gemini), so it gets its own registry
- * rather than bloating the instrument one with fields it can't use.
+ * Separate from the launch-focused instrumentation registry in
+ * `../agents/registry.ts`: MCP configuration has no launch, two scopes, and six
+ * agents (including VS Code and Gemini), so it gets its own registry rather than
+ * adding unused fields to that one.
  *
- * Each agent declares a per-scope {@link McpInstallAction}: `cli` where the
- * agent ships an `mcp add` subcommand (the installed binary writes the format
- * that same binary reads — it can never drift from the agent's own schema), and
- * `file` where the only documented mechanism is a config file we merge into.
- * The file shapes mirror `docs/phoenix/integrations/remote-mcp.mdx`, which is
- * the contract to keep them true to.
+ * Each agent declares a per-scope {@link McpInstallAction}: `cli` runs the
+ * agent's own `mcp add` (so the format can't drift from the agent's schema);
+ * `file` merges into a config file. The file shapes mirror
+ * `docs/phoenix/integrations/remote-mcp.mdx`.
  */
 
 import * as path from "node:path";
@@ -70,12 +66,12 @@ export type McpInstallAction =
       /** Read-back that confirms the entry actually landed. */
       verifyArgs?: string[];
       /**
-       * The subset of `headers` this agent's `mcp add` cannot persist. Codex
-       * stores only a bearer token via `--bearer-token-env-var`, so any other
-       * header — or a bearer value that isn't `${VAR}`-shaped — would be
-       * silently dropped, leaving a config that looks authenticated but isn't.
-       * A non-empty result stops the run. Absent means every header is honored
-       * (the raw `--header` agents).
+       * The subset of `headers` this agent's `mcp add` cannot persist; a
+       * non-empty result stops the run rather than write a config that looks
+       * authenticated but isn't. Codex, for example, stores only a bearer token
+       * via `--bearer-token-env-var`, so it drops any other header (and any
+       * bearer value that isn't `${VAR}`-shaped). Absent means every header is
+       * honored (the raw `--header` agents).
        */
       droppedHeaders?: (headers: McpHeader[]) => McpHeader[];
     }
@@ -143,10 +139,9 @@ function headersField(headers: McpHeader[]): {
 
 /**
  * The env-var name behind an `Authorization: Bearer ${VAR}` header, if the
- * value is exactly that shape. Codex's `mcp add` cannot store an arbitrary
- * header — only `--bearer-token-env-var` — so a bearer header aimed at Codex is
- * translated to the env var it references, and a literal token (no env
- * indirection) simply yields no bearer flag.
+ * value is exactly that shape. Codex's `mcp add` stores only
+ * `--bearer-token-env-var`, so a bearer header is translated to the env var it
+ * references; a literal token yields no bearer flag.
  */
 function bearerTokenEnvVar(headers: McpHeader[]): string | undefined {
   const auth = headers.find(
@@ -163,8 +158,10 @@ function bearerTokenEnvVar(headers: McpHeader[]): string | undefined {
 // Per-agent install builders
 // ---------------------------------------------------------------------------
 
-/** Claude Code and Gemini share the same `mcp add` shape, only the scope
- *  flag differs. Both take `--scope user|project` and raw `--header`s. */
+/**
+ * Claude Code and Gemini share one `mcp add` shape — both take
+ * `--scope user|project` and raw `--header`s; only the scope flag differs.
+ */
 function httpCliAdd(
   binary: string,
   scopeFlag: "user" | "project",

--- a/js/packages/phoenix-cli/src/setup/mcp/agents.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/agents.ts
@@ -69,6 +69,15 @@ export type McpInstallAction =
       removeArgs?: string[];
       /** Read-back that confirms the entry actually landed. */
       verifyArgs?: string[];
+      /**
+       * The subset of `headers` this agent's `mcp add` cannot persist. Codex
+       * stores only a bearer token via `--bearer-token-env-var`, so any other
+       * header — or a bearer value that isn't `${VAR}`-shaped — would be
+       * silently dropped, leaving a config that looks authenticated but isn't.
+       * A non-empty result stops the run. Absent means every header is honored
+       * (the raw `--header` agents).
+       */
+      droppedHeaders?: (headers: McpHeader[]) => McpHeader[];
     }
   | {
       kind: "file";
@@ -250,6 +259,17 @@ export const MCP_AGENTS: readonly McpAgent[] = [
         },
         removeArgs: ["mcp", "remove", PHOENIX_MCP_SERVER_NAME],
         verifyArgs: ["mcp", "get", PHOENIX_MCP_SERVER_NAME],
+        droppedHeaders: (headers) => {
+          // Codex persists only the bearer env var derived from a matching
+          // Authorization header; every other header — and an Authorization
+          // header whose value isn't `Bearer ${VAR}` — is discarded by
+          // `codex mcp add`, so report those as un-storable.
+          const honorsAuth = bearerTokenEnvVar(headers) !== undefined;
+          return headers.filter(
+            (header) =>
+              !(honorsAuth && header.name.toLowerCase() === "authorization")
+          );
+        },
       },
     },
   },

--- a/js/packages/phoenix-cli/src/setup/mcp/agents.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/agents.ts
@@ -130,6 +130,18 @@ function headersObject(
 }
 
 /**
+ * A spreadable `{ headers }` fragment — present only when there are headers, so
+ * a URL-only (OAuth) config carries no empty `headers` key. Spread it into a
+ * server entry: `{ url, ...headersField(headers) }`.
+ */
+function headersField(headers: McpHeader[]): {
+  headers?: Record<string, string>;
+} {
+  const obj = headersObject(headers);
+  return obj ? { headers: obj } : {};
+}
+
+/**
  * The env-var name behind an `Authorization: Bearer ${VAR}` header, if the
  * value is exactly that shape. Codex's `mcp add` cannot store an arbitrary
  * header — only `--bearer-token-env-var` — so a bearer header aimed at Codex is
@@ -197,7 +209,7 @@ function cursorPatch(
     mcpServers: {
       [PHOENIX_MCP_SERVER_NAME]: {
         url,
-        ...(headersObject(headers) ? { headers: headersObject(headers) } : {}),
+        ...headersField(headers),
       },
     },
   };
@@ -213,7 +225,7 @@ function opencodePatch(
         type: "remote",
         url,
         enabled: true,
-        ...(headersObject(headers) ? { headers: headersObject(headers) } : {}),
+        ...headersField(headers),
       },
     },
   };
@@ -341,9 +353,7 @@ export const MCP_AGENTS: readonly McpAgent[] = [
             name: PHOENIX_MCP_SERVER_NAME,
             type: "http",
             url,
-            ...(headersObject(headers)
-              ? { headers: headersObject(headers) }
-              : {}),
+            ...headersField(headers),
           }),
         ],
       },
@@ -357,9 +367,7 @@ export const MCP_AGENTS: readonly McpAgent[] = [
             [PHOENIX_MCP_SERVER_NAME]: {
               type: "http",
               url,
-              ...(headersObject(headers)
-                ? { headers: headersObject(headers) }
-                : {}),
+              ...headersField(headers),
             },
           },
         }),

--- a/js/packages/phoenix-cli/src/setup/mcp/agents.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/agents.ts
@@ -1,0 +1,359 @@
+/**
+ * The coding agents `px setup mcp` can register the Phoenix remote MCP server
+ * with, and how each one is configured per scope.
+ *
+ * This is a separate registry from the instrumentation one in
+ * `../agents/registry.ts`. That registry is launch-focused — it knows how to
+ * *run* an agent to instrument a repo, and only covers the four agents that can
+ * take that hand-off. MCP configuration is a different concern (no launch, two
+ * scopes, six agents including VS Code and Gemini), so it gets its own registry
+ * rather than bloating the instrument one with fields it can't use.
+ *
+ * Each agent declares a per-scope {@link McpInstallAction}: `cli` where the
+ * agent ships an `mcp add` subcommand (the installed binary writes the format
+ * that same binary reads — it can never drift from the agent's own schema), and
+ * `file` where the only documented mechanism is a config file we merge into.
+ * The file shapes mirror `docs/phoenix/integrations/remote-mcp.mdx`, which is
+ * the contract to keep them true to.
+ */
+
+import * as path from "node:path";
+
+/** The name the Phoenix MCP server is registered under in every agent config. */
+export const PHOENIX_MCP_SERVER_NAME = "phoenix";
+
+export type McpAgentId =
+  | "claude"
+  | "codex"
+  | "gemini"
+  | "cursor"
+  | "opencode"
+  | "vscode";
+
+export type McpScope = "global" | "local";
+
+/** A single HTTP header to attach for the API-key bearer fallback. */
+export interface McpHeader {
+  name: string;
+  value: string;
+}
+
+/** The filesystem facts an install needs to resolve its target path. */
+export interface McpInstallContext {
+  /** The user's home directory — where global configs live. */
+  home: string;
+  /** The repo root — where local (repo-scoped) configs live. */
+  cwd: string;
+}
+
+/**
+ * How one agent is configured for one scope.
+ *
+ * `cli` runs the agent's own `mcp add`; `removeArgs`/`verifyArgs` are optional
+ * because not every agent ships a `remove`/`get` (Gemini and `code --add-mcp`
+ * do not). When `verifyArgs` is absent the executor trusts the add's exit code;
+ * when `removeArgs` is absent it cannot retry an add refused for already
+ * existing, and reports the refusal instead.
+ *
+ * `file` merges a JSON fragment into a config file — absolute for a global
+ * install (`~/.cursor/mcp.json`), repo-relative for a local one.
+ */
+export type McpInstallAction =
+  | {
+      kind: "cli";
+      /** Binary that owns the config it writes. */
+      binary: string;
+      /** argv (after the binary) that registers the server. */
+      addArgs: (url: string, headers: McpHeader[]) => string[];
+      /** Best-effort removal to make a re-run idempotent when `add` refuses. */
+      removeArgs?: string[];
+      /** Read-back that confirms the entry actually landed. */
+      verifyArgs?: string[];
+    }
+  | {
+      kind: "file";
+      /** Absolute path to the config file for this scope. */
+      path: (ctx: McpInstallContext) => string;
+      /** How that path reads in the report (repo-relative, or `~/…`). */
+      displayPath: (ctx: McpInstallContext) => string;
+      /** Keys applied only when the file is created (e.g. `$schema`). */
+      createDefaults?: Record<string, unknown>;
+      /** The JSON fragment to merge in. */
+      patch: (url: string, headers: McpHeader[]) => Record<string, unknown>;
+    };
+
+export interface McpAgent {
+  id: McpAgentId;
+  /** "Claude Code", "Codex", … */
+  label: string;
+  /** Binary name for PATH detection. */
+  binary: string;
+  /**
+   * Per-scope install. A scope absent from the map is unsupported by the agent
+   * — Codex reads only a single global `~/.codex/config.toml`, so it has no
+   * `local` entry, and the command says so when `--local` names it.
+   */
+  install: Partial<Record<McpScope, McpInstallAction>>;
+}
+
+// ---------------------------------------------------------------------------
+// Header helpers
+// ---------------------------------------------------------------------------
+
+/** `--header "Name: value"` pairs, for agents whose CLI takes raw headers. */
+function headerFlags(headers: McpHeader[]): string[] {
+  return headers.flatMap((header) => [
+    "--header",
+    `${header.name}: ${header.value}`,
+  ]);
+}
+
+/** A `headers` object for file configs, or undefined when there are none. */
+function headersObject(
+  headers: McpHeader[]
+): Record<string, string> | undefined {
+  if (headers.length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    headers.map((header) => [header.name, header.value])
+  );
+}
+
+/**
+ * The env-var name behind an `Authorization: Bearer ${VAR}` header, if the
+ * value is exactly that shape. Codex's `mcp add` cannot store an arbitrary
+ * header — only `--bearer-token-env-var` — so a bearer header aimed at Codex is
+ * translated to the env var it references, and a literal token (no env
+ * indirection) simply yields no bearer flag.
+ */
+function bearerTokenEnvVar(headers: McpHeader[]): string | undefined {
+  const auth = headers.find(
+    (header) => header.name.toLowerCase() === "authorization"
+  );
+  if (!auth) {
+    return undefined;
+  }
+  const match = auth.value.match(/^Bearer\s+\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$/);
+  return match?.[1];
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent install builders
+// ---------------------------------------------------------------------------
+
+/** Claude Code and Gemini share the same `mcp add` shape, only the scope
+ *  flag differs. Both take `--scope user|project` and raw `--header`s. */
+function httpCliAdd(
+  binary: string,
+  scopeFlag: "user" | "project",
+  { verify }: { verify: boolean }
+): McpInstallAction {
+  return {
+    kind: "cli",
+    binary,
+    addArgs: (url, headers) => [
+      "mcp",
+      "add",
+      "--scope",
+      scopeFlag,
+      "--transport",
+      "http",
+      ...headerFlags(headers),
+      PHOENIX_MCP_SERVER_NAME,
+      url,
+    ],
+    removeArgs: [
+      "mcp",
+      "remove",
+      "--scope",
+      scopeFlag,
+      PHOENIX_MCP_SERVER_NAME,
+    ],
+    ...(verify ? { verifyArgs: ["mcp", "get", PHOENIX_MCP_SERVER_NAME] } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// File-config fragments
+// ---------------------------------------------------------------------------
+
+const OPENCODE_DEFAULTS = { $schema: "https://opencode.ai/config.json" };
+
+function cursorPatch(
+  url: string,
+  headers: McpHeader[]
+): Record<string, unknown> {
+  return {
+    mcpServers: {
+      [PHOENIX_MCP_SERVER_NAME]: {
+        url,
+        ...(headersObject(headers) ? { headers: headersObject(headers) } : {}),
+      },
+    },
+  };
+}
+
+function opencodePatch(
+  url: string,
+  headers: McpHeader[]
+): Record<string, unknown> {
+  return {
+    mcp: {
+      [PHOENIX_MCP_SERVER_NAME]: {
+        type: "remote",
+        url,
+        enabled: true,
+        ...(headersObject(headers) ? { headers: headersObject(headers) } : {}),
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export const MCP_AGENTS: readonly McpAgent[] = [
+  {
+    id: "claude",
+    label: "Claude Code",
+    binary: "claude",
+    install: {
+      // `--scope user` is user-wide; `--scope project` writes the shared
+      // `.mcp.json` at the repo root (the "repo" scope a --local install means).
+      global: httpCliAdd("claude", "user", { verify: true }),
+      local: httpCliAdd("claude", "project", { verify: true }),
+    },
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    binary: "codex",
+    install: {
+      // Codex reads one global `~/.codex/config.toml`; there is no repo-scoped
+      // config, so only `global` is offered. `codex mcp add` writes the TOML
+      // itself, so we never format TOML by hand.
+      global: {
+        kind: "cli",
+        binary: "codex",
+        addArgs: (url, headers) => {
+          const envVar = bearerTokenEnvVar(headers);
+          return [
+            "mcp",
+            "add",
+            PHOENIX_MCP_SERVER_NAME,
+            "--url",
+            url,
+            ...(envVar ? ["--bearer-token-env-var", envVar] : []),
+          ];
+        },
+        removeArgs: ["mcp", "remove", PHOENIX_MCP_SERVER_NAME],
+        verifyArgs: ["mcp", "get", PHOENIX_MCP_SERVER_NAME],
+      },
+    },
+  },
+  {
+    id: "gemini",
+    label: "Gemini CLI",
+    binary: "gemini",
+    install: {
+      // Gemini's `mcp add` mirrors Claude's flags but ships no `get`, so there
+      // is no read-back — the add's exit code is trusted.
+      global: httpCliAdd("gemini", "user", { verify: false }),
+      local: httpCliAdd("gemini", "project", { verify: false }),
+    },
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    binary: "cursor-agent",
+    install: {
+      global: {
+        kind: "file",
+        path: (ctx) => path.join(ctx.home, ".cursor", "mcp.json"),
+        displayPath: () => "~/.cursor/mcp.json",
+        patch: cursorPatch,
+      },
+      local: {
+        kind: "file",
+        path: (ctx) => path.join(ctx.cwd, ".cursor", "mcp.json"),
+        displayPath: () => ".cursor/mcp.json",
+        patch: cursorPatch,
+      },
+    },
+  },
+  {
+    id: "opencode",
+    label: "OpenCode",
+    binary: "opencode",
+    install: {
+      global: {
+        kind: "file",
+        path: (ctx) =>
+          path.join(ctx.home, ".config", "opencode", "opencode.json"),
+        displayPath: () => "~/.config/opencode/opencode.json",
+        createDefaults: OPENCODE_DEFAULTS,
+        patch: opencodePatch,
+      },
+      local: {
+        kind: "file",
+        path: (ctx) => path.join(ctx.cwd, "opencode.json"),
+        displayPath: () => "opencode.json",
+        createDefaults: OPENCODE_DEFAULTS,
+        patch: opencodePatch,
+      },
+    },
+  },
+  {
+    id: "vscode",
+    label: "VS Code",
+    binary: "code",
+    install: {
+      // Global: the user-profile `mcp.json` path is platform-specific, so we
+      // let the `code` CLI write it rather than guessing the location.
+      global: {
+        kind: "cli",
+        binary: "code",
+        addArgs: (url, headers) => [
+          "--add-mcp",
+          JSON.stringify({
+            name: PHOENIX_MCP_SERVER_NAME,
+            type: "http",
+            url,
+            ...(headersObject(headers)
+              ? { headers: headersObject(headers) }
+              : {}),
+          }),
+        ],
+      },
+      // Local: the documented workspace file.
+      local: {
+        kind: "file",
+        path: (ctx) => path.join(ctx.cwd, ".vscode", "mcp.json"),
+        displayPath: () => ".vscode/mcp.json",
+        patch: (url, headers) => ({
+          servers: {
+            [PHOENIX_MCP_SERVER_NAME]: {
+              type: "http",
+              url,
+              ...(headersObject(headers)
+                ? { headers: headersObject(headers) }
+                : {}),
+            },
+          },
+        }),
+      },
+    },
+  },
+];
+
+/** The agent with this id, or undefined when the id is unknown. */
+export function getMcpAgent(id: string): McpAgent | undefined {
+  return MCP_AGENTS.find((agent) => agent.id === id);
+}
+
+/** Every id `--agent` accepts, for help text and error messages. */
+export const MCP_AGENT_IDS: readonly McpAgentId[] = MCP_AGENTS.map(
+  (agent) => agent.id
+);

--- a/js/packages/phoenix-cli/src/setup/mcp/install.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/install.ts
@@ -1,0 +1,127 @@
+/**
+ * Execute one MCP install action — run the agent's `mcp add`, or merge the
+ * server entry into its config file.
+ *
+ * The CLI path mirrors the docs-MCP install in `../steps/offerDocsMcp.ts`: add
+ * first, and only when the add is refused *and* the agent's own listing shows
+ * an entry under our name do we remove-then-retry — removing before knowing the
+ * add works would destroy a working registration a failed retry can't put back.
+ * The read-back (`verifyArgs`) is the drift guard: an add whose flags changed
+ * meaning while still exiting 0 is caught by the entry not showing up.
+ *
+ * This never throws for an install that simply didn't take: it returns a
+ * `failed` result with a reason, and the caller decides how loud to be.
+ */
+
+import type { SetupDeps } from "../deps";
+import { writeMcpConfig } from "../util/mcpConfig";
+import type { McpHeader, McpInstallAction, McpInstallContext } from "./agents";
+
+export type McpInstallOutcome = "configured" | "failed";
+
+export interface McpInstallResult {
+  outcome: McpInstallOutcome;
+  /** The config file written (repo-relative or `~/…`), for file-based installs. */
+  file?: string;
+  /** Why the install failed, when it did. */
+  reason?: string;
+}
+
+/** Registering a server is one config write; a slow CLI start is still fine. */
+const CLI_INSTALL_TIMEOUT_MS = 30_000;
+
+export interface RunMcpInstallArgs {
+  action: McpInstallAction;
+  /** The Phoenix MCP URL (endpoint + `/mcp`). */
+  url: string;
+  /** Headers for the API-key bearer fallback; empty for OAuth. */
+  headers: McpHeader[];
+  /** Home and repo-root the file paths resolve against. */
+  installContext: McpInstallContext;
+}
+
+export async function runMcpInstall(
+  deps: Pick<SetupDeps, "processes">,
+  { action, url, headers, installContext }: RunMcpInstallArgs
+): Promise<McpInstallResult> {
+  try {
+    return action.kind === "cli"
+      ? await runCliInstall(deps, action, { url, headers, installContext })
+      : runFileInstall(action, { url, headers, installContext });
+  } catch (error) {
+    return {
+      outcome: "failed",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function runCliInstall(
+  deps: Pick<SetupDeps, "processes">,
+  action: Extract<McpInstallAction, { kind: "cli" }>,
+  {
+    url,
+    headers,
+    installContext,
+  }: Pick<RunMcpInstallArgs, "url" | "headers" | "installContext">
+): Promise<McpInstallResult> {
+  // Every exec runs in the repo root: a `--scope project` add must land the
+  // config in this repo, not wherever px happened to be launched from.
+  const exec = (args: string[]) =>
+    deps.processes.exec({
+      command: action.binary,
+      args,
+      cwd: installContext.cwd,
+      timeoutMs: CLI_INSTALL_TIMEOUT_MS,
+    });
+
+  const fail = (reason: string): McpInstallResult => ({
+    outcome: "failed",
+    reason,
+  });
+
+  let added = await exec(action.addArgs(url, headers));
+  if (added.exitCode !== 0) {
+    // Retry through remove only when we can both confirm an entry exists and
+    // remove it — otherwise a refused add is just reported.
+    if (action.removeArgs && action.verifyArgs) {
+      const existing = await exec(action.verifyArgs);
+      if (existing.exitCode !== 0) {
+        return fail(added.stderr.trim() || `exit code ${added.exitCode}`);
+      }
+      await exec(action.removeArgs);
+      added = await exec(action.addArgs(url, headers));
+      if (added.exitCode !== 0) {
+        return fail(added.stderr.trim() || `exit code ${added.exitCode}`);
+      }
+    } else {
+      return fail(added.stderr.trim() || `exit code ${added.exitCode}`);
+    }
+  }
+
+  // Trust the add's exit code only when the agent has no listing to read back
+  // from; otherwise confirm the entry actually registered.
+  if (action.verifyArgs) {
+    const verified = await exec(action.verifyArgs);
+    if (verified.exitCode !== 0) {
+      return fail("the server did not show up in the agent's MCP list");
+    }
+  }
+  return { outcome: "configured" };
+}
+
+function runFileInstall(
+  action: Extract<McpInstallAction, { kind: "file" }>,
+  {
+    url,
+    headers,
+    installContext,
+  }: Pick<RunMcpInstallArgs, "url" | "headers" | "installContext">
+): McpInstallResult {
+  writeMcpConfig({
+    absolutePath: action.path(installContext),
+    patch: action.patch(url, headers),
+    ...(action.createDefaults ? { createDefaults: action.createDefaults } : {}),
+  });
+  return { outcome: "configured", file: action.displayPath(installContext) };
+}

--- a/js/packages/phoenix-cli/src/setup/mcp/install.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/install.ts
@@ -2,15 +2,14 @@
  * Execute one MCP install action — run the agent's `mcp add`, or merge the
  * server entry into its config file.
  *
- * The CLI path mirrors the docs-MCP install in `../steps/offerDocsMcp.ts`: add
- * first, and only when the add is refused *and* the agent's own listing shows
- * an entry under our name do we remove-then-retry — removing before knowing the
- * add works would destroy a working registration a failed retry can't put back.
- * The read-back (`verifyArgs`) is the drift guard: an add whose flags changed
- * meaning while still exiting 0 is caught by the entry not showing up.
+ * The CLI path adds first, and only remove-then-retries when the add is refused
+ * *and* the agent's own listing already shows an entry under our name — removing
+ * before the add is known to work could destroy a registration a failed retry
+ * can't restore. The `verifyArgs` read-back guards against drift: an add whose
+ * flags changed meaning while still exiting 0 shows up as a missing entry.
  *
- * This never throws for an install that simply didn't take: it returns a
- * `failed` result with a reason, and the caller decides how loud to be.
+ * Never throws when an install simply didn't take — returns a `failed` result
+ * with a reason for the caller to handle.
  */
 
 import type { SetupDeps } from "../deps";

--- a/js/packages/phoenix-cli/src/setup/mcp/install.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/install.ts
@@ -119,7 +119,8 @@ function runFileInstall(
   }: Pick<RunMcpInstallArgs, "url" | "headers" | "installContext">
 ): McpInstallResult {
   writeMcpConfig({
-    absolutePath: action.path(installContext),
+    filePath: action.path(installContext),
+    displayPath: action.displayPath(installContext),
     patch: action.patch(url, headers),
     ...(action.createDefaults ? { createDefaults: action.createDefaults } : {}),
   });

--- a/js/packages/phoenix-cli/src/setup/mcp/runSetupMcp.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/runSetupMcp.ts
@@ -1,0 +1,318 @@
+/**
+ * `px setup mcp` — register the Phoenix remote MCP server with a coding agent.
+ *
+ * Phoenix serves an MCP endpoint at `<base-url>/mcp`; this lane wires that URL
+ * into a coding agent's config so the agent can search, query, and operate on
+ * Phoenix data. The base URL is inferred by the command layer from the same
+ * sources every `px` command uses (flag → env → active profile → default), so
+ * the user never re-types it — this module receives the resolved endpoint.
+ *
+ * Auth is OAuth by default: the config is URL-only and the agent opens Phoenix's
+ * built-in browser login on first use. `--header` supplies the API-key bearer
+ * fallback for headless clients, and each agent applies it in its own way
+ * (see {@link ./agents}).
+ *
+ * The bare command (no `--agent`) walks two prompts — scope, then agent — with
+ * the endpoint shown (and, unless pinned by `--endpoint`, confirmable) first. A
+ * headless run must name its agent and takes global scope by default.
+ */
+
+import { isEndpointUrl, normalizeEndpoint } from "../../validation/endpoint";
+import { probeBinary } from "../agents/registry";
+import type { SetupDeps } from "../deps";
+import { HeadlessInputError, SetupFatalError } from "../errors";
+import {
+  getMcpAgent,
+  MCP_AGENTS,
+  MCP_AGENT_IDS,
+  PHOENIX_MCP_SERVER_NAME,
+  type McpAgent,
+  type McpAgentId,
+  type McpHeader,
+  type McpScope,
+} from "./agents";
+import { runMcpInstall } from "./install";
+
+/** What a run did, in the shape the summary and `--format json` print. */
+export interface McpSetupReport {
+  /** The Phoenix base URL the server was pointed at (no trailing `/mcp`). */
+  endpoint: string;
+  /** The full MCP URL written into the agent config. */
+  url: string;
+  serverName: string;
+  agent: McpAgentId;
+  scope: McpScope;
+  /** `oauth` when URL-only; `header` when a bearer/custom header was written. */
+  auth: "oauth" | "header";
+  /** The config file written, for file-based agents (repo-relative or `~/…`). */
+  file?: string;
+}
+
+export interface McpSetupInputs {
+  /** Resolved Phoenix base URL (normalized, no trailing slash). */
+  endpoint: string;
+  /** True when `--endpoint` pinned it — skips the interactive confirm prompt. */
+  endpointExplicit: boolean;
+  /** Pinned agent, or undefined to detect + prompt. */
+  agent?: McpAgentId;
+  /** Pinned scope, or undefined (interactive prompts; headless defaults global). */
+  scope?: McpScope;
+  /** Headers for the bearer fallback; empty means OAuth (URL only). */
+  headers: McpHeader[];
+  headless: boolean;
+}
+
+export const COPY = {
+  endpointPrompt: "Phoenix endpoint",
+  endpointInvalid:
+    "Enter a full http:// or https:// URL (e.g. http://localhost:6006).",
+  usingEndpoint: (url: string) =>
+    `Registering the Phoenix MCP server at ${url}`,
+  scopePrompt: "Where should the MCP server be configured?",
+  scopeGlobalLabel: "Global",
+  scopeGlobalHint: "available across all your projects",
+  scopeLocalLabel: "This repo",
+  scopeLocalHint: "written into this project's config, checked in with it",
+  agentPrompt: "Which coding agent?",
+  detectedHint: "detected",
+  headlessNeedsAgent: `--agent is required with --no-input. Pass one of: ${MCP_AGENT_IDS.join(", ")}.`,
+  localNeedsRepo:
+    "--local must run inside a git repository. Re-run from your project, or use --global.",
+  codexGlobalOnly:
+    "Codex reads only a global config, so it is always configured globally.",
+  codexGlobalOnlyHeadless:
+    "Codex has no repo-scoped config. Drop --local (Codex is always global).",
+  scopeUnsupported: (agentLabel: string, scope: McpScope) =>
+    `${agentLabel} does not support ${scope} MCP configuration.`,
+  configuredCli: (agentLabel: string) =>
+    `Registered the Phoenix MCP server with ${agentLabel}.`,
+  configuredFile: (agentLabel: string, file: string) =>
+    `Wrote the Phoenix MCP server to ${file} for ${agentLabel}.`,
+  installFailed: (agentLabel: string, reason: string) =>
+    `Could not configure ${agentLabel}: ${reason}`,
+  nextStepOAuth: (agentLabel: string) =>
+    `Open ${agentLabel} and run /mcp (or use the ${PHOENIX_MCP_SERVER_NAME} server) — it will open a browser to log in to Phoenix on first use.`,
+  nextStepHeader:
+    "The server is configured with your bearer header — no browser login needed.",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Entry
+// ---------------------------------------------------------------------------
+
+export async function runSetupMcp(
+  deps: Pick<SetupDeps, "context" | "prompter" | "processes">,
+  inputs: McpSetupInputs
+): Promise<McpSetupReport> {
+  const endpoint = await resolveEndpoint(deps, inputs);
+  const url = `${endpoint}/mcp`;
+
+  const scope = await resolveScope(deps, inputs);
+  const agent = await resolveAgent(deps, inputs);
+  const effectiveScope = await reconcileScope(deps, agent, scope, inputs);
+
+  if (effectiveScope === "local") {
+    await assertGitRepo(deps);
+  }
+
+  const action = agent.install[effectiveScope];
+  if (!action) {
+    // Guarded by reconcileScope for the codex case; this is the belt-and-braces
+    // guard for any future agent/scope gap.
+    throw new SetupFatalError(
+      COPY.scopeUnsupported(agent.label, effectiveScope)
+    );
+  }
+
+  const installContext = {
+    home: resolveHome(deps),
+    cwd: deps.context.cwd,
+  };
+  const result = await runMcpInstall(deps, {
+    action,
+    url,
+    headers: inputs.headers,
+    installContext,
+  });
+  if (result.outcome === "failed") {
+    throw new SetupFatalError(
+      COPY.installFailed(agent.label, result.reason ?? "unknown error")
+    );
+  }
+
+  const auth = inputs.headers.length > 0 ? "header" : "oauth";
+  if (!inputs.headless) {
+    deps.prompter.line(
+      result.file
+        ? COPY.configuredFile(agent.label, result.file)
+        : COPY.configuredCli(agent.label)
+    );
+    deps.prompter.line(
+      auth === "oauth" ? COPY.nextStepOAuth(agent.label) : COPY.nextStepHeader
+    );
+  }
+
+  return {
+    endpoint,
+    url,
+    serverName: PHOENIX_MCP_SERVER_NAME,
+    agent: agent.id,
+    scope: effectiveScope,
+    auth,
+    ...(result.file ? { file: result.file } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint
+// ---------------------------------------------------------------------------
+
+async function resolveEndpoint(
+  deps: Pick<SetupDeps, "prompter">,
+  inputs: McpSetupInputs
+): Promise<string> {
+  // Headless, or endpoint pinned by flag: take the resolved value as-is.
+  if (inputs.headless || inputs.endpointExplicit) {
+    return normalizeEndpoint(inputs.endpoint);
+  }
+  // Interactive: show the inferred endpoint as the default and let the user
+  // accept it (Enter) or point somewhere else.
+  const entered = await deps.prompter.textInput({
+    message: COPY.endpointPrompt,
+    defaultValue: inputs.endpoint,
+    validate: (value) =>
+      isEndpointUrl(value) ? undefined : COPY.endpointInvalid,
+  });
+  const endpoint = normalizeEndpoint(entered);
+  deps.prompter.line(COPY.usingEndpoint(`${endpoint}/mcp`));
+  return endpoint;
+}
+
+// ---------------------------------------------------------------------------
+// Scope
+// ---------------------------------------------------------------------------
+
+async function resolveScope(
+  deps: Pick<SetupDeps, "prompter">,
+  inputs: McpSetupInputs
+): Promise<McpScope> {
+  if (inputs.scope) {
+    return inputs.scope;
+  }
+  // Headless defaults to global — the safe, agent-agnostic choice, and the one
+  // scope every agent supports.
+  if (inputs.headless) {
+    return "global";
+  }
+  return deps.prompter.select<McpScope>({
+    message: COPY.scopePrompt,
+    options: [
+      {
+        value: "global",
+        label: COPY.scopeGlobalLabel,
+        hint: COPY.scopeGlobalHint,
+      },
+      {
+        value: "local",
+        label: COPY.scopeLocalLabel,
+        hint: COPY.scopeLocalHint,
+      },
+    ],
+  });
+}
+
+/**
+ * Codex has no repo-scoped config. When `local` names it, a headless run errors
+ * (they pinned a scope the agent can't honor), while an interactive run says so
+ * and falls back to global rather than dead-ending.
+ */
+async function reconcileScope(
+  deps: Pick<SetupDeps, "prompter">,
+  agent: McpAgent,
+  scope: McpScope,
+  inputs: McpSetupInputs
+): Promise<McpScope> {
+  if (agent.install[scope]) {
+    return scope;
+  }
+  if (scope === "local" && agent.install.global) {
+    if (inputs.headless) {
+      throw new HeadlessInputError(COPY.codexGlobalOnlyHeadless);
+    }
+    deps.prompter.line(COPY.codexGlobalOnly);
+    return "global";
+  }
+  throw new SetupFatalError(COPY.scopeUnsupported(agent.label, scope));
+}
+
+async function assertGitRepo(
+  deps: Pick<SetupDeps, "context" | "processes">
+): Promise<void> {
+  const check = await deps.processes.exec({
+    command: "git",
+    args: ["rev-parse", "--is-inside-work-tree"],
+    cwd: deps.context.cwd,
+  });
+  const isRepo = check.exitCode === 0 && check.stdout.trim() === "true";
+  if (!isRepo) {
+    // Same class either mode: it's a bad invocation, not a runtime failure.
+    throw new HeadlessInputError(COPY.localNeedsRepo);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Agent
+// ---------------------------------------------------------------------------
+
+async function resolveAgent(
+  deps: Pick<SetupDeps, "prompter" | "processes">,
+  inputs: McpSetupInputs
+): Promise<McpAgent> {
+  if (inputs.agent) {
+    const agent = getMcpAgent(inputs.agent);
+    if (!agent) {
+      // Unreachable: the command layer validates --agent against MCP_AGENT_IDS.
+      throw new HeadlessInputError(COPY.headlessNeedsAgent);
+    }
+    return agent;
+  }
+  if (inputs.headless) {
+    throw new HeadlessInputError(COPY.headlessNeedsAgent);
+  }
+
+  const detected = await detectMcpAgents(deps);
+  const detectedIds = new Set(detected.map((agent) => agent.id));
+  // Detected agents first (with a hint), then the rest — so a user can still
+  // configure an agent whose binary isn't on PATH (e.g. the VS Code app without
+  // the `code` shell command).
+  const ordered = [
+    ...MCP_AGENTS.filter((agent) => detectedIds.has(agent.id)),
+    ...MCP_AGENTS.filter((agent) => !detectedIds.has(agent.id)),
+  ];
+  const chosen = await deps.prompter.select<McpAgentId>({
+    message: COPY.agentPrompt,
+    options: ordered.map((agent) => ({
+      value: agent.id,
+      label: agent.label,
+      ...(detectedIds.has(agent.id) ? { hint: COPY.detectedHint } : {}),
+    })),
+  });
+  // `chosen` is one of MCP_AGENTS' ids by construction.
+  return getMcpAgent(chosen)!;
+}
+
+/** Agents whose binary answers `--version`, in registry order. */
+async function detectMcpAgents(
+  deps: Pick<SetupDeps, "processes">
+): Promise<McpAgent[]> {
+  const probes = await Promise.all(
+    MCP_AGENTS.map((agent) => probeBinary(deps, agent.binary))
+  );
+  return MCP_AGENTS.filter((_, index) => probes[index]);
+}
+
+/** The user's home directory, read only through the run context's env copy. */
+function resolveHome(deps: Pick<SetupDeps, "context">): string {
+  const { env } = deps.context;
+  return env.HOME ?? env.USERPROFILE ?? "";
+}

--- a/js/packages/phoenix-cli/src/setup/mcp/runSetupMcp.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/runSetupMcp.ts
@@ -84,6 +84,11 @@ export const COPY = {
     "Codex has no repo-scoped config. Drop --local (Codex is always global).",
   scopeUnsupported: (agentLabel: string, scope: McpScope) =>
     `${agentLabel} does not support ${scope} MCP configuration.`,
+  headersUnsupported: (agentLabel: string, dropped: McpHeader[]) =>
+    `${agentLabel} can't store this header (${dropped
+      .map((header) => header.name)
+      .join(", ")}) — it only accepts a bearer token via env var. Pass ` +
+    `--header "Authorization: Bearer \${VAR}", or omit --header to use OAuth.`,
   configuredCli: (agentLabel: string) =>
     `Registered the Phoenix MCP server with ${agentLabel}.`,
   configuredFile: (agentLabel: string, file: string) =>
@@ -122,6 +127,17 @@ export async function runSetupMcp(
     throw new SetupFatalError(
       COPY.scopeUnsupported(agent.label, effectiveScope)
     );
+  }
+
+  // Refuse headers the agent can't actually persist rather than writing a
+  // config that reports `auth: "header"` but carries no credential.
+  if (action.kind === "cli" && action.droppedHeaders) {
+    const dropped = action.droppedHeaders(inputs.headers);
+    if (dropped.length > 0) {
+      throw new HeadlessInputError(
+        COPY.headersUnsupported(agent.label, dropped)
+      );
+    }
   }
 
   const installContext = {

--- a/js/packages/phoenix-cli/src/setup/mcp/runSetupMcp.ts
+++ b/js/packages/phoenix-cli/src/setup/mcp/runSetupMcp.ts
@@ -1,20 +1,14 @@
 /**
- * `px setup mcp` — register the Phoenix remote MCP server with a coding agent.
+ * `px setup mcp` — register the Phoenix remote MCP server (`<base-url>/mcp`)
+ * with a coding agent's config. This module receives the already-resolved
+ * endpoint from the command layer.
  *
- * Phoenix serves an MCP endpoint at `<base-url>/mcp`; this lane wires that URL
- * into a coding agent's config so the agent can search, query, and operate on
- * Phoenix data. The base URL is inferred by the command layer from the same
- * sources every `px` command uses (flag → env → active profile → default), so
- * the user never re-types it — this module receives the resolved endpoint.
+ * Auth defaults to OAuth (URL-only config; the agent handles browser login on
+ * first use). `--header` adds an API-key bearer fallback for headless clients,
+ * applied per agent (see {@link ./agents}).
  *
- * Auth is OAuth by default: the config is URL-only and the agent opens Phoenix's
- * built-in browser login on first use. `--header` supplies the API-key bearer
- * fallback for headless clients, and each agent applies it in its own way
- * (see {@link ./agents}).
- *
- * The bare command (no `--agent`) walks two prompts — scope, then agent — with
- * the endpoint shown (and, unless pinned by `--endpoint`, confirmable) first. A
- * headless run must name its agent and takes global scope by default.
+ * Without `--agent` the command prompts for scope then agent, after confirming
+ * the endpoint. A headless run requires `--agent` and defaults to global scope.
  */
 
 import { isEndpointUrl, normalizeEndpoint } from "../../validation/endpoint";
@@ -122,8 +116,7 @@ export async function runSetupMcp(
 
   const action = agent.install[effectiveScope];
   if (!action) {
-    // Guarded by reconcileScope for the codex case; this is the belt-and-braces
-    // guard for any future agent/scope gap.
+    // reconcileScope already handles codex; this covers any future scope gap.
     throw new SetupFatalError(
       COPY.scopeUnsupported(agent.label, effectiveScope)
     );
@@ -238,9 +231,9 @@ async function resolveScope(
 }
 
 /**
- * Codex has no repo-scoped config. When `local` names it, a headless run errors
- * (they pinned a scope the agent can't honor), while an interactive run says so
- * and falls back to global rather than dead-ending.
+ * Codex has no repo-scoped config. When `--local` names it, a headless run
+ * errors on the unsupported scope; an interactive run warns and falls back to
+ * global.
  */
 async function reconcileScope(
   deps: Pick<SetupDeps, "prompter">,

--- a/js/packages/phoenix-cli/src/setup/steps/offerDocsMcp.ts
+++ b/js/packages/phoenix-cli/src/setup/steps/offerDocsMcp.ts
@@ -22,6 +22,8 @@
  * agent config unless `--docs-mcp` asked for it.
  */
 
+import * as path from "node:path";
+
 import { DOCS_MCP_SERVER_URL, type CodingAgent } from "../agents/registry";
 import * as COPY from "../copy";
 import type { SetupDeps } from "../deps";
@@ -178,8 +180,8 @@ async function runOffer(
   // A write that throws (unparseable existing file, permissions) is handled
   // by the catch-all in offerDocsMcp.
   writeMcpConfig({
-    directory: deps.context.cwd,
-    relativePath: install.relativePath,
+    filePath: path.join(deps.context.cwd, install.relativePath),
+    displayPath: install.relativePath,
     patch: install.patch(DOCS_MCP_SERVER_URL),
     ...(install.createDefaults
       ? { createDefaults: install.createDefaults }

--- a/js/packages/phoenix-cli/src/setup/util/mcpConfig.ts
+++ b/js/packages/phoenix-cli/src/setup/util/mcpConfig.ts
@@ -12,19 +12,16 @@ import * as path from "node:path";
 
 export interface WriteMcpConfigArgs {
   /**
-   * Repo root the relative config path resolves against. Ignored when
-   * `absolutePath` is given (a global-scope install targets a file outside the
-   * repo, e.g. `~/.cursor/mcp.json`).
+   * Absolute path to the config file to merge into. Callers compose it from a
+   * repo root or the user's home directory before calling — this function does
+   * not join paths.
    */
-  directory?: string;
-  /** Config file path, relative to `directory`. Ignored when `absolutePath` is given. */
-  relativePath?: string;
+  filePath: string;
   /**
-   * Absolute path to the config file. When set it is used verbatim and
-   * `directory`/`relativePath` are ignored — the global-scope escape hatch for
-   * configs that live in the user's home directory rather than the repo.
+   * How the path reads in the "could not be parsed" error: the repo-relative
+   * path where the caller has one, else the absolute `filePath` (the default).
    */
-  absolutePath?: string;
+  displayPath?: string;
   /**
    * JSON fragment to merge in: container and server-name keys merge, a
    * server entry itself is replaced wholesale.
@@ -75,22 +72,14 @@ export class McpConfigUnreadableError extends Error {
 }
 
 export function writeMcpConfig({
-  directory,
-  relativePath,
-  absolutePath,
+  filePath,
+  displayPath = filePath,
   patch,
   createDefaults,
 }: WriteMcpConfigArgs): void {
-  const filePath =
-    absolutePath ?? path.join(directory ?? "", relativePath ?? "");
   if (!path.isAbsolute(filePath)) {
-    throw new Error(
-      "writeMcpConfig requires an absolute path (pass `absolutePath`, or a `directory` that is absolute)"
-    );
+    throw new Error("writeMcpConfig requires an absolute path");
   }
-  // What the "could not be parsed" error names: the repo-relative path when we
-  // have one, else the absolute path a global install targets.
-  const displayPath = relativePath ?? filePath;
 
   let existing: Record<string, unknown> = createDefaults ?? {};
   if (fs.existsSync(filePath)) {

--- a/js/packages/phoenix-cli/src/setup/util/mcpConfig.ts
+++ b/js/packages/phoenix-cli/src/setup/util/mcpConfig.ts
@@ -11,10 +11,20 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 export interface WriteMcpConfigArgs {
-  /** Repo root the relative config path resolves against. */
-  directory: string;
-  /** Config file path, relative to `directory`. */
-  relativePath: string;
+  /**
+   * Repo root the relative config path resolves against. Ignored when
+   * `absolutePath` is given (a global-scope install targets a file outside the
+   * repo, e.g. `~/.cursor/mcp.json`).
+   */
+  directory?: string;
+  /** Config file path, relative to `directory`. Ignored when `absolutePath` is given. */
+  relativePath?: string;
+  /**
+   * Absolute path to the config file. When set it is used verbatim and
+   * `directory`/`relativePath` are ignored — the global-scope escape hatch for
+   * configs that live in the user's home directory rather than the repo.
+   */
+  absolutePath?: string;
   /**
    * JSON fragment to merge in: container and server-name keys merge, a
    * server entry itself is replaced wholesale.
@@ -67,10 +77,20 @@ export class McpConfigUnreadableError extends Error {
 export function writeMcpConfig({
   directory,
   relativePath,
+  absolutePath,
   patch,
   createDefaults,
 }: WriteMcpConfigArgs): void {
-  const filePath = path.join(directory, relativePath);
+  const filePath =
+    absolutePath ?? path.join(directory ?? "", relativePath ?? "");
+  if (!path.isAbsolute(filePath)) {
+    throw new Error(
+      "writeMcpConfig requires an absolute path (pass `absolutePath`, or a `directory` that is absolute)"
+    );
+  }
+  // What the "could not be parsed" error names: the repo-relative path when we
+  // have one, else the absolute path a global install targets.
+  const displayPath = relativePath ?? filePath;
 
   let existing: Record<string, unknown> = createDefaults ?? {};
   if (fs.existsSync(filePath)) {
@@ -79,12 +99,12 @@ export function writeMcpConfig({
       parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
     } catch (error) {
       throw new McpConfigUnreadableError(
-        relativePath,
+        displayPath,
         error instanceof Error ? error.message : String(error)
       );
     }
     if (!isPlainObject(parsed)) {
-      throw new McpConfigUnreadableError(relativePath, "not a JSON object");
+      throw new McpConfigUnreadableError(displayPath, "not a JSON object");
     }
     existing = parsed;
   }

--- a/js/packages/phoenix-cli/test/setup/mcp/agents.test.ts
+++ b/js/packages/phoenix-cli/test/setup/mcp/agents.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Per-agent, per-scope install descriptors: the argv the CLI agents run and the
+ * JSON fragments the file agents merge. These are the contract the executor
+ * hands to the agent binaries and config files, so they are pinned here.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getMcpAgent,
+  MCP_AGENT_IDS,
+  type McpAgent,
+  type McpHeader,
+  type McpInstallAction,
+} from "../../../src/setup/mcp/agents";
+
+const URL = "http://localhost:6006/mcp";
+const CTX = { home: "/home/me", cwd: "/repo" };
+const NO_HEADERS: McpHeader[] = [];
+const BEARER: McpHeader[] = [
+  { name: "Authorization", value: "Bearer ${PHOENIX_API_KEY}" },
+];
+
+function agent(id: string): McpAgent {
+  const found = getMcpAgent(id);
+  if (!found) {
+    throw new Error(`unknown agent in test: ${id}`);
+  }
+  return found;
+}
+
+function cli(action: McpInstallAction | undefined) {
+  if (!action || action.kind !== "cli") {
+    throw new Error("expected a cli install action");
+  }
+  return action;
+}
+
+function file(action: McpInstallAction | undefined) {
+  if (!action || action.kind !== "file") {
+    throw new Error("expected a file install action");
+  }
+  return action;
+}
+
+describe("MCP agent registry", () => {
+  it("every advertised id resolves to an agent with a global install", () => {
+    for (const id of MCP_AGENT_IDS) {
+      const found = agent(id);
+      expect(found.install.global).toBeDefined();
+    }
+  });
+
+  describe("claude", () => {
+    it("registers over http, scoped user for global and project for local", () => {
+      expect(
+        cli(agent("claude").install.global).addArgs(URL, NO_HEADERS)
+      ).toEqual([
+        "mcp",
+        "add",
+        "--scope",
+        "user",
+        "--transport",
+        "http",
+        "phoenix",
+        URL,
+      ]);
+      expect(
+        cli(agent("claude").install.local).addArgs(URL, NO_HEADERS)
+      ).toEqual([
+        "mcp",
+        "add",
+        "--scope",
+        "project",
+        "--transport",
+        "http",
+        "phoenix",
+        URL,
+      ]);
+    });
+
+    it("passes a header through as a --header flag", () => {
+      expect(cli(agent("claude").install.global).addArgs(URL, BEARER)).toEqual([
+        "mcp",
+        "add",
+        "--scope",
+        "user",
+        "--transport",
+        "http",
+        "--header",
+        "Authorization: Bearer ${PHOENIX_API_KEY}",
+        "phoenix",
+        URL,
+      ]);
+    });
+
+    it("reads the entry back to confirm it landed", () => {
+      expect(cli(agent("claude").install.global).verifyArgs).toEqual([
+        "mcp",
+        "get",
+        "phoenix",
+      ]);
+    });
+  });
+
+  describe("codex", () => {
+    it("has no repo-scoped install", () => {
+      expect(agent("codex").install.local).toBeUndefined();
+    });
+
+    it("adds a streamable-http server by url", () => {
+      expect(
+        cli(agent("codex").install.global).addArgs(URL, NO_HEADERS)
+      ).toEqual(["mcp", "add", "phoenix", "--url", URL]);
+    });
+
+    it("translates an Authorization: Bearer ${VAR} header to --bearer-token-env-var", () => {
+      expect(cli(agent("codex").install.global).addArgs(URL, BEARER)).toEqual([
+        "mcp",
+        "add",
+        "phoenix",
+        "--url",
+        URL,
+        "--bearer-token-env-var",
+        "PHOENIX_API_KEY",
+      ]);
+    });
+
+    it("ignores a literal (non-env) bearer token it cannot store", () => {
+      const literal: McpHeader[] = [
+        { name: "Authorization", value: "Bearer sk-abc123" },
+      ];
+      expect(cli(agent("codex").install.global).addArgs(URL, literal)).toEqual([
+        "mcp",
+        "add",
+        "phoenix",
+        "--url",
+        URL,
+      ]);
+    });
+  });
+
+  describe("gemini", () => {
+    it("mirrors claude's flags but has no read-back (no `mcp get`)", () => {
+      const global = cli(agent("gemini").install.global);
+      expect(global.addArgs(URL, NO_HEADERS)).toEqual([
+        "mcp",
+        "add",
+        "--scope",
+        "user",
+        "--transport",
+        "http",
+        "phoenix",
+        URL,
+      ]);
+      expect(global.verifyArgs).toBeUndefined();
+    });
+  });
+
+  describe("cursor", () => {
+    it("targets ~/.cursor/mcp.json globally and .cursor/mcp.json locally", () => {
+      const global = file(agent("cursor").install.global);
+      expect(global.path(CTX)).toBe("/home/me/.cursor/mcp.json");
+      expect(global.displayPath(CTX)).toBe("~/.cursor/mcp.json");
+      const local = file(agent("cursor").install.local);
+      expect(local.path(CTX)).toBe("/repo/.cursor/mcp.json");
+      expect(local.displayPath(CTX)).toBe(".cursor/mcp.json");
+    });
+
+    it("writes a url-only server, and a headers object only when given headers", () => {
+      const global = file(agent("cursor").install.global);
+      expect(global.patch(URL, NO_HEADERS)).toEqual({
+        mcpServers: { phoenix: { url: URL } },
+      });
+      expect(global.patch(URL, BEARER)).toEqual({
+        mcpServers: {
+          phoenix: {
+            url: URL,
+            headers: { Authorization: "Bearer ${PHOENIX_API_KEY}" },
+          },
+        },
+      });
+    });
+  });
+
+  describe("opencode", () => {
+    it("targets the platform config dir globally and opencode.json locally", () => {
+      const global = file(agent("opencode").install.global);
+      expect(global.path(CTX)).toBe("/home/me/.config/opencode/opencode.json");
+      expect(global.displayPath(CTX)).toBe("~/.config/opencode/opencode.json");
+      expect(file(agent("opencode").install.local).path(CTX)).toBe(
+        "/repo/opencode.json"
+      );
+    });
+
+    it("carries the $schema default and a remote-enabled server entry", () => {
+      const global = file(agent("opencode").install.global);
+      expect(global.createDefaults).toEqual({
+        $schema: "https://opencode.ai/config.json",
+      });
+      expect(global.patch(URL, NO_HEADERS)).toEqual({
+        mcp: { phoenix: { type: "remote", url: URL, enabled: true } },
+      });
+    });
+  });
+
+  describe("vscode", () => {
+    it("uses the code CLI globally and a workspace file locally", () => {
+      const global = cli(agent("vscode").install.global);
+      expect(global.binary).toBe("code");
+      expect(global.addArgs(URL, NO_HEADERS)).toEqual([
+        "--add-mcp",
+        JSON.stringify({ name: "phoenix", type: "http", url: URL }),
+      ]);
+      const local = file(agent("vscode").install.local);
+      expect(local.displayPath(CTX)).toBe(".vscode/mcp.json");
+      expect(local.patch(URL, NO_HEADERS)).toEqual({
+        servers: { phoenix: { type: "http", url: URL } },
+      });
+    });
+
+    it("embeds headers in the --add-mcp json when supplied", () => {
+      expect(cli(agent("vscode").install.global).addArgs(URL, BEARER)).toEqual([
+        "--add-mcp",
+        JSON.stringify({
+          name: "phoenix",
+          type: "http",
+          url: URL,
+          headers: { Authorization: "Bearer ${PHOENIX_API_KEY}" },
+        }),
+      ]);
+    });
+  });
+});

--- a/js/packages/phoenix-cli/test/setup/mcp/agents.test.ts
+++ b/js/packages/phoenix-cli/test/setup/mcp/agents.test.ts
@@ -138,6 +138,20 @@ describe("MCP agent registry", () => {
         URL,
       ]);
     });
+
+    it("reports which headers it can't store, so the run can refuse them", () => {
+      const dropped = cli(agent("codex").install.global).droppedHeaders;
+      expect(dropped).toBeDefined();
+      // A translatable bearer header is honored — nothing dropped.
+      expect(dropped!(BEARER)).toEqual([]);
+      // A literal bearer token and any non-Authorization header can't be stored.
+      expect(
+        dropped!([{ name: "Authorization", value: "Bearer sk-abc123" }])
+      ).toEqual([{ name: "Authorization", value: "Bearer sk-abc123" }]);
+      expect(dropped!([{ name: "X-Api-Key", value: "abc123" }])).toEqual([
+        { name: "X-Api-Key", value: "abc123" },
+      ]);
+    });
   });
 
   describe("gemini", () => {

--- a/js/packages/phoenix-cli/test/setup/mcp/runSetupMcp.test.ts
+++ b/js/packages/phoenix-cli/test/setup/mcp/runSetupMcp.test.ts
@@ -138,6 +138,30 @@ describe("runSetupMcp", () => {
       expect(add?.args).toContain("PHOENIX_API_KEY");
     });
 
+    it("refuses a header codex can't store instead of silently dropping it", async () => {
+      const calls: CommandSpec[] = [];
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        processes: { exec: agentExecFake(calls) },
+      });
+
+      // A non-Authorization header (and a literal bearer token) can't survive
+      // `codex mcp add`, so the run must error rather than write a config that
+      // claims header auth but carries no credential.
+      await expect(
+        runSetupMcp(
+          deps,
+          inputs({
+            agent: "codex",
+            scope: "global",
+            headers: [{ name: "X-Api-Key", value: "abc123" }],
+          })
+        )
+      ).rejects.toBeInstanceOf(HeadlessInputError);
+      // Nothing was added — we stopped before the install ran.
+      expect(calls.some((c) => c.args[1] === "add")).toBe(false);
+    });
+
     it("fails when the read-back never shows the entry", async () => {
       const deps = buildFakeDeps({
         context: { cwd: repo, env: { HOME: home } },

--- a/js/packages/phoenix-cli/test/setup/mcp/runSetupMcp.test.ts
+++ b/js/packages/phoenix-cli/test/setup/mcp/runSetupMcp.test.ts
@@ -1,0 +1,362 @@
+/**
+ * `runSetupMcp` orchestration: endpoint inference, scope/agent resolution, and
+ * the two install mechanisms. CLI agents are driven through an exec spy; file
+ * agents write real temp dirs (global under a fake HOME, local under the cwd).
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { formatMcpSetupOutput } from "../../../src/commands/formatSetup";
+import type { CommandSpec, ExecResult } from "../../../src/setup/deps";
+import { HeadlessInputError, SetupFatalError } from "../../../src/setup/errors";
+import {
+  runSetupMcp,
+  type McpSetupInputs,
+} from "../../../src/setup/mcp/runSetupMcp";
+import { buildFakeDeps, scriptedPrompter } from "../fakes";
+
+const ENDPOINT = "http://localhost:6006";
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+/** exec fake: git rev-parse says "in a repo"; every agent CLI call exits 0. */
+function agentExecFake(
+  calls: CommandSpec[]
+): (spec: CommandSpec) => Promise<ExecResult> {
+  return async (spec) => {
+    calls.push(spec);
+    if (spec.command === "git") {
+      return { exitCode: 0, stdout: "true\n", stderr: "" };
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  };
+}
+
+function inputs(overrides: Partial<McpSetupInputs>): McpSetupInputs {
+  return {
+    endpoint: ENDPOINT,
+    endpointExplicit: true,
+    headers: [],
+    headless: true,
+    ...overrides,
+  };
+}
+
+describe("runSetupMcp", () => {
+  let home: string;
+  let repo: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "px-mcp-home-"));
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), "px-mcp-repo-"));
+  });
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  describe("CLI agents", () => {
+    it("registers codex globally via `codex mcp add --url …/mcp`", async () => {
+      const calls: CommandSpec[] = [];
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        processes: { exec: agentExecFake(calls) },
+      });
+
+      const report = await runSetupMcp(
+        deps,
+        inputs({ agent: "codex", scope: "global" })
+      );
+
+      expect(report).toEqual({
+        endpoint: ENDPOINT,
+        url: `${ENDPOINT}/mcp`,
+        serverName: "phoenix",
+        agent: "codex",
+        scope: "global",
+        auth: "oauth",
+      });
+      const add = calls.find(
+        (c) => c.command === "codex" && c.args[1] === "add"
+      );
+      expect(add?.args).toEqual([
+        "mcp",
+        "add",
+        "phoenix",
+        "--url",
+        `${ENDPOINT}/mcp`,
+      ]);
+    });
+
+    it("registers claude locally via --scope project, running in the repo", async () => {
+      const calls: CommandSpec[] = [];
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        processes: { exec: agentExecFake(calls) },
+      });
+
+      const report = await runSetupMcp(
+        deps,
+        inputs({ agent: "claude", scope: "local" })
+      );
+
+      expect(report.scope).toBe("local");
+      const claudeCalls = calls.filter((c) => c.command === "claude");
+      expect(claudeCalls[0]?.args).toContain("project");
+      // A --scope project add must land in this repo, not px's launch dir.
+      expect(claudeCalls.every((c) => c.cwd === repo)).toBe(true);
+      // The read-back confirms the entry landed.
+      expect(claudeCalls.some((c) => c.args[1] === "get")).toBe(true);
+    });
+
+    it("translates a bearer header to codex's --bearer-token-env-var and reports header auth", async () => {
+      const calls: CommandSpec[] = [];
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        processes: { exec: agentExecFake(calls) },
+      });
+
+      const report = await runSetupMcp(
+        deps,
+        inputs({
+          agent: "codex",
+          scope: "global",
+          headers: [
+            { name: "Authorization", value: "Bearer ${PHOENIX_API_KEY}" },
+          ],
+        })
+      );
+
+      expect(report.auth).toBe("header");
+      const add = calls.find((c) => c.args[1] === "add");
+      expect(add?.args).toContain("--bearer-token-env-var");
+      expect(add?.args).toContain("PHOENIX_API_KEY");
+    });
+
+    it("fails when the read-back never shows the entry", async () => {
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        processes: {
+          exec: async (spec) =>
+            spec.args[1] === "get"
+              ? { exitCode: 1, stdout: "", stderr: "not found" }
+              : { exitCode: 0, stdout: "", stderr: "" },
+        },
+      });
+
+      await expect(
+        runSetupMcp(deps, inputs({ agent: "claude", scope: "global" }))
+      ).rejects.toBeInstanceOf(SetupFatalError);
+    });
+  });
+
+  describe("file agents", () => {
+    it("writes cursor's global config under HOME, preserving other servers", async () => {
+      const cursorConfig = path.join(home, ".cursor", "mcp.json");
+      fs.mkdirSync(path.dirname(cursorConfig), { recursive: true });
+      fs.writeFileSync(
+        cursorConfig,
+        JSON.stringify({ mcpServers: { mine: { command: "my-mcp" } } })
+      );
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+      });
+
+      const report = await runSetupMcp(
+        deps,
+        inputs({ agent: "cursor", scope: "global" })
+      );
+
+      expect(report.file).toBe("~/.cursor/mcp.json");
+      expect(readJson(cursorConfig)).toEqual({
+        mcpServers: {
+          mine: { command: "my-mcp" },
+          phoenix: { url: `${ENDPOINT}/mcp` },
+        },
+      });
+    });
+
+    it("writes vscode's workspace file under the repo with a bearer header", async () => {
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        // Local scope: the git-repo guard must see a repo.
+        processes: { exec: agentExecFake([]) },
+      });
+
+      const report = await runSetupMcp(
+        deps,
+        inputs({
+          agent: "vscode",
+          scope: "local",
+          headers: [
+            { name: "Authorization", value: "Bearer ${PHOENIX_API_KEY}" },
+          ],
+        })
+      );
+
+      expect(report.file).toBe(".vscode/mcp.json");
+      expect(readJson(path.join(repo, ".vscode", "mcp.json"))).toEqual({
+        servers: {
+          phoenix: {
+            type: "http",
+            url: `${ENDPOINT}/mcp`,
+            headers: { Authorization: "Bearer ${PHOENIX_API_KEY}" },
+          },
+        },
+      });
+    });
+
+    it("re-running a file install is idempotent", async () => {
+      const run = () =>
+        runSetupMcp(
+          buildFakeDeps({
+            context: { cwd: repo, env: { HOME: home } },
+            processes: { exec: agentExecFake([]) },
+          }),
+          inputs({ agent: "opencode", scope: "local" })
+        );
+      await run();
+      const configPath = path.join(repo, "opencode.json");
+      const first = fs.readFileSync(configPath, "utf-8");
+      await run();
+      expect(fs.readFileSync(configPath, "utf-8")).toBe(first);
+    });
+  });
+
+  describe("endpoint", () => {
+    it("appends /mcp and strips a trailing slash", async () => {
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+      });
+      const report = await runSetupMcp(
+        deps,
+        inputs({
+          agent: "cursor",
+          scope: "global",
+          endpoint: "https://phoenix.example.com/",
+        })
+      );
+      expect(report.url).toBe("https://phoenix.example.com/mcp");
+    });
+  });
+
+  describe("scope reconciliation", () => {
+    it("errors when --local names codex, which is global-only (headless)", async () => {
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        processes: { exec: agentExecFake([]) },
+      });
+      await expect(
+        runSetupMcp(deps, inputs({ agent: "codex", scope: "local" }))
+      ).rejects.toBeInstanceOf(HeadlessInputError);
+    });
+
+    it("falls back to global for codex --local interactively, telling the user", async () => {
+      const prompter = scriptedPrompter([]);
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        prompter,
+        processes: { exec: agentExecFake([]) },
+      });
+      const report = await runSetupMcp(
+        deps,
+        inputs({ agent: "codex", scope: "local", headless: false })
+      );
+      expect(report.scope).toBe("global");
+      expect(prompter.output.some((m) => m.includes("Codex"))).toBe(true);
+    });
+
+    it("errors on --local outside a git repository", async () => {
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        processes: {
+          exec: async (spec) =>
+            spec.command === "git"
+              ? { exitCode: 128, stdout: "", stderr: "not a repo" }
+              : { exitCode: 0, stdout: "", stderr: "" },
+        },
+      });
+      await expect(
+        runSetupMcp(deps, inputs({ agent: "cursor", scope: "local" }))
+      ).rejects.toBeInstanceOf(HeadlessInputError);
+    });
+  });
+
+  describe("headless", () => {
+    it("requires an agent", async () => {
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+      });
+      await expect(
+        runSetupMcp(deps, inputs({ agent: undefined }))
+      ).rejects.toBeInstanceOf(HeadlessInputError);
+    });
+
+    it("defaults the scope to global", async () => {
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+      });
+      const report = await runSetupMcp(
+        deps,
+        inputs({ agent: "cursor", scope: undefined })
+      );
+      expect(report.scope).toBe("global");
+    });
+  });
+
+  describe("interactive", () => {
+    it("prompts for scope then agent, defaulting the endpoint", async () => {
+      // endpoint textInput (accept default) → scope select → agent select.
+      const prompter = scriptedPrompter([undefined, "global", "cursor"]);
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+        prompter,
+        // every --version probe succeeds, so all agents show as detected.
+        processes: {
+          exec: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        },
+      });
+
+      const report = await runSetupMcp(
+        deps,
+        inputs({ endpointExplicit: false, headless: false, scope: undefined })
+      );
+
+      expect(report.agent).toBe("cursor");
+      expect(report.scope).toBe("global");
+      expect(report.url).toBe(`${ENDPOINT}/mcp`);
+      // Endpoint, scope, and agent were all asked.
+      expect(prompter.transcript).toHaveLength(3);
+    });
+  });
+
+  describe("formatMcpSetupOutput", () => {
+    it("renders raw as single-line JSON and pretty as a summary", async () => {
+      const deps = buildFakeDeps({
+        context: { cwd: repo, env: { HOME: home } },
+      });
+      const report = await runSetupMcp(
+        deps,
+        inputs({ agent: "cursor", scope: "global" })
+      );
+
+      const raw = formatMcpSetupOutput({ report, format: "raw" });
+      expect(raw).not.toContain("\n");
+      expect(JSON.parse(raw)).toMatchObject({
+        agent: "cursor",
+        scope: "global",
+        url: `${ENDPOINT}/mcp`,
+        auth: "oauth",
+      });
+
+      const pretty = formatMcpSetupOutput({ report, format: "pretty" });
+      expect(pretty).toContain("phoenix");
+      expect(pretty).toContain(`${ENDPOINT}/mcp`);
+    });
+  });
+});

--- a/js/packages/phoenix-cli/test/setup/mcpConfig.test.ts
+++ b/js/packages/phoenix-cli/test/setup/mcpConfig.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `writeMcpConfig` — the absolute-path escape hatch used by global-scope
+ * installs, plus the merge/refuse behavior shared with local installs.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  McpConfigUnreadableError,
+  writeMcpConfig,
+} from "../../src/setup/util/mcpConfig";
+
+describe("writeMcpConfig", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "px-mcp-config-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes to an absolute path outside any repo (global scope)", () => {
+    const target = path.join(dir, "home", ".cursor", "mcp.json");
+    writeMcpConfig({
+      absolutePath: target,
+      patch: { mcpServers: { phoenix: { url: "http://x/mcp" } } },
+    });
+    expect(JSON.parse(fs.readFileSync(target, "utf-8"))).toEqual({
+      mcpServers: { phoenix: { url: "http://x/mcp" } },
+    });
+  });
+
+  it("merges into an existing absolute-path file, leaving other servers", () => {
+    const target = path.join(dir, "mcp.json");
+    fs.writeFileSync(
+      target,
+      JSON.stringify({ mcpServers: { keep: { url: "y" } } })
+    );
+    writeMcpConfig({
+      absolutePath: target,
+      patch: { mcpServers: { phoenix: { url: "http://x/mcp" } } },
+    });
+    expect(JSON.parse(fs.readFileSync(target, "utf-8"))).toEqual({
+      mcpServers: { keep: { url: "y" }, phoenix: { url: "http://x/mcp" } },
+    });
+  });
+
+  it("refuses a relative target rather than writing to the wrong place", () => {
+    expect(() =>
+      writeMcpConfig({
+        relativePath: "mcp.json",
+        patch: {},
+      })
+    ).toThrow(/absolute path/);
+  });
+
+  it("refuses an unparseable existing file instead of clobbering it", () => {
+    const target = path.join(dir, "mcp.json");
+    fs.writeFileSync(target, "{ not json");
+    expect(() => writeMcpConfig({ absolutePath: target, patch: {} })).toThrow(
+      McpConfigUnreadableError
+    );
+    expect(fs.readFileSync(target, "utf-8")).toBe("{ not json");
+  });
+});

--- a/js/packages/phoenix-cli/test/setup/mcpConfig.test.ts
+++ b/js/packages/phoenix-cli/test/setup/mcpConfig.test.ts
@@ -26,7 +26,7 @@ describe("writeMcpConfig", () => {
   it("writes to an absolute path outside any repo (global scope)", () => {
     const target = path.join(dir, "home", ".cursor", "mcp.json");
     writeMcpConfig({
-      absolutePath: target,
+      filePath: target,
       patch: { mcpServers: { phoenix: { url: "http://x/mcp" } } },
     });
     expect(JSON.parse(fs.readFileSync(target, "utf-8"))).toEqual({
@@ -41,7 +41,7 @@ describe("writeMcpConfig", () => {
       JSON.stringify({ mcpServers: { keep: { url: "y" } } })
     );
     writeMcpConfig({
-      absolutePath: target,
+      filePath: target,
       patch: { mcpServers: { phoenix: { url: "http://x/mcp" } } },
     });
     expect(JSON.parse(fs.readFileSync(target, "utf-8"))).toEqual({
@@ -52,7 +52,7 @@ describe("writeMcpConfig", () => {
   it("refuses a relative target rather than writing to the wrong place", () => {
     expect(() =>
       writeMcpConfig({
-        relativePath: "mcp.json",
+        filePath: "mcp.json",
         patch: {},
       })
     ).toThrow(/absolute path/);
@@ -61,7 +61,7 @@ describe("writeMcpConfig", () => {
   it("refuses an unparseable existing file instead of clobbering it", () => {
     const target = path.join(dir, "mcp.json");
     fs.writeFileSync(target, "{ not json");
-    expect(() => writeMcpConfig({ absolutePath: target, patch: {} })).toThrow(
+    expect(() => writeMcpConfig({ filePath: target, patch: {} })).toThrow(
       McpConfigUnreadableError
     );
     expect(fs.readFileSync(target, "utf-8")).toBe("{ not json");


### PR DESCRIPTION
## Summary

Adds `px setup mcp`, a new lane of the `px setup` flow that registers the Phoenix **remote MCP server** (`<endpoint>/mcp`) with a coding agent so the agent can search, query, and operate on Phoenix data. The endpoint is inferred through the same flag → env → profile → default merge every `px` command uses, so the user never re-types their Phoenix URL.

```bash
px setup mcp                          # pick scope (global default) + agent, interactively
px setup mcp --agent codex            # configure one agent
px setup mcp --agent claude --local   # write this repo's .mcp.json
px setup mcp --agent codex --no-input --format raw
```

## What's in it

- **Six agents:** `claude`, `codex`, `gemini`, `cursor`, `opencode`, `vscode`. Where an agent ships an `mcp add` the CLI drives it (the binary writes the schema it reads, so config can't drift); the rest get a two-level JSON merge into their config file.
- **Scope:** `--global` (user-wide, default) or `--local` (repo — Codex is global-only, reconciled with a message interactively and an error headlessly).
- **Auth:** OAuth by default (URL-only config, browser login on first use); `--header` (repeatable) wires an API-key bearer fallback for headless clients.
- **Headless:** `--no-input` requires `--agent` and defaults scope to global; `--format json|raw` prints a machine-readable report with the same `{error, code, hint}` envelope as the rest of `px`.
- `writeMcpConfig` gains an absolute-path escape hatch so a global-scope file install can target `~/.cursor/mcp.json` rather than a repo-relative path.
- `setup` enables positional options so subcommand flags that share a name with its own (`--agent`, `--format`, `--no-input`) reach the subcommand.

## Docs

- New `px setup mcp` subsection (with options table) in the Mintlify CLI reference.
- A tip on the **Remote MCP Server** Connect page pointing at the CLI helper that automates per-client config.
- CLI `README.md` and the `phoenix-cli` skill.

## Addressed from review

- **Codex header handling:** a header the agent can't persist (anything but `Authorization: Bearer ${VAR}`) now stops the run instead of silently writing a config that reports `auth: "header"` but carries no credential.
- **Structured errors:** config resolution (`--profile`, stored config) now runs inside the error funnel, so `--format json|raw` gets the `{error, code, hint}` envelope and correct exit code instead of a bare stderr line.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — new `test/setup/mcp/*` and `test/setup/mcpConfig.test.ts` pass (36/36)
- [x] `pnpm fmt:check` and `pnpm lint` clean

## Known follow-ups

- **Re-run idempotency:** Gemini (has `remove`, no `get`) and VS Code global (`--add-mcp`, neither) can't retry-through-remove on a refused re-add.
- **Env-var placeholder headers** (`Bearer ${VAR}`) are written verbatim into file configs (Cursor/OpenCode/VS Code), which use `${env:VAR}` syntax rather than `${VAR}`.
- The add→verify→remove→re-add dance is duplicated between `install.ts` and `offerDocsMcp.ts`; worth extracting.
