### PR TITLE
docs: reorganize agent-assisted setup narrative; promote quickstart links

### DIFF
--- a/docs/phoenix/agent-assisted-setup.mdx
+++ b/docs/phoenix/agent-assisted-setup.mdx
@@ -1,58 +1,56 @@
 ---
 title: "Agent-Assisted Setup"
 description: >-
-  Connect your app to Phoenix and get traces flowing with a single command —
-  `px setup` hands the instrumentation to your coding agent and waits until a
-  real trace arrives.
+  Add Phoenix tracing to your app with a single command — `px setup` hands the
+  instrumentation to your coding agent and waits until a real trace arrives.
 ---
 
 # Agent-Assisted Setup
 
-The fastest way to add Phoenix tracing to your application. One command walks you through connecting, hands the instrumentation to your coding agent, and confirms a real trace arrived.
+The fastest way to add Phoenix tracing to your application. One command connects your app to Phoenix, hands the instrumentation to your coding agent, and confirms a real trace arrived — so "done" means traces are actually flowing.
 
 <Tip>
-**Get started.** Run this from your app's root directory:
+**Run this from your app's root directory:**
 ```bash
 npx -y @arizeai/phoenix-cli setup
 ```
 Already installed the CLI (`npm install -g @arizeai/phoenix-cli`)? Just run `px setup`.
 </Tip>
 
-## What `px setup` does
-
-`px setup` runs an interactive flow:
-
-1. **Checks git safety.** Warns on a dirty tree so agent edits stay separate from your own work.
-2. **Establishes the connection.** Asks where your Phoenix instance is running, handles auth, and writes a gitignored `.env.phoenix` file.
-3. **Hands off instrumentation.** Passes an instrumentation task to a coding agent (Claude Code, Codex, Cursor, or OpenCode), which detects your language, LLM providers, and frameworks, then adds tracing.
-4. **Verifies traces.** Waits until the Phoenix API confirms a real trace arrived, so "done" means traces are actually flowing.
-5. **Sets up tooling.** Optionally points `px` at the new project and installs Phoenix [skills](/docs/phoenix/integrations/developer-tools/coding-agents#skills) so your agent can query what you captured.
-=======
-The fastest way to add Phoenix tracing to your application. Run one command from your app's root and Phoenix walks you through connecting, hands the instrumentation to your coding agent, and confirms a real trace arrived.
-
-<Tip>
-**Get started — run this from your app's root directory:**
-```bash
-npx -y @arizeai/phoenix-cli setup
-```
-Already have the CLI installed (`npm install -g @arizeai/phoenix-cli`)? Just run `px setup`.
-</Tip>
-
-
 <Info>
 **Supported stacks:** Python and TypeScript/JavaScript. See the [full integration list](/docs/phoenix/integrations) for the LLM providers and frameworks Phoenix instruments.
 </Info>
 
-## Re-run individual steps
+## What happens when you run it
 
-The connection questions only need answering once. Re-run a single slice on a repo that's already registered:
+`px setup` walks you through an interactive flow with five steps:
+
+1. **Checks git safety.** Warns on a dirty tree so agent edits stay separate from your own work.
+2. **Establishes the connection.** Asks where your Phoenix instance is running, handles auth, and writes a gitignored `.env.phoenix` file.
+3. **Hands off instrumentation.** Passes an instrumentation task to a coding agent (Claude Code, Codex, Cursor, or OpenCode), which detects your language, LLM providers, and frameworks, then adds tracing.
+4. **Verifies traces.** Waits until the Phoenix API confirms a real trace arrived.
+5. **Sets up tooling.** Optionally points `px` at the new project and installs Phoenix [skills](/docs/phoenix/integrations/developer-tools/coding-agents#skills) so your agent can query what you captured.
+
+## Confirm traces are flowing
+
+`px setup` verifies traces automatically. To check for yourself:
+
+1. Run your application and trigger at least one LLM call.
+2. Open the Phoenix UI (local: http://localhost:6006, or your Phoenix Cloud URL).
+3. Open the **Traces** view and verify traces appear under your project.
+
+If no traces appear, check the [Troubleshooting FAQ](/docs/phoenix/tracing/concepts-tracing/faqs-tracing).
+
+## Re-run a single step
+
+The connection questions only need answering once. On a repo that's already registered, re-run just the slice you need:
 
 ```bash
 px setup instrument   # Instrument and verify traces again
 px setup skills       # Install the coding-agent skills alone
 ```
 
-## Non-interactive use (CI or agents)
+## Run non-interactively (CI or agents)
 
 Pass flags instead of answering prompts:
 
@@ -66,17 +64,7 @@ px setup --no-input --instrument --agent claude --yolo --format raw
 
 See the [CLI reference](/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli#px-setup) for the full list of flags.
 
-## Validate your setup
-
-`px setup` verifies traces automatically. To confirm manually:
-
-1. Run your application and trigger at least one LLM call.
-2. Open the Phoenix UI (local: http://localhost:6006, or your Phoenix Cloud URL).
-3. Open the **Traces** view and verify traces appear under your project.
-
-If no traces appear, check the [Troubleshooting FAQ](/docs/phoenix/tracing/concepts-tracing/faqs-tracing).
-
-## Using a different agent
+## Use an unsupported agent
 
 `px setup` hands off to Claude Code, Codex, Cursor, and OpenCode. If your agent isn't one of those (Windsurf, Copilot, and others), paste this prompt into it instead:
 

--- a/docs/phoenix/get-started/get-started-tracing.mdx
+++ b/docs/phoenix/get-started/get-started-tracing.mdx
@@ -1,6 +1,10 @@
 ---
 title: "Send Traces From Your App"
 ---
+<Info>
+  **Want your coding agent to do this for you?** If you're using Claude Code, Cursor, Copilot, or another AI coding assistant, try [Agent-Assisted Setup](/docs/phoenix/agent-assisted-setup) to add Phoenix tracing automatically with a single command.
+</Info>
+
 This guide walks through a complete workflow for understanding and improving an agent application using Phoenix. The goal is not just to run an application, but to understand how it behaves, determine whether its outputs are correct, and make changes that can be tested and verified. Each guide in this series introduces one piece of that workflow and builds on the previous one.
 
 A trace is a record of a single run of your application, broken down into spans that show what happened at each step (how agents, tasks, and tools executed) and provides the raw data needed for everything that follows.
@@ -43,10 +47,6 @@ REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST as
 REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
 REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
 </div>
-
-<Info>
-  **Want your coding agent to do this for you?** If you’re using Claude Code, Cursor, Copilot, or another AI coding assistant, try [Agent-Assisted Setup](/docs/phoenix/agent-assisted-setup) to add Phoenix tracing automatically.
-</Info>
 
 We’ll use the CrewAI framework in Python, but Phoenix works with many agent frameworks and orchestration libraries. You can find the full list of supported frameworks on our [Integrations Page. ](https://arize.com/docs/phoenix/integrations)
 

--- a/docs/phoenix/get-started/ts-get-started-tracing.mdx
+++ b/docs/phoenix/get-started/ts-get-started-tracing.mdx
@@ -1,6 +1,10 @@
 ---
 title: "Send Traces From Your App"
 ---
+<Info>
+  **Want your coding agent to do this for you?** If you're using Claude Code, Cursor, Copilot, or another AI coding assistant, try [Agent-Assisted Setup](/docs/phoenix/agent-assisted-setup) to add Phoenix tracing automatically with a single command.
+</Info>
+
 This guide walks through a complete workflow for understanding and improving an agent application using Phoenix. The goal is not just to run an application, but to understand how it behaves, determine whether its outputs are correct, and make changes that can be tested and verified. Each guide in this series introduces one piece of that workflow and builds on the previous one.
 
 A trace is a record of a single run of your application, broken down into spans that show what happened at each step (how agents, tasks, and tools executed) and provides the raw data needed for everything that follows. 
@@ -8,10 +12,6 @@ A trace is a record of a single run of your application, broken down into spans 
 In this guide, we’ll get tracing set up in Phoenix Cloud and walk through how to instrument an application. We’ll start by setting up a Phoenix Cloud instance, create a simple agent, and then send a single trace so we can see everything end to end.
 
 We’ll use the Mastra framework in TypeScript, but Phoenix works with many agent frameworks and orchestration libraries. You can find the full list of supported frameworks on our [Integrations Page](https://arize.com/docs/phoenix/integrations).
-
-<Info>
-  **Want your coding agent to do this for you?** If you’re using Claude Code, Cursor, Copilot, or another AI coding assistant, try [Agent-Assisted Setup](/docs/phoenix/agent-assisted-setup) to add Phoenix tracing automatically.
-</Info>
 
 ## **Before We Start**
 


### PR DESCRIPTION
## Summary

Cleans up and reorganizes the **Agent-Assisted Setup** docs page and promotes the link to it in the tracing quickstarts.

### `agent-assisted-setup.mdx`
- **Fix:** the committed page contained a stray `=======` merge-conflict marker with a duplicated intro paragraph and `<Tip>` block — removed.
- **Reorganize** into a clear top-to-bottom narrative with descriptive titles:
  1. Get started (command + supported stacks)
  2. What happens when you run it (the 5-step flow)
  3. Confirm traces are flowing (verify)
  4. Re-run a single step
  5. Run non-interactively (CI or agents)
  6. Use an unsupported agent

  Previously "Validate your setup" was buried *after* the CI/advanced sections; the happy path now comes first.

### Quickstarts
- Moved the Agent-Assisted Setup `<Info>` callout to the **top** of the Python and TypeScript tracing quickstarts (`get-started-tracing.mdx`, `ts-get-started-tracing.mdx`) so readers can skip straight to the one-command path, and tightened the copy.

## Test plan
- Docs-only change. Verified no merge markers remain and links use the `/docs/phoenix/...` absolute form.