### PR TITLE
fix(cli): px auth login pre-flights OAuth discovery before the browser flow

### DIFF
--- a/js/.changeset/px-auth-login-preflight.md
+++ b/js/.changeset/px-auth-login-preflight.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": patch
+---
+
+`px auth login` now probes the server's `.well-known/oauth-authorization-server` discovery document before starting the browser flow, bailing out cleanly with a network error when the server is unreachable and an auth error when the server does not support OAuth login

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -11,6 +11,7 @@ import {
 } from "../exitCodes";
 import { writeError, writeOutput } from "../io";
 import {
+  OAUTH_UNSUPPORTED_MESSAGE,
   discoverOAuthAuthorizationServer,
   resolveTargetProfileName,
   revokeOAuthToken,
@@ -406,9 +407,7 @@ async function authLoginHandler(options: AuthLoginOptions): Promise<void> {
       );
     }
     if (discovery.status === "unsupported") {
-      throw new AuthRequiredError(
-        "This Phoenix server does not support OAuth login; use an API key."
-      );
+      throw new AuthRequiredError(OAUTH_UNSUPPORTED_MESSAGE);
     }
 
     const settingsAtLogin = loadSettings({ strict: true });

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -11,6 +11,7 @@ import {
 } from "../exitCodes";
 import { writeError, writeOutput } from "../io";
 import {
+  discoverOAuthAuthorizationServer,
   resolveTargetProfileName,
   revokeOAuthToken,
   runBrowserLoginFlow,
@@ -391,6 +392,23 @@ async function authLoginHandler(options: AuthLoginOptions): Promise<void> {
         message: "Configuration Error:\n  - Phoenix endpoint not configured",
       });
       process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    // Pre-flight before binding a callback port or opening a browser: bail
+    // cleanly when the server is down or does not run the OAuth authorization
+    // server, instead of sending the user through a consent flow that can
+    // only fail at the token exchange.
+    const discovery = await discoverOAuthAuthorizationServer({ endpoint });
+    if (discovery.status === "unreachable") {
+      throw new NetworkError(
+        `Could not reach the Phoenix server at ${endpoint}: ${discovery.detail}. ` +
+          "Check that the server is running and the endpoint is correct."
+      );
+    }
+    if (discovery.status === "unsupported") {
+      throw new AuthRequiredError(
+        "This Phoenix server does not support OAuth login; use an API key."
+      );
     }
 
     const settingsAtLogin = loadSettings({ strict: true });

--- a/js/packages/phoenix-cli/src/oauth.ts
+++ b/js/packages/phoenix-cli/src/oauth.ts
@@ -31,6 +31,11 @@ const OAUTH_LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
 export const OAUTH_TOKEN_REQUEST_TIMEOUT_MS = 30 * 1000;
 /** Best-effort and blocking a wizard, so it gives up sooner than a token call. */
 export const OAUTH_REVOKE_TIMEOUT_MS = 10 * 1000;
+/**
+ * A quick pre-flight, not a token exchange: nothing has been consented to yet,
+ * so giving up fast costs the user only a retry, not a browser round trip.
+ */
+export const OAUTH_DISCOVERY_TIMEOUT_MS = 5 * 1000;
 export const OAUTH_REFRESH_BUFFER_MS = 60 * 1000;
 const SETTINGS_LOCK_TIMEOUT_MS = 10 * 1000;
 const SETTINGS_LOCK_RETRY_MS = 50;
@@ -57,6 +62,71 @@ export const OAuthAuthorizationServerMetadataSchema = z.object({
   authorization_endpoint: z.string().min(1),
   token_endpoint: z.string().min(1),
 });
+
+export type OAuthAuthorizationServerMetadata = z.infer<
+  typeof OAuthAuthorizationServerMetadataSchema
+>;
+
+export type OAuthDiscoveryResult =
+  /** The server is up and advertises a working authorization server. */
+  | { status: "supported"; metadata: OAuthAuthorizationServerMetadata }
+  /** The server answered, but not with RFC 8414 metadata — no OAuth here. */
+  | { status: "unsupported" }
+  /** The server never answered: down, unresolvable, or timed out. */
+  | { status: "unreachable"; detail: string };
+
+/**
+ * Probe the RFC 8414 discovery document. One request settles both pre-flight
+ * questions a login needs answered: is the server even up (a dead host fails
+ * the fetch), and does it run the OAuth authorization server (a Phoenix
+ * without one answers unknown paths with the SPA's index.html and a 200,
+ * which is why only a parsing document counts as support).
+ */
+export async function discoverOAuthAuthorizationServer({
+  endpoint,
+  fetchImpl = fetch,
+}: {
+  endpoint: string;
+  fetchImpl?: typeof fetch;
+}): Promise<OAuthDiscoveryResult> {
+  let response: Response;
+  try {
+    response = await fetchImpl(
+      new URL(
+        ".well-known/oauth-authorization-server",
+        normalizeEndpoint(endpoint)
+      ),
+      { signal: AbortSignal.timeout(OAUTH_DISCOVERY_TIMEOUT_MS) }
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      return {
+        status: "unreachable",
+        detail: `the server did not respond within ${
+          OAUTH_DISCOVERY_TIMEOUT_MS / 1000
+        }s`,
+      };
+    }
+    return {
+      status: "unreachable",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (!response.ok) {
+    return { status: "unsupported" };
+  }
+  let document: unknown;
+  try {
+    document = await response.json();
+  } catch {
+    return { status: "unsupported" };
+  }
+  const parsed = OAuthAuthorizationServerMetadataSchema.safeParse(document);
+  return parsed.success
+    ? { status: "supported", metadata: parsed.data }
+    : { status: "unsupported" };
+}
 
 export interface PkcePair {
   verifier: string;

--- a/js/packages/phoenix-cli/src/oauth.ts
+++ b/js/packages/phoenix-cli/src/oauth.ts
@@ -63,17 +63,16 @@ export const OAuthAuthorizationServerMetadataSchema = z.object({
   token_endpoint: z.string().min(1),
 });
 
-export type OAuthAuthorizationServerMetadata = z.infer<
-  typeof OAuthAuthorizationServerMetadataSchema
->;
-
 export type OAuthDiscoveryResult =
   /** The server is up and advertises a working authorization server. */
-  | { status: "supported"; metadata: OAuthAuthorizationServerMetadata }
+  | { status: "supported" }
   /** The server answered, but not with RFC 8414 metadata — no OAuth here. */
   | { status: "unsupported" }
-  /** The server never answered: down, unresolvable, or timed out. */
+  /** The server never answered or is unhealthy: down, timed out, or 5xx. */
   | { status: "unreachable"; detail: string };
+
+export const OAUTH_UNSUPPORTED_MESSAGE =
+  "This Phoenix server does not support OAuth login; use an API key.";
 
 /**
  * Probe the RFC 8414 discovery document. One request settles both pre-flight
@@ -113,6 +112,14 @@ export async function discoverOAuthAuthorizationServer({
     };
   }
 
+  // A 5xx is a health verdict, not a capability verdict: a server mid-restart
+  // must not be reported as permanently lacking OAuth support.
+  if (response.status >= 500) {
+    return {
+      status: "unreachable",
+      detail: `the server responded with HTTP ${response.status}`,
+    };
+  }
   if (!response.ok) {
     return { status: "unsupported" };
   }
@@ -122,9 +129,8 @@ export async function discoverOAuthAuthorizationServer({
   } catch {
     return { status: "unsupported" };
   }
-  const parsed = OAuthAuthorizationServerMetadataSchema.safeParse(document);
-  return parsed.success
-    ? { status: "supported", metadata: parsed.data }
+  return OAuthAuthorizationServerMetadataSchema.safeParse(document).success
+    ? { status: "supported" }
     : { status: "unsupported" };
 }
 
@@ -614,9 +620,7 @@ async function postTokenRequest({
   }
 
   if (response.status === 404) {
-    throw new AuthRequiredError(
-      "This Phoenix server does not support OAuth login; use an API key."
-    );
+    throw new AuthRequiredError(OAUTH_UNSUPPORTED_MESSAGE);
   }
   if (!response.ok) {
     const text = await response.text();

--- a/js/packages/phoenix-cli/src/setup/deps/oauthLogin.ts
+++ b/js/packages/phoenix-cli/src/setup/deps/oauthLogin.ts
@@ -10,13 +10,10 @@
  */
 
 import {
-  OAuthAuthorizationServerMetadataSchema,
-  normalizeEndpoint,
+  discoverOAuthAuthorizationServer,
   revokeOAuthToken,
   runBrowserLoginFlow,
 } from "../../oauth";
-
-const SUPPORT_PROBE_TIMEOUT_MS = 5_000;
 
 export interface OAuthLoginArgs {
   /** Normalized origin, no trailing slash. */
@@ -79,23 +76,11 @@ export function createSystemOAuthLogin({
   const apiOrigin = (endpoint: string) => apiUrl ?? endpoint;
   return {
     async isSupported(endpoint) {
-      try {
-        const response = await fetchImpl(
-          new URL(
-            ".well-known/oauth-authorization-server",
-            normalizeEndpoint(apiOrigin(endpoint))
-          ),
-          { signal: AbortSignal.timeout(SUPPORT_PROBE_TIMEOUT_MS) }
-        );
-        if (!response.ok) {
-          return false;
-        }
-        const document: unknown = await response.json();
-        return OAuthAuthorizationServerMetadataSchema.safeParse(document)
-          .success;
-      } catch {
-        return false;
-      }
+      const discovery = await discoverOAuthAuthorizationServer({
+        endpoint: apiOrigin(endpoint),
+        fetchImpl,
+      });
+      return discovery.status === "supported";
     },
 
     async login({ endpoint, onAuthorizationUrl, onBrowserOpenFailed, signal }) {

--- a/js/packages/phoenix-cli/test/auth.test.ts
+++ b/js/packages/phoenix-cli/test/auth.test.ts
@@ -464,6 +464,17 @@ describe("px auth login/logout", () => {
         },
       });
       server = await withServer(async (request, response) => {
+        if (request.url === "/.well-known/oauth-authorization-server") {
+          response.writeHead(200, { "Content-Type": "application/json" });
+          response.end(
+            JSON.stringify({
+              issuer: "http://phoenix.example",
+              authorization_endpoint: "http://phoenix.example/oauth2/authorize",
+              token_endpoint: "http://phoenix.example/oauth2/token",
+            })
+          );
+          return;
+        }
         if (request.url === "/oauth2/token" && request.method === "POST") {
           const body = new URLSearchParams(await readRequestBody(request));
           expect(body.get("grant_type")).toBe("authorization_code");
@@ -555,7 +566,18 @@ describe("px auth login/logout", () => {
   it("maps token endpoint 404 to AUTH_REQUIRED with API key hint", async () => {
     let server: Awaited<ReturnType<typeof withServer>> | undefined;
     try {
-      server = await withServer((_request, response) => {
+      server = await withServer((request, response) => {
+        if (request.url === "/.well-known/oauth-authorization-server") {
+          response.writeHead(200, { "Content-Type": "application/json" });
+          response.end(
+            JSON.stringify({
+              issuer: "http://phoenix.example",
+              authorization_endpoint: "http://phoenix.example/oauth2/authorize",
+              token_endpoint: "http://phoenix.example/oauth2/token",
+            })
+          );
+          return;
+        }
         response.writeHead(404);
         response.end();
       });
@@ -593,6 +615,67 @@ describe("px auth login/logout", () => {
     } finally {
       await server?.close();
     }
+  });
+
+  it("bails with AUTH_REQUIRED before the flow when the server lacks OAuth discovery", async () => {
+    let server: Awaited<ReturnType<typeof withServer>> | undefined;
+    try {
+      // A Phoenix without an authorization server answers unknown paths with
+      // the SPA's index.html and a 200 — the trap the discovery gate exists
+      // to catch.
+      server = await withServer((_request, response) => {
+        response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+        response.end("<!doctype html><html><body>Phoenix</body></html>");
+      });
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+        code?: number
+      ) => {
+        throw new Error(`process.exit:${code}`);
+      }) as never);
+
+      await expect(
+        createAuthCommand().parseAsync(
+          ["login", "--endpoint", server.url, "--no-browser"],
+          { from: "user" }
+        )
+      ).rejects.toThrow(`process.exit:${ExitCode.AUTH_REQUIRED}`);
+      expect(exitSpy).toHaveBeenCalledWith(ExitCode.AUTH_REQUIRED);
+      const stderr = captured(stderrSpy);
+      expect(stderr).toContain("does not support OAuth login");
+      // The gate must fire before the flow starts — no authorization URL.
+      expect(stderr).not.toContain("/oauth2/authorize");
+    } finally {
+      await server?.close();
+    }
+  });
+
+  it("bails with NETWORK_ERROR before the flow when the server is unreachable", async () => {
+    // Bind and immediately close a server so the port is known-dead.
+    const server = await withServer((_request, response) => {
+      response.end();
+    });
+    await server.close();
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createAuthCommand().parseAsync(
+        ["login", "--endpoint", server.url, "--no-browser"],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+    const stderr = captured(stderrSpy);
+    expect(stderr).toContain("Could not reach the Phoenix server");
+    expect(stderr).not.toContain("/oauth2/authorize");
   });
 
   it("logout revokes the refresh token and leaves the API key", async () => {

--- a/js/packages/phoenix-cli/test/auth.test.ts
+++ b/js/packages/phoenix-cli/test/auth.test.ts
@@ -68,6 +68,23 @@ function captured(spy: ReturnType<typeof vi.spyOn>): string {
   return spy.mock.calls.map((call) => String(call[0])).join("\n");
 }
 
+function spyOnExit() {
+  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit:${code}`);
+  }) as never);
+}
+
+function respondWithOAuthDiscovery(response: http.ServerResponse): void {
+  response.writeHead(200, { "Content-Type": "application/json" });
+  response.end(
+    JSON.stringify({
+      issuer: "http://phoenix.example",
+      authorization_endpoint: "http://phoenix.example/oauth2/authorize",
+      token_endpoint: "http://phoenix.example/oauth2/token",
+    })
+  );
+}
+
 async function runAuthCommand(args: string[]): Promise<void> {
   const command = createAuthCommand();
   command.exitOverride();
@@ -465,14 +482,7 @@ describe("px auth login/logout", () => {
       });
       server = await withServer(async (request, response) => {
         if (request.url === "/.well-known/oauth-authorization-server") {
-          response.writeHead(200, { "Content-Type": "application/json" });
-          response.end(
-            JSON.stringify({
-              issuer: "http://phoenix.example",
-              authorization_endpoint: "http://phoenix.example/oauth2/authorize",
-              token_endpoint: "http://phoenix.example/oauth2/token",
-            })
-          );
+          respondWithOAuthDiscovery(response);
           return;
         }
         if (request.url === "/oauth2/token" && request.method === "POST") {
@@ -568,14 +578,7 @@ describe("px auth login/logout", () => {
     try {
       server = await withServer((request, response) => {
         if (request.url === "/.well-known/oauth-authorization-server") {
-          response.writeHead(200, { "Content-Type": "application/json" });
-          response.end(
-            JSON.stringify({
-              issuer: "http://phoenix.example",
-              authorization_endpoint: "http://phoenix.example/oauth2/authorize",
-              token_endpoint: "http://phoenix.example/oauth2/token",
-            })
-          );
+          respondWithOAuthDiscovery(response);
           return;
         }
         response.writeHead(404);
@@ -599,11 +602,7 @@ describe("px auth login/logout", () => {
           );
         }
       });
-      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-        code?: number
-      ) => {
-        throw new Error(`process.exit:${code}`);
-      }) as never);
+      const exitSpy = spyOnExit();
 
       await expect(
         createAuthCommand().parseAsync(
@@ -629,11 +628,7 @@ describe("px auth login/logout", () => {
       });
       vi.spyOn(console, "log").mockImplementation(() => {});
       const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-        code?: number
-      ) => {
-        throw new Error(`process.exit:${code}`);
-      }) as never);
+      const exitSpy = spyOnExit();
 
       await expect(
         createAuthCommand().parseAsync(
@@ -651,6 +646,30 @@ describe("px auth login/logout", () => {
     }
   });
 
+  it("treats a 5xx discovery response as unreachable, not as missing OAuth support", async () => {
+    let server: Awaited<ReturnType<typeof withServer>> | undefined;
+    try {
+      server = await withServer((_request, response) => {
+        response.writeHead(503);
+        response.end();
+      });
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const exitSpy = spyOnExit();
+
+      await expect(
+        createAuthCommand().parseAsync(
+          ["login", "--endpoint", server.url, "--no-browser"],
+          { from: "user" }
+        )
+      ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+      expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+      expect(captured(stderrSpy)).toContain("HTTP 503");
+    } finally {
+      await server?.close();
+    }
+  });
+
   it("bails with NETWORK_ERROR before the flow when the server is unreachable", async () => {
     // Bind and immediately close a server so the port is known-dead.
     const server = await withServer((_request, response) => {
@@ -660,11 +679,7 @@ describe("px auth login/logout", () => {
 
     vi.spyOn(console, "log").mockImplementation(() => {});
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = spyOnExit();
 
     await expect(
       createAuthCommand().parseAsync(


### PR DESCRIPTION
## Problem

`px auth login` jumped straight into the browser OAuth flow without checking whether the server was even up or ran an OAuth authorization server. Against a down server or an older Phoenix without OAuth, the user got a callback port bound, a browser opened, and a failure only at the token exchange (or a dead consent page).

## Fix

- Added a shared `discoverOAuthAuthorizationServer()` in `oauth.ts` that probes the RFC 8414 `.well-known/oauth-authorization-server` document (5s timeout) and distinguishes three outcomes: **supported** (document parses), **unsupported** (server answered but no OAuth — catches the SPA answering unknown paths with a 200 index.html), and **unreachable** (fetch failed/timed out).
- `px auth login` now runs this pre-flight before binding the callback port or opening a browser:
  - unreachable → `Could not reach the Phoenix server at <endpoint>…` and exit `5` (NETWORK_ERROR)
  - no OAuth support → `This Phoenix server does not support OAuth login; use an API key.` and exit `4` (AUTH_REQUIRED), matching the existing token-exchange 404 message
- `px setup`'s `isSupported` probe did the same fetch inline; it now delegates to the shared function so login and setup can't drift.
- Patch changeset for `@arizeai/phoenix-cli`.

## Tests

- New: login against an SPA-only server exits 4 without ever printing an authorize URL; login against a dead port exits 5.
- Updated existing login stubs to serve the discovery document since login now requires it.
- Full `pnpm test` in `js/packages/phoenix-cli`: 805 passed, 1 failed — the failure is a pre-existing `pxiApp.test.tsx` Mac-Delete timeout that also fails on a clean checkout of `main`, unrelated to this change. All auth/oauth/setup tests pass.
- Verified live: `px auth login --endpoint <dead port>` exits 5 with the reach error; against a plain HTTP server it exits 4 with the API-key hint, no browser opened.