### PR TITLE
feat(ui): add icon prefixes to settings tabs

### DIFF
--- a/app/src/components/agent/PxiGlyph.tsx
+++ b/app/src/components/agent/PxiGlyph.tsx
@@ -35,6 +35,36 @@ export function getPxiGlyphSVGDataUrl({ fill }: { fill: string }) {
   return `data:image/svg+xml,${encodeURIComponent(svgMarkup)}`;
 }
 
+// The outline glyph sits in the same 24px viewBox as the icon set so it
+// renders at the same optical size as other icons — the inner margin keeps
+// the dense five-cell grid from reading larger than its neighbors.
+const OUTLINE_VIEWBOX_SIZE = 24;
+const OUTLINE_STROKE_WIDTH = 1.5;
+const OUTLINE_INSET = (OUTLINE_VIEWBOX_SIZE - svgSize) / 2;
+
+/**
+ * Stroked, icon-sized variant of the PXI brand glyph for places that use
+ * outline iconography (tab prefixes, menus) where the filled glyph reads too
+ * heavy.
+ */
+export function PxiGlyphOutline({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={`0 0 ${OUTLINE_VIEWBOX_SIZE} ${OUTLINE_VIEWBOX_SIZE}`}
+      style={{ fill: "none", stroke: "currentColor" }}
+      strokeWidth={OUTLINE_STROKE_WIDTH}
+    >
+      <g transform={`translate(${OUTLINE_INSET} ${OUTLINE_INSET})`}>
+        {gridCells.map((cell, index) => (
+          <rect key={index} {...cell} />
+        ))}
+      </g>
+    </svg>
+  );
+}
+
 export type PxiGlyphAnimation =
   | "wave-reveal"
   | "orbit-reveal"

--- a/app/src/components/agent/index.tsx
+++ b/app/src/components/agent/index.tsx
@@ -9,6 +9,7 @@ export { SystemSettingsWarning } from "./SystemSettingsWarning";
 export { AgentChatPanel, FloatingAgentChatPanel } from "./AgentChatPanel";
 export { AgentChatTopNavButton } from "./AgentChatTopNavButton";
 export { AgentChatWidget } from "./AgentChatWidget";
+export { PxiGlyph } from "./PxiGlyph";
 export { PxiOutline } from "./PxiOutline";
 export type {
   PxiOutlineGlowMode,

--- a/app/src/components/agent/index.tsx
+++ b/app/src/components/agent/index.tsx
@@ -9,7 +9,7 @@ export { SystemSettingsWarning } from "./SystemSettingsWarning";
 export { AgentChatPanel, FloatingAgentChatPanel } from "./AgentChatPanel";
 export { AgentChatTopNavButton } from "./AgentChatTopNavButton";
 export { AgentChatWidget } from "./AgentChatWidget";
-export { PxiGlyph } from "./PxiGlyph";
+export { PxiGlyphOutline } from "./PxiGlyph";
 export { PxiOutline } from "./PxiOutline";
 export type {
   PxiOutlineGlowMode,

--- a/app/src/components/core/icon/Icons.tsx
+++ b/app/src/components/core/icon/Icons.tsx
@@ -1941,6 +1941,19 @@ export const SlideIn = () => (
   </svg>
 );
 
+export const Sparkle = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    style={{ fill: "none", stroke: "currentColor" }}
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" />
+  </svg>
+);
+
 export const Split = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -1,10 +1,20 @@
 import { css } from "@emotion/react";
+import type { ReactNode } from "react";
 import { Suspense } from "react";
 import type { Key } from "react-aria-components";
 import { Collection } from "react-aria-components";
 import { Navigate, Outlet, useMatch, useNavigate } from "react-router";
 
-import { Loading, Tab, TabList, TabPanel, Tabs } from "@phoenix/components";
+import {
+  Icon,
+  Icons,
+  Loading,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+} from "@phoenix/components";
+import { PxiGlyph } from "@phoenix/components/agent";
 import {
   useIsAdmin,
   useViewerCanManageSandboxes,
@@ -22,6 +32,12 @@ const VERTICAL_TABS_MEDIA_QUERY = "(min-width: 900px)";
 const settingsPageCSS = css`
   overflow: hidden;
   height: 100%;
+`;
+
+const tabLabelCSS = css`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--global-dimension-size-100);
 `;
 
 const settingsTabListCSS = css`
@@ -52,20 +68,23 @@ const settingsTabPanelCSS = css`
   }
 `;
 
+// Icons follow the associations established elsewhere in the app (side nav,
+// session tabs): Database for datasets, MessageSquare for prompts, Edit2 for
+// annotations, and the PXI glyph for the assistant.
 const TABS = [
-  { id: "general", label: "General" },
-  { id: "users", label: "Users" },
-  { id: "api-keys", label: "API Keys" },
-  { id: "providers", label: "AI Providers" },
-  { id: "sandboxes", label: "Sandboxes" },
-  { id: "models", label: "Models" },
-  { id: "secrets", label: "Secrets" },
-  { id: "datasets", label: "Datasets" },
-  { id: "annotations", label: "Annotations" },
-  { id: "prompts", label: "Prompts" },
-  { id: "data", label: "Data Retention" },
-  { id: "agents", label: "Assistant" },
-] as const satisfies readonly { id: string; label: string }[];
+  { id: "general", label: "General", icon: <Icons.Settings /> },
+  { id: "users", label: "Users", icon: <Icons.Person /> },
+  { id: "api-keys", label: "API Keys", icon: <Icons.Key /> },
+  { id: "providers", label: "AI Providers", icon: <Icons.Globe /> },
+  { id: "sandboxes", label: "Sandboxes", icon: <Icons.Console /> },
+  { id: "models", label: "Models", icon: <Icons.LLMOutput /> },
+  { id: "secrets", label: "Secrets", icon: <Icons.Lock /> },
+  { id: "datasets", label: "Datasets", icon: <Icons.Database /> },
+  { id: "annotations", label: "Annotations", icon: <Icons.Edit2 /> },
+  { id: "prompts", label: "Prompts", icon: <Icons.MessageSquare /> },
+  { id: "data", label: "Data Retention", icon: <Icons.HardDrive /> },
+  { id: "agents", label: "Assistant", icon: <PxiGlyph /> },
+] as const satisfies readonly { id: string; label: string; icon: ReactNode }[];
 
 type SettingsTabId = (typeof TABS)[number]["id"];
 
@@ -107,7 +126,14 @@ export function SettingsPage() {
         orientation={isLargeScreen ? "vertical" : "horizontal"}
       >
         <TabList items={tabs} css={settingsTabListCSS} aria-label="Settings">
-          {(item) => <Tab id={item.id}>{item.label}</Tab>}
+          {(item) => (
+            <Tab id={item.id}>
+              <span css={tabLabelCSS}>
+                <Icon svg={item.icon} />
+                {item.label}
+              </span>
+            </Tab>
+          )}
         </TabList>
         <Collection items={tabs}>
           {(item) => (

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -14,7 +14,7 @@ import {
   TabPanel,
   Tabs,
 } from "@phoenix/components";
-import { PxiGlyph } from "@phoenix/components/agent";
+import { PxiGlyphOutline } from "@phoenix/components/agent";
 import {
   useIsAdmin,
   useViewerCanManageSandboxes,
@@ -75,7 +75,7 @@ const TABS = [
   { id: "general", label: "General", icon: <Icons.Settings /> },
   { id: "users", label: "Users", icon: <Icons.Person /> },
   { id: "api-keys", label: "API Keys", icon: <Icons.Key /> },
-  { id: "providers", label: "AI Providers", icon: <Icons.Globe /> },
+  { id: "providers", label: "AI Providers", icon: <Icons.Sparkle /> },
   { id: "sandboxes", label: "Sandboxes", icon: <Icons.Console /> },
   { id: "models", label: "Models", icon: <Icons.LLMOutput /> },
   { id: "secrets", label: "Secrets", icon: <Icons.Lock /> },
@@ -83,7 +83,7 @@ const TABS = [
   { id: "annotations", label: "Annotations", icon: <Icons.Edit2 /> },
   { id: "prompts", label: "Prompts", icon: <Icons.MessageSquare /> },
   { id: "data", label: "Data Retention", icon: <Icons.HardDrive /> },
-  { id: "agents", label: "Assistant", icon: <PxiGlyph /> },
+  { id: "agents", label: "Assistant", icon: <PxiGlyphOutline /> },
 ] as const satisfies readonly { id: string; label: string; icon: ReactNode }[];
 
 type SettingsTabId = (typeof TABS)[number]["id"];


### PR DESCRIPTION
## Summary

Adds an icon prefix to every settings tab for faster visual scanning, reusing icon associations already established elsewhere in the app:

| Tab | Icon |
| --- | --- |
| General | Settings (gear) |
| Users | Person |
| API Keys | Key |
| AI Providers | Sparkle (new lucide icon) |
| Sandboxes | Console |
| Models | LLMOutput |
| Secrets | Lock |
| Datasets | Database (matches side nav) |
| Annotations | Edit2 (matches session annotations tab) |
| Prompts | MessageSquare (matches side nav) |
| Data Retention | HardDrive |
| Assistant | PXI glyph (new outline variant) |

Also:
- Adds `Icons.Sparkle` (lucide sparkle) to the icon set
- Adds `PxiGlyphOutline` — a stroked, icon-sized variant of the PXI brand glyph in the standard 24px viewBox, exported from `@phoenix/components/agent`

## Screenshots

Vertical tab rail (≥900px):

![settings tabs with icons, vertical rail](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14512-settings-tabs-vertical.png)

Horizontal scrollable tab bar (<900px):

![settings tabs with icons, horizontal bar](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14512-settings-tabs-horizontal.png)