### PR TITLE
test(phoenix-client): migrate remaining tests to @arizeai/phoenix-testing

### DIFF
--- a/js/packages/phoenix-client/test/client.test.ts
+++ b/js/packages/phoenix-client/test/client.test.ts
@@ -1,29 +1,44 @@
-import { describe, expect, it } from "vitest";
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
-import { createClient, HttpError } from "../src";
+import { HttpError } from "../src";
+import { createTestClient } from "./testUtils";
 
-/** A client whose transport answers every request with `response`. */
-function clientAnswering(response: Response) {
-  return createClient({
-    getEnvironmentOptions: () => ({}),
-    options: {
-      baseUrl: "https://phoenix.example.com",
-      fetch: async () => response,
-    },
-  });
-}
+const http = createHttp();
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
 
 describe("non-2xx responses", () => {
   it("throw an HttpError carrying the status, so callers can branch on it", async () => {
-    const client = clientAnswering(
-      new Response(JSON.stringify({ detail: "unauthorized" }), {
-        status: 401,
-        statusText: "Unauthorized",
-        headers: { "content-type": "application/json" },
-      })
+    server.use(
+      http.get("/v1/projects", ({ response }) =>
+        response.untyped(
+          new Response(JSON.stringify({ detail: "unauthorized" }), {
+            status: 401,
+            statusText: "Unauthorized",
+            headers: { "content-type": "application/json" },
+          })
+        )
+      )
     );
 
-    const error = await client.GET("/v1/projects").catch((e: unknown) => e);
+    const error = await createTestClient()
+      .GET("/v1/projects")
+      .catch((e: unknown) => e);
 
     expect(error).toBeInstanceOf(HttpError);
     expect(error).toMatchObject({ status: 401, statusText: "Unauthorized" });

--- a/js/packages/phoenix-client/test/datasets/getDataset.test.ts
+++ b/js/packages/phoenix-client/test/datasets/getDataset.test.ts
@@ -1,152 +1,224 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHttp, type componentsV1 } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
+import { HttpError } from "../../src";
 import { getDataset } from "../../src/datasets/getDataset";
-import * as getDatasetExamplesModule from "../../src/datasets/getDatasetExamples";
-import * as getDatasetInfoModule from "../../src/datasets/getDatasetInfo";
+import { createTestClient } from "../testUtils";
 
-const mockDatasetInfo = {
+const http = createHttp();
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await createMockServer();
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+const datasetInfo: componentsV1["schemas"]["DatasetWithExampleCount"] = {
   id: "dataset-123",
   name: "Test Dataset",
   description: "A test dataset",
   metadata: { foo: "bar" },
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  example_count: 2,
 };
 
-const mockDatasetExamples = {
-  versionId: "v1",
-  examples: [
-    {
-      id: "ex-1",
-      updatedAt: new Date("2024-01-01T00:00:00Z"),
-      input: { text: "input1" },
-      output: { text: "output1" },
-      metadata: {},
-    },
-    {
-      id: "ex-2",
-      updatedAt: new Date("2024-01-02T00:00:00Z"),
-      input: { text: "input2" },
-      output: { text: "output2" },
-      metadata: {},
-    },
-  ],
+const exampleOne: componentsV1["schemas"]["DatasetExample"] = {
+  id: "ex-1",
+  node_id: "ex-1",
+  input: { text: "input1" },
+  output: { text: "output1" },
+  metadata: {},
+  updated_at: "2024-01-01T00:00:00Z",
 };
 
-const mockDatasetExamplesV2 = {
-  versionId: "v2",
-  examples: [
-    {
-      id: "ex-3",
-      updatedAt: new Date("2024-01-03T00:00:00Z"),
-      input: { text: "input3" },
-      output: { text: "output3" },
-      metadata: {},
-    },
-  ],
+const exampleTwo: componentsV1["schemas"]["DatasetExample"] = {
+  id: "ex-2",
+  node_id: "ex-2",
+  input: { text: "input2" },
+  output: { text: "output2" },
+  metadata: {},
+  updated_at: "2024-01-02T00:00:00Z",
 };
+
+const exampleThree: componentsV1["schemas"]["DatasetExample"] = {
+  id: "ex-3",
+  node_id: "ex-3",
+  input: { text: "input3" },
+  output: { text: "output3" },
+  metadata: {},
+  updated_at: "2024-01-03T00:00:00Z",
+};
+
+/** Register a handler answering `GET /v1/datasets/{id}` with `datasetInfo`. */
+function stubDatasetInfo() {
+  server.use(
+    http.get("/v1/datasets/{id}", ({ response }) =>
+      response(200).json({ data: datasetInfo })
+    )
+  );
+}
+
+/** Register a handler answering `GET /v1/datasets` (lookup by name). */
+function stubDatasetInfoByName() {
+  server.use(
+    http.get("/v1/datasets", ({ response }) =>
+      response(200).json({ data: [datasetInfo], next_cursor: null })
+    )
+  );
+}
+
+type CapturedExamplesRequest = {
+  datasetId: string;
+  query: URLSearchParams;
+};
+
+/**
+ * Register a handler for the dataset examples endpoint that captures every
+ * request and answers with the given examples payload.
+ */
+function stubDatasetExamples(
+  data: componentsV1["schemas"]["ListDatasetExamplesData"]
+): CapturedExamplesRequest[] {
+  const requests: CapturedExamplesRequest[] = [];
+  server.use(
+    http.get("/v1/datasets/{id}/examples", ({ params, request, response }) => {
+      requests.push({
+        datasetId: params.id,
+        query: new URL(request.url).searchParams,
+      });
+      return response(200).json({ data });
+    })
+  );
+  return requests;
+}
 
 describe("getDataset", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should return merged dataset info and examples", async () => {
-    vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockResolvedValue(
-      mockDatasetInfo
-    );
-    vi.spyOn(getDatasetExamplesModule, "getDatasetExamples").mockResolvedValue(
-      mockDatasetExamples
-    );
+    stubDatasetInfo();
+    stubDatasetExamples({
+      dataset_id: "dataset-123",
+      version_id: "v1",
+      examples: [exampleOne, exampleTwo],
+    });
 
-    const dataset = await getDataset({ dataset: { datasetId: "dataset-123" } });
+    const dataset = await getDataset({
+      client: createTestClient(),
+      dataset: { datasetId: "dataset-123" },
+    });
+
     expect(dataset).toBeDefined();
     expect(dataset.id).toBe("dataset-123");
     expect(dataset.name).toBe("Test Dataset");
     expect(dataset.versionId).toBe("v1");
-    const examples = dataset.examples;
-    expect(examples.length).toBe(2);
-    expect(examples[0]?.id).toBe("ex-1");
-    expect(examples[1]?.id).toBe("ex-2");
+    expect(dataset.examples).toHaveLength(2);
+    expect(dataset.examples[0]?.id).toBe("ex-1");
+    expect(dataset.examples[1]?.id).toBe("ex-2");
   });
 
   it("should support getting dataset by version ID", async () => {
-    const getDatasetExamplesSpy = vi
-      .spyOn(getDatasetExamplesModule, "getDatasetExamples")
-      .mockResolvedValue(mockDatasetExamplesV2);
-    vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockResolvedValue(
-      mockDatasetInfo
-    );
+    stubDatasetInfo();
+    const requests = stubDatasetExamples({
+      dataset_id: "dataset-123",
+      version_id: "v2",
+      examples: [exampleThree],
+    });
 
     const dataset = await getDataset({
+      client: createTestClient(),
       dataset: { datasetId: "dataset-123", versionId: "v2" },
     });
 
-    expect(getDatasetExamplesSpy).toHaveBeenCalledWith({
-      client: expect.any(Object),
-      dataset: { datasetId: "dataset-123", versionId: "v2" },
-    });
+    expect(requests[0]?.datasetId).toBe("dataset-123");
+    expect(requests[0]?.query.get("version_id")).toBe("v2");
     expect(dataset.versionId).toBe("v2");
-    expect(dataset.examples.length).toBe(1);
+    expect(dataset.examples).toHaveLength(1);
     expect(dataset.examples[0]?.id).toBe("ex-3");
   });
 
   it("should work without versionId (uses latest version)", async () => {
-    vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockResolvedValue(
-      mockDatasetInfo
-    );
-    vi.spyOn(getDatasetExamplesModule, "getDatasetExamples").mockResolvedValue(
-      mockDatasetExamples
-    );
+    stubDatasetInfo();
+    const requests = stubDatasetExamples({
+      dataset_id: "dataset-123",
+      version_id: "v1",
+      examples: [exampleOne, exampleTwo],
+    });
 
     const dataset = await getDataset({
+      client: createTestClient(),
       dataset: { datasetId: "dataset-123" },
     });
 
+    expect(requests[0]?.query.get("version_id")).toBeNull();
     expect(dataset.versionId).toBe("v1");
-    expect(dataset.examples.length).toBe(2);
+    expect(dataset.examples).toHaveLength(2);
   });
 
   it("should propagate errors from getDatasetInfo", async () => {
-    vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockRejectedValue(
-      new Error("info error")
+    server.use(
+      http.get("/v1/datasets/{id}", ({ response }) =>
+        response(404).text("Dataset not found")
+      )
     );
-    vi.spyOn(getDatasetExamplesModule, "getDatasetExamples").mockResolvedValue(
-      mockDatasetExamples
-    );
+    stubDatasetExamples({
+      dataset_id: "dataset-123",
+      version_id: "v1",
+      examples: [exampleOne, exampleTwo],
+    });
+
     await expect(
-      getDataset({ dataset: { datasetId: "dataset-123" } })
-    ).rejects.toThrow("info error");
+      getDataset({
+        client: createTestClient(),
+        dataset: { datasetId: "dataset-123" },
+      })
+    ).rejects.toThrow(HttpError);
   });
 
   it("should propagate errors from getDatasetExamples", async () => {
-    vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockResolvedValue(
-      mockDatasetInfo
+    stubDatasetInfo();
+    server.use(
+      http.get("/v1/datasets/{id}/examples", ({ response }) =>
+        response(404).text("Dataset not found")
+      )
     );
-    vi.spyOn(getDatasetExamplesModule, "getDatasetExamples").mockRejectedValue(
-      new Error("examples error")
-    );
+
     await expect(
-      getDataset({ dataset: { datasetId: "dataset-123" } })
-    ).rejects.toThrow("examples error");
+      getDataset({
+        client: createTestClient(),
+        dataset: { datasetId: "dataset-123" },
+      })
+    ).rejects.toThrow(HttpError);
   });
 
   it("should return merged dataset info and examples when getting by name", async () => {
-    vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockResolvedValue(
-      mockDatasetInfo
-    );
-    vi.spyOn(getDatasetExamplesModule, "getDatasetExamples").mockResolvedValue(
-      mockDatasetExamples
-    );
+    stubDatasetInfoByName();
+    stubDatasetExamples({
+      dataset_id: "dataset-123",
+      version_id: "v1",
+      examples: [exampleOne, exampleTwo],
+    });
 
     const dataset = await getDataset({
+      client: createTestClient(),
       dataset: { datasetName: "Test Dataset" },
     });
+
     expect(dataset).toBeDefined();
     expect(dataset.id).toBe("dataset-123");
     expect(dataset.name).toBe("Test Dataset");
     expect(dataset.versionId).toBe("v1");
-    const examples = dataset.examples;
-    expect(examples.length).toBe(2);
-    expect(examples[0]?.id).toBe("ex-1");
-    expect(examples[1]?.id).toBe("ex-2");
+    expect(dataset.examples).toHaveLength(2);
+    expect(dataset.examples[0]?.id).toBe("ex-1");
+    expect(dataset.examples[1]?.id).toBe("ex-2");
   });
 });


### PR DESCRIPTION
## Summary

- Migrated `test/client.test.ts` and `test/datasets/getDataset.test.ts` — the last two `phoenix-client` tests that exercised Phoenix API calls via ad-hoc `fetch`/module stubs — to use `@arizeai/phoenix-testing`'s `createMockServer`/`createHttp` MSW mock server, matching the pattern already used by the other 27 test files in the package.
- `getDataset.test.ts` previously verified `getDataset`'s merge logic by `vi.spyOn`-ing `getDatasetInfo`/`getDatasetExamples` directly; it now drives `getDataset` through mocked `GET /v1/datasets/{id}`, `GET /v1/datasets/{id}/examples`, and `GET /v1/datasets` (by-name lookup) handlers, asserting against OpenAPI-typed request/response shapes (`componentsV1`) instead of hand-rolled mock objects.
- `client.test.ts`'s non-2xx `HttpError` test now goes through the mock server instead of a manual `fetch` stub returning a `Response`.

The remaining tests in the package that don't use `@arizeai/phoenix-testing` (`authFetch.test.ts`, `config.test.ts`, pure-utility tests, the `src/testing/*` harness tests, and the `dryRun` experiment/evaluator tests) don't call the Phoenix HTTP API directly or test generic, schema-independent infrastructure, so they're left on their existing mocking approach — consistent with how already-migrated files (e.g. `runExperimentTracing.test.ts`) also spy on `getDataset` for the same reason.

## Test plan

- [x] `pnpm --filter @arizeai/phoenix-client test` — all 49 test files / 460 tests pass (1 pre-existing skip)
- [x] `pnpm --filter @arizeai/phoenix-client typecheck` — passes with no errors
- [x] `pnpm oxlint` / `pnpm oxfmt --check` on the changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01RHfpfSw9c3erZPTYhVBDhC)_