### PR TITLE
feat(phoenix-sqlean): vendor nalgeon/sqlean.py as arize-phoenix-sqlean

### DIFF
--- a/.agents/skills/phoenix-sqlean/SKILL.md
+++ b/.agents/skills/phoenix-sqlean/SKILL.md
@@ -17,37 +17,93 @@ upstream dropped Windows wheels at SQLite 3.50.4 and ships none today.
 
 Pins live in `packages/phoenix-sqlean/Makefile`. Each has a partner that must move with it:
 
-| Pin | Lockstep partner |
+| Pin | Moves with |
 |---|---|
-| `SQLITE_VERSION` | `SQLITE_RELEASE_YEAR` — the download URL embeds both; a mismatch 404s at fetch time |
-| `SQLEAN_VERSION` | `SQLEAN_VERSION` in `setup.py` — compiled in as the macro `sqlean_version()` returns |
-| `XXHASH_VERSION` | whatever sqlean's own `Makefile` fetches for that release |
+| `SQLITE_VERSION` | `SQLITE_RELEASE_YEAR` (the URL embeds both, so a mismatch 404s) and `SQLITE_SHA256` |
+| `SQLEAN_COMMIT` | `SQLEAN_VERSION` in the `Makefile` *and* in `setup.py` — the commit is what gets fetched, the strings only describe it |
+| `SQLEAN_VERSION` | `setup.py`'s copy, compiled in as what `sqlean_version()` returns. Suffix `+<short sha>` iff `SQLEAN_COMMIT` sits ahead of the named tag |
+| `XXHASH_TAG` | `XXHASH_COMMIT` + `XXHASH_SHA256`, and the tag sqlean's own `Makefile` fetches |
 
-Verify locally. **CI does not catch a pin mismatch.**
+`check-sqlean-pin`, a prerequisite of `download-sqlean`, enforces the `SQLEAN_*` rows for one
+`ls-remote`: suffix prefixes the commit, base is a real tag, suffix present iff ahead, `setup.py`
+agrees. It cannot tell you the base names the *wrong* release — the single-commit fetch carries no
+ancestry. `SQLITE_*` and `XXHASH_*` have only their hash checks.
+
+### With the script
+
+`scripts/check-upstream.sh` resolves and rewrites every pin, hashes included:
 
 ```bash
 cd packages/phoenix-sqlean
-make prepare-src download-sqlite download-sqlean   # always the full chain:
-                                                   # download-sqlean APPENDS init.c to the
-                                                   # amalgamation, so running it alone double-appends
+./scripts/check-upstream.sh sqlite            # detection only, no downloads
+./scripts/check-upstream.sh sqlite --apply    # rewrite pins, print a Markdown summary
+./scripts/check-upstream.sh sqlean [--apply]  # also moves XXHASH_* if sqlean moved its own
+```
+
+`phoenix-sqlean-upstream.yml` runs this weekly. It verifies nothing by design — run the prep chain
+afterwards.
+
+### By hand
+
+Resolve a tag to a commit with `git ls-remote <repo> 'refs/tags/<version>*'`, taking the peeled
+`^{}` line when the tag is annotated. sqlean also carries a non-version tag (`incubator`), so
+filter by shape before picking a latest.
+
+For `SQLITE_SHA256`, confirm the download against the SHA3-256 in the `PRODUCT` line on
+<https://sqlite.org/download.html> *before* recording the SHA-256 (`shasum` cannot do SHA3).
+Skipping that makes the pin trust-on-first-use.
+
+### Verify
+
+```bash
+cd packages/phoenix-sqlean
+make prepare-src download-sqlite download-sqlean   # always the full chain: download-sqlean
+                                                   # APPENDS init.c, so alone it double-appends
 python setup.py build_ext -i
 python -m tests
 ```
 
+## Staying current
+
+Dependabot cannot see these pins — no custom-regex manager — and there is no Renovate here.
+`phoenix-sqlean-upstream.yml` fills the gap: weekly, one draft PR per component, no model involved.
+
+**It builds and tests nothing.** `phoenix-sqlean-ci.yml` verifies on the PR across the full
+OS/arch/interpreter matrix; verifying in the bump job would be a subset of that, on the one platform
+where the likeliest failure — `patch(1)` on the MSVC patch — cannot reproduce.
+
+A failure of the script itself is different: upstream changed shape, so it exits before writing and
+the job goes red with no PR, because there is no computed bump to review.
+
+`XXHASH_*` is deliberately unwatched. sqlean drives it, and `download-sqlean` already fails when
+sqlean moves its own pin.
+
 ## Gotchas
 
-- **`src/test_windirent.h` is pinned at 3.50.4 — do not re-sync it.** SQLite removed the file in
-  3.51.0 and no newer tag has it. It is vendored deliberately, not downloaded.
-- **sqlean >= 0.28 needs `crypto/xxhash.impl.h`, which sqlean does not ship.** The Makefile fetches
-  it from xxHash. Any new third-party source needs a `THIRD_PARTY_LICENSES` section *and* its SPDX
-  identifier added to `license=` in `setup.py`.
+- **`src/test_windirent.h` is pinned at 3.50.4 — do not re-sync it.** SQLite removed it in 3.51.0
+  and no newer tag has it. Vendored deliberately, not downloaded.
+- **sqlean >= 0.28 needs `crypto/xxhash.impl.h`, which sqlean does not ship.** Any new third-party
+  source needs a `THIRD_PARTY_LICENSES` section *and* its SPDX identifier in `license=`.
 - **`patch(1)` failing on `src/sqlean-time-msvc.patch` is the intended tripwire**, not a breakage.
-  Regenerate the patch against the new sqlean sources.
-- **The `sqlean_version()` test is a tautology.** It compares the compiled macro against `setup.py`'s
-  own constant, so a Makefile/`setup.py` mismatch still passes.
-- **Keep the version plain SemVer.** release-please's version regex is unanchored, so `3.53.4.1` and
-  `3.53.4.post1` silently truncate to `3.53.4`, colliding with an existing tag and no error. The
-  package version is intentionally independent of the bundled SQLite version.
+  Regenerate it against the new sqlean sources.
+- **"sqlean fetches xxHash X, but XXHASH_TAG is Y" is the other one.** Move all three `XXHASH_*`
+  pins, and the version named in `THIRD_PARTY_LICENSES`.
+- **The `sqlean_version()` test is a tautology on its own** — it compares the compiled macro to
+  `setup.py`'s own constant, proving only that the binary is not stale. `check-sqlean-pin` is what
+  ties that constant back to `SQLEAN_COMMIT`.
+- **Changing `SQLEAN_VERSION` alone does not trigger a recompile.** It only moves a `-D` flag, and
+  `build_ext` keys on source mtime. `touch src/sqlean.c` after editing, or the version test fails
+  against a merely stale build.
+- **sqlean is fetched over git, not as a source archive.** GitHub archives are not byte-stable, so
+  they cannot be checksum-pinned; a commit fetch needs no checksum because git hashes every object
+  it receives. Hence `download-sqlean` needs `git` on PATH.
+- **The other two downloads are plain HTTP and get SHA-256 checks.** curl verifies nothing.
+  `XXHASH_COMMIT` fixes which bytes are correct, the hash proves they are those.
+  `src/test_windirent.h` needs neither — it is committed to this repo.
+- **Keep the package version plain SemVer.** release-please's version regex is unanchored, so
+  `3.53.4.1` and `3.53.4.post1` truncate to `3.53.4` and collide with an existing tag, silently.
+  For the same reason `VERSION` must stay above `SQLEAN_VERSION` in `setup.py`. The package version
+  is intentionally independent of the bundled SQLite version.
 - **pyright's `exclude` in the root `pyproject.toml` must restate all three defaults**
   (`**/node_modules`, `**/__pycache__`, `**/.*`). Dropping `**/.*` makes pyright walk `.venv`.
   Nothing in CI runs pyright, so this fails silently in editors only.
@@ -65,7 +121,12 @@ python -m tests
 
 ## Release-please paths
 
-Changes under `packages/phoenix-sqlean/` and `.github/` are invisible to the root `arize-phoenix`
-component. `.agents/`, `pyproject.toml`, and `release-please-config.json` are **not** — a `feat:`
-or `fix:` touching those bumps `arize-phoenix`. Put them in a `chore:` commit, and note that this
-repo squash-merges, so the split must be by PR, not by commit.
+The root `arize-phoenix` component ignores a commit when **every** file it touches is under its
+`exclude-paths` in `release-please-config.json` — `packages`, `.github`, `.agents`, `.claude`,
+`.gitignore`, `scripts`, `docs`, `tests`, and more. Treat that list as the source of truth; it is
+easy to assume a dot-directory is excluded when it is not.
+
+`pyproject.toml` and `release-please-config.json` are **not** excluded, and the repo squash-merges,
+so either one drags the whole commit into the root component — a `feat:`/`fix:` PR mixing them with
+package work bumps `arize-phoenix` as a side effect. Split by PR; a `chore:` commit alone does not
+prevent it.

--- a/.github/workflows/phoenix-sqlean-ci.yml
+++ b/.github/workflows/phoenix-sqlean-ci.yml
@@ -1,0 +1,83 @@
+name: phoenix-sqlean CI
+
+# Build-and-test for the vendored arize-phoenix-sqlean C extension
+# (packages/phoenix-sqlean, a fork of nalgeon/sqlean.py). Publishing is
+# handled by the build-sqlean/publish-sqlean jobs in publish.yaml.
+#
+# Source preparation (downloading the SQLite amalgamation and sqlean
+# extension sources) runs once on Ubuntu and is handed to the build legs
+# as an artifact: the Makefile needs make/curl/unzip, which Windows
+# runners don't provide.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/phoenix-sqlean/**
+      - .github/workflows/phoenix-sqlean-ci.yml
+  pull_request:
+    paths:
+      - packages/phoenix-sqlean/**
+      - .github/workflows/phoenix-sqlean-ci.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  download-sources:
+    name: Download and store sources
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download SQLite and sqlean extension sources
+        working-directory: packages/phoenix-sqlean
+        run: make prepare-src download-sqlite download-sqlean
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sqlean-sources
+          path: |
+            packages/phoenix-sqlean/MANIFEST.in
+            packages/phoenix-sqlean/Makefile
+            packages/phoenix-sqlean/README.md
+            packages/phoenix-sqlean/LICENSE
+            packages/phoenix-sqlean/setup.cfg
+            packages/phoenix-sqlean/setup.py
+            packages/phoenix-sqlean/sqlean
+            packages/phoenix-sqlean/src
+            packages/phoenix-sqlean/sqlite
+            packages/phoenix-sqlean/tests
+
+  test:
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    needs: download-sources
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sqlean-sources
+          path: pkg
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build extension in place and run tests
+        working-directory: pkg
+        run: |
+          python -m pip install --upgrade setuptools wheel
+          python setup.py build_ext -i
+          python -m tests

--- a/.github/workflows/phoenix-sqlean-ci.yml
+++ b/.github/workflows/phoenix-sqlean-ci.yml
@@ -1,0 +1,128 @@
+name: phoenix-sqlean CI
+
+# Build-and-test for the vendored arize-phoenix-sqlean C extension
+# (packages/phoenix-sqlean, a fork of nalgeon/sqlean.py). Publishing is
+# handled by the build-sqlean/publish-sqlean jobs in publish.yaml.
+#
+# Source preparation (downloading the SQLite amalgamation and sqlean
+# extension sources) runs once on Ubuntu and is handed to the build legs
+# as an artifact: the Makefile needs make/curl/unzip, which Windows
+# runners don't provide.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Filter Changes
+    runs-on: ubuntu-latest
+    outputs:
+      sqlean: ${{ steps.filter.outputs.sqlean }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            sqlean:
+              - "packages/phoenix-sqlean/**"
+              - ".github/workflows/phoenix-sqlean-ci.yml"
+
+  download-sources:
+    name: Download and store sources
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.sqlean == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download SQLite and sqlean extension sources
+        working-directory: packages/phoenix-sqlean
+        run: make prepare-src download-sqlite download-sqlean
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sqlean-sources
+          path: |
+            packages/phoenix-sqlean/MANIFEST.in
+            packages/phoenix-sqlean/Makefile
+            packages/phoenix-sqlean/README.md
+            packages/phoenix-sqlean/LICENSE
+            packages/phoenix-sqlean/setup.cfg
+            packages/phoenix-sqlean/setup.py
+            packages/phoenix-sqlean/sqlean
+            packages/phoenix-sqlean/src
+            packages/phoenix-sqlean/sqlite
+            packages/phoenix-sqlean/tests
+
+  test:
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    needs: [changes, download-sources]
+    if: needs.changes.outputs.sqlean == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        # Covers every OS/arch pair that publish.yaml ships a wheel for, so
+        # a build break surfaces on the PR rather than at publication time.
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+          - windows-latest
+          - windows-11-arm
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+        exclude:
+          # CPython publishes no Windows ARM64 build for 3.10, so
+          # actions/setup-python cannot provide it on windows-11-arm.
+          - os: windows-11-arm
+            python-version: "3.10"
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sqlean-sources
+          path: pkg
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build extension in place and run tests
+        working-directory: pkg
+        run: |
+          python -m pip install --upgrade setuptools wheel
+          python setup.py build_ext -i
+          python -m tests
+
+  ci-required:
+    name: phoenix-sqlean CI Required
+    needs:
+      - changes
+      - download-sources
+      - test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all required jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more CI jobs were cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"

--- a/.github/workflows/phoenix-sqlean-upstream.yml
+++ b/.github/workflows/phoenix-sqlean-upstream.yml
@@ -1,0 +1,142 @@
+name: phoenix-sqlean upstream pins
+
+# Opens a draft PR when SQLite or sqlean ships a release newer than the pins in
+# packages/phoenix-sqlean/Makefile. No dependency bot can see those pins:
+# Dependabot has no custom-regex manager, and SQLite's packed version maps to no
+# standard versioning scheme.
+#
+# No model runs here -- the bump is fully mechanical, so network access stays in
+# reviewable `run:` steps. Judgment calls (pinning past a tag, regenerating the
+# MSVC patch) are left to the reviewer as a checklist in the PR body.
+#
+# Deliberately builds and tests nothing: opening the PR runs
+# phoenix-sqlean-ci.yml, which repeats the same tripwires across every
+# OS/arch/interpreter pair -- including the Windows legs, the only place the
+# MSVC patch is exercised. Verifying here would be a strict subset of that, on
+# the one platform where the likeliest failure cannot reproduce.
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"  # Mondays 14:00 UTC. SQLite ships a few times a year.
+  workflow_dispatch:
+
+concurrency:
+  group: phoenix-sqlean-upstream-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Check ${{ matrix.component }} pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [sqlite, sqlean]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # One HTTP request or one ls-remote, no downloads -- everything below is
+      # gated on it, so the common "already current" run is fast.
+      - name: Detect newer release
+        id: check
+        working-directory: packages/phoenix-sqlean
+        run: ./scripts/check-upstream.sh ${{ matrix.component }}
+
+      - name: Check for an existing open PR
+        if: steps.check.outputs.outdated == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          TITLE: ${{ steps.check.outputs.title }}
+        run: |
+          set -euo pipefail
+          count=$(gh pr list --search "$TITLE in:title" --state open --json number --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [ "$count" -gt 0 ]; then
+            echo "A PR for this bump is already open; skipping."
+          fi
+
+      - name: Rewrite the pins
+        if: steps.check.outputs.outdated == 'true' && steps.existing.outputs.count == '0'
+        working-directory: packages/phoenix-sqlean
+        run: |
+          set -euo pipefail
+          mkdir -p ../../.scratch
+          ./scripts/check-upstream.sh ${{ matrix.component }} --apply \
+            | tee ../../.scratch/pr-body.md
+
+      - name: Commit and open pull request
+        if: steps.check.outputs.outdated == 'true' && steps.existing.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          BRANCH: ${{ steps.check.outputs.branch }}
+          TITLE: ${{ steps.check.outputs.title }}
+        run: |
+          set -euo pipefail
+          # Explicit paths: only pin files, never a fetched amalgamation.
+          git add packages/phoenix-sqlean/Makefile \
+                  packages/phoenix-sqlean/setup.py \
+                  packages/phoenix-sqlean/THIRD_PARTY_LICENSES
+          if git diff --cached --quiet; then
+            echo "No pin changes staged — exiting cleanly."
+            exit 0
+          fi
+
+          # Always a draft: every bump needs a human on the checklist above,
+          # whether or not it builds.
+          {
+            echo
+            echo "> [!NOTE]"
+            echo "> **Opened as a draft.** Verification happens on this PR:"
+            echo "> \`phoenix-sqlean-ci.yml\` runs the source-prep tripwires and then"
+            echo "> builds and tests every OS/arch/interpreter pair \`publish.yaml\`"
+            echo "> ships a wheel for — including the Windows legs, the only place"
+            echo "> \`src/sqlean-time-msvc.patch\` is ever exercised."
+            echo ">"
+            echo "> Mark ready once those are green and the checklist above is settled."
+            echo ">"
+            echo "> Opened by run"
+            echo "> $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID."
+          } >> .scratch/pr-body.md
+          gh auth setup-git
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -m "$TITLE"
+          git push -u origin "$BRANCH"
+          gh pr create --draft \
+            --base main \
+            --head "$BRANCH" \
+            --title "$TITLE" \
+            --body-file .scratch/pr-body.md
+
+  # Failure here means the bump could not be *computed* -- upstream changed
+  # shape, so the script exited before writing and there is no PR to carry the
+  # signal, and no author watching a scheduled run. A bump that computes but
+  # does not build is not a failure: its draft PR is its own notification.
+  slack-notification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs: [bump]
+    # Not 'cancelled': cancel-in-progress means a manual dispatch cancels an
+    # in-flight scheduled run, which is routine.
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Notify failure
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: phoenix-sqlean upstream pin check failed — could not compute a bump, so no PR was opened\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -274,6 +274,116 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         if: steps.check.outputs.needed == 'true'
 
+  # arize-phoenix-sqlean is a vendored C extension (fork of nalgeon/sqlean.py),
+  # so it cannot go through the pure-Python `uv build` matrix above: wheels are
+  # compiled per platform and interpreter with cibuildwheel. Source preparation
+  # (downloading the SQLite amalgamation and sqlean extension sources that the
+  # sdist bundles) runs once on Ubuntu and is handed to the build legs as an
+  # artifact, because the Makefile needs make/curl/unzip, which the Windows
+  # runner does not provide.
+  sqlean-sources:
+    name: Prepare arize-phoenix-sqlean sources
+    runs-on: ubuntu-latest
+    needs: list-python-packages
+    if: contains(fromJSON(needs.list-python-packages.outputs.package_paths), 'packages/phoenix-sqlean')
+    permissions:
+      contents: read
+    outputs:
+      needed: ${{ steps.ref.outputs.needed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Resolve ref from manifest
+        id: ref
+        run: |
+          VERSION=$(jq -r '.["packages/phoenix-sqlean"] // empty' .release-please-manifest.json)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Missing version for packages/phoenix-sqlean in manifest"
+            exit 1
+          fi
+          TAG="arize-phoenix-sqlean-v${VERSION}"
+          # Until release-please creates the first release of this package, the
+          # manifest version has no tag — skip instead of failing the run.
+          if git ls-remote --exit-code origin "refs/tags/${TAG}" > /dev/null 2>&1; then
+            echo "needed=true" >> $GITHUB_OUTPUT
+            echo "ref=refs/tags/${TAG}" >> $GITHUB_OUTPUT
+          else
+            echo "Tag ${TAG} does not exist yet; skipping arize-phoenix-sqlean"
+            echo "needed=false" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.ref.outputs.needed == 'true'
+        with:
+          persist-credentials: false
+          ref: ${{ steps.ref.outputs.ref }}
+      - name: Download SQLite and sqlean extension sources
+        if: steps.ref.outputs.needed == 'true'
+        working-directory: packages/phoenix-sqlean
+        run: make prepare-src download-sqlite download-sqlean
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: steps.ref.outputs.needed == 'true'
+        with:
+          name: arize-phoenix-sqlean-sources
+          path: packages/phoenix-sqlean
+
+  build-sqlean:
+    name: Build arize-phoenix-sqlean (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: sqlean-sources
+    if: needs.sqlean-sources.result == 'success' && needs.sqlean-sources.outputs.needed == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: arize-phoenix-sqlean-sources
+          path: pkg
+      - name: Set up QEMU for aarch64 wheels
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
+      - name: Build wheels
+        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
+        with:
+          package-dir: pkg
+        env:
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_BUILD: "cp310-macosx* cp311-macosx* cp312-macosx* cp313-macosx* cp314-macosx* cp310-manylinux* cp311-manylinux* cp312-manylinux* cp313-manylinux* cp314-manylinux* cp310-win* cp311-win* cp312-win* cp313-win* cp314-win*"
+          MACOSX_DEPLOYMENT_TARGET: "10.15"
+      - name: Build sdist
+        if: runner.os == 'Linux'
+        run: pipx run build --sdist --outdir wheelhouse pkg
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: arize-phoenix-sqlean-dist-${{ matrix.os }}
+          path: wheelhouse/
+
+  publish-sqlean:
+    name: Publish arize-phoenix-sqlean
+    runs-on: ubuntu-latest
+    needs: build-sqlean
+    if: needs.build-sqlean.result == 'success'
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: arize-phoenix-sqlean-dist-*
+          path: dist/
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
   trigger-version-updates:
     name: Trigger dependency updates
     runs-on: ubuntu-latest
@@ -324,8 +434,8 @@ jobs:
 
   slack:
     name: Slack notification
-    needs: [list-python-packages, publish-phoenix, publish-packages, trigger-version-updates]
-    if: always() && inputs.feature_branch == '' && (needs.publish-phoenix.result != 'skipped' || needs.publish-packages.result != 'skipped')
+    needs: [list-python-packages, publish-phoenix, publish-packages, publish-sqlean, trigger-version-updates]
+    if: always() && inputs.feature_branch == '' && (needs.publish-phoenix.result != 'skipped' || needs.publish-packages.result != 'skipped' || needs.publish-sqlean.result != 'skipped')
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -334,16 +444,17 @@ jobs:
         env:
           PHOENIX_RESULT: ${{ needs.publish-phoenix.result }}
           PACKAGES_RESULT: ${{ needs.publish-packages.result }}
+          SQLEAN_RESULT: ${{ needs.publish-sqlean.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "$PHOENIX_RESULT" = "failure" ] || [ "$PACKAGES_RESULT" = "failure" ]; then
+          if [ "$PHOENIX_RESULT" = "failure" ] || [ "$PACKAGES_RESULT" = "failure" ] || [ "$SQLEAN_RESULT" = "failure" ]; then
             {
               echo "text<<EOF"
               echo "🚨🚨🚨 PYPI Publication Failed 🚨🚨🚨"
               echo "$RUN_URL"
               echo "EOF"
             } >> $GITHUB_OUTPUT
-          elif [ "$PHOENIX_RESULT" = "success" ] || [ "$PACKAGES_RESULT" = "success" ]; then
+          elif [ "$PHOENIX_RESULT" = "success" ] || [ "$PACKAGES_RESULT" = "success" ] || [ "$SQLEAN_RESULT" = "success" ]; then
             {
               echo "text<<EOF"
               echo "PYPI Publication Succeeded"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -274,6 +274,127 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         if: steps.check.outputs.needed == 'true'
 
+  # arize-phoenix-sqlean is a vendored C extension (fork of nalgeon/sqlean.py),
+  # so it cannot go through the pure-Python `uv build` matrix above: wheels are
+  # compiled per platform and interpreter with cibuildwheel. Source preparation
+  # (downloading the SQLite amalgamation and sqlean extension sources that the
+  # sdist bundles) runs once on Ubuntu and is handed to the build legs as an
+  # artifact, because the Makefile needs make/curl/unzip, which the Windows
+  # runner does not provide.
+  sqlean-sources:
+    name: Prepare arize-phoenix-sqlean sources
+    runs-on: ubuntu-latest
+    needs: list-python-packages
+    if: contains(fromJSON(needs.list-python-packages.outputs.package_paths), 'packages/phoenix-sqlean')
+    permissions:
+      contents: read
+    outputs:
+      needed: ${{ steps.ref.outputs.needed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Resolve ref from manifest
+        id: ref
+        run: |
+          VERSION=$(jq -r '.["packages/phoenix-sqlean"] // empty' .release-please-manifest.json)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Missing version for packages/phoenix-sqlean in manifest"
+            exit 1
+          fi
+          TAG="arize-phoenix-sqlean-v${VERSION}"
+          # Until release-please creates the first release of this package, the
+          # manifest version has no tag — skip instead of failing the run.
+          if git ls-remote --exit-code origin "refs/tags/${TAG}" > /dev/null 2>&1; then
+            echo "needed=true" >> $GITHUB_OUTPUT
+            echo "ref=refs/tags/${TAG}" >> $GITHUB_OUTPUT
+          else
+            echo "Tag ${TAG} does not exist yet; skipping arize-phoenix-sqlean"
+            echo "needed=false" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.ref.outputs.needed == 'true'
+        with:
+          persist-credentials: false
+          ref: ${{ steps.ref.outputs.ref }}
+      - name: Download SQLite and sqlean extension sources
+        if: steps.ref.outputs.needed == 'true'
+        working-directory: packages/phoenix-sqlean
+        run: make prepare-src download-sqlite download-sqlean
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: steps.ref.outputs.needed == 'true'
+        with:
+          name: arize-phoenix-sqlean-sources
+          path: packages/phoenix-sqlean
+
+  build-sqlean:
+    name: Build arize-phoenix-sqlean (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: sqlean-sources
+    if: needs.sqlean-sources.result == 'success' && needs.sqlean-sources.outputs.needed == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: arize-phoenix-sqlean-sources
+          path: pkg
+      - name: Set up QEMU for aarch64 wheels
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
+      - name: Build wheels
+        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
+        with:
+          package-dir: pkg
+        env:
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_WINDOWS: AMD64 ARM64
+          CIBW_BUILD: "cp310-macosx* cp311-macosx* cp312-macosx* cp313-macosx* cp314-macosx* cp310-manylinux* cp311-manylinux* cp312-manylinux* cp313-manylinux* cp314-manylinux* cp310-win* cp311-win* cp312-win* cp313-win* cp314-win*"
+          # Import and exercise each wheel before it is uploaded. The command
+          # runs in a temp dir against the installed wheel, not the source
+          # tree, so CIBW_TEST_SOURCES must supply everything the suite reads
+          # from the working directory: tests/ plus setup.py and README.md,
+          # because tests/extensions.py imports SQLEAN_VERSION from setup.py
+          # and setup.py reads README.md at import time (hence setuptools).
+          # cibuildwheel skips tests for cross-compiled wheels (macOS x86_64,
+          # win_arm64); the native ARM legs in phoenix-sqlean-ci.yml cover those.
+          CIBW_TEST_SOURCES: tests setup.py README.md
+          CIBW_TEST_REQUIRES: setuptools==83.0.0
+          CIBW_TEST_COMMAND: python -m tests
+          MACOSX_DEPLOYMENT_TARGET: "10.15"
+      - name: Build sdist
+        if: runner.os == 'Linux'
+        run: pipx run build==1.5.0 --sdist --outdir wheelhouse pkg
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: arize-phoenix-sqlean-dist-${{ matrix.os }}
+          path: wheelhouse/
+
+  publish-sqlean:
+    name: Publish arize-phoenix-sqlean
+    runs-on: ubuntu-latest
+    needs: build-sqlean
+    if: needs.build-sqlean.result == 'success'
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: arize-phoenix-sqlean-dist-*
+          path: dist/
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
   trigger-version-updates:
     name: Trigger dependency updates
     runs-on: ubuntu-latest
@@ -324,8 +445,8 @@ jobs:
 
   slack:
     name: Slack notification
-    needs: [list-python-packages, publish-phoenix, publish-packages, trigger-version-updates]
-    if: always() && inputs.feature_branch == '' && (needs.publish-phoenix.result != 'skipped' || needs.publish-packages.result != 'skipped')
+    needs: [list-python-packages, publish-phoenix, publish-packages, publish-sqlean, trigger-version-updates]
+    if: always() && inputs.feature_branch == '' && (needs.publish-phoenix.result != 'skipped' || needs.publish-packages.result != 'skipped' || needs.publish-sqlean.result != 'skipped')
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -334,16 +455,17 @@ jobs:
         env:
           PHOENIX_RESULT: ${{ needs.publish-phoenix.result }}
           PACKAGES_RESULT: ${{ needs.publish-packages.result }}
+          SQLEAN_RESULT: ${{ needs.publish-sqlean.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "$PHOENIX_RESULT" = "failure" ] || [ "$PACKAGES_RESULT" = "failure" ]; then
+          if [ "$PHOENIX_RESULT" = "failure" ] || [ "$PACKAGES_RESULT" = "failure" ] || [ "$SQLEAN_RESULT" = "failure" ]; then
             {
               echo "text<<EOF"
               echo "🚨🚨🚨 PYPI Publication Failed 🚨🚨🚨"
               echo "$RUN_URL"
               echo "EOF"
             } >> $GITHUB_OUTPUT
-          elif [ "$PHOENIX_RESULT" = "success" ] || [ "$PACKAGES_RESULT" = "success" ]; then
+          elif [ "$PHOENIX_RESULT" = "success" ] || [ "$PACKAGES_RESULT" = "success" ] || [ "$SQLEAN_RESULT" = "success" ]; then
             {
               echo "text<<EOF"
               echo "PYPI Publication Succeeded"

--- a/packages/phoenix-sqlean/.gitignore
+++ b/packages/phoenix-sqlean/.gitignore
@@ -1,0 +1,164 @@
+# Project specific stuff
+sqlite/
+wheelhouse/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/packages/phoenix-sqlean/.gitignore
+++ b/packages/phoenix-sqlean/.gitignore
@@ -1,0 +1,168 @@
+# Project specific stuff
+sqlite/
+wheelhouse/
+# Transient prep artifacts, left behind when download-sqlean fails partway.
+# sqlean-src/ is a full upstream checkout.
+sqlean-src/
+sqlite.zip
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/packages/phoenix-sqlean/LICENSE
+++ b/packages/phoenix-sqlean/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2007 Gerhard Häring, 2018+ Charles Leifer, 2023+ Anton Zhiyanov
+
+This software is provided 'as-is', without any express or implied warranty. In
+no event will the authors be held liable for any damages arising from the use
+of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+       claim that you wrote the original software. If you use this software in
+       a product, an acknowledgment in the product documentation would be
+       appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+       misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.

--- a/packages/phoenix-sqlean/MANIFEST.in
+++ b/packages/phoenix-sqlean/MANIFEST.in
@@ -1,0 +1,29 @@
+include MANIFEST.in
+include README.md
+include LICENSE
+include THIRD_PARTY_LICENSES
+include setup.py
+include src/*.h
+include src/*.c
+include src/*.patch
+
+include sqlite/*.h
+include sqlite/*.c
+include sqlite/crypto/*.h
+include sqlite/define/*.h
+include sqlite/fileio/*.h
+include sqlite/fuzzy/*.h
+include sqlite/init.h/*.h
+include sqlite/ipaddr/*.h
+include sqlite/math/*.h
+include sqlite/regexp/*.h
+include sqlite/regexp/pcre2/*.h
+include sqlite/stats/*.h
+include sqlite/text/*.h
+include sqlite/text/utf8/*.h
+include sqlite/time/*.h
+include sqlite/unicode/*.h
+include sqlite/uuid/*.h
+include sqlite/vsv/*.h
+
+global-exclude *~ *.pyc

--- a/packages/phoenix-sqlean/Makefile
+++ b/packages/phoenix-sqlean/Makefile
@@ -1,0 +1,97 @@
+# Copyright (c) 2023 Anton Zhiyanov, MIT License
+# https://github.com/nalgeon/sqlite
+
+.PHONY: build
+
+SQLITE_RELEASE_YEAR := 2025
+SQLITE_VERSION := 3500400
+SQLEAN_VERSION := 0.27.4
+
+prepare-src:
+	mkdir -p sqlite
+	rm -rf sqlite/*
+
+download-sqlite:
+	# test_windirent.h (the opendir() family shim that fileio needs on
+	# Windows) is vendored in src/ rather than downloaded: SQLite removed
+	# the file from its master branch, and an unpinned download silently
+	# turns into a 404 page that breaks the Windows compile. The vendored
+	# copy is taken from the SQLite tag matching $(SQLITE_VERSION).
+	cp src/test_windirent.h sqlite/test_windirent.h
+	curl -fL https://sqlite.org/$(SQLITE_RELEASE_YEAR)/sqlite-amalgamation-$(SQLITE_VERSION).zip --output sqlite.zip
+	unzip sqlite.zip
+	mv sqlite-amalgamation-$(SQLITE_VERSION)/* sqlite
+	rmdir sqlite-amalgamation-$(SQLITE_VERSION)
+	rm -f sqlite.zip
+
+download-sqlean:
+	curl -fL https://github.com/nalgeon/sqlean/archive/refs/tags/$(SQLEAN_VERSION).zip --output sqlean.zip
+	unzip sqlean.zip
+	mv sqlean-$(SQLEAN_VERSION) sqlean-src
+	mkdir -p \
+		  sqlite/crypto \
+		  sqlite/define \
+		  sqlite/fileio \
+		  sqlite/fuzzy \
+		  sqlite/ipaddr \
+		  sqlite/math \
+		  sqlite/regexp/pcre2 \
+		  sqlite/stats \
+		  sqlite/text \
+		  sqlite/text/utf8 \
+		  sqlite/time \
+		  sqlite/unicode \
+		  sqlite/uuid \
+		  sqlite/vsv
+	cp sqlean-src/src/crypto/*.h sqlite/crypto/
+	cp sqlean-src/src/define/*.h sqlite/define/
+	cp sqlean-src/src/fileio/*.h sqlite/fileio/
+	cp sqlean-src/src/fuzzy/*.h sqlite/fuzzy/
+	cp sqlean-src/src/ipaddr/*.h sqlite/ipaddr/
+	cp sqlean-src/src/math/*.h sqlite/math/
+	cp sqlean-src/src/regexp/*.h sqlite/regexp/
+	cp sqlean-src/src/regexp/pcre2/*.h sqlite/regexp/pcre2
+	cp sqlean-src/src/stats/*.h sqlite/stats/
+	cp sqlean-src/src/text/*.h sqlite/text/
+	cp sqlean-src/src/text/utf8/*.h sqlite/text/utf8
+	cp sqlean-src/src/time/*.h sqlite/time/
+	cp sqlean-src/src/unicode/*.h sqlite/unicode/
+	cp sqlean-src/src/uuid/*.h sqlite/uuid/
+	cp sqlean-src/src/vsv/*.h sqlite/vsv/
+	cp sqlean-src/src/*.h sqlite/
+	cat sqlean-src/src/crypto/*.c > sqlite/sqlean-crypto.c
+	cat sqlean-src/src/define/*.c > sqlite/sqlean-define.c
+	cat sqlean-src/src/fileio/*.c > sqlite/sqlean-fileio.c
+	cat sqlean-src/src/fuzzy/*.c > sqlite/sqlean-fuzzy.c
+	cat sqlean-src/src/ipaddr/*.c > sqlite/sqlean-ipaddr.c
+	cat sqlean-src/src/math/*.c > sqlite/sqlean-math.c
+	cat sqlean-src/src/regexp/pcre2/*.c sqlean-src/src/regexp/*.c > sqlite/sqlean-regexp.c
+	cat sqlean-src/src/stats/*.c > sqlite/sqlean-stats.c
+	cat sqlean-src/src/text/utf8/*.c sqlean-src/src/text/*.c > sqlite/sqlean-text.c
+	cat sqlean-src/src/time/*.c > sqlite/sqlean-time.c
+	# MSVC's C compiler rejects file-scope consts initialized from other
+	# consts (error C2099), which gcc and clang accept; the patch replaces
+	# those initializers in the time extension with their computed literal
+	# values. patch(1) errors out if the sources drift (e.g. on a
+	# SQLEAN_VERSION bump), so a stale patch fails here instead of
+	# surfacing as a compile error on Windows only.
+	patch sqlite/sqlean-time.c src/sqlean-time-msvc.patch
+	cat sqlean-src/src/unicode/*.c > sqlite/sqlean-unicode.c
+	cat sqlean-src/src/uuid/*.c > sqlite/sqlean-uuid.c
+	cat sqlean-src/src/vsv/*.c > sqlite/sqlean-vsv.c
+	cat src/init.c >> sqlite/sqlite3.c
+	cp src/init.h sqlite
+	rm -rf sqlean-src
+	rm -f sqlean.zip
+
+clean:
+	rm -rf build/*
+	rm -f dist/*
+	rm -rf sqlean/*.so
+	rm -rf sqlean.py.egg-info
+
+build:
+	python -m pip install --upgrade setuptools wheel
+	python setup.py build_ext -i
+	python -m tests
+	python -m pip wheel . -w dist

--- a/packages/phoenix-sqlean/Makefile
+++ b/packages/phoenix-sqlean/Makefile
@@ -1,0 +1,168 @@
+# Copyright (c) 2023 Anton Zhiyanov, MIT License
+# https://github.com/nalgeon/sqlite
+
+.PHONY: build check-sqlean-pin
+
+# The download URL embeds both, so a mismatch 404s at fetch time.
+SQLITE_RELEASE_YEAR := 2026
+SQLITE_VERSION := 3530400
+# Recorded by confirming the download against the SHA3-256 in sqlite.org's
+# PRODUCT line, then re-hashing (shasum cannot do SHA3). Release files there
+# are immutable, so a mismatch means different bytes.
+SQLITE_SHA256 := 1e71ddf93849c6a6ecf58b827c0692073d2dd7ee40196158068f7b29f422e87d
+SQLEAN_REPO := https://github.com/nalgeon/sqlean.git
+# The release SQLEAN_COMMIT corresponds to, +<short sha> when the commit sits
+# ahead of it. check-sqlean-pin enforces that, and that setup.py's copy agrees
+# -- setup.py's is the one compiled in as what sqlean_version() reports.
+SQLEAN_VERSION := 0.28.3+6b969da
+# Pinned by commit, not tag: a tag can be moved to different content, a commit
+# cannot, and git verifies every object it receives. Why a given pin was
+# chosen belongs in the commit that moved it.
+SQLEAN_COMMIT := 6b969da844d9c3c79a0b226b403b3d8227b4ed46
+# sqlean's crypto extension includes crypto/xxhash.impl.h but does not ship it.
+# XXHASH_TAG is the tag sqlean's own Makefile fetches; download-sqlean asserts
+# they still agree, so an upstream move stops the build.
+XXHASH_TAG := v0.8.3
+# Plain HTTP, unlike the sqlean fetch: curl verifies nothing. The commit fixes
+# which content is correct, XXHASH_SHA256 proves the bytes are it.
+XXHASH_COMMIT := e626a72bc2321cd320e953a0ccf1584cad60f363
+XXHASH_SHA256 := 17973c0dc49d9854ca26caa191f0e12f7a424b68858d9a78de3860d959d85e4b
+
+prepare-src:
+	mkdir -p sqlite
+	rm -rf sqlite/*
+
+download-sqlite:
+	# Vendored, not downloaded: SQLite removed this Windows opendir() shim in
+	# 3.51.0, so the copy in src/ is pinned at 3.50.4 and deliberately NOT tied
+	# to $(SQLITE_VERSION). Do not re-sync it on a bump.
+	cp src/test_windirent.h sqlite/test_windirent.h
+	curl -fL https://sqlite.org/$(SQLITE_RELEASE_YEAR)/sqlite-amalgamation-$(SQLITE_VERSION).zip --output sqlite.zip
+	echo "$(SQLITE_SHA256)  sqlite.zip" | shasum -a 256 -c -
+	unzip sqlite.zip
+	mv sqlite-amalgamation-$(SQLITE_VERSION)/* sqlite
+	rmdir sqlite-amalgamation-$(SQLITE_VERSION)
+	rm -f sqlite.zip
+
+# Catches SQLEAN_VERSION and SQLEAN_COMMIT disagreeing, which nothing else
+# would: no build step relates the compiled sources to the reported version.
+# Costs one ls-remote. Does not check ancestry -- the single-commit fetch
+# below carries none -- so it catches moving one pin and not the other, not a
+# base version that names the wrong release.
+check-sqlean-pin:
+	@base=$$(echo '$(SQLEAN_VERSION)' | cut -d+ -f1); \
+	suffix=$$(echo '$(SQLEAN_VERSION)' | cut -s -d+ -f2); \
+	case '$(SQLEAN_COMMIT)' in $$suffix*) ;; *) \
+		echo "SQLEAN_VERSION suffix '+$$suffix' is not a prefix of SQLEAN_COMMIT $(SQLEAN_COMMIT)" >&2; \
+		exit 1;; \
+	esac; \
+	refs=$$(git ls-remote $(SQLEAN_REPO) "refs/tags/$$base" "refs/tags/$$base^{}"); \
+	if [ -z "$$refs" ]; then \
+		echo "SQLEAN_VERSION base '$$base' is not a tag in $(SQLEAN_REPO)" >&2; \
+		exit 1; \
+	fi; \
+	tag=$$(echo "$$refs" | grep '\^{}$$' | cut -f1); \
+	[ -n "$$tag" ] || tag=$$(echo "$$refs" | cut -f1); \
+	if [ -z "$$suffix" ] && [ "$$tag" != "$(SQLEAN_COMMIT)" ]; then \
+		echo "SQLEAN_VERSION claims tag $$base ($$tag), but SQLEAN_COMMIT is $(SQLEAN_COMMIT)" >&2; \
+		exit 1; \
+	fi; \
+	if [ -n "$$suffix" ] && [ "$$tag" = "$(SQLEAN_COMMIT)" ]; then \
+		echo "SQLEAN_COMMIT is exactly tag $$base -- drop the '+$$suffix' suffix from SQLEAN_VERSION" >&2; \
+		exit 1; \
+	fi; \
+	compiled=$$(sed -n 's/^SQLEAN_VERSION = "\([^"]*\)".*/\1/p' setup.py | head -1); \
+	if [ "$$compiled" != "$(SQLEAN_VERSION)" ]; then \
+		echo "setup.py SQLEAN_VERSION ($$compiled) != Makefile SQLEAN_VERSION ($(SQLEAN_VERSION))" >&2; \
+		exit 1; \
+	fi; \
+	echo "sqlean pin OK: $(SQLEAN_VERSION) -> $(SQLEAN_COMMIT)"
+
+download-sqlean: check-sqlean-pin
+	# Over git by commit, not a GitHub source archive: those are generated on
+	# demand and not byte-stable, so they cannot be checksum-pinned. Git hashes
+	# every object it receives, so no checksum is needed here; a bad
+	# SQLEAN_COMMIT fails at fetch.
+	rm -rf sqlean-src
+	mkdir sqlean-src
+	# --template= skips hook templates: a global init.templateDir would
+	# otherwise install hooks in this throwaway repo and fire them on checkout.
+	git -C sqlean-src init -q --template=
+	git -C sqlean-src remote add origin $(SQLEAN_REPO)
+	git -C sqlean-src fetch -q --depth 1 origin $(SQLEAN_COMMIT)
+	git -C sqlean-src checkout -q FETCH_HEAD
+	# Here rather than in check-sqlean-pin because it reads sqlean's Makefile,
+	# which exists only between the checkout above and the cleanup below. An
+	# empty $$ref -- sqlean sourcing xxHash some other way -- fails too.
+	@ref=$$(sed -n 's|.*xxhash/raw/\([^/]*\)/xxhash.h.*|\1|p' sqlean-src/Makefile | head -1); \
+	if [ "$$ref" != "$(XXHASH_TAG)" ]; then \
+		echo "sqlean $(SQLEAN_COMMIT) fetches xxHash '$$ref', but XXHASH_TAG is $(XXHASH_TAG)" >&2; \
+		exit 1; \
+	fi; \
+	echo "xxHash pin OK: sqlean asks for $(XXHASH_TAG)"
+	# Into the sqlean tree, so the crypto/*.h copy below picks it up.
+	curl -fL https://github.com/cyan4973/xxhash/raw/$(XXHASH_COMMIT)/xxhash.h --output sqlean-src/src/crypto/xxhash.impl.h
+	echo "$(XXHASH_SHA256)  sqlean-src/src/crypto/xxhash.impl.h" | shasum -a 256 -c -
+	mkdir -p \
+		  sqlite/crypto \
+		  sqlite/define \
+		  sqlite/fileio \
+		  sqlite/fuzzy \
+		  sqlite/ipaddr \
+		  sqlite/math \
+		  sqlite/regexp/pcre2 \
+		  sqlite/stats \
+		  sqlite/text \
+		  sqlite/text/utf8 \
+		  sqlite/time \
+		  sqlite/unicode \
+		  sqlite/uuid \
+		  sqlite/vsv
+	cp sqlean-src/src/crypto/*.h sqlite/crypto/
+	cp sqlean-src/src/define/*.h sqlite/define/
+	cp sqlean-src/src/fileio/*.h sqlite/fileio/
+	cp sqlean-src/src/fuzzy/*.h sqlite/fuzzy/
+	cp sqlean-src/src/ipaddr/*.h sqlite/ipaddr/
+	cp sqlean-src/src/math/*.h sqlite/math/
+	cp sqlean-src/src/regexp/*.h sqlite/regexp/
+	cp sqlean-src/src/regexp/pcre2/*.h sqlite/regexp/pcre2
+	cp sqlean-src/src/stats/*.h sqlite/stats/
+	cp sqlean-src/src/text/*.h sqlite/text/
+	cp sqlean-src/src/text/utf8/*.h sqlite/text/utf8
+	cp sqlean-src/src/time/*.h sqlite/time/
+	cp sqlean-src/src/unicode/*.h sqlite/unicode/
+	cp sqlean-src/src/uuid/*.h sqlite/uuid/
+	cp sqlean-src/src/vsv/*.h sqlite/vsv/
+	cp sqlean-src/src/*.h sqlite/
+	cat sqlean-src/src/crypto/*.c > sqlite/sqlean-crypto.c
+	cat sqlean-src/src/define/*.c > sqlite/sqlean-define.c
+	cat sqlean-src/src/fileio/*.c > sqlite/sqlean-fileio.c
+	cat sqlean-src/src/fuzzy/*.c > sqlite/sqlean-fuzzy.c
+	cat sqlean-src/src/ipaddr/*.c > sqlite/sqlean-ipaddr.c
+	cat sqlean-src/src/math/*.c > sqlite/sqlean-math.c
+	cat sqlean-src/src/regexp/pcre2/*.c sqlean-src/src/regexp/*.c > sqlite/sqlean-regexp.c
+	cat sqlean-src/src/stats/*.c > sqlite/sqlean-stats.c
+	cat sqlean-src/src/text/utf8/*.c sqlean-src/src/text/*.c > sqlite/sqlean-text.c
+	cat sqlean-src/src/time/*.c > sqlite/sqlean-time.c
+	# MSVC rejects file-scope consts initialized from other consts (C2099),
+	# which gcc and clang accept; the patch swaps them for literals. patch(1)
+	# failing on a bump is the tripwire -- otherwise it breaks Windows only.
+	patch sqlite/sqlean-time.c src/sqlean-time-msvc.patch
+	cat sqlean-src/src/unicode/*.c > sqlite/sqlean-unicode.c
+	cat sqlean-src/src/uuid/*.c > sqlite/sqlean-uuid.c
+	cat sqlean-src/src/vsv/*.c > sqlite/sqlean-vsv.c
+	cat src/init.c >> sqlite/sqlite3.c
+	cp src/init.h sqlite
+	rm -rf sqlean-src
+
+clean:
+	rm -rf build/*
+	rm -f dist/*
+	rm -rf sqlean/*.so
+	rm -rf sqlean.py.egg-info
+
+build:
+	python -m pip install --upgrade setuptools wheel
+	python setup.py build_ext -i
+	python -m tests
+	python -m pip wheel . -w dist

--- a/packages/phoenix-sqlean/README.md
+++ b/packages/phoenix-sqlean/README.md
@@ -1,0 +1,128 @@
+# arize-phoenix-sqlean
+
+This package provides an SQLite Python wrapper bundled with [sqlean](https://github.com/nalgeon/sqlean) extensions. It's a drop-in replacement for the standard library's [sqlite3](https://docs.python.org/3/library/sqlite3.html) module.
+
+> [!NOTE]
+> This is a modified fork of [nalgeon/sqlean.py](https://github.com/nalgeon/sqlean.py),
+> which was archived upstream in February 2026. It was imported at upstream commit
+> [`bdd7097`](https://github.com/nalgeon/sqlean.py/commit/bdd7097f8d5777bc9e3ac3235d9be66b9db34519)
+> and is maintained by [Arize AI](https://arize.com) as part of the Phoenix monorepo.
+> Original work by Anton Zhiyanov and contributors,
+> [zlib License](https://github.com/Arize-ai/phoenix/blob/main/packages/phoenix-sqlean/LICENSE).
+> The `src/` directory contains code derived from CPython's `sqlite3` module
+> (PSF License 2.0). Builds download the SQLite amalgamation (public domain) and
+> [sqlean](https://github.com/nalgeon/sqlean) extension sources (MIT License), which
+> include PCRE2 (BSD 3-Clause), STC (MIT), and code based on Go's time package
+> (BSD 3-Clause). Full notices and the CPython change summary are in
+> [THIRD_PARTY_LICENSES](https://github.com/Arize-ai/phoenix/blob/main/packages/phoenix-sqlean/THIRD_PARTY_LICENSES).
+
+```
+pip install arize-phoenix-sqlean
+```
+
+```python
+import sqlean
+
+# enable all extensions
+sqlean.extensions.enable_all()
+
+# has the same API as the default sqlite3 module
+conn = sqlean.connect(":memory:")
+conn.execute("create table employees(id, name)")
+
+# and comes with sqlean extensions
+cur = conn.execute("select median(value) from generate_series(1, 99)")
+print(cur.fetchone())
+# (50.0,)
+
+conn.close()
+```
+
+## Extensions
+
+This package bundles essential SQLite extensions:
+
+-   [crypto](https://github.com/nalgeon/sqlean/blob/main/docs/crypto.md): Hashing, encoding and decoding data
+-   [define](https://github.com/nalgeon/sqlean/blob/main/docs/define.md): User-defined functions and dynamic SQL
+-   [fileio](https://github.com/nalgeon/sqlean/blob/main/docs/fileio.md): Reading and writing files
+-   [fuzzy](https://github.com/nalgeon/sqlean/blob/main/docs/fuzzy.md): Fuzzy string matching and phonetics
+-   [ipaddr](https://github.com/nalgeon/sqlean/blob/main/docs/ipaddr.md): IP address manipulation
+-   [regexp](https://github.com/nalgeon/sqlean/blob/main/docs/regexp.md): Regular expressions
+-   [stats](https://github.com/nalgeon/sqlean/blob/main/docs/stats.md): Math statistics
+-   [text](https://github.com/nalgeon/sqlean/blob/main/docs/text.md): String functions
+-   [time](https://github.com/nalgeon/sqlean/blob/main/docs/time.md): High-precision date/time
+-   [uuid](https://github.com/nalgeon/sqlean/blob/main/docs/uuid.md): Universally Unique IDentifiers
+-   [vsv](https://github.com/nalgeon/sqlean/blob/main/docs/vsv.md): CSV files as virtual tables
+
+## Installation
+
+```
+pip install arize-phoenix-sqlean
+```
+
+Note that the package name is `arize-phoenix-sqlean`, while the code imports are just `sqlean` — the same import name as the upstream `sqlean.py` package, so this fork is a drop-in replacement (only one of the two can be installed in an environment).
+
+A binary package (wheel) is available for the following operating systems:
+
+-   Linux (x86_64/aarch64)
+-   macOS (x86_64/arm64)
+-   Windows (x86_64)
+
+## Usage
+
+All extensions are disabled by default. You can still use `sqlean` as a drop-in replacement for `sqlite3`:
+
+```python
+import sqlean as sqlite3
+
+conn = sqlite3.connect(":memory:")
+cur = conn.execute("select 'sql is awesome'")
+print(cur.fetchone())
+conn.close()
+```
+
+To enable all extensions, call `sqlean.extensions.enable_all()` before calling `connect()`:
+
+```python
+import sqlean
+
+sqlean.extensions.enable_all()
+
+conn = sqlean.connect(":memory:")
+cur = conn.execute("select median(value) from generate_series(1, 99)")
+print(cur.fetchone())
+conn.close()
+```
+
+To enable specific extensions, call `sqlean.extensions.enable()`:
+
+```python
+import sqlean
+
+sqlean.extensions.enable("stats", "text")
+
+conn = sqlean.connect(":memory:")
+cur = conn.execute("select median(value) from generate_series(1, 99)")
+print(cur.fetchone())
+conn.close()
+```
+
+## Building from source
+
+Prepare source files:
+
+```
+make prepare-src
+make download-sqlite
+make download-sqlean
+```
+
+Build and test the package:
+
+```
+make clean build
+```
+
+## Credits
+
+Based on the [pysqlite3](https://github.com/coleifer/pysqlite3) project by Charles Leifer, which is in turn based on [pysqlite](https://github.com/ghaering/pysqlite) by Gerhard Häring. Available under the [zlib license](https://github.com/Arize-ai/phoenix/blob/main/packages/phoenix-sqlean/LICENSE).

--- a/packages/phoenix-sqlean/THIRD_PARTY_LICENSES
+++ b/packages/phoenix-sqlean/THIRD_PARTY_LICENSES
@@ -1,0 +1,232 @@
+sqlean
+======
+
+The bundled sqlean extension sources are distributed under the MIT License:
+
+Copyright (c) 2021+ Anton Zhiyanov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+PCRE2
+=====
+
+PCRE2 is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
+
+Releases 10.00 and above of PCRE2 are distributed under the terms of the "BSD"
+licence, as specified below, with one exemption for certain binary
+redistributions. The documentation for PCRE2, supplied in the "doc" directory,
+is distributed under the same terms as the software itself. The data in the
+testdata directory is not copyrighted and is in the public domain.
+
+The basic library functions are written in C and are freestanding. Also
+included in the distribution is a just-in-time compiler that can be used to
+optimize pattern matching. This is an optional feature that can be omitted when
+the library is built.
+
+THE BASIC LIBRARY FUNCTIONS
+---------------------------
+
+Written by: Philip Hazel
+Email local part: Philip.Hazel
+Email domain: gmail.com
+
+Retired from University of Cambridge Computing Service,
+Cambridge, England.
+
+Copyright (c) 1997-2022 University of Cambridge
+All rights reserved.
+
+PCRE2 JUST-IN-TIME COMPILATION SUPPORT
+--------------------------------------
+
+Written by: Zoltan Herczeg
+Email local part: hzmester
+Email domain: freemail.hu
+
+Copyright(c) 2010-2022 Zoltan Herczeg
+All rights reserved.
+
+STACK-LESS JUST-IN-TIME COMPILER
+--------------------------------
+
+Written by: Zoltan Herczeg
+Email local part: hzmester
+Email domain: freemail.hu
+
+Copyright(c) 2009-2022 Zoltan Herczeg
+All rights reserved.
+
+THE "BSD" LICENCE
+-----------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notices,
+ this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+ notices, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+
+ * Neither the name of the University of Cambridge nor the names of any
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+EXEMPTION FOR BINARY LIBRARY-LIKE PACKAGES
+------------------------------------------
+
+The second condition in the BSD licence (covering binary redistributions) does
+not apply all the way down a chain of software. If binary package A includes
+PCRE2, it must respect the condition, but if package B is software that
+includes package A, the condition is not imposed on package B unless it uses
+PCRE2 independently.
+
+
+STC
+===
+
+The sqlean text extension contains code from STC:
+
+MIT License
+
+Copyright (c) 2023 Tyge Løvset
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Go
+==
+
+The sqlean time extension is based on Go's time package:
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+ * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CPython
+~~~~~~~
+
+Parts of the SQLite wrapper are derived from CPython's sqlite3 module. They
+have been modified to compile against the bundled SQLite amalgamation and to
+initialize the bundled sqlean extensions.
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+Copyright (c) 2001 Python Software Foundation; All Rights Reserved
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001 Python Software Foundation; All Rights Reserved"
+are retained in Python alone or in any derivative version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee. This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.

--- a/packages/phoenix-sqlean/THIRD_PARTY_LICENSES
+++ b/packages/phoenix-sqlean/THIRD_PARTY_LICENSES
@@ -1,0 +1,267 @@
+sqlean
+======
+
+The bundled sqlean extension sources are distributed under the MIT License:
+
+Copyright (c) 2021+ Anton Zhiyanov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+PCRE2
+=====
+
+PCRE2 is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
+
+Releases 10.00 and above of PCRE2 are distributed under the terms of the "BSD"
+licence, as specified below, with one exemption for certain binary
+redistributions. The documentation for PCRE2, supplied in the "doc" directory,
+is distributed under the same terms as the software itself. The data in the
+testdata directory is not copyrighted and is in the public domain.
+
+The basic library functions are written in C and are freestanding. Also
+included in the distribution is a just-in-time compiler that can be used to
+optimize pattern matching. This is an optional feature that can be omitted when
+the library is built.
+
+THE BASIC LIBRARY FUNCTIONS
+---------------------------
+
+Written by: Philip Hazel
+Email local part: Philip.Hazel
+Email domain: gmail.com
+
+Retired from University of Cambridge Computing Service,
+Cambridge, England.
+
+Copyright (c) 1997-2022 University of Cambridge
+All rights reserved.
+
+PCRE2 JUST-IN-TIME COMPILATION SUPPORT
+--------------------------------------
+
+Written by: Zoltan Herczeg
+Email local part: hzmester
+Email domain: freemail.hu
+
+Copyright(c) 2010-2022 Zoltan Herczeg
+All rights reserved.
+
+STACK-LESS JUST-IN-TIME COMPILER
+--------------------------------
+
+Written by: Zoltan Herczeg
+Email local part: hzmester
+Email domain: freemail.hu
+
+Copyright(c) 2009-2022 Zoltan Herczeg
+All rights reserved.
+
+THE "BSD" LICENCE
+-----------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notices,
+ this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+ notices, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+
+ * Neither the name of the University of Cambridge nor the names of any
+ contributors may be used to endorse or promote products derived from this
+ software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+EXEMPTION FOR BINARY LIBRARY-LIKE PACKAGES
+------------------------------------------
+
+The second condition in the BSD licence (covering binary redistributions) does
+not apply all the way down a chain of software. If binary package A includes
+PCRE2, it must respect the condition, but if package B is software that
+includes package A, the condition is not imposed on package B unless it uses
+PCRE2 independently.
+
+
+STC
+===
+
+The sqlean text extension contains code from STC:
+
+MIT License
+
+Copyright (c) 2023 Tyge Løvset
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Go
+==
+
+The sqlean time extension is based on Go's time package:
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+ * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+CPython
+~~~~~~~
+
+Parts of the SQLite wrapper are derived from CPython's sqlite3 module. They
+have been modified to compile against the bundled SQLite amalgamation and to
+initialize the bundled sqlean extensions.
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+Copyright (c) 2001 Python Software Foundation; All Rights Reserved
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001 Python Software Foundation; All Rights Reserved"
+are retained in Python alone or in any derivative version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee. This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+xxHash
+~~~~~~
+
+sqlean's crypto extension includes xxHash's header-only implementation as
+crypto/xxhash.impl.h. It is fetched at build time from xxHash v0.8.3 (see
+XXHASH_COMMIT in the Makefile) and compiled into the bundled extension.
+
+Copyright (c) 2012-2023 Yann Collet
+
+BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/phoenix-sqlean/scripts/check-upstream.sh
+++ b/packages/phoenix-sqlean/scripts/check-upstream.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+#
+# Reports -- and with --apply, rewrites -- the upstream pins in ../Makefile when
+# a newer release exists. No dependency bot can see those pins: Dependabot has
+# no custom-regex manager, and SQLite's packed version maps to no standard
+# versioning scheme.
+#
+#   check-upstream.sh sqlite            # detection only, no downloads
+#   check-upstream.sh sqlite --apply    # resolve, hash, and rewrite the pins
+#   check-upstream.sh sqlean [--apply]
+#
+# Detection is kept cheap (one HTTP request or one ls-remote) so callers can
+# decide whether the expensive path is worth running.
+#
+# Edits only, verifies nothing -- the tripwires live in `make prepare-src
+# download-sqlite download-sqlean`, which the caller runs afterwards. So writing
+# a wrong hash is safe: the next fetch refuses to proceed.
+#
+# Machine-readable results go to $GITHUB_OUTPUT when set; a Markdown PR body
+# goes to stdout.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SQLITE_DOWNLOAD_PAGE="https://sqlite.org/download.html"
+XXHASH_REPO="https://github.com/Cyan4973/xxHash.git"
+
+component=${1:-}
+apply=${2:-}
+
+if [ "$component" != "sqlite" ] && [ "$component" != "sqlean" ]; then
+    echo "usage: $0 {sqlite|sqlean} [--apply]" >&2
+    exit 2
+fi
+if [ -n "$apply" ] && [ "$apply" != "--apply" ]; then
+    echo "usage: $0 {sqlite|sqlean} [--apply]" >&2
+    exit 2
+fi
+
+# The Makefile is the single source of truth; nothing here keeps its own copy.
+pin() {
+    sed -n "s/^$1 := \(.*\)/\1/p" Makefile | head -1
+}
+
+# Through a temp file rather than `sed -i`: the BSD and GNU spellings of that
+# flag are incompatible, and this runs on both macOS and the CI runners.
+set_pin() {
+    local file=$1 name=$2 value=$3 tmp
+    tmp=$(mktemp)
+    awk -v n="$name" -v v="$value" -v sep="$4" '
+        $0 ~ "^" n " " sep " " { print n " " sep " " v; next }
+        { print }
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+}
+
+emit() {
+    [ -n "${GITHUB_OUTPUT:-}" ] && echo "$1=$2" >> "$GITHUB_OUTPUT"
+    return 0
+}
+
+# Peel an annotated tag to its commit; a lightweight tag has no ^{} line, so
+# fall back to the ref. Pinning a tag object instead of a commit would make the
+# later `git checkout` behave differently than intended.
+tag_commit() {
+    local repo=$1 tag=$2 refs peeled
+    refs=$(git ls-remote "$repo" "refs/tags/$tag" "refs/tags/$tag^{}")
+    peeled=$(echo "$refs" | grep '\^{}$' | cut -f1)
+    if [ -n "$peeled" ]; then echo "$peeled"; else echo "$refs" | cut -f1; fi
+}
+
+case "$component" in
+sqlite)
+    current=$(pin SQLITE_VERSION)
+    # sqlite.org's machine-readable line carries the whole bump:
+    #   PRODUCT,<version>,<year>/sqlite-amalgamation-<packed>.zip,<size>,<sha3>
+    product=$(curl -fsSL "$SQLITE_DOWNLOAD_PAGE" \
+        | grep -E '^PRODUCT,[^,]+,[0-9]{4}/sqlite-amalgamation-[0-9]+\.zip,' | head -1)
+    if [ -z "$product" ]; then
+        echo "::error::No amalgamation PRODUCT line found on $SQLITE_DOWNLOAD_PAGE" >&2
+        exit 1
+    fi
+    IFS=, read -r _ human relpath _ sha3 <<< "$product"
+    year=${relpath%%/*}
+    packed=${relpath##*/sqlite-amalgamation-}
+    packed=${packed%.zip}
+
+    emit current "$current"
+    emit latest "$packed"
+    if [ "$packed" -le "$current" ]; then
+        emit outdated false
+        echo "SQLite pin $current is current (latest $packed)." >&2
+        exit 0
+    fi
+    emit outdated true
+    emit version "$human"
+    emit title "fix(phoenix-sqlean): bump bundled SQLite to $human"
+    emit branch "deps/phoenix-sqlean-sqlite-$human"
+
+    if [ "$apply" != "--apply" ]; then
+        echo "SQLite $human ($packed) is newer than the pinned $current." >&2
+        exit 0
+    fi
+
+    # Before set_pin runs: pin() would otherwise read back the new value.
+    old_year=$(pin SQLITE_RELEASE_YEAR)
+    old_sha=$(pin SQLITE_SHA256)
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+    curl -fsSL "https://sqlite.org/$relpath" --output "$tmpdir/sqlite.zip"
+    # Confirm against the published SHA3-256 before recording anything;
+    # skipping it would make the pin trust-on-first-use.
+    got=$(python3 -c "import hashlib,sys;print(hashlib.sha3_256(open(sys.argv[1],'rb').read()).hexdigest())" "$tmpdir/sqlite.zip")
+    if [ "$got" != "$sha3" ]; then
+        echo "::error::SHA3-256 mismatch for $relpath (published $sha3, got $got)" >&2
+        exit 1
+    fi
+    # shasum is the one hash tool on both macOS and the CI runners, and it
+    # cannot do SHA3 -- hence the two-hash dance.
+    sha256=$(shasum -a 256 "$tmpdir/sqlite.zip" | cut -d' ' -f1)
+
+    set_pin Makefile SQLITE_RELEASE_YEAR "$year" ":="
+    set_pin Makefile SQLITE_VERSION "$packed" ":="
+    set_pin Makefile SQLITE_SHA256 "$sha256" ":="
+
+    cat <<EOF
+Bumps the bundled SQLite amalgamation to **$human**.
+
+| Pin | Was | Now |
+|---|---|---|
+| \`SQLITE_RELEASE_YEAR\` | $old_year | $year |
+| \`SQLITE_VERSION\` | $current | $packed |
+| \`SQLITE_SHA256\` | \`${old_sha:0:16}...\` | \`${sha256:0:16}...\` |
+
+The download's SHA3-256 was confirmed against the \`PRODUCT\` line on
+<$SQLITE_DOWNLOAD_PAGE> before \`SQLITE_SHA256\` was recorded, so this pin is
+anchored to what upstream publishes rather than to a single fetch.
+
+Release notes: <https://sqlite.org/releaselog/${human//./_}.html>
+
+Reviewer checklist:
+
+- [ ] \`src/test_windirent.h\` is **not** re-synced. It is pinned at 3.50.4, the
+      last release that shipped it, and is deliberately unrelated to this bump.
+
+Generated by \`.github/workflows/phoenix-sqlean-upstream.yml\`.
+EOF
+    ;;
+
+sqlean)
+    repo=$(pin SQLEAN_REPO)
+    current=$(pin SQLEAN_VERSION)
+    base=${current%%+*}
+    # sqlean carries a non-version tag (`incubator`), which a bare
+    # `sort -V | tail -1` would pick. Filter to version-shaped tags.
+    latest=$(git ls-remote --tags "$repo" | grep -v '\^{}' | sed 's|.*refs/tags/||' \
+        | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+    if [ -z "$latest" ]; then
+        echo "::error::No version-shaped tags found in $repo" >&2
+        exit 1
+    fi
+
+    emit current "$base"
+    emit latest "$latest"
+    # sort -V, not string compare, so a pin deliberately ahead of the newest
+    # tag reads as current instead of being walked backwards.
+    newest=$(printf '%s\n%s\n' "$base" "$latest" | sort -V | tail -1)
+    if [ "$newest" = "$base" ]; then
+        emit outdated false
+        echo "sqlean pin $current is current (latest tag $latest)." >&2
+        exit 0
+    fi
+    emit outdated true
+    emit version "$latest"
+    emit title "fix(phoenix-sqlean): bump bundled sqlean to $latest"
+    emit branch "deps/phoenix-sqlean-sqlean-$latest"
+
+    if [ "$apply" != "--apply" ]; then
+        echo "sqlean $latest is newer than the pinned $base." >&2
+        exit 0
+    fi
+
+    old_commit=$(pin SQLEAN_COMMIT)
+    commit=$(tag_commit "$repo" "$latest")
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    # Fetched only to read its Makefile: sqlean pins its own xxHash, and ours
+    # must move with it (download-sqlean asserts this).
+    git -C "$tmpdir" init -q --template=
+    git -C "$tmpdir" remote add origin "$repo"
+    git -C "$tmpdir" fetch -q --depth 1 origin "$commit"
+    git -C "$tmpdir" checkout -q FETCH_HEAD
+    xxhash_tag=$(sed -n 's|.*xxhash/raw/\([^/]*\)/xxhash.h.*|\1|p' "$tmpdir/Makefile" | head -1)
+    if [ -z "$xxhash_tag" ]; then
+        echo "::error::sqlean $latest no longer fetches xxhash.h the expected way; bump by hand" >&2
+        exit 1
+    fi
+
+    set_pin Makefile SQLEAN_COMMIT "$commit" ":="
+    # No +<sha> suffix: this lands exactly on a tag, and check-sqlean-pin
+    # rejects a stale one -- so the tripwire validates this script's output.
+    set_pin Makefile SQLEAN_VERSION "$latest" ":="
+    set_pin setup.py SQLEAN_VERSION "\"$latest\"" "="
+
+    xxhash_note="unchanged (\`$(pin XXHASH_TAG)\`)"
+    if [ "$xxhash_tag" != "$(pin XXHASH_TAG)" ]; then
+        xxhash_commit=$(tag_commit "$XXHASH_REPO" "$xxhash_tag")
+        curl -fsSL "https://github.com/cyan4973/xxhash/raw/$xxhash_commit/xxhash.h" \
+            --output "$tmpdir/xxhash.h"
+        xxhash_sha=$(shasum -a 256 "$tmpdir/xxhash.h" | cut -d' ' -f1)
+        old_tag=$(pin XXHASH_TAG)
+        set_pin Makefile XXHASH_TAG "$xxhash_tag" ":="
+        set_pin Makefile XXHASH_COMMIT "$xxhash_commit" ":="
+        set_pin Makefile XXHASH_SHA256 "$xxhash_sha" ":="
+        tmp=$(mktemp)
+        sed "s|from xxHash $old_tag |from xxHash $xxhash_tag |" THIRD_PARTY_LICENSES > "$tmp"
+        mv "$tmp" THIRD_PARTY_LICENSES
+        xxhash_note="**moved $old_tag -> $xxhash_tag** (sqlean changed its own pin)"
+    fi
+
+    cat <<EOF
+Bumps the bundled sqlean to **$latest**.
+
+| Pin | Was | Now |
+|---|---|---|
+| \`SQLEAN_VERSION\` | $current | $latest |
+| \`SQLEAN_COMMIT\` | \`${old_commit:0:12}...\` | \`$commit\` |
+| xxHash | | $xxhash_note |
+
+\`SQLEAN_VERSION\` is set to the plain tag with no \`+<sha>\` suffix, because
+this pin lands exactly on \`$latest\`. \`setup.py\` was moved in lockstep, so
+\`sqlean_version()\` reports the same string.
+
+Reviewer checklist:
+
+- [ ] **Tag or past it?** This pins the release tag. If a post-release fix is
+      wanted instead, retarget \`SQLEAN_COMMIT\` at that commit and add the
+      \`+<short sha>\` suffix back to both \`SQLEAN_VERSION\` values.
+- [ ] \`src/sqlean-time-msvc.patch\` still applies. If \`patch(1)\` failed in
+      CI, regenerate it against the new time sources -- that failure is the
+      intended tripwire, not a breakage.
+
+Generated by \`.github/workflows/phoenix-sqlean-upstream.yml\`.
+EOF
+    ;;
+esac

--- a/packages/phoenix-sqlean/setup.cfg
+++ b/packages/phoenix-sqlean/setup.cfg
@@ -1,0 +1,3 @@
+[build_ext]
+include_dirs=/usr/include
+library_dirs=/usr/lib

--- a/packages/phoenix-sqlean/setup.py
+++ b/packages/phoenix-sqlean/setup.py
@@ -1,0 +1,196 @@
+# Originally by Gerhard Häring, zlib license
+# https://github.com/ghaering/pysqlite
+
+# Modified by Charles Leifer
+# https://github.com/coleifer/pysqlite3
+
+# Modified by Anton Zhiyanov
+# https://github.com/nalgeon/sqlean.py
+
+# SQLite Python wrapper bundled with Sqlean extensions.
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+import setuptools
+from setuptools import Extension
+from setuptools.command.build_ext import build_ext
+
+log = logging.getLogger(__name__)
+
+PACKAGE_NAME = "sqlean"
+SQLEAN_VERSION = "0.27.4"
+VERSION = "0.1.0"  # x-release-please-version
+
+SHORT_DESCRIPTION = "sqlite3 with extensions"
+LONG_DESCRIPTION = Path("README.md").read_text()
+
+
+# Module sources
+sources = [
+    os.path.join("src", source)
+    for source in [
+        "module.c",
+        "connection.c",
+        "cursor.c",
+        "cache.c",
+        "microprotocols.c",
+        "prepare_protocol.c",
+        "statement.c",
+        "util.c",
+        "row.c",
+        "blob.c",
+    ]
+]
+
+# Packages
+packages = [PACKAGE_NAME]
+
+# Work around clang raising hard error for unused arguments
+if sys.platform == "darwin":
+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
+    os.environ["CFLAGS"] = "-Qunused-arguments"
+    log.info("CFLAGS: " + os.environ["CFLAGS"])
+
+
+def quote_argument(arg):
+    q = '\\"' if sys.platform == "win32" and sys.version_info < (3, 7) else '"'
+    return q + arg + q
+
+
+define_macros = [("MODULE_NAME", quote_argument(PACKAGE_NAME + ".dbapi2"))]
+
+
+class Builder(build_ext):
+    description = "Builds a C extension using a sqlite3 amalgamation"
+
+    amalgamation_root = "sqlite"
+
+    def build_extension(self, ext):
+        log.info(self.description)
+
+        # gcc optimization level
+        ext.extra_compile_args.append("-O1")
+
+        self._setup_defines(ext)
+        self._setup_sources(ext)
+
+        if sys.platform != "win32":
+            # Include math library, required for fts5.
+            ext.extra_link_args.append("-lm")
+
+        build_ext.build_extension(self, ext)
+
+    def _setup_defines(self, ext):
+        # sqlite options
+        features = (
+            "ENABLE_DBPAGE_VTAB",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_EXPLAIN_COMMENTS",
+            "ENABLE_FTS4",
+            "ENABLE_FTS5",
+            "ENABLE_GEOPOLY",
+            "ENABLE_JSON1",
+            "ENABLE_MATH_FUNCTIONS",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_STMTVTAB",
+            "LIKE_DOESNT_MATCH_BLOBS",
+            "USE_URI",
+        )
+        for feature in features:
+            ext.define_macros.append(("SQLITE_%s" % feature, "1"))
+
+        # Increase the maximum number of "host parameters" which SQLite will accept
+        ext.define_macros.append(("SQLITE_MAX_VARIABLE_NUMBER", "250000"))
+
+        # Increase maximum allowed memory-map size to 1TB
+        ext.define_macros.append(("SQLITE_MAX_MMAP_SIZE", str(2**40)))
+
+        # Auto-load sqlean extensions
+        ext.define_macros.append(("SQLITE_EXTRA_INIT", "core_init"))
+        ext.define_macros.append(("SQLEAN_VERSION", quote_argument(SQLEAN_VERSION)))
+
+        # Extension-specific flags
+        ext.define_macros.append(("PCRE2_CODE_UNIT_WIDTH", "8"))
+        ext.define_macros.append(("LINK_SIZE", "2"))
+        ext.define_macros.append(("HAVE_CONFIG_H", "1"))
+        ext.define_macros.append(("SUPPORT_UNICODE", "1"))
+        if sys.platform == "win32":
+            ext.define_macros.append(("BYTE_ORDER", "LITTLE_ENDIAN"))
+            ext.define_macros.append(("PCRE2_STATIC", "1"))
+
+    def _setup_sources(self, ext):
+        ext.include_dirs.append(self.amalgamation_root)
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlite3.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-crypto.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-define.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-fileio.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-fuzzy.c"))
+        if sys.platform != "win32":
+            # ipaddr uses POSIX networking headers (arpa/inet.h) that MSVC
+            # cannot compile, so it is excluded from Windows builds — same as
+            # sqlean's own Windows distribution. sqlean.c already guards the
+            # corresponding init calls with !defined(_WIN32).
+            ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-ipaddr.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-regexp.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-stats.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-text.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-time.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-unicode.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-uuid.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-vsv.c"))
+        ext.sources.append(os.path.join("src", "sqlean.c"))
+
+    def __setattr__(self, k, v):
+        # Make sure we don't link against the SQLite
+        # library, no matter what setup.cfg says
+        if k == "libraries":
+            v = None
+        self.__dict__[k] = v
+
+
+def get_setup_args():
+    return dict(
+        name="arize-phoenix-sqlean",
+        version=VERSION,
+        description=SHORT_DESCRIPTION,
+        long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/markdown",
+        author="Anton Zhiyanov",
+        author_email="m@antonz.org",
+        maintainer="Arize AI",
+        maintainer_email="phoenix-devs@arize.com",
+        license="Zlib AND MIT AND BSD-3-Clause AND PSF-2.0",
+        license_files=["LICENSE", "THIRD_PARTY_LICENSES"],
+        platforms="ALL",
+        url="https://github.com/Arize-ai/phoenix/tree/main/packages/phoenix-sqlean",
+        package_dir={PACKAGE_NAME: PACKAGE_NAME},
+        packages=packages,
+        python_requires=">=3.9",
+        ext_modules=[
+            Extension(
+                name=f"{PACKAGE_NAME}._sqlite3",
+                sources=sources,
+                define_macros=define_macros,
+            )
+        ],
+        classifiers=[
+            "Development Status :: 4 - Beta",
+            "Intended Audience :: Developers",
+            "Operating System :: MacOS :: MacOS X",
+            "Operating System :: Microsoft :: Windows",
+            "Operating System :: POSIX",
+            "Programming Language :: C",
+            "Programming Language :: Python",
+            "Topic :: Database :: Database Engines/Servers",
+            "Topic :: Software Development :: Libraries :: Python Modules",
+        ],
+        cmdclass={"build_ext": Builder},
+    )
+
+
+if __name__ == "__main__":
+    setuptools.setup(**get_setup_args())

--- a/packages/phoenix-sqlean/setup.py
+++ b/packages/phoenix-sqlean/setup.py
@@ -1,0 +1,199 @@
+# Originally by Gerhard Häring, zlib license
+# https://github.com/ghaering/pysqlite
+
+# Modified by Charles Leifer
+# https://github.com/coleifer/pysqlite3
+
+# Modified by Anton Zhiyanov
+# https://github.com/nalgeon/sqlean.py
+
+# SQLite Python wrapper bundled with Sqlean extensions.
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+import setuptools
+from setuptools import Extension
+from setuptools.command.build_ext import build_ext
+
+log = logging.getLogger(__name__)
+
+PACKAGE_NAME = "sqlean"
+VERSION = "0.1.0"  # x-release-please-version
+SQLEAN_VERSION = "0.28.3+6b969da"
+
+SHORT_DESCRIPTION = "sqlite3 with extensions"
+LONG_DESCRIPTION = Path("README.md").read_text()
+
+
+# Module sources
+sources = [
+    os.path.join("src", source)
+    for source in [
+        "module.c",
+        "connection.c",
+        "cursor.c",
+        "cache.c",
+        "microprotocols.c",
+        "prepare_protocol.c",
+        "statement.c",
+        "util.c",
+        "row.c",
+        "blob.c",
+    ]
+]
+
+# Packages
+packages = [PACKAGE_NAME]
+
+# Work around clang raising hard error for unused arguments
+if sys.platform == "darwin":
+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
+    os.environ["CFLAGS"] = "-Qunused-arguments"
+    log.info("CFLAGS: " + os.environ["CFLAGS"])
+
+
+def quote_argument(arg):
+    q = '\\"' if sys.platform == "win32" and sys.version_info < (3, 7) else '"'
+    return q + arg + q
+
+
+define_macros = [("MODULE_NAME", quote_argument(PACKAGE_NAME + ".dbapi2"))]
+
+
+class Builder(build_ext):
+    description = "Builds a C extension using a sqlite3 amalgamation"
+
+    amalgamation_root = "sqlite"
+
+    def build_extension(self, ext):
+        log.info(self.description)
+
+        # gcc optimization level
+        ext.extra_compile_args.append("-O1")
+
+        self._setup_defines(ext)
+        self._setup_sources(ext)
+
+        if sys.platform != "win32":
+            # Include math library, required for fts5.
+            ext.extra_link_args.append("-lm")
+
+        build_ext.build_extension(self, ext)
+
+    def _setup_defines(self, ext):
+        # sqlite options
+        features = (
+            "ENABLE_DBPAGE_VTAB",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_EXPLAIN_COMMENTS",
+            "ENABLE_FTS4",
+            "ENABLE_FTS5",
+            "ENABLE_GEOPOLY",
+            "ENABLE_JSON1",
+            "ENABLE_MATH_FUNCTIONS",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_STMTVTAB",
+            "LIKE_DOESNT_MATCH_BLOBS",
+            "USE_URI",
+        )
+        for feature in features:
+            ext.define_macros.append(("SQLITE_%s" % feature, "1"))
+
+        # Increase the maximum number of "host parameters" which SQLite will accept
+        ext.define_macros.append(("SQLITE_MAX_VARIABLE_NUMBER", "250000"))
+
+        # Increase maximum allowed memory-map size to 1TB
+        ext.define_macros.append(("SQLITE_MAX_MMAP_SIZE", str(2**40)))
+
+        # Auto-load sqlean extensions
+        ext.define_macros.append(("SQLITE_EXTRA_INIT", "core_init"))
+        ext.define_macros.append(("SQLEAN_VERSION", quote_argument(SQLEAN_VERSION)))
+
+        # Extension-specific flags
+        ext.define_macros.append(("PCRE2_CODE_UNIT_WIDTH", "8"))
+        ext.define_macros.append(("LINK_SIZE", "2"))
+        ext.define_macros.append(("HAVE_CONFIG_H", "1"))
+        ext.define_macros.append(("SUPPORT_UNICODE", "1"))
+        if sys.platform == "win32":
+            ext.define_macros.append(("BYTE_ORDER", "LITTLE_ENDIAN"))
+            ext.define_macros.append(("PCRE2_STATIC", "1"))
+
+    def _setup_sources(self, ext):
+        ext.include_dirs.append(self.amalgamation_root)
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlite3.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-crypto.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-define.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-fileio.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-fuzzy.c"))
+        if sys.platform != "win32":
+            # ipaddr uses POSIX networking headers (arpa/inet.h) that MSVC
+            # cannot compile, so it is excluded from Windows builds — same as
+            # sqlean's own Windows distribution. sqlean.c already guards the
+            # corresponding init calls with !defined(_WIN32).
+            ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-ipaddr.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-regexp.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-stats.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-text.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-time.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-unicode.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-uuid.c"))
+        ext.sources.append(os.path.join(self.amalgamation_root, "sqlean-vsv.c"))
+        ext.sources.append(os.path.join("src", "sqlean.c"))
+
+    def __setattr__(self, k, v):
+        # Make sure we don't link against the SQLite
+        # library, no matter what setup.cfg says
+        if k == "libraries":
+            v = None
+        self.__dict__[k] = v
+
+
+def get_setup_args():
+    return dict(
+        name="arize-phoenix-sqlean",
+        version=VERSION,
+        description=SHORT_DESCRIPTION,
+        long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/markdown",
+        author="Anton Zhiyanov",
+        author_email="m@antonz.org",
+        maintainer="Arize AI",
+        maintainer_email="phoenix-devs@arize.com",
+        # Zlib: this wrapper (via pysqlite). MIT: sqlean. BSD-2-Clause:
+        # xxHash. BSD-3-Clause: PCRE2. PSF-2.0: CPython's sqlite3 module.
+        # Keep in sync with the sections in THIRD_PARTY_LICENSES.
+        license="Zlib AND MIT AND BSD-2-Clause AND BSD-3-Clause AND PSF-2.0",
+        license_files=["LICENSE", "THIRD_PARTY_LICENSES"],
+        platforms="ALL",
+        url="https://github.com/Arize-ai/phoenix/tree/main/packages/phoenix-sqlean",
+        package_dir={PACKAGE_NAME: PACKAGE_NAME},
+        packages=packages,
+        python_requires=">=3.10, <3.15",
+        ext_modules=[
+            Extension(
+                name=f"{PACKAGE_NAME}._sqlite3",
+                sources=sources,
+                define_macros=define_macros,
+            )
+        ],
+        classifiers=[
+            "Development Status :: 4 - Beta",
+            "Intended Audience :: Developers",
+            "Operating System :: MacOS :: MacOS X",
+            "Operating System :: Microsoft :: Windows",
+            "Operating System :: POSIX",
+            "Programming Language :: C",
+            "Programming Language :: Python",
+            "Topic :: Database :: Database Engines/Servers",
+            "Topic :: Software Development :: Libraries :: Python Modules",
+        ],
+        cmdclass={"build_ext": Builder},
+    )
+
+
+if __name__ == "__main__":
+    setuptools.setup(**get_setup_args())

--- a/packages/phoenix-sqlean/sqlean/__init__.py
+++ b/packages/phoenix-sqlean/sqlean/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2005 Gerhard Haring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+from sqlean import extensions
+from sqlean.dbapi2 import *

--- a/packages/phoenix-sqlean/sqlean/dbapi2.py
+++ b/packages/phoenix-sqlean/sqlean/dbapi2.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2004-2005 Gerhard Häring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+"""
+DB-API 2.0 interface for SQLite databases.
+"""
+
+import datetime
+import time
+import collections.abc
+
+from sqlean._sqlite3 import *
+
+paramstyle = "qmark"
+
+threadsafety = 1
+
+apilevel = "2.0"
+
+Date = datetime.date
+
+Time = datetime.time
+
+Timestamp = datetime.datetime
+
+
+def DateFromTicks(ticks):
+    return Date(*time.localtime(ticks)[:3])
+
+
+def TimeFromTicks(ticks):
+    return Time(*time.localtime(ticks)[3:6])
+
+
+def TimestampFromTicks(ticks):
+    return Timestamp(*time.localtime(ticks)[:6])
+
+
+version_info = tuple([int(x) for x in version.split(".")])
+sqlite_version_info = tuple([int(x) for x in sqlite_version.split(".")])
+
+Binary = memoryview
+collections.abc.Sequence.register(Row)
+
+
+def register_adapters_and_converters():
+    def adapt_date(val):
+        return val.isoformat()
+
+    def adapt_datetime(val):
+        return val.isoformat(" ")
+
+    def convert_date(val):
+        return datetime.date(*map(int, val.split(b"-")))
+
+    def convert_timestamp(val):
+        datepart, timepart = val.split(b" ")
+        year, month, day = map(int, datepart.split(b"-"))
+        timepart_full = timepart.split(b".")
+        hours, minutes, seconds = map(int, timepart_full[0].split(b":"))
+        if len(timepart_full) == 2:
+            microseconds = int("{:0<6.6}".format(timepart_full[1].decode()))
+        else:
+            microseconds = 0
+
+        val = datetime.datetime(year, month, day, hours, minutes, seconds, microseconds)
+        return val
+
+    register_adapter(datetime.date, adapt_date)
+    register_adapter(datetime.datetime, adapt_datetime)
+    register_converter("date", convert_date)
+    register_converter("timestamp", convert_timestamp)
+
+
+register_adapters_and_converters()
+
+# Clean up namespace
+
+del register_adapters_and_converters

--- a/packages/phoenix-sqlean/sqlean/extensions.py
+++ b/packages/phoenix-sqlean/sqlean/extensions.py
@@ -1,0 +1,58 @@
+"""
+Extension management.
+"""
+
+import os
+
+_extensions = {
+    "crypto",
+    "define",
+    "fileio",
+    "fuzzy",
+    "ipaddr",
+    "regexp",
+    "stats",
+    "text",
+    "time",
+    "unicode",
+    "uuid",
+    "vsv",
+}
+
+
+def enable_all():
+    """Enables all extensions."""
+    os.environ["SQLEAN_ENABLE"] = "1"
+
+
+def disable_all():
+    """Disables all extensions."""
+    os.environ["SQLEAN_ENABLE"] = "0"
+
+
+def enable(*names):
+    """Enables specific extensions."""
+    _clear_flags()
+    for name in names:
+        if name not in _extensions:
+            continue
+        os.environ[f"SQLEAN_ENABLE_{name.upper()}"] = "1"
+
+
+def disable(*names):
+    """Disables specific extensions."""
+    _clear_flags()
+    for name in names:
+        if name not in _extensions:
+            continue
+        os.environ[f"SQLEAN_ENABLE_{name.upper()}"] = "0"
+
+
+def _clear_flags():
+    """Clears 'enabled' flags for all extensions."""
+    if "SQLEAN_ENABLE" in os.environ:
+        del os.environ["SQLEAN_ENABLE"]
+    for name in _extensions:
+        flag = f"SQLEAN_ENABLE_{name.upper()}"
+        if flag in os.environ:
+            del os.environ[flag]

--- a/packages/phoenix-sqlean/src/blob.c
+++ b/packages/phoenix-sqlean/src/blob.c
@@ -1,0 +1,654 @@
+#include "blob.h"
+#include "util.h"
+
+
+int pysqlite_blob_init(pysqlite_Blob *self, pysqlite_Connection* connection,
+                       sqlite3_blob *blob)
+{
+    Py_INCREF(connection);
+    self->connection = connection;
+    self->offset = 0;
+    self->blob = blob;
+    self->in_weakreflist = NULL;
+
+    Py_BEGIN_ALLOW_THREADS
+    self->length = sqlite3_blob_bytes(self->blob);
+    Py_END_ALLOW_THREADS
+
+    if (!pysqlite_check_thread(self->connection)) {
+        return -1;
+    }
+    return 0;
+}
+
+static void remove_blob_from_connection_blob_list(pysqlite_Blob *self)
+{
+    Py_ssize_t i;
+    PyObject *item, *ref;
+
+    for (i = 0; i < PyList_GET_SIZE(self->connection->blobs); i++) {
+        item = PyList_GET_ITEM(self->connection->blobs, i);
+        if (PyWeakref_GetRef(item, &ref) == 1) {
+            if (ref == (PyObject *)self) {
+                PyList_SetSlice(self->connection->blobs, i, i+1, NULL);
+                break;
+            }
+        }
+    }
+}
+
+static void _close_blob_inner(pysqlite_Blob* self)
+{
+    sqlite3_blob *blob;
+
+    /* close the blob */
+    blob = self->blob;
+    self->blob = NULL;
+    if (blob) {
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_blob_close(blob);
+        Py_END_ALLOW_THREADS
+    }
+
+    /* remove from connection weaklist */
+    remove_blob_from_connection_blob_list(self);
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }
+}
+
+static void pysqlite_blob_dealloc(pysqlite_Blob* self)
+{
+    _close_blob_inner(self);
+    Py_XDECREF(self->connection);
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+/*
+ * Checks if a blob object is usable (i. e. not closed).
+ *
+ * 0 => error; 1 => ok
+ */
+int pysqlite_check_blob(pysqlite_Blob *blob)
+{
+
+    if (!blob->blob) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Cannot operate on a closed blob.");
+        return 0;
+    } else if (!pysqlite_check_connection(blob->connection) ||
+               !pysqlite_check_thread(blob->connection)) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+
+PyObject* pysqlite_blob_close(pysqlite_Blob *self)
+{
+
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    _close_blob_inner(self);
+    Py_RETURN_NONE;
+};
+
+
+static Py_ssize_t pysqlite_blob_length(pysqlite_Blob *self)
+{
+    if (!pysqlite_check_blob(self)) {
+        return -1;
+    }
+
+    return self->length;
+};
+
+static PyObject* inner_read(pysqlite_Blob *self, int read_length, int offset)
+{
+    PyObject *buffer;
+    char *raw_buffer;
+    int rc;
+
+    buffer = PyBytes_FromStringAndSize(NULL, read_length);
+    if (!buffer) {
+        return NULL;
+    }
+    raw_buffer = PyBytes_AS_STRING(buffer);
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_blob_read(self->blob, raw_buffer, read_length, self->offset);
+    Py_END_ALLOW_THREADS
+
+    if (rc != SQLITE_OK){
+        Py_DECREF(buffer);
+        /* For some reason after modifying blob the
+           error is not set on the connection db. */
+        if (rc == SQLITE_ABORT) {
+            PyErr_SetString(pysqlite_OperationalError,
+                            "Cannot operate on modified blob");
+        } else {
+            _pysqlite_seterror(self->connection->db);
+        }
+        return NULL;
+    }
+    return buffer;
+}
+
+
+PyObject* pysqlite_blob_read(pysqlite_Blob *self, PyObject *args)
+{
+    int read_length = -1;
+    PyObject *buffer;
+
+    if (!PyArg_ParseTuple(args, "|i", &read_length)) {
+        return NULL;
+    }
+
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    if (read_length < 0) {
+        /* same as file read. */
+        read_length = self->length;
+    }
+
+    /* making sure we don't read more then blob size */
+    if (read_length > self->length - self->offset) {
+        read_length = self->length - self->offset;
+    }
+
+    buffer = inner_read(self, read_length, self->offset);
+
+    if (buffer != NULL) {
+        /* update offset on sucess. */
+        self->offset += read_length;
+    }
+
+    return buffer;
+};
+
+static int write_inner(pysqlite_Blob *self, const void *buf, Py_ssize_t len, int offset)
+{
+    int rc;
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_blob_write(self->blob, buf, len, offset);
+    Py_END_ALLOW_THREADS
+    if (rc != SQLITE_OK) {
+        /* For some reason after modifying blob the
+        error is not set on the connection db. */
+        if (rc == SQLITE_ABORT) {
+            PyErr_SetString(pysqlite_OperationalError,
+                            "Cannot operate on modified blob");
+        } else {
+            _pysqlite_seterror(self->connection->db);
+        }
+        return -1;
+    }
+    return 0;
+}
+
+
+PyObject* pysqlite_blob_write(pysqlite_Blob *self, PyObject *data)
+{
+    Py_buffer data_buffer;
+    int rc;
+
+    if (PyObject_GetBuffer(data, &data_buffer, PyBUF_SIMPLE) < 0) {
+        return NULL;
+    }
+
+    if (data_buffer.len > INT_MAX) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "data longer than INT_MAX bytes");
+        PyBuffer_Release(&data_buffer);
+        return NULL;
+    }
+
+    if (data_buffer.len > self->length - self->offset) {
+        PyErr_SetString(PyExc_ValueError,
+                        "data longer than blob length");
+        PyBuffer_Release(&data_buffer);
+        return NULL;
+    }
+
+    if (!pysqlite_check_blob(self)) {
+        PyBuffer_Release(&data_buffer);
+        return NULL;
+    }
+
+    rc = write_inner(self, data_buffer.buf, data_buffer.len, self->offset);
+
+    if (rc == 0) {
+        self->offset += (int)data_buffer.len;
+        PyBuffer_Release(&data_buffer);
+        Py_RETURN_NONE;
+    } else {
+        PyBuffer_Release(&data_buffer);
+        return NULL;
+    }
+}
+
+
+PyObject* pysqlite_blob_seek(pysqlite_Blob *self, PyObject *args)
+{
+    int offset, from_what = 0;
+
+    if (!PyArg_ParseTuple(args, "i|i", &offset, &from_what)) {
+        return NULL;
+    }
+
+
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    switch (from_what) {
+        case 0:  // relative to blob begin
+            break;
+        case 1:  // relative to current position
+            if (offset > INT_MAX - self->offset) {
+                goto overflow;
+            }
+            offset = self->offset + offset;
+            break;
+        case 2:  // relative to blob end
+            if (offset > INT_MAX - self->length) {
+                goto overflow;
+            }
+            offset = self->length + offset;
+            break;
+        default:
+            PyErr_SetString(PyExc_ValueError,
+                                "from_what should be 0, 1 or 2");
+            return NULL;
+    }
+
+    if (offset < 0 || offset > self->length) {
+        PyErr_SetString(PyExc_ValueError, "offset out of blob range");
+        return NULL;
+    }
+
+    self->offset = offset;
+    Py_RETURN_NONE;
+
+overflow:
+    PyErr_SetString(PyExc_OverflowError, "seek offset result in overflow");
+    return NULL;
+}
+
+
+PyObject* pysqlite_blob_tell(pysqlite_Blob *self)
+{
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    return PyLong_FromLong(self->offset);
+}
+
+
+PyObject* pysqlite_blob_enter(pysqlite_Blob *self)
+{
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+
+PyObject* pysqlite_blob_exit(pysqlite_Blob *self, PyObject *args)
+{
+    PyObject *res;
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    res = pysqlite_blob_close(self);
+    if (!res) {
+        return NULL;
+    }
+    Py_XDECREF(res);
+
+    Py_RETURN_FALSE;
+}
+
+static PyObject* pysqlite_blob_concat(pysqlite_Blob *self, PyObject *args)
+{
+    if (pysqlite_check_blob(self)) {
+        PyErr_SetString(PyExc_SystemError,
+                        "Blob don't support concatenation");
+    }
+    return NULL;
+}
+
+static PyObject* pysqlite_blob_repeat(pysqlite_Blob *self, PyObject *args)
+{
+    if (pysqlite_check_blob(self)) {
+        PyErr_SetString(PyExc_SystemError,
+                        "Blob don't support repeat operation");
+    }
+    return NULL;
+}
+
+static int pysqlite_blob_contains(pysqlite_Blob *self, PyObject *args)
+{
+    if (pysqlite_check_blob(self)) {
+        PyErr_SetString(PyExc_SystemError,
+                        "Blob don't support contains operation");
+    }
+    return -1;
+}
+
+static PyObject* pysqlite_blob_item(pysqlite_Blob *self, Py_ssize_t i)
+{
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    if (i < 0 || i >= self->length) {
+        PyErr_SetString(PyExc_IndexError, "Blob index out of range");
+        return NULL;
+    }
+
+    return inner_read(self, 1, i);
+}
+
+static int pysqlite_blob_ass_item(pysqlite_Blob *self, Py_ssize_t i, PyObject *v)
+{
+    const char *buf;
+
+    if (!pysqlite_check_blob(self)) {
+        return -1;
+    }
+
+    if (i < 0 || i >= self->length) {
+        PyErr_SetString(PyExc_IndexError, "Blob index out of range");
+        return -1;
+    }
+    if (v == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Blob object doesn't support item deletion");
+        return -1;
+    }
+    if (! (PyBytes_Check(v) && PyBytes_Size(v)==1) ) {
+        PyErr_SetString(PyExc_IndexError,
+                        "Blob assignment must be length-1 bytes()");
+        return -1;
+    }
+
+    buf = PyBytes_AsString(v);
+    return write_inner(self, buf, 1, i);
+}
+
+
+static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
+{
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    if (PyIndex_Check(item)) {
+        Py_ssize_t i = PyNumber_AsSsize_t(item, PyExc_IndexError);
+        if (i == -1 && PyErr_Occurred())
+            return NULL;
+        if (i < 0)
+            i += self->length;
+        if (i < 0 || i >= self->length) {
+            PyErr_SetString(PyExc_IndexError,
+                "Blob index out of range");
+            return NULL;
+        }
+        // TODO: I am not sure...
+        return inner_read(self, 1, i);
+    }
+    else if (PySlice_Check(item)) {
+        Py_ssize_t start, stop, step, slicelen;
+
+        if (PySlice_GetIndicesEx(item, self->length,
+                         &start, &stop, &step, &slicelen) < 0) {
+            return NULL;
+        }
+
+        if (slicelen <= 0) {
+            return PyBytes_FromStringAndSize("", 0);
+        } else if (step == 1) {
+            return inner_read(self, slicelen, start);
+        } else {
+            char *result_buf = (char *)PyMem_Malloc(slicelen);
+            char *data_buff = NULL;
+            Py_ssize_t cur, i;
+            PyObject *result;
+            int rc;
+
+            if (result_buf == NULL)
+                return PyErr_NoMemory();
+
+            data_buff = (char *)PyMem_Malloc(stop - start);
+            if (data_buff == NULL) {
+                PyMem_Free(result_buf);
+                return PyErr_NoMemory();
+            }
+
+            Py_BEGIN_ALLOW_THREADS
+            rc = sqlite3_blob_read(self->blob, data_buff, stop - start, start);
+            Py_END_ALLOW_THREADS
+
+            if (rc != SQLITE_OK){
+                /* For some reason after modifying blob the
+                   error is not set on the connection db. */
+                if (rc == SQLITE_ABORT) {
+                    PyErr_SetString(pysqlite_OperationalError,
+                                    "Cannot operate on modified blob");
+                } else {
+                    _pysqlite_seterror(self->connection->db);
+                }
+                PyMem_Free(result_buf);
+                PyMem_Free(data_buff);
+                return NULL;
+            }
+
+            for (cur = 0, i = 0; i < slicelen;
+                 cur += step, i++) {
+                result_buf[i] = data_buff[cur];
+            }
+            result = PyBytes_FromStringAndSize(result_buf,
+                                                slicelen);
+            PyMem_Free(result_buf);
+            PyMem_Free(data_buff);
+            return result;
+        }
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError,
+                        "Blob indices must be integers");
+        return NULL;
+    }
+}
+
+
+static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyObject *value)
+{
+    int rc = 0;
+
+    if (!pysqlite_check_blob(self)) {
+        return -1;
+    }
+
+    if (PyIndex_Check(item)) {
+        Py_ssize_t i = PyNumber_AsSsize_t(item, PyExc_IndexError);
+        const char *buf;
+
+        if (i == -1 && PyErr_Occurred())
+            return -1;
+        if (i < 0)
+            i += self->length;
+        if (i < 0 || i >= self->length) {
+            PyErr_SetString(PyExc_IndexError,
+                            "Blob index out of range");
+            return -1;
+        }
+        if (value == NULL) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Blob doesn't support item deletion");
+            return -1;
+        }
+        if (! (PyBytes_Check(value) && PyBytes_Size(value)==1) ) {
+            PyErr_SetString(PyExc_IndexError,
+                            "Blob assignment must be length-1 bytes()");
+            return -1;
+        }
+
+        buf = PyBytes_AsString(value);
+        return write_inner(self, buf, 1, i);
+    }
+    else if (PySlice_Check(item)) {
+        Py_ssize_t start, stop, step, slicelen;
+        Py_buffer vbuf;
+
+        if (PySlice_GetIndicesEx(item,
+                                 self->length, &start, &stop,
+                                 &step, &slicelen) < 0) {
+            return -1;
+        }
+        if (value == NULL) {
+            PyErr_SetString(PyExc_TypeError,
+                "Blob object doesn't support slice deletion");
+            return -1;
+        }
+        if (PyObject_GetBuffer(value, &vbuf, PyBUF_SIMPLE) < 0)
+            return -1;
+        if (vbuf.len != slicelen) {
+            PyErr_SetString(PyExc_IndexError,
+                "Blob slice assignment is wrong size");
+            PyBuffer_Release(&vbuf);
+            return -1;
+        }
+
+        if (slicelen == 0) {
+        }
+        else if (step == 1) {
+            rc = write_inner(self, vbuf.buf, slicelen, start);
+        }
+        else {
+            Py_ssize_t cur, i;
+            char *data_buff;
+
+
+            data_buff = (char *)PyMem_Malloc(stop - start);
+            if (data_buff == NULL) {
+                PyErr_NoMemory();
+                return -1;
+            }
+
+            Py_BEGIN_ALLOW_THREADS
+            rc = sqlite3_blob_read(self->blob, data_buff, stop - start, start);
+            Py_END_ALLOW_THREADS
+
+            if (rc != SQLITE_OK){
+                /* For some reason after modifying blob the
+                   error is not set on the connection db. */
+                if (rc == SQLITE_ABORT) {
+                    PyErr_SetString(pysqlite_OperationalError,
+                                    "Cannot operate on modified blob");
+                } else {
+                    _pysqlite_seterror(self->connection->db);
+                }
+                PyMem_Free(data_buff);
+                rc = -1;
+            }
+
+            for (cur = 0, i = 0;
+                 i < slicelen;
+                 cur += step, i++)
+            {
+                data_buff[cur] = ((char *)vbuf.buf)[i];
+            }
+
+            Py_BEGIN_ALLOW_THREADS
+            rc = sqlite3_blob_write(self->blob, data_buff, stop - start, start);
+            Py_END_ALLOW_THREADS
+
+            if (rc != SQLITE_OK){
+                /* For some reason after modifying blob the
+                   error is not set on the connection db. */
+                if (rc == SQLITE_ABORT) {
+                    PyErr_SetString(pysqlite_OperationalError,
+                                    "Cannot operate on modified blob");
+                } else {
+                    _pysqlite_seterror(self->connection->db);
+                }
+                PyMem_Free(data_buff);
+                rc = -1;
+            }
+            rc = 0;
+
+        }
+        PyBuffer_Release(&vbuf);
+        return rc;
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError,
+                        "Blob indices must be integer");
+        return -1;
+    }
+}
+
+
+static PyMethodDef blob_methods[] = {
+    {"read", (PyCFunction)pysqlite_blob_read, METH_VARARGS,
+        PyDoc_STR("read data from blob")},
+    {"write", (PyCFunction)pysqlite_blob_write, METH_O,
+        PyDoc_STR("write data to blob")},
+    {"close", (PyCFunction)pysqlite_blob_close, METH_NOARGS,
+        PyDoc_STR("close blob")},
+    {"seek", (PyCFunction)pysqlite_blob_seek, METH_VARARGS,
+        PyDoc_STR("change blob current offset")},
+    {"tell", (PyCFunction)pysqlite_blob_tell, METH_NOARGS,
+        PyDoc_STR("return blob current offset")},
+    {"__enter__", (PyCFunction)pysqlite_blob_enter, METH_NOARGS,
+        PyDoc_STR("blob context manager enter")},
+    {"__exit__", (PyCFunction)pysqlite_blob_exit, METH_VARARGS,
+        PyDoc_STR("blob context manager exit")},
+    {NULL, NULL}
+};
+
+static PySequenceMethods blob_sequence_methods = {
+    .sq_length = (lenfunc)pysqlite_blob_length,
+    .sq_concat = (binaryfunc)pysqlite_blob_concat,
+    .sq_repeat = (ssizeargfunc)pysqlite_blob_repeat,
+    .sq_item = (ssizeargfunc)pysqlite_blob_item,
+    .sq_ass_item = (ssizeobjargproc)pysqlite_blob_ass_item,
+    .sq_contains = (objobjproc)pysqlite_blob_contains,
+};
+
+static PyMappingMethods blob_mapping_methods = {
+    (lenfunc)pysqlite_blob_length,
+    (binaryfunc)pysqlite_blob_subscript,
+    (objobjargproc)pysqlite_blob_ass_subscript,
+};
+
+PyTypeObject pysqlite_BlobType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".Blob",
+        .tp_basicsize = sizeof(pysqlite_Blob),
+        .tp_dealloc = (destructor)pysqlite_blob_dealloc,
+        .tp_as_sequence = &blob_sequence_methods,
+        .tp_as_mapping = &blob_mapping_methods,
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_weaklistoffset = offsetof(pysqlite_Blob, in_weakreflist),
+        .tp_methods = blob_methods,
+};
+
+extern int pysqlite_blob_setup_types(void)
+{
+    pysqlite_BlobType.tp_new = PyType_GenericNew;
+    return PyType_Ready(&pysqlite_BlobType);
+}

--- a/packages/phoenix-sqlean/src/blob.h
+++ b/packages/phoenix-sqlean/src/blob.h
@@ -1,0 +1,26 @@
+#ifndef PYSQLITE_BLOB_H
+#define PYSQLITE_BLOB_H
+#include "Python.h"
+#include "sqlite3.h"
+#include "connection.h"
+
+typedef struct
+{
+    PyObject_HEAD
+    pysqlite_Connection* connection;
+    sqlite3_blob *blob;
+    int offset;
+    int length;
+
+    PyObject* in_weakreflist; /* List of weak references */
+} pysqlite_Blob;
+
+extern PyTypeObject pysqlite_BlobType;
+
+int pysqlite_blob_init(pysqlite_Blob* self, pysqlite_Connection* connection,
+                       sqlite3_blob *blob);
+PyObject* pysqlite_blob_close(pysqlite_Blob *self);
+
+int pysqlite_blob_setup_types(void);
+
+#endif

--- a/packages/phoenix-sqlean/src/cache.c
+++ b/packages/phoenix-sqlean/src/cache.c
@@ -1,0 +1,362 @@
+/* cache .c - a LRU cache
+ *
+ * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "cache.h"
+#include <limits.h>
+
+/* only used internally */
+pysqlite_Node* pysqlite_new_node(PyObject* key, PyObject* data)
+{
+    pysqlite_Node* node;
+
+    node = (pysqlite_Node*) (pysqlite_NodeType.tp_alloc(&pysqlite_NodeType, 0));
+    if (!node) {
+        return NULL;
+    }
+
+    Py_INCREF(key);
+    node->key = key;
+
+    Py_INCREF(data);
+    node->data = data;
+
+    node->prev = NULL;
+    node->next = NULL;
+
+    return node;
+}
+
+void pysqlite_node_dealloc(pysqlite_Node* self)
+{
+    Py_DECREF(self->key);
+    Py_DECREF(self->data);
+
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+int pysqlite_cache_init(pysqlite_Cache* self, PyObject* args, PyObject* kwargs)
+{
+    PyObject* factory;
+    int size = 10;
+
+    self->factory = NULL;
+
+    if (!PyArg_ParseTuple(args, "O|i", &factory, &size)) {
+        return -1;
+    }
+
+    /* minimum cache size is 5 entries */
+    if (size < 5) {
+        size = 5;
+    }
+    self->size = size;
+    self->first = NULL;
+    self->last = NULL;
+
+    self->mapping = PyDict_New();
+    if (!self->mapping) {
+        return -1;
+    }
+
+    Py_INCREF(factory);
+    self->factory = factory;
+
+    self->decref_factory = 1;
+
+    return 0;
+}
+
+void pysqlite_cache_dealloc(pysqlite_Cache* self)
+{
+    pysqlite_Node* node;
+    pysqlite_Node* delete_node;
+
+    if (!self->factory) {
+        /* constructor failed, just get out of here */
+        return;
+    }
+
+    /* iterate over all nodes and deallocate them */
+    node = self->first;
+    while (node) {
+        delete_node = node;
+        node = node->next;
+        Py_DECREF(delete_node);
+    }
+
+    if (self->decref_factory) {
+        Py_DECREF(self->factory);
+    }
+    Py_DECREF(self->mapping);
+
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+PyObject* pysqlite_cache_get(pysqlite_Cache* self, PyObject* key)
+{
+    pysqlite_Node* node;
+    pysqlite_Node* ptr;
+    PyObject* data;
+
+    node = (pysqlite_Node*)PyDict_GetItemWithError(self->mapping, key);
+    if (node) {
+        /* an entry for this key already exists in the cache */
+
+        /* increase usage counter of the node found */
+        if (node->count < LONG_MAX) {
+            node->count++;
+        }
+
+        /* if necessary, reorder entries in the cache by swapping positions */
+        if (node->prev && node->count > node->prev->count) {
+            ptr = node->prev;
+
+            while (ptr->prev && node->count > ptr->prev->count) {
+                ptr = ptr->prev;
+            }
+
+            if (node->next) {
+                node->next->prev = node->prev;
+            } else {
+                self->last = node->prev;
+            }
+            if (node->prev) {
+                node->prev->next = node->next;
+            }
+            if (ptr->prev) {
+                ptr->prev->next = node;
+            } else {
+                self->first = node;
+            }
+
+            node->next = ptr;
+            node->prev = ptr->prev;
+            if (!node->prev) {
+                self->first = node;
+            }
+            ptr->prev = node;
+        }
+    }
+    else if (PyErr_Occurred()) {
+        return NULL;
+    }
+    else {
+        /* There is no entry for this key in the cache, yet. We'll insert a new
+         * entry in the cache, and make space if necessary by throwing the
+         * least used item out of the cache. */
+
+        if (PyDict_Size(self->mapping) == self->size) {
+            if (self->last) {
+                node = self->last;
+
+                if (PyDict_DelItem(self->mapping, self->last->key) != 0) {
+                    return NULL;
+                }
+
+                if (node->prev) {
+                    node->prev->next = NULL;
+                }
+                self->last = node->prev;
+                node->prev = NULL;
+
+                Py_DECREF(node);
+            }
+        }
+
+        /* We cannot replace this by PyObject_CallOneArg() since
+         * PyObject_CallFunction() has a special case when using a
+         * single tuple as argument. */
+        data = PyObject_CallFunction(self->factory, "O", key);
+
+        if (!data) {
+            return NULL;
+        }
+
+        node = pysqlite_new_node(key, data);
+        if (!node) {
+            return NULL;
+        }
+        node->prev = self->last;
+
+        Py_DECREF(data);
+
+        if (PyDict_SetItem(self->mapping, key, (PyObject*)node) != 0) {
+            Py_DECREF(node);
+            return NULL;
+        }
+
+        if (self->last) {
+            self->last->next = node;
+        } else {
+            self->first = node;
+        }
+        self->last = node;
+    }
+
+    Py_INCREF(node->data);
+    return node->data;
+}
+
+PyObject* pysqlite_cache_display(pysqlite_Cache* self, PyObject* args)
+{
+    pysqlite_Node* ptr;
+    PyObject* prevkey;
+    PyObject* nextkey;
+    PyObject* display_str;
+
+    ptr = self->first;
+
+    while (ptr) {
+        if (ptr->prev) {
+            prevkey = ptr->prev->key;
+        } else {
+            prevkey = Py_None;
+        }
+
+        if (ptr->next) {
+            nextkey = ptr->next->key;
+        } else {
+            nextkey = Py_None;
+        }
+
+        display_str = PyUnicode_FromFormat("%S <- %S -> %S\n",
+                                           prevkey, ptr->key, nextkey);
+        if (!display_str) {
+            return NULL;
+        }
+        PyObject_Print(display_str, stdout, Py_PRINT_RAW);
+        Py_DECREF(display_str);
+
+        ptr = ptr->next;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef cache_methods[] = {
+    {"get", (PyCFunction)pysqlite_cache_get, METH_O,
+        PyDoc_STR("Gets an entry from the cache or calls the factory function to produce one.")},
+    {"display", (PyCFunction)pysqlite_cache_display, METH_NOARGS,
+        PyDoc_STR("For debugging only.")},
+    {NULL, NULL}
+};
+
+PyTypeObject pysqlite_NodeType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME "Node",                             /* tp_name */
+        sizeof(pysqlite_Node),                          /* tp_basicsize */
+        0,                                              /* tp_itemsize */
+        (destructor)pysqlite_node_dealloc,              /* tp_dealloc */
+        0,                                              /* tp_print */
+        0,                                              /* tp_getattr */
+        0,                                              /* tp_setattr */
+        0,                                              /* tp_reserved */
+        0,                                              /* tp_repr */
+        0,                                              /* tp_as_number */
+        0,                                              /* tp_as_sequence */
+        0,                                              /* tp_as_mapping */
+        0,                                              /* tp_hash */
+        0,                                              /* tp_call */
+        0,                                              /* tp_str */
+        0,                                              /* tp_getattro */
+        0,                                              /* tp_setattro */
+        0,                                              /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,         /* tp_flags */
+        0,                                              /* tp_doc */
+        0,                                              /* tp_traverse */
+        0,                                              /* tp_clear */
+        0,                                              /* tp_richcompare */
+        0,                                              /* tp_weaklistoffset */
+        0,                                              /* tp_iter */
+        0,                                              /* tp_iternext */
+        0,                                              /* tp_methods */
+        0,                                              /* tp_members */
+        0,                                              /* tp_getset */
+        0,                                              /* tp_base */
+        0,                                              /* tp_dict */
+        0,                                              /* tp_descr_get */
+        0,                                              /* tp_descr_set */
+        0,                                              /* tp_dictoffset */
+        (initproc)0,                                    /* tp_init */
+        0,                                              /* tp_alloc */
+        0,                                              /* tp_new */
+        0                                               /* tp_free */
+};
+
+PyTypeObject pysqlite_CacheType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".Cache",                           /* tp_name */
+        sizeof(pysqlite_Cache),                         /* tp_basicsize */
+        0,                                              /* tp_itemsize */
+        (destructor)pysqlite_cache_dealloc,             /* tp_dealloc */
+        0,                                              /* tp_print */
+        0,                                              /* tp_getattr */
+        0,                                              /* tp_setattr */
+        0,                                              /* tp_reserved */
+        0,                                              /* tp_repr */
+        0,                                              /* tp_as_number */
+        0,                                              /* tp_as_sequence */
+        0,                                              /* tp_as_mapping */
+        0,                                              /* tp_hash */
+        0,                                              /* tp_call */
+        0,                                              /* tp_str */
+        0,                                              /* tp_getattro */
+        0,                                              /* tp_setattro */
+        0,                                              /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,         /* tp_flags */
+        0,                                              /* tp_doc */
+        0,                                              /* tp_traverse */
+        0,                                              /* tp_clear */
+        0,                                              /* tp_richcompare */
+        0,                                              /* tp_weaklistoffset */
+        0,                                              /* tp_iter */
+        0,                                              /* tp_iternext */
+        cache_methods,                                  /* tp_methods */
+        0,                                              /* tp_members */
+        0,                                              /* tp_getset */
+        0,                                              /* tp_base */
+        0,                                              /* tp_dict */
+        0,                                              /* tp_descr_get */
+        0,                                              /* tp_descr_set */
+        0,                                              /* tp_dictoffset */
+        (initproc)pysqlite_cache_init,                  /* tp_init */
+        0,                                              /* tp_alloc */
+        0,                                              /* tp_new */
+        0                                               /* tp_free */
+};
+
+extern int pysqlite_cache_setup_types(void)
+{
+    int rc;
+
+    pysqlite_NodeType.tp_new = PyType_GenericNew;
+    pysqlite_CacheType.tp_new = PyType_GenericNew;
+
+    rc = PyType_Ready(&pysqlite_NodeType);
+    if (rc < 0) {
+        return rc;
+    }
+
+    rc = PyType_Ready(&pysqlite_CacheType);
+    return rc;
+}

--- a/packages/phoenix-sqlean/src/cache.h
+++ b/packages/phoenix-sqlean/src/cache.h
@@ -1,0 +1,74 @@
+/* cache.h - definitions for the LRU cache
+ *
+ * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PYSQLITE_CACHE_H
+#define PYSQLITE_CACHE_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+/* The LRU cache is implemented as a combination of a doubly-linked with a
+ * dictionary. The list items are of type 'Node' and the dictionary has the
+ * nodes as values. */
+
+typedef struct _pysqlite_Node
+{
+    PyObject_HEAD
+    PyObject* key;
+    PyObject* data;
+    long count;
+    struct _pysqlite_Node* prev;
+    struct _pysqlite_Node* next;
+} pysqlite_Node;
+
+typedef struct
+{
+    PyObject_HEAD
+    int size;
+
+    /* a dictionary mapping keys to Node entries */
+    PyObject* mapping;
+
+    /* the factory callable */
+    PyObject* factory;
+
+    pysqlite_Node* first;
+    pysqlite_Node* last;
+
+    /* if set, decrement the factory function when the Cache is deallocated.
+     * this is almost always desirable, but not in the pysqlite context */
+    int decref_factory;
+} pysqlite_Cache;
+
+extern PyTypeObject pysqlite_NodeType;
+extern PyTypeObject pysqlite_CacheType;
+
+int pysqlite_node_init(pysqlite_Node* self, PyObject* args, PyObject* kwargs);
+void pysqlite_node_dealloc(pysqlite_Node* self);
+
+int pysqlite_cache_init(pysqlite_Cache* self, PyObject* args, PyObject* kwargs);
+void pysqlite_cache_dealloc(pysqlite_Cache* self);
+PyObject* pysqlite_cache_get(pysqlite_Cache* self, PyObject* args);
+
+int pysqlite_cache_setup_types(void);
+
+#endif

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -1,0 +1,2219 @@
+/* connection.c - the connection type
+ *
+ * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "cache.h"
+#include "module.h"
+#include "structmember.h"
+#include "connection.h"
+#include "statement.h"
+#include "cursor.h"
+#include "blob.h"
+#include "prepare_protocol.h"
+#include "util.h"
+
+#define ACTION_FINALIZE 1
+#define ACTION_RESET 2
+
+#if SQLITE_VERSION_NUMBER >= 3003008
+#ifndef SQLITE_OMIT_LOAD_EXTENSION
+#define HAVE_LOAD_EXTENSION
+#endif
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3006011
+#define HAVE_BACKUP_API
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3014002
+#define HAVE_TRACE_V2
+#endif
+
+#if SQLITE_VERSION_NUMBER >= 3025000
+#define HAVE_WINDOW_FUNCTION
+#endif
+
+#if SQLITE_HAS_CODEC
+#define HAVE_ENCRYPTION
+#endif
+
+#if PY_VERSION_HEX < 0x030D0000
+    #define PyLong_AsInt _PyLong_AsInt
+#endif
+
+_Py_IDENTIFIER(cursor);
+
+static const char * const begin_statements[] = {
+    "BEGIN ",
+    "BEGIN DEFERRED",
+    "BEGIN IMMEDIATE",
+    "BEGIN EXCLUSIVE",
+    NULL
+};
+
+static int pysqlite_connection_set_isolation_level(pysqlite_Connection* self, PyObject* isolation_level, void *Py_UNUSED(ignored));
+static void _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self);
+
+
+static void _sqlite3_result_error(sqlite3_context* ctx, const char* errmsg, int len)
+{
+    /* in older SQLite versions, calling sqlite3_result_error in callbacks
+     * triggers a bug in SQLite that leads either to irritating results or
+     * segfaults, depending on the SQLite version */
+#if SQLITE_VERSION_NUMBER >= 3003003
+    sqlite3_result_error(ctx, errmsg, len);
+#else
+    PyErr_SetString(pysqlite_OperationalError, errmsg);
+#endif
+}
+
+int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    static char *kwlist[] = {
+        "database", "timeout", "detect_types", "isolation_level",
+        "check_same_thread", "factory", "cached_statements", "uri", "flags",
+        "vfs", NULL
+    };
+
+    const char* database;
+    PyObject* database_obj;
+    int detect_types = 0;
+    PyObject* isolation_level = NULL;
+    PyObject* factory = NULL;
+    int check_same_thread = 1;
+    int cached_statements = 100;
+    int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+    char *vfs = NULL;
+    int uri = 0;
+    double timeout = 5.0;
+    int rc;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&|diOiOipiz", kwlist,
+                                     PyUnicode_FSConverter, &database_obj, &timeout, &detect_types,
+                                     &isolation_level, &check_same_thread,
+                                     &factory, &cached_statements, &uri,
+                                     &flags, &vfs))
+    {
+        return -1;
+    }
+
+    database = PyBytes_AsString(database_obj);
+
+    self->initialized = 1;
+
+    self->begin_statement = NULL;
+
+    Py_CLEAR(self->statement_cache);
+    Py_CLEAR(self->statements);
+    Py_CLEAR(self->cursors);
+    Py_CLEAR(self->blobs);
+
+    Py_INCREF(Py_None);
+    Py_XSETREF(self->row_factory, Py_None);
+
+    Py_INCREF(&PyUnicode_Type);
+    Py_XSETREF(self->text_factory, (PyObject*)&PyUnicode_Type);
+
+#ifndef SQLITE_OPEN_URI
+    if (uri) {
+        PyErr_SetString(pysqlite_NotSupportedError, "URIs not supported");
+        return -1;
+    }
+#endif
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_open_v2(database, &self->db,
+                         flags | (uri ? SQLITE_OPEN_URI : 0), vfs);
+    Py_END_ALLOW_THREADS
+
+    Py_DECREF(database_obj);
+
+    if (rc != SQLITE_OK) {
+        _pysqlite_seterror(self->db);
+        return -1;
+    }
+
+    if (!isolation_level) {
+        isolation_level = PyUnicode_FromString("");
+        if (!isolation_level) {
+            return -1;
+        }
+    } else {
+        Py_INCREF(isolation_level);
+    }
+    Py_CLEAR(self->isolation_level);
+    if (pysqlite_connection_set_isolation_level(self, isolation_level, NULL) < 0) {
+        Py_DECREF(isolation_level);
+        return -1;
+    }
+    Py_DECREF(isolation_level);
+
+    self->statement_cache = (pysqlite_Cache*)PyObject_CallFunction((PyObject*)&pysqlite_CacheType, "Oi", self, cached_statements);
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+
+    self->created_statements = 0;
+    self->created_cursors = 0;
+
+    /* Create lists of weak references to statements/cursors/blobs */
+    self->statements = PyList_New(0);
+    self->cursors = PyList_New(0);
+    self->blobs = PyList_New(0);
+    if (!self->statements || !self->cursors || !self->blobs) {
+        return -1;
+    }
+
+    /* By default, the Cache class INCREFs the factory in its initializer, and
+     * decrefs it in its deallocator method. Since this would create a circular
+     * reference here, we're breaking it by decrementing self, and telling the
+     * cache class to not decref the factory (self) in its deallocator.
+     */
+    self->statement_cache->decref_factory = 0;
+    Py_DECREF(self);
+
+    self->detect_types = detect_types;
+    self->timeout = timeout;
+    (void)sqlite3_busy_timeout(self->db, (int)(timeout*1000));
+    self->thread_ident = PyThread_get_thread_ident();
+    if (!check_same_thread && sqlite3_libversion_number() < 3003001) {
+        PyErr_SetString(pysqlite_NotSupportedError, "shared connections not available");
+        return -1;
+    }
+    self->check_same_thread = check_same_thread;
+
+    self->function_pinboard_trace_callback = NULL;
+    self->function_pinboard_progress_handler = NULL;
+    self->function_pinboard_authorizer_cb = NULL;
+    self->function_pinboard_busy_handler_cb = NULL;
+
+    Py_XSETREF(self->collations, PyDict_New());
+    if (!self->collations) {
+        return -1;
+    }
+
+    self->Warning               = pysqlite_Warning;
+    self->Error                 = pysqlite_Error;
+    self->InterfaceError        = pysqlite_InterfaceError;
+    self->DatabaseError         = pysqlite_DatabaseError;
+    self->DataError             = pysqlite_DataError;
+    self->OperationalError      = pysqlite_OperationalError;
+    self->IntegrityError        = pysqlite_IntegrityError;
+    self->InternalError         = pysqlite_InternalError;
+    self->ProgrammingError      = pysqlite_ProgrammingError;
+    self->NotSupportedError     = pysqlite_NotSupportedError;
+
+    return 0;
+}
+
+/* action in (ACTION_RESET, ACTION_FINALIZE) */
+void pysqlite_do_all_statements(pysqlite_Connection* self, int action, int reset_cursors)
+{
+    int i;
+    PyObject* weakref;
+    PyObject* statement;
+    pysqlite_Cursor* cursor;
+
+    for (i = 0; i < PyList_Size(self->statements); i++) {
+        weakref = PyList_GetItem(self->statements, i);
+        if (PyWeakref_GetRef(weakref, &statement) == 1) {
+            if (action == ACTION_RESET) {
+                (void)pysqlite_statement_reset((pysqlite_Statement*)statement);
+            } else {
+                (void)pysqlite_statement_finalize((pysqlite_Statement*)statement);
+            }
+            Py_DECREF(statement);
+        }
+    }
+
+    if (reset_cursors) {
+        for (i = 0; i < PyList_Size(self->cursors); i++) {
+            weakref = PyList_GetItem(self->cursors, i);
+            if (PyWeakref_GetRef(weakref, (PyObject**)&cursor) == 1) {
+                cursor->reset = 1;
+                Py_DECREF(cursor);
+            }
+        }
+    }
+}
+
+void pysqlite_connection_dealloc(pysqlite_Connection* self)
+{
+    Py_XDECREF(self->statement_cache);
+
+    /* Clean up if user has not called .close() explicitly. */
+    if (self->db) {
+        sqlite3_close_v2(self->db);
+    }
+
+    Py_XDECREF(self->isolation_level);
+    Py_XDECREF(self->function_pinboard_trace_callback);
+    Py_XDECREF(self->function_pinboard_progress_handler);
+    Py_XDECREF(self->function_pinboard_authorizer_cb);
+    Py_XDECREF(self->function_pinboard_busy_handler_cb);
+    Py_XDECREF(self->row_factory);
+    Py_XDECREF(self->text_factory);
+    Py_XDECREF(self->collations);
+    Py_XDECREF(self->statements);
+    Py_XDECREF(self->cursors);
+    Py_XDECREF(self->blobs);
+
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+/*
+ * Registers a cursor with the connection.
+ *
+ * 0 => error; 1 => ok
+ */
+int pysqlite_connection_register_cursor(pysqlite_Connection* connection, PyObject* cursor)
+{
+    PyObject* weakref;
+
+    weakref = PyWeakref_NewRef((PyObject*)cursor, NULL);
+    if (!weakref) {
+        goto error;
+    }
+
+    if (PyList_Append(connection->cursors, weakref) != 0) {
+        Py_CLEAR(weakref);
+        goto error;
+    }
+
+    Py_DECREF(weakref);
+
+    return 1;
+error:
+    return 0;
+}
+
+PyObject* pysqlite_connection_cursor(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    static char *kwlist[] = {"factory", NULL};
+    PyObject* factory = NULL;
+    PyObject* cursor;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O", kwlist,
+                                     &factory)) {
+        return NULL;
+    }
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (factory == NULL) {
+        factory = (PyObject*)&pysqlite_CursorType;
+    }
+
+    cursor = PyObject_CallFunctionObjArgs(factory, (PyObject *)self, NULL);
+    if (cursor == NULL)
+        return NULL;
+    if (!PyObject_TypeCheck(cursor, &pysqlite_CursorType)) {
+        PyErr_Format(PyExc_TypeError,
+                     "factory must return a cursor, not %.100s",
+                     Py_TYPE(cursor)->tp_name);
+        Py_DECREF(cursor);
+        return NULL;
+    }
+
+    _pysqlite_drop_unused_cursor_references(self);
+
+    if (cursor && self->row_factory != Py_None) {
+        Py_INCREF(self->row_factory);
+        Py_XSETREF(((pysqlite_Cursor *)cursor)->row_factory, self->row_factory);
+    }
+
+    return cursor;
+}
+
+PyObject* pysqlite_connection_blob(pysqlite_Connection *self, PyObject *args,
+                                   PyObject *kwargs)
+{
+    static char *kwlist[] = {"table", "column", "row", "readonly",
+                             "dbname", NULL, NULL};
+    int rc;
+    const char *dbname = "main", *table, *column;
+    long long row;
+    int readonly = 0;
+    sqlite3_blob *blob;
+    pysqlite_Blob *pyblob = NULL;
+    PyObject *weakref;
+
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ssL|ps", kwlist,
+                                     &table, &column, &row, &readonly,
+                                     &dbname)) {
+        return NULL;
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_blob_open(self->db, dbname, table, column, row,
+                           !readonly, &blob);
+    Py_END_ALLOW_THREADS
+
+    if (rc != SQLITE_OK) {
+        _pysqlite_seterror(self->db);
+        return NULL;
+    }
+
+    pyblob = PyObject_New(pysqlite_Blob, &pysqlite_BlobType);
+    if (!pyblob) {
+        goto error;
+    }
+
+    rc = pysqlite_blob_init(pyblob, self, blob);
+    if (rc) {
+        Py_CLEAR(pyblob);
+        goto error;
+    }
+
+    // Add our blob to connection blobs list
+    weakref = PyWeakref_NewRef((PyObject*)pyblob, NULL);
+    if (!weakref) {
+        Py_CLEAR(pyblob);
+        goto error;
+    }
+    if (PyList_Append(self->blobs, weakref) != 0) {
+        Py_CLEAR(weakref);
+        Py_CLEAR(pyblob);
+        goto error;
+    }
+    Py_DECREF(weakref);
+
+    return (PyObject*)pyblob;
+
+error:
+    Py_BEGIN_ALLOW_THREADS
+    sqlite3_blob_close(blob);
+    Py_END_ALLOW_THREADS
+    return NULL;
+}
+
+static void pysqlite_close_all_blobs(pysqlite_Connection *self)
+{
+    int i;
+    PyObject *weakref;
+    PyObject *blob;
+
+    for (i = 0; i < PyList_GET_SIZE(self->blobs); i++) {
+        weakref = PyList_GET_ITEM(self->blobs, i);
+        if (PyWeakref_GetRef(weakref, &blob) == 1) {
+            pysqlite_blob_close((pysqlite_Blob*)blob);
+            Py_DECREF(blob);
+        }
+    }
+}
+
+PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args)
+{
+    int rc;
+
+    if (!pysqlite_check_thread(self)) {
+        return NULL;
+    }
+
+    pysqlite_do_all_statements(self, ACTION_FINALIZE, 1);
+
+    pysqlite_close_all_blobs(self);
+
+    if (self->db) {
+        rc = sqlite3_close_v2(self->db);
+
+        if (rc != SQLITE_OK) {
+            _pysqlite_seterror(self->db);
+            return NULL;
+        } else {
+            self->db = NULL;
+        }
+    }
+
+    Py_RETURN_NONE;
+}
+
+/*
+ * Checks if a connection object is usable (i. e. not closed).
+ *
+ * 0 => error; 1 => ok
+ */
+int pysqlite_check_connection(pysqlite_Connection* con)
+{
+    if (!con->initialized) {
+        PyErr_SetString(pysqlite_ProgrammingError, "Base Connection.__init__ not called.");
+        return 0;
+    }
+
+    if (!con->db) {
+        PyErr_SetString(pysqlite_ProgrammingError, "Cannot operate on a closed database.");
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+PyObject* _pysqlite_connection_begin(pysqlite_Connection* self)
+{
+    int rc;
+    sqlite3_stmt* statement;
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_prepare_v2(self->db, self->begin_statement, -1, &statement, NULL);
+    Py_END_ALLOW_THREADS
+
+    if (rc != SQLITE_OK) {
+        _pysqlite_seterror(self->db);
+        goto error;
+    }
+
+    rc = pysqlite_step(statement, self);
+    if (rc != SQLITE_DONE) {
+        _pysqlite_seterror(self->db);
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_finalize(statement);
+    Py_END_ALLOW_THREADS
+
+    if (rc != SQLITE_OK && !PyErr_Occurred()) {
+        _pysqlite_seterror(self->db);
+    }
+
+error:
+    if (PyErr_Occurred()) {
+        return NULL;
+    } else {
+        Py_RETURN_NONE;
+    }
+}
+
+PyObject* pysqlite_connection_commit(pysqlite_Connection* self, PyObject* args)
+{
+    int rc;
+    sqlite3_stmt* statement;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!sqlite3_get_autocommit(self->db)) {
+
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_prepare_v2(self->db, "COMMIT", -1, &statement, NULL);
+        Py_END_ALLOW_THREADS
+        if (rc != SQLITE_OK) {
+            _pysqlite_seterror(self->db);
+            goto error;
+        }
+
+        rc = pysqlite_step(statement, self);
+        if (rc != SQLITE_DONE) {
+            _pysqlite_seterror(self->db);
+        }
+
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_finalize(statement);
+        Py_END_ALLOW_THREADS
+        if (rc != SQLITE_OK && !PyErr_Occurred()) {
+            _pysqlite_seterror(self->db);
+        }
+
+    }
+
+error:
+    if (PyErr_Occurred()) {
+        return NULL;
+    } else {
+        Py_RETURN_NONE;
+    }
+}
+
+PyObject* pysqlite_connection_rollback(pysqlite_Connection* self, PyObject* args)
+{
+    int rc;
+    sqlite3_stmt* statement;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!sqlite3_get_autocommit(self->db)) {
+        pysqlite_do_all_statements(self, ACTION_RESET, 1);
+
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_prepare_v2(self->db, "ROLLBACK", -1, &statement, NULL);
+        Py_END_ALLOW_THREADS
+        if (rc != SQLITE_OK) {
+            _pysqlite_seterror(self->db);
+            goto error;
+        }
+
+        rc = pysqlite_step(statement, self);
+        if (rc != SQLITE_DONE) {
+            _pysqlite_seterror(self->db);
+        }
+
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_finalize(statement);
+        Py_END_ALLOW_THREADS
+        if (rc != SQLITE_OK && !PyErr_Occurred()) {
+            _pysqlite_seterror(self->db);
+        }
+
+    }
+
+error:
+    if (PyErr_Occurred()) {
+        return NULL;
+    } else {
+        Py_RETURN_NONE;
+    }
+}
+
+static int
+_pysqlite_set_result(sqlite3_context* context, PyObject* py_val)
+{
+    if (py_val == Py_None) {
+        sqlite3_result_null(context);
+    } else if (PyLong_Check(py_val)) {
+        sqlite_int64 value = _pysqlite_long_as_int64(py_val);
+        if (value == -1 && PyErr_Occurred())
+            return -1;
+        sqlite3_result_int64(context, value);
+    } else if (PyFloat_Check(py_val)) {
+        sqlite3_result_double(context, PyFloat_AsDouble(py_val));
+    } else if (PyUnicode_Check(py_val)) {
+        const char *str = PyUnicode_AsUTF8(py_val);
+        if (str == NULL)
+            return -1;
+        sqlite3_result_text(context, str, -1, SQLITE_TRANSIENT);
+    } else if (PyObject_CheckBuffer(py_val)) {
+        Py_buffer view;
+        if (PyObject_GetBuffer(py_val, &view, PyBUF_SIMPLE) != 0) {
+            PyErr_SetString(PyExc_ValueError,
+                            "could not convert BLOB to buffer");
+            return -1;
+        }
+        if (view.len > INT_MAX) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "BLOB longer than INT_MAX bytes");
+            PyBuffer_Release(&view);
+            return -1;
+        }
+        sqlite3_result_blob(context, view.buf, (int)view.len, SQLITE_TRANSIENT);
+        PyBuffer_Release(&view);
+    } else {
+        return -1;
+    }
+    return 0;
+}
+
+PyObject* _pysqlite_build_py_params(sqlite3_context *context, int argc, sqlite3_value** argv)
+{
+    PyObject* args;
+    int i;
+    sqlite3_value* cur_value;
+    PyObject* cur_py_value;
+    const char* val_str;
+    Py_ssize_t buflen;
+
+    args = PyTuple_New(argc);
+    if (!args) {
+        return NULL;
+    }
+
+    for (i = 0; i < argc; i++) {
+        cur_value = argv[i];
+        switch (sqlite3_value_type(argv[i])) {
+            case SQLITE_INTEGER:
+                cur_py_value = PyLong_FromLongLong(sqlite3_value_int64(cur_value));
+                break;
+            case SQLITE_FLOAT:
+                cur_py_value = PyFloat_FromDouble(sqlite3_value_double(cur_value));
+                break;
+            case SQLITE_TEXT:
+                val_str = (const char*)sqlite3_value_text(cur_value);
+                cur_py_value = PyUnicode_FromString(val_str);
+                /* TODO: have a way to show errors here */
+                if (!cur_py_value) {
+                    PyErr_Clear();
+                    Py_INCREF(Py_None);
+                    cur_py_value = Py_None;
+                }
+                break;
+            case SQLITE_BLOB:
+                buflen = sqlite3_value_bytes(cur_value);
+                cur_py_value = PyBytes_FromStringAndSize(
+                    sqlite3_value_blob(cur_value), buflen);
+                break;
+            case SQLITE_NULL:
+            default:
+                Py_INCREF(Py_None);
+                cur_py_value = Py_None;
+        }
+
+        if (!cur_py_value) {
+            Py_DECREF(args);
+            return NULL;
+        }
+
+        PyTuple_SET_ITEM(args, i, cur_py_value);
+
+    }
+
+    return args;
+}
+
+void _pysqlite_func_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
+{
+    PyObject* args;
+    PyObject* py_func;
+    PyObject* py_retval = NULL;
+    int ok;
+
+    PyGILState_STATE threadstate;
+
+    threadstate = PyGILState_Ensure();
+
+    py_func = (PyObject*)sqlite3_user_data(context);
+
+    args = _pysqlite_build_py_params(context, argc, argv);
+    if (args) {
+        py_retval = PyObject_CallObject(py_func, args);
+        Py_DECREF(args);
+    }
+
+    ok = 0;
+    if (py_retval) {
+        ok = _pysqlite_set_result(context, py_retval) == 0;
+        Py_DECREF(py_retval);
+    }
+    if (!ok) {
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+        _sqlite3_result_error(context, "user-defined function raised exception", -1);
+    }
+
+    PyGILState_Release(threadstate);
+}
+
+static void _pysqlite_step_callback(sqlite3_context *context, int argc, sqlite3_value** params)
+{
+    PyObject* args;
+    PyObject* function_result = NULL;
+    PyObject* aggregate_class;
+    PyObject** aggregate_instance;
+    PyObject* stepmethod = NULL;
+
+    PyGILState_STATE threadstate;
+
+    threadstate = PyGILState_Ensure();
+
+    aggregate_class = (PyObject*)sqlite3_user_data(context);
+
+    aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+
+    if (*aggregate_instance == NULL) {
+        *aggregate_instance = PyObject_CallObject(aggregate_class, NULL);
+
+        if (PyErr_Occurred()) {
+            *aggregate_instance = 0;
+            if (_pysqlite_enable_callback_tracebacks) {
+                PyErr_Print();
+            } else {
+                PyErr_Clear();
+            }
+            _sqlite3_result_error(context, "user-defined aggregate's '__init__' method raised error", -1);
+            goto error;
+        }
+    }
+
+    stepmethod = PyObject_GetAttrString(*aggregate_instance, "step");
+    if (!stepmethod) {
+        goto error;
+    }
+
+    args = _pysqlite_build_py_params(context, argc, params);
+    if (!args) {
+        goto error;
+    }
+
+    function_result = PyObject_CallObject(stepmethod, args);
+    Py_DECREF(args);
+
+    if (!function_result) {
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+        _sqlite3_result_error(context, "user-defined aggregate's 'step' method raised error", -1);
+    }
+
+error:
+    Py_XDECREF(stepmethod);
+    Py_XDECREF(function_result);
+
+    PyGILState_Release(threadstate);
+}
+
+void _pysqlite_final_callback(sqlite3_context* context)
+{
+    PyObject* function_result;
+    PyObject** aggregate_instance;
+    _Py_IDENTIFIER(finalize);
+    int ok;
+    PyObject *exception, *value, *tb;
+    int restore;
+
+    PyGILState_STATE threadstate;
+
+    threadstate = PyGILState_Ensure();
+
+    aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, 0);
+    if (aggregate_instance == NULL) {
+        /* No rows matched the query, the step handler was never called. */
+        goto error;
+    }
+    else if (!*aggregate_instance) {
+        /* this branch is executed if there was an exception in the aggregate's
+         * __init__ */
+
+        goto error;
+    }
+
+    /* Keep the exception (if any) of the last call to step() */
+    PyErr_Fetch(&exception, &value, &tb);
+    restore = 1;
+
+    function_result = _PyObject_CallMethodId(*aggregate_instance, &PyId_finalize, NULL);
+
+    Py_DECREF(*aggregate_instance);
+
+    ok = 0;
+    if (function_result) {
+        ok = _pysqlite_set_result(context, function_result) == 0;
+        Py_DECREF(function_result);
+    }
+    if (!ok) {
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+        _sqlite3_result_error(context, "user-defined aggregate's 'finalize' method raised error", -1);
+#if SQLITE_VERSION_NUMBER < 3003003
+        /* with old SQLite versions, _sqlite3_result_error() sets a new Python
+           exception, so don't restore the previous exception */
+        restore = 0;
+#endif
+    }
+
+    if (restore) {
+        /* Restore the exception (if any) of the last call to step(),
+           but clear also the current exception if finalize() failed */
+        PyErr_Restore(exception, value, tb);
+    }
+
+error:
+    PyGILState_Release(threadstate);
+}
+
+#ifdef HAVE_WINDOW_FUNCTION
+
+void _pysqlite_value_callback(sqlite3_context* context)
+{
+    PyObject* function_result;
+    PyObject** aggregate_instance;
+    _Py_IDENTIFIER(value);
+    int ok;
+    PyObject *exception, *val, *tb;
+    int restore;
+
+    PyGILState_STATE threadstate;
+
+    threadstate = PyGILState_Ensure();
+
+    aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    if (!*aggregate_instance) {
+        goto error;
+    }
+
+    /* Keep the exception (if any) of the last call to step() or inverse() */
+    PyErr_Fetch(&exception, &val, &tb);
+    restore = 1;
+
+    function_result = _PyObject_CallMethodId(*aggregate_instance, &PyId_value, NULL);
+
+    ok = 0;
+    if (function_result) {
+        ok = _pysqlite_set_result(context, function_result) == 0;
+        Py_DECREF(function_result);
+    }
+    if (!ok) {
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+        _sqlite3_result_error(context, "user-defined window function's 'value' method raised error", -1);
+    }
+
+    if (restore) {
+        /* Restore the exception (if any) of the last call to step(),
+           but clear also the current exception if finalize() failed */
+        PyErr_Restore(exception, val, tb);
+    }
+
+error:
+    PyGILState_Release(threadstate);
+}
+
+static void _pysqlite_inverse_callback(sqlite3_context *context, int argc, sqlite3_value** params)
+{
+    PyObject* args;
+    PyObject* function_result = NULL;
+    PyObject** aggregate_instance;
+    PyObject* invmethod = NULL;
+
+    PyGILState_STATE threadstate;
+
+    threadstate = PyGILState_Ensure();
+
+    aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    if (!*aggregate_instance) {
+        goto error;
+    }
+
+    invmethod = PyObject_GetAttrString(*aggregate_instance, "inverse");
+    if (!invmethod) {
+        goto error;
+    }
+
+    args = _pysqlite_build_py_params(context, argc, params);
+    if (!args) {
+        goto error;
+    }
+
+    function_result = PyObject_CallObject(invmethod, args);
+    Py_DECREF(args);
+
+    if (!function_result) {
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+        _sqlite3_result_error(context, "user-defined aggregate's 'inverse' method raised error", -1);
+    }
+
+error:
+    Py_XDECREF(invmethod);
+    Py_XDECREF(function_result);
+
+    PyGILState_Release(threadstate);
+}
+
+#endif
+
+static void _pysqlite_drop_unused_statement_references(pysqlite_Connection* self)
+{
+    PyObject* new_list;
+    PyObject* weakref;
+    PyObject* ref;
+    int i;
+
+    /* we only need to do this once in a while */
+    if (self->created_statements++ < 200) {
+        return;
+    }
+
+    self->created_statements = 0;
+
+    new_list = PyList_New(0);
+    if (!new_list) {
+        return;
+    }
+
+    for (i = 0; i < PyList_Size(self->statements); i++) {
+        weakref = PyList_GetItem(self->statements, i);
+        if (PyWeakref_GetRef(weakref, &ref) == 1) {
+            Py_DECREF(ref);
+            if (PyList_Append(new_list, weakref) != 0) {
+                Py_DECREF(new_list);
+                return;
+            }
+        }
+    }
+
+    Py_SETREF(self->statements, new_list);
+}
+
+static void _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self)
+{
+    PyObject* new_list;
+    PyObject* weakref;
+    PyObject* ref;
+    int i;
+
+    /* we only need to do this once in a while */
+    if (self->created_cursors++ < 200) {
+        return;
+    }
+
+    self->created_cursors = 0;
+
+    new_list = PyList_New(0);
+    if (!new_list) {
+        return;
+    }
+
+    for (i = 0; i < PyList_Size(self->cursors); i++) {
+        weakref = PyList_GetItem(self->cursors, i);
+        if (PyWeakref_GetRef(weakref, &ref) == 1) {
+            Py_DECREF(ref);
+            if (PyList_Append(new_list, weakref) != 0) {
+                Py_DECREF(new_list);
+                return;
+            }
+        }
+    }
+
+    Py_SETREF(self->cursors, new_list);
+}
+
+static void _destructor(void* args)
+{
+    Py_DECREF((PyObject *)args);
+}
+
+
+PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    static char *kwlist[] = {"name", "narg", "func", "deterministic", NULL};
+
+    PyObject* func;
+    char* name;
+    int narg;
+    int rc;
+    int deterministic = 0;
+    int flags = SQLITE_UTF8;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "siO|p", kwlist,
+                                     &name, &narg, &func, &deterministic))
+    {
+        return NULL;
+    }
+
+    if (deterministic) {
+#if SQLITE_VERSION_NUMBER < 3008003
+        PyErr_SetString(pysqlite_NotSupportedError,
+                        "deterministic=True requires SQLite 3.8.3 or higher");
+        return NULL;
+#else
+        if (sqlite3_libversion_number() < 3008003) {
+            PyErr_SetString(pysqlite_NotSupportedError,
+                            "deterministic=True requires SQLite 3.8.3 or higher");
+            return NULL;
+        }
+        flags |= SQLITE_DETERMINISTIC;
+#endif
+    }
+    Py_INCREF(func);
+    rc = sqlite3_create_function_v2(self->db,
+                                    name,
+                                    narg,
+                                    flags,
+                                    (void*)func,
+                                    _pysqlite_func_callback,
+                                    NULL,
+                                    NULL,
+                                    &_destructor);
+
+    if (rc != SQLITE_OK) {
+        /* Workaround for SQLite bug: no error code or string is available here */
+        PyErr_SetString(pysqlite_OperationalError, "Error creating function");
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+PyObject* pysqlite_connection_create_aggregate(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    PyObject* aggregate_class;
+
+    int n_arg;
+    char* name;
+    static char *kwlist[] = { "name", "n_arg", "aggregate_class", NULL };
+    int rc;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "siO:create_aggregate",
+                                      kwlist, &name, &n_arg, &aggregate_class)) {
+        return NULL;
+    }
+
+    Py_INCREF(aggregate_class);
+    rc = sqlite3_create_function_v2(self->db,
+                                    name,
+                                    n_arg,
+                                    SQLITE_UTF8,
+                                    (void*)aggregate_class,
+                                    0,
+                                    &_pysqlite_step_callback,
+                                    &_pysqlite_final_callback,
+                                    &_destructor);
+
+    if (rc != SQLITE_OK) {
+        /* Workaround for SQLite bug: no error code or string is available here */
+        PyErr_SetString(pysqlite_OperationalError, "Error creating aggregate");
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+#ifdef HAVE_WINDOW_FUNCTION
+
+PyObject* pysqlite_connection_create_window_function(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    PyObject* window_function_class;
+
+    int n_arg;
+    char* name;
+    static char *kwlist[] = { "name", "n_arg", "window_function_class", NULL };
+    int rc;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "siO:create_window_function",
+                                      kwlist, &name, &n_arg, &window_function_class)) {
+        return NULL;
+    }
+
+    Py_INCREF(window_function_class);
+    rc = sqlite3_create_window_function(
+        self->db,
+        name,
+        n_arg,
+        SQLITE_UTF8,
+        (void*)window_function_class,
+        &_pysqlite_step_callback,
+        &_pysqlite_final_callback,
+        &_pysqlite_value_callback,
+        &_pysqlite_inverse_callback,
+        &_destructor);
+
+    if (rc != SQLITE_OK) {
+        /* Workaround for SQLite bug: no error code or string is available here */
+        PyErr_SetString(pysqlite_OperationalError, "Error creating window function");
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+#endif
+
+
+static int _authorizer_callback(void* user_arg, int action, const char* arg1, const char* arg2 , const char* dbname, const char* access_attempt_source)
+{
+    PyObject *ret;
+    int rc;
+    PyGILState_STATE gilstate;
+
+    gilstate = PyGILState_Ensure();
+
+    ret = PyObject_CallFunction((PyObject*)user_arg, "issss", action, arg1, arg2, dbname, access_attempt_source);
+
+    if (ret == NULL) {
+        if (_pysqlite_enable_callback_tracebacks)
+            PyErr_Print();
+        else
+            PyErr_Clear();
+
+        rc = SQLITE_DENY;
+    }
+    else {
+        if (PyLong_Check(ret)) {
+            rc = PyLong_AsInt(ret);
+            if (rc == -1 && PyErr_Occurred()) {
+                if (_pysqlite_enable_callback_tracebacks)
+                    PyErr_Print();
+                else
+                    PyErr_Clear();
+                rc = SQLITE_DENY;
+            }
+        }
+        else {
+            rc = SQLITE_DENY;
+        }
+        Py_DECREF(ret);
+    }
+
+    PyGILState_Release(gilstate);
+    return rc;
+}
+
+static int _progress_handler(void* user_arg)
+{
+    int rc;
+    PyObject *ret;
+    PyGILState_STATE gilstate;
+
+    gilstate = PyGILState_Ensure();
+    ret = PyObject_CallObject((PyObject*)user_arg, NULL);
+
+    if (!ret) {
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+
+        /* abort query if error occurred */
+        rc = 1;
+    } else {
+        rc = (int)PyObject_IsTrue(ret);
+        Py_DECREF(ret);
+    }
+
+    PyGILState_Release(gilstate);
+    return rc;
+}
+
+static int _busy_handler(void* user_arg, int n)
+{
+    int rc;
+    PyObject *ret;
+    PyGILState_STATE gilstate;
+
+    gilstate = PyGILState_Ensure();
+    ret = PyObject_CallFunction((PyObject*)user_arg, "i", n);
+
+    if (ret == NULL) {
+        if (_pysqlite_enable_callback_tracebacks)
+            PyErr_Print();
+        else
+            PyErr_Clear();
+
+        rc = 0;
+    }
+    else {
+        if (PyLong_Check(ret))
+            rc = PyLong_AsInt(ret);
+        else
+            rc = 0;
+
+        Py_DECREF(ret);
+    }
+
+    PyGILState_Release(gilstate);
+    return rc;
+}
+
+#ifdef HAVE_TRACE_V2
+static int _trace_callback(unsigned int type, void *ctx, void *stmt, void *sql)
+{
+    if (type != SQLITE_TRACE_STMT) {
+        return 0;
+    }
+
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+    PyObject *py_statement = NULL;
+    const char *expanded_sql = sqlite3_expanded_sql((sqlite3_stmt *)stmt);
+    if (expanded_sql == NULL) {
+        sqlite3 *db = sqlite3_db_handle((sqlite3_stmt *)stmt);
+        if (sqlite3_errcode(db) == SQLITE_NOMEM) {
+            (void)PyErr_NoMemory();
+            goto exit;
+        }
+        PyErr_SetString(pysqlite_DataError, "Expanded SQL string exceeds the maximum string length");
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+
+        py_statement = PyUnicode_FromString((const char *)sql);
+    } else {
+        py_statement = PyUnicode_FromString(expanded_sql);
+        sqlite3_free((void *)expanded_sql);
+    }
+
+    if (py_statement) {
+        PyObject *ret = PyObject_CallFunctionObjArgs((PyObject*)ctx, py_statement, NULL);
+        Py_DECREF(py_statement);
+        Py_XDECREF(ret);
+    }
+
+    if (PyErr_Occurred()) {
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+    }
+exit:
+    PyGILState_Release(gilstate);
+    return 0;
+}
+#else
+static void _trace_callback(void* user_arg, const char* statement_string)
+{
+    PyObject *py_statement = NULL;
+    PyObject *ret = NULL;
+
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+    py_statement = PyUnicode_FromString(statement_string);
+    if (py_statement) {
+        ret = PyObject_CallFunctionObjArgs((PyObject*)user_arg, py_statement, NULL);
+        Py_DECREF(py_statement);
+    }
+
+    if (ret) {
+        Py_DECREF(ret);
+    } else {
+        if (_pysqlite_enable_callback_tracebacks) {
+            PyErr_Print();
+        } else {
+            PyErr_Clear();
+        }
+    }
+
+    PyGILState_Release(gilstate);
+}
+#endif
+
+static PyObject* pysqlite_connection_set_authorizer(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    PyObject* authorizer_cb;
+
+    static char *kwlist[] = { "authorizer_callback", NULL };
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O:set_authorizer",
+                                      kwlist, &authorizer_cb)) {
+        return NULL;
+    }
+
+    int rc;
+    if (authorizer_cb == Py_None) {
+        rc = sqlite3_set_authorizer(self->db, NULL, NULL);
+        Py_XSETREF(self->function_pinboard_authorizer_cb, NULL);
+    }
+    else {
+        Py_INCREF(authorizer_cb);
+        Py_XSETREF(self->function_pinboard_authorizer_cb, authorizer_cb);
+        rc = sqlite3_set_authorizer(self->db, _authorizer_callback, (void*)authorizer_cb);
+    }
+
+    if (rc != SQLITE_OK) {
+        PyErr_SetString(pysqlite_OperationalError, "Error setting authorizer callback");
+        Py_XSETREF(self->function_pinboard_authorizer_cb, NULL);
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject* pysqlite_connection_set_progress_handler(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    PyObject* progress_handler;
+    int n;
+
+    static char *kwlist[] = { "progress_handler", "n", NULL };
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "Oi:set_progress_handler",
+                                      kwlist, &progress_handler, &n)) {
+        return NULL;
+    }
+
+    if (progress_handler == Py_None) {
+        /* None clears the progress handler previously set */
+        sqlite3_progress_handler(self->db, 0, 0, (void*)0);
+        Py_XSETREF(self->function_pinboard_progress_handler, NULL);
+    } else {
+        sqlite3_progress_handler(self->db, n, _progress_handler, progress_handler);
+        Py_INCREF(progress_handler);
+        Py_XSETREF(self->function_pinboard_progress_handler, progress_handler);
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyObject* pysqlite_connection_set_busy_handler(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    PyObject* busy_handler;
+
+    static char *kwlist[] = { "busy_handler", NULL };
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O:set_busy_handler",
+                                      kwlist, &busy_handler)) {
+        return NULL;
+    }
+
+    int rc;
+    if (busy_handler == Py_None) {
+        rc = sqlite3_busy_handler(self->db, NULL, NULL);
+        Py_XSETREF(self->function_pinboard_busy_handler_cb, NULL);
+    }
+    else {
+        Py_INCREF(busy_handler);
+        Py_XSETREF(self->function_pinboard_busy_handler_cb, busy_handler);
+        rc = sqlite3_busy_handler(self->db, _busy_handler, (void*)busy_handler);
+    }
+
+    if (rc != SQLITE_OK) {
+        PyErr_SetString(pysqlite_OperationalError, "Error setting busy handler");
+        Py_XSETREF(self->function_pinboard_busy_handler_cb, NULL);
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject* pysqlite_connection_set_busy_timeout(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    double busy_timeout;
+
+    static char *kwlist[] = { "timeout", NULL };
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "d:set_busy_timeout",
+                                      kwlist, &busy_timeout)) {
+        return NULL;
+    }
+
+    int rc;
+    rc = sqlite3_busy_timeout(self->db, (int)busy_timeout * 1000);
+    if (rc != SQLITE_OK) {
+        PyErr_SetString(pysqlite_OperationalError, "Error setting busy timeout");
+        return NULL;
+    }
+    else {
+        Py_XDECREF(self->function_pinboard_busy_handler_cb);
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyObject* pysqlite_connection_set_trace_callback(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    PyObject* trace_callback;
+
+    static char *kwlist[] = { "trace_callback", NULL };
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O:set_trace_callback",
+                                      kwlist, &trace_callback)) {
+        return NULL;
+    }
+
+    if (trace_callback == Py_None) {
+        /* None clears the trace callback previously set */
+#ifdef HAVE_TRACE_V2
+        sqlite3_trace_v2(self->db, SQLITE_TRACE_STMT, NULL, (void*)0);
+#else
+        sqlite3_trace(self->db, 0, (void*)0);
+#endif
+        Py_XSETREF(self->function_pinboard_trace_callback, NULL);
+    } else {
+#ifdef HAVE_TRACE_V2
+        sqlite3_trace_v2(self->db, SQLITE_TRACE_STMT, _trace_callback, trace_callback);
+#else
+        sqlite3_trace(self->db, _trace_callback, trace_callback);
+#endif
+        Py_INCREF(trace_callback);
+        Py_XSETREF(self->function_pinboard_trace_callback, trace_callback);
+    }
+
+    Py_RETURN_NONE;
+}
+
+#ifdef HAVE_LOAD_EXTENSION
+static PyObject* pysqlite_enable_load_extension(pysqlite_Connection* self, PyObject* args)
+{
+    int rc;
+    int onoff;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTuple(args, "i", &onoff)) {
+        return NULL;
+    }
+
+    rc = sqlite3_enable_load_extension(self->db, onoff);
+
+    if (rc != SQLITE_OK) {
+        PyErr_SetString(pysqlite_OperationalError, "Error enabling load extension");
+        return NULL;
+    } else {
+        Py_RETURN_NONE;
+    }
+}
+
+static PyObject* pysqlite_load_extension(pysqlite_Connection* self, PyObject* args)
+{
+    int rc;
+    char* extension_name;
+    char* errmsg;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTuple(args, "s", &extension_name)) {
+        return NULL;
+    }
+
+    rc = sqlite3_load_extension(self->db, extension_name, 0, &errmsg);
+    if (rc != 0) {
+        PyErr_SetString(pysqlite_OperationalError, errmsg);
+        return NULL;
+    } else {
+        Py_RETURN_NONE;
+    }
+}
+#endif
+
+int pysqlite_check_thread(pysqlite_Connection* self)
+{
+    if (self->check_same_thread) {
+        if (PyThread_get_thread_ident() != self->thread_ident) {
+            PyErr_Format(pysqlite_ProgrammingError,
+                        "SQLite objects created in a thread can only be used in that same thread. "
+                        "The object was created in thread id %lu and this is thread id %lu.",
+                        self->thread_ident, PyThread_get_thread_ident());
+            return 0;
+        }
+
+    }
+    return 1;
+}
+
+static PyObject* pysqlite_connection_get_isolation_level(pysqlite_Connection* self, void* unused)
+{
+    Py_INCREF(self->isolation_level);
+    return self->isolation_level;
+}
+
+static PyObject* pysqlite_connection_get_total_changes(pysqlite_Connection* self, void* unused)
+{
+    if (!pysqlite_check_connection(self)) {
+        return NULL;
+    } else {
+        return Py_BuildValue("i", sqlite3_total_changes(self->db));
+    }
+}
+
+static PyObject* pysqlite_connection_get_in_transaction(pysqlite_Connection* self, void* unused)
+{
+    if (!pysqlite_check_connection(self)) {
+        return NULL;
+    }
+    if (!sqlite3_get_autocommit(self->db)) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
+static int
+pysqlite_connection_set_isolation_level(pysqlite_Connection* self, PyObject* isolation_level, void *Py_UNUSED(ignored))
+{
+    if (isolation_level == NULL) {
+        PyErr_SetString(PyExc_AttributeError, "cannot delete attribute");
+        return -1;
+    }
+    if (isolation_level == Py_None) {
+        PyObject *res = pysqlite_connection_commit(self, NULL);
+        if (!res) {
+            return -1;
+        }
+        Py_DECREF(res);
+
+        self->begin_statement = NULL;
+    } else {
+        const char * const *candidate;
+
+        if (!PyUnicode_Check(isolation_level)) {
+            PyErr_Format(PyExc_TypeError,
+                         "isolation_level must be a string or None, not %.100s",
+                         Py_TYPE(isolation_level)->tp_name);
+            return -1;
+        }
+
+        const char *level = PyUnicode_AsUTF8(isolation_level);
+        if (level == NULL) {
+            return -1;
+        }
+        for (candidate = begin_statements; *candidate; candidate++) {
+            if (sqlite3_stricmp(level, *candidate + 6) == 0)
+                break;
+        }
+        if (!*candidate) {
+            PyErr_SetString(PyExc_ValueError,
+                            "invalid value for isolation_level");
+            return -1;
+        }
+        self->begin_statement = *candidate;
+    }
+
+    Py_INCREF(isolation_level);
+    Py_XSETREF(self->isolation_level, isolation_level);
+    return 0;
+}
+
+PyObject* pysqlite_connection_call(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
+{
+    PyObject* sql;
+    pysqlite_Statement* statement;
+    PyObject* weakref;
+    int rc;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
+    if (!PyArg_ParseTuple(args, "U", &sql))
+        return NULL;
+
+    _pysqlite_drop_unused_statement_references(self);
+
+    statement = PyObject_New(pysqlite_Statement, &pysqlite_StatementType);
+    if (!statement) {
+        return NULL;
+    }
+
+    statement->db = NULL;
+    statement->st = NULL;
+    statement->sql = NULL;
+    statement->in_use = 0;
+    statement->in_weakreflist = NULL;
+
+    rc = pysqlite_statement_create(statement, self, sql);
+    if (rc != SQLITE_OK) {
+        if (rc == PYSQLITE_TOO_MUCH_SQL) {
+            PyErr_SetString(pysqlite_Warning, "You can only execute one statement at a time.");
+        } else if (rc == PYSQLITE_SQL_WRONG_TYPE) {
+            if (PyErr_ExceptionMatches(PyExc_TypeError))
+                PyErr_SetString(pysqlite_Warning, "SQL is of wrong type. Must be string.");
+        } else {
+            (void)pysqlite_statement_reset(statement);
+            _pysqlite_seterror(self->db);
+        }
+        goto error;
+    }
+
+    weakref = PyWeakref_NewRef((PyObject*)statement, NULL);
+    if (weakref == NULL)
+        goto error;
+    if (PyList_Append(self->statements, weakref) != 0) {
+        Py_DECREF(weakref);
+        goto error;
+    }
+    Py_DECREF(weakref);
+
+    return (PyObject*)statement;
+
+error:
+    Py_DECREF(statement);
+    return NULL;
+}
+
+PyObject* pysqlite_connection_execute(pysqlite_Connection* self, PyObject* args)
+{
+    PyObject* cursor = 0;
+    PyObject* result = 0;
+    PyObject* method = 0;
+
+    cursor = _PyObject_CallMethodId((PyObject*)self, &PyId_cursor, NULL);
+    if (!cursor) {
+        goto error;
+    }
+
+    method = PyObject_GetAttrString(cursor, "execute");
+    if (!method) {
+        Py_CLEAR(cursor);
+        goto error;
+    }
+
+    result = PyObject_CallObject(method, args);
+    if (!result) {
+        Py_CLEAR(cursor);
+    }
+
+error:
+    Py_XDECREF(result);
+    Py_XDECREF(method);
+
+    return cursor;
+}
+
+PyObject* pysqlite_connection_executemany(pysqlite_Connection* self, PyObject* args)
+{
+    PyObject* cursor = 0;
+    PyObject* result = 0;
+    PyObject* method = 0;
+
+    cursor = _PyObject_CallMethodId((PyObject*)self, &PyId_cursor, NULL);
+    if (!cursor) {
+        goto error;
+    }
+
+    method = PyObject_GetAttrString(cursor, "executemany");
+    if (!method) {
+        Py_CLEAR(cursor);
+        goto error;
+    }
+
+    result = PyObject_CallObject(method, args);
+    if (!result) {
+        Py_CLEAR(cursor);
+    }
+
+error:
+    Py_XDECREF(result);
+    Py_XDECREF(method);
+
+    return cursor;
+}
+
+PyObject* pysqlite_connection_executescript(pysqlite_Connection* self, PyObject* args)
+{
+    PyObject* cursor = 0;
+    PyObject* result = 0;
+    PyObject* method = 0;
+
+    cursor = _PyObject_CallMethodId((PyObject*)self, &PyId_cursor, NULL);
+    if (!cursor) {
+        goto error;
+    }
+
+    method = PyObject_GetAttrString(cursor, "executescript");
+    if (!method) {
+        Py_CLEAR(cursor);
+        goto error;
+    }
+
+    result = PyObject_CallObject(method, args);
+    if (!result) {
+        Py_CLEAR(cursor);
+    }
+
+error:
+    Py_XDECREF(result);
+    Py_XDECREF(method);
+
+    return cursor;
+}
+
+/* ------------------------- COLLATION CODE ------------------------ */
+
+static int
+pysqlite_collation_callback(
+        void* context,
+        int text1_length, const void* text1_data,
+        int text2_length, const void* text2_data)
+{
+    PyObject* callback = (PyObject*)context;
+    PyObject* string1 = 0;
+    PyObject* string2 = 0;
+    PyGILState_STATE gilstate;
+    PyObject* retval = NULL;
+    long longval;
+    int result = 0;
+    gilstate = PyGILState_Ensure();
+
+    if (PyErr_Occurred()) {
+        goto finally;
+    }
+
+    string1 = PyUnicode_FromStringAndSize((const char*)text1_data, text1_length);
+    string2 = PyUnicode_FromStringAndSize((const char*)text2_data, text2_length);
+
+    if (!string1 || !string2) {
+        goto finally; /* failed to allocate strings */
+    }
+
+    retval = PyObject_CallFunctionObjArgs(callback, string1, string2, NULL);
+
+    if (!retval) {
+        /* execution failed */
+        goto finally;
+    }
+
+    longval = PyLong_AsLongAndOverflow(retval, &result);
+    if (longval == -1 && PyErr_Occurred()) {
+        PyErr_Clear();
+        result = 0;
+    }
+    else if (!result) {
+        if (longval > 0)
+            result = 1;
+        else if (longval < 0)
+            result = -1;
+    }
+
+finally:
+    Py_XDECREF(string1);
+    Py_XDECREF(string2);
+    Py_XDECREF(retval);
+    PyGILState_Release(gilstate);
+    return result;
+}
+
+static PyObject *
+pysqlite_connection_interrupt(pysqlite_Connection* self, PyObject* args)
+{
+    PyObject* retval = NULL;
+
+    if (!pysqlite_check_connection(self)) {
+        goto finally;
+    }
+
+    sqlite3_interrupt(self->db);
+
+    Py_INCREF(Py_None);
+    retval = Py_None;
+
+finally:
+    return retval;
+}
+
+#ifdef HAVE_BACKUP_API
+static PyObject *
+pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *target = NULL;
+    int pages = -1;
+    PyObject *progress = Py_None;
+    const char *name = "main";
+    int rc;
+    int callback_error = 0;
+    double sleep_s = 0.25;
+    int sleep_ms = 0;
+    sqlite3 *bck_conn;
+    sqlite3_backup *bck_handle;
+    static char *keywords[] = {"target", "pages", "progress", "name", "sleep", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|$iOsd:backup", keywords,
+                                     &pysqlite_ConnectionType, &target,
+                                     &pages, &progress, &name, &sleep_s)) {
+        return NULL;
+    }
+
+    if (!pysqlite_check_connection((pysqlite_Connection *)target)) {
+        return NULL;
+    }
+
+    if ((pysqlite_Connection *)target == self) {
+        PyErr_SetString(PyExc_ValueError, "target cannot be the same connection instance");
+        return NULL;
+    }
+    if (sleep_s < 0) {
+        PyErr_SetString(PyExc_ValueError, "sleep must be greater-than or equal to zero");
+        return NULL;
+    }
+    sleep_ms = (int)(sleep_s * 1000.0);
+
+#if SQLITE_VERSION_NUMBER < 3008008
+    /* Since 3.8.8 this is already done, per commit
+       https://www.sqlite.org/src/info/169b5505498c0a7e */
+    if (!sqlite3_get_autocommit(((pysqlite_Connection *)target)->db)) {
+        PyErr_SetString(pysqlite_OperationalError, "target is in transaction");
+        return NULL;
+    }
+#endif
+
+    if (progress != Py_None && !PyCallable_Check(progress)) {
+        PyErr_SetString(PyExc_TypeError, "progress argument must be a callable");
+        return NULL;
+    }
+
+    if (pages == 0) {
+        pages = -1;
+    }
+
+    bck_conn = ((pysqlite_Connection *)target)->db;
+
+    Py_BEGIN_ALLOW_THREADS
+    bck_handle = sqlite3_backup_init(bck_conn, "main", self->db, name);
+    Py_END_ALLOW_THREADS
+
+    if (bck_handle) {
+        do {
+            Py_BEGIN_ALLOW_THREADS
+            rc = sqlite3_backup_step(bck_handle, pages);
+            Py_END_ALLOW_THREADS
+
+            if (progress != Py_None) {
+                PyObject *res;
+
+                res = PyObject_CallFunction(progress, "iii", rc,
+                                            sqlite3_backup_remaining(bck_handle),
+                                            sqlite3_backup_pagecount(bck_handle));
+                if (res == NULL) {
+                    /* User's callback raised an error: interrupt the loop and
+                       propagate it. */
+                    callback_error = 1;
+                    rc = -1;
+                } else {
+                    Py_DECREF(res);
+                }
+            }
+
+            /* Sleep for a while if there are still further pages to copy and
+               the engine could not make any progress */
+            if (rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
+                Py_BEGIN_ALLOW_THREADS
+                sqlite3_sleep(sleep_ms);
+                Py_END_ALLOW_THREADS
+            }
+        } while (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED);
+
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_backup_finish(bck_handle);
+        Py_END_ALLOW_THREADS
+    } else {
+        rc = _pysqlite_seterror(bck_conn);
+    }
+
+    if (!callback_error && rc != SQLITE_OK) {
+        /* We cannot use _pysqlite_seterror() here because the backup APIs do
+           not set the error status on the connection object, but rather on
+           the backup handle. */
+        if (rc == SQLITE_NOMEM) {
+            (void)PyErr_NoMemory();
+        } else {
+            PyErr_SetString(pysqlite_OperationalError, sqlite3_errstr(rc));
+        }
+    }
+
+    if (!callback_error && rc == SQLITE_OK) {
+        Py_RETURN_NONE;
+    } else {
+        return NULL;
+    }
+}
+#endif
+
+static PyObject *
+pysqlite_connection_create_collation(pysqlite_Connection* self, PyObject* args)
+{
+    PyObject* callable;
+    PyObject* name = NULL;
+    PyObject* retval;
+    const char *name_str;
+    int rc;
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        goto finally;
+    }
+
+    if (!PyArg_ParseTuple(args, "UO:create_collation(name, callback)",
+                          &name, &callable)) {
+        goto finally;
+    }
+
+    name_str = PyUnicode_AsUTF8(name);
+    if (!name_str)
+        goto finally;
+
+    if (callable != Py_None && !PyCallable_Check(callable)) {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        goto finally;
+    }
+
+    if (callable != Py_None) {
+        if (PyDict_SetItem(self->collations, name, callable) == -1)
+            goto finally;
+    } else {
+        if (PyDict_DelItem(self->collations, name) == -1)
+            goto finally;
+    }
+
+    rc = sqlite3_create_collation(self->db,
+                                  name_str,
+                                  SQLITE_UTF8,
+                                  (callable != Py_None) ? callable : NULL,
+                                  (callable != Py_None) ? pysqlite_collation_callback : NULL);
+    if (rc != SQLITE_OK) {
+        PyDict_DelItem(self->collations, name);
+        _pysqlite_seterror(self->db);
+        goto finally;
+    }
+
+finally:
+    if (PyErr_Occurred()) {
+        retval = NULL;
+    } else {
+        Py_INCREF(Py_None);
+        retval = Py_None;
+    }
+
+    return retval;
+}
+
+/* Called when the connection is used as a context manager. Returns itself as a
+ * convenience to the caller. */
+static PyObject *
+pysqlite_connection_enter(pysqlite_Connection* self, PyObject* args)
+{
+    Py_INCREF(self);
+    return (PyObject*)self;
+}
+
+/** Called when the connection is used as a context manager. If there was any
+ * exception, a rollback takes place; otherwise we commit. */
+static PyObject *
+pysqlite_connection_exit(pysqlite_Connection* self, PyObject* args)
+{
+    PyObject* exc_type, *exc_value, *exc_tb;
+    const char* method_name;
+    PyObject* result;
+
+    if (!PyArg_ParseTuple(args, "OOO", &exc_type, &exc_value, &exc_tb)) {
+        return NULL;
+    }
+
+    if (exc_type == Py_None && exc_value == Py_None && exc_tb == Py_None) {
+        method_name = "commit";
+    } else {
+        method_name = "rollback";
+    }
+
+    result = PyObject_CallMethod((PyObject*)self, method_name, NULL);
+    if (!result) {
+        return NULL;
+    }
+    Py_DECREF(result);
+
+    Py_RETURN_FALSE;
+}
+
+#ifdef HAVE_ENCRYPTION
+PyObject* pysqlite_connection_key(pysqlite_Connection *self, PyObject *args)
+{
+    Py_buffer key_buffer;
+    int rc;
+
+    if (!pysqlite_check_connection(self)) {
+        return NULL;
+    }
+    if (!PyArg_ParseTuple(args, "s*", &key_buffer)) {
+        return NULL;
+    }
+
+    rc = sqlite3_key(self->db, key_buffer.buf, key_buffer.len);
+    PyBuffer_Release(&key_buffer);
+
+    if (rc != SQLITE_OK) {
+        PyErr_SetString(pysqlite_OperationalError, sqlite3_errstr(rc));
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+PyObject* pysqlite_connection_rekey(pysqlite_Connection *self, PyObject *args)
+{
+    Py_buffer key_buffer;
+    int rc;
+
+    if (!pysqlite_check_connection(self)) {
+        return NULL;
+    }
+    if (!PyArg_ParseTuple(args, "s*", &key_buffer)) {
+        return NULL;
+    }
+
+    rc = sqlite3_rekey(self->db, key_buffer.buf, key_buffer.len);
+    PyBuffer_Release(&key_buffer);
+
+    if (rc != SQLITE_OK) {
+        PyErr_SetString(pysqlite_OperationalError, sqlite3_errstr(rc));
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+#endif
+
+static const char connection_doc[] =
+PyDoc_STR("SQLite database connection object.");
+
+static PyGetSetDef connection_getset[] = {
+    {"isolation_level",  (getter)pysqlite_connection_get_isolation_level, (setter)pysqlite_connection_set_isolation_level},
+    {"total_changes",  (getter)pysqlite_connection_get_total_changes, (setter)0},
+    {"in_transaction",  (getter)pysqlite_connection_get_in_transaction, (setter)0},
+    {NULL}
+};
+
+static PyMethodDef connection_methods[] = {
+    {"cursor", (PyCFunction)(void(*)(void))pysqlite_connection_cursor, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Return a cursor for the connection.")},
+    {"open_blob", (PyCFunction)pysqlite_connection_blob, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("return a blob object")},
+    {"close", (PyCFunction)pysqlite_connection_close, METH_NOARGS,
+        PyDoc_STR("Closes the connection.")},
+    {"commit", (PyCFunction)pysqlite_connection_commit, METH_NOARGS,
+        PyDoc_STR("Commit the current transaction.")},
+    {"rollback", (PyCFunction)pysqlite_connection_rollback, METH_NOARGS,
+        PyDoc_STR("Roll back the current transaction.")},
+    {"create_function", (PyCFunction)(void(*)(void))pysqlite_connection_create_function, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Creates a new function. Non-standard.")},
+    {"create_aggregate", (PyCFunction)(void(*)(void))pysqlite_connection_create_aggregate, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Creates a new aggregate. Non-standard.")},
+    #ifdef HAVE_WINDOW_FUNCTION
+    {"create_window_function", (PyCFunction)pysqlite_connection_create_window_function, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Creates a new window function. Non-standard.")},
+    #endif
+    {"set_authorizer", (PyCFunction)(void(*)(void))pysqlite_connection_set_authorizer, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Sets authorizer callback. Non-standard.")},
+    {"set_busy_handler", (PyCFunction)(void(*)(void))pysqlite_connection_set_busy_handler, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Sets busy handler. Non-standard.")},
+    {"set_busy_timeout", (PyCFunction)(void(*)(void))pysqlite_connection_set_busy_timeout, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Sets busy timeout. Non-standard.")},
+    #ifdef HAVE_LOAD_EXTENSION
+    {"enable_load_extension", (PyCFunction)pysqlite_enable_load_extension, METH_VARARGS,
+        PyDoc_STR("Enable dynamic loading of SQLite extension modules. Non-standard.")},
+    {"load_extension", (PyCFunction)pysqlite_load_extension, METH_VARARGS,
+        PyDoc_STR("Load SQLite extension module. Non-standard.")},
+    #endif
+    {"set_progress_handler", (PyCFunction)(void(*)(void))pysqlite_connection_set_progress_handler, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Sets progress handler callback. Non-standard.")},
+    {"set_trace_callback", (PyCFunction)(void(*)(void))pysqlite_connection_set_trace_callback, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Sets a trace callback called for each SQL statement (passed as unicode). Non-standard.")},
+    {"execute", (PyCFunction)pysqlite_connection_execute, METH_VARARGS,
+        PyDoc_STR("Executes a SQL statement. Non-standard.")},
+    {"executemany", (PyCFunction)pysqlite_connection_executemany, METH_VARARGS,
+        PyDoc_STR("Repeatedly executes a SQL statement. Non-standard.")},
+    {"executescript", (PyCFunction)pysqlite_connection_executescript, METH_VARARGS,
+        PyDoc_STR("Executes a multiple SQL statements at once. Non-standard.")},
+    {"create_collation", (PyCFunction)pysqlite_connection_create_collation, METH_VARARGS,
+        PyDoc_STR("Creates a collation function. Non-standard.")},
+    {"interrupt", (PyCFunction)pysqlite_connection_interrupt, METH_NOARGS,
+        PyDoc_STR("Abort any pending database operation. Non-standard.")},
+#ifdef HAVE_ENCRYPTION
+    {"set_key", (PyCFunction)(void(*)(void))pysqlite_connection_key, METH_VARARGS,
+        PyDoc_STR("Set encryption key for database. Non-standard.")},
+    {"reset_key", (PyCFunction)(void(*)(void))pysqlite_connection_rekey, METH_VARARGS,
+        PyDoc_STR("Set encryption key for database. Non-standard.")},
+#endif
+    #ifdef HAVE_BACKUP_API
+    {"backup", (PyCFunction)(void(*)(void))pysqlite_connection_backup, METH_VARARGS | METH_KEYWORDS,
+        PyDoc_STR("Makes a backup of the database. Non-standard.")},
+    #endif
+    {"__enter__", (PyCFunction)pysqlite_connection_enter, METH_NOARGS,
+        PyDoc_STR("For context manager. Non-standard.")},
+    {"__exit__", (PyCFunction)pysqlite_connection_exit, METH_VARARGS,
+        PyDoc_STR("For context manager. Non-standard.")},
+    {NULL, NULL}
+};
+
+static struct PyMemberDef connection_members[] =
+{
+    {"Warning", T_OBJECT, offsetof(pysqlite_Connection, Warning), READONLY},
+    {"Error", T_OBJECT, offsetof(pysqlite_Connection, Error), READONLY},
+    {"InterfaceError", T_OBJECT, offsetof(pysqlite_Connection, InterfaceError), READONLY},
+    {"DatabaseError", T_OBJECT, offsetof(pysqlite_Connection, DatabaseError), READONLY},
+    {"DataError", T_OBJECT, offsetof(pysqlite_Connection, DataError), READONLY},
+    {"OperationalError", T_OBJECT, offsetof(pysqlite_Connection, OperationalError), READONLY},
+    {"IntegrityError", T_OBJECT, offsetof(pysqlite_Connection, IntegrityError), READONLY},
+    {"InternalError", T_OBJECT, offsetof(pysqlite_Connection, InternalError), READONLY},
+    {"ProgrammingError", T_OBJECT, offsetof(pysqlite_Connection, ProgrammingError), READONLY},
+    {"NotSupportedError", T_OBJECT, offsetof(pysqlite_Connection, NotSupportedError), READONLY},
+    {"row_factory", T_OBJECT, offsetof(pysqlite_Connection, row_factory)},
+    {"text_factory", T_OBJECT, offsetof(pysqlite_Connection, text_factory)},
+    {NULL}
+};
+
+PyTypeObject pysqlite_ConnectionType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".Connection",                      /* tp_name */
+        sizeof(pysqlite_Connection),                    /* tp_basicsize */
+        0,                                              /* tp_itemsize */
+        (destructor)pysqlite_connection_dealloc,        /* tp_dealloc */
+        0,                                              /* tp_print */
+        0,                                              /* tp_getattr */
+        0,                                              /* tp_setattr */
+        0,                                              /* tp_reserved */
+        0,                                              /* tp_repr */
+        0,                                              /* tp_as_number */
+        0,                                              /* tp_as_sequence */
+        0,                                              /* tp_as_mapping */
+        0,                                              /* tp_hash */
+        (ternaryfunc)pysqlite_connection_call,          /* tp_call */
+        0,                                              /* tp_str */
+        0,                                              /* tp_getattro */
+        0,                                              /* tp_setattro */
+        0,                                              /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,         /* tp_flags */
+        connection_doc,                                 /* tp_doc */
+        0,                                              /* tp_traverse */
+        0,                                              /* tp_clear */
+        0,                                              /* tp_richcompare */
+        0,                                              /* tp_weaklistoffset */
+        0,                                              /* tp_iter */
+        0,                                              /* tp_iternext */
+        connection_methods,                             /* tp_methods */
+        connection_members,                             /* tp_members */
+        connection_getset,                              /* tp_getset */
+        0,                                              /* tp_base */
+        0,                                              /* tp_dict */
+        0,                                              /* tp_descr_get */
+        0,                                              /* tp_descr_set */
+        0,                                              /* tp_dictoffset */
+        (initproc)pysqlite_connection_init,             /* tp_init */
+        0,                                              /* tp_alloc */
+        0,                                              /* tp_new */
+        0                                               /* tp_free */
+};
+
+extern int pysqlite_connection_setup_types(void)
+{
+    pysqlite_ConnectionType.tp_new = PyType_GenericNew;
+    return PyType_Ready(&pysqlite_ConnectionType);
+}

--- a/packages/phoenix-sqlean/src/connection.h
+++ b/packages/phoenix-sqlean/src/connection.h
@@ -1,0 +1,129 @@
+/* connection.h - definitions for the connection type
+ *
+ * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PYSQLITE_CONNECTION_H
+#define PYSQLITE_CONNECTION_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+#include "pythread.h"
+#include "structmember.h"
+
+#include "cache.h"
+#include "module.h"
+
+#include "sqlite3.h"
+
+typedef struct
+{
+    PyObject_HEAD
+    sqlite3* db;
+
+    /* the type detection mode. Only 0, PARSE_DECLTYPES, PARSE_COLNAMES or a
+     * bitwise combination thereof makes sense */
+    int detect_types;
+
+    /* the timeout value in seconds for database locks */
+    double timeout;
+
+    /* for internal use in the timeout handler: when did the timeout handler
+     * first get called with count=0? */
+    double timeout_started;
+
+    /* None for autocommit, otherwise a PyUnicode with the isolation level */
+    PyObject* isolation_level;
+
+    /* NULL for autocommit, otherwise a string with the BEGIN statement */
+    const char* begin_statement;
+
+    /* 1 if a check should be performed for each API call if the connection is
+     * used from the same thread it was created in */
+    int check_same_thread;
+
+    int initialized;
+
+    /* thread identification of the thread the connection was created in */
+    unsigned long thread_ident;
+
+    pysqlite_Cache* statement_cache;
+
+    /* Lists of weak references to statements, blobs and cursors used within this connection */
+    PyObject* statements;
+    PyObject* cursors;
+    PyObject* blobs;
+
+    /* Counters for how many statements/cursors were created in the connection. May be
+     * reset to 0 at certain intervals */
+    int created_statements;
+    int created_cursors;
+
+    PyObject* row_factory;
+
+    /* Determines how bytestrings from SQLite are converted to Python objects:
+     * - PyUnicode_Type:        Python Unicode objects are constructed from UTF-8 bytestrings
+     * - PyBytes_Type:          The bytestrings are returned as-is.
+     * - Any custom callable:   Any object returned from the callable called with the bytestring
+     *                          as single parameter.
+     */
+    PyObject* text_factory;
+
+    /* remember references to functions/classes used in trace/progress/auth cb */
+    PyObject* function_pinboard_trace_callback;
+    PyObject* function_pinboard_progress_handler;
+    PyObject* function_pinboard_authorizer_cb;
+    PyObject* function_pinboard_busy_handler_cb;
+
+    /* a dictionary of registered collation name => collation callable mappings */
+    PyObject* collations;
+
+    /* Exception objects */
+    PyObject* Warning;
+    PyObject* Error;
+    PyObject* InterfaceError;
+    PyObject* DatabaseError;
+    PyObject* DataError;
+    PyObject* OperationalError;
+    PyObject* IntegrityError;
+    PyObject* InternalError;
+    PyObject* ProgrammingError;
+    PyObject* NotSupportedError;
+} pysqlite_Connection;
+
+extern PyTypeObject pysqlite_ConnectionType;
+
+PyObject* pysqlite_connection_alloc(PyTypeObject* type, int aware);
+void pysqlite_connection_dealloc(pysqlite_Connection* self);
+PyObject* pysqlite_connection_cursor(pysqlite_Connection* self, PyObject* args, PyObject* kwargs);
+PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args);
+PyObject* _pysqlite_connection_begin(pysqlite_Connection* self);
+PyObject* pysqlite_connection_commit(pysqlite_Connection* self, PyObject* args);
+PyObject* pysqlite_connection_rollback(pysqlite_Connection* self, PyObject* args);
+PyObject* pysqlite_connection_new(PyTypeObject* type, PyObject* args, PyObject* kw);
+int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject* kwargs);
+
+int pysqlite_connection_register_cursor(pysqlite_Connection* connection, PyObject* cursor);
+int pysqlite_check_thread(pysqlite_Connection* self);
+int pysqlite_check_connection(pysqlite_Connection* con);
+
+int pysqlite_connection_setup_types(void);
+
+#endif

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -1,0 +1,970 @@
+/* cursor.c - the cursor type
+ *
+ * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "cursor.h"
+#include "module.h"
+#include "util.h"
+
+PyObject* pysqlite_cursor_iternext(pysqlite_Cursor* self);
+
+static const char errmsg_fetch_across_rollback[] = "Cursor needed to be reset because of commit/rollback and can no longer be fetched from.";
+
+static int pysqlite_cursor_init(pysqlite_Cursor* self, PyObject* args, PyObject* kwargs)
+{
+    pysqlite_Connection* connection;
+
+    if (!PyArg_ParseTuple(args, "O!", &pysqlite_ConnectionType, &connection))
+    {
+        return -1;
+    }
+
+    Py_INCREF(connection);
+    Py_XSETREF(self->connection, connection);
+    Py_CLEAR(self->statement);
+    Py_CLEAR(self->next_row);
+    Py_CLEAR(self->row_cast_map);
+
+    Py_INCREF(Py_None);
+    Py_XSETREF(self->description, Py_None);
+
+    Py_INCREF(Py_None);
+    Py_XSETREF(self->lastrowid, Py_None);
+
+    self->arraysize = 1;
+    self->closed = 0;
+    self->reset = 0;
+
+    self->rowcount = -1L;
+
+    Py_INCREF(Py_None);
+    Py_XSETREF(self->row_factory, Py_None);
+
+    if (!pysqlite_check_thread(self->connection)) {
+        return -1;
+    }
+
+    if (!pysqlite_connection_register_cursor(connection, (PyObject*)self)) {
+        return -1;
+    }
+
+    self->initialized = 1;
+
+    return 0;
+}
+
+static void pysqlite_cursor_dealloc(pysqlite_Cursor* self)
+{
+    /* Reset the statement if the user has not closed the cursor */
+    if (self->statement) {
+        pysqlite_statement_reset(self->statement);
+        Py_DECREF(self->statement);
+    }
+
+    Py_XDECREF(self->connection);
+    Py_XDECREF(self->row_cast_map);
+    Py_XDECREF(self->description);
+    Py_XDECREF(self->lastrowid);
+    Py_XDECREF(self->row_factory);
+    Py_XDECREF(self->next_row);
+
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }
+
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject *
+_pysqlite_get_converter(const char *keystr, Py_ssize_t keylen)
+{
+    PyObject *key;
+    PyObject *upcase_key;
+    PyObject *retval;
+    _Py_IDENTIFIER(upper);
+
+    key = PyUnicode_FromStringAndSize(keystr, keylen);
+    if (!key) {
+        return NULL;
+    }
+    upcase_key = _PyObject_CallMethodId(key, &PyId_upper, NULL);
+    Py_DECREF(key);
+    if (!upcase_key) {
+        return NULL;
+    }
+
+    retval = PyDict_GetItemWithError(_pysqlite_converters, upcase_key);
+    Py_DECREF(upcase_key);
+
+    return retval;
+}
+
+static int
+pysqlite_build_row_cast_map(pysqlite_Cursor* self)
+{
+    int i;
+    const char* pos;
+    const char* colname;
+    const char* decltype;
+    PyObject* converter;
+
+    if (!self->connection->detect_types) {
+        return 0;
+    }
+
+    Py_XSETREF(self->row_cast_map, PyList_New(0));
+    if (!self->row_cast_map) {
+        return -1;
+    }
+
+    for (i = 0; i < sqlite3_column_count(self->statement->st); i++) {
+        converter = NULL;
+
+        if (self->connection->detect_types & PARSE_COLNAMES) {
+            colname = sqlite3_column_name(self->statement->st, i);
+            if (colname) {
+                const char *type_start = NULL;
+                for (pos = colname; *pos != 0; pos++) {
+                    if (*pos == '[') {
+                        type_start = pos + 1;
+                    }
+                    else if (*pos == ']' && type_start != NULL) {
+                        converter = _pysqlite_get_converter(type_start, pos - type_start);
+                        if (!converter && PyErr_Occurred()) {
+                            Py_CLEAR(self->row_cast_map);
+                            return -1;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!converter && self->connection->detect_types & PARSE_DECLTYPES) {
+            decltype = sqlite3_column_decltype(self->statement->st, i);
+            if (decltype) {
+                for (pos = decltype;;pos++) {
+                    /* Converter names are split at '(' and blanks.
+                     * This allows 'INTEGER NOT NULL' to be treated as 'INTEGER' and
+                     * 'NUMBER(10)' to be treated as 'NUMBER', for example.
+                     * In other words, it will work as people expect it to work.*/
+                    if (*pos == ' ' || *pos == '(' || *pos == 0) {
+                        converter = _pysqlite_get_converter(decltype, pos - decltype);
+                        if (!converter && PyErr_Occurred()) {
+                            Py_CLEAR(self->row_cast_map);
+                            return -1;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!converter) {
+            converter = Py_None;
+        }
+
+        if (PyList_Append(self->row_cast_map, converter) != 0) {
+            Py_CLEAR(self->row_cast_map);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static PyObject *
+_pysqlite_build_column_name(pysqlite_Cursor *self, const char *colname)
+{
+    const char* pos;
+    Py_ssize_t len;
+
+    if (!colname) {
+        Py_RETURN_NONE;
+    }
+
+    if (self->connection->detect_types & PARSE_COLNAMES) {
+        for (pos = colname; *pos; pos++) {
+            if (*pos == '[') {
+                if ((pos != colname) && (*(pos-1) == ' ')) {
+                    pos--;
+                }
+                break;
+            }
+        }
+        len = pos - colname;
+    }
+    else {
+        len = strlen(colname);
+    }
+    return PyUnicode_FromStringAndSize(colname, len);
+}
+
+static PyObject *
+_pysqlite_build_column_decltype(pysqlite_Cursor *self, const char *decltype)
+{
+    if (!decltype) {
+        Py_RETURN_NONE;
+    }
+    return PyUnicode_FromStringAndSize(decltype, strlen(decltype));
+}
+
+/*
+ * Returns a row from the currently active SQLite statement
+ *
+ * Precondidition:
+ * - sqlite3_step() has been called before and it returned SQLITE_ROW.
+ */
+static PyObject *
+_pysqlite_fetch_one_row(pysqlite_Cursor* self)
+{
+    int i, numcols;
+    PyObject* row;
+    PyObject* item = NULL;
+    int coltype;
+    PyObject* converter;
+    PyObject* converted;
+    Py_ssize_t nbytes;
+    const char* val_str;
+    char buf[200];
+    const char* colname;
+    PyObject* error_msg;
+
+    if (self->reset) {
+        PyErr_SetString(pysqlite_InterfaceError, errmsg_fetch_across_rollback);
+        return NULL;
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    numcols = sqlite3_data_count(self->statement->st);
+    Py_END_ALLOW_THREADS
+
+    row = PyTuple_New(numcols);
+    if (!row)
+        return NULL;
+
+    for (i = 0; i < numcols; i++) {
+        if (self->connection->detect_types
+                && self->row_cast_map != NULL
+                && i < PyList_GET_SIZE(self->row_cast_map))
+        {
+            converter = PyList_GET_ITEM(self->row_cast_map, i);
+        }
+        else {
+            converter = Py_None;
+        }
+
+        if (converter != Py_None) {
+            nbytes = sqlite3_column_bytes(self->statement->st, i);
+            val_str = (const char*)sqlite3_column_blob(self->statement->st, i);
+            if (!val_str) {
+                Py_INCREF(Py_None);
+                converted = Py_None;
+            } else {
+                item = PyBytes_FromStringAndSize(val_str, nbytes);
+                if (!item)
+                    goto error;
+                converted = PyObject_CallFunction(converter, "O", item);
+                Py_DECREF(item);
+            }
+        } else {
+            Py_BEGIN_ALLOW_THREADS
+            coltype = sqlite3_column_type(self->statement->st, i);
+            Py_END_ALLOW_THREADS
+            if (coltype == SQLITE_NULL) {
+                Py_INCREF(Py_None);
+                converted = Py_None;
+            } else if (coltype == SQLITE_INTEGER) {
+                converted = PyLong_FromLongLong(sqlite3_column_int64(self->statement->st, i));
+            } else if (coltype == SQLITE_FLOAT) {
+                converted = PyFloat_FromDouble(sqlite3_column_double(self->statement->st, i));
+            } else if (coltype == SQLITE_TEXT) {
+                val_str = (const char*)sqlite3_column_text(self->statement->st, i);
+                nbytes = sqlite3_column_bytes(self->statement->st, i);
+                if (self->connection->text_factory == (PyObject*)&PyUnicode_Type) {
+                    converted = PyUnicode_FromStringAndSize(val_str, nbytes);
+                    if (!converted && PyErr_ExceptionMatches(PyExc_UnicodeDecodeError)) {
+                        PyErr_Clear();
+                        colname = sqlite3_column_name(self->statement->st, i);
+                        if (!colname) {
+                            colname = "<unknown column name>";
+                        }
+                        PyOS_snprintf(buf, sizeof(buf) - 1, "Could not decode to UTF-8 column '%s' with text '%s'",
+                                     colname , val_str);
+                        error_msg = PyUnicode_Decode(buf, strlen(buf), "ascii", "replace");
+                        if (!error_msg) {
+                            PyErr_SetString(pysqlite_OperationalError, "Could not decode to UTF-8");
+                        } else {
+                            PyErr_SetObject(pysqlite_OperationalError, error_msg);
+                            Py_DECREF(error_msg);
+                        }
+                    }
+                } else if (self->connection->text_factory == (PyObject*)&PyBytes_Type) {
+                    converted = PyBytes_FromStringAndSize(val_str, nbytes);
+                } else if (self->connection->text_factory == (PyObject*)&PyByteArray_Type) {
+                    converted = PyByteArray_FromStringAndSize(val_str, nbytes);
+                } else {
+                    converted = PyObject_CallFunction(self->connection->text_factory, "y#", val_str, nbytes);
+                }
+            } else {
+                /* coltype == SQLITE_BLOB */
+                nbytes = sqlite3_column_bytes(self->statement->st, i);
+                converted = PyBytes_FromStringAndSize(
+                    sqlite3_column_blob(self->statement->st, i), nbytes);
+            }
+        }
+
+        if (!converted) {
+            goto error;
+        }
+        PyTuple_SET_ITEM(row, i, converted);
+    }
+
+    if (PyErr_Occurred())
+        goto error;
+
+    return row;
+
+error:
+    Py_DECREF(row);
+    return NULL;
+}
+
+/*
+ * Checks if a cursor object is usable.
+ *
+ * 0 => error; 1 => ok
+ */
+static int check_cursor(pysqlite_Cursor* cur)
+{
+    if (!cur->initialized) {
+        PyErr_SetString(pysqlite_ProgrammingError, "Base Cursor.__init__ not called.");
+        return 0;
+    }
+
+    if (cur->closed) {
+        PyErr_SetString(pysqlite_ProgrammingError, "Cannot operate on a closed cursor.");
+        return 0;
+    }
+
+    if (cur->locked) {
+        PyErr_SetString(pysqlite_ProgrammingError, "Recursive use of cursors not allowed.");
+        return 0;
+    }
+
+    return pysqlite_check_thread(cur->connection) && pysqlite_check_connection(cur->connection);
+}
+
+static PyObject *
+_pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
+{
+    PyObject* operation;
+    PyObject* parameters_list = NULL;
+    PyObject* parameters_iter = NULL;
+    PyObject* parameters = NULL;
+    int i;
+    int rc;
+    PyObject* func_args;
+    PyObject* result;
+    int numcols;
+    PyObject* column_name;
+    PyObject* column_decltype;
+    PyObject* second_argument = NULL;
+    sqlite_int64 lastrowid;
+
+    if (!check_cursor(self)) {
+        goto error;
+    }
+
+    self->locked = 1;
+    self->reset = 0;
+
+    Py_CLEAR(self->next_row);
+
+    if (multiple) {
+        /* executemany() */
+        if (!PyArg_ParseTuple(args, "UO", &operation, &second_argument)) {
+            goto error;
+        }
+
+        if (PyIter_Check(second_argument)) {
+            /* iterator */
+            Py_INCREF(second_argument);
+            parameters_iter = second_argument;
+        } else {
+            /* sequence */
+            parameters_iter = PyObject_GetIter(second_argument);
+            if (!parameters_iter) {
+                goto error;
+            }
+        }
+    } else {
+        /* execute() */
+        if (!PyArg_ParseTuple(args, "U|O", &operation, &second_argument)) {
+            goto error;
+        }
+
+        parameters_list = PyList_New(0);
+        if (!parameters_list) {
+            goto error;
+        }
+
+        if (second_argument == NULL) {
+            second_argument = PyTuple_New(0);
+            if (!second_argument) {
+                goto error;
+            }
+        } else {
+            Py_INCREF(second_argument);
+        }
+        if (PyList_Append(parameters_list, second_argument) != 0) {
+            Py_DECREF(second_argument);
+            goto error;
+        }
+        Py_DECREF(second_argument);
+
+        parameters_iter = PyObject_GetIter(parameters_list);
+        if (!parameters_iter) {
+            goto error;
+        }
+    }
+
+    if (self->statement != NULL) {
+        /* There is an active statement */
+        pysqlite_statement_reset(self->statement);
+    }
+
+    /* reset description and rowcount */
+    Py_INCREF(Py_None);
+    Py_SETREF(self->description, Py_None);
+    self->rowcount = 0L;
+
+    func_args = PyTuple_New(1);
+    if (!func_args) {
+        goto error;
+    }
+    Py_INCREF(operation);
+    if (PyTuple_SetItem(func_args, 0, operation) != 0) {
+        goto error;
+    }
+
+    if (self->statement) {
+        (void)pysqlite_statement_reset(self->statement);
+    }
+
+    Py_XSETREF(self->statement,
+              (pysqlite_Statement *)pysqlite_cache_get(self->connection->statement_cache, func_args));
+    Py_DECREF(func_args);
+
+    if (!self->statement) {
+        goto error;
+    }
+
+    if (self->statement->in_use) {
+        Py_SETREF(self->statement,
+                  PyObject_New(pysqlite_Statement, &pysqlite_StatementType));
+        if (!self->statement) {
+            goto error;
+        }
+        rc = pysqlite_statement_create(self->statement, self->connection, operation);
+        if (rc != SQLITE_OK) {
+            Py_CLEAR(self->statement);
+            goto error;
+        }
+    }
+
+    pysqlite_statement_reset(self->statement);
+    pysqlite_statement_mark_dirty(self->statement);
+
+    /* We start a transaction implicitly before a DML statement.
+       SELECT is the only exception. See #9924. */
+    if (self->connection->begin_statement && self->statement->is_dml) {
+        if (sqlite3_get_autocommit(self->connection->db)) {
+            result = _pysqlite_connection_begin(self->connection);
+            if (!result) {
+                goto error;
+            }
+            Py_DECREF(result);
+        }
+    }
+
+    while (1) {
+        parameters = PyIter_Next(parameters_iter);
+        if (!parameters) {
+            break;
+        }
+
+        pysqlite_statement_mark_dirty(self->statement);
+
+        pysqlite_statement_bind_parameters(self->statement, parameters);
+        if (PyErr_Occurred()) {
+            goto error;
+        }
+
+        rc = pysqlite_step(self->statement->st, self->connection);
+        if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
+            if (PyErr_Occurred()) {
+                /* there was an error that occurred in a user-defined callback */
+                if (_pysqlite_enable_callback_tracebacks) {
+                    PyErr_Print();
+                } else {
+                    PyErr_Clear();
+                }
+            }
+            (void)pysqlite_statement_reset(self->statement);
+            _pysqlite_seterror(self->connection->db);
+            goto error;
+        }
+
+        if (pysqlite_build_row_cast_map(self) != 0) {
+            PyErr_Format(pysqlite_OperationalError, "Error while building row_cast_map");
+            goto error;
+        }
+
+        assert(rc == SQLITE_ROW || rc == SQLITE_DONE);
+        Py_BEGIN_ALLOW_THREADS
+        numcols = sqlite3_column_count(self->statement->st);
+        Py_END_ALLOW_THREADS
+        if (self->description == Py_None && numcols > 0) {
+            Py_SETREF(self->description, PyTuple_New(numcols));
+            if (!self->description) {
+                goto error;
+            }
+            for (i = 0; i < numcols; i++) {
+                const char *colname;
+                const char *decltype;
+                colname = sqlite3_column_name(self->statement->st, i);
+                if (colname == NULL) {
+                    PyErr_NoMemory();
+                    goto error;
+                }
+                column_name = _pysqlite_build_column_name(self, colname);
+                if (!column_name) {
+                    goto error;
+                }
+                decltype = sqlite3_column_decltype(self->statement->st, i);
+                column_decltype = _pysqlite_build_column_decltype(self, decltype);
+                if (!column_decltype) {
+                    Py_DECREF(column_name);
+                    goto error;
+                }
+
+                PyObject *descriptor = PyTuple_Pack(7, column_name, column_decltype,
+                                                    Py_None, Py_None, Py_None,
+                                                    Py_None, Py_None);
+                Py_DECREF(column_name);
+                Py_DECREF(column_decltype);
+                if (descriptor == NULL) {
+                    goto error;
+                }
+                PyTuple_SET_ITEM(self->description, i, descriptor);
+            }
+        }
+
+        if (self->statement->is_dml) {
+            self->rowcount += (long)sqlite3_changes(self->connection->db);
+        } else {
+            self->rowcount= -1L;
+        }
+
+        if (!multiple) {
+            Py_DECREF(self->lastrowid);
+            Py_BEGIN_ALLOW_THREADS
+            lastrowid = sqlite3_last_insert_rowid(self->connection->db);
+            Py_END_ALLOW_THREADS
+            self->lastrowid = PyLong_FromLongLong(lastrowid);
+        }
+
+        if (rc == SQLITE_ROW) {
+            if (multiple) {
+                PyErr_SetString(pysqlite_ProgrammingError, "executemany() can only execute DML statements.");
+                goto error;
+            }
+
+            self->next_row = _pysqlite_fetch_one_row(self);
+            if (self->next_row == NULL)
+                goto error;
+        } else if (rc == SQLITE_DONE && !multiple) {
+            pysqlite_statement_reset(self->statement);
+            Py_CLEAR(self->statement);
+        }
+
+        if (multiple) {
+            pysqlite_statement_reset(self->statement);
+        }
+        Py_XDECREF(parameters);
+    }
+
+error:
+    Py_XDECREF(parameters);
+    Py_XDECREF(parameters_iter);
+    Py_XDECREF(parameters_list);
+
+    self->locked = 0;
+
+    if (PyErr_Occurred()) {
+        self->rowcount = -1L;
+        return NULL;
+    } else {
+        Py_INCREF(self);
+        return (PyObject*)self;
+    }
+}
+
+PyObject* pysqlite_cursor_execute(pysqlite_Cursor* self, PyObject* args)
+{
+    return _pysqlite_query_execute(self, 0, args);
+}
+
+PyObject* pysqlite_cursor_executemany(pysqlite_Cursor* self, PyObject* args)
+{
+    return _pysqlite_query_execute(self, 1, args);
+}
+
+static PyObject *
+pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
+{
+    PyObject* script_obj;
+    const char* script_cstr;
+    sqlite3_stmt* statement;
+    int rc;
+    PyObject* result;
+
+    if (!PyArg_ParseTuple(args, "O", &script_obj)) {
+        return NULL;
+    }
+
+    if (!check_cursor(self)) {
+        return NULL;
+    }
+
+    self->reset = 0;
+
+    if (PyUnicode_Check(script_obj)) {
+        script_cstr = PyUnicode_AsUTF8(script_obj);
+        if (!script_cstr) {
+            return NULL;
+        }
+    } else {
+        PyErr_SetString(PyExc_ValueError, "script argument must be unicode.");
+        return NULL;
+    }
+
+    /* commit first */
+    result = pysqlite_connection_commit(self->connection, NULL);
+    if (!result) {
+        goto error;
+    }
+    Py_DECREF(result);
+
+    while (1) {
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_prepare_v2(self->connection->db,
+                                script_cstr,
+                                -1,
+                                &statement,
+                                &script_cstr);
+        Py_END_ALLOW_THREADS
+        if (rc != SQLITE_OK) {
+            _pysqlite_seterror(self->connection->db);
+            goto error;
+        }
+
+        /* execute statement, and ignore results of SELECT statements */
+        do {
+            rc = pysqlite_step(statement, self->connection);
+            if (PyErr_Occurred()) {
+                (void)sqlite3_finalize(statement);
+                goto error;
+            }
+        } while (rc == SQLITE_ROW);
+
+        if (rc != SQLITE_DONE) {
+            (void)sqlite3_finalize(statement);
+            _pysqlite_seterror(self->connection->db);
+            goto error;
+        }
+
+        rc = sqlite3_finalize(statement);
+        if (rc != SQLITE_OK) {
+            _pysqlite_seterror(self->connection->db);
+            goto error;
+        }
+
+        if (*script_cstr == (char)0) {
+            break;
+        }
+    }
+
+error:
+    if (PyErr_Occurred()) {
+        return NULL;
+    } else {
+        Py_INCREF(self);
+        return (PyObject*)self;
+    }
+}
+
+PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self)
+{
+    PyObject* next_row_tuple;
+    PyObject* next_row;
+    int rc;
+
+    if (!check_cursor(self)) {
+        return NULL;
+    }
+
+    if (self->reset) {
+        PyErr_SetString(pysqlite_InterfaceError, errmsg_fetch_across_rollback);
+        return NULL;
+    }
+
+    if (!self->next_row) {
+         if (self->statement) {
+            (void)pysqlite_statement_reset(self->statement);
+            Py_CLEAR(self->statement);
+        }
+        return NULL;
+    }
+
+    next_row_tuple = self->next_row;
+    assert(next_row_tuple != NULL);
+    self->next_row = NULL;
+
+    if (self->row_factory != Py_None) {
+        next_row = PyObject_CallFunction(self->row_factory, "OO", self, next_row_tuple);
+        if (next_row == NULL) {
+            self->next_row = next_row_tuple;
+            return NULL;
+        }
+        Py_DECREF(next_row_tuple);
+    } else {
+        next_row = next_row_tuple;
+    }
+
+    if (self->statement) {
+        rc = pysqlite_step(self->statement->st, self->connection);
+        if (PyErr_Occurred()) {
+            (void)pysqlite_statement_reset(self->statement);
+            Py_DECREF(next_row);
+            return NULL;
+        }
+        if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
+            (void)pysqlite_statement_reset(self->statement);
+            Py_DECREF(next_row);
+            _pysqlite_seterror(self->connection->db);
+            return NULL;
+        }
+
+        if (rc == SQLITE_ROW) {
+            self->next_row = _pysqlite_fetch_one_row(self);
+            if (self->next_row == NULL) {
+                (void)pysqlite_statement_reset(self->statement);
+                return NULL;
+            }
+        }
+    }
+
+    return next_row;
+}
+
+PyObject* pysqlite_cursor_fetchone(pysqlite_Cursor* self, PyObject* args)
+{
+    PyObject* row;
+
+    row = pysqlite_cursor_iternext(self);
+    if (!row && !PyErr_Occurred()) {
+        Py_RETURN_NONE;
+    }
+
+    return row;
+}
+
+PyObject* pysqlite_cursor_fetchmany(pysqlite_Cursor* self, PyObject* args, PyObject* kwargs)
+{
+    static char *kwlist[] = {"size", NULL};
+
+    PyObject* row;
+    PyObject* list;
+    int maxrows = self->arraysize;
+    int counter = 0;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|i:fetchmany", kwlist, &maxrows)) {
+        return NULL;
+    }
+
+    list = PyList_New(0);
+    if (!list) {
+        return NULL;
+    }
+
+    while ((row = pysqlite_cursor_iternext(self))) {
+        PyList_Append(list, row);
+        Py_XDECREF(row);
+
+        if (++counter == maxrows) {
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        Py_DECREF(list);
+        return NULL;
+    } else {
+        return list;
+    }
+}
+
+PyObject* pysqlite_cursor_fetchall(pysqlite_Cursor* self, PyObject* args)
+{
+    PyObject* row;
+    PyObject* list;
+
+    list = PyList_New(0);
+    if (!list) {
+        return NULL;
+    }
+
+    while ((row = pysqlite_cursor_iternext(self))) {
+        PyList_Append(list, row);
+        Py_XDECREF(row);
+    }
+
+    if (PyErr_Occurred()) {
+        Py_DECREF(list);
+        return NULL;
+    } else {
+        return list;
+    }
+}
+
+PyObject* pysqlite_noop(pysqlite_Connection* self, PyObject* args)
+{
+    /* don't care, return None */
+    Py_RETURN_NONE;
+}
+
+PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
+{
+    if (!self->connection) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Base Cursor.__init__ not called.");
+        return NULL;
+    }
+    if (!pysqlite_check_thread(self->connection) || !pysqlite_check_connection(self->connection)) {
+        return NULL;
+    }
+
+    if (self->statement) {
+        (void)pysqlite_statement_reset(self->statement);
+        Py_CLEAR(self->statement);
+    }
+
+    self->closed = 1;
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef cursor_methods[] = {
+    {"execute", (PyCFunction)pysqlite_cursor_execute, METH_VARARGS,
+        PyDoc_STR("Executes a SQL statement.")},
+    {"executemany", (PyCFunction)pysqlite_cursor_executemany, METH_VARARGS,
+        PyDoc_STR("Repeatedly executes a SQL statement.")},
+    {"executescript", (PyCFunction)pysqlite_cursor_executescript, METH_VARARGS,
+        PyDoc_STR("Executes a multiple SQL statements at once. Non-standard.")},
+    {"fetchone", (PyCFunction)pysqlite_cursor_fetchone, METH_NOARGS,
+        PyDoc_STR("Fetches one row from the resultset.")},
+    {"fetchmany", (PyCFunction)(void(*)(void))pysqlite_cursor_fetchmany, METH_VARARGS|METH_KEYWORDS,
+        PyDoc_STR("Fetches several rows from the resultset.")},
+    {"fetchall", (PyCFunction)pysqlite_cursor_fetchall, METH_NOARGS,
+        PyDoc_STR("Fetches all rows from the resultset.")},
+    {"close", (PyCFunction)pysqlite_cursor_close, METH_NOARGS,
+        PyDoc_STR("Closes the cursor.")},
+    {"setinputsizes", (PyCFunction)pysqlite_noop, METH_VARARGS,
+        PyDoc_STR("Required by DB-API. Does nothing in pysqlite.")},
+    {"setoutputsize", (PyCFunction)pysqlite_noop, METH_VARARGS,
+        PyDoc_STR("Required by DB-API. Does nothing in pysqlite.")},
+    {NULL, NULL}
+};
+
+static struct PyMemberDef cursor_members[] =
+{
+    {"connection", T_OBJECT, offsetof(pysqlite_Cursor, connection), READONLY},
+    {"description", T_OBJECT, offsetof(pysqlite_Cursor, description), READONLY},
+    {"arraysize", T_INT, offsetof(pysqlite_Cursor, arraysize), 0},
+    {"lastrowid", T_OBJECT, offsetof(pysqlite_Cursor, lastrowid), READONLY},
+    {"rowcount", T_LONG, offsetof(pysqlite_Cursor, rowcount), READONLY},
+    {"row_factory", T_OBJECT, offsetof(pysqlite_Cursor, row_factory), 0},
+    {NULL}
+};
+
+static const char cursor_doc[] =
+PyDoc_STR("SQLite database cursor class.");
+
+PyTypeObject pysqlite_CursorType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".Cursor",                          /* tp_name */
+        sizeof(pysqlite_Cursor),                        /* tp_basicsize */
+        0,                                              /* tp_itemsize */
+        (destructor)pysqlite_cursor_dealloc,            /* tp_dealloc */
+        0,                                              /* tp_print */
+        0,                                              /* tp_getattr */
+        0,                                              /* tp_setattr */
+        0,                                              /* tp_reserved */
+        0,                                              /* tp_repr */
+        0,                                              /* tp_as_number */
+        0,                                              /* tp_as_sequence */
+        0,                                              /* tp_as_mapping */
+        0,                                              /* tp_hash */
+        0,                                              /* tp_call */
+        0,                                              /* tp_str */
+        0,                                              /* tp_getattro */
+        0,                                              /* tp_setattro */
+        0,                                              /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE, /* tp_flags */
+        cursor_doc,                                     /* tp_doc */
+        0,                                              /* tp_traverse */
+        0,                                              /* tp_clear */
+        0,                                              /* tp_richcompare */
+        offsetof(pysqlite_Cursor, in_weakreflist),      /* tp_weaklistoffset */
+        PyObject_SelfIter,                              /* tp_iter */
+        (iternextfunc)pysqlite_cursor_iternext,         /* tp_iternext */
+        cursor_methods,                                 /* tp_methods */
+        cursor_members,                                 /* tp_members */
+        0,                                              /* tp_getset */
+        0,                                              /* tp_base */
+        0,                                              /* tp_dict */
+        0,                                              /* tp_descr_get */
+        0,                                              /* tp_descr_set */
+        0,                                              /* tp_dictoffset */
+        (initproc)pysqlite_cursor_init,                 /* tp_init */
+        0,                                              /* tp_alloc */
+        0,                                              /* tp_new */
+        0                                               /* tp_free */
+};
+
+extern int pysqlite_cursor_setup_types(void)
+{
+    pysqlite_CursorType.tp_new = PyType_GenericNew;
+    return PyType_Ready(&pysqlite_CursorType);
+}

--- a/packages/phoenix-sqlean/src/cursor.h
+++ b/packages/phoenix-sqlean/src/cursor.h
@@ -1,0 +1,70 @@
+/* cursor.h - definitions for the cursor type
+ *
+ * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PYSQLITE_CURSOR_H
+#define PYSQLITE_CURSOR_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+#include "statement.h"
+#include "connection.h"
+#include "module.h"
+
+typedef struct
+{
+    PyObject_HEAD
+    pysqlite_Connection* connection;
+    PyObject* description;
+    PyObject* row_cast_map;
+    int arraysize;
+    PyObject* lastrowid;
+    long rowcount;
+    PyObject* row_factory;
+    pysqlite_Statement* statement;
+    int closed;
+    int reset;
+    int locked;
+    int initialized;
+
+    /* the next row to be returned, NULL if no next row available */
+    PyObject* next_row;
+
+    PyObject* in_weakreflist; /* List of weak references */
+} pysqlite_Cursor;
+
+extern PyTypeObject pysqlite_CursorType;
+
+PyObject* pysqlite_cursor_execute(pysqlite_Cursor* self, PyObject* args);
+PyObject* pysqlite_cursor_executemany(pysqlite_Cursor* self, PyObject* args);
+PyObject* pysqlite_cursor_getiter(pysqlite_Cursor *self);
+PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self);
+PyObject* pysqlite_cursor_fetchone(pysqlite_Cursor* self, PyObject* args);
+PyObject* pysqlite_cursor_fetchmany(pysqlite_Cursor* self, PyObject* args, PyObject* kwargs);
+PyObject* pysqlite_cursor_fetchall(pysqlite_Cursor* self, PyObject* args);
+PyObject* pysqlite_noop(pysqlite_Connection* self, PyObject* args);
+PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args);
+
+int pysqlite_cursor_setup_types(void);
+
+#define UNKNOWN (-1)
+#endif

--- a/packages/phoenix-sqlean/src/init.c
+++ b/packages/phoenix-sqlean/src/init.c
@@ -1,0 +1,5 @@
+#include "init.h"
+
+int core_init(const char* dummy) {
+    return sqlite3_auto_extension((void*)sqlite3_sqlean_init);
+}

--- a/packages/phoenix-sqlean/src/init.h
+++ b/packages/phoenix-sqlean/src/init.h
@@ -1,0 +1,10 @@
+#ifndef INIT_H
+#define INIT_H
+
+#include <stdlib.h>
+
+#include "sqlite3ext.h"
+
+int sqlite3_sqlean_init(sqlite3* db, char** errmsg_ptr, const sqlite3_api_routines* api);
+
+#endif /* INIT_H */

--- a/packages/phoenix-sqlean/src/microprotocols.c
+++ b/packages/phoenix-sqlean/src/microprotocols.c
@@ -1,0 +1,153 @@
+/* microprotocols.c - minimalist and non-validating protocols implementation
+ *
+ * Copyright (C) 2003-2004 Federico Di Gregorio <fog@debian.org>
+ *
+ * This file is part of psycopg and was adapted for pysqlite. Federico Di
+ * Gregorio gave the permission to use it within pysqlite under the following
+ * license:
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <Python.h>
+#include <structmember.h>
+
+#include "cursor.h"
+#include "microprotocols.h"
+#include "prepare_protocol.h"
+
+
+/** the adapters registry **/
+
+static PyObject *psyco_adapters = NULL;
+
+/* pysqlite_microprotocols_init - initialize the adapters dictionary */
+
+int
+pysqlite_microprotocols_init(PyObject *dict)
+{
+    /* create adapters dictionary and put it in module namespace */
+    if ((psyco_adapters = PyDict_New()) == NULL) {
+        return -1;
+    }
+
+    return PyDict_SetItemString(dict, "adapters", psyco_adapters);
+}
+
+
+/* pysqlite_microprotocols_add - add a reverse type-caster to the dictionary */
+
+int
+pysqlite_microprotocols_add(PyTypeObject *type, PyObject *proto, PyObject *cast)
+{
+    PyObject* key;
+    int rc;
+
+    if (proto == NULL) proto = (PyObject*)&pysqlite_PrepareProtocolType;
+
+    key = Py_BuildValue("(OO)", (PyObject*)type, proto);
+    if (!key) {
+        return -1;
+    }
+
+    rc = PyDict_SetItem(psyco_adapters, key, cast);
+    Py_DECREF(key);
+
+    return rc;
+}
+
+/* pysqlite_microprotocols_adapt - adapt an object to the built-in protocol */
+
+PyObject *
+pysqlite_microprotocols_adapt(PyObject *obj, PyObject *proto, PyObject *alt)
+{
+    PyObject *adapter, *key, *adapted;
+
+    /* we don't check for exact type conformance as specified in PEP 246
+       because the pysqlite_PrepareProtocolType type is abstract and there is no
+       way to get a quotable object to be its instance */
+
+    /* look for an adapter in the registry */
+    key = Py_BuildValue("(OO)", (PyObject*)obj->ob_type, proto);
+    if (!key) {
+        return NULL;
+    }
+    adapter = PyDict_GetItemWithError(psyco_adapters, key);
+    Py_DECREF(key);
+    if (adapter) {
+        Py_INCREF(adapter);
+        adapted = PyObject_CallFunctionObjArgs(adapter, obj, NULL);
+        Py_DECREF(adapter);
+        return adapted;
+    }
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    /* try to have the protocol adapt this object*/
+    if (PyObject_HasAttrString(proto, "__adapt__")) {
+        _Py_IDENTIFIER(__adapt__);
+        adapted = _PyObject_CallMethodId(proto, &PyId___adapt__, "O", obj);
+
+        if (adapted == Py_None) {
+            Py_DECREF(adapted);
+        }
+        else if (adapted || !PyErr_ExceptionMatches(PyExc_TypeError)) {
+            return adapted;
+        }
+        else {
+            PyErr_Clear();
+        }
+    }
+
+    /* and finally try to have the object adapt itself */
+    if (PyObject_HasAttrString(obj, "__conform__")) {
+        _Py_IDENTIFIER(__conform__);
+        PyObject *adapted = _PyObject_CallMethodId(obj, &PyId___conform__,"O", proto);
+
+        if (adapted == Py_None) {
+            Py_DECREF(adapted);
+        }
+        else if (adapted || !PyErr_ExceptionMatches(PyExc_TypeError)) {
+            return adapted;
+        }
+        else {
+            PyErr_Clear();
+        }
+    }
+
+    if (alt) {
+        Py_INCREF(alt);
+        return alt;
+    }
+
+    /* else set the right exception and return NULL */
+    PyErr_SetString(pysqlite_ProgrammingError, "can't adapt");
+    return NULL;
+}
+
+/** module-level functions **/
+
+PyObject *
+pysqlite_adapt(pysqlite_Cursor *self, PyObject *args)
+{
+    PyObject *obj, *alt = NULL;
+    PyObject *proto = (PyObject*)&pysqlite_PrepareProtocolType;
+
+    if (!PyArg_ParseTuple(args, "O|OO", &obj, &proto, &alt)) return NULL;
+    return pysqlite_microprotocols_adapt(obj, proto, alt);
+}

--- a/packages/phoenix-sqlean/src/microprotocols.h
+++ b/packages/phoenix-sqlean/src/microprotocols.h
@@ -1,0 +1,52 @@
+/* microprotocols.c - definitions for minimalist and non-validating protocols
+ *
+ * Copyright (C) 2003-2004 Federico Di Gregorio <fog@debian.org>
+ *
+ * This file is part of psycopg and was adapted for pysqlite. Federico Di
+ * Gregorio gave the permission to use it within pysqlite under the following
+ * license:
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PSYCOPG_MICROPROTOCOLS_H
+#define PSYCOPG_MICROPROTOCOLS_H 1
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+/** the names of the three mandatory methods **/
+
+#define MICROPROTOCOLS_GETQUOTED_NAME "getquoted"
+#define MICROPROTOCOLS_GETSTRING_NAME "getstring"
+#define MICROPROTOCOLS_GETBINARY_NAME "getbinary"
+
+/** exported functions **/
+
+/* used by module.c to init the microprotocols system */
+extern int pysqlite_microprotocols_init(PyObject *dict);
+extern int pysqlite_microprotocols_add(
+    PyTypeObject *type, PyObject *proto, PyObject *cast);
+extern PyObject *pysqlite_microprotocols_adapt(
+    PyObject *obj, PyObject *proto, PyObject *alt);
+
+extern PyObject *
+    pysqlite_adapt(pysqlite_Cursor* self, PyObject *args);
+#define pysqlite_adapt_doc \
+    "adapt(obj, protocol, alternate) -> adapt obj to given protocol. Non-standard."
+
+#endif /* !defined(PSYCOPG_MICROPROTOCOLS_H) */

--- a/packages/phoenix-sqlean/src/module.c
+++ b/packages/phoenix-sqlean/src/module.c
@@ -1,0 +1,583 @@
+/* module.c - the module itself
+ *
+ * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "connection.h"
+#include "statement.h"
+#include "cursor.h"
+#include "cache.h"
+#include "prepare_protocol.h"
+#include "microprotocols.h"
+#include "row.h"
+#include "blob.h"
+
+#if SQLITE_VERSION_NUMBER >= 3003003
+#define HAVE_SHARED_CACHE
+#endif
+
+/* static objects at module-level */
+
+PyObject *pysqlite_Error = NULL;
+PyObject *pysqlite_Warning = NULL;
+PyObject *pysqlite_InterfaceError = NULL;
+PyObject *pysqlite_DatabaseError = NULL;
+PyObject *pysqlite_InternalError = NULL;
+PyObject *pysqlite_OperationalError = NULL;
+PyObject *pysqlite_ProgrammingError = NULL;
+PyObject *pysqlite_IntegrityError = NULL;
+PyObject *pysqlite_DataError = NULL;
+PyObject *pysqlite_NotSupportedError = NULL;
+
+PyObject* _pysqlite_converters = NULL;
+int _pysqlite_enable_callback_tracebacks = 0;
+int pysqlite_BaseTypeAdapted = 0;
+
+static PyObject* module_connect(PyObject* self, PyObject* args, PyObject*
+        kwargs)
+{
+    /* Python seems to have no way of extracting a single keyword-arg at
+     * C-level, so this code is redundant with the one in connection_init in
+     * connection.c and must always be copied from there ... */
+
+    static char *kwlist[] = {
+        "database", "timeout", "detect_types", "isolation_level",
+        "check_same_thread", "factory", "cached_statements", "uri",
+        "flags", "vfs", NULL
+    };
+    PyObject* database;
+    int detect_types = 0;
+    PyObject* isolation_level;
+    PyObject* factory = NULL;
+    int check_same_thread = 1;
+    int cached_statements;
+    int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+    char *vfs = NULL;
+    int uri = 0;
+    double timeout = 5.0;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|diOiOipiz", kwlist,
+                                     &database, &timeout, &detect_types,
+                                     &isolation_level, &check_same_thread,
+                                     &factory, &cached_statements, &uri,
+                                     &flags, &vfs))
+    {
+        return NULL;
+    }
+
+    if (factory == NULL) {
+        factory = (PyObject*)&pysqlite_ConnectionType;
+    }
+
+    return PyObject_Call(factory, args, kwargs);
+}
+
+PyDoc_STRVAR(module_connect_doc,
+"connect(database[, timeout, detect_types, isolation_level,\n\
+        check_same_thread, factory, cached_statements, uri, flags, vfs])\n\
+\n\
+Opens a connection to the SQLite database file *database*. You can use\n\
+\":memory:\" to open a database connection to a database that resides in\n\
+RAM instead of on disk.");
+
+static PyObject* module_complete(PyObject* self, PyObject* args, PyObject*
+        kwargs)
+{
+    static char *kwlist[] = {"statement", NULL};
+    char* statement;
+
+    PyObject* result;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s", kwlist, &statement))
+    {
+        return NULL;
+    }
+
+    if (sqlite3_complete(statement)) {
+        result = Py_True;
+    } else {
+        result = Py_False;
+    }
+
+    Py_INCREF(result);
+
+    return result;
+}
+
+PyDoc_STRVAR(module_complete_doc,
+"complete_statement(sql)\n\
+\n\
+Checks if a string contains a complete SQL statement. Non-standard.");
+
+#ifdef HAVE_SHARED_CACHE
+static PyObject* module_enable_shared_cache(PyObject* self, PyObject* args, PyObject*
+        kwargs)
+{
+    static char *kwlist[] = {"do_enable", NULL};
+    int do_enable;
+    int rc;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "i", kwlist, &do_enable))
+    {
+        return NULL;
+    }
+
+    rc = sqlite3_enable_shared_cache(do_enable);
+
+    if (rc != SQLITE_OK) {
+        PyErr_SetString(pysqlite_OperationalError, "Changing the shared_cache flag failed");
+        return NULL;
+    } else {
+        Py_RETURN_NONE;
+    }
+}
+
+PyDoc_STRVAR(module_enable_shared_cache_doc,
+"enable_shared_cache(do_enable)\n\
+\n\
+Enable or disable shared cache mode for the calling thread.\n\
+Experimental/Non-standard.");
+#endif /* HAVE_SHARED_CACHE */
+
+static PyObject* module_register_adapter(PyObject* self, PyObject* args)
+{
+    PyTypeObject* type;
+    PyObject* caster;
+    int rc;
+
+    if (!PyArg_ParseTuple(args, "OO", &type, &caster)) {
+        return NULL;
+    }
+
+    /* a basic type is adapted; there's a performance optimization if that's not the case
+     * (99 % of all usages) */
+    if (type == &PyLong_Type || type == &PyFloat_Type
+            || type == &PyUnicode_Type || type == &PyByteArray_Type) {
+        pysqlite_BaseTypeAdapted = 1;
+    }
+
+    rc = pysqlite_microprotocols_add(type, (PyObject*)&pysqlite_PrepareProtocolType, caster);
+    if (rc == -1)
+        return NULL;
+
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(module_register_adapter_doc,
+"register_adapter(type, callable)\n\
+\n\
+Registers an adapter with pysqlite's adapter registry. Non-standard.");
+
+static PyObject* module_register_converter(PyObject* self, PyObject* args)
+{
+    PyObject* orig_name;
+    PyObject* name = NULL;
+    PyObject* callable;
+    PyObject* retval = NULL;
+    _Py_IDENTIFIER(upper);
+
+    if (!PyArg_ParseTuple(args, "UO", &orig_name, &callable)) {
+        return NULL;
+    }
+
+    /* convert the name to upper case */
+    name = _PyObject_CallMethodId(orig_name, &PyId_upper, NULL);
+    if (!name) {
+        goto error;
+    }
+
+    if (PyDict_SetItem(_pysqlite_converters, name, callable) != 0) {
+        goto error;
+    }
+
+    Py_INCREF(Py_None);
+    retval = Py_None;
+error:
+    Py_XDECREF(name);
+    return retval;
+}
+
+PyDoc_STRVAR(module_register_converter_doc,
+"register_converter(typename, callable)\n\
+\n\
+Registers a converter with pysqlite. Non-standard.");
+
+static PyObject* enable_callback_tracebacks(PyObject* self, PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "i", &_pysqlite_enable_callback_tracebacks)) {
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(enable_callback_tracebacks_doc,
+"enable_callback_tracebacks(flag)\n\
+\n\
+Enable or disable callback functions throwing errors to stderr.");
+
+static void converters_init(PyObject* dict)
+{
+    _pysqlite_converters = PyDict_New();
+    if (!_pysqlite_converters) {
+        return;
+    }
+
+    PyDict_SetItemString(dict, "converters", _pysqlite_converters);
+}
+
+static PyMethodDef module_methods[] = {
+    {"connect",  (PyCFunction)(void(*)(void))module_connect,
+     METH_VARARGS | METH_KEYWORDS, module_connect_doc},
+    {"complete_statement",  (PyCFunction)(void(*)(void))module_complete,
+     METH_VARARGS | METH_KEYWORDS, module_complete_doc},
+#ifdef HAVE_SHARED_CACHE
+    {"enable_shared_cache",  (PyCFunction)(void(*)(void))module_enable_shared_cache,
+     METH_VARARGS | METH_KEYWORDS, module_enable_shared_cache_doc},
+#endif
+    {"register_adapter", (PyCFunction)module_register_adapter,
+     METH_VARARGS, module_register_adapter_doc},
+    {"register_converter", (PyCFunction)module_register_converter,
+     METH_VARARGS, module_register_converter_doc},
+    {"adapt",  (PyCFunction)pysqlite_adapt, METH_VARARGS,
+     pysqlite_adapt_doc},
+    {"enable_callback_tracebacks",  (PyCFunction)enable_callback_tracebacks,
+     METH_VARARGS, enable_callback_tracebacks_doc},
+    {NULL, NULL}
+};
+
+struct _IntConstantPair {
+    const char *constant_name;
+    int constant_value;
+};
+
+typedef struct _IntConstantPair IntConstantPair;
+
+/* sqlite API error codes */
+static const IntConstantPair _error_codes[] = {
+  {"SQLITE_OK", SQLITE_OK},
+  {"SQLITE_ERROR", SQLITE_ERROR},
+  {"SQLITE_INTERNAL", SQLITE_INTERNAL},
+  {"SQLITE_PERM", SQLITE_PERM},
+  {"SQLITE_ABORT", SQLITE_ABORT},
+  {"SQLITE_BUSY", SQLITE_BUSY},
+  {"SQLITE_LOCKED", SQLITE_LOCKED},
+  {"SQLITE_NOMEM", SQLITE_NOMEM},
+  {"SQLITE_READONLY", SQLITE_READONLY},
+  {"SQLITE_INTERRUPT", SQLITE_INTERRUPT},
+  {"SQLITE_IOERR", SQLITE_IOERR},
+  {"SQLITE_CORRUPT", SQLITE_CORRUPT},
+  {"SQLITE_NOTFOUND", SQLITE_NOTFOUND},
+  {"SQLITE_FULL", SQLITE_FULL},
+  {"SQLITE_CANTOPEN", SQLITE_CANTOPEN},
+  {"SQLITE_PROTOCOL", SQLITE_PROTOCOL},
+  {"SQLITE_EMPTY", SQLITE_EMPTY},
+  {"SQLITE_SCHEMA", SQLITE_SCHEMA},
+  {"SQLITE_TOOBIG", SQLITE_TOOBIG},
+  {"SQLITE_CONSTRAINT", SQLITE_CONSTRAINT},
+  {"SQLITE_MISMATCH", SQLITE_MISMATCH},
+  {"SQLITE_MISUSE", SQLITE_MISUSE},
+#ifdef SQLITE_NOLFS
+  {"SQLITE_NOLFS", SQLITE_NOLFS},
+#endif
+#ifdef SQLITE_AUTH
+  {"SQLITE_AUTH", SQLITE_AUTH},
+#endif
+#ifdef SQLITE_FORMAT
+  {"SQLITE_FORMAT", SQLITE_FORMAT},
+#endif
+#ifdef SQLITE_RANGE
+  {"SQLITE_RANGE", SQLITE_RANGE},
+#endif
+#ifdef SQLITE_NOTADB
+  {"SQLITE_NOTADB", SQLITE_NOTADB},
+#endif
+  {"SQLITE_DONE", SQLITE_DONE},
+  {"SQLITE_ROW", SQLITE_ROW},
+  {(char*)NULL, 0},
+  {"SQLITE_UNKNOWN", -1}
+};
+
+const char *sqlite3ErrName(int rc) {
+    int i;
+    for (i = 0; _error_codes[i].constant_name != 0; i++) {
+        if (_error_codes[i].constant_value == rc)
+          return _error_codes[i].constant_name;
+    }
+    // No error code matched.
+    return _error_codes[i+1].constant_name;
+}
+
+static const IntConstantPair _int_constants[] = {
+    {"PARSE_DECLTYPES", PARSE_DECLTYPES},
+    {"PARSE_COLNAMES", PARSE_COLNAMES},
+
+    {"SQLITE_OK", SQLITE_OK},
+    /* enumerated return values for sqlite3_set_authorizer() callback */
+    {"SQLITE_DENY", SQLITE_DENY},
+    {"SQLITE_IGNORE", SQLITE_IGNORE},
+
+    /* enumerated values for sqlite3_set_authorizer() callback */
+    {"SQLITE_CREATE_INDEX", SQLITE_CREATE_INDEX},
+    {"SQLITE_CREATE_TABLE", SQLITE_CREATE_TABLE},
+    {"SQLITE_CREATE_TEMP_INDEX", SQLITE_CREATE_TEMP_INDEX},
+    {"SQLITE_CREATE_TEMP_TABLE", SQLITE_CREATE_TEMP_TABLE},
+    {"SQLITE_CREATE_TEMP_TRIGGER", SQLITE_CREATE_TEMP_TRIGGER},
+    {"SQLITE_CREATE_TEMP_VIEW", SQLITE_CREATE_TEMP_VIEW},
+    {"SQLITE_CREATE_TRIGGER", SQLITE_CREATE_TRIGGER},
+    {"SQLITE_CREATE_VIEW", SQLITE_CREATE_VIEW},
+    {"SQLITE_DELETE", SQLITE_DELETE},
+    {"SQLITE_DROP_INDEX", SQLITE_DROP_INDEX},
+    {"SQLITE_DROP_TABLE", SQLITE_DROP_TABLE},
+    {"SQLITE_DROP_TEMP_INDEX", SQLITE_DROP_TEMP_INDEX},
+    {"SQLITE_DROP_TEMP_TABLE", SQLITE_DROP_TEMP_TABLE},
+    {"SQLITE_DROP_TEMP_TRIGGER", SQLITE_DROP_TEMP_TRIGGER},
+    {"SQLITE_DROP_TEMP_VIEW", SQLITE_DROP_TEMP_VIEW},
+    {"SQLITE_DROP_TRIGGER", SQLITE_DROP_TRIGGER},
+    {"SQLITE_DROP_VIEW", SQLITE_DROP_VIEW},
+    {"SQLITE_INSERT", SQLITE_INSERT},
+    {"SQLITE_OPEN_CREATE", SQLITE_OPEN_CREATE},
+    {"SQLITE_OPEN_FULLMUTEX", SQLITE_OPEN_FULLMUTEX},
+    {"SQLITE_OPEN_MEMORY", SQLITE_OPEN_MEMORY},
+    {"SQLITE_OPEN_NOMUTEX", SQLITE_OPEN_NOMUTEX},
+    {"SQLITE_OPEN_PRIVATECACHE", SQLITE_OPEN_PRIVATECACHE},
+    {"SQLITE_OPEN_READONLY", SQLITE_OPEN_READONLY},
+    {"SQLITE_OPEN_SHAREDCACHE", SQLITE_OPEN_SHAREDCACHE},
+    {"SQLITE_OPEN_READWRITE", SQLITE_OPEN_READWRITE},
+    {"SQLITE_OPEN_URI", SQLITE_OPEN_URI},
+    {"SQLITE_PRAGMA", SQLITE_PRAGMA},
+    {"SQLITE_READ", SQLITE_READ},
+    {"SQLITE_SELECT", SQLITE_SELECT},
+    {"SQLITE_TRANSACTION", SQLITE_TRANSACTION},
+    {"SQLITE_UPDATE", SQLITE_UPDATE},
+    {"SQLITE_ATTACH", SQLITE_ATTACH},
+    {"SQLITE_DETACH", SQLITE_DETACH},
+#if SQLITE_VERSION_NUMBER >= 3002001
+    {"SQLITE_ALTER_TABLE", SQLITE_ALTER_TABLE},
+    {"SQLITE_REINDEX", SQLITE_REINDEX},
+#endif
+#if SQLITE_VERSION_NUMBER >= 3003000
+    {"SQLITE_ANALYZE", SQLITE_ANALYZE},
+#endif
+#if SQLITE_VERSION_NUMBER >= 3003007
+    {"SQLITE_CREATE_VTABLE", SQLITE_CREATE_VTABLE},
+    {"SQLITE_DROP_VTABLE", SQLITE_DROP_VTABLE},
+#endif
+#if SQLITE_VERSION_NUMBER >= 3003008
+    {"SQLITE_FUNCTION", SQLITE_FUNCTION},
+#endif
+#if SQLITE_VERSION_NUMBER >= 3006008
+    {"SQLITE_SAVEPOINT", SQLITE_SAVEPOINT},
+#endif
+#if SQLITE_VERSION_NUMBER >= 3008003
+    {"SQLITE_RECURSIVE", SQLITE_RECURSIVE},
+#endif
+#if SQLITE_VERSION_NUMBER >= 3006011
+    {"SQLITE_DONE", SQLITE_DONE},
+#endif
+    {(char*)NULL, 0}
+};
+
+
+static struct PyModuleDef _sqlite3module = {
+        PyModuleDef_HEAD_INIT,
+        "_sqlite3",
+        NULL,
+        -1,
+        module_methods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+
+static int add_to_dict(PyObject *dict, const char *key, int value)
+{
+    int sawerror;
+    PyObject *value_obj = PyLong_FromLong(value);
+    PyObject *name = PyUnicode_FromString(key);
+
+    if (!value_obj || !name) {
+        Py_XDECREF(name);
+        Py_XDECREF(value_obj);
+        return 1;
+    }
+
+    sawerror = PyDict_SetItem(dict, name, value_obj) < 0;
+
+    Py_DECREF(value_obj);
+    Py_DECREF(name);
+
+    if (sawerror)
+        return 1;
+    return 0;
+}
+
+PyMODINIT_FUNC PyInit__sqlite3(void)
+{
+    PyObject *module, *dict;
+    PyObject *tmp_obj;
+    int i;
+
+    int rc = sqlite3_initialize();
+    if (rc != SQLITE_OK) {
+        PyErr_SetString(PyExc_ImportError, sqlite3_errstr(rc));
+        return NULL;
+    }
+
+    module = PyModule_Create(&_sqlite3module);
+
+    if (!module ||
+        (pysqlite_row_setup_types() < 0) ||
+        (pysqlite_cursor_setup_types() < 0) ||
+        (pysqlite_connection_setup_types() < 0) ||
+        (pysqlite_cache_setup_types() < 0) ||
+        (pysqlite_statement_setup_types() < 0) ||
+        (pysqlite_prepare_protocol_setup_types() < 0) ||
+        (pysqlite_blob_setup_types() < 0)
+       ) {
+        Py_XDECREF(module);
+        return NULL;
+    }
+
+    Py_INCREF(&pysqlite_ConnectionType);
+    PyModule_AddObject(module, "Connection", (PyObject*) &pysqlite_ConnectionType);
+    Py_INCREF(&pysqlite_CursorType);
+    PyModule_AddObject(module, "Cursor", (PyObject*) &pysqlite_CursorType);
+    Py_INCREF(&pysqlite_CacheType);
+    PyModule_AddObject(module, "Statement", (PyObject*)&pysqlite_StatementType);
+    Py_INCREF(&pysqlite_StatementType);
+    PyModule_AddObject(module, "Cache", (PyObject*) &pysqlite_CacheType);
+    Py_INCREF(&pysqlite_PrepareProtocolType);
+    PyModule_AddObject(module, "PrepareProtocol", (PyObject*) &pysqlite_PrepareProtocolType);
+    Py_INCREF(&pysqlite_RowType);
+    PyModule_AddObject(module, "Row", (PyObject*) &pysqlite_RowType);
+
+    if (!(dict = PyModule_GetDict(module))) {
+        goto error;
+    }
+
+    /*** Create DB-API Exception hierarchy */
+
+    if (!(pysqlite_Error = PyErr_NewException(MODULE_NAME ".Error", PyExc_Exception, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "Error", pysqlite_Error);
+
+    if (!(pysqlite_Warning = PyErr_NewException(MODULE_NAME ".Warning", PyExc_Exception, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "Warning", pysqlite_Warning);
+
+    /* Error subclasses */
+
+    if (!(pysqlite_InterfaceError = PyErr_NewException(MODULE_NAME ".InterfaceError", pysqlite_Error, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "InterfaceError", pysqlite_InterfaceError);
+
+    if (!(pysqlite_DatabaseError = PyErr_NewException(MODULE_NAME ".DatabaseError", pysqlite_Error, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "DatabaseError", pysqlite_DatabaseError);
+
+    /* pysqlite_DatabaseError subclasses */
+
+    if (!(pysqlite_InternalError = PyErr_NewException(MODULE_NAME ".InternalError", pysqlite_DatabaseError, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "InternalError", pysqlite_InternalError);
+
+    if (!(pysqlite_OperationalError = PyErr_NewException(MODULE_NAME ".OperationalError", pysqlite_DatabaseError, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "OperationalError", pysqlite_OperationalError);
+
+    if (!(pysqlite_ProgrammingError = PyErr_NewException(MODULE_NAME ".ProgrammingError", pysqlite_DatabaseError, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "ProgrammingError", pysqlite_ProgrammingError);
+
+    if (!(pysqlite_IntegrityError = PyErr_NewException(MODULE_NAME ".IntegrityError", pysqlite_DatabaseError,NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "IntegrityError", pysqlite_IntegrityError);
+
+    if (!(pysqlite_DataError = PyErr_NewException(MODULE_NAME ".DataError", pysqlite_DatabaseError, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "DataError", pysqlite_DataError);
+
+    if (!(pysqlite_NotSupportedError = PyErr_NewException(MODULE_NAME ".NotSupportedError", pysqlite_DatabaseError, NULL))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "NotSupportedError", pysqlite_NotSupportedError);
+
+    /* In Python 2.x, setting Connection.text_factory to
+       OptimizedUnicode caused Unicode objects to be returned for
+       non-ASCII data and bytestrings to be returned for ASCII data.
+       Now OptimizedUnicode is an alias for str, so it has no
+       effect. */
+    Py_INCREF((PyObject*)&PyUnicode_Type);
+    PyDict_SetItemString(dict, "OptimizedUnicode", (PyObject*)&PyUnicode_Type);
+
+    /* Set integer constants */
+    for (i = 0; _int_constants[i].constant_name != NULL; i++) {
+        if (add_to_dict(dict, _int_constants[i].constant_name,
+                        _int_constants[i].constant_value) != 0)
+            goto error;
+    }
+
+    /* Set error constants */
+    for (i = 0; _error_codes[i].constant_name != 0; i++) {
+        if (add_to_dict(dict, _error_codes[i].constant_name,
+                        _error_codes[i].constant_value) != 0)
+            goto error;
+    }
+
+    if (!(tmp_obj = PyUnicode_FromString(PYSQLITE_VERSION))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "version", tmp_obj);
+    Py_DECREF(tmp_obj);
+
+    if (!(tmp_obj = PyUnicode_FromString(sqlite3_libversion()))) {
+        goto error;
+    }
+    PyDict_SetItemString(dict, "sqlite_version", tmp_obj);
+    Py_DECREF(tmp_obj);
+
+    /* initialize microprotocols layer */
+    pysqlite_microprotocols_init(dict);
+
+    /* initialize the default converters */
+    converters_init(dict);
+
+error:
+    if (PyErr_Occurred())
+    {
+        PyErr_SetString(PyExc_ImportError, MODULE_NAME ": init failed");
+        Py_XDECREF(module);
+        module = NULL;
+    }
+    return module;
+}

--- a/packages/phoenix-sqlean/src/module.h
+++ b/packages/phoenix-sqlean/src/module.h
@@ -1,0 +1,55 @@
+/* module.h - definitions for the module
+ *
+ * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PYSQLITE_MODULE_H
+#define PYSQLITE_MODULE_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+#define PYSQLITE_VERSION "2.6.0"
+
+extern PyObject* pysqlite_Error;
+extern PyObject* pysqlite_Warning;
+extern PyObject* pysqlite_InterfaceError;
+extern PyObject* pysqlite_DatabaseError;
+extern PyObject* pysqlite_InternalError;
+extern PyObject* pysqlite_OperationalError;
+extern PyObject* pysqlite_ProgrammingError;
+extern PyObject* pysqlite_IntegrityError;
+extern PyObject* pysqlite_DataError;
+extern PyObject* pysqlite_NotSupportedError;
+
+/* A dictionary, mapping column types (INTEGER, VARCHAR, etc.) to converter
+ * functions, that convert the SQL value to the appropriate Python value.
+ * The key is uppercase.
+ */
+extern PyObject* _pysqlite_converters;
+
+extern int _pysqlite_enable_callback_tracebacks;
+extern int pysqlite_BaseTypeAdapted;
+
+extern const char *sqlite3ErrName(int rc);
+
+#define PARSE_DECLTYPES 1
+#define PARSE_COLNAMES 2
+#endif

--- a/packages/phoenix-sqlean/src/prepare_protocol.c
+++ b/packages/phoenix-sqlean/src/prepare_protocol.c
@@ -1,0 +1,86 @@
+/* prepare_protocol.c - the protocol for preparing values for SQLite
+ *
+ * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "prepare_protocol.h"
+
+int pysqlite_prepare_protocol_init(pysqlite_PrepareProtocol* self, PyObject* args, PyObject* kwargs)
+{
+    return 0;
+}
+
+void pysqlite_prepare_protocol_dealloc(pysqlite_PrepareProtocol* self)
+{
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+PyTypeObject pysqlite_PrepareProtocolType= {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".PrepareProtocol",                 /* tp_name */
+        sizeof(pysqlite_PrepareProtocol),               /* tp_basicsize */
+        0,                                              /* tp_itemsize */
+        (destructor)pysqlite_prepare_protocol_dealloc,  /* tp_dealloc */
+        0,                                              /* tp_print */
+        0,                                              /* tp_getattr */
+        0,                                              /* tp_setattr */
+        0,                                              /* tp_reserved */
+        0,                                              /* tp_repr */
+        0,                                              /* tp_as_number */
+        0,                                              /* tp_as_sequence */
+        0,                                              /* tp_as_mapping */
+        0,                                              /* tp_hash */
+        0,                                              /* tp_call */
+        0,                                              /* tp_str */
+        0,                                              /* tp_getattro */
+        0,                                              /* tp_setattro */
+        0,                                              /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT,                             /* tp_flags */
+        0,                                              /* tp_doc */
+        0,                                              /* tp_traverse */
+        0,                                              /* tp_clear */
+        0,                                              /* tp_richcompare */
+        0,                                              /* tp_weaklistoffset */
+        0,                                              /* tp_iter */
+        0,                                              /* tp_iternext */
+        0,                                              /* tp_methods */
+        0,                                              /* tp_members */
+        0,                                              /* tp_getset */
+        0,                                              /* tp_base */
+        0,                                              /* tp_dict */
+        0,                                              /* tp_descr_get */
+        0,                                              /* tp_descr_set */
+        0,                                              /* tp_dictoffset */
+        (initproc)pysqlite_prepare_protocol_init,       /* tp_init */
+        0,                                              /* tp_alloc */
+        0,                                              /* tp_new */
+        0                                               /* tp_free */
+};
+
+extern int pysqlite_prepare_protocol_setup_types(void)
+{
+    int rc;
+    pysqlite_PrepareProtocolType.tp_new = PyType_GenericNew;
+    //Py_TYPE(&pysqlite_PrepareProtocolType)= &PyType_Type;
+    rc = PyType_Ready(&pysqlite_PrepareProtocolType);
+    return rc;
+    //return PyType_Ready(&pysqlite_PrepareProtocolType);
+}

--- a/packages/phoenix-sqlean/src/prepare_protocol.h
+++ b/packages/phoenix-sqlean/src/prepare_protocol.h
@@ -1,0 +1,42 @@
+/* prepare_protocol.h - the protocol for preparing values for SQLite
+ *
+ * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PYSQLITE_PREPARE_PROTOCOL_H
+#define PYSQLITE_PREPARE_PROTOCOL_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+typedef struct
+{
+    PyObject_HEAD
+} pysqlite_PrepareProtocol;
+
+extern PyTypeObject pysqlite_PrepareProtocolType;
+
+int pysqlite_prepare_protocol_init(pysqlite_PrepareProtocol* self, PyObject* args, PyObject* kwargs);
+void pysqlite_prepare_protocol_dealloc(pysqlite_PrepareProtocol* self);
+
+int pysqlite_prepare_protocol_setup_types(void);
+
+#define UNKNOWN (-1)
+#endif

--- a/packages/phoenix-sqlean/src/row.c
+++ b/packages/phoenix-sqlean/src/row.c
@@ -1,0 +1,277 @@
+/* row.c - an enhanced tuple for database rows
+ *
+ * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "row.h"
+#include "cursor.h"
+
+void pysqlite_row_dealloc(pysqlite_Row* self)
+{
+    Py_XDECREF(self->data);
+    Py_XDECREF(self->description);
+
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject *
+pysqlite_row_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    pysqlite_Row *self;
+    PyObject* data;
+    pysqlite_Cursor* cursor;
+
+    assert(type != NULL && type->tp_alloc != NULL);
+
+    if (!PyArg_ParseTuple(args, "OO", &cursor, &data))
+        return NULL;
+
+    if (!PyObject_TypeCheck((PyObject*)cursor, &pysqlite_CursorType)) {
+        PyErr_SetString(PyExc_TypeError, "instance of cursor required for first argument");
+        return NULL;
+    }
+
+    if (!PyTuple_Check(data)) {
+        PyErr_SetString(PyExc_TypeError, "tuple required for second argument");
+        return NULL;
+    }
+
+    self = (pysqlite_Row *) type->tp_alloc(type, 0);
+    if (self == NULL)
+        return NULL;
+
+    Py_INCREF(data);
+    self->data = data;
+
+    Py_INCREF(cursor->description);
+    self->description = cursor->description;
+
+    return (PyObject *) self;
+}
+
+PyObject* pysqlite_row_item(pysqlite_Row* self, Py_ssize_t idx)
+{
+   PyObject* item = PyTuple_GetItem(self->data, idx);
+   Py_XINCREF(item);
+   return item;
+}
+
+static int
+equal_ignore_case(PyObject *left, PyObject *right)
+{
+    int eq = PyObject_RichCompareBool(left, right, Py_EQ);
+    if (eq) {
+        return eq;
+    }
+    if (!PyUnicode_Check(left) || !PyUnicode_Check(right)) {
+        return 0;
+    }
+    if (!PyUnicode_IS_ASCII(left) || !PyUnicode_IS_ASCII(right)) {
+        return 0;
+    }
+
+    Py_ssize_t len = PyUnicode_GET_LENGTH(left);
+    if (PyUnicode_GET_LENGTH(right) != len) {
+        return 0;
+    }
+    const Py_UCS1 *p1 = PyUnicode_1BYTE_DATA(left);
+    const Py_UCS1 *p2 = PyUnicode_1BYTE_DATA(right);
+    for (; len; len--, p1++, p2++) {
+        if (Py_TOLOWER(*p1) != Py_TOLOWER(*p2)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+PyObject* pysqlite_row_subscript(pysqlite_Row* self, PyObject* idx)
+{
+    Py_ssize_t _idx;
+    Py_ssize_t nitems, i;
+    PyObject* item;
+
+    if (PyLong_Check(idx)) {
+        _idx = PyNumber_AsSsize_t(idx, PyExc_IndexError);
+        if (_idx == -1 && PyErr_Occurred())
+            return NULL;
+        if (_idx < 0)
+           _idx += PyTuple_GET_SIZE(self->data);
+        item = PyTuple_GetItem(self->data, _idx);
+        Py_XINCREF(item);
+        return item;
+    } else if (PyUnicode_Check(idx)) {
+        nitems = PyTuple_Size(self->description);
+
+        for (i = 0; i < nitems; i++) {
+            PyObject *obj;
+            obj = PyTuple_GET_ITEM(self->description, i);
+            obj = PyTuple_GET_ITEM(obj, 0);
+            int eq = equal_ignore_case(idx, obj);
+            if (eq < 0) {
+                return NULL;
+            }
+
+            if (eq) {
+                /* found item */
+                item = PyTuple_GetItem(self->data, i);
+                Py_INCREF(item);
+                return item;
+            }
+        }
+
+        PyErr_SetString(PyExc_IndexError, "No item with that key");
+        return NULL;
+    }
+    else if (PySlice_Check(idx)) {
+        return PyObject_GetItem(self->data, idx);
+    }
+    else {
+        PyErr_SetString(PyExc_IndexError, "Index must be int or string");
+        return NULL;
+    }
+}
+
+static Py_ssize_t
+pysqlite_row_length(pysqlite_Row* self)
+{
+    return PyTuple_GET_SIZE(self->data);
+}
+
+PyObject* pysqlite_row_keys(pysqlite_Row* self, PyObject *Py_UNUSED(ignored))
+{
+    PyObject* list;
+    Py_ssize_t nitems, i;
+
+    list = PyList_New(0);
+    if (!list) {
+        return NULL;
+    }
+    nitems = PyTuple_Size(self->description);
+
+    for (i = 0; i < nitems; i++) {
+        if (PyList_Append(list, PyTuple_GET_ITEM(PyTuple_GET_ITEM(self->description, i), 0)) != 0) {
+            Py_DECREF(list);
+            return NULL;
+        }
+    }
+
+    return list;
+}
+
+static PyObject* pysqlite_iter(pysqlite_Row* self)
+{
+    return PyObject_GetIter(self->data);
+}
+
+static Py_hash_t pysqlite_row_hash(pysqlite_Row *self)
+{
+    return PyObject_Hash(self->description) ^ PyObject_Hash(self->data);
+}
+
+static PyObject* pysqlite_row_richcompare(pysqlite_Row *self, PyObject *_other, int opid)
+{
+    if (opid != Py_EQ && opid != Py_NE)
+        Py_RETURN_NOTIMPLEMENTED;
+
+    if (PyObject_TypeCheck(_other, &pysqlite_RowType)) {
+        pysqlite_Row *other = (pysqlite_Row *)_other;
+        int eq = PyObject_RichCompareBool(self->description, other->description, Py_EQ);
+        if (eq < 0) {
+            return NULL;
+        }
+        if (eq) {
+            return PyObject_RichCompare(self->data, other->data, opid);
+        }
+        return PyBool_FromLong(opid != Py_EQ);
+    }
+    Py_RETURN_NOTIMPLEMENTED;
+}
+
+PyMappingMethods pysqlite_row_as_mapping = {
+    /* mp_length        */ (lenfunc)pysqlite_row_length,
+    /* mp_subscript     */ (binaryfunc)pysqlite_row_subscript,
+    /* mp_ass_subscript */ (objobjargproc)0,
+};
+
+static PySequenceMethods pysqlite_row_as_sequence = {
+   /* sq_length */         (lenfunc)pysqlite_row_length,
+   /* sq_concat */         0,
+   /* sq_repeat */         0,
+   /* sq_item */           (ssizeargfunc)pysqlite_row_item,
+};
+
+
+static PyMethodDef pysqlite_row_methods[] = {
+    {"keys", (PyCFunction)pysqlite_row_keys, METH_NOARGS,
+        PyDoc_STR("Returns the keys of the row.")},
+    {NULL, NULL}
+};
+
+
+PyTypeObject pysqlite_RowType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".Row",                             /* tp_name */
+        sizeof(pysqlite_Row),                           /* tp_basicsize */
+        0,                                              /* tp_itemsize */
+        (destructor)pysqlite_row_dealloc,               /* tp_dealloc */
+        0,                                              /* tp_print */
+        0,                                              /* tp_getattr */
+        0,                                              /* tp_setattr */
+        0,                                              /* tp_reserved */
+        0,                                              /* tp_repr */
+        0,                                              /* tp_as_number */
+        0,                                              /* tp_as_sequence */
+        0,                                              /* tp_as_mapping */
+        (hashfunc)pysqlite_row_hash,                    /* tp_hash */
+        0,                                              /* tp_call */
+        0,                                              /* tp_str */
+        0,                                              /* tp_getattro */
+        0,                                              /* tp_setattro */
+        0,                                              /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,         /* tp_flags */
+        0,                                              /* tp_doc */
+        (traverseproc)0,                                /* tp_traverse */
+        0,                                              /* tp_clear */
+        (richcmpfunc)pysqlite_row_richcompare,          /* tp_richcompare */
+        0,                                              /* tp_weaklistoffset */
+        (getiterfunc)pysqlite_iter,                     /* tp_iter */
+        0,                                              /* tp_iternext */
+        pysqlite_row_methods,                           /* tp_methods */
+        0,                                              /* tp_members */
+        0,                                              /* tp_getset */
+        0,                                              /* tp_base */
+        0,                                              /* tp_dict */
+        0,                                              /* tp_descr_get */
+        0,                                              /* tp_descr_set */
+        0,                                              /* tp_dictoffset */
+        0,                                              /* tp_init */
+        0,                                              /* tp_alloc */
+        0,                                              /* tp_new */
+        0                                               /* tp_free */
+};
+
+extern int pysqlite_row_setup_types(void)
+{
+    pysqlite_RowType.tp_new = pysqlite_row_new;
+    pysqlite_RowType.tp_as_mapping = &pysqlite_row_as_mapping;
+    pysqlite_RowType.tp_as_sequence = &pysqlite_row_as_sequence;
+    return PyType_Ready(&pysqlite_RowType);
+}

--- a/packages/phoenix-sqlean/src/row.h
+++ b/packages/phoenix-sqlean/src/row.h
@@ -1,0 +1,40 @@
+/* row.h - an enhanced tuple for database rows
+ *
+ * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PYSQLITE_ROW_H
+#define PYSQLITE_ROW_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+typedef struct _Row
+{
+    PyObject_HEAD
+    PyObject* data;
+    PyObject* description;
+} pysqlite_Row;
+
+extern PyTypeObject pysqlite_RowType;
+
+int pysqlite_row_setup_types(void);
+
+#endif

--- a/packages/phoenix-sqlean/src/sqlean-time-msvc.patch
+++ b/packages/phoenix-sqlean/src/sqlean-time-msvc.patch
@@ -1,0 +1,47 @@
+--- sqlean-time.c
++++ sqlean-time.c
+@@ -13,11 +13,11 @@
+ 
+ // Common durations.
+ const Duration Nanosecond = 1;
+-const Duration Microsecond = 1000 * Nanosecond;
+-const Duration Millisecond = 1000 * Microsecond;
+-const Duration Second = 1000 * Millisecond;
+-const Duration Minute = 60 * Second;
+-const Duration Hour = 60 * Minute;
++const Duration Microsecond = 1000;
++const Duration Millisecond = 1000000;
++const Duration Second = 1000000000;
++const Duration Minute = 60000000000LL;
++const Duration Hour = 3600000000000LL;
+ 
+ #pragma region Conversion
+ 
+@@ -939,9 +939,9 @@
+ #pragma region Private
+ 
+ static const int64_t seconds_per_minute = 60;
+-static const int64_t seconds_per_hour = 60 * seconds_per_minute;
+-static const int64_t seconds_per_day = 24 * seconds_per_hour;
+-static const int64_t seconds_per_week = 7 * seconds_per_day;
++static const int64_t seconds_per_hour = 3600;
++static const int64_t seconds_per_day = 86400;
++static const int64_t seconds_per_week = 604800;
+ static const int64_t days_per_400_years = 365 * 400 + 97;
+ static const int64_t days_per_100_years = 365 * 100 + 24;
+ static const int64_t days_per_4_years = 365 * 4 + 1;
+@@ -954,11 +954,10 @@
+ // Offsets to convert between internal and absolute or Unix times.
+ // = (absoluteZeroYear - internalYear) * 365.2425 * secondsPerDay
+ static const int64_t absolute_to_internal = -9223371966579724800LL;
+-static const int64_t internal_to_absolute = -absolute_to_internal;
++static const int64_t internal_to_absolute = 9223371966579724800LL;
+ 
+-static const int64_t unix_to_internal =
+-    (1969 * 365 + 1969 / 4 - 1969 / 100 + 1969 / 400) * seconds_per_day;
+-static const int64_t internal_to_unix = -unix_to_internal;
++static const int64_t unix_to_internal = 62135596800LL;
++static const int64_t internal_to_unix = -62135596800LL;
+ 
+ // days_before[m] counts the number of days in a non-leap year
+ // before month m begins. There is an entry for m=12, counting

--- a/packages/phoenix-sqlean/src/sqlean.c
+++ b/packages/phoenix-sqlean/src/sqlean.c
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 Anton Zhiyanov, MIT License
+// https://github.com/nalgeon/sqlean.py
+
+// Sqlean extensions bundle.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sqlite3ext.h"
+SQLITE_EXTENSION_INIT1
+
+// extensions
+#include "crypto/extension.h"
+#include "define/extension.h"
+#include "fileio/extension.h"
+#include "fuzzy/extension.h"
+#if !defined(_WIN32)
+#include "ipaddr/extension.h"
+#endif
+#include "regexp/extension.h"
+#include "stats/extension.h"
+#include "text/extension.h"
+#include "time/extension.h"
+#include "unicode/extension.h"
+#include "uuid/extension.h"
+#include "vsv/extension.h"
+
+// sqlean header
+#include "sqlean.h"
+
+// sqlean_version returns the current Sqlean version.
+static void sqlean_version(sqlite3_context* context, int argc, sqlite3_value** argv) {
+    sqlite3_result_text(context, SQLEAN_VERSION, -1, SQLITE_STATIC);
+}
+
+// init_all initializes all extensions.
+static int init_all(sqlite3* db) {
+    crypto_init(db);
+    define_init(db);
+    fileio_init(db);
+    fuzzy_init(db);
+#if !defined(_WIN32)
+    ipaddr_init(db);
+#endif
+    regexp_init(db);
+    stats_init(db);
+    text_init(db);
+    time_init(db);
+    unicode_init(db);
+    uuid_init(db);
+    vsv_init(db);
+    return SQLITE_OK;
+}
+
+// init_extension initializes the extension if it's enabled according to the env variable.
+static int init_extension(const char* flag, int (*init_fn)(sqlite3* db), sqlite3* db) {
+    const char* enabled = getenv(flag);
+    if (enabled == NULL || strcmp(enabled, "0") == 0) {
+        // disable the extension unless it is explicitly enabled
+        return SQLITE_OK;
+    }
+    return init_fn(db);
+}
+
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+    int sqlite3_sqlean_init(sqlite3* db, char** errmsg_ptr, const sqlite3_api_routines* api) {
+    (void)errmsg_ptr;
+    SQLITE_EXTENSION_INIT2(api);
+
+    const char* enable_all = getenv("SQLEAN_ENABLE");
+    if (enable_all != NULL && strcmp(enable_all, "0") == 0) {
+        // SQLEAN_ENABLE == 0, disable all extensions
+        return SQLITE_OK;
+    }
+
+    static const int flags = SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC;
+    sqlite3_create_function(db, "sqlean_version", 0, flags, 0, sqlean_version, 0, 0);
+
+    if (enable_all != NULL) {
+        // SQLEAN_ENABLE != 0, enable all extensions
+        init_all(db);
+        return SQLITE_OK;
+    }
+
+    // SQLEAN_ENABLE is not set, enable individual extensions
+    init_extension("SQLEAN_ENABLE_CRYPTO", crypto_init, db);
+    init_extension("SQLEAN_ENABLE_DEFINE", define_init, db);
+    init_extension("SQLEAN_ENABLE_FILEIO", fileio_init, db);
+    init_extension("SQLEAN_ENABLE_FUZZY", fuzzy_init, db);
+#if !defined(_WIN32)
+    init_extension("SQLEAN_ENABLE_IPADDR", ipaddr_init, db);
+#endif
+    init_extension("SQLEAN_ENABLE_REGEXP", regexp_init, db);
+    init_extension("SQLEAN_ENABLE_STATS", stats_init, db);
+    init_extension("SQLEAN_ENABLE_TEXT", text_init, db);
+    init_extension("SQLEAN_ENABLE_TIME", time_init, db);
+    init_extension("SQLEAN_ENABLE_UNICODE", unicode_init, db);
+    init_extension("SQLEAN_ENABLE_UUID", uuid_init, db);
+    init_extension("SQLEAN_ENABLE_VSV", vsv_init, db);
+    return SQLITE_OK;
+}

--- a/packages/phoenix-sqlean/src/statement.c
+++ b/packages/phoenix-sqlean/src/statement.c
@@ -1,0 +1,512 @@
+/* statement.c - the statement type
+ *
+ * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "statement.h"
+#include "cursor.h"
+#include "connection.h"
+#include "microprotocols.h"
+#include "prepare_protocol.h"
+#include "util.h"
+
+/* prototypes */
+static int pysqlite_check_remaining_sql(const char* tail);
+
+typedef enum {
+    LINECOMMENT_1,
+    IN_LINECOMMENT,
+    COMMENTSTART_1,
+    IN_COMMENT,
+    COMMENTEND_1,
+    NORMAL
+} parse_remaining_sql_state;
+
+typedef enum {
+    TYPE_LONG,
+    TYPE_FLOAT,
+    TYPE_UNICODE,
+    TYPE_BUFFER,
+    TYPE_UNKNOWN
+} parameter_type;
+
+int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* connection, PyObject* sql)
+{
+    const char* tail;
+    int rc;
+    const char* sql_cstr;
+    Py_ssize_t sql_cstr_len;
+    const char* p;
+
+    self->st = NULL;
+    self->in_use = 0;
+
+    assert(PyUnicode_Check(sql));
+
+    sql_cstr = PyUnicode_AsUTF8AndSize(sql, &sql_cstr_len);
+    if (sql_cstr == NULL) {
+        rc = PYSQLITE_SQL_WRONG_TYPE;
+        return rc;
+    }
+    if (strlen(sql_cstr) != (size_t)sql_cstr_len) {
+        PyErr_SetString(PyExc_ValueError, "the query contains a null character");
+        return PYSQLITE_SQL_WRONG_TYPE;
+    }
+
+    self->in_weakreflist = NULL;
+    Py_INCREF(sql);
+    self->sql = sql;
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_prepare_v2(connection->db,
+                            sql_cstr,
+                            -1,
+                            &self->st,
+                            &tail);
+    self->is_dml = !sqlite3_stmt_readonly(self->st);
+    Py_END_ALLOW_THREADS
+
+    /* To retain backward-compatibility, we need to treat DDL and certain types
+     * of transactions as being "not-dml".
+     */
+    if (self->is_dml) {
+        for (p = sql_cstr; *p != 0; p++) {
+            switch (*p) {
+                case ' ':
+                case '\r':
+                case '\n':
+                case '\t':
+                    continue;
+            }
+
+            /* DML iff statement is not a CREATE/DROP/BEGIN. */
+            self->is_dml = (PyOS_strnicmp(p, "begin", 5) &&
+                            PyOS_strnicmp(p, "create", 6) &&
+                            PyOS_strnicmp(p, "drop", 4) &&
+                            PyOS_strnicmp(p, "alter", 5) &&
+                            PyOS_strnicmp(p, "analyze", 7) &&
+                            PyOS_strnicmp(p, "reindex", 7) &&
+                            PyOS_strnicmp(p, "vacuum", 6) &&
+                            PyOS_strnicmp(p, "pragma", 6));
+            break;
+        }
+    }
+
+    self->db = connection->db;
+
+    if (rc == SQLITE_OK && pysqlite_check_remaining_sql(tail)) {
+        (void)sqlite3_finalize(self->st);
+        self->st = NULL;
+        rc = PYSQLITE_TOO_MUCH_SQL;
+    }
+
+    return rc;
+}
+
+int pysqlite_statement_bind_parameter(pysqlite_Statement* self, int pos, PyObject* parameter)
+{
+    int rc = SQLITE_OK;
+    const char *string;
+    Py_ssize_t buflen;
+    parameter_type paramtype;
+
+    if (parameter == Py_None) {
+        rc = sqlite3_bind_null(self->st, pos);
+        goto final;
+    }
+
+    if (PyLong_CheckExact(parameter)) {
+        paramtype = TYPE_LONG;
+    } else if (PyFloat_CheckExact(parameter)) {
+        paramtype = TYPE_FLOAT;
+    } else if (PyUnicode_CheckExact(parameter)) {
+        paramtype = TYPE_UNICODE;
+    } else if (PyLong_Check(parameter)) {
+        paramtype = TYPE_LONG;
+    } else if (PyFloat_Check(parameter)) {
+        paramtype = TYPE_FLOAT;
+    } else if (PyUnicode_Check(parameter)) {
+        paramtype = TYPE_UNICODE;
+    } else if (PyObject_CheckBuffer(parameter)) {
+        paramtype = TYPE_BUFFER;
+    } else {
+        paramtype = TYPE_UNKNOWN;
+    }
+
+    switch (paramtype) {
+        case TYPE_LONG: {
+            sqlite_int64 value = _pysqlite_long_as_int64(parameter);
+            if (value == -1 && PyErr_Occurred())
+                rc = -1;
+            else
+                rc = sqlite3_bind_int64(self->st, pos, value);
+            break;
+        }
+        case TYPE_FLOAT:
+            rc = sqlite3_bind_double(self->st, pos, PyFloat_AsDouble(parameter));
+            break;
+        case TYPE_UNICODE:
+            string = PyUnicode_AsUTF8AndSize(parameter, &buflen);
+            if (string == NULL)
+                return -1;
+            if (buflen > INT_MAX) {
+                PyErr_SetString(PyExc_OverflowError,
+                                "string longer than INT_MAX bytes");
+                return -1;
+            }
+            rc = sqlite3_bind_text(self->st, pos, string, (int)buflen, SQLITE_TRANSIENT);
+            break;
+        case TYPE_BUFFER: {
+            Py_buffer view;
+            if (PyObject_GetBuffer(parameter, &view, PyBUF_SIMPLE) != 0) {
+                PyErr_SetString(PyExc_ValueError, "could not convert BLOB to buffer");
+                return -1;
+            }
+            if (view.len > INT_MAX) {
+                PyErr_SetString(PyExc_OverflowError,
+                                "BLOB longer than INT_MAX bytes");
+                PyBuffer_Release(&view);
+                return -1;
+            }
+            rc = sqlite3_bind_blob(self->st, pos, view.buf, (int)view.len, SQLITE_TRANSIENT);
+            PyBuffer_Release(&view);
+            break;
+        }
+        case TYPE_UNKNOWN:
+            rc = -1;
+    }
+
+final:
+    return rc;
+}
+
+/* returns 0 if the object is one of Python's internal ones that don't need to be adapted */
+static int _need_adapt(PyObject* obj)
+{
+    if (pysqlite_BaseTypeAdapted) {
+        return 1;
+    }
+
+    if (PyLong_CheckExact(obj) || PyFloat_CheckExact(obj)
+          || PyUnicode_CheckExact(obj) || PyByteArray_CheckExact(obj)) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+void pysqlite_statement_bind_parameters(pysqlite_Statement* self, PyObject* parameters)
+{
+    PyObject* current_param;
+    PyObject* adapted;
+    const char* binding_name;
+    int i;
+    int rc;
+    int num_params_needed;
+    Py_ssize_t num_params;
+
+    Py_BEGIN_ALLOW_THREADS
+    num_params_needed = sqlite3_bind_parameter_count(self->st);
+    Py_END_ALLOW_THREADS
+
+    if (PyTuple_CheckExact(parameters) || PyList_CheckExact(parameters) || (!PyDict_Check(parameters) && PySequence_Check(parameters))) {
+        /* parameters passed as sequence */
+        if (PyTuple_CheckExact(parameters)) {
+            num_params = PyTuple_GET_SIZE(parameters);
+        } else if (PyList_CheckExact(parameters)) {
+            num_params = PyList_GET_SIZE(parameters);
+        } else {
+            num_params = PySequence_Size(parameters);
+        }
+        if (num_params != num_params_needed) {
+            PyErr_Format(pysqlite_ProgrammingError,
+                         "Incorrect number of bindings supplied. The current "
+                         "statement uses %d, and there are %zd supplied.",
+                         num_params_needed, num_params);
+            return;
+        }
+        for (i = 0; i < num_params; i++) {
+            if (PyTuple_CheckExact(parameters)) {
+                current_param = PyTuple_GET_ITEM(parameters, i);
+                Py_XINCREF(current_param);
+            } else if (PyList_CheckExact(parameters)) {
+                current_param = PyList_GET_ITEM(parameters, i);
+                Py_XINCREF(current_param);
+            } else {
+                current_param = PySequence_GetItem(parameters, i);
+            }
+            if (!current_param) {
+                return;
+            }
+
+            if (!_need_adapt(current_param)) {
+                adapted = current_param;
+            } else {
+                adapted = pysqlite_microprotocols_adapt(current_param, (PyObject*)&pysqlite_PrepareProtocolType, current_param);
+                Py_DECREF(current_param);
+                if (!adapted) {
+                    return;
+                }
+            }
+
+            rc = pysqlite_statement_bind_parameter(self, i + 1, adapted);
+            Py_DECREF(adapted);
+
+            if (rc != SQLITE_OK) {
+                if (!PyErr_Occurred()) {
+                    PyErr_Format(pysqlite_InterfaceError, "Error binding parameter %d - probably unsupported type.", i);
+                }
+                return;
+            }
+        }
+    } else if (PyDict_Check(parameters)) {
+        /* parameters passed as dictionary */
+        for (i = 1; i <= num_params_needed; i++) {
+            PyObject *binding_name_obj;
+            Py_BEGIN_ALLOW_THREADS
+            binding_name = sqlite3_bind_parameter_name(self->st, i);
+            Py_END_ALLOW_THREADS
+            if (!binding_name) {
+                PyErr_Format(pysqlite_ProgrammingError, "Binding %d has no name, but you supplied a dictionary (which has only names).", i);
+                return;
+            }
+
+            binding_name++; /* skip first char (the colon) */
+            binding_name_obj = PyUnicode_FromString(binding_name);
+            if (!binding_name_obj) {
+                return;
+            }
+            if (PyDict_CheckExact(parameters)) {
+                current_param = PyDict_GetItemWithError(parameters, binding_name_obj);
+                Py_XINCREF(current_param);
+            } else {
+                current_param = PyObject_GetItem(parameters, binding_name_obj);
+            }
+            Py_DECREF(binding_name_obj);
+            if (!current_param) {
+                if (!PyErr_Occurred() || PyErr_ExceptionMatches(PyExc_LookupError)) {
+                    PyErr_Format(pysqlite_ProgrammingError, "You did not supply a value for binding %d.", i);
+                }
+                return;
+            }
+
+            if (!_need_adapt(current_param)) {
+                adapted = current_param;
+            } else {
+                adapted = pysqlite_microprotocols_adapt(current_param, (PyObject*)&pysqlite_PrepareProtocolType, current_param);
+                Py_DECREF(current_param);
+                if (!adapted) {
+                    return;
+                }
+            }
+
+            rc = pysqlite_statement_bind_parameter(self, i, adapted);
+            Py_DECREF(adapted);
+
+            if (rc != SQLITE_OK) {
+                if (!PyErr_Occurred()) {
+                    PyErr_Format(pysqlite_InterfaceError, "Error binding parameter :%s - probably unsupported type.", binding_name);
+                }
+                return;
+           }
+        }
+    } else {
+        PyErr_SetString(PyExc_ValueError, "parameters are of unsupported type");
+    }
+}
+
+int pysqlite_statement_finalize(pysqlite_Statement* self)
+{
+    int rc;
+
+    rc = SQLITE_OK;
+    if (self->st) {
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_finalize(self->st);
+        Py_END_ALLOW_THREADS
+        self->st = NULL;
+    }
+
+    self->in_use = 0;
+
+    return rc;
+}
+
+int pysqlite_statement_reset(pysqlite_Statement* self)
+{
+    int rc;
+
+    rc = SQLITE_OK;
+
+    if (self->in_use && self->st) {
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_reset(self->st);
+        Py_END_ALLOW_THREADS
+
+        if (rc == SQLITE_OK) {
+            self->in_use = 0;
+        }
+    }
+
+    return rc;
+}
+
+void pysqlite_statement_mark_dirty(pysqlite_Statement* self)
+{
+    self->in_use = 1;
+}
+
+void pysqlite_statement_dealloc(pysqlite_Statement* self)
+{
+    if (self->st) {
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_finalize(self->st);
+        Py_END_ALLOW_THREADS
+    }
+
+    self->st = NULL;
+
+    Py_XDECREF(self->sql);
+
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }
+
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+/*
+ * Checks if there is anything left in an SQL string after SQLite compiled it.
+ * This is used to check if somebody tried to execute more than one SQL command
+ * with one execute()/executemany() command, which the DB-API and we don't
+ * allow.
+ *
+ * Returns 1 if there is more left than should be. 0 if ok.
+ */
+static int pysqlite_check_remaining_sql(const char* tail)
+{
+    const char* pos = tail;
+
+    parse_remaining_sql_state state = NORMAL;
+
+    for (;;) {
+        switch (*pos) {
+            case 0:
+                return 0;
+            case '-':
+                if (state == NORMAL) {
+                    state  = LINECOMMENT_1;
+                } else if (state == LINECOMMENT_1) {
+                    state = IN_LINECOMMENT;
+                }
+                break;
+            case ' ':
+            case '\t':
+                break;
+            case '\n':
+            case 13:
+                if (state == IN_LINECOMMENT) {
+                    state = NORMAL;
+                }
+                break;
+            case '/':
+                if (state == NORMAL) {
+                    state = COMMENTSTART_1;
+                } else if (state == COMMENTEND_1) {
+                    state = NORMAL;
+                } else if (state == COMMENTSTART_1) {
+                    return 1;
+                }
+                break;
+            case '*':
+                if (state == NORMAL) {
+                    return 1;
+                } else if (state == LINECOMMENT_1) {
+                    return 1;
+                } else if (state == COMMENTSTART_1) {
+                    state = IN_COMMENT;
+                } else if (state == IN_COMMENT) {
+                    state = COMMENTEND_1;
+                }
+                break;
+            default:
+                if (state == COMMENTEND_1) {
+                    state = IN_COMMENT;
+                } else if (state == IN_LINECOMMENT) {
+                } else if (state == IN_COMMENT) {
+                } else {
+                    return 1;
+                }
+        }
+
+        pos++;
+    }
+
+    return 0;
+}
+
+PyTypeObject pysqlite_StatementType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".Statement",                       /* tp_name */
+        sizeof(pysqlite_Statement),                     /* tp_basicsize */
+        0,                                              /* tp_itemsize */
+        (destructor)pysqlite_statement_dealloc,         /* tp_dealloc */
+        0,                                              /* tp_print */
+        0,                                              /* tp_getattr */
+        0,                                              /* tp_setattr */
+        0,                                              /* tp_reserved */
+        0,                                              /* tp_repr */
+        0,                                              /* tp_as_number */
+        0,                                              /* tp_as_sequence */
+        0,                                              /* tp_as_mapping */
+        0,                                              /* tp_hash */
+        0,                                              /* tp_call */
+        0,                                              /* tp_str */
+        0,                                              /* tp_getattro */
+        0,                                              /* tp_setattro */
+        0,                                              /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT,                             /* tp_flags */
+        0,                                              /* tp_doc */
+        0,                                              /* tp_traverse */
+        0,                                              /* tp_clear */
+        0,                                              /* tp_richcompare */
+        offsetof(pysqlite_Statement, in_weakreflist),   /* tp_weaklistoffset */
+        0,                                              /* tp_iter */
+        0,                                              /* tp_iternext */
+        0,                                              /* tp_methods */
+        0,                                              /* tp_members */
+        0,                                              /* tp_getset */
+        0,                                              /* tp_base */
+        0,                                              /* tp_dict */
+        0,                                              /* tp_descr_get */
+        0,                                              /* tp_descr_set */
+        0,                                              /* tp_dictoffset */
+        (initproc)0,                                    /* tp_init */
+        0,                                              /* tp_alloc */
+        0,                                              /* tp_new */
+        0                                               /* tp_free */
+};
+
+extern int pysqlite_statement_setup_types(void)
+{
+    pysqlite_StatementType.tp_new = PyType_GenericNew;
+    return PyType_Ready(&pysqlite_StatementType);
+}

--- a/packages/phoenix-sqlean/src/statement.h
+++ b/packages/phoenix-sqlean/src/statement.h
@@ -1,0 +1,60 @@
+/* statement.h - definitions for the statement type
+ *
+ * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PYSQLITE_STATEMENT_H
+#define PYSQLITE_STATEMENT_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+#include "connection.h"
+#include "sqlite3.h"
+
+#define PYSQLITE_TOO_MUCH_SQL (-100)
+#define PYSQLITE_SQL_WRONG_TYPE (-101)
+
+typedef struct
+{
+    PyObject_HEAD
+    sqlite3* db;
+    sqlite3_stmt* st;
+    PyObject* sql;
+    int in_use;
+    int is_dml;
+    PyObject* in_weakreflist; /* List of weak references */
+} pysqlite_Statement;
+
+extern PyTypeObject pysqlite_StatementType;
+
+int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* connection, PyObject* sql);
+void pysqlite_statement_dealloc(pysqlite_Statement* self);
+
+int pysqlite_statement_bind_parameter(pysqlite_Statement* self, int pos, PyObject* parameter);
+void pysqlite_statement_bind_parameters(pysqlite_Statement* self, PyObject* parameters);
+
+int pysqlite_statement_finalize(pysqlite_Statement* self);
+int pysqlite_statement_reset(pysqlite_Statement* self);
+void pysqlite_statement_mark_dirty(pysqlite_Statement* self);
+
+int pysqlite_statement_setup_types(void);
+
+#endif

--- a/packages/phoenix-sqlean/src/test_windirent.h
+++ b/packages/phoenix-sqlean/src/test_windirent.h
@@ -1,0 +1,158 @@
+/*
+** 2015 November 30
+**
+** The author disclaims copyright to this source code.  In place of
+** a legal notice, here is a blessing:
+**
+**    May you do good and not evil.
+**    May you find forgiveness for yourself and forgive others.
+**    May you share freely, never taking more than you give.
+**
+*************************************************************************
+** This file contains declarations for most of the opendir() family of
+** POSIX functions on Win32 using the MSVCRT.
+*/
+
+#if defined(_WIN32) && defined(_MSC_VER) && !defined(SQLITE_WINDIRENT_H)
+#define SQLITE_WINDIRENT_H
+
+/*
+** We need several data types from the Windows SDK header.
+*/
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include "windows.h"
+
+/*
+** We need several support functions from the SQLite core.
+*/
+
+#include "sqlite3.h"
+
+/*
+** We need several things from the ANSI and MSVCRT headers.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <io.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/*
+** We may need several defines that should have been in "sys/stat.h".
+*/
+
+#ifndef S_ISREG
+#define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+
+#ifndef S_ISDIR
+#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+
+#ifndef S_ISLNK
+#define S_ISLNK(mode) (0)
+#endif
+
+/*
+** We may need to provide the "mode_t" type.
+*/
+
+#ifndef MODE_T_DEFINED
+  #define MODE_T_DEFINED
+  typedef unsigned short mode_t;
+#endif
+
+/*
+** We may need to provide the "ino_t" type.
+*/
+
+#ifndef INO_T_DEFINED
+  #define INO_T_DEFINED
+  typedef unsigned short ino_t;
+#endif
+
+/*
+** We need to define "NAME_MAX" if it was not present in "limits.h".
+*/
+
+#ifndef NAME_MAX
+#  ifdef FILENAME_MAX
+#    define NAME_MAX (FILENAME_MAX)
+#  else
+#    define NAME_MAX (260)
+#  endif
+#  define DIRENT_NAME_MAX (NAME_MAX)
+#endif
+
+/*
+** We need to define "NULL_INTPTR_T" and "BAD_INTPTR_T".
+*/
+
+#ifndef NULL_INTPTR_T
+#  define NULL_INTPTR_T ((intptr_t)(0))
+#endif
+
+#ifndef BAD_INTPTR_T
+#  define BAD_INTPTR_T ((intptr_t)(-1))
+#endif
+
+/*
+** We need to provide the necessary structures and related types.
+*/
+
+#ifndef DIRENT_DEFINED
+#define DIRENT_DEFINED
+typedef struct DIRENT DIRENT;
+typedef DIRENT *LPDIRENT;
+struct DIRENT {
+  ino_t d_ino;               /* Sequence number, do not use. */
+  unsigned d_attributes;     /* Win32 file attributes. */
+  char d_name[NAME_MAX + 1]; /* Name within the directory. */
+};
+#endif
+
+#ifndef DIR_DEFINED
+#define DIR_DEFINED
+typedef struct DIR DIR;
+typedef DIR *LPDIR;
+struct DIR {
+  intptr_t d_handle; /* Value returned by "_findfirst". */
+  DIRENT d_first;    /* DIRENT constructed based on "_findfirst". */
+  DIRENT d_next;     /* DIRENT constructed based on "_findnext". */
+};
+#endif
+
+/*
+** Provide a macro, for use by the implementation, to determine if a
+** particular directory entry should be skipped over when searching for
+** the next directory entry that should be returned by the readdir().
+*/
+
+#ifndef is_filtered
+#  define is_filtered(a) ((((a).attrib)&_A_HIDDEN) || (((a).attrib)&_A_SYSTEM))
+#endif
+
+/*
+** Provide the function prototype for the POSIX compatible getenv()
+** function.  This function is not thread-safe.
+*/
+
+extern const char *windirent_getenv(const char *name);
+
+/*
+** Finally, we can provide the function prototypes for the opendir(),
+** readdir(), and closedir() POSIX functions.
+*/
+
+extern LPDIR opendir(const char *dirname);
+extern LPDIRENT readdir(LPDIR dirp);
+extern INT closedir(LPDIR dirp);
+
+#endif /* defined(WIN32) && defined(_MSC_VER) */

--- a/packages/phoenix-sqlean/src/util.c
+++ b/packages/phoenix-sqlean/src/util.c
@@ -1,0 +1,175 @@
+/* util.c - various utility functions
+ *
+ * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "module.h"
+#include "connection.h"
+
+int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection)
+{
+    int rc;
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_step(statement);
+    Py_END_ALLOW_THREADS
+
+    return rc;
+}
+
+/**
+ * Checks the SQLite error code and sets the appropriate DB-API exception.
+ * Returns the error code (0 means no error occurred).
+ */
+int _pysqlite_seterror(sqlite3* db)
+{
+    PyObject *exc_class;
+    int errorcode = sqlite3_errcode(db);
+
+    switch (errorcode)
+    {
+        case SQLITE_OK:
+            PyErr_Clear();
+            return errorcode;
+        case SQLITE_INTERNAL:
+        case SQLITE_NOTFOUND:
+            exc_class = pysqlite_InternalError;
+            break;
+        case SQLITE_NOMEM:
+            (void)PyErr_NoMemory();
+            return errorcode;
+        case SQLITE_ERROR:
+        case SQLITE_PERM:
+        case SQLITE_ABORT:
+        case SQLITE_BUSY:
+        case SQLITE_LOCKED:
+        case SQLITE_READONLY:
+        case SQLITE_INTERRUPT:
+        case SQLITE_IOERR:
+        case SQLITE_FULL:
+        case SQLITE_CANTOPEN:
+        case SQLITE_PROTOCOL:
+        case SQLITE_EMPTY:
+        case SQLITE_SCHEMA:
+            exc_class = pysqlite_OperationalError;
+            break;
+        case SQLITE_CORRUPT:
+            exc_class = pysqlite_DatabaseError;
+            break;
+        case SQLITE_TOOBIG:
+            exc_class = pysqlite_DataError;
+            break;
+        case SQLITE_CONSTRAINT:
+        case SQLITE_MISMATCH:
+            exc_class = pysqlite_IntegrityError;
+            break;
+        case SQLITE_MISUSE:
+            exc_class = pysqlite_ProgrammingError;;
+            break;
+        default:
+            exc_class = pysqlite_DatabaseError;
+            break;
+    }
+
+    /* Create and set the exception. */
+    {
+        const char *error_msg;
+        const char *error_name;
+        PyObject *exc = NULL;
+        PyObject *args = NULL;
+        PyObject *py_code = NULL;
+        PyObject *py_name = NULL;
+
+        error_name = sqlite3ErrName(errorcode);
+
+        error_msg = sqlite3_errmsg(db);
+
+        args = Py_BuildValue("(s)", error_msg);
+        if (!args)
+            goto error;
+
+        exc = PyObject_Call(exc_class, args, NULL);
+        if (!exc)
+            goto error;
+
+        py_code = Py_BuildValue("i", errorcode);
+        if (!py_code)
+            goto error;
+
+        if (PyObject_SetAttrString(exc, "sqlite_errorcode", py_code) < 0)
+            goto error;
+
+        py_name = Py_BuildValue("s", error_name);
+        if (!py_name)
+            goto error;
+
+        if (PyObject_SetAttrString(exc, "sqlite_errorname", py_name) < 0)
+            goto error;
+
+        PyErr_SetObject((PyObject *) Py_TYPE(exc), exc);
+
+    error:
+        Py_XDECREF(py_code);
+        Py_XDECREF(py_name);
+        Py_XDECREF(args);
+        Py_XDECREF(exc);
+    }
+
+    return errorcode;
+}
+
+#ifdef WORDS_BIGENDIAN
+# define IS_LITTLE_ENDIAN 0
+#else
+# define IS_LITTLE_ENDIAN 1
+#endif
+
+sqlite_int64
+_pysqlite_long_as_int64(PyObject * py_val)
+{
+    int overflow;
+    long long value = PyLong_AsLongLongAndOverflow(py_val, &overflow);
+    if (value == -1 && PyErr_Occurred())
+        return -1;
+    if (!overflow) {
+# if SIZEOF_LONG_LONG > 8
+        if (-0x8000000000000000LL <= value && value <= 0x7FFFFFFFFFFFFFFFLL)
+# endif
+            return value;
+    }
+    else if (sizeof(value) < sizeof(sqlite_int64)) {
+        sqlite_int64 int64val;
+#if PY_VERSION_HEX < 0x030D0000
+        if (_PyLong_AsByteArray((PyLongObject *)py_val,
+                                (unsigned char *)&int64val, sizeof(int64val),
+                                IS_LITTLE_ENDIAN, 1 /* signed */) >= 0) {
+#else
+        if (_PyLong_AsByteArray((PyLongObject *)py_val,
+                                (unsigned char *)&int64val, sizeof(int64val),
+                                IS_LITTLE_ENDIAN, 1 /* signed */, 1) >= 0) {
+#endif
+            return int64val;
+        }
+    }
+    PyErr_SetString(PyExc_OverflowError,
+                    "Python int too large to convert to SQLite INTEGER");
+    return -1;
+}

--- a/packages/phoenix-sqlean/src/util.h
+++ b/packages/phoenix-sqlean/src/util.h
@@ -1,0 +1,84 @@
+/* util.h - various utility functions
+ *
+ * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
+ *
+ * This file is part of pysqlite.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PYSQLITE_UTIL_H
+#define PYSQLITE_UTIL_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+#include "pythread.h"
+#include "sqlite3.h"
+#include "connection.h"
+
+int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection);
+
+/**
+ * Checks the SQLite error code and sets the appropriate DB-API exception.
+ * Returns the error code (0 means no error occurred).
+ */
+int _pysqlite_seterror(sqlite3* db);
+
+sqlite_int64 _pysqlite_long_as_int64(PyObject * value);
+
+#ifndef _Py_CAST
+#  define _Py_CAST(type, expr) ((type)(expr))
+#endif
+
+// Cast argument to PyObject* type.
+#ifndef _PyObject_CAST
+#  define _PyObject_CAST(op) _Py_CAST(PyObject*, op)
+#endif
+
+#if PY_VERSION_HEX < 0x030A00A3 && !defined(Py_NewRef)
+static inline PyObject* _Py_NewRef(PyObject *obj)
+{
+    Py_INCREF(obj);
+    return obj;
+}
+#define Py_NewRef(obj) _Py_NewRef(_PyObject_CAST(obj))
+#endif
+
+#if PY_VERSION_HEX < 0x030D0000
+static inline int PyWeakref_GetRef(PyObject *ref, PyObject **pobj)
+{
+    PyObject *obj;
+    if (ref != NULL && !PyWeakref_Check(ref)) {
+        *pobj = NULL;
+        PyErr_SetString(PyExc_TypeError, "expected a weakref");
+        return -1;
+    }
+    obj = PyWeakref_GetObject(ref);
+    if (obj == NULL) {
+        // SystemError if ref is NULL
+        *pobj = NULL;
+        return -1;
+    }
+    if (obj == Py_None) {
+        *pobj = NULL;
+        return 0;
+    }
+    *pobj = Py_NewRef(obj);
+    return (*pobj != NULL);
+}
+#endif
+
+#endif

--- a/packages/phoenix-sqlean/tests/__main__.py
+++ b/packages/phoenix-sqlean/tests/__main__.py
@@ -1,0 +1,41 @@
+import optparse
+import sys
+import unittest
+
+from tests.backup import suite as backup_suite
+from tests.dbapi import suite as dbapi_suite
+from tests.extensions import suite as extensions_suite
+from tests.factory import suite as factory_suite
+from tests.hooks import suite as hooks_suite
+from tests.regression import suite as regression_suite
+from tests.transactions import suite as transactions_suite
+from tests.ttypes import suite as types_suite
+from tests.userfunctions import suite as userfunctions_suite
+
+
+def test(verbosity=1, failfast=False):
+    runner = unittest.TextTestRunner(verbosity=verbosity, failfast=failfast)
+    all_tests = unittest.TestSuite((
+        backup_suite(),
+        dbapi_suite(),
+        extensions_suite(),
+        factory_suite(),
+        hooks_suite(),
+        regression_suite(),
+        transactions_suite(),
+        types_suite(),
+        userfunctions_suite()))
+    results = runner.run(all_tests)
+    return results.failures, results.errors
+
+
+if __name__ == '__main__':
+    parser = optparse.OptionParser()
+    parser.add_option('-v', '--verbosity', default=1, dest='verbosity',
+                      type='int', help='output verbosity, default=1')
+    parser.add_option('-f', '--failfast', action='store_true', dest='failfast')
+    options, args = parser.parse_args()
+
+    failures, errors = test(options.verbosity, options.failfast)
+    if failures or errors:
+        sys.exit(1)

--- a/packages/phoenix-sqlean/tests/backup.py
+++ b/packages/phoenix-sqlean/tests/backup.py
@@ -1,0 +1,183 @@
+from sqlean import dbapi2 as sqlite
+import unittest
+
+
+@unittest.skipIf(sqlite.sqlite_version_info < (3, 6, 11), "Backup API not supported")
+class BackupTests(unittest.TestCase):
+    def setUp(self):
+        cx = self.cx = sqlite.connect(":memory:")
+        cx.execute('CREATE TABLE foo (key INTEGER)')
+        cx.executemany('INSERT INTO foo (key) VALUES (?)', [(3,), (4,)])
+        cx.commit()
+
+    def tearDown(self):
+        self.cx.close()
+
+    def verify_backup(self, bckcx):
+        result = bckcx.execute("SELECT key FROM foo ORDER BY key").fetchall()
+        self.assertEqual(result[0][0], 3)
+        self.assertEqual(result[1][0], 4)
+
+    def test_bad_target_none(self):
+        with self.assertRaises(TypeError):
+            self.cx.backup(None)
+
+    def test_bad_target_filename(self):
+        with self.assertRaises(TypeError):
+            self.cx.backup('some_file_name.db')
+
+    def test_bad_target_same_connection(self):
+        with self.assertRaises(ValueError):
+            self.cx.backup(self.cx)
+
+    def test_bad_target_closed_connection(self):
+        bck = sqlite.connect(':memory:')
+        bck.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cx.backup(bck)
+
+    def test_bad_target_in_transaction(self):
+        bck = sqlite.connect(':memory:')
+        bck.execute('CREATE TABLE bar (key INTEGER)')
+        bck.executemany('INSERT INTO bar (key) VALUES (?)', [(3,), (4,)])
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            self.cx.backup(bck)
+        if sqlite.sqlite_version_info < (3, 8, 8):
+            self.assertEqual(str(cm.exception), 'target is in transaction')
+
+    def test_keyword_only_args(self):
+        with self.assertRaises(TypeError):
+            with sqlite.connect(':memory:') as bck:
+                self.cx.backup(bck, 1)
+
+    def test_simple(self):
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck)
+            self.verify_backup(bck)
+
+    def test_progress(self):
+        journal = []
+
+        def progress(status, remaining, total):
+            journal.append(status)
+
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck, pages=1, progress=progress)
+            self.verify_backup(bck)
+
+        self.assertEqual(len(journal), 2)
+        self.assertEqual(journal[0], sqlite.SQLITE_OK)
+        self.assertEqual(journal[1], sqlite.SQLITE_DONE)
+
+    def test_progress_all_pages_at_once_1(self):
+        journal = []
+
+        def progress(status, remaining, total):
+            journal.append(remaining)
+
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck, progress=progress)
+            self.verify_backup(bck)
+
+        self.assertEqual(len(journal), 1)
+        self.assertEqual(journal[0], 0)
+
+    def test_progress_all_pages_at_once_2(self):
+        journal = []
+
+        def progress(status, remaining, total):
+            journal.append(remaining)
+
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck, pages=-1, progress=progress)
+            self.verify_backup(bck)
+
+        self.assertEqual(len(journal), 1)
+        self.assertEqual(journal[0], 0)
+
+    def test_sleep(self):
+        with self.assertRaises(ValueError) as bm:
+            with sqlite.connect(':memory:') as bck:
+                self.cx.backup(bck, sleep=-1)
+        self.assertEqual(str(bm.exception), 'sleep must be greater-than or equal to zero')
+
+        with self.assertRaises(TypeError):
+            with sqlite.connect(':memory:') as bck:
+                self.cx.backup(bck, sleep=None)
+
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck, sleep=10)
+            self.verify_backup(bck)
+
+    def test_non_callable_progress(self):
+        with self.assertRaises(TypeError) as cm:
+            with sqlite.connect(':memory:') as bck:
+                self.cx.backup(bck, pages=1, progress='bar')
+        self.assertEqual(str(cm.exception), 'progress argument must be a callable')
+
+    def test_modifying_progress(self):
+        journal = []
+
+        def progress(status, remaining, total):
+            if not journal:
+                self.cx.execute('INSERT INTO foo (key) VALUES (?)', (remaining+1000,))
+                self.cx.commit()
+            journal.append(remaining)
+
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck, pages=1, progress=progress)
+            self.verify_backup(bck)
+
+            result = bck.execute("SELECT key FROM foo"
+                                 " WHERE key >= 1000"
+                                 " ORDER BY key").fetchall()
+            self.assertEqual(result[0][0], 1001)
+
+        self.assertEqual(len(journal), 3)
+        self.assertEqual(journal[0], 1)
+        self.assertEqual(journal[1], 1)
+        self.assertEqual(journal[2], 0)
+
+    def test_failing_progress(self):
+        def progress(status, remaining, total):
+            raise SystemError('nearly out of space')
+
+        with self.assertRaises(SystemError) as err:
+            with sqlite.connect(':memory:') as bck:
+                self.cx.backup(bck, progress=progress)
+        self.assertEqual(str(err.exception), 'nearly out of space')
+
+    def test_database_source_name(self):
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck, name='main')
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck, name='temp')
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            with sqlite.connect(':memory:') as bck:
+                self.cx.backup(bck, name='non-existing')
+        self.assertIn(
+            str(cm.exception),
+            ['SQL logic error', 'SQL logic error or missing database']
+        )
+
+        self.cx.execute("ATTACH DATABASE ':memory:' AS attached_db")
+        self.cx.execute('CREATE TABLE attached_db.foo (key INTEGER)')
+        self.cx.executemany('INSERT INTO attached_db.foo (key) VALUES (?)', [(3,), (4,)])
+        self.cx.commit()
+        with sqlite.connect(':memory:') as bck:
+            self.cx.backup(bck, name='attached_db')
+            self.verify_backup(bck)
+
+
+def suite():
+    loader = unittest.TestLoader()
+    tests = [loader.loadTestsFromTestCase(t) for t in (
+        BackupTests,)]
+    return unittest.TestSuite(tests)
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/dbapi.py
+++ b/packages/phoenix-sqlean/tests/dbapi.py
@@ -1,0 +1,1227 @@
+#-*- coding: iso-8859-1 -*-
+# pysqlite2/test/dbapi.py: tests for DB-API compliance
+#
+# Copyright (C) 2004-2010 Gerhard H�ring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+import os
+import tempfile
+import threading
+import unittest
+
+from sqlean import dbapi2 as sqlite
+
+#from test.support import TESTFN, unlink
+TESTFN = os.path.join(tempfile.gettempdir(), 'pysqlite3_test')
+from os import unlink
+
+
+class ModuleTests(unittest.TestCase):
+    def test_APILevel(self):
+        self.assertEqual(sqlite.apilevel, "2.0",
+                         "apilevel is %s, should be 2.0" % sqlite.apilevel)
+
+    def test_ThreadSafety(self):
+        self.assertEqual(sqlite.threadsafety, 1,
+                         "threadsafety is %d, should be 1" % sqlite.threadsafety)
+
+    def test_ParamStyle(self):
+        self.assertEqual(sqlite.paramstyle, "qmark",
+                         "paramstyle is '%s', should be 'qmark'" %
+                         sqlite.paramstyle)
+
+    def test_Warning(self):
+        self.assertTrue(issubclass(sqlite.Warning, Exception),
+                     "Warning is not a subclass of Exception")
+
+    def test_Error(self):
+        self.assertTrue(issubclass(sqlite.Error, Exception),
+                        "Error is not a subclass of Exception")
+
+    def test_InterfaceError(self):
+        self.assertTrue(issubclass(sqlite.InterfaceError, sqlite.Error),
+                        "InterfaceError is not a subclass of Error")
+
+    def test_DatabaseError(self):
+        self.assertTrue(issubclass(sqlite.DatabaseError, sqlite.Error),
+                        "DatabaseError is not a subclass of Error")
+
+    def test_DataError(self):
+        self.assertTrue(issubclass(sqlite.DataError, sqlite.DatabaseError),
+                        "DataError is not a subclass of DatabaseError")
+
+    def test_OperationalError(self):
+        self.assertTrue(issubclass(sqlite.OperationalError, sqlite.DatabaseError),
+                        "OperationalError is not a subclass of DatabaseError")
+
+    def test_IntegrityError(self):
+        self.assertTrue(issubclass(sqlite.IntegrityError, sqlite.DatabaseError),
+                        "IntegrityError is not a subclass of DatabaseError")
+
+    def test_InternalError(self):
+        self.assertTrue(issubclass(sqlite.InternalError, sqlite.DatabaseError),
+                        "InternalError is not a subclass of DatabaseError")
+
+    def test_ProgrammingError(self):
+        self.assertTrue(issubclass(sqlite.ProgrammingError, sqlite.DatabaseError),
+                        "ProgrammingError is not a subclass of DatabaseError")
+
+    def test_NotSupportedError(self):
+        self.assertTrue(issubclass(sqlite.NotSupportedError,
+                                   sqlite.DatabaseError),
+                        "NotSupportedError is not a subclass of DatabaseError")
+
+    def test_ErrorCodeOnException(self):
+        with self.assertRaises(sqlite.Error) as cm:
+            db = sqlite.connect('/no/such/file/exists')
+        e = cm.exception
+        self.assertEqual(e.sqlite_errorcode, sqlite.SQLITE_CANTOPEN)
+        self.assertEqual(e.sqlite_errorname, "SQLITE_CANTOPEN")
+        self.assertEqual(str(e), "unable to open database file")
+
+class ConnectionTests(unittest.TestCase):
+
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        cu = self.cx.cursor()
+        cu.execute("create table test(id integer primary key, name text)")
+        cu.execute("insert into test(name) values (?)", ("foo",))
+
+    def tearDown(self):
+        self.cx.close()
+
+    def test_Commit(self):
+        self.cx.commit()
+
+    def test_CommitAfterNoChanges(self):
+        """
+        A commit should also work when no changes were made to the database.
+        """
+        self.cx.commit()
+        self.cx.commit()
+
+    def test_Rollback(self):
+        self.cx.rollback()
+
+    def test_RollbackAfterNoChanges(self):
+        """
+        A rollback should also work when no changes were made to the database.
+        """
+        self.cx.rollback()
+        self.cx.rollback()
+
+    def test_Cursor(self):
+        cu = self.cx.cursor()
+
+    def test_FailedOpen(self):
+        YOU_CANNOT_OPEN_THIS = "/foo/bar/bla/23534/mydb.db"
+        with self.assertRaises(sqlite.OperationalError):
+            con = sqlite.connect(YOU_CANNOT_OPEN_THIS)
+
+    def test_Close(self):
+        self.cx.close()
+
+    def test_Exceptions(self):
+        # Optional DB-API extension.
+        self.assertEqual(self.cx.Warning, sqlite.Warning)
+        self.assertEqual(self.cx.Error, sqlite.Error)
+        self.assertEqual(self.cx.InterfaceError, sqlite.InterfaceError)
+        self.assertEqual(self.cx.DatabaseError, sqlite.DatabaseError)
+        self.assertEqual(self.cx.DataError, sqlite.DataError)
+        self.assertEqual(self.cx.OperationalError, sqlite.OperationalError)
+        self.assertEqual(self.cx.IntegrityError, sqlite.IntegrityError)
+        self.assertEqual(self.cx.InternalError, sqlite.InternalError)
+        self.assertEqual(self.cx.ProgrammingError, sqlite.ProgrammingError)
+        self.assertEqual(self.cx.NotSupportedError, sqlite.NotSupportedError)
+
+    def test_InTransaction(self):
+        # Can't use db from setUp because we want to test initial state.
+        cx = sqlite.connect(":memory:")
+        cu = cx.cursor()
+        self.assertEqual(cx.in_transaction, False)
+        cu.execute("create table transactiontest(id integer primary key, name text)")
+        self.assertEqual(cx.in_transaction, False)
+        cu.execute("insert into transactiontest(name) values (?)", ("foo",))
+        self.assertEqual(cx.in_transaction, True)
+        cu.execute("select name from transactiontest where name=?", ["foo"])
+        row = cu.fetchone()
+        self.assertEqual(cx.in_transaction, True)
+        cx.commit()
+        self.assertEqual(cx.in_transaction, False)
+        cu.execute("select name from transactiontest where name=?", ["foo"])
+        row = cu.fetchone()
+        self.assertEqual(cx.in_transaction, False)
+
+    def test_InTransactionRO(self):
+        with self.assertRaises(AttributeError):
+            self.cx.in_transaction = True
+
+    def test_OpenWithPathLikeObject(self):
+        """ Checks that we can successfully connect to a database using an object that
+            is PathLike, i.e. has __fspath__(). """
+        self.addCleanup(unlink, TESTFN)
+        class Path:
+            def __fspath__(self):
+                return TESTFN
+        path = Path()
+        with sqlite.connect(path) as cx:
+            cx.execute('create table test(id integer)')
+
+    def test_OpenUri(self):
+        if sqlite.sqlite_version_info < (3, 7, 7):
+            with self.assertRaises(sqlite.NotSupportedError):
+                sqlite.connect(':memory:', uri=True)
+            return
+        self.addCleanup(unlink, TESTFN)
+        with sqlite.connect(TESTFN) as cx:
+            cx.execute('create table test(id integer)')
+        with sqlite.connect('file:' + TESTFN, uri=True) as cx:
+            cx.execute('insert into test(id) values(0)')
+        with sqlite.connect('file:' + TESTFN + '?mode=ro', uri=True) as cx:
+            with self.assertRaises(sqlite.OperationalError):
+                cx.execute('insert into test(id) values(1)')
+
+    @unittest.skipIf(sqlite.sqlite_version_info >= (3, 3, 1),
+                     'needs sqlite versions older than 3.3.1')
+    def test_SameThreadErrorOnOldVersion(self):
+        with self.assertRaises(sqlite.NotSupportedError) as cm:
+            sqlite.connect(':memory:', check_same_thread=False)
+        self.assertEqual(str(cm.exception), 'shared connections not available')
+
+class CursorTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cu = self.cx.cursor()
+        self.cu.execute(
+            "create table test(id integer primary key, name text, "
+            "income number, unique_test text unique)"
+        )
+        self.cu.execute("insert into test(name) values (?)", ("foo",))
+
+    def tearDown(self):
+        self.cu.close()
+        self.cx.close()
+
+    def test_ExecuteNoArgs(self):
+        self.cu.execute("delete from test")
+
+    def test_ExecuteIllegalSql(self):
+        with self.assertRaises(sqlite.OperationalError):
+            self.cu.execute("select asdf")
+
+    def test_ExecuteTooMuchSql(self):
+        with self.assertRaises(sqlite.Warning):
+            self.cu.execute("select 5+4; select 4+5")
+
+    def test_ExecuteTooMuchSql2(self):
+        self.cu.execute("select 5+4; -- foo bar")
+
+    def test_ExecuteTooMuchSql3(self):
+        self.cu.execute("""
+            select 5+4;
+
+            /*
+            foo
+            */
+            """)
+
+    def test_ExecuteWrongSqlArg(self):
+        with self.assertRaises(TypeError):
+            self.cu.execute(42)
+
+    def test_ExecuteArgInt(self):
+        self.cu.execute("insert into test(id) values (?)", (42,))
+
+    def test_ExecuteArgFloat(self):
+        self.cu.execute("insert into test(income) values (?)", (2500.32,))
+
+    def test_ExecuteArgString(self):
+        self.cu.execute("insert into test(name) values (?)", ("Hugo",))
+
+    def test_ExecuteArgStringWithZeroByte(self):
+        self.cu.execute("insert into test(name) values (?)", ("Hu\x00go",))
+
+        self.cu.execute("select name from test where id=?", (self.cu.lastrowid,))
+        row = self.cu.fetchone()
+        self.assertEqual(row[0], "Hu\x00go")
+
+    def test_ExecuteNonIterable(self):
+        with self.assertRaises(ValueError) as cm:
+            self.cu.execute("insert into test(id) values (?)", 42)
+        self.assertEqual(str(cm.exception), 'parameters are of unsupported type')
+
+    def test_ExecuteWrongNoOfArgs1(self):
+        # too many parameters
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cu.execute("insert into test(id) values (?)", (17, "Egon"))
+
+    def test_ExecuteWrongNoOfArgs2(self):
+        # too little parameters
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cu.execute("insert into test(id) values (?)")
+
+    def test_ExecuteWrongNoOfArgs3(self):
+        # no parameters, parameters are needed
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cu.execute("insert into test(id) values (?)")
+
+    def test_ExecuteParamList(self):
+        self.cu.execute("insert into test(name) values ('foo')")
+        self.cu.execute("select name from test where name=?", ["foo"])
+        row = self.cu.fetchone()
+        self.assertEqual(row[0], "foo")
+
+    def test_ExecuteParamSequence(self):
+        class L(object):
+            def __len__(self):
+                return 1
+            def __getitem__(self, x):
+                assert x == 0
+                return "foo"
+
+        self.cu.execute("insert into test(name) values ('foo')")
+        self.cu.execute("select name from test where name=?", L())
+        row = self.cu.fetchone()
+        self.assertEqual(row[0], "foo")
+
+    def test_ExecuteDictMapping(self):
+        self.cu.execute("insert into test(name) values ('foo')")
+        self.cu.execute("select name from test where name=:name", {"name": "foo"})
+        row = self.cu.fetchone()
+        self.assertEqual(row[0], "foo")
+
+    def test_ExecuteDictMapping_Mapping(self):
+        class D(dict):
+            def __missing__(self, key):
+                return "foo"
+
+        self.cu.execute("insert into test(name) values ('foo')")
+        self.cu.execute("select name from test where name=:name", D())
+        row = self.cu.fetchone()
+        self.assertEqual(row[0], "foo")
+
+    def test_ExecuteDictMappingTooLittleArgs(self):
+        self.cu.execute("insert into test(name) values ('foo')")
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cu.execute("select name from test where name=:name and id=:id", {"name": "foo"})
+
+    def test_ExecuteDictMappingNoArgs(self):
+        self.cu.execute("insert into test(name) values ('foo')")
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cu.execute("select name from test where name=:name")
+
+    def test_ExecuteDictMappingUnnamed(self):
+        self.cu.execute("insert into test(name) values ('foo')")
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cu.execute("select name from test where name=?", {"name": "foo"})
+
+    def test_Close(self):
+        self.cu.close()
+
+    def test_RowcountExecute(self):
+        self.cu.execute("delete from test")
+        self.cu.execute("insert into test(name) values ('foo')")
+        self.cu.execute("insert into test(name) values ('foo')")
+        self.cu.execute("update test set name='bar'")
+        self.assertEqual(self.cu.rowcount, 2)
+
+    def test_RowcountSelect(self):
+        """
+        pysqlite does not know the rowcount of SELECT statements, because we
+        don't fetch all rows after executing the select statement. The rowcount
+        has thus to be -1.
+        """
+        self.cu.execute("select 5 union select 6")
+        self.assertEqual(self.cu.rowcount, -1)
+
+    def test_RowcountExecutemany(self):
+        self.cu.execute("delete from test")
+        self.cu.executemany("insert into test(name) values (?)", [(1,), (2,), (3,)])
+        self.assertEqual(self.cu.rowcount, 3)
+
+    def test_TotalChanges(self):
+        self.cu.execute("insert into test(name) values ('foo')")
+        self.cu.execute("insert into test(name) values ('foo')")
+        self.assertLess(2, self.cx.total_changes, msg='total changes reported wrong value')
+
+    # Checks for executemany:
+    # Sequences are required by the DB-API, iterators
+    # enhancements in pysqlite.
+
+    def test_ExecuteManySequence(self):
+        self.cu.executemany("insert into test(income) values (?)", [(x,) for x in range(100, 110)])
+
+    def test_ExecuteManyIterator(self):
+        class MyIter:
+            def __init__(self):
+                self.value = 5
+
+            def __next__(self):
+                if self.value == 10:
+                    raise StopIteration
+                else:
+                    self.value += 1
+                    return (self.value,)
+
+        self.cu.executemany("insert into test(income) values (?)", MyIter())
+
+    def test_ExecuteManyGenerator(self):
+        def mygen():
+            for i in range(5):
+                yield (i,)
+
+        self.cu.executemany("insert into test(income) values (?)", mygen())
+
+    def test_ExecuteManyWrongSqlArg(self):
+        with self.assertRaises(TypeError):
+            self.cu.executemany(42, [(3,)])
+
+    def test_ExecuteManySelect(self):
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cu.executemany("select ?", [(3,)])
+
+    def test_ExecuteManyNotIterable(self):
+        with self.assertRaises(TypeError):
+            self.cu.executemany("insert into test(income) values (?)", 42)
+
+    def test_FetchIter(self):
+        # Optional DB-API extension.
+        self.cu.execute("delete from test")
+        self.cu.execute("insert into test(id) values (?)", (5,))
+        self.cu.execute("insert into test(id) values (?)", (6,))
+        self.cu.execute("select id from test order by id")
+        lst = []
+        for row in self.cu:
+            lst.append(row[0])
+        self.assertEqual(lst[0], 5)
+        self.assertEqual(lst[1], 6)
+
+    def test_Fetchone(self):
+        self.cu.execute("select name from test")
+        row = self.cu.fetchone()
+        self.assertEqual(row[0], "foo")
+        row = self.cu.fetchone()
+        self.assertEqual(row, None)
+
+    def test_FetchoneNoStatement(self):
+        cur = self.cx.cursor()
+        row = cur.fetchone()
+        self.assertEqual(row, None)
+
+    def test_ArraySize(self):
+        # must default ot 1
+        self.assertEqual(self.cu.arraysize, 1)
+
+        # now set to 2
+        self.cu.arraysize = 2
+
+        # now make the query return 3 rows
+        self.cu.execute("delete from test")
+        self.cu.execute("insert into test(name) values ('A')")
+        self.cu.execute("insert into test(name) values ('B')")
+        self.cu.execute("insert into test(name) values ('C')")
+        self.cu.execute("select name from test")
+        res = self.cu.fetchmany()
+
+        self.assertEqual(len(res), 2)
+
+    def test_Fetchmany(self):
+        self.cu.execute("select name from test")
+        res = self.cu.fetchmany(100)
+        self.assertEqual(len(res), 1)
+        res = self.cu.fetchmany(100)
+        self.assertEqual(res, [])
+
+    def test_FetchmanyKwArg(self):
+        """Checks if fetchmany works with keyword arguments"""
+        self.cu.execute("select name from test")
+        res = self.cu.fetchmany(size=100)
+        self.assertEqual(len(res), 1)
+
+    def test_Fetchall(self):
+        self.cu.execute("select name from test")
+        res = self.cu.fetchall()
+        self.assertEqual(len(res), 1)
+        res = self.cu.fetchall()
+        self.assertEqual(res, [])
+
+    def test_Setinputsizes(self):
+        self.cu.setinputsizes([3, 4, 5])
+
+    def test_Setoutputsize(self):
+        self.cu.setoutputsize(5, 0)
+
+    def test_SetoutputsizeNoColumn(self):
+        self.cu.setoutputsize(42)
+
+    def test_CursorConnection(self):
+        # Optional DB-API extension.
+        self.assertEqual(self.cu.connection, self.cx)
+
+    def test_WrongCursorCallable(self):
+        with self.assertRaises(TypeError):
+            def f(): pass
+            cur = self.cx.cursor(f)
+
+    def test_CursorWrongClass(self):
+        class Foo: pass
+        foo = Foo()
+        with self.assertRaises(TypeError):
+            cur = sqlite.Cursor(foo)
+
+    def test_LastRowIDOnReplace(self):
+        """
+        INSERT OR REPLACE and REPLACE INTO should produce the same behavior.
+        """
+        sql = '{} INTO test(id, unique_test) VALUES (?, ?)'
+        for statement in ('INSERT OR REPLACE', 'REPLACE'):
+            with self.subTest(statement=statement):
+                self.cu.execute(sql.format(statement), (1, 'foo'))
+                self.assertEqual(self.cu.lastrowid, 1)
+
+    def test_LastRowIDOnIgnore(self):
+        self.cu.execute(
+            "insert or ignore into test(unique_test) values (?)",
+            ('test',))
+        self.assertEqual(self.cu.lastrowid, 2)
+        self.cu.execute(
+            "insert or ignore into test(unique_test) values (?)",
+            ('test',))
+        self.assertEqual(self.cu.lastrowid, 2)
+
+    def test_LastRowIDInsertOR(self):
+        results = []
+        for statement in ('FAIL', 'ABORT', 'ROLLBACK'):
+            sql = 'INSERT OR {} INTO test(unique_test) VALUES (?)'
+            with self.subTest(statement='INSERT OR {}'.format(statement)):
+                self.cu.execute(sql.format(statement), (statement,))
+                results.append((statement, self.cu.lastrowid))
+                with self.assertRaises(sqlite.IntegrityError):
+                    self.cu.execute(sql.format(statement), (statement,))
+                results.append((statement, self.cu.lastrowid))
+        expected = [
+            ('FAIL', 2), ('FAIL', 2),
+            ('ABORT', 3), ('ABORT', 3),
+            ('ROLLBACK', 4), ('ROLLBACK', 4),
+        ]
+        self.assertEqual(results, expected)
+
+class BlobTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(id integer primary key, blob_col blob)")
+        self.blob_data = b"a" * 100
+        self.cx.execute("insert into test(blob_col) values (?)", (self.blob_data, ))
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.second_data = b"b" * 100
+
+    def tearDown(self):
+        self.blob.close()
+        self.cx.close()
+
+    def test_Length(self):
+        self.assertEqual(len(self.blob), 100)
+
+    def test_Tell(self):
+        self.assertEqual(self.blob.tell(), 0)
+
+    def test_SeekFromBlobStart(self):
+        self.blob.seek(10)
+        self.assertEqual(self.blob.tell(), 10)
+        self.blob.seek(10, 0)
+        self.assertEqual(self.blob.tell(), 10)
+
+    def test_SeekFromCurrentPosition(self):
+        self.blob.seek(10, 1)
+        self.blob.seek(10, 1)
+        self.assertEqual(self.blob.tell(), 20)
+
+    def test_SeekFromBlobEnd(self):
+        self.blob.seek(-10, 2)
+        self.assertEqual(self.blob.tell(), 90)
+
+    def test_BlobSeekOverBlobSize(self):
+        with self.assertRaises(ValueError):
+            self.blob.seek(1000)
+
+    def test_BlobSeekUnderBlobSize(self):
+        with self.assertRaises(ValueError):
+            self.blob.seek(-10)
+
+    def test_BlobRead(self):
+        self.assertEqual(self.blob.read(), self.blob_data)
+
+    def test_BlobReadSize(self):
+        self.assertEqual(len(self.blob.read(10)), 10)
+
+    def test_BlobReadAdvanceOffset(self):
+        self.blob.read(10)
+        self.assertEqual(self.blob.tell(), 10)
+
+    def test_BlobReadStartAtOffset(self):
+        self.blob.seek(10)
+        self.blob.write(self.second_data[:10])
+        self.blob.seek(10)
+        self.assertEqual(self.blob.read(10), self.second_data[:10])
+
+    def test_BlobWrite(self):
+        self.blob.write(self.second_data)
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], self.second_data)
+
+    def test_BlobWriteAtOffset(self):
+        self.blob.seek(50)
+        self.blob.write(self.second_data[:50])
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0],
+                         self.blob_data[:50] + self.second_data[:50])
+
+    def test_BlobWriteAdvanceOffset(self):
+        self.blob.write(self.second_data[:50])
+        self.assertEqual(self.blob.tell(), 50)
+
+    def test_BlobWriteMoreThenBlobSize(self):
+        with self.assertRaises(ValueError):
+            self.blob.write(b"a" * 1000)
+
+    def test_BlobReadAfterRowChange(self):
+        self.cx.execute("UPDATE test SET blob_col='aaaa' where id=1")
+        with self.assertRaises(sqlite.OperationalError):
+            self.blob.read()
+
+    def test_BlobWriteAfterRowChange(self):
+        self.cx.execute("UPDATE test SET blob_col='aaaa' where id=1")
+        with self.assertRaises(sqlite.OperationalError):
+            self.blob.write(b"aaa")
+
+    def test_BlobWriteWhenReadOnly(self):
+        read_only_blob = \
+            self.cx.open_blob("test", "blob_col", 1, readonly=True)
+        with self.assertRaises(sqlite.OperationalError):
+            read_only_blob.write(b"aaa")
+        read_only_blob.close()
+
+    def test_BlobOpenWithBadDb(self):
+        with self.assertRaises(sqlite.OperationalError):
+            self.cx.open_blob("test", "blob_col", 1, dbname="notexisintg")
+
+    def test_BlobOpenWithBadTable(self):
+        with self.assertRaises(sqlite.OperationalError):
+            self.cx.open_blob("notexisintg", "blob_col", 1)
+
+    def test_BlobOpenWithBadColumn(self):
+        with self.assertRaises(sqlite.OperationalError):
+            self.cx.open_blob("test", "notexisting", 1)
+
+    def test_BlobOpenWithBadRow(self):
+        with self.assertRaises(sqlite.OperationalError):
+            self.cx.open_blob("test", "blob_col", 2)
+
+    def test_BlobGetItem(self):
+        self.assertEqual(self.blob[5], b"a")
+
+    def test_BlobGetItemIndexOutOfRange(self):
+        with self.assertRaises(IndexError):
+            self.blob[105]
+        with self.assertRaises(IndexError):
+            self.blob[-105]
+
+    def test_BlobGetItemNegativeIndex(self):
+        self.assertEqual(self.blob[-5], b"a")
+
+    def test_BlobGetItemInvalidIndex(self):
+        with self.assertRaises(TypeError):
+            self.blob[b"a"]
+
+    def test_BlobGetSlice(self):
+        self.assertEqual(self.blob[5:10], b"aaaaa")
+
+    def test_BlobGetSliceNegativeIndex(self):
+        self.assertEqual(self.blob[5:-5], self.blob_data[5:-5])
+
+    def test_BlobGetSliceInvalidIndex(self):
+        with self.assertRaises(TypeError):
+            self.blob[5:b"a"]
+
+    def test_BlobGetSliceWithSkip(self):
+        self.blob.write(b"abcdefghij")
+        self.assertEqual(self.blob[0:10:2], b"acegi")
+
+    def test_BlobSetItem(self):
+        self.blob[0] = b"b"
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], b"b" + self.blob_data[1:])
+
+    def test_BlobSetSlice(self):
+        self.blob[0:5] = b"bbbbb"
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], b"bbbbb" + self.blob_data[5:])
+
+    def test_BlobSetSliceWithSkip(self):
+        self.blob[0:10:2] = b"bbbbb"
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], b"bababababa" + self.blob_data[10:])
+
+    def test_BlobGetEmptySlice(self):
+        self.assertEqual(self.blob[5:5], b"")
+
+    def test_BlobSetSliceWrongLength(self):
+        with self.assertRaises(IndexError):
+            self.blob[5:10] = b"a"
+
+    def test_BlobConcatNotSupported(self):
+        with self.assertRaises(SystemError):
+            self.blob + self.blob
+
+    def test_BlobRepeateNotSupported(self):
+        with self.assertRaises(SystemError):
+            self.blob * 5
+
+    def test_BlobContainsNotSupported(self):
+        with self.assertRaises(SystemError):
+            b"aaaaa" in self.blob
+
+@unittest.skipUnless(threading, 'This test requires threading.')
+class ThreadTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(id integer primary key, name text, bin binary, ratio number, ts timestamp)")
+
+    def tearDown(self):
+        self.cur.close()
+        self.con.close()
+
+    def test_ConCursor(self):
+        def run(con, errors):
+            try:
+                cur = con.cursor()
+                errors.append("did not raise ProgrammingError")
+                return
+            except sqlite.ProgrammingError:
+                return
+            except:
+                errors.append("raised wrong exception")
+
+        errors = []
+        t = threading.Thread(target=run, kwargs={"con": self.con, "errors": errors})
+        t.start()
+        t.join()
+        if len(errors) > 0:
+            self.fail("\n".join(errors))
+
+    def test_ConCommit(self):
+        def run(con, errors):
+            try:
+                con.commit()
+                errors.append("did not raise ProgrammingError")
+                return
+            except sqlite.ProgrammingError:
+                return
+            except:
+                errors.append("raised wrong exception")
+
+        errors = []
+        t = threading.Thread(target=run, kwargs={"con": self.con, "errors": errors})
+        t.start()
+        t.join()
+        if len(errors) > 0:
+            self.fail("\n".join(errors))
+
+    def test_ConRollback(self):
+        def run(con, errors):
+            try:
+                con.rollback()
+                errors.append("did not raise ProgrammingError")
+                return
+            except sqlite.ProgrammingError:
+                return
+            except:
+                errors.append("raised wrong exception")
+
+        errors = []
+        t = threading.Thread(target=run, kwargs={"con": self.con, "errors": errors})
+        t.start()
+        t.join()
+        if len(errors) > 0:
+            self.fail("\n".join(errors))
+
+    def test_ConClose(self):
+        def run(con, errors):
+            try:
+                con.close()
+                errors.append("did not raise ProgrammingError")
+                return
+            except sqlite.ProgrammingError:
+                return
+            except:
+                errors.append("raised wrong exception")
+
+        errors = []
+        t = threading.Thread(target=run, kwargs={"con": self.con, "errors": errors})
+        t.start()
+        t.join()
+        if len(errors) > 0:
+            self.fail("\n".join(errors))
+
+    def test_CurImplicitBegin(self):
+        def run(cur, errors):
+            try:
+                cur.execute("insert into test(name) values ('a')")
+                errors.append("did not raise ProgrammingError")
+                return
+            except sqlite.ProgrammingError:
+                return
+            except:
+                errors.append("raised wrong exception")
+
+        errors = []
+        t = threading.Thread(target=run, kwargs={"cur": self.cur, "errors": errors})
+        t.start()
+        t.join()
+        if len(errors) > 0:
+            self.fail("\n".join(errors))
+
+    def test_CurClose(self):
+        def run(cur, errors):
+            try:
+                cur.close()
+                errors.append("did not raise ProgrammingError")
+                return
+            except sqlite.ProgrammingError:
+                return
+            except:
+                errors.append("raised wrong exception")
+
+        errors = []
+        t = threading.Thread(target=run, kwargs={"cur": self.cur, "errors": errors})
+        t.start()
+        t.join()
+        if len(errors) > 0:
+            self.fail("\n".join(errors))
+
+    def test_CurExecute(self):
+        def run(cur, errors):
+            try:
+                cur.execute("select name from test")
+                errors.append("did not raise ProgrammingError")
+                return
+            except sqlite.ProgrammingError:
+                return
+            except:
+                errors.append("raised wrong exception")
+
+        errors = []
+        self.cur.execute("insert into test(name) values ('a')")
+        t = threading.Thread(target=run, kwargs={"cur": self.cur, "errors": errors})
+        t.start()
+        t.join()
+        if len(errors) > 0:
+            self.fail("\n".join(errors))
+
+    def test_CurIterNext(self):
+        def run(cur, errors):
+            try:
+                row = cur.fetchone()
+                errors.append("did not raise ProgrammingError")
+                return
+            except sqlite.ProgrammingError:
+                return
+            except:
+                errors.append("raised wrong exception")
+
+        errors = []
+        self.cur.execute("insert into test(name) values ('a')")
+        self.cur.execute("select name from test")
+        t = threading.Thread(target=run, kwargs={"cur": self.cur, "errors": errors})
+        t.start()
+        t.join()
+        if len(errors) > 0:
+            self.fail("\n".join(errors))
+
+class ConstructorTests(unittest.TestCase):
+    def test_Date(self):
+        d = sqlite.Date(2004, 10, 28)
+
+    def test_Time(self):
+        t = sqlite.Time(12, 39, 35)
+
+    def test_Timestamp(self):
+        ts = sqlite.Timestamp(2004, 10, 28, 12, 39, 35)
+
+    def test_DateFromTicks(self):
+        d = sqlite.DateFromTicks(42)
+
+    def test_TimeFromTicks(self):
+        t = sqlite.TimeFromTicks(42)
+
+    def test_TimestampFromTicks(self):
+        ts = sqlite.TimestampFromTicks(42)
+
+    def test_Binary(self):
+        b = sqlite.Binary(b"\0'")
+
+class ExtensionTests(unittest.TestCase):
+    def test_ScriptStringSql(self):
+        con = sqlite.connect(":memory:")
+        cur = con.cursor()
+        cur.executescript("""
+            -- bla bla
+            /* a stupid comment */
+            create table a(i);
+            insert into a(i) values (5);
+            """)
+        cur.execute("select i from a")
+        res = cur.fetchone()[0]
+        self.assertEqual(res, 5)
+
+    def test_ScriptSyntaxError(self):
+        con = sqlite.connect(":memory:")
+        cur = con.cursor()
+        with self.assertRaises(sqlite.OperationalError):
+            cur.executescript("create table test(x); asdf; create table test2(x)")
+
+    def test_ScriptErrorNormal(self):
+        con = sqlite.connect(":memory:")
+        cur = con.cursor()
+        with self.assertRaises(sqlite.OperationalError):
+            cur.executescript("create table test(sadfsadfdsa); select foo from hurz;")
+
+    def test_CursorExecutescriptAsBytes(self):
+        con = sqlite.connect(":memory:")
+        cur = con.cursor()
+        with self.assertRaises(ValueError) as cm:
+            cur.executescript(b"create table test(foo); insert into test(foo) values (5);")
+        self.assertEqual(str(cm.exception), 'script argument must be unicode.')
+
+    def test_ConnectionExecute(self):
+        con = sqlite.connect(":memory:")
+        result = con.execute("select 5").fetchone()[0]
+        self.assertEqual(result, 5, "Basic test of Connection.execute")
+
+    def test_ConnectionExecutemany(self):
+        con = sqlite.connect(":memory:")
+        con.execute("create table test(foo)")
+        con.executemany("insert into test(foo) values (?)", [(3,), (4,)])
+        result = con.execute("select foo from test order by foo").fetchall()
+        self.assertEqual(result[0][0], 3, "Basic test of Connection.executemany")
+        self.assertEqual(result[1][0], 4, "Basic test of Connection.executemany")
+
+    def test_ConnectionExecutescript(self):
+        con = sqlite.connect(":memory:")
+        con.executescript("create table test(foo); insert into test(foo) values (5);")
+        result = con.execute("select foo from test").fetchone()[0]
+        self.assertEqual(result, 5, "Basic test of Connection.executescript")
+
+class ClosedConTests(unittest.TestCase):
+    def test_ClosedConCursor(self):
+        con = sqlite.connect(":memory:")
+        con.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            cur = con.cursor()
+
+    def test_ClosedConCommit(self):
+        con = sqlite.connect(":memory:")
+        con.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            con.commit()
+
+    def test_ClosedConRollback(self):
+        con = sqlite.connect(":memory:")
+        con.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            con.rollback()
+
+    def test_ClosedCurExecute(self):
+        con = sqlite.connect(":memory:")
+        cur = con.cursor()
+        con.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            cur.execute("select 4")
+
+    def test_ClosedBlobRead(self):
+        con = sqlite.connect(":memory:")
+        con.execute("create table test(id integer primary key, blob_col blob)")
+        con.execute("insert into test(blob_col) values (zeroblob(100))")
+        blob = con.open_blob("test", "blob_col", 1)
+        con.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            blob.read()
+
+    def test_ClosedCreateFunction(self):
+        con = sqlite.connect(":memory:")
+        con.close()
+        def f(x): return 17
+        with self.assertRaises(sqlite.ProgrammingError):
+            con.create_function("foo", 1, f)
+
+    def test_ClosedCreateAggregate(self):
+        con = sqlite.connect(":memory:")
+        con.close()
+        class Agg:
+            def __init__(self):
+                pass
+            def step(self, x):
+                pass
+            def finalize(self):
+                return 17
+        with self.assertRaises(sqlite.ProgrammingError):
+            con.create_aggregate("foo", 1, Agg)
+
+    def test_ClosedSetAuthorizer(self):
+        con = sqlite.connect(":memory:")
+        con.close()
+        def authorizer(*args):
+            return sqlite.DENY
+        with self.assertRaises(sqlite.ProgrammingError):
+            con.set_authorizer(authorizer)
+
+    def test_ClosedSetProgressCallback(self):
+        con = sqlite.connect(":memory:")
+        con.close()
+        def progress(): pass
+        with self.assertRaises(sqlite.ProgrammingError):
+            con.set_progress_handler(progress, 100)
+
+    def test_ClosedCall(self):
+        con = sqlite.connect(":memory:")
+        con.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            con()
+
+class ClosedCurTests(unittest.TestCase):
+    def test_Closed(self):
+        con = sqlite.connect(":memory:")
+        cur = con.cursor()
+        cur.close()
+
+        for method_name in ("execute", "executemany", "executescript", "fetchall", "fetchmany", "fetchone"):
+            if method_name in ("execute", "executescript"):
+                params = ("select 4 union select 5",)
+            elif method_name == "executemany":
+                params = ("insert into foo(bar) values (?)", [(3,), (4,)])
+            else:
+                params = []
+
+            with self.assertRaises(sqlite.ProgrammingError):
+                method = getattr(cur, method_name)
+                method(*params)
+
+
+class SqliteColumnTypeTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(':memory:')
+        self.cx.execute('create table test(a text, b datetime)')
+        self.cx.execute('create view test_view as select * from test')
+
+    def test_DeclTypes(self):
+        curs = self.cx.execute('select * from test')
+        self.assertEqual(curs.description, (
+            ('a', 'TEXT', None, None, None, None, None),
+            ('b', 'datetime', None, None, None, None, None),
+        ))
+
+        curs = self.cx.execute('select * from test_view')
+        self.assertEqual(curs.description, (
+            ('a', 'TEXT', None, None, None, None, None),
+            ('b', 'datetime', None, None, None, None, None),
+        ))
+
+        # Expressions return NULL decltype, reported as None.
+        curs = self.cx.execute('select b + b as c from test_view')
+        self.assertEqual(curs.description, (
+            ('c', None, None, None, None, None, None),
+        ))
+
+
+class SqliteOnConflictTests(unittest.TestCase):
+    """
+    Tests for SQLite's "insert on conflict" feature.
+
+    See https://www.sqlite.org/lang_conflict.html for details.
+    """
+
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cu = self.cx.cursor()
+        self.cu.execute("""
+          CREATE TABLE test(
+            id INTEGER PRIMARY KEY, name TEXT, unique_name TEXT UNIQUE
+          );
+        """)
+
+    def tearDown(self):
+        self.cu.close()
+        self.cx.close()
+
+    def test_OnConflictRollbackWithExplicitTransaction(self):
+        self.cx.isolation_level = None  # autocommit mode
+        self.cu = self.cx.cursor()
+        # Start an explicit transaction.
+        self.cu.execute("BEGIN")
+        self.cu.execute("INSERT INTO test(name) VALUES ('abort_test')")
+        self.cu.execute("INSERT OR ROLLBACK INTO test(unique_name) VALUES ('foo')")
+        with self.assertRaises(sqlite.IntegrityError):
+            self.cu.execute("INSERT OR ROLLBACK INTO test(unique_name) VALUES ('foo')")
+        # Use connection to commit.
+        self.cx.commit()
+        self.cu.execute("SELECT name, unique_name from test")
+        # Transaction should have rolled back and nothing should be in table.
+        self.assertEqual(self.cu.fetchall(), [])
+
+    def test_OnConflictAbortRaisesWithExplicitTransactions(self):
+        # Abort cancels the current sql statement but doesn't change anything
+        # about the current transaction.
+        self.cx.isolation_level = None  # autocommit mode
+        self.cu = self.cx.cursor()
+        # Start an explicit transaction.
+        self.cu.execute("BEGIN")
+        self.cu.execute("INSERT INTO test(name) VALUES ('abort_test')")
+        self.cu.execute("INSERT OR ABORT INTO test(unique_name) VALUES ('foo')")
+        with self.assertRaises(sqlite.IntegrityError):
+            self.cu.execute("INSERT OR ABORT INTO test(unique_name) VALUES ('foo')")
+        self.cx.commit()
+        self.cu.execute("SELECT name, unique_name FROM test")
+        # Expect the first two inserts to work, third to do nothing.
+        self.assertEqual(self.cu.fetchall(), [('abort_test', None), (None, 'foo',)])
+
+    def test_OnConflictRollbackWithoutTransaction(self):
+        # Start of implicit transaction
+        self.cu.execute("INSERT INTO test(name) VALUES ('abort_test')")
+        self.cu.execute("INSERT OR ROLLBACK INTO test(unique_name) VALUES ('foo')")
+        with self.assertRaises(sqlite.IntegrityError):
+            self.cu.execute("INSERT OR ROLLBACK INTO test(unique_name) VALUES ('foo')")
+        self.cu.execute("SELECT name, unique_name FROM test")
+        # Implicit transaction is rolled back on error.
+        self.assertEqual(self.cu.fetchall(), [])
+
+    def test_OnConflictAbortRaisesWithoutTransactions(self):
+        # Abort cancels the current sql statement but doesn't change anything
+        # about the current transaction.
+        self.cu.execute("INSERT INTO test(name) VALUES ('abort_test')")
+        self.cu.execute("INSERT OR ABORT INTO test(unique_name) VALUES ('foo')")
+        with self.assertRaises(sqlite.IntegrityError):
+            self.cu.execute("INSERT OR ABORT INTO test(unique_name) VALUES ('foo')")
+        # Make sure all other values were inserted.
+        self.cu.execute("SELECT name, unique_name FROM test")
+        self.assertEqual(self.cu.fetchall(), [('abort_test', None), (None, 'foo',)])
+
+    def test_OnConflictFail(self):
+        self.cu.execute("INSERT OR FAIL INTO test(unique_name) VALUES ('foo')")
+        with self.assertRaises(sqlite.IntegrityError):
+            self.cu.execute("INSERT OR FAIL INTO test(unique_name) VALUES ('foo')")
+        self.assertEqual(self.cu.fetchall(), [])
+
+    def test_OnConflictIgnore(self):
+        self.cu.execute("INSERT OR IGNORE INTO test(unique_name) VALUES ('foo')")
+        # Nothing should happen.
+        self.cu.execute("INSERT OR IGNORE INTO test(unique_name) VALUES ('foo')")
+        self.cu.execute("SELECT unique_name FROM test")
+        self.assertEqual(self.cu.fetchall(), [('foo',)])
+
+    def test_OnConflictReplace(self):
+        self.cu.execute("INSERT OR REPLACE INTO test(name, unique_name) VALUES ('Data!', 'foo')")
+        # There shouldn't be an IntegrityError exception.
+        self.cu.execute("INSERT OR REPLACE INTO test(name, unique_name) VALUES ('Very different data!', 'foo')")
+        self.cu.execute("SELECT name, unique_name FROM test")
+        self.assertEqual(self.cu.fetchall(), [('Very different data!', 'foo')])
+
+
+class ClosedBlobTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(id integer primary key, blob_col blob)")
+        self.cx.execute("insert into test(blob_col) values (zeroblob(100))")
+
+    def tearDown(self):
+        self.cx.close()
+
+    def test_ClosedRead(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.blob.read()
+
+    def test_ClosedWrite(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.blob.write(b"aaaaaaaaa")
+
+    def test_ClosedSeek(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.blob.seek(10)
+
+    def test_ClosedTell(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.blob.tell()
+
+    def test_ClosedClose(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.blob.close()
+
+
+class BlobContextManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(id integer primary key, blob_col blob)")
+        self.cx.execute("insert into test(blob_col) values (zeroblob(100))")
+
+    def tearDown(self):
+        self.cx.close()
+
+    def test_ContextExecute(self):
+        data = b"a" * 100
+        with self.cx.open_blob("test", "blob_col", 1) as blob:
+            blob.write(data)
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], data)
+
+    def test_ContextCloseBlob(self):
+        with self.cx.open_blob("test", "blob_col", 1) as blob:
+            blob.seek(10)
+        with self.assertRaises(sqlite.ProgrammingError):
+            blob.close()
+
+
+def suite():
+    loader = unittest.TestLoader()
+    tests = [loader.loadTestsFromTestCase(t) for t in (
+        ModuleTests,
+        ConnectionTests,
+        CursorTests,
+        ThreadTests,
+        ConstructorTests,
+        ExtensionTests,
+        ClosedConTests,
+        ClosedCurTests,
+        SqliteColumnTypeTests,
+        SqliteOnConflictTests,
+        BlobTests,
+        ClosedBlobTests,
+        BlobContextManagerTests)]
+    return unittest.TestSuite(tests)
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/extensions.py
+++ b/packages/phoenix-sqlean/tests/extensions.py
@@ -1,0 +1,134 @@
+import sys
+import unittest
+
+import sqlean
+from setup import SQLEAN_VERSION
+from sqlean import dbapi2 as sqlite
+
+
+class FuncTest(unittest.TestCase):
+    def setUp(self):
+        sqlean.extensions.enable_all()
+        self.conn = sqlite.connect(":memory:")
+        self.conn.close()
+        self.conn = sqlite.connect(":memory:")
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_crypto(self):
+        self._assert_eq("hex(md5('abc'))", "900150983cd24fb0d6963f7d28e17f72".upper())
+        self._assert_eq("encode('abcd', 'base64')", "YWJjZA==")
+        self._assert_eq("decode('YWJjZA==', 'base64')", b"abcd")
+
+    def test_define(self):
+        self._assert_eq("define('sumn', '?1 * (?1 + 1) / 2')", None)
+        self._assert_eq("sumn(5)", (1 + 2 + 3 + 4 + 5))
+        self._assert_eq("eval('select abs(-42)')", "42")
+        self._assert_eq("define_free()", None)
+
+    def test_fuzzy(self):
+        self._assert_eq("dlevenshtein('abc', 'abcd')", 1)
+        self._assert_eq("caverphone('awesome')", "AWSM111111")
+
+    @unittest.skipIf(sys.platform == "win32", "ipaddr extension is not available on Windows")
+    def test_ipaddr(self):
+        self._assert_eq("iphost('192.168.16.12/24')", "192.168.16.12")
+        self._assert_eq("ipcontains('192.168.16.0/24', '192.168.16.3')", 1)
+
+    def test_math(self):
+        self._assert_eq("trunc(3.9)", 3)
+        self._assert_eq("sqrt(100)", 10)
+        self._assert_eq("round(degrees(pi()))", 180)
+
+    def test_regexp(self):
+        self._assert_eq(r"regexp_replace('1 10 100', '\d+', '**')", "** ** **")
+        self._assert_eq("regexp_substr('abcdef', 'b(.)d')", "bcd")
+        self._assert_eq("regexp_capture('abcdef', 'b(.)d', 1)", "c")
+
+    def test_stats(self):
+        self._assert_eq("percentile(value, 50) from generate_series(1, 99)", 50)
+        self._assert_eq("median(value) from generate_series(1, 99)", 50)
+
+    def test_text(self):
+        self._assert_eq("text_substring('hello world', 7)", "world")
+        self._assert_eq("text_split('one|two|three', '|', 2)", "two")
+        self._assert_eq("text_translate('hello', 'l', '1')", "he11o")
+
+    def test_time(self):
+        self._assert_eq("time_to_unix(time_date(2011, 11, 18))", 1321574400)
+
+    def test_uuid(self):
+        self._assert_eq("length(uuid4())", 36)
+
+    def test_unicode(self):
+        self._assert_eq("nupper('пРиВеТ')", "ПРИВЕТ")
+        self._assert_eq("unaccent('hôtel')", "hotel")
+
+    def test_version(self):
+        self._assert_eq("sqlean_version()", SQLEAN_VERSION)
+
+    def _assert_eq(self, expr, want):
+        cur = self.conn.execute(f"select {expr}")
+        got = cur.fetchone()[0]
+        self.assertEqual(got, want)
+
+
+class EnableTest(unittest.TestCase):
+    def setUp(self):
+        sqlean.extensions.enable("stats", "text")
+        self.conn = sqlite.connect(":memory:")
+
+    def test_enabled_1(self):
+        sql = "select median(value) from generate_series(1, 99)"
+        cur = self.conn.execute(sql)
+        got = cur.fetchone()[0]
+        self.assertEqual(got, 50)
+
+    def test_enabled_2(self):
+        sql = "select text_substring('hello world', 7)"
+        cur = self.conn.execute(sql)
+        got = cur.fetchone()[0]
+        self.assertEqual(got, "world")
+
+    def test_disabled(self):
+        sql = "select dlevenshtein('abc', 'abcd')"
+        with self.assertRaises(Exception, msg="no such function: dlevenshtein"):
+            self.conn.execute(sql)
+
+    def tearDown(self):
+        self.conn.close()
+
+
+class PragmaTest(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite.connect(":memory:")
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_temp_store(self):
+        val = self._get_opt("TEMP_STORE")
+        self.assertEqual(val, "1")
+
+    def _get_opt(self, name):
+        cur = self.conn.execute("PRAGMA compile_options;")
+        for row in cur.fetchall():
+            if row[0].startswith(name + "="):
+                return row[0].split("=")[1]
+
+
+def suite():
+    loader = unittest.TestLoader()
+    cases = (FuncTest, EnableTest, PragmaTest)
+    tests = [loader.loadTestsFromTestCase(c) for c in cases]
+    return unittest.TestSuite(tests)
+
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/factory.py
+++ b/packages/phoenix-sqlean/tests/factory.py
@@ -1,0 +1,320 @@
+#-*- coding: iso-8859-1 -*-
+# pysqlite2/test/factory.py: tests for the various factories in pysqlite
+#
+# Copyright (C) 2005-2007 Gerhard H�ring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+import unittest
+from sqlean import dbapi2 as sqlite
+from collections.abc import Sequence
+
+class MyConnection(sqlite.Connection):
+    def __init__(self, *args, **kwargs):
+        sqlite.Connection.__init__(self, *args, **kwargs)
+
+def dict_factory(cursor, row):
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
+class MyCursor(sqlite.Cursor):
+    def __init__(self, *args, **kwargs):
+        sqlite.Cursor.__init__(self, *args, **kwargs)
+        self.row_factory = dict_factory
+
+class ConnectionFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:", factory=MyConnection)
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_IsInstance(self):
+        self.assertIsInstance(self.con, MyConnection)
+
+class CursorFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_IsInstance(self):
+        cur = self.con.cursor()
+        self.assertIsInstance(cur, sqlite.Cursor)
+        cur = self.con.cursor(MyCursor)
+        self.assertIsInstance(cur, MyCursor)
+        cur = self.con.cursor(factory=lambda con: MyCursor(con))
+        self.assertIsInstance(cur, MyCursor)
+
+    def test_InvalidFactory(self):
+        # not a callable at all
+        self.assertRaises(TypeError, self.con.cursor, None)
+        # invalid callable with not exact one argument
+        self.assertRaises(TypeError, self.con.cursor, lambda: None)
+        # invalid callable returning non-cursor
+        self.assertRaises(TypeError, self.con.cursor, lambda con: None)
+
+class RowFactoryTestsBackwardsCompat(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+
+    def test_IsProducedByFactory(self):
+        cur = self.con.cursor(factory=MyCursor)
+        cur.execute("select 4+5 as foo")
+        row = cur.fetchone()
+        self.assertIsInstance(row, dict)
+        cur.close()
+
+    def tearDown(self):
+        self.con.close()
+
+class RowFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+
+    def test_CustomFactory(self):
+        self.con.row_factory = lambda cur, row: list(row)
+        row = self.con.execute("select 1, 2").fetchone()
+        self.assertIsInstance(row, list)
+
+    def test_SqliteRowIndex(self):
+        self.con.row_factory = sqlite.Row
+        row = self.con.execute("select 1 as a_1, 2 as b").fetchone()
+        self.assertIsInstance(row, sqlite.Row)
+
+        self.assertEqual(row["a_1"], 1, "by name: wrong result for column 'a_1'")
+        self.assertEqual(row["b"], 2, "by name: wrong result for column 'b'")
+
+        self.assertEqual(row["A_1"], 1, "by name: wrong result for column 'A_1'")
+        self.assertEqual(row["B"], 2, "by name: wrong result for column 'B'")
+
+        self.assertEqual(row[0], 1, "by index: wrong result for column 0")
+        self.assertEqual(row[1], 2, "by index: wrong result for column 1")
+        self.assertEqual(row[-1], 2, "by index: wrong result for column -1")
+        self.assertEqual(row[-2], 1, "by index: wrong result for column -2")
+
+        with self.assertRaises(IndexError):
+            row['c']
+        with self.assertRaises(IndexError):
+            row['a_\x11']
+        with self.assertRaises(IndexError):
+            row['a_\x7f1']
+        with self.assertRaises(IndexError):
+            row[2]
+        with self.assertRaises(IndexError):
+            row[-3]
+        with self.assertRaises(IndexError):
+            row[2**1000]
+
+    def test_SqliteRowIndexUnicode(self):
+        self.con.row_factory = sqlite.Row
+        row = self.con.execute("select 1 as \xff").fetchone()
+        self.assertEqual(row["\xff"], 1)
+        with self.assertRaises(IndexError):
+            row['\u0178']
+        with self.assertRaises(IndexError):
+            row['\xdf']
+
+    def test_SqliteRowSlice(self):
+        # A sqlite.Row can be sliced like a list.
+        self.con.row_factory = sqlite.Row
+        row = self.con.execute("select 1, 2, 3, 4").fetchone()
+        self.assertEqual(row[0:0], ())
+        self.assertEqual(row[0:1], (1,))
+        self.assertEqual(row[1:3], (2, 3))
+        self.assertEqual(row[3:1], ())
+        # Explicit bounds are optional.
+        self.assertEqual(row[1:], (2, 3, 4))
+        self.assertEqual(row[:3], (1, 2, 3))
+        # Slices can use negative indices.
+        self.assertEqual(row[-2:-1], (3,))
+        self.assertEqual(row[-2:], (3, 4))
+        # Slicing supports steps.
+        self.assertEqual(row[0:4:2], (1, 3))
+        self.assertEqual(row[3:0:-2], (4, 2))
+
+    def test_SqliteRowIter(self):
+        """Checks if the row object is iterable"""
+        self.con.row_factory = sqlite.Row
+        row = self.con.execute("select 1 as a, 2 as b").fetchone()
+        for col in row:
+            pass
+
+    def test_SqliteRowAsTuple(self):
+        """Checks if the row object can be converted to a tuple"""
+        self.con.row_factory = sqlite.Row
+        row = self.con.execute("select 1 as a, 2 as b").fetchone()
+        t = tuple(row)
+        self.assertEqual(t, (row['a'], row['b']))
+
+    def test_SqliteRowAsDict(self):
+        """Checks if the row object can be correctly converted to a dictionary"""
+        self.con.row_factory = sqlite.Row
+        row = self.con.execute("select 1 as a, 2 as b").fetchone()
+        d = dict(row)
+        self.assertEqual(d["a"], row["a"])
+        self.assertEqual(d["b"], row["b"])
+
+    def test_SqliteRowHashCmp(self):
+        """Checks if the row object compares and hashes correctly"""
+        self.con.row_factory = sqlite.Row
+        row_1 = self.con.execute("select 1 as a, 2 as b").fetchone()
+        row_2 = self.con.execute("select 1 as a, 2 as b").fetchone()
+        row_3 = self.con.execute("select 1 as a, 3 as b").fetchone()
+        row_4 = self.con.execute("select 1 as b, 2 as a").fetchone()
+        row_5 = self.con.execute("select 2 as b, 1 as a").fetchone()
+
+        self.assertTrue(row_1 == row_1)
+        self.assertTrue(row_1 == row_2)
+        self.assertFalse(row_1 == row_3)
+        self.assertFalse(row_1 == row_4)
+        self.assertFalse(row_1 == row_5)
+        self.assertFalse(row_1 == object())
+
+        self.assertFalse(row_1 != row_1)
+        self.assertFalse(row_1 != row_2)
+        self.assertTrue(row_1 != row_3)
+        self.assertTrue(row_1 != row_4)
+        self.assertTrue(row_1 != row_5)
+        self.assertTrue(row_1 != object())
+
+        with self.assertRaises(TypeError):
+            row_1 > row_2
+        with self.assertRaises(TypeError):
+            row_1 < row_2
+        with self.assertRaises(TypeError):
+            row_1 >= row_2
+        with self.assertRaises(TypeError):
+            row_1 <= row_2
+
+        self.assertEqual(hash(row_1), hash(row_2))
+
+    def test_SqliteRowAsSequence(self):
+        """ Checks if the row object can act like a sequence """
+        self.con.row_factory = sqlite.Row
+        row = self.con.execute("select 1 as a, 2 as b").fetchone()
+
+        as_tuple = tuple(row)
+        self.assertEqual(list(reversed(row)), list(reversed(as_tuple)))
+        self.assertIsInstance(row, Sequence)
+
+    def test_FakeCursorClass(self):
+        # Issue #24257: Incorrect use of PyObject_IsInstance() caused
+        # segmentation fault.
+        # Issue #27861: Also applies for cursor factory.
+        class FakeCursor(str):
+            __class__ = sqlite.Cursor
+        self.con.row_factory = sqlite.Row
+        self.assertRaises(TypeError, self.con.cursor, FakeCursor)
+        self.assertRaises(TypeError, sqlite.Row, FakeCursor(), ())
+
+    def tearDown(self):
+        self.con.close()
+
+class TextFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+
+    def test_Unicode(self):
+        austria = "�sterreich"
+        row = self.con.execute("select ?", (austria,)).fetchone()
+        self.assertEqual(type(row[0]), str, "type of row[0] must be unicode")
+
+    def test_String(self):
+        self.con.text_factory = bytes
+        austria = "�sterreich"
+        row = self.con.execute("select ?", (austria,)).fetchone()
+        self.assertEqual(type(row[0]), bytes, "type of row[0] must be bytes")
+        self.assertEqual(row[0], austria.encode("utf-8"), "column must equal original data in UTF-8")
+
+    def test_Custom(self):
+        self.con.text_factory = lambda x: str(x, "utf-8", "ignore")
+        austria = "�sterreich"
+        row = self.con.execute("select ?", (austria,)).fetchone()
+        self.assertEqual(type(row[0]), str, "type of row[0] must be unicode")
+        self.assertTrue(row[0].endswith("reich"), "column must contain original data")
+
+    def test_OptimizedUnicode(self):
+        # In py3k, str objects are always returned when text_factory
+        # is OptimizedUnicode
+        self.con.text_factory = sqlite.OptimizedUnicode
+        austria = "�sterreich"
+        germany = "Deutchland"
+        a_row = self.con.execute("select ?", (austria,)).fetchone()
+        d_row = self.con.execute("select ?", (germany,)).fetchone()
+        self.assertEqual(type(a_row[0]), str, "type of non-ASCII row must be str")
+        self.assertEqual(type(d_row[0]), str, "type of ASCII-only row must be str")
+
+    def tearDown(self):
+        self.con.close()
+
+class TextFactoryTestsWithEmbeddedZeroBytes(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        self.con.execute("create table test (value text)")
+        self.con.execute("insert into test (value) values (?)", ("a\x00b",))
+
+    def test_String(self):
+        # text_factory defaults to str
+        row = self.con.execute("select value from test").fetchone()
+        self.assertIs(type(row[0]), str)
+        self.assertEqual(row[0], "a\x00b")
+
+    def test_Bytes(self):
+        self.con.text_factory = bytes
+        row = self.con.execute("select value from test").fetchone()
+        self.assertIs(type(row[0]), bytes)
+        self.assertEqual(row[0], b"a\x00b")
+
+    def test_Bytearray(self):
+        self.con.text_factory = bytearray
+        row = self.con.execute("select value from test").fetchone()
+        self.assertIs(type(row[0]), bytearray)
+        self.assertEqual(row[0], b"a\x00b")
+
+    def test_Custom(self):
+        # A custom factory should receive a bytes argument
+        self.con.text_factory = lambda x: x
+        row = self.con.execute("select value from test").fetchone()
+        self.assertIs(type(row[0]), bytes)
+        self.assertEqual(row[0], b"a\x00b")
+
+    def tearDown(self):
+        self.con.close()
+
+def suite():
+    loader = unittest.TestLoader()
+    tests = [loader.loadTestsFromTestCase(t) for t in (
+        ConnectionFactoryTests,
+        CursorFactoryTests,
+        RowFactoryTestsBackwardsCompat,
+        RowFactoryTests,
+        TextFactoryTests,
+        TextFactoryTestsWithEmbeddedZeroBytes)]
+    return unittest.TestSuite(tests)
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/hooks.py
+++ b/packages/phoenix-sqlean/tests/hooks.py
@@ -1,0 +1,329 @@
+#-*- coding: iso-8859-1 -*-
+# pysqlite2/test/hooks.py: tests for various SQLite-specific hooks
+#
+# Copyright (C) 2006-2007 Gerhard H�ring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+import os
+import unittest
+from sqlean import dbapi2 as sqlite
+
+
+class CollationTests(unittest.TestCase):
+    def test_CreateCollationNotString(self):
+        con = sqlite.connect(":memory:")
+        with self.assertRaises(TypeError):
+            con.create_collation(None, lambda x, y: (x > y) - (x < y))
+
+    def test_CreateCollationNotCallable(self):
+        con = sqlite.connect(":memory:")
+        with self.assertRaises(TypeError) as cm:
+            con.create_collation("X", 42)
+        self.assertEqual(str(cm.exception), 'parameter must be callable')
+
+    def test_CreateCollationNotAscii(self):
+        con = sqlite.connect(":memory:")
+        con.create_collation("coll�", lambda x, y: (x > y) - (x < y))
+
+    def test_CreateCollationBadUpper(self):
+        class BadUpperStr(str):
+            def upper(self):
+                return None
+        con = sqlite.connect(":memory:")
+        mycoll = lambda x, y: -((x > y) - (x < y))
+        con.create_collation(BadUpperStr("mycoll"), mycoll)
+        result = con.execute("""
+            select x from (
+            select 'a' as x
+            union
+            select 'b' as x
+            ) order by x collate mycoll
+            """).fetchall()
+        self.assertEqual(result[0][0], 'b')
+        self.assertEqual(result[1][0], 'a')
+
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 2, 1),
+                     'old SQLite versions crash on this test')
+    def test_CollationIsUsed(self):
+        def mycoll(x, y):
+            # reverse order
+            return -((x > y) - (x < y))
+
+        con = sqlite.connect(":memory:")
+        con.create_collation("mycoll", mycoll)
+        sql = """
+            select x from (
+            select 'a' as x
+            union
+            select 'b' as x
+            union
+            select 'c' as x
+            ) order by x collate mycoll
+            """
+        result = con.execute(sql).fetchall()
+        self.assertEqual(result, [('c',), ('b',), ('a',)],
+                         msg='the expected order was not returned')
+
+        con.create_collation("mycoll", None)
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            result = con.execute(sql).fetchall()
+        self.assertEqual(str(cm.exception), 'no such collation sequence: mycoll')
+
+    def test_CollationReturnsLargeInteger(self):
+        def mycoll(x, y):
+            # reverse order
+            return -((x > y) - (x < y)) * 2**32
+        con = sqlite.connect(":memory:")
+        con.create_collation("mycoll", mycoll)
+        sql = """
+            select x from (
+            select 'a' as x
+            union
+            select 'b' as x
+            union
+            select 'c' as x
+            ) order by x collate mycoll
+            """
+        result = con.execute(sql).fetchall()
+        self.assertEqual(result, [('c',), ('b',), ('a',)],
+                         msg="the expected order was not returned")
+
+    def test_CollationRegisterTwice(self):
+        """
+        Register two different collation functions under the same name.
+        Verify that the last one is actually used.
+        """
+        con = sqlite.connect(":memory:")
+        con.create_collation("mycoll", lambda x, y: (x > y) - (x < y))
+        con.create_collation("mycoll", lambda x, y: -((x > y) - (x < y)))
+        result = con.execute("""
+            select x from (select 'a' as x union select 'b' as x) order by x collate mycoll
+            """).fetchall()
+        self.assertEqual(result[0][0], 'b')
+        self.assertEqual(result[1][0], 'a')
+
+    def test_DeregisterCollation(self):
+        """
+        Register a collation, then deregister it. Make sure an error is raised if we try
+        to use it.
+        """
+        con = sqlite.connect(":memory:")
+        con.create_collation("mycoll", lambda x, y: (x > y) - (x < y))
+        con.create_collation("mycoll", None)
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            con.execute("select 'a' as x union select 'b' as x order by x collate mycoll")
+        self.assertEqual(str(cm.exception), 'no such collation sequence: mycoll')
+
+class ProgressTests(unittest.TestCase):
+    def test_ProgressHandlerUsed(self):
+        """
+        Test that the progress handler is invoked once it is set.
+        """
+        con = sqlite.connect(":memory:")
+        progress_calls = []
+        def progress():
+            progress_calls.append(None)
+            return 0
+        con.set_progress_handler(progress, 1)
+        con.execute("""
+            create table foo(a, b)
+            """)
+        self.assertTrue(progress_calls)
+
+
+    def test_OpcodeCount(self):
+        """
+        Test that the opcode argument is respected.
+        """
+        con = sqlite.connect(":memory:")
+        progress_calls = []
+        def progress():
+            progress_calls.append(None)
+            return 0
+        con.set_progress_handler(progress, 1)
+        curs = con.cursor()
+        curs.execute("""
+            create table foo (a, b)
+            """)
+        first_count = len(progress_calls)
+        progress_calls = []
+        con.set_progress_handler(progress, 2)
+        curs.execute("""
+            create table bar (a, b)
+            """)
+        second_count = len(progress_calls)
+        self.assertGreaterEqual(first_count, second_count)
+
+    def test_CancelOperation(self):
+        """
+        Test that returning a non-zero value stops the operation in progress.
+        """
+        con = sqlite.connect(":memory:")
+        def progress():
+            return 1
+        con.set_progress_handler(progress, 1)
+        curs = con.cursor()
+        self.assertRaises(
+            sqlite.OperationalError,
+            curs.execute,
+            "create table bar (a, b)")
+
+    def test_ClearHandler(self):
+        """
+        Test that setting the progress handler to None clears the previously set handler.
+        """
+        con = sqlite.connect(":memory:")
+        action = 0
+        def progress():
+            nonlocal action
+            action = 1
+            return 0
+        con.set_progress_handler(progress, 1)
+        con.set_progress_handler(None, 1)
+        con.execute("select 1 union select 2 union select 3").fetchall()
+        self.assertEqual(action, 0, "progress handler was not cleared")
+
+class TraceCallbackTests(unittest.TestCase):
+    def test_TraceCallbackUsed(self):
+        """
+        Test that the trace callback is invoked once it is set.
+        """
+        con = sqlite.connect(":memory:")
+        traced_statements = []
+        def trace(statement):
+            traced_statements.append(statement)
+        con.set_trace_callback(trace)
+        con.execute("create table foo(a, b)")
+        self.assertTrue(traced_statements)
+        self.assertTrue(any("create table foo" in stmt for stmt in traced_statements))
+
+    def test_TraceCallbackError(self):
+        """
+        Test behavior when exception raised in trace callback.
+        """
+        con = sqlite.connect(":memory:")
+        def trace(statement):
+            raise Exception('uh-oh')
+        con.set_trace_callback(trace)
+        con.execute("create table foo(a, b)")
+        con.set_trace_callback(None)
+
+    def test_ClearTraceCallback(self):
+        """
+        Test that setting the trace callback to None clears the previously set callback.
+        """
+        con = sqlite.connect(":memory:")
+        traced_statements = []
+        def trace(statement):
+            traced_statements.append(statement)
+        con.set_trace_callback(trace)
+        con.set_trace_callback(None)
+        con.execute("create table foo(a, b)")
+        self.assertFalse(traced_statements, "trace callback was not cleared")
+
+    def test_UnicodeContent(self):
+        """
+        Test that the statement can contain unicode literals.
+        """
+        unicode_value = '\xf6\xe4\xfc\xd6\xc4\xdc\xdf\u20ac'
+        con = sqlite.connect(":memory:")
+        traced_statements = []
+        def trace(statement):
+            traced_statements.append(statement)
+        con.set_trace_callback(trace)
+        con.execute("create table foo(x)")
+        # Can't execute bound parameters as their values don't appear
+        # in traced statements before SQLite 3.6.21
+        # (cf. http://www.sqlite.org/draft/releaselog/3_6_21.html)
+        con.execute('insert into foo(x) values ("%s")' % unicode_value)
+        con.commit()
+        self.assertTrue(any(unicode_value in stmt for stmt in traced_statements),
+                        "Unicode data %s garbled in trace callback: %s"
+                        % (ascii(unicode_value), ', '.join(map(ascii, traced_statements))))
+
+    def test_TraceCallbackContent(self):
+        # set_trace_callback() shouldn't produce duplicate content (bpo-26187)
+        traced_statements = []
+        def trace(statement):
+            traced_statements.append(statement)
+
+        queries = ["create table foo(x)",
+                   "insert into foo(x) values(1)"]
+        self.addCleanup(os.unlink, 'tracecb.db')
+        con1 = sqlite.connect('tracecb.db', isolation_level=None)
+        con2 = sqlite.connect('tracecb.db')
+        con1.set_trace_callback(trace)
+        cur = con1.cursor()
+        cur.execute(queries[0])
+        con2.execute("create table bar(x)")
+        cur.execute(queries[1])
+        self.assertEqual(traced_statements, queries)
+
+
+class TestBusyHandlerTimeout(unittest.TestCase):
+    def test_busy_handler(self):
+        accum = []
+        def custom_handler(n):
+            accum.append(n)
+            return 0 if n == 3 else 1
+
+        self.addCleanup(os.unlink, 'busy.db')
+        conn1 = sqlite.connect('busy.db')
+        conn2 = sqlite.connect('busy.db')
+        conn2.set_busy_handler(custom_handler)
+
+        conn1.execute('begin exclusive')
+        with self.assertRaises(sqlite.OperationalError):
+            conn2.execute('create table test(id)')
+        self.assertEqual(accum, [0, 1, 2, 3])
+        accum.clear()
+
+        conn2.set_busy_handler(None)
+        with self.assertRaises(sqlite.OperationalError):
+            conn2.execute('create table test(id)')
+        self.assertEqual(accum, [])
+
+        conn2.set_busy_handler(custom_handler)
+        with self.assertRaises(sqlite.OperationalError):
+            conn2.execute('create table test(id)')
+        self.assertEqual(accum, [0, 1, 2, 3])
+        accum.clear()
+
+        conn2.set_busy_timeout(0.01)  # Clears busy handler.
+        with self.assertRaises(sqlite.OperationalError):
+            conn2.execute('create table test(id)')
+        self.assertEqual(accum, [])
+
+
+def suite():
+    loader = unittest.TestLoader()
+    tests = [loader.loadTestsFromTestCase(t) for t in (
+        CollationTests,
+        ProgressTests,
+        TraceCallbackTests,
+        TestBusyHandlerTimeout)]
+    return unittest.TestSuite(tests)
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/regression.py
+++ b/packages/phoenix-sqlean/tests/regression.py
@@ -1,0 +1,413 @@
+#-*- coding: iso-8859-1 -*-
+# pysqlite2/test/regression.py: pysqlite regression tests
+#
+# Copyright (C) 2006-2010 Gerhard H�ring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+import datetime
+import functools
+import unittest
+from sqlean import dbapi2 as sqlite
+import weakref
+#from test import support
+
+class RegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_PragmaUserVersion(self):
+        # This used to crash pysqlite because this pragma command returns NULL for the column name
+        cur = self.con.cursor()
+        cur.execute("pragma user_version")
+
+    def test_PragmaSchemaVersion(self):
+        # This still crashed pysqlite <= 2.2.1
+        con = sqlite.connect(":memory:", detect_types=sqlite.PARSE_COLNAMES)
+        try:
+            cur = self.con.cursor()
+            cur.execute("pragma schema_version")
+        finally:
+            cur.close()
+            con.close()
+
+    def test_StatementReset(self):
+        # pysqlite 2.1.0 to 2.2.0 have the problem that not all statements are
+        # reset before a rollback, but only those that are still in the
+        # statement cache. The others are not accessible from the connection object.
+        con = sqlite.connect(":memory:", cached_statements=5)
+        cursors = [con.cursor() for x in range(5)]
+        cursors[0].execute("create table test(x)")
+        for i in range(10):
+            cursors[0].executemany("insert into test(x) values (?)", [(x,) for x in range(10)])
+
+        for i in range(5):
+            cursors[i].execute(" " * i + "select x from test")
+
+        con.rollback()
+
+    def test_ColumnNameWithSpaces(self):
+        cur = self.con.cursor()
+        cur.execute('select 1 as "foo bar [datetime]"')
+        self.assertEqual(cur.description[0][0], "foo bar [datetime]")
+
+        cur.execute('select 1 as "foo baz"')
+        self.assertEqual(cur.description[0][0], "foo baz")
+
+    def test_StatementFinalizationOnCloseDb(self):
+        # pysqlite versions <= 2.3.3 only finalized statements in the statement
+        # cache when closing the database. statements that were still
+        # referenced in cursors weren't closed and could provoke "
+        # "OperationalError: Unable to close due to unfinalised statements".
+        con = sqlite.connect(":memory:")
+        cursors = []
+        # default statement cache size is 100
+        for i in range(105):
+            cur = con.cursor()
+            cursors.append(cur)
+            cur.execute("select 1 x union select " + str(i))
+        con.close()
+
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 2, 2), 'needs sqlite 3.2.2 or newer')
+    def test_OnConflictRollback(self):
+        con = sqlite.connect(":memory:")
+        con.execute("create table foo(x, unique(x) on conflict rollback)")
+        con.execute("insert into foo(x) values (1)")
+        try:
+            con.execute("insert into foo(x) values (1)")
+        except sqlite.DatabaseError:
+            pass
+        con.execute("insert into foo(x) values (2)")
+        try:
+            con.commit()
+        except sqlite.OperationalError:
+            self.fail("pysqlite knew nothing about the implicit ROLLBACK")
+
+    def test_WorkaroundForBuggySqliteTransferBindings(self):
+        """
+        pysqlite would crash with older SQLite versions unless
+        a workaround is implemented.
+        """
+        self.con.execute("create table foo(bar)")
+        self.con.execute("drop table foo")
+        self.con.execute("create table foo(bar)")
+
+    def test_EmptyStatement(self):
+        """
+        pysqlite used to segfault with SQLite versions 3.5.x. These return NULL
+        for "no-operation" statements
+        """
+        self.con.execute("")
+
+    def test_TypeMapUsage(self):
+        """
+        pysqlite until 2.4.1 did not rebuild the row_cast_map when recompiling
+        a statement. This test exhibits the problem.
+        """
+        SELECT = "select * from foo"
+        con = sqlite.connect(":memory:",detect_types=sqlite.PARSE_DECLTYPES)
+        con.execute("create table foo(bar timestamp)")
+        con.execute("insert into foo(bar) values (?)", (datetime.datetime.now(),))
+        con.execute(SELECT)
+        con.execute("drop table foo")
+        con.execute("create table foo(bar integer)")
+        con.execute("insert into foo(bar) values (5)")
+        con.execute(SELECT)
+
+    def test_ErrorMsgDecodeError(self):
+        # When porting the module to Python 3.0, the error message about
+        # decoding errors disappeared. This verifies they're back again.
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            self.con.execute("select 'xxx' || ? || 'yyy' colname",
+                             (bytes(bytearray([250])),)).fetchone()
+        msg = "Could not decode to UTF-8 column 'colname' with text 'xxx"
+        self.assertIn(msg, str(cm.exception))
+
+    def test_RegisterAdapter(self):
+        """
+        See issue 3312.
+        """
+        self.assertRaises(TypeError, sqlite.register_adapter, {}, None)
+
+    def test_SetIsolationLevel(self):
+        # See issue 27881.
+        class CustomStr(str):
+            def upper(self):
+                return None
+            def __del__(self):
+                con.isolation_level = ""
+
+        con = sqlite.connect(":memory:")
+        con.isolation_level = None
+        for level in "", "DEFERRED", "IMMEDIATE", "EXCLUSIVE":
+            with self.subTest(level=level):
+                con.isolation_level = level
+                con.isolation_level = level.lower()
+                con.isolation_level = level.capitalize()
+                con.isolation_level = CustomStr(level)
+
+        # setting isolation_level failure should not alter previous state
+        con.isolation_level = None
+        con.isolation_level = "DEFERRED"
+        pairs = [
+            (1, TypeError), (b'', TypeError), ("abc", ValueError),
+            ("\xe9", ValueError),
+        ]
+        for value, exc in pairs:
+            with self.subTest(level=value):
+                with self.assertRaises(exc):
+                    con.isolation_level = value
+                self.assertEqual(con.isolation_level, "DEFERRED")
+
+    def test_CursorConstructorCallCheck(self):
+        """
+        Verifies that cursor methods check whether base class __init__ was
+        called.
+        """
+        class Cursor(sqlite.Cursor):
+            def __init__(self, con):
+                pass
+
+        con = sqlite.connect(":memory:")
+        cur = Cursor(con)
+        with self.assertRaises(sqlite.ProgrammingError):
+            cur.execute("select 4+5").fetchall()
+        with self.assertRaisesRegex(sqlite.ProgrammingError,
+                                    r'^Base Cursor\.__init__ not called\.$'):
+            cur.close()
+
+    def test_StrSubclass(self):
+        """
+        The Python 3.0 port of the module didn't cope with values of subclasses of str.
+        """
+        class MyStr(str): pass
+        self.con.execute("select ?", (MyStr("abc"),))
+
+    def test_ConnectionConstructorCallCheck(self):
+        """
+        Verifies that connection methods check whether base class __init__ was
+        called.
+        """
+        class Connection(sqlite.Connection):
+            def __init__(self, name):
+                pass
+
+        con = Connection(":memory:")
+        with self.assertRaises(sqlite.ProgrammingError):
+            cur = con.cursor()
+
+    def test_CursorRegistration(self):
+        """
+        Verifies that subclassed cursor classes are correctly registered with
+        the connection object, too.  (fetch-across-rollback problem)
+        """
+        class Connection(sqlite.Connection):
+            def cursor(self):
+                return Cursor(self)
+
+        class Cursor(sqlite.Cursor):
+            def __init__(self, con):
+                sqlite.Cursor.__init__(self, con)
+
+        con = Connection(":memory:")
+        cur = con.cursor()
+        cur.execute("create table foo(x)")
+        cur.executemany("insert into foo(x) values (?)", [(3,), (4,), (5,)])
+        cur.execute("select x from foo")
+        con.rollback()
+        with self.assertRaises(sqlite.InterfaceError):
+            cur.fetchall()
+
+    def test_AutoCommit(self):
+        """
+        Verifies that creating a connection in autocommit mode works.
+        2.5.3 introduced a regression so that these could no longer
+        be created.
+        """
+        con = sqlite.connect(":memory:", isolation_level=None)
+
+    def test_PragmaAutocommit(self):
+        """
+        Verifies that running a PRAGMA statement that does an autocommit does
+        work. This did not work in 2.5.3/2.5.4.
+        """
+        cur = self.con.cursor()
+        cur.execute("create table foo(bar)")
+        cur.execute("insert into foo(bar) values (5)")
+
+        cur.execute("pragma page_size")
+        row = cur.fetchone()
+
+    def test_ConnectionCall(self):
+        """
+        Call a connection with a non-string SQL request: check error handling
+        of the statement constructor.
+        """
+        self.assertRaises(TypeError, self.con, 1)
+
+    def test_Collation(self):
+        def collation_cb(a, b):
+            return 1
+        self.assertRaises(UnicodeEncodeError, self.con.create_collation,
+            # Lone surrogate cannot be encoded to the default encoding (utf8)
+            "\uDC80", collation_cb)
+
+    def test_RecursiveCursorUse(self):
+        """
+        http://bugs.python.org/issue10811
+
+        Recursively using a cursor, such as when reusing it from a generator led to segfaults.
+        Now we catch recursive cursor usage and raise a ProgrammingError.
+        """
+        con = sqlite.connect(":memory:")
+
+        cur = con.cursor()
+        cur.execute("create table a (bar)")
+        cur.execute("create table b (baz)")
+
+        def foo():
+            cur.execute("insert into a (bar) values (?)", (1,))
+            yield 1
+
+        with self.assertRaises(sqlite.ProgrammingError):
+            cur.executemany("insert into b (baz) values (?)",
+                            ((i,) for i in foo()))
+
+    def test_ConvertTimestampMicrosecondPadding(self):
+        """
+        http://bugs.python.org/issue14720
+
+        The microsecond parsing of convert_timestamp() should pad with zeros,
+        since the microsecond string "456" actually represents "456000".
+        """
+
+        con = sqlite.connect(":memory:", detect_types=sqlite.PARSE_DECLTYPES)
+        cur = con.cursor()
+        cur.execute("CREATE TABLE t (x TIMESTAMP)")
+
+        # Microseconds should be 456000
+        cur.execute("INSERT INTO t (x) VALUES ('2012-04-04 15:06:00.456')")
+
+        # Microseconds should be truncated to 123456
+        cur.execute("INSERT INTO t (x) VALUES ('2012-04-04 15:06:00.123456789')")
+
+        cur.execute("SELECT * FROM t")
+        values = [x[0] for x in cur.fetchall()]
+
+        self.assertEqual(values, [
+            datetime.datetime(2012, 4, 4, 15, 6, 0, 456000),
+            datetime.datetime(2012, 4, 4, 15, 6, 0, 123456),
+        ])
+
+    def test_InvalidIsolationLevelType(self):
+        # isolation level is a string, not an integer
+        self.assertRaises(TypeError,
+                          sqlite.connect, ":memory:", isolation_level=123)
+
+
+    def test_NullCharacter(self):
+        # Issue #21147
+        con = sqlite.connect(":memory:")
+        self.assertRaises(ValueError, con, "\0select 1")
+        self.assertRaises(ValueError, con, "select 1\0")
+        cur = con.cursor()
+        self.assertRaises(ValueError, cur.execute, " \0select 2")
+        self.assertRaises(ValueError, cur.execute, "select 2\0")
+
+    def test_CommitCursorReset(self):
+        """
+        Connection.commit() did reset cursors, which made sqlite3
+        to return rows multiple times when fetched from cursors
+        after commit. See issues 10513 and 23129 for details.
+        """
+        con = sqlite.connect(":memory:")
+        con.executescript("""
+        create table t(c);
+        create table t2(c);
+        insert into t values(0);
+        insert into t values(1);
+        insert into t values(2);
+        """)
+
+        self.assertEqual(con.isolation_level, "")
+
+        counter = 0
+        for i, row in enumerate(con.execute("select c from t")):
+            with self.subTest(i=i, row=row):
+                con.execute("insert into t2(c) values (?)", (i,))
+                con.commit()
+                if counter == 0:
+                    self.assertEqual(row[0], 0)
+                elif counter == 1:
+                    self.assertEqual(row[0], 1)
+                elif counter == 2:
+                    self.assertEqual(row[0], 2)
+                counter += 1
+        self.assertEqual(counter, 3, "should have returned exactly three rows")
+
+    def test_Bpo31770(self):
+        """
+        The interpreter shouldn't crash in case Cursor.__init__() is called
+        more than once.
+        """
+        def callback(*args):
+            pass
+        con = sqlite.connect(":memory:")
+        cur = sqlite.Cursor(con)
+        ref = weakref.ref(cur, callback)
+        cur.__init__(con)
+        del cur
+        # The interpreter shouldn't crash when ref is collected.
+        del ref
+        #support.gc_collect()
+
+    def test_DelIsolation_levelSegfault(self):
+        with self.assertRaises(AttributeError):
+            del self.con.isolation_level
+
+    def test_Bpo37347(self):
+        class Printer:
+            def log(self, *args):
+                return sqlite.SQLITE_OK
+
+        for method in [self.con.set_trace_callback,
+                       functools.partial(self.con.set_progress_handler, n=1),
+                       self.con.set_authorizer]:
+            printer_instance = Printer()
+            method(printer_instance.log)
+            method(printer_instance.log)  # Register twice, incref twice.
+            self.con.execute('select 1')  # Triggers segfault.
+            method(None)
+
+
+def suite():
+    loader = unittest.TestLoader()
+    tests = [loader.loadTestsFromTestCase(t) for t in (
+        RegressionTests,)]
+    return unittest.TestSuite(tests)
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/transactions.py
+++ b/packages/phoenix-sqlean/tests/transactions.py
@@ -1,0 +1,301 @@
+#-*- coding: iso-8859-1 -*-
+# pysqlite2/test/transactions.py: tests transactions
+#
+# Copyright (C) 2005-2007 Gerhard H�ring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+import glob, os, unittest
+from sqlean import dbapi2 as sqlite
+
+def get_db_path():
+    return "sqlite_testdb"
+
+class TransactionTests(unittest.TestCase):
+    def setUp(self):
+        try:
+            os.remove(get_db_path())
+        except OSError:
+            pass
+
+        self.con1 = sqlite.connect(get_db_path(), timeout=0.1)
+        self.cur1 = self.con1.cursor()
+
+        self.con2 = sqlite.connect(get_db_path(), timeout=0.1)
+        self.cur2 = self.con2.cursor()
+
+    def tearDown(self):
+        self.cur1.close()
+        self.con1.close()
+
+        self.cur2.close()
+        self.con2.close()
+
+        try:
+            os.unlink(get_db_path())
+        except OSError:
+            pass
+
+    def test_DMLDoesNotAutoCommitBefore(self):
+        self.cur1.execute("create table test(i)")
+        self.cur1.execute("insert into test(i) values (5)")
+        self.cur1.execute("create table test2(j)")
+        self.cur2.execute("select i from test")
+        res = self.cur2.fetchall()
+        self.assertEqual(len(res), 0)
+
+    def test_InsertStartsTransaction(self):
+        self.cur1.execute("create table test(i)")
+        self.cur1.execute("insert into test(i) values (5)")
+        self.cur2.execute("select i from test")
+        res = self.cur2.fetchall()
+        self.assertEqual(len(res), 0)
+
+    def test_UpdateStartsTransaction(self):
+        self.cur1.execute("create table test(i)")
+        self.cur1.execute("insert into test(i) values (5)")
+        self.con1.commit()
+        self.cur1.execute("update test set i=6")
+        self.cur2.execute("select i from test")
+        res = self.cur2.fetchone()[0]
+        self.assertEqual(res, 5)
+
+    def test_DeleteStartsTransaction(self):
+        self.cur1.execute("create table test(i)")
+        self.cur1.execute("insert into test(i) values (5)")
+        self.con1.commit()
+        self.cur1.execute("delete from test")
+        self.cur2.execute("select i from test")
+        res = self.cur2.fetchall()
+        self.assertEqual(len(res), 1)
+
+    def test_ReplaceStartsTransaction(self):
+        self.cur1.execute("create table test(i)")
+        self.cur1.execute("insert into test(i) values (5)")
+        self.con1.commit()
+        self.cur1.execute("replace into test(i) values (6)")
+        self.cur2.execute("select i from test")
+        res = self.cur2.fetchall()
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0][0], 5)
+
+    def test_ToggleAutoCommit(self):
+        self.cur1.execute("create table test(i)")
+        self.cur1.execute("insert into test(i) values (5)")
+        self.con1.isolation_level = None
+        self.assertEqual(self.con1.isolation_level, None)
+        self.cur2.execute("select i from test")
+        res = self.cur2.fetchall()
+        self.assertEqual(len(res), 1)
+
+        self.con1.isolation_level = "DEFERRED"
+        self.assertEqual(self.con1.isolation_level , "DEFERRED")
+        self.cur1.execute("insert into test(i) values (5)")
+        self.cur2.execute("select i from test")
+        res = self.cur2.fetchall()
+        self.assertEqual(len(res), 1)
+
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 2, 2),
+                     'test hangs on sqlite versions older than 3.2.2')
+    def test_RaiseTimeout(self):
+        self.cur1.execute("create table test(i)")
+        self.cur1.execute("insert into test(i) values (5)")
+        with self.assertRaises(sqlite.OperationalError):
+            self.cur2.execute("insert into test(i) values (5)")
+
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 2, 2),
+                     'test hangs on sqlite versions older than 3.2.2')
+    def test_Locking(self):
+        """
+        This tests the improved concurrency with pysqlite 2.3.4. You needed
+        to roll back con2 before you could commit con1.
+        """
+        self.cur1.execute("create table test(i)")
+        self.cur1.execute("insert into test(i) values (5)")
+        with self.assertRaises(sqlite.OperationalError):
+            self.cur2.execute("insert into test(i) values (5)")
+        # NO self.con2.rollback() HERE!!!
+        self.con1.commit()
+
+    def test_RollbackCursorConsistency(self):
+        """
+        Checks if cursors on the connection are set into a "reset" state
+        when a rollback is done on the connection.
+        """
+        con = sqlite.connect(":memory:")
+        cur = con.cursor()
+        cur.execute("create table test(x)")
+        cur.execute("insert into test(x) values (5)")
+        cur.execute("select 1 union select 2 union select 3")
+
+        con.rollback()
+        with self.assertRaises(sqlite.InterfaceError):
+            cur.fetchall()
+
+class SpecialCommandTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        self.cur = self.con.cursor()
+
+    def test_DropTable(self):
+        self.cur.execute("create table test(i)")
+        self.cur.execute("insert into test(i) values (5)")
+        self.cur.execute("drop table test")
+
+    def test_Pragma(self):
+        self.cur.execute("create table test(i)")
+        self.cur.execute("insert into test(i) values (5)")
+        self.cur.execute("pragma count_changes=1")
+
+    def tearDown(self):
+        self.cur.close()
+        self.con.close()
+
+class TransactionalDDL(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+
+    def test_DdlDoesNotAutostartTransaction(self):
+        # For backwards compatibility reasons, DDL statements should not
+        # implicitly start a transaction.
+        self.con.execute("create table test(i)")
+        self.con.rollback()
+        result = self.con.execute("select * from test").fetchall()
+        self.assertEqual(result, [])
+
+        self.con.execute("alter table test rename to test2")
+        self.con.rollback()
+        result = self.con.execute("select * from test2").fetchall()
+        self.assertEqual(result, [])
+
+    def test_ImmediateTransactionalDDL(self):
+        # You can achieve transactional DDL by issuing a BEGIN
+        # statement manually.
+        self.con.execute("begin immediate")
+        self.con.execute("create table test(i)")
+        self.con.rollback()
+        with self.assertRaises(sqlite.OperationalError):
+            self.con.execute("select * from test")
+
+    def test_TransactionalDDL(self):
+        # You can achieve transactional DDL by issuing a BEGIN
+        # statement manually.
+        self.con.execute("begin")
+        self.con.execute("create table test(i)")
+        self.con.rollback()
+        with self.assertRaises(sqlite.OperationalError):
+            self.con.execute("select * from test")
+
+    def tearDown(self):
+        self.con.close()
+
+
+class DMLStatementDetectionTestCase(unittest.TestCase):
+    """
+    https://bugs.python.org/issue36859
+
+    Use sqlite3_stmt_readonly to determine if the statement is DML or not.
+    """
+    def setUp(self):
+        for f in glob.glob(get_db_path() + '*'):
+            try:
+                os.unlink(f)
+            except OSError:
+                pass
+    tearDown = setUp
+
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 8, 3),
+                     'needs sqlite 3.8.3 or newer')
+    def test_dml_detection_cte(self):
+        conn = sqlite.connect(':memory:')
+        conn.execute('create table kv ("key" text, "val" integer)')
+        self.assertFalse(conn.in_transaction)
+        conn.execute('insert into kv (key, val) values (?, ?), (?, ?)',
+                     ('k1', 1, 'k2', 2))
+        self.assertTrue(conn.in_transaction)
+
+        conn.commit()
+        self.assertFalse(conn.in_transaction)
+
+        rc = conn.execute('update kv set val=val + ?', (10,))
+        self.assertEqual(rc.rowcount, 2)
+        self.assertTrue(conn.in_transaction)
+        conn.commit()
+        self.assertFalse(conn.in_transaction)
+
+        rc = conn.execute('with c(k, v) as (select key, val + ? from kv) '
+                          'update kv set val=(select v from c where k=kv.key)',
+                          (100,))
+        self.assertEqual(rc.rowcount, 2)
+        self.assertTrue(conn.in_transaction)
+
+        curs = conn.execute('select key, val from kv order by key')
+        self.assertEqual(curs.fetchall(), [('k1', 111), ('k2', 112)])
+
+    def test_dml_detection_sql_comment(self):
+        conn = sqlite.connect(':memory:')
+        conn.execute('create table kv ("key" text, "val" integer)')
+        conn.execute('insert into kv (key, val) values (?, ?), (?, ?)',
+                     ('k1', 1, 'k2', 2))
+        conn.commit()
+
+        self.assertFalse(conn.in_transaction)
+        rc = conn.execute('-- a comment\nupdate kv set val=val + ?', (10,))
+        self.assertEqual(rc.rowcount, 2)
+        self.assertTrue(conn.in_transaction)
+
+        curs = conn.execute('select key, val from kv order by key')
+        self.assertEqual(curs.fetchall(), [('k1', 11), ('k2', 12)])
+        conn.rollback()
+
+    def test_dml_detection_begin_exclusive(self):
+        conn = sqlite.connect(':memory:')
+        conn.execute('begin exclusive')
+        self.assertTrue(conn.in_transaction)
+        conn.execute('rollback')
+        self.assertFalse(conn.in_transaction)
+
+    def test_dml_detection_vacuum(self):
+        conn = sqlite.connect(':memory:')
+        conn.execute('vacuum')
+        self.assertFalse(conn.in_transaction)
+
+    def test_dml_detection_pragma(self):
+        conn = sqlite.connect(get_db_path())
+        conn.execute('pragma journal_mode=\'wal\'')
+        jmode, = conn.execute('pragma journal_mode').fetchone()
+        self.assertEqual(jmode, 'wal')
+        self.assertFalse(conn.in_transaction)
+
+
+def suite():
+    loader = unittest.TestLoader()
+    tests = [loader.loadTestsFromTestCase(t) for t in (
+        TransactionTests,
+        SpecialCommandTests,
+        TransactionalDDL,
+        DMLStatementDetectionTestCase)]
+    return unittest.TestSuite(tests)
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/ttypes.py
+++ b/packages/phoenix-sqlean/tests/ttypes.py
@@ -1,0 +1,445 @@
+#-*- coding: iso-8859-1 -*-
+# pysqlite2/test/types.py: tests for type conversion and detection
+#
+# Copyright (C) 2005 Gerhard H�ring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+import datetime
+import unittest
+from sqlean import dbapi2 as sqlite
+try:
+    import zlib
+except ImportError:
+    zlib = None
+
+
+class SqliteTypeTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(i integer, s varchar, f number, b blob)")
+
+    def tearDown(self):
+        self.cur.close()
+        self.con.close()
+
+    def test_String(self):
+        self.cur.execute("insert into test(s) values (?)", ("�sterreich",))
+        self.cur.execute("select s from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], "�sterreich")
+
+    def test_SmallInt(self):
+        self.cur.execute("insert into test(i) values (?)", (42,))
+        self.cur.execute("select i from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], 42)
+
+    def test_LargeInt(self):
+        num = 2**40
+        self.cur.execute("insert into test(i) values (?)", (num,))
+        self.cur.execute("select i from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], num)
+
+    def test_Float(self):
+        val = 3.14
+        self.cur.execute("insert into test(f) values (?)", (val,))
+        self.cur.execute("select f from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], val)
+
+    def test_Blob(self):
+        sample = b"Guglhupf"
+        val = memoryview(sample)
+        self.cur.execute("insert into test(b) values (?)", (val,))
+        self.cur.execute("select b from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], sample)
+
+    def test_UnicodeExecute(self):
+        self.cur.execute("select '�sterreich'")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], "�sterreich")
+
+class DeclTypesTests(unittest.TestCase):
+    class Foo:
+        def __init__(self, _val):
+            if isinstance(_val, bytes):
+                # sqlite3 always calls __init__ with a bytes created from a
+                # UTF-8 string when __conform__ was used to store the object.
+                _val = _val.decode('utf-8')
+            self.val = _val
+
+        def __eq__(self, other):
+            if not isinstance(other, DeclTypesTests.Foo):
+                return NotImplemented
+            return self.val == other.val
+
+        def __conform__(self, protocol):
+            if protocol is sqlite.PrepareProtocol:
+                return self.val
+            else:
+                return None
+
+        def __str__(self):
+            return "<%s>" % self.val
+
+    class BadConform:
+        def __init__(self, exc):
+            self.exc = exc
+        def __conform__(self, protocol):
+            raise self.exc
+
+    def setUp(self):
+        self.con = sqlite.connect(":memory:", detect_types=sqlite.PARSE_DECLTYPES)
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(i int, s str, f float, b bool, u unicode, foo foo, bin blob, n1 number, n2 number(5), bad bad)")
+
+        # override float, make them always return the same number
+        sqlite.converters["FLOAT"] = lambda x: 47.2
+
+        # and implement two custom ones
+        sqlite.converters["BOOL"] = lambda x: bool(int(x))
+        sqlite.converters["FOO"] = DeclTypesTests.Foo
+        sqlite.converters["BAD"] = DeclTypesTests.BadConform
+        sqlite.converters["WRONG"] = lambda x: "WRONG"
+        sqlite.converters["NUMBER"] = float
+
+    def tearDown(self):
+        del sqlite.converters["FLOAT"]
+        del sqlite.converters["BOOL"]
+        del sqlite.converters["FOO"]
+        del sqlite.converters["BAD"]
+        del sqlite.converters["WRONG"]
+        del sqlite.converters["NUMBER"]
+        self.cur.close()
+        self.con.close()
+
+    def test_String(self):
+        # default
+        self.cur.execute("insert into test(s) values (?)", ("foo",))
+        self.cur.execute('select s as "s [WRONG]" from test')
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], "foo")
+
+    def test_SmallInt(self):
+        # default
+        self.cur.execute("insert into test(i) values (?)", (42,))
+        self.cur.execute("select i from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], 42)
+
+    def test_LargeInt(self):
+        # default
+        num = 2**40
+        self.cur.execute("insert into test(i) values (?)", (num,))
+        self.cur.execute("select i from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], num)
+
+    def test_Float(self):
+        # custom
+        val = 3.14
+        self.cur.execute("insert into test(f) values (?)", (val,))
+        self.cur.execute("select f from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], 47.2)
+
+    def test_Bool(self):
+        # custom
+        self.cur.execute("insert into test(b) values (?)", (False,))
+        self.cur.execute("select b from test")
+        row = self.cur.fetchone()
+        self.assertIs(row[0], False)
+
+        self.cur.execute("delete from test")
+        self.cur.execute("insert into test(b) values (?)", (True,))
+        self.cur.execute("select b from test")
+        row = self.cur.fetchone()
+        self.assertIs(row[0], True)
+
+    def test_Unicode(self):
+        # default
+        val = "\xd6sterreich"
+        self.cur.execute("insert into test(u) values (?)", (val,))
+        self.cur.execute("select u from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], val)
+
+    def test_Foo(self):
+        val = DeclTypesTests.Foo("bla")
+        self.cur.execute("insert into test(foo) values (?)", (val,))
+        self.cur.execute("select foo from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], val)
+
+    def test_ErrorInConform(self):
+        val = DeclTypesTests.BadConform(TypeError)
+        with self.assertRaises(sqlite.InterfaceError):
+            self.cur.execute("insert into test(bad) values (?)", (val,))
+        with self.assertRaises(sqlite.InterfaceError):
+            self.cur.execute("insert into test(bad) values (:val)", {"val": val})
+
+        val = DeclTypesTests.BadConform(KeyboardInterrupt)
+        with self.assertRaises(KeyboardInterrupt):
+            self.cur.execute("insert into test(bad) values (?)", (val,))
+        with self.assertRaises(KeyboardInterrupt):
+            self.cur.execute("insert into test(bad) values (:val)", {"val": val})
+
+    def test_UnsupportedSeq(self):
+        class Bar: pass
+        val = Bar()
+        with self.assertRaises(sqlite.InterfaceError):
+            self.cur.execute("insert into test(f) values (?)", (val,))
+
+    def test_UnsupportedDict(self):
+        class Bar: pass
+        val = Bar()
+        with self.assertRaises(sqlite.InterfaceError):
+            self.cur.execute("insert into test(f) values (:val)", {"val": val})
+
+    def test_Blob(self):
+        # default
+        sample = b"Guglhupf"
+        val = memoryview(sample)
+        self.cur.execute("insert into test(bin) values (?)", (val,))
+        self.cur.execute("select bin from test")
+        row = self.cur.fetchone()
+        self.assertEqual(row[0], sample)
+
+    def test_Number1(self):
+        self.cur.execute("insert into test(n1) values (5)")
+        value = self.cur.execute("select n1 from test").fetchone()[0]
+        # if the converter is not used, it's an int instead of a float
+        self.assertEqual(type(value), float)
+
+    def test_Number2(self):
+        """Checks whether converter names are cut off at '(' characters"""
+        self.cur.execute("insert into test(n2) values (5)")
+        value = self.cur.execute("select n2 from test").fetchone()[0]
+        # if the converter is not used, it's an int instead of a float
+        self.assertEqual(type(value), float)
+
+class ColNamesTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:", detect_types=sqlite.PARSE_COLNAMES)
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(x foo)")
+
+        sqlite.converters["FOO"] = lambda x: "[%s]" % x.decode("ascii")
+        sqlite.converters["BAR"] = lambda x: "<%s>" % x.decode("ascii")
+        sqlite.converters["EXC"] = lambda x: 5/0
+        sqlite.converters["B1B1"] = lambda x: "MARKER"
+
+    def tearDown(self):
+        del sqlite.converters["FOO"]
+        del sqlite.converters["BAR"]
+        del sqlite.converters["EXC"]
+        del sqlite.converters["B1B1"]
+        self.cur.close()
+        self.con.close()
+
+    def test_DeclTypeNotUsed(self):
+        """
+        Assures that the declared type is not used when PARSE_DECLTYPES
+        is not set.
+        """
+        self.cur.execute("insert into test(x) values (?)", ("xxx",))
+        self.cur.execute("select x from test")
+        val = self.cur.fetchone()[0]
+        self.assertEqual(val, "xxx")
+
+    def test_None(self):
+        self.cur.execute("insert into test(x) values (?)", (None,))
+        self.cur.execute("select x from test")
+        val = self.cur.fetchone()[0]
+        self.assertEqual(val, None)
+
+    def test_ColName(self):
+        self.cur.execute("insert into test(x) values (?)", ("xxx",))
+        self.cur.execute('select x as "x y [bar]" from test')
+        val = self.cur.fetchone()[0]
+        self.assertEqual(val, "<xxx>")
+
+        # Check if the stripping of colnames works. Everything after the first
+        # whitespace should be stripped.
+        self.assertEqual(self.cur.description[0][0], "x y")
+
+    def test_CaseInConverterName(self):
+        self.cur.execute("select 'other' as \"x [b1b1]\"")
+        val = self.cur.fetchone()[0]
+        self.assertEqual(val, "MARKER")
+
+    def test_CursorDescriptionNoRow(self):
+        """
+        cursor.description should at least provide the column name(s), even if
+        no row returned.
+        """
+        self.cur.execute("select * from test where 0 = 1")
+        self.assertEqual(self.cur.description[0][0], "x")
+
+    def test_CursorDescriptionInsert(self):
+        self.cur.execute("insert into test values (1)")
+        self.assertIsNone(self.cur.description)
+
+
+@unittest.skipIf(sqlite.sqlite_version_info < (3, 8, 3), "CTEs not supported")
+class CommonTableExpressionTests(unittest.TestCase):
+
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(x foo)")
+
+    def tearDown(self):
+        self.cur.close()
+        self.con.close()
+
+    def test_CursorDescriptionCTESimple(self):
+        self.cur.execute("with one as (select 1) select * from one")
+        self.assertIsNotNone(self.cur.description)
+        self.assertEqual(self.cur.description[0][0], "1")
+
+    def test_CursorDescriptionCTESMultipleColumns(self):
+        self.cur.execute("insert into test values(1)")
+        self.cur.execute("insert into test values(2)")
+        self.cur.execute("with testCTE as (select * from test) select * from testCTE")
+        self.assertIsNotNone(self.cur.description)
+        self.assertEqual(self.cur.description[0][0], "x")
+
+    def test_CursorDescriptionCTE(self):
+        self.cur.execute("insert into test values (1)")
+        self.cur.execute("with bar as (select * from test) select * from test where x = 1")
+        self.assertIsNotNone(self.cur.description)
+        self.assertEqual(self.cur.description[0][0], "x")
+        self.cur.execute("with bar as (select * from test) select * from test where x = 2")
+        self.assertIsNotNone(self.cur.description)
+        self.assertEqual(self.cur.description[0][0], "x")
+
+
+class ObjectAdaptationTests(unittest.TestCase):
+    def cast(obj):
+        return float(obj)
+    cast = staticmethod(cast)
+
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        try:
+            del sqlite.adapters[int]
+        except:
+            pass
+        sqlite.register_adapter(int, ObjectAdaptationTests.cast)
+        self.cur = self.con.cursor()
+
+    def tearDown(self):
+        del sqlite.adapters[(int, sqlite.PrepareProtocol)]
+        self.cur.close()
+        self.con.close()
+
+    def test_CasterIsUsed(self):
+        self.cur.execute("select ?", (4,))
+        val = self.cur.fetchone()[0]
+        self.assertEqual(type(val), float)
+
+@unittest.skipUnless(zlib, "requires zlib")
+class BinaryConverterTests(unittest.TestCase):
+    def convert(s):
+        return zlib.decompress(s)
+    convert = staticmethod(convert)
+
+    def setUp(self):
+        self.con = sqlite.connect(":memory:", detect_types=sqlite.PARSE_COLNAMES)
+        sqlite.register_converter("bin", BinaryConverterTests.convert)
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_BinaryInputForConverter(self):
+        testdata = b"abcdefg" * 10
+        result = self.con.execute('select ? as "x [bin]"', (memoryview(zlib.compress(testdata)),)).fetchone()[0]
+        self.assertEqual(testdata, result)
+
+class DateTimeTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:", detect_types=sqlite.PARSE_DECLTYPES)
+        self.cur = self.con.cursor()
+        self.cur.execute("create table test(d date, ts timestamp)")
+
+    def tearDown(self):
+        self.cur.close()
+        self.con.close()
+
+    def test_SqliteDate(self):
+        d = sqlite.Date(2004, 2, 14)
+        self.cur.execute("insert into test(d) values (?)", (d,))
+        self.cur.execute("select d from test")
+        d2 = self.cur.fetchone()[0]
+        self.assertEqual(d, d2)
+
+    def test_SqliteTimestamp(self):
+        ts = sqlite.Timestamp(2004, 2, 14, 7, 15, 0)
+        self.cur.execute("insert into test(ts) values (?)", (ts,))
+        self.cur.execute("select ts from test")
+        ts2 = self.cur.fetchone()[0]
+        self.assertEqual(ts, ts2)
+
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 1),
+                     'the date functions are available on 3.1 or later')
+    def test_SqlTimestamp(self):
+        now = datetime.datetime.utcnow()
+        self.cur.execute("insert into test(ts) values (current_timestamp)")
+        self.cur.execute("select ts from test")
+        ts = self.cur.fetchone()[0]
+        self.assertEqual(type(ts), datetime.datetime)
+        self.assertEqual(ts.year, now.year)
+
+    def test_DateTimeSubSeconds(self):
+        ts = sqlite.Timestamp(2004, 2, 14, 7, 15, 0, 500000)
+        self.cur.execute("insert into test(ts) values (?)", (ts,))
+        self.cur.execute("select ts from test")
+        ts2 = self.cur.fetchone()[0]
+        self.assertEqual(ts, ts2)
+
+    def test_DateTimeSubSecondsFloatingPoint(self):
+        ts = sqlite.Timestamp(2004, 2, 14, 7, 15, 0, 510241)
+        self.cur.execute("insert into test(ts) values (?)", (ts,))
+        self.cur.execute("select ts from test")
+        ts2 = self.cur.fetchone()[0]
+        self.assertEqual(ts, ts2)
+
+def suite():
+    loader = unittest.TestLoader()
+    tests = [loader.loadTestsFromTestCase(t) for t in (
+        SqliteTypeTests,
+        DeclTypesTests,
+        ColNamesTests,
+        ObjectAdaptationTests,
+        BinaryConverterTests,
+        DateTimeTests,
+        CommonTableExpressionTests)]
+    return unittest.TestSuite(tests)
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/userfunctions.py
+++ b/packages/phoenix-sqlean/tests/userfunctions.py
@@ -1,0 +1,535 @@
+#-*- coding: iso-8859-1 -*-
+# pysqlite2/test/userfunctions.py: tests for user-defined functions and
+#                                  aggregates.
+#
+# Copyright (C) 2005-2007 Gerhard H�ring <gh@ghaering.de>
+#
+# This file is part of pysqlite.
+#
+# This software is provided 'as-is', without any express or implied
+# warranty.  In no event will the authors be held liable for any damages
+# arising from the use of this software.
+#
+# Permission is granted to anyone to use this software for any purpose,
+# including commercial applications, and to alter it and redistribute it
+# freely, subject to the following restrictions:
+#
+# 1. The origin of this software must not be misrepresented; you must not
+#    claim that you wrote the original software. If you use this software
+#    in a product, an acknowledgment in the product documentation would be
+#    appreciated but is not required.
+# 2. Altered source versions must be plainly marked as such, and must not be
+#    misrepresented as being the original software.
+# 3. This notice may not be removed or altered from any source distribution.
+
+import unittest
+import unittest.mock
+from sqlean import dbapi2 as sqlite
+
+def func_returntext():
+    return "foo"
+def func_returnunicode():
+    return "bar"
+def func_returnint():
+    return 42
+def func_returnfloat():
+    return 3.14
+def func_returnnull():
+    return None
+def func_returnblob():
+    return b"blob"
+def func_returnlonglong():
+    return 1<<31
+def func_raiseexception():
+    5/0
+
+def func_isstring(v):
+    return type(v) is str
+def func_isint(v):
+    return type(v) is int
+def func_isfloat(v):
+    return type(v) is float
+def func_isnone(v):
+    return type(v) is type(None)
+def func_isblob(v):
+    return isinstance(v, (bytes, memoryview))
+def func_islonglong(v):
+    return isinstance(v, int) and v >= 1<<31
+
+def func(*args):
+    return len(args)
+
+class AggrNoStep:
+    def __init__(self):
+        pass
+
+    def finalize(self):
+        return 1
+
+class AggrNoFinalize:
+    def __init__(self):
+        pass
+
+    def step(self, x):
+        pass
+
+class AggrExceptionInInit:
+    def __init__(self):
+        5/0
+
+    def step(self, x):
+        pass
+
+    def finalize(self):
+        pass
+
+class AggrExceptionInStep:
+    def __init__(self):
+        pass
+
+    def step(self, x):
+        5/0
+
+    def finalize(self):
+        return 42
+
+class AggrExceptionInFinalize:
+    def __init__(self):
+        pass
+
+    def step(self, x):
+        pass
+
+    def finalize(self):
+        5/0
+
+class AggrCheckType:
+    def __init__(self):
+        self.val = None
+
+    def step(self, whichType, val):
+        theType = {"str": str, "int": int, "float": float, "None": type(None),
+                   "blob": bytes}
+        self.val = int(theType[whichType] is type(val))
+
+    def finalize(self):
+        return self.val
+
+class AggrCheckTypes:
+    def __init__(self):
+        self.val = 0
+
+    def step(self, whichType, *vals):
+        theType = {"str": str, "int": int, "float": float, "None": type(None),
+                   "blob": bytes}
+        for val in vals:
+            self.val += int(theType[whichType] is type(val))
+
+    def finalize(self):
+        return self.val
+
+class AggrSum:
+    def __init__(self):
+        self.val = 0.0
+
+    def step(self, val):
+        self.val += val
+
+    def finalize(self):
+        return self.val
+
+class FunctionTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+
+        self.con.create_function("returntext", 0, func_returntext)
+        self.con.create_function("returnunicode", 0, func_returnunicode)
+        self.con.create_function("returnint", 0, func_returnint)
+        self.con.create_function("returnfloat", 0, func_returnfloat)
+        self.con.create_function("returnnull", 0, func_returnnull)
+        self.con.create_function("returnblob", 0, func_returnblob)
+        self.con.create_function("returnlonglong", 0, func_returnlonglong)
+        self.con.create_function("raiseexception", 0, func_raiseexception)
+
+        self.con.create_function("isstring", 1, func_isstring)
+        self.con.create_function("isint", 1, func_isint)
+        self.con.create_function("isfloat", 1, func_isfloat)
+        self.con.create_function("isnone", 1, func_isnone)
+        self.con.create_function("isblob", 1, func_isblob)
+        self.con.create_function("islonglong", 1, func_islonglong)
+        self.con.create_function("spam", -1, func)
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_FuncErrorOnCreate(self):
+        with self.assertRaises(sqlite.OperationalError):
+            self.con.create_function("bla", -100, lambda x: 2*x)
+
+    def test_FuncRefCount(self):
+        def getfunc():
+            def f():
+                return 1
+            return f
+        f = getfunc()
+        globals()["foo"] = f
+        # self.con.create_function("reftest", 0, getfunc())
+        self.con.create_function("reftest", 0, f)
+        cur = self.con.cursor()
+        cur.execute("select reftest()")
+
+    def test_FuncReturnText(self):
+        cur = self.con.cursor()
+        cur.execute("select returntext()")
+        val = cur.fetchone()[0]
+        self.assertEqual(type(val), str)
+        self.assertEqual(val, "foo")
+
+    def test_FuncReturnUnicode(self):
+        cur = self.con.cursor()
+        cur.execute("select returnunicode()")
+        val = cur.fetchone()[0]
+        self.assertEqual(type(val), str)
+        self.assertEqual(val, "bar")
+
+    def test_FuncReturnInt(self):
+        cur = self.con.cursor()
+        cur.execute("select returnint()")
+        val = cur.fetchone()[0]
+        self.assertEqual(type(val), int)
+        self.assertEqual(val, 42)
+
+    def test_FuncReturnFloat(self):
+        cur = self.con.cursor()
+        cur.execute("select returnfloat()")
+        val = cur.fetchone()[0]
+        self.assertEqual(type(val), float)
+        if val < 3.139 or val > 3.141:
+            self.fail("wrong value")
+
+    def test_FuncReturnNull(self):
+        cur = self.con.cursor()
+        cur.execute("select returnnull()")
+        val = cur.fetchone()[0]
+        self.assertEqual(type(val), type(None))
+        self.assertEqual(val, None)
+
+    def test_FuncReturnBlob(self):
+        cur = self.con.cursor()
+        cur.execute("select returnblob()")
+        val = cur.fetchone()[0]
+        self.assertEqual(type(val), bytes)
+        self.assertEqual(val, b"blob")
+
+    def test_FuncReturnLongLong(self):
+        cur = self.con.cursor()
+        cur.execute("select returnlonglong()")
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1<<31)
+
+    def test_FuncException(self):
+        cur = self.con.cursor()
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            cur.execute("select raiseexception()")
+            cur.fetchone()
+        self.assertEqual(str(cm.exception), 'user-defined function raised exception')
+
+    def test_ParamString(self):
+        cur = self.con.cursor()
+        cur.execute("select isstring(?)", ("foo",))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_ParamInt(self):
+        cur = self.con.cursor()
+        cur.execute("select isint(?)", (42,))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_ParamFloat(self):
+        cur = self.con.cursor()
+        cur.execute("select isfloat(?)", (3.14,))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_ParamNone(self):
+        cur = self.con.cursor()
+        cur.execute("select isnone(?)", (None,))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_ParamBlob(self):
+        cur = self.con.cursor()
+        cur.execute("select isblob(?)", (memoryview(b"blob"),))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_ParamLongLong(self):
+        cur = self.con.cursor()
+        cur.execute("select islonglong(?)", (1<<42,))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_AnyArguments(self):
+        cur = self.con.cursor()
+        cur.execute("select spam(?, ?)", (1, 2))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 2)
+
+    def test_FuncNonDeterministic(self):
+        mock = unittest.mock.Mock(return_value=None)
+        self.con.create_function("deterministic", 0, mock, deterministic=False)
+        self.con.execute("select deterministic() = deterministic()")
+        self.assertEqual(mock.call_count, 2)
+
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 8, 3), "deterministic parameter not supported")
+    def test_FuncDeterministic(self):
+        mock = unittest.mock.Mock(return_value=None)
+        self.con.create_function("deterministic", 0, mock, True)
+        self.con.execute("select 1 where deterministic() AND deterministic()")
+        self.assertEqual(mock.call_count, 1)
+
+    @unittest.skipIf(sqlite.sqlite_version_info >= (3, 8, 3), "SQLite < 3.8.3 needed")
+    def test_FuncDeterministicNotSupported(self):
+        with self.assertRaises(sqlite.NotSupportedError):
+            self.con.create_function("deterministic", 0, int, deterministic=True)
+
+
+class AggregateTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        cur = self.con.cursor()
+        cur.execute("""
+            create table test(
+                t text,
+                i integer,
+                f float,
+                n,
+                b blob
+                )
+            """)
+        cur.execute("insert into test(t, i, f, n, b) values (?, ?, ?, ?, ?)",
+            ("foo", 5, 3.14, None, memoryview(b"blob"),))
+
+        self.con.create_aggregate("nostep", 1, AggrNoStep)
+        self.con.create_aggregate("nofinalize", 1, AggrNoFinalize)
+        self.con.create_aggregate("excInit", 1, AggrExceptionInInit)
+        self.con.create_aggregate("excStep", 1, AggrExceptionInStep)
+        self.con.create_aggregate("excFinalize", 1, AggrExceptionInFinalize)
+        self.con.create_aggregate("checkType", 2, AggrCheckType)
+        self.con.create_aggregate("checkTypes", -1, AggrCheckTypes)
+        self.con.create_aggregate("mysum", 1, AggrSum)
+
+    def tearDown(self):
+        #self.cur.close()
+        #self.con.close()
+        pass
+
+    def test_AggrErrorOnCreate(self):
+        with self.assertRaises(sqlite.OperationalError):
+            self.con.create_function("bla", -100, AggrSum)
+
+    def test_AggrNoStep(self):
+        cur = self.con.cursor()
+        with self.assertRaises(AttributeError) as cm:
+            cur.execute("select nostep(t) from test")
+        self.assertEqual(str(cm.exception), "'AggrNoStep' object has no attribute 'step'")
+
+    def test_AggrNoFinalize(self):
+        cur = self.con.cursor()
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            cur.execute("select nofinalize(t) from test")
+            val = cur.fetchone()[0]
+        self.assertEqual(str(cm.exception), "user-defined aggregate's 'finalize' method raised error")
+
+    def test_AggrExceptionInInit(self):
+        cur = self.con.cursor()
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            cur.execute("select excInit(t) from test")
+            val = cur.fetchone()[0]
+        self.assertEqual(str(cm.exception), "user-defined aggregate's '__init__' method raised error")
+
+    def test_AggrExceptionInStep(self):
+        cur = self.con.cursor()
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            cur.execute("select excStep(t) from test")
+            val = cur.fetchone()[0]
+        self.assertEqual(str(cm.exception), "user-defined aggregate's 'step' method raised error")
+
+    def test_AggrExceptionInFinalize(self):
+        cur = self.con.cursor()
+        with self.assertRaises(sqlite.OperationalError) as cm:
+            cur.execute("select excFinalize(t) from test")
+            val = cur.fetchone()[0]
+        self.assertEqual(str(cm.exception), "user-defined aggregate's 'finalize' method raised error")
+
+    def test_AggrCheckParamStr(self):
+        cur = self.con.cursor()
+        cur.execute("select checkType('str', ?)", ("foo",))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_AggrCheckParamInt(self):
+        cur = self.con.cursor()
+        cur.execute("select checkType('int', ?)", (42,))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_AggrCheckParamsInt(self):
+        cur = self.con.cursor()
+        cur.execute("select checkTypes('int', ?, ?)", (42, 24))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 2)
+
+    def test_AggrCheckParamFloat(self):
+        cur = self.con.cursor()
+        cur.execute("select checkType('float', ?)", (3.14,))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_AggrCheckParamNone(self):
+        cur = self.con.cursor()
+        cur.execute("select checkType('None', ?)", (None,))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_AggrCheckParamBlob(self):
+        cur = self.con.cursor()
+        cur.execute("select checkType('blob', ?)", (memoryview(b"blob"),))
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 1)
+
+    def test_AggrCheckAggrSum(self):
+        cur = self.con.cursor()
+        cur.execute("delete from test")
+        cur.executemany("insert into test(i) values (?)", [(10,), (20,), (30,)])
+        cur.execute("select mysum(i) from test")
+        val = cur.fetchone()[0]
+        self.assertEqual(val, 60)
+
+    def test_AggrNoMatch(self):
+        cur = self.con.execute('select mysum(i) from (select 1 as i) where i == 0')
+        val = cur.fetchone()[0]
+        self.assertIsNone(val)
+
+
+@unittest.skipIf(sqlite.sqlite_version_info < (3, 25, 0),
+                 'requires sqlite with window-function support')
+class WindowFunctionTests(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite.connect(":memory:")
+        self.conn.execute('create table sample (id integer primary key, '
+                          'counter integer, value real);')
+        self.conn.execute('insert into sample (counter, value) values '
+                          '(?,?),(?,?),(?,?),(?,?),(?,?)', (
+                              1, 10.,
+                              1, 20.,
+                              2, 1.,
+                              2, 2.,
+                              3, 100.))
+
+    def test_user_defined_window_function(self):
+        class MySum(object):
+            def __init__(self): self._value = 0
+            def step(self, value): self._value += value
+            def inverse(self, value): self._value -= value
+            def value(self): return self._value
+            def finalize(self): return self._value
+
+        self.conn.create_window_function('mysum', -1, MySum)
+
+        q = ('select counter, value, mysum(value) over (partition by counter) '
+             'from sample order by id')
+        self.assertEqual(self.conn.execute(q).fetchall(), [
+            (1, 10., 30.), (1, 20., 30.),
+            (2, 1., 3.), (2, 2., 3.),
+            (3, 100., 100.)])
+
+
+class AuthorizerTests(unittest.TestCase):
+    @staticmethod
+    def authorizer_cb(action, arg1, arg2, dbname, source):
+        if action != sqlite.SQLITE_SELECT:
+            return sqlite.SQLITE_DENY
+        if arg2 == 'c2' or arg1 == 't2':
+            return sqlite.SQLITE_DENY
+        return sqlite.SQLITE_OK
+
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        self.con.executescript("""
+            create table t1 (c1, c2);
+            create table t2 (c1, c2);
+            insert into t1 (c1, c2) values (1, 2);
+            insert into t2 (c1, c2) values (4, 5);
+            """)
+
+        # For our security test:
+        self.con.execute("select c2 from t2")
+
+        self.con.set_authorizer(self.authorizer_cb)
+
+    def tearDown(self):
+        pass
+
+    def test_table_access(self):
+        with self.assertRaises(sqlite.DatabaseError) as cm:
+            self.con.execute("select * from t2")
+        self.assertIn('prohibited', str(cm.exception))
+
+    def test_column_access(self):
+        with self.assertRaises(sqlite.DatabaseError) as cm:
+            self.con.execute("select c2 from t1")
+        self.assertIn('prohibited', str(cm.exception))
+
+    def test_clear_authorizer(self):
+        self.con.set_authorizer(None)
+        self.con.execute('select * from t2')
+        self.con.execute('select c2 from t1')
+
+class AuthorizerRaiseExceptionTests(AuthorizerTests):
+    @staticmethod
+    def authorizer_cb(action, arg1, arg2, dbname, source):
+        if action != sqlite.SQLITE_SELECT:
+            raise ValueError
+        if arg2 == 'c2' or arg1 == 't2':
+            raise ValueError
+        return sqlite.SQLITE_OK
+
+class AuthorizerIllegalTypeTests(AuthorizerTests):
+    @staticmethod
+    def authorizer_cb(action, arg1, arg2, dbname, source):
+        if action != sqlite.SQLITE_SELECT:
+            return 0.0
+        if arg2 == 'c2' or arg1 == 't2':
+            return 0.0
+        return sqlite.SQLITE_OK
+
+class AuthorizerLargeIntegerTests(AuthorizerTests):
+    @staticmethod
+    def authorizer_cb(action, arg1, arg2, dbname, source):
+        if action != sqlite.SQLITE_SELECT:
+            return 2**32
+        if arg2 == 'c2' or arg1 == 't2':
+            return 2**32
+        return sqlite.SQLITE_OK
+
+
+def suite():
+    loader = unittest.TestLoader()
+    tests = [loader.loadTestsFromTestCase(t) for t in (
+        FunctionTests,
+        AggregateTests,
+        WindowFunctionTests,
+        AuthorizerTests,
+        AuthorizerRaiseExceptionTests,
+        AuthorizerIllegalTypeTests,
+        AuthorizerLargeIntegerTests)]
+    return unittest.TestSuite(tests)
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -374,8 +374,15 @@ venvPath = "."
 venv = ".venv"
 extraPaths = ["src"]
 pythonVersion = "3.10"
+# Restating the defaults ("**/node_modules", "**/__pycache__") is required
+# because setting exclude replaces them. packages/phoenix-sqlean is a vendored
+# fork of nalgeon/sqlean.py and is not held to this repo's typing standards.
+exclude = ["**/node_modules", "**/__pycache__", "packages/phoenix-sqlean"]
 
 [tool.ruff]
+# Apply excludes even to files passed explicitly on the command line
+# (editor/hook integrations do this), so vendored code stays untouched.
+force-exclude = true
 exclude = [
   "api_reference",
   "dist/",
@@ -386,6 +393,9 @@ exclude = [
   "docs/",
   "src/phoenix/trace/v1/evaluation_pb2.py*",
   "src/phoenix/vendor/json_canonicalization_scheme",
+  # Vendored fork of nalgeon/sqlean.py — keep formatting identical to upstream
+  # so diffs against the imported source stay reviewable.
+  "packages/phoenix-sqlean",
 ]
 line-length = 100
 target-version = "py310"
@@ -433,6 +443,9 @@ override-dependencies = [
 
 [tool.uv.workspace]
 members = ["packages/*"]
+# phoenix-sqlean is a vendored setup.py-based C extension (fork of
+# nalgeon/sqlean.py), not a uv-managed project.
+exclude = ["packages/phoenix-sqlean"]
 
 [tool.uv.sources]
 arize-phoenix-client = { workspace = true }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -32,6 +32,11 @@
         "packages/phoenix-otel": {
             "package-name": "arize-phoenix-otel",
             "release-type": "python"
+        },
+        "packages/phoenix-sqlean": {
+            "package-name": "arize-phoenix-sqlean",
+            "release-type": "python",
+            "extra-files": ["setup.py"]
         }
     }
 }


### PR DESCRIPTION
## Summary

Vendors [nalgeon/sqlean.py](https://github.com/nalgeon/sqlean.py) — archived upstream in February 2026 — into `packages/phoenix-sqlean` as a maintained fork, published as **`arize-phoenix-sqlean`** (import name stays `sqlean`, so it is a drop-in replacement).

Phoenix's SQLite backend depends on sqlean.py for the `percentile()` aggregate, Unicode-aware `text_*` functions, and a guaranteed-recent bundled SQLite. With upstream archived, its wheel gaps are frozen: no Windows wheels for ≥3.50 and no cp314 Windows wheels at all (see the platform-conditional pins in `pyproject.toml`). This fork lets us close those gaps ourselves.

The code is imported as a **squashed snapshot** of upstream's final commit ([`bdd7097`](https://github.com/nalgeon/sqlean.py/commit/bdd7097f8d5777bc9e3ac3235d9be66b9db34519), recorded in the import commit and the package README) rather than with embedded upstream history, so the CLA check evaluates only this PR's author. Upstream history remains browsable in the archived repo.

### What's in this PR

- **Subtree import** (squashed) of upstream at its final commit `bdd7097`.
- **Fork marking** (zlib License requirement): README notice recording upstream provenance and component licenses.
- **Release wiring**: registered in release-please as `arize-phoenix-sqlean`; the first release PR will initialize its manifest entry at 0.1.0 (own semver line; bundled SQLite/sqlean versions stay pinned in the package Makefile); `publish.yaml` gains `build-sqlean` (cibuildwheel: linux x86_64/aarch64, macOS x86_64/arm64, cp310–cp314, plus an sdist bundling the downloaded sources) and `publish-sqlean` (PyPI Trusted Publisher; no GitHub environment). `build-sqlean` skips gracefully until the package's first release tag exists.
- **CI**: new `phoenix-sqlean-ci.yml` builds the extension and runs its tests on ubuntu **and windows** × Python 3.10–3.14. Windows wheels shipped upstream through 3.49.x and were dropped for maintenance reasons, not a technical blocker; this PR reinstates the one compile-breaking regression (the `sqlean-ipaddr.c` platform guard — ipaddr uses POSIX networking headers and has always been excluded from Windows builds). Windows *publishing* is deferred until this matrix is green.
- **Monorepo hygiene**: vendored tree excluded from ruff, basedpyright, and the uv workspace (it is a setup.py-based C extension, not a uv project).

### Review notes

The imported tree is byte-identical to upstream `bdd7097` except for: the README fork notice and install-name updates, `setup.py` packaging changes (distribution name, release-please-managed version, maintainer, upstream-sourced ipaddr Windows guard, import-order formatting), and the deleted nested `.github/workflows/` (ported to root workflows). Verifiable with `diff -r` against an upstream checkout; the vendored code itself does not need line review.

Submission containing materials of a third party: nalgeon/sqlean.py (zlib License), including code derived from CPython's `sqlite3` module (PSF License 2.0); builds download the SQLite amalgamation (public domain) and nalgeon/sqlean extension sources (MIT License), which include PCRE2 (BSD 3-Clause), STC (MIT), and code based on Go’s time package (BSD 3-Clause). Full notices ship in both wheels and source distributions.

### Follow-ups (not in this PR)

1. Create the PyPI Trusted Publisher for `arize-phoenix-sqlean` (required before first release; no GitHub environment needed).
2. First release via a `feat(phoenix-sqlean):` commit or `Release-As` footer.
3. Add the `windows-latest` cibuildwheel leg to `publish.yaml` once the CI matrix is green.
4. Swap Phoenix's `sqlean.py` pins to `arize-phoenix-sqlean` once published.

## Test plan

- `phoenix-sqlean CI` runs on this PR: 10-leg build-and-test matrix (ubuntu/windows × 3.10–3.14), including the first Windows build of these sources since upstream 3.49.x.
- Locally validated: `setup.py` reports `arize-phoenix-sqlean 0.1.0`; workflow YAML and release-please JSON parse; `uv sync` and all pre-commit hooks pass.



