### PR TITLE
test(cli): migrate CLI tests to phoenix-testing MSW mocks and add command coverage

### DIFF
--- a/js/packages/phoenix-cli/.agents/skills/phoenix-cli-development/SKILL.md
+++ b/js/packages/phoenix-cli/.agents/skills/phoenix-cli-development/SKILL.md
@@ -275,12 +275,20 @@ pnpm test          # run all tests
 pnpm test:watch    # watch mode
 ```
 
+HTTP is mocked with `@arizeai/phoenix-testing` (MSW handlers generated from the OpenAPI definition) — tests MUST NOT stub the global `fetch`. Use the shared harness:
+
+- `test/mockServer.ts` — call `const mock = setupMockPhoenixServer()` at module top level; every documented Phoenix endpoint answers with schema-generated data, and unhandled requests fail the test. Pin exact responses per-test with the typed `http` namespace: `mock.server.use(http.get("/v1/projects", ({ response }) => response(200).json({...})))`. Assert on the request (params, query, body) by capturing values inside the handler.
+- `test/testUtils.ts` — `BASE_ARGS` (endpoint + `--no-progress` args), `mockProcessExit()` (throws `process.exit:<code>` for exit-code assertions), and `captureCliOutput()` (silenced stdout/stderr spies).
+- Raw non-OpenAPI handlers (GraphQL, third-party hosts) use msw re-exported from `@arizeai/phoenix-testing` (`HttpResponse`, `http`); `HttpResponse.error()` simulates network failure.
+- Injected-fetch dependency injection (e.g. `fetchImpl` params in OAuth helpers) is fine as-is and does not need MSW.
+
 When adding a command, tests MUST cover:
 
-- The handler logic (mocking the Phoenix client)
+- The handler logic over HTTP (typed MSW handlers, not client mocks)
 - Formatter output for each format mode
 - Edge cases: missing config, network errors, empty results
 - Exit code correctness for error paths
+- One run against the generated handlers alone (no pinned responses) to prove the command works end-to-end against spec-conformant data
 
 ## Build and Run
 

--- a/js/packages/phoenix-cli/package.json
+++ b/js/packages/phoenix-cli/package.json
@@ -57,6 +57,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@arizeai/phoenix-testing": "workspace:*",
     "@types/cross-spawn": "^6.0.6",
     "@types/node": "^26.1.1",
     "@types/react": "19.2.17",

--- a/js/packages/phoenix-cli/test/annotate.test.ts
+++ b/js/packages/phoenix-cli/test/annotate.test.ts
@@ -1,3 +1,4 @@
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AnnotationMutationResult } from "../src/commands/annotationMutations";
@@ -5,60 +6,51 @@ import { formatAnnotationMutationOutput } from "../src/commands/formatAnnotation
 import { createSpanCommand } from "../src/commands/span";
 import { createTraceCommand } from "../src/commands/trace";
 import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
 
-function makeFetchMock(
-  responses: Array<
-    { ok: boolean; status?: number; body?: unknown } | { error: Error }
-  >
-) {
-  let callIndex = 0;
-  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
-    const response = responses[callIndex++] ?? responses[responses.length - 1];
-    if ("error" in response) {
-      return Promise.reject(response.error);
-    }
-    const status = response.status ?? (response.ok ? 200 : 500);
-    const url =
-      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
-    const body = response.body ?? {};
-    const text = JSON.stringify(body);
-    return Promise.resolve({
-      ok: response.ok,
-      status,
-      statusText: response.ok ? "OK" : "Error",
-      url,
-      headers: new Headers(),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(text),
-    });
-  });
-}
-
-function getFetchUrl(arg: unknown): string {
-  if (arg instanceof Request) return arg.url;
-  return String(arg);
-}
-
-function getFetchMethod(arg: unknown, init?: RequestInit): string {
-  if (arg instanceof Request) return arg.method;
-  return init?.method ?? "GET";
-}
-
-async function getFetchBody(
-  arg: unknown,
-  init?: RequestInit
-): Promise<unknown> {
-  if (arg instanceof Request) {
-    const text = await arg.clone().text();
-    return text ? JSON.parse(text) : undefined;
-  }
-  if (typeof init?.body === "string") {
-    return JSON.parse(init.body);
-  }
-  return undefined;
-}
+const mock = setupMockPhoenixServer();
 
 const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+interface CapturedAnnotationRequest {
+  query?: URLSearchParams;
+  body?: unknown;
+  count: number;
+}
+
+/**
+ * Pin the span_annotations POST endpoint to a fixed inserted ID and record the
+ * request's query string, JSON body, and call count for later assertions.
+ */
+function captureSpanAnnotationsRequest(insertedId: string) {
+  const captured: CapturedAnnotationRequest = { count: 0 };
+  mock.server.use(
+    http.post("/v1/span_annotations", async ({ request, response }) => {
+      captured.count += 1;
+      captured.query = new URL(request.url).searchParams;
+      captured.body = await request.clone().json();
+      return response(200).json({ data: [{ id: insertedId }] });
+    })
+  );
+  return captured;
+}
+
+/**
+ * Pin the trace_annotations POST endpoint to a fixed inserted ID and record
+ * the request's query string, JSON body, and call count for later assertions.
+ */
+function captureTraceAnnotationsRequest(insertedId: string) {
+  const captured: CapturedAnnotationRequest = { count: 0 };
+  mock.server.use(
+    http.post("/v1/trace_annotations", async ({ request, response }) => {
+      captured.count += 1;
+      captured.query = new URL(request.url).searchParams;
+      captured.body = await request.clone().json();
+      return response(200).json({ data: [{ id: insertedId }] });
+    })
+  );
+  return captured;
+}
 
 describe("formatAnnotationMutationOutput", () => {
   const annotation: AnnotationMutationResult = {
@@ -101,17 +93,10 @@ describe("formatAnnotationMutationOutput", () => {
 describe("span annotate", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("posts a sync span annotation and returns raw structured output", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "span-annotation-1" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanAnnotationsRequest("span-annotation-1");
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -130,17 +115,9 @@ describe("span annotate", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
-      "/v1/span_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain("sync=true");
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("POST");
-    await expect(
-      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).resolves.toEqual({
+    expect(captured.count).toBe(1);
+    expect(captured.query?.get("sync")).toBe("true");
+    expect(captured.body).toEqual({
       data: [
         {
           span_id: "span-123",
@@ -168,13 +145,7 @@ describe("span annotate", () => {
   });
 
   it("passes through a custom annotator kind for span annotation", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "span-annotation-3" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanAnnotationsRequest("span-annotation-3");
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -195,9 +166,7 @@ describe("span annotate", () => {
       { from: "user" }
     );
 
-    await expect(
-      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).resolves.toEqual({
+    expect(captured.body).toEqual({
       data: [
         {
           span_id: "span-789",
@@ -224,13 +193,7 @@ describe("span annotate", () => {
   });
 
   it("returns pretty output for a scored span annotation", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "span-annotation-2" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    captureSpanAnnotationsRequest("span-annotation-2");
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -258,8 +221,7 @@ describe("span annotate", () => {
   });
 
   it("fails with INVALID_ARGUMENT when --name is missing", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -275,12 +237,11 @@ describe("span annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("fails with INVALID_ARGUMENT when all result fields are blank", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -306,12 +267,11 @@ describe("span annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("fails with INVALID_ARGUMENT when --score is invalid", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -335,7 +295,7 @@ describe("span annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "Invalid value for --score: not-a-number. Expected a finite number."
@@ -344,8 +304,7 @@ describe("span annotate", () => {
   });
 
   it("fails with INVALID_ARGUMENT when --score contains trailing non-numeric characters", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -369,7 +328,7 @@ describe("span annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "Invalid value for --score: 0abc. Expected a finite number."
@@ -378,8 +337,7 @@ describe("span annotate", () => {
   });
 
   it("fails with INVALID_ARGUMENT when --annotator-kind is invalid", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -405,18 +363,15 @@ describe("span annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("surfaces 404 API errors", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: false,
-        status: 404,
-        body: { detail: "Spans with IDs missing-span do not exist." },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    mock.server.use(
+      http.post("/v1/span_annotations", ({ response }) =>
+        response(404).text("Spans with IDs missing-span do not exist.")
+      )
+    );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -447,12 +402,9 @@ describe("span annotate", () => {
   });
 
   it("uses NETWORK_ERROR on fetch failures", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        error: new TypeError("fetch failed"),
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    mock.server.use(
+      http.post("/v1/span_annotations", () => HttpResponse.error())
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -482,17 +434,10 @@ describe("span annotate", () => {
 describe("trace annotate", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("posts a sync trace annotation and returns json output", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "trace-annotation-1" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureTraceAnnotationsRequest("trace-annotation-1");
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -511,14 +456,9 @@ describe("trace annotate", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
-      "/v1/trace_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain("sync=true");
-    await expect(
-      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).resolves.toEqual({
+    expect(captured.count).toBe(1);
+    expect(captured.query?.get("sync")).toBe("true");
+    expect(captured.body).toEqual({
       data: [
         {
           trace_id: "trace-123",
@@ -549,13 +489,7 @@ describe("trace annotate", () => {
   });
 
   it("passes through a custom annotator kind for trace annotation", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "trace-annotation-2" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureTraceAnnotationsRequest("trace-annotation-2");
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -576,9 +510,7 @@ describe("trace annotate", () => {
       { from: "user" }
     );
 
-    await expect(
-      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).resolves.toEqual({
+    expect(captured.body).toEqual({
       data: [
         {
           trace_id: "trace-456",
@@ -605,14 +537,18 @@ describe("trace annotate", () => {
   });
 
   it("surfaces 500 API errors for trace annotation", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: false,
-        status: 500,
-        body: { detail: "Internal server error" },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    mock.server.use(
+      http.post("/v1/trace_annotations", ({ response }) =>
+        response.untyped(
+          HttpResponse.json(
+            { detail: "Internal server error" },
+            {
+              status: 500,
+            }
+          )
+        )
+      )
+    );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -643,8 +579,7 @@ describe("trace annotate", () => {
   });
 
   it("fails with INVALID_ARGUMENT when trace --score is invalid", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureTraceAnnotationsRequest("trace-annotation-unused");
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -668,7 +603,7 @@ describe("trace annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "Invalid value for --score: NaN-ish. Expected a finite number."
@@ -680,24 +615,21 @@ describe("trace annotate", () => {
 describe("trace get", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("uses the resolved full trace ID when fetching trace annotations for a prefix lookup", async () => {
     const resolvedTraceId = "trace-1234567890abcdef";
     const traceIdPrefix = "trace-1234";
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: {
-          data: {
-            id: "project-default",
-          },
-        },
-      },
-      {
-        ok: true,
-        body: {
+    const capturedTraceAnnotations: { query?: URLSearchParams } = {};
+
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}", ({ response }) =>
+        response(200).json({
+          data: { id: "project-default", name: "default" },
+        })
+      ),
+      http.get("/v1/projects/{project_identifier}/spans", ({ response }) =>
+        response(200).json({
           data: [
             {
               name: "root",
@@ -719,24 +651,20 @@ describe("trace get", () => {
             },
           ],
           next_cursor: null,
-        },
-      },
-      {
-        ok: true,
-        body: {
-          data: [],
-          next_cursor: null,
-        },
-      },
-      {
-        ok: true,
-        body: {
-          data: [],
-          next_cursor: null,
-        },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+        })
+      ),
+      http.get(
+        "/v1/projects/{project_identifier}/trace_annotations",
+        ({ request, response }) => {
+          capturedTraceAnnotations.query = new URL(request.url).searchParams;
+          return response(200).json({ data: [], next_cursor: null });
+        }
+      ),
+      http.get(
+        "/v1/projects/{project_identifier}/span_annotations",
+        ({ response }) => response(200).json({ data: [], next_cursor: null })
+      )
+    );
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -754,28 +682,25 @@ describe("trace get", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    const traceAnnotationsUrl = new URL(
-      getFetchUrl(fetchMock.mock.calls[2][0])
-    );
-    expect(traceAnnotationsUrl.searchParams.getAll("trace_ids")).toEqual([
+    expect(capturedTraceAnnotations.query?.getAll("trace_ids")).toEqual([
       resolvedTraceId,
     ]);
   });
 
   it("includes trace and span annotations in raw output when requested", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: {
-          data: {
-            id: "project-default",
-          },
-        },
-      },
-      {
-        ok: true,
-        body: {
+    const captured: {
+      traceAnnotationsProject?: string;
+      spanAnnotationsProject?: string;
+    } = {};
+
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}", ({ response }) =>
+        response(200).json({
+          data: { id: "project-default", name: "default" },
+        })
+      ),
+      http.get("/v1/projects/{project_identifier}/spans", ({ response }) =>
+        response(200).json({
           data: [
             {
               name: "root",
@@ -797,56 +722,61 @@ describe("trace get", () => {
             },
           ],
           next_cursor: null,
-        },
-      },
-      {
-        ok: true,
-        body: {
-          data: [
-            {
-              id: "trace-annotation-1",
-              created_at: "2026-01-13T10:00:00.500Z",
-              updated_at: "2026-01-13T10:00:00.500Z",
-              source: "API",
-              user_id: null,
-              name: "reviewer",
-              annotator_kind: "HUMAN",
-              result: {
-                label: "pass",
+        })
+      ),
+      http.get(
+        "/v1/projects/{project_identifier}/trace_annotations",
+        ({ params, response }) => {
+          captured.traceAnnotationsProject = params.project_identifier;
+          return response(200).json({
+            data: [
+              {
+                id: "trace-annotation-1",
+                created_at: "2026-01-13T10:00:00.500Z",
+                updated_at: "2026-01-13T10:00:00.500Z",
+                source: "API",
+                user_id: null,
+                name: "reviewer",
+                annotator_kind: "HUMAN",
+                result: {
+                  label: "pass",
+                },
+                metadata: null,
+                identifier: "",
+                trace_id: "trace-123",
               },
-              metadata: null,
-              identifier: "",
-              trace_id: "trace-123",
-            },
-          ],
-          next_cursor: null,
-        },
-      },
-      {
-        ok: true,
-        body: {
-          data: [
-            {
-              id: "span-annotation-1",
-              created_at: "2026-01-13T10:00:00.750Z",
-              updated_at: "2026-01-13T10:00:00.750Z",
-              source: "API",
-              user_id: null,
-              name: "accuracy",
-              annotator_kind: "CODE",
-              result: {
-                score: 0.9,
+            ],
+            next_cursor: null,
+          });
+        }
+      ),
+      http.get(
+        "/v1/projects/{project_identifier}/span_annotations",
+        ({ params, response }) => {
+          captured.spanAnnotationsProject = params.project_identifier;
+          return response(200).json({
+            data: [
+              {
+                id: "span-annotation-1",
+                created_at: "2026-01-13T10:00:00.750Z",
+                updated_at: "2026-01-13T10:00:00.750Z",
+                source: "API",
+                user_id: null,
+                name: "accuracy",
+                annotator_kind: "CODE",
+                result: {
+                  score: 0.9,
+                },
+                metadata: null,
+                identifier: "",
+                span_id: "span-123",
               },
-              metadata: null,
-              identifier: "",
-              span_id: "span-123",
-            },
-          ],
-          next_cursor: null,
-        },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+            ],
+            next_cursor: null,
+          });
+        }
+      )
+    );
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -864,13 +794,8 @@ describe("trace get", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "/v1/projects/project-default/trace_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
-      "/v1/projects/project-default/span_annotations"
-    );
+    expect(captured.traceAnnotationsProject).toBe("project-default");
+    expect(captured.spanAnnotationsProject).toBe("project-default");
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     expect(output).toBeTruthy();
@@ -896,17 +821,10 @@ describe("trace get", () => {
 describe("annotate --identifier round-trip", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("threads --identifier into the span_annotations request body", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "span-annotation-id" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanAnnotationsRequest("span-annotation-id");
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -927,9 +845,7 @@ describe("annotate --identifier round-trip", () => {
       { from: "user" }
     );
 
-    await expect(
-      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).resolves.toEqual({
+    expect(captured.body).toEqual({
       data: [
         {
           span_id: "span-123",
@@ -943,13 +859,7 @@ describe("annotate --identifier round-trip", () => {
   });
 
   it("threads --identifier into the trace_annotations request body", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "trace-annotation-id" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureTraceAnnotationsRequest("trace-annotation-id");
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -970,9 +880,7 @@ describe("annotate --identifier round-trip", () => {
       { from: "user" }
     );
 
-    await expect(
-      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).resolves.toEqual({
+    expect(captured.body).toEqual({
       data: [
         {
           trace_id: "trace-123",
@@ -986,13 +894,7 @@ describe("annotate --identifier round-trip", () => {
   });
 
   it("echoes the supplied --identifier in the raw mutation result", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "trace-annotation-id" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    captureTraceAnnotationsRequest("trace-annotation-id");
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/js/packages/phoenix-cli/test/annotate.test.ts
+++ b/js/packages/phoenix-cli/test/annotate.test.ts
@@ -1,4 +1,4 @@
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AnnotationMutationResult } from "../src/commands/annotationMutations";

--- a/js/packages/phoenix-cli/test/annotate.test.ts
+++ b/js/packages/phoenix-cli/test/annotate.test.ts
@@ -7,10 +7,9 @@ import { createSpanCommand } from "../src/commands/span";
 import { createTraceCommand } from "../src/commands/trace";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 interface CapturedAnnotationRequest {
   query?: URLSearchParams;
@@ -97,8 +96,7 @@ describe("span annotate", () => {
 
   it("posts a sync span annotation and returns raw structured output", async () => {
     const captured = captureSpanAnnotationsRequest("span-annotation-1");
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -128,7 +126,7 @@ describe("span annotate", () => {
         },
       ],
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify({
         id: "span-annotation-1",
         targetType: "span",
@@ -141,13 +139,12 @@ describe("span annotate", () => {
         identifier: "",
       })
     );
-    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(io.stderr).not.toHaveBeenCalled();
   });
 
   it("passes through a custom annotator kind for span annotation", async () => {
     const captured = captureSpanAnnotationsRequest("span-annotation-3");
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -177,7 +174,7 @@ describe("span annotate", () => {
         },
       ],
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify({
         id: "span-annotation-3",
         targetType: "span",
@@ -194,8 +191,7 @@ describe("span annotate", () => {
 
   it("returns pretty output for a scored span annotation", async () => {
     captureSpanAnnotationsRequest("span-annotation-2");
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -212,10 +208,10 @@ describe("span annotate", () => {
       { from: "user" }
     );
 
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       expect.stringContaining("Target: span span-456")
     );
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       expect.stringContaining("Explanation: looks good")
     );
   });
@@ -223,11 +219,7 @@ describe("span annotate", () => {
   it("fails with INVALID_ARGUMENT when --name is missing", async () => {
     const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(
@@ -243,11 +235,7 @@ describe("span annotate", () => {
   it("fails with INVALID_ARGUMENT when all result fields are blank", async () => {
     const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(
@@ -273,11 +261,7 @@ describe("span annotate", () => {
   it("fails with INVALID_ARGUMENT when --score is invalid", async () => {
     const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(
@@ -306,11 +290,7 @@ describe("span annotate", () => {
   it("fails with INVALID_ARGUMENT when --score contains trailing non-numeric characters", async () => {
     const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(
@@ -339,11 +319,7 @@ describe("span annotate", () => {
   it("fails with INVALID_ARGUMENT when --annotator-kind is invalid", async () => {
     const captured = captureSpanAnnotationsRequest("span-annotation-unused");
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(
@@ -373,11 +349,7 @@ describe("span annotate", () => {
       )
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(
@@ -406,11 +378,7 @@ describe("span annotate", () => {
       http.post("/v1/span_annotations", () => HttpResponse.error())
     );
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(
@@ -438,8 +406,7 @@ describe("trace annotate", () => {
 
   it("posts a sync trace annotation and returns json output", async () => {
     const captured = captureTraceAnnotationsRequest("trace-annotation-1");
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -469,7 +436,7 @@ describe("trace annotate", () => {
         },
       ],
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify(
         {
           id: "trace-annotation-1",
@@ -490,8 +457,7 @@ describe("trace annotate", () => {
 
   it("passes through a custom annotator kind for trace annotation", async () => {
     const captured = captureTraceAnnotationsRequest("trace-annotation-2");
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -521,7 +487,7 @@ describe("trace annotate", () => {
         },
       ],
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify({
         id: "trace-annotation-2",
         targetType: "trace",
@@ -550,11 +516,7 @@ describe("trace annotate", () => {
       )
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createTraceCommand().parseAsync(
@@ -581,11 +543,7 @@ describe("trace annotate", () => {
   it("fails with INVALID_ARGUMENT when trace --score is invalid", async () => {
     const captured = captureTraceAnnotationsRequest("trace-annotation-unused");
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createTraceCommand().parseAsync(
@@ -665,8 +623,7 @@ describe("trace get", () => {
         ({ response }) => response(200).json({ data: [], next_cursor: null })
       )
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -777,8 +734,7 @@ describe("trace get", () => {
         }
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -797,7 +753,7 @@ describe("trace get", () => {
     expect(captured.traceAnnotationsProject).toBe("project-default");
     expect(captured.spanAnnotationsProject).toBe("project-default");
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     expect(output).toBeTruthy();
 
     const parsedOutput = JSON.parse(String(output));
@@ -825,8 +781,7 @@ describe("annotate --identifier round-trip", () => {
 
   it("threads --identifier into the span_annotations request body", async () => {
     const captured = captureSpanAnnotationsRequest("span-annotation-id");
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -860,8 +815,7 @@ describe("annotate --identifier round-trip", () => {
 
   it("threads --identifier into the trace_annotations request body", async () => {
     const captured = captureTraceAnnotationsRequest("trace-annotation-id");
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -895,8 +849,7 @@ describe("annotate --identifier round-trip", () => {
 
   it("echoes the supplied --identifier in the raw mutation result", async () => {
     captureTraceAnnotationsRequest("trace-annotation-id");
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -915,7 +868,7 @@ describe("annotate --identifier round-trip", () => {
       { from: "user" }
     );
 
-    const echoed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const echoed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(echoed.identifier).toBe("px-coding-session:abc12345");
   });
 });

--- a/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
@@ -8,10 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 const CATEGORICAL: componentsV1["schemas"]["CategoricalAnnotationConfig"] = {
   id: "cat-id-001",
@@ -90,8 +89,7 @@ describe("annotation-config get", () => {
 
   it("GETs by identifier and prints the config as a single object (raw)", async () => {
     const captured = captureGetAnnotationConfigRequest();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       ["get", "quality", "--format", "raw", ...BASE_ARGS],
@@ -100,7 +98,7 @@ describe("annotation-config get", () => {
 
     expect(captured.count).toBe(1);
     expect(captured.identifier).toBe("quality");
-    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(CATEGORICAL));
+    expect(io.stdout).toHaveBeenCalledWith(JSON.stringify(CATEGORICAL));
   });
 
   it("exits FAILURE when the identifier is not found", async () => {
@@ -113,11 +111,7 @@ describe("annotation-config get", () => {
       )
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
@@ -141,8 +135,7 @@ describe("annotation-config create", () => {
 
   it("POSTs a categorical config built from repeatable --value flags", async () => {
     const captured = captureCreateAnnotationConfigRequest();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       [
@@ -173,13 +166,12 @@ describe("annotation-config create", () => {
       { label: "good", score: 1 },
       { label: "bad", score: 0 },
     ]);
-    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(CATEGORICAL));
+    expect(io.stdout).toHaveBeenCalledWith(JSON.stringify(CATEGORICAL));
   });
 
   it("lowercases --type and defaults optimization_direction to NONE", async () => {
     const captured = captureCreateAnnotationConfigRequest();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       [
@@ -207,11 +199,7 @@ describe("annotation-config create", () => {
   it("exits INVALID_ARGUMENT when --type is missing", async () => {
     const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
@@ -227,11 +215,7 @@ describe("annotation-config create", () => {
   it("exits INVALID_ARGUMENT for an invalid --type", async () => {
     const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
@@ -247,11 +231,7 @@ describe("annotation-config create", () => {
   it("exits INVALID_ARGUMENT when a categorical config has no values", async () => {
     const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
@@ -267,11 +247,7 @@ describe("annotation-config create", () => {
   it("exits INVALID_ARGUMENT when a value flag is used on a non-categorical type", async () => {
     const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
@@ -296,11 +272,7 @@ describe("annotation-config create", () => {
   it("exits INVALID_ARGUMENT before any network call when a numeric flag is not a number", async () => {
     const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
@@ -325,8 +297,7 @@ describe("annotation-config create", () => {
 
   it("accepts a lowercase --optimization-direction and sends it uppercased", async () => {
     const captured = captureCreateAnnotationConfigRequest();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       [

--- a/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
@@ -1,59 +1,19 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import type { componentsV1 } from "@arizeai/phoenix-testing";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";
 import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
 
-function makeFetchMock(
-  responses: Array<{ ok: boolean; status?: number; body?: unknown }>
-) {
-  let callIndex = 0;
-  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
-    const resp = responses[callIndex++] ?? responses[responses.length - 1];
-    const status = resp.status ?? (resp.ok ? 200 : 500);
-    const url =
-      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
-    const body = resp.body ?? {};
-    const text = JSON.stringify(body);
-    return Promise.resolve({
-      ok: resp.ok,
-      status,
-      statusText: resp.ok ? "OK" : "Error",
-      url,
-      headers: new Headers(),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(text),
-    });
-  });
-}
-
-function getFetchUrl(arg: unknown): string {
-  if (arg instanceof Request) return arg.url;
-  return String(arg);
-}
-
-function getFetchMethod(arg: unknown, init?: RequestInit): string {
-  if (arg instanceof Request) return arg.method;
-  return init?.method ?? "GET";
-}
-
-async function getFetchBody(
-  arg: unknown,
-  init?: RequestInit
-): Promise<unknown> {
-  if (arg instanceof Request) {
-    const text = await arg.clone().text();
-    return text ? JSON.parse(text) : undefined;
-  }
-  const body = init?.body;
-  return typeof body === "string" ? JSON.parse(body) : body;
-}
+const mock = setupMockPhoenixServer();
 
 const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
-const CATEGORICAL = {
+const CATEGORICAL: componentsV1["schemas"]["CategoricalAnnotationConfig"] = {
   id: "cat-id-001",
   name: "quality",
   type: "CATEGORICAL",
@@ -64,6 +24,45 @@ const CATEGORICAL = {
     { label: "bad", score: 0 },
   ],
 };
+
+/**
+ * Register a handler for GET /v1/annotation_configs/{config_identifier} that
+ * answers with the given config and records the requested identifier and the
+ * number of calls.
+ */
+function captureGetAnnotationConfigRequest() {
+  const captured: { identifier?: string; count: number } = { count: 0 };
+  mock.server.use(
+    http.get(
+      "/v1/annotation_configs/{config_identifier}",
+      ({ params, response }) => {
+        captured.count += 1;
+        captured.identifier = params.config_identifier;
+        return response(200).json({ data: CATEGORICAL });
+      }
+    )
+  );
+  return captured;
+}
+
+/**
+ * Register a handler for POST /v1/annotation_configs that records the request
+ * body and the number of calls. Tests that must never reach the network
+ * assert `count === 0`.
+ */
+function captureCreateAnnotationConfigRequest() {
+  const captured: { body?: Record<string, unknown>; count: number } = {
+    count: 0,
+  };
+  mock.server.use(
+    http.post("/v1/annotation_configs", async ({ request, response }) => {
+      captured.count += 1;
+      captured.body = (await request.clone().json()) as Record<string, unknown>;
+      return response(200).json({ data: CATEGORICAL });
+    })
+  );
+  return captured;
+}
 
 function useIsolatedProfilesDir() {
   let tmpDir: string;
@@ -87,14 +86,10 @@ describe("annotation-config get", () => {
   useIsolatedProfilesDir();
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("GETs by identifier and prints the config as a single object (raw)", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureGetAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -103,20 +98,20 @@ describe("annotation-config get", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
-      "/v1/annotation_configs/quality"
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("GET");
+    expect(captured.count).toBe(1);
+    expect(captured.identifier).toBe("quality");
     expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(CATEGORICAL));
   });
 
   it("exits FAILURE when the identifier is not found", async () => {
     // The client throws on a 404, which the handler's catch maps to FAILURE.
-    const fetchMock = makeFetchMock([{ ok: false, status: 404, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    // 404 is not a documented status for this operation, so pin an untyped
+    // response.
+    mock.server.use(
+      http.get("/v1/annotation_configs/{config_identifier}", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 404 }))
+      )
+    );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -142,14 +137,10 @@ describe("annotation-config create", () => {
   useIsolatedProfilesDir();
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("POSTs a categorical config built from repeatable --value flags", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -173,18 +164,8 @@ describe("annotation-config create", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
-      "/v1/annotation_configs"
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("POST");
-
-    const body = (await getFetchBody(
-      fetchMock.mock.calls[0][0],
-      fetchMock.mock.calls[0][1]
-    )) as Record<string, unknown>;
+    expect(captured.count).toBe(1);
+    const body = captured.body as Record<string, unknown>;
     expect(body.type).toBe("CATEGORICAL");
     expect(body.name).toBe("quality");
     expect(body.optimization_direction).toBe("MAXIMIZE");
@@ -196,10 +177,7 @@ describe("annotation-config create", () => {
   });
 
   it("lowercases --type and defaults optimization_direction to NONE", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -219,10 +197,7 @@ describe("annotation-config create", () => {
       { from: "user" }
     );
 
-    const body = (await getFetchBody(
-      fetchMock.mock.calls[0][0],
-      fetchMock.mock.calls[0][1]
-    )) as Record<string, unknown>;
+    const body = captured.body as Record<string, unknown>;
     expect(body.type).toBe("CONTINUOUS");
     expect(body.optimization_direction).toBe("NONE");
     expect(body.lower_bound).toBe(0);
@@ -230,8 +205,7 @@ describe("annotation-config create", () => {
   });
 
   it("exits INVALID_ARGUMENT when --type is missing", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -247,12 +221,11 @@ describe("annotation-config create", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("exits INVALID_ARGUMENT for an invalid --type", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -268,12 +241,11 @@ describe("annotation-config create", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("exits INVALID_ARGUMENT when a categorical config has no values", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -289,12 +261,11 @@ describe("annotation-config create", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("exits INVALID_ARGUMENT when a value flag is used on a non-categorical type", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -319,12 +290,11 @@ describe("annotation-config create", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("exits INVALID_ARGUMENT before any network call when a numeric flag is not a number", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -350,14 +320,11 @@ describe("annotation-config create", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
     // A typo'd bound must never be sent to the API as null.
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("accepts a lowercase --optimization-direction and sends it uppercased", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureCreateAnnotationConfigRequest();
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -377,10 +344,7 @@ describe("annotation-config create", () => {
       { from: "user" }
     );
 
-    const body = (await getFetchBody(
-      fetchMock.mock.calls[0][0],
-      fetchMock.mock.calls[0][1]
-    )) as Record<string, unknown>;
+    const body = captured.body as Record<string, unknown>;
     expect(body.optimization_direction).toBe("MAXIMIZE");
   });
 });

--- a/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigGetCreate.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import type { componentsV1 } from "@arizeai/phoenix-testing";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";

--- a/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
@@ -1,63 +1,22 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import type { componentsV1 } from "@arizeai/phoenix-testing";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";
 import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
 
-/**
- * Build a fetch mock that returns each queued response in order, falling back
- * to the last response once exhausted.
- */
-function makeFetchMock(
-  responses: Array<{ ok: boolean; status?: number; body?: unknown }>
-) {
-  let callIndex = 0;
-  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
-    const resp = responses[callIndex++] ?? responses[responses.length - 1];
-    const status = resp.status ?? (resp.ok ? 200 : 500);
-    const url =
-      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
-    const body = resp.body ?? {};
-    const text = JSON.stringify(body);
-    return Promise.resolve({
-      ok: resp.ok,
-      status,
-      statusText: resp.ok ? "OK" : "Error",
-      url,
-      headers: new Headers(),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(text),
-    });
-  });
-}
-
-function getFetchUrl(arg: unknown): string {
-  if (arg instanceof Request) return arg.url;
-  return String(arg);
-}
-
-function getFetchMethod(arg: unknown, init?: RequestInit): string {
-  if (arg instanceof Request) return arg.method;
-  return init?.method ?? "GET";
-}
-
-async function getFetchBody(
-  arg: unknown,
-  init?: RequestInit
-): Promise<unknown> {
-  if (arg instanceof Request) {
-    const text = await arg.clone().text();
-    return text ? JSON.parse(text) : undefined;
-  }
-  const body = init?.body;
-  return typeof body === "string" ? JSON.parse(body) : body;
-}
+const mock = setupMockPhoenixServer();
 
 const BASE_ARGS = ["--endpoint", "http://localhost:6006"];
 
-const CATEGORICAL = {
+type AnnotationConfig =
+  componentsV1["schemas"]["GetAnnotationConfigResponseBody"]["data"];
+
+const CATEGORICAL: componentsV1["schemas"]["CategoricalAnnotationConfig"] = {
   id: "cat-id-001",
   name: "quality",
   type: "CATEGORICAL",
@@ -69,7 +28,7 @@ const CATEGORICAL = {
   ],
 };
 
-const CONTINUOUS = {
+const CONTINUOUS: componentsV1["schemas"]["ContinuousAnnotationConfig"] = {
   id: "cont-id-002",
   name: "score",
   type: "CONTINUOUS",
@@ -78,6 +37,50 @@ const CONTINUOUS = {
   lower_bound: 0,
   upper_bound: 1,
 };
+
+/**
+ * Register handlers for the update flow: GET by identifier answers with
+ * `existing`, PUT answers with `updated` (defaults to `existing`). Records
+ * the GET identifier, the PUT config id and body, and per-handler call
+ * counts so tests can assert which calls happened.
+ */
+function captureAnnotationConfigUpdateFlow(
+  existing: AnnotationConfig,
+  updated: AnnotationConfig = existing
+) {
+  const captured: {
+    getIdentifier?: string;
+    getCount: number;
+    putConfigId?: string;
+    putBody?: Record<string, unknown>;
+    putCount: number;
+  } = { getCount: 0, putCount: 0 };
+
+  mock.server.use(
+    http.get(
+      "/v1/annotation_configs/{config_identifier}",
+      ({ params, response }) => {
+        captured.getCount += 1;
+        captured.getIdentifier = params.config_identifier;
+        return response(200).json({ data: existing });
+      }
+    ),
+    http.put(
+      "/v1/annotation_configs/{config_id}",
+      async ({ params, request, response }) => {
+        captured.putCount += 1;
+        captured.putConfigId = params.config_id;
+        captured.putBody = (await request.clone().json()) as Record<
+          string,
+          unknown
+        >;
+        return response(200).json({ data: updated });
+      }
+    )
+  );
+
+  return captured;
+}
 
 /**
  * Point XDG_CONFIG_HOME at a clean temp dir so the CLI's settings resolution
@@ -105,18 +108,13 @@ describe("annotation-config update", () => {
   useIsolatedProfilesDir();
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("fetches the config then PUTs a merged body changing only --name", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-      {
-        ok: true,
-        body: { data: { ...CATEGORICAL, name: "renamed" } },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL, {
+      ...CATEGORICAL,
+      name: "renamed",
+    });
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -125,23 +123,14 @@ describe("annotation-config update", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
     // First call: GET by identifier
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
-      "/v1/annotation_configs/quality"
-    );
+    expect(captured.getCount).toBe(1);
+    expect(captured.getIdentifier).toBe("quality");
     // Second call: PUT using the resolved ID
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
-      "/v1/annotation_configs/cat-id-001"
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[1][0], fetchMock.mock.calls[1][1])
-    ).toBe("PUT");
+    expect(captured.putCount).toBe(1);
+    expect(captured.putConfigId).toBe("cat-id-001");
 
-    const body = (await getFetchBody(
-      fetchMock.mock.calls[1][0],
-      fetchMock.mock.calls[1][1]
-    )) as Record<string, unknown>;
+    const body = captured.putBody as Record<string, unknown>;
     // Changed field
     expect(body.name).toBe("renamed");
     // Preserved fields
@@ -154,11 +143,7 @@ describe("annotation-config update", () => {
   });
 
   it("updates categorical values from --values JSON", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-      { ok: true, body: { data: CATEGORICAL } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -174,10 +159,7 @@ describe("annotation-config update", () => {
       { from: "user" }
     );
 
-    const body = (await getFetchBody(
-      fetchMock.mock.calls[1][0],
-      fetchMock.mock.calls[1][1]
-    )) as Record<string, unknown>;
+    const body = captured.putBody as Record<string, unknown>;
     expect(body.values).toEqual([
       { label: "excellent", score: 2 },
       { label: "poor" },
@@ -185,11 +167,7 @@ describe("annotation-config update", () => {
   });
 
   it("updates categorical values from repeatable --value flags", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-      { ok: true, body: { data: CATEGORICAL } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -207,10 +185,7 @@ describe("annotation-config update", () => {
       { from: "user" }
     );
 
-    const body = (await getFetchBody(
-      fetchMock.mock.calls[1][0],
-      fetchMock.mock.calls[1][1]
-    )) as Record<string, unknown>;
+    const body = captured.putBody as Record<string, unknown>;
     expect(body.values).toEqual([
       { label: "excellent", score: 2 },
       { label: "poor" },
@@ -218,10 +193,7 @@ describe("annotation-config update", () => {
   });
 
   it("exits INVALID_ARGUMENT when both --value and --values are supplied", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -249,8 +221,7 @@ describe("annotation-config update", () => {
   });
 
   it("exits INVALID_ARGUMENT before any network call when a numeric flag is not a number", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: { data: CONTINUOUS } }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CONTINUOUS);
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -275,15 +246,12 @@ describe("annotation-config update", () => {
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
     // A typo'd bound must never reach the API (it would silently clear the
     // existing bound to null).
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.getCount).toBe(0);
+    expect(captured.putCount).toBe(0);
   });
 
   it("accepts a lowercase --optimization-direction and sends it uppercased", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-      { ok: true, body: { data: CATEGORICAL } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -299,19 +267,12 @@ describe("annotation-config update", () => {
       { from: "user" }
     );
 
-    const body = (await getFetchBody(
-      fetchMock.mock.calls[1][0],
-      fetchMock.mock.calls[1][1]
-    )) as Record<string, unknown>;
+    const body = captured.putBody as Record<string, unknown>;
     expect(body.optimization_direction).toBe("MINIMIZE");
   });
 
   it("updates continuous bounds", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CONTINUOUS } },
-      { ok: true, body: { data: CONTINUOUS } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CONTINUOUS);
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -329,10 +290,7 @@ describe("annotation-config update", () => {
       { from: "user" }
     );
 
-    const body = (await getFetchBody(
-      fetchMock.mock.calls[1][0],
-      fetchMock.mock.calls[1][1]
-    )) as Record<string, unknown>;
+    const body = captured.putBody as Record<string, unknown>;
     expect(body.type).toBe("CONTINUOUS");
     expect(body.lower_bound).toBe(-1);
     expect(body.upper_bound).toBe(10);
@@ -340,11 +298,7 @@ describe("annotation-config update", () => {
 
   it("outputs the updated config as a single object with --format raw", async () => {
     const updated = { ...CATEGORICAL, name: "renamed" };
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: CATEGORICAL } },
-      { ok: true, body: { data: updated } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    captureAnnotationConfigUpdateFlow(CATEGORICAL, updated);
     vi.spyOn(console, "error").mockImplementation(() => {});
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -366,8 +320,7 @@ describe("annotation-config update", () => {
   });
 
   it("exits INVALID_ARGUMENT when no fields are provided", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -384,12 +337,12 @@ describe("annotation-config update", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
     // No network call should happen — validation fails first.
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.getCount).toBe(0);
+    expect(captured.putCount).toBe(0);
   });
 
   it("exits INVALID_ARGUMENT for an invalid --optimization-direction", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -412,12 +365,12 @@ describe("annotation-config update", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.getCount).toBe(0);
+    expect(captured.putCount).toBe(0);
   });
 
   it("exits INVALID_ARGUMENT when --values is used on a non-categorical config", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: { data: CONTINUOUS } }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationConfigUpdateFlow(CONTINUOUS);
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -441,12 +394,18 @@ describe("annotation-config update", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
     // The GET happened, but the PUT never fired because the merge threw.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(captured.getCount).toBe(1);
+    expect(captured.putCount).toBe(0);
   });
 
   it("exits FAILURE when the config is not found", async () => {
-    const fetchMock = makeFetchMock([{ ok: false, status: 404, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    // 404 is not a documented status for this operation, so pin an untyped
+    // response.
+    mock.server.use(
+      http.get("/v1/annotation_configs/{config_identifier}", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 404 }))
+      )
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number

--- a/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import type { componentsV1 } from "@arizeai/phoenix-testing";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";

--- a/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigUpdate.test.ts
@@ -8,10 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAnnotationConfigCommand } from "../src/commands/annotationConfig";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006"];
 
 type AnnotationConfig =
   componentsV1["schemas"]["GetAnnotationConfigResponseBody"]["data"];
@@ -115,11 +114,10 @@ describe("annotation-config update", () => {
       ...CATEGORICAL,
       name: "renamed",
     });
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
-      ["update", "quality", "--name", "renamed", ...BASE_ARGS, "--no-progress"],
+      ["update", "quality", "--name", "renamed", ...BASE_ARGS],
       { from: "user" }
     );
 
@@ -144,8 +142,7 @@ describe("annotation-config update", () => {
 
   it("updates categorical values from --values JSON", async () => {
     const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       [
@@ -154,7 +151,6 @@ describe("annotation-config update", () => {
         "--values",
         '[{"label":"excellent","score":2},{"label":"poor"}]',
         ...BASE_ARGS,
-        "--no-progress",
       ],
       { from: "user" }
     );
@@ -168,8 +164,7 @@ describe("annotation-config update", () => {
 
   it("updates categorical values from repeatable --value flags", async () => {
     const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       [
@@ -180,7 +175,6 @@ describe("annotation-config update", () => {
         "--value",
         "poor",
         ...BASE_ARGS,
-        "--no-progress",
       ],
       { from: "user" }
     );
@@ -195,11 +189,7 @@ describe("annotation-config update", () => {
   it("exits INVALID_ARGUMENT when both --value and --values are supplied", async () => {
     captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
@@ -211,7 +201,6 @@ describe("annotation-config update", () => {
           "--values",
           '[{"label":"bad"}]',
           ...BASE_ARGS,
-          "--no-progress",
         ],
         { from: "user" }
       )
@@ -223,22 +212,11 @@ describe("annotation-config update", () => {
   it("exits INVALID_ARGUMENT before any network call when a numeric flag is not a number", async () => {
     const captured = captureAnnotationConfigUpdateFlow(CONTINUOUS);
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
-        [
-          "update",
-          "score",
-          "--lower-bound",
-          "abc",
-          ...BASE_ARGS,
-          "--no-progress",
-        ],
+        ["update", "score", "--lower-bound", "abc", ...BASE_ARGS],
         { from: "user" }
       )
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
@@ -252,8 +230,7 @@ describe("annotation-config update", () => {
 
   it("accepts a lowercase --optimization-direction and sends it uppercased", async () => {
     const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       [
@@ -262,7 +239,6 @@ describe("annotation-config update", () => {
         "--optimization-direction",
         "minimize",
         ...BASE_ARGS,
-        "--no-progress",
       ],
       { from: "user" }
     );
@@ -273,8 +249,7 @@ describe("annotation-config update", () => {
 
   it("updates continuous bounds", async () => {
     const captured = captureAnnotationConfigUpdateFlow(CONTINUOUS);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       [
@@ -285,7 +260,6 @@ describe("annotation-config update", () => {
         "--upper-bound",
         "10",
         ...BASE_ARGS,
-        "--no-progress",
       ],
       { from: "user" }
     );
@@ -299,8 +273,7 @@ describe("annotation-config update", () => {
   it("outputs the updated config as a single object with --format raw", async () => {
     const updated = { ...CATEGORICAL, name: "renamed" };
     captureAnnotationConfigUpdateFlow(CATEGORICAL, updated);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createAnnotationConfigCommand().parseAsync(
       [
@@ -311,26 +284,21 @@ describe("annotation-config update", () => {
         "--format",
         "raw",
         ...BASE_ARGS,
-        "--no-progress",
       ],
       { from: "user" }
     );
 
-    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(updated));
+    expect(io.stdout).toHaveBeenCalledWith(JSON.stringify(updated));
   });
 
   it("exits INVALID_ARGUMENT when no fields are provided", async () => {
     const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
-        ["update", "quality", ...BASE_ARGS, "--no-progress"],
+        ["update", "quality", ...BASE_ARGS],
         { from: "user" }
       )
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
@@ -344,11 +312,7 @@ describe("annotation-config update", () => {
   it("exits INVALID_ARGUMENT for an invalid --optimization-direction", async () => {
     const captured = captureAnnotationConfigUpdateFlow(CATEGORICAL);
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
@@ -358,7 +322,6 @@ describe("annotation-config update", () => {
           "--optimization-direction",
           "SIDEWAYS",
           ...BASE_ARGS,
-          "--no-progress",
         ],
         { from: "user" }
       )
@@ -372,22 +335,11 @@ describe("annotation-config update", () => {
   it("exits INVALID_ARGUMENT when --values is used on a non-categorical config", async () => {
     const captured = captureAnnotationConfigUpdateFlow(CONTINUOUS);
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
-        [
-          "update",
-          "score",
-          "--values",
-          '[{"label":"good"}]',
-          ...BASE_ARGS,
-          "--no-progress",
-        ],
+        ["update", "score", "--values", '[{"label":"good"}]', ...BASE_ARGS],
         { from: "user" }
       )
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
@@ -407,15 +359,11 @@ describe("annotation-config update", () => {
       )
     );
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAnnotationConfigCommand().parseAsync(
-        ["update", "missing", "--name", "x", ...BASE_ARGS, "--no-progress"],
+        ["update", "missing", "--name", "x", ...BASE_ARGS],
         { from: "user" }
       )
     ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);

--- a/js/packages/phoenix-cli/test/api.test.ts
+++ b/js/packages/phoenix-cli/test/api.test.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, http as mswHttp } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse, http as mswHttp } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/js/packages/phoenix-cli/test/api.test.ts
+++ b/js/packages/phoenix-cli/test/api.test.ts
@@ -1,3 +1,4 @@
+import { HttpResponse, http as mswHttp } from "@arizeai/phoenix-testing/msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -6,6 +7,31 @@ import {
   isNonQuery,
 } from "../src/commands/api";
 import { renderCurlCommand } from "../src/curl";
+import { setupMockPhoenixServer } from "./mockServer";
+
+const mock = setupMockPhoenixServer();
+
+const GRAPHQL_URL = "http://localhost:6006/graphql";
+
+/**
+ * Register a handler for the Phoenix GraphQL endpoint (not part of the
+ * OpenAPI spec, so it needs a raw msw handler) and return a capture object
+ * recording every request that reaches it.
+ */
+function useGraphqlEndpoint(responseBody: Record<string, unknown>) {
+  const captured: { count: number; bodies: unknown[] } = {
+    count: 0,
+    bodies: [],
+  };
+  mock.server.use(
+    mswHttp.post(GRAPHQL_URL, async ({ request }) => {
+      captured.count += 1;
+      captured.bodies.push(await request.clone().json());
+      return HttpResponse.json(responseBody);
+    })
+  );
+  return captured;
+}
 
 describe("isNonQuery", () => {
   it("returns false for an anonymous shorthand query", () => {
@@ -197,24 +223,18 @@ describe("renderCurlCommand", () => {
 describe("api graphql command", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("executes fetch in normal mode", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        data: {
-          projects: {
-            edges: [],
-          },
+    const graphqlCapture = useGraphqlEndpoint({
+      data: {
+        projects: {
+          edges: [],
         },
-      }),
+      },
     });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    vi.stubGlobal("fetch", fetchMock);
 
     await createApiCommand().parseAsync(
       [
@@ -226,7 +246,10 @@ describe("api graphql command", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(graphqlCapture.count).toBe(1);
+    expect(graphqlCapture.bodies[0]).toEqual({
+      query: "{ projects { edges { node { name } } } }",
+    });
     expect(stdoutSpy).toHaveBeenCalledWith(
       JSON.stringify(
         {
@@ -244,11 +267,9 @@ describe("api graphql command", () => {
   });
 
   it("prints curl and does not execute fetch when --curl is set", async () => {
-    const fetchMock = vi.fn();
+    const graphqlCapture = useGraphqlEndpoint({ data: {} });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    vi.stubGlobal("fetch", fetchMock);
 
     await createApiCommand().parseAsync(
       [
@@ -263,7 +284,7 @@ describe("api graphql command", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(graphqlCapture.count).toBe(0);
     expect(stderrSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining("curl \\"));
@@ -291,15 +312,13 @@ describe("api graphql command", () => {
   });
 
   it("rejects --show-token when --curl is not set", async () => {
-    const fetchMock = vi.fn();
+    const graphqlCapture = useGraphqlEndpoint({ data: {} });
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
     ) => {
       throw new Error(`process.exit:${code}`);
     }) as never);
-
-    vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       createApiCommand().parseAsync(
@@ -314,7 +333,7 @@ describe("api graphql command", () => {
       )
     ).rejects.toThrow("process.exit:1");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(graphqlCapture.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       "Error: --show-token can only be used with --curl."
     );
@@ -322,15 +341,13 @@ describe("api graphql command", () => {
   });
 
   it("still rejects mutations in curl mode", async () => {
-    const fetchMock = vi.fn();
+    const graphqlCapture = useGraphqlEndpoint({ data: {} });
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
     ) => {
       throw new Error(`process.exit:${code}`);
     }) as never);
-
-    vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       createApiCommand().parseAsync(
@@ -345,7 +362,7 @@ describe("api graphql command", () => {
       )
     ).rejects.toThrow("process.exit:1");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(graphqlCapture.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       "Error: Only queries are permitted. Mutations and subscriptions are not allowed."
     );

--- a/js/packages/phoenix-cli/test/api.test.ts
+++ b/js/packages/phoenix-cli/test/api.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/commands/api";
 import { renderCurlCommand } from "../src/curl";
 import { setupMockPhoenixServer } from "./mockServer";
+import { captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
 
@@ -233,8 +234,7 @@ describe("api graphql command", () => {
         },
       },
     });
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createApiCommand().parseAsync(
       [
@@ -250,7 +250,7 @@ describe("api graphql command", () => {
     expect(graphqlCapture.bodies[0]).toEqual({
       query: "{ projects { edges { node { name } } } }",
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify(
         {
           data: {
@@ -263,13 +263,12 @@ describe("api graphql command", () => {
         2
       )
     );
-    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(io.stderr).not.toHaveBeenCalled();
   });
 
   it("prints curl and does not execute fetch when --curl is set", async () => {
     const graphqlCapture = useGraphqlEndpoint({ data: {} });
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createApiCommand().parseAsync(
       [
@@ -285,28 +284,28 @@ describe("api graphql command", () => {
     );
 
     expect(graphqlCapture.count).toBe(0);
-    expect(stderrSpy).not.toHaveBeenCalled();
-    expect(stdoutSpy).toHaveBeenCalledTimes(1);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining("curl \\"));
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stderr).not.toHaveBeenCalled();
+    expect(io.stdout).toHaveBeenCalledTimes(1);
+    expect(io.stdout).toHaveBeenCalledWith(expect.stringContaining("curl \\"));
+    expect(io.stdout).toHaveBeenCalledWith(
       expect.stringContaining("  -X POST \\")
     );
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       expect.stringContaining("  -H 'Content-Type: application/json' \\\n")
     );
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       expect.stringContaining(
         "  -H 'Authorization: Bearer ************************************' \\\n"
       )
     );
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       expect.stringContaining(
         `  --data-raw '${JSON.stringify({
           query: "{ projects { edges { node { name } } } }",
         })}' \\`
       )
     );
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       expect.stringContaining("  'http://localhost:6006/graphql'")
     );
   });
@@ -314,11 +313,7 @@ describe("api graphql command", () => {
   it("rejects --show-token when --curl is not set", async () => {
     const graphqlCapture = useGraphqlEndpoint({ data: {} });
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createApiCommand().parseAsync(
@@ -343,11 +338,7 @@ describe("api graphql command", () => {
   it("still rejects mutations in curl mode", async () => {
     const graphqlCapture = useGraphqlEndpoint({ data: {} });
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createApiCommand().parseAsync(

--- a/js/packages/phoenix-cli/test/auth.test.ts
+++ b/js/packages/phoenix-cli/test/auth.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/commands/auth";
 import { ExitCode } from "../src/exitCodes";
 import type { SettingsFile } from "../src/settings";
+import { mockProcessExit } from "./testUtils";
 
 function readRequestBody(request: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -66,12 +67,6 @@ function readTempSettings(tmpDir: string): SettingsFile {
 
 function captured(spy: ReturnType<typeof vi.spyOn>): string {
   return spy.mock.calls.map((call) => String(call[0])).join("\n");
-}
-
-function spyOnExit() {
-  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-    throw new Error(`process.exit:${code}`);
-  }) as never);
 }
 
 function respondWithOAuthDiscovery(response: http.ServerResponse): void {
@@ -602,7 +597,7 @@ describe("px auth login/logout", () => {
           );
         }
       });
-      const exitSpy = spyOnExit();
+      const exitSpy = mockProcessExit();
 
       await expect(
         createAuthCommand().parseAsync(
@@ -628,7 +623,7 @@ describe("px auth login/logout", () => {
       });
       vi.spyOn(console, "log").mockImplementation(() => {});
       const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const exitSpy = spyOnExit();
+      const exitSpy = mockProcessExit();
 
       await expect(
         createAuthCommand().parseAsync(
@@ -655,7 +650,7 @@ describe("px auth login/logout", () => {
       });
       vi.spyOn(console, "log").mockImplementation(() => {});
       const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const exitSpy = spyOnExit();
+      const exitSpy = mockProcessExit();
 
       await expect(
         createAuthCommand().parseAsync(
@@ -679,7 +674,7 @@ describe("px auth login/logout", () => {
 
     vi.spyOn(console, "log").mockImplementation(() => {});
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = spyOnExit();
+    const exitSpy = mockProcessExit();
 
     await expect(
       createAuthCommand().parseAsync(

--- a/js/packages/phoenix-cli/test/confirm.test.ts
+++ b/js/packages/phoenix-cli/test/confirm.test.ts
@@ -20,6 +20,7 @@ import {
   parseBooleanEnvironmentVariable,
 } from "../src/confirm";
 import { ExitCode, InvalidArgumentError } from "../src/exitCodes";
+import { mockProcessExit } from "./testUtils";
 
 describe("confirmAction", () => {
   afterEach(() => {
@@ -71,9 +72,7 @@ describe("confirmOrExit", () => {
 
   beforeEach(() => {
     originalIsTTY = process.stdin.isTTY;
-    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    exitSpy = mockProcessExit();
     stderrWriteSpy = vi
       .spyOn(process.stderr, "write")
       .mockImplementation((() => true) as never);

--- a/js/packages/phoenix-cli/test/datasetCommand.test.ts
+++ b/js/packages/phoenix-cli/test/datasetCommand.test.ts
@@ -1,5 +1,5 @@
 import type { componentsV1 } from "@arizeai/phoenix-testing";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createDatasetCommand } from "../src/commands/dataset";

--- a/js/packages/phoenix-cli/test/datasetCommand.test.ts
+++ b/js/packages/phoenix-cli/test/datasetCommand.test.ts
@@ -5,13 +5,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDatasetCommand } from "../src/commands/dataset";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 type Dataset = componentsV1["schemas"]["Dataset"];
 type DatasetExample = componentsV1["schemas"]["DatasetExample"];
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 // A hex identifier is treated as a dataset ID directly, skipping the
 // `/v1/datasets?name=...` name-resolution round-trip.
@@ -55,12 +54,6 @@ const EXAMPLE_TWO: DatasetExample = {
   updated_at: "2026-06-15T00:00:00.000Z",
 };
 
-function mockProcessExit() {
-  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-    throw new Error(`process.exit:${code}`);
-  }) as never);
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -77,8 +70,7 @@ describe("dataset list", () => {
         });
       })
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createDatasetCommand().parseAsync(
       ["list", "--format", "raw", "--limit", "50", ...BASE_ARGS],
@@ -88,7 +80,7 @@ describe("dataset list", () => {
     expect(capturedQuery?.get("limit")).toBe("50");
     expect(capturedQuery?.get("cursor")).toBeNull();
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const datasets = JSON.parse(String(output));
     expect(datasets).toEqual([DATASET_GOLDEN, DATASET_SCRATCH]);
   });
@@ -112,8 +104,7 @@ describe("dataset list", () => {
         });
       })
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createDatasetCommand().parseAsync(
       ["list", "--format", "raw", ...BASE_ARGS],
@@ -121,7 +112,7 @@ describe("dataset list", () => {
     );
 
     expect(capturedCursors).toEqual([null, "cursor-page-2"]);
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const datasets = JSON.parse(String(output));
     expect(datasets.map((d: Dataset) => d.name)).toEqual([
       "golden-set",
@@ -131,8 +122,7 @@ describe("dataset list", () => {
 
   it("exits NETWORK_ERROR when the request fails at the network level", async () => {
     mock.server.use(http.get("/v1/datasets", () => HttpResponse.error()));
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -143,15 +133,14 @@ describe("dataset list", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
-    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+    expect(String(io.stderr.mock.calls[0]?.[0])).toContain(
       "Error fetching datasets"
     );
   });
 
   it("completes end-to-end against the generated OpenAPI handlers", async () => {
     // No pinned handlers: every response comes from the schema-generated mocks.
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await createDatasetCommand().parseAsync(
@@ -160,7 +149,7 @@ describe("dataset list", () => {
     );
 
     expect(exitSpy).not.toHaveBeenCalled();
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const datasets = JSON.parse(String(output));
     expect(Array.isArray(datasets)).toBe(true);
     expect(datasets.length).toBeGreaterThan(0);
@@ -202,8 +191,7 @@ describe("dataset get", () => {
         }
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createDatasetCommand().parseAsync(
       [
@@ -226,7 +214,7 @@ describe("dataset get", () => {
     expect(capturedExamplesQuery?.get("version_id")).toBe("version-007");
     expect(capturedExamplesQuery?.getAll("split")).toEqual(["train"]);
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(output));
     expect(parsed).toEqual({
       dataset_id: DATASET_ID,
@@ -256,8 +244,7 @@ describe("dataset get", () => {
         })
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createDatasetCommand().parseAsync(
       ["get", DATASET_ID, "--format", "raw", ...BASE_ARGS],
@@ -265,7 +252,7 @@ describe("dataset get", () => {
     );
 
     expect(resolutionCalls).toBe(0);
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(output));
     expect(parsed.dataset_id).toBe(DATASET_ID);
     expect(parsed.examples).toEqual([EXAMPLE_ONE]);
@@ -277,8 +264,7 @@ describe("dataset get", () => {
         response(200).json({ data: [], next_cursor: null })
       )
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -289,7 +275,7 @@ describe("dataset get", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
-    const stderrCall = String(stderrSpy.mock.calls[0]?.[0]);
+    const stderrCall = String(io.stderr.mock.calls[0]?.[0]);
     expect(stderrCall).toContain("Error fetching dataset");
     expect(stderrCall).toContain('Dataset not found: "no-such-dataset"');
   });
@@ -300,8 +286,7 @@ describe("dataset get", () => {
       // request needs to fail to exercise the network error path.
       http.get("/v1/datasets/{id}/examples", () => HttpResponse.error())
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -312,7 +297,7 @@ describe("dataset get", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
-    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+    expect(String(io.stderr.mock.calls[0]?.[0])).toContain(
       "Error fetching dataset"
     );
   });

--- a/js/packages/phoenix-cli/test/datasetCommand.test.ts
+++ b/js/packages/phoenix-cli/test/datasetCommand.test.ts
@@ -1,0 +1,319 @@
+import type { componentsV1 } from "@arizeai/phoenix-testing";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createDatasetCommand } from "../src/commands/dataset";
+import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
+
+type Dataset = componentsV1["schemas"]["Dataset"];
+type DatasetExample = componentsV1["schemas"]["DatasetExample"];
+
+const mock = setupMockPhoenixServer();
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+// A hex identifier is treated as a dataset ID directly, skipping the
+// `/v1/datasets?name=...` name-resolution round-trip.
+const DATASET_ID = "abc123";
+
+const DATASET_GOLDEN: Dataset = {
+  id: DATASET_ID,
+  name: "golden-set",
+  description: "Curated regression examples",
+  metadata: {},
+  created_at: "2026-06-01T00:00:00.000Z",
+  updated_at: "2026-06-15T00:00:00.000Z",
+  example_count: 2,
+};
+
+const DATASET_SCRATCH: Dataset = {
+  id: "def456",
+  name: "scratch",
+  description: null,
+  metadata: {},
+  created_at: "2026-06-02T00:00:00.000Z",
+  updated_at: "2026-06-02T00:00:00.000Z",
+  example_count: 0,
+};
+
+const EXAMPLE_ONE: DatasetExample = {
+  id: "RGF0YXNldEV4YW1wbGU6MQ==",
+  node_id: "RGF0YXNldEV4YW1wbGU6MQ==",
+  input: { question: "What is Phoenix?" },
+  output: { answer: "An AI observability platform" },
+  metadata: { split: "train" },
+  updated_at: "2026-06-15T00:00:00.000Z",
+};
+
+const EXAMPLE_TWO: DatasetExample = {
+  id: "RGF0YXNldEV4YW1wbGU6Mg==",
+  node_id: "RGF0YXNldEV4YW1wbGU6Mg==",
+  input: { question: "What is a span?" },
+  output: { answer: "A unit of work in a trace" },
+  metadata: { split: "train" },
+  updated_at: "2026-06-15T00:00:00.000Z",
+};
+
+function mockProcessExit() {
+  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit:${code}`);
+  }) as never);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("dataset list", () => {
+  it("outputs pinned datasets in raw mode and propagates --limit", async () => {
+    let capturedQuery: URLSearchParams | undefined;
+    mock.server.use(
+      http.get("/v1/datasets", ({ request, response }) => {
+        capturedQuery = new URL(request.url).searchParams;
+        return response(200).json({
+          data: [DATASET_GOLDEN, DATASET_SCRATCH],
+          next_cursor: null,
+        });
+      })
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createDatasetCommand().parseAsync(
+      ["list", "--format", "raw", "--limit", "50", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(capturedQuery?.get("limit")).toBe("50");
+    expect(capturedQuery?.get("cursor")).toBeNull();
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const datasets = JSON.parse(String(output));
+    expect(datasets).toEqual([DATASET_GOLDEN, DATASET_SCRATCH]);
+  });
+
+  it("follows next_cursor across pages", async () => {
+    const capturedCursors: Array<string | null> = [];
+    let page = 0;
+    mock.server.use(
+      http.get("/v1/datasets", ({ request, response }) => {
+        capturedCursors.push(new URL(request.url).searchParams.get("cursor"));
+        page += 1;
+        if (page === 1) {
+          return response(200).json({
+            data: [DATASET_GOLDEN],
+            next_cursor: "cursor-page-2",
+          });
+        }
+        return response(200).json({
+          data: [DATASET_SCRATCH],
+          next_cursor: null,
+        });
+      })
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createDatasetCommand().parseAsync(
+      ["list", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(capturedCursors).toEqual([null, "cursor-page-2"]);
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const datasets = JSON.parse(String(output));
+    expect(datasets.map((d: Dataset) => d.name)).toEqual([
+      "golden-set",
+      "scratch",
+    ]);
+  });
+
+  it("exits NETWORK_ERROR when the request fails at the network level", async () => {
+    mock.server.use(http.get("/v1/datasets", () => HttpResponse.error()));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createDatasetCommand().parseAsync(
+        ["list", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+      "Error fetching datasets"
+    );
+  });
+
+  it("completes end-to-end against the generated OpenAPI handlers", async () => {
+    // No pinned handlers: every response comes from the schema-generated mocks.
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await createDatasetCommand().parseAsync(
+      ["list", "--format", "raw", "--limit", "2", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const datasets = JSON.parse(String(output));
+    expect(Array.isArray(datasets)).toBe(true);
+    expect(datasets.length).toBeGreaterThan(0);
+    expect(typeof datasets[0].id).toBe("string");
+  });
+});
+
+describe("dataset get", () => {
+  it("resolves a dataset name to an ID and propagates version and split", async () => {
+    let capturedResolutionQuery: URLSearchParams | undefined;
+    let capturedExamplesId: string | undefined;
+    let capturedExamplesQuery: URLSearchParams | undefined;
+    mock.server.use(
+      // Name resolution: a non-hex identifier is looked up by name.
+      http.get("/v1/datasets", ({ request, response }) => {
+        capturedResolutionQuery = new URL(request.url).searchParams;
+        return response(200).json({
+          data: [DATASET_GOLDEN],
+          next_cursor: null,
+        });
+      }),
+      // Dataset metadata fetch (for the display name).
+      http.get("/v1/datasets/{id}", ({ response }) =>
+        response(200).json({ data: DATASET_GOLDEN })
+      ),
+      http.get(
+        "/v1/datasets/{id}/examples",
+        ({ params, request, response }) => {
+          capturedExamplesId = params.id;
+          capturedExamplesQuery = new URL(request.url).searchParams;
+          return response(200).json({
+            data: {
+              dataset_id: DATASET_ID,
+              version_id: "version-007",
+              filtered_splits: ["train"],
+              examples: [EXAMPLE_ONE, EXAMPLE_TWO],
+            },
+          });
+        }
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createDatasetCommand().parseAsync(
+      [
+        "get",
+        "golden-set",
+        "--format",
+        "raw",
+        "--version",
+        "version-007",
+        "--split",
+        "train",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(capturedResolutionQuery?.get("name")).toBe("golden-set");
+    expect(capturedResolutionQuery?.get("limit")).toBe("1");
+    expect(capturedExamplesId).toBe(DATASET_ID);
+    expect(capturedExamplesQuery?.get("version_id")).toBe("version-007");
+    expect(capturedExamplesQuery?.getAll("split")).toEqual(["train"]);
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsed = JSON.parse(String(output));
+    expect(parsed).toEqual({
+      dataset_id: DATASET_ID,
+      version_id: "version-007",
+      filtered_splits: ["train"],
+      examples: [EXAMPLE_ONE, EXAMPLE_TWO],
+    });
+  });
+
+  it("skips name resolution when the identifier is a hex ID", async () => {
+    let resolutionCalls = 0;
+    mock.server.use(
+      http.get("/v1/datasets", ({ response }) => {
+        resolutionCalls += 1;
+        return response(200).json({ data: [], next_cursor: null });
+      }),
+      http.get("/v1/datasets/{id}", ({ response }) =>
+        response(200).json({ data: DATASET_GOLDEN })
+      ),
+      http.get("/v1/datasets/{id}/examples", ({ params, response }) =>
+        response(200).json({
+          data: {
+            dataset_id: params.id,
+            version_id: "version-latest",
+            examples: [EXAMPLE_ONE],
+          },
+        })
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createDatasetCommand().parseAsync(
+      ["get", DATASET_ID, "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(resolutionCalls).toBe(0);
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsed = JSON.parse(String(output));
+    expect(parsed.dataset_id).toBe(DATASET_ID);
+    expect(parsed.examples).toEqual([EXAMPLE_ONE]);
+  });
+
+  it("exits FAILURE with an error on stderr when the name matches no dataset", async () => {
+    mock.server.use(
+      http.get("/v1/datasets", ({ response }) =>
+        response(200).json({ data: [], next_cursor: null })
+      )
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createDatasetCommand().parseAsync(
+        ["get", "no-such-dataset", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    const stderrCall = String(stderrSpy.mock.calls[0]?.[0]);
+    expect(stderrCall).toContain("Error fetching dataset");
+    expect(stderrCall).toContain('Dataset not found: "no-such-dataset"');
+  });
+
+  it("exits NETWORK_ERROR when the examples request fails at the network level", async () => {
+    mock.server.use(
+      // The display-name fetch swallows its own errors, so only the examples
+      // request needs to fail to exercise the network error path.
+      http.get("/v1/datasets/{id}/examples", () => HttpResponse.error())
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createDatasetCommand().parseAsync(
+        ["get", DATASET_ID, "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+      "Error fetching dataset"
+    );
+  });
+});

--- a/js/packages/phoenix-cli/test/delete.test.ts
+++ b/js/packages/phoenix-cli/test/delete.test.ts
@@ -41,9 +41,12 @@ import {
 } from "../src/confirm";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
 
+// Deliberately NOT composed from the shared BASE_ARGS: these tests assert on
+// the "Deleted ..." progress messages, which --no-progress would suppress.
 const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--yes"];
 
 const datasetFixture: componentsV1["schemas"]["Dataset"] = {
@@ -178,11 +181,7 @@ describe("dataset delete", () => {
       )
     );
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createDatasetCommand().parseAsync(
@@ -219,11 +218,7 @@ describe("dataset delete", () => {
     vi.mocked(confirmOrExit).mockClear();
     const listCounter = countDatasetListCalls();
     const deleted = captureDatasetDelete();
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createDatasetCommand().parseAsync(
@@ -243,11 +238,7 @@ describe("dataset delete", () => {
     vi.mocked(confirmOrExit).mockClear();
     const listCounter = countDatasetListCalls();
     const deleted = captureDatasetDelete();
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createDatasetCommand().parseAsync(
@@ -436,11 +427,7 @@ describe("experiment delete", () => {
       new Error("Experiment not found: exp-999")
     );
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createExperimentCommand().parseAsync(

--- a/js/packages/phoenix-cli/test/delete.test.ts
+++ b/js/packages/phoenix-cli/test/delete.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import type { componentsV1 } from "@arizeai/phoenix-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type * as ConfirmModule from "../src/confirm";
@@ -39,43 +40,61 @@ import {
   ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES,
 } from "../src/confirm";
 import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
 
-function makeFetchMock(
-  responses: Array<{ ok: boolean; status?: number; body?: unknown }>
-) {
-  let callIndex = 0;
-  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
-    const resp = responses[callIndex++] ?? responses[responses.length - 1];
-    const status = resp.status ?? (resp.ok ? 200 : 500);
-    const url =
-      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
-    const body = resp.body ?? {};
-    const text = JSON.stringify(body);
-    return Promise.resolve({
-      ok: resp.ok,
-      status,
-      statusText: resp.ok ? "OK" : "Error",
-      url,
-      headers: new Headers(),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(text),
-    });
-  });
-}
-
-/** Extract URL from a fetch call argument (either a Request object or a string) */
-function getFetchUrl(arg: unknown): string {
-  if (arg instanceof Request) return arg.url;
-  return String(arg);
-}
-
-/** Extract HTTP method from a fetch call (either from Request object or RequestInit) */
-function getFetchMethod(arg: unknown, init?: RequestInit): string {
-  if (arg instanceof Request) return arg.method;
-  return init?.method ?? "GET";
-}
+const mock = setupMockPhoenixServer();
 
 const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--yes"];
+
+const datasetFixture: componentsV1["schemas"]["Dataset"] = {
+  id: "abc123",
+  name: "my-dataset",
+  description: null,
+  metadata: {},
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  example_count: 0,
+};
+
+/** Pin GET /v1/datasets so name resolution finds the fixture dataset. */
+function usePinnedDatasetList() {
+  mock.server.use(
+    http.get("/v1/datasets", ({ response }) =>
+      response(200).json({ data: [datasetFixture], next_cursor: null })
+    )
+  );
+}
+
+/**
+ * Register a DELETE /v1/datasets/{id} handler that records the deleted id and
+ * how many times it was called.
+ */
+function captureDatasetDelete() {
+  const captured: { id?: string; calls: number } = { calls: 0 };
+  mock.server.use(
+    http.delete("/v1/datasets/{id}", ({ params, response }) => {
+      captured.calls += 1;
+      captured.id = params.id;
+      return response(204).empty();
+    })
+  );
+  return captured;
+}
+
+/**
+ * Register a GET /v1/datasets handler that counts calls, for asserting that
+ * no name-resolution request was made.
+ */
+function countDatasetListCalls() {
+  const counter = { calls: 0 };
+  mock.server.use(
+    http.get("/v1/datasets", ({ response }) => {
+      counter.calls += 1;
+      return response(200).json({ data: [datasetFixture], next_cursor: null });
+    })
+  );
+  return counter;
+}
 
 beforeEach(() => {
   vi.stubEnv(ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES, "true");
@@ -112,20 +131,13 @@ describe("dataset delete", () => {
   useIsolatedProfilesDir();
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("resolves dataset name to ID then calls DELETE /v1/datasets/{id}", async () => {
-    // First call: GET /v1/datasets?name=my-dataset (resolveDatasetId)
-    // Second call: DELETE /v1/datasets/{id}
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: [{ id: "abc123", name: "my-dataset" }] },
-      },
-      { ok: true, body: {} },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    // First request: GET /v1/datasets?name=my-dataset (resolveDatasetId)
+    // Second request: DELETE /v1/datasets/{id}
+    const listCounter = countDatasetListCalls();
+    const deleted = captureDatasetDelete();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createDatasetCommand().parseAsync(
@@ -133,24 +145,19 @@ describe("dataset delete", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
     // First call resolves name → ID
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain("/v1/datasets");
+    expect(listCounter.calls).toBe(1);
     // Second call is the DELETE
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toMatch(
-      /\/v1\/datasets\/abc123/
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[1][0], fetchMock.mock.calls[1][1])
-    ).toBe("DELETE");
+    expect(deleted.calls).toBe(1);
+    expect(deleted.id).toBe("abc123");
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining("my-dataset")
     );
   });
 
   it("passes dataset ID directly (no name resolution) when identifier looks like an ID", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const listCounter = countDatasetListCalls();
+    const deleted = captureDatasetDelete();
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createDatasetCommand().parseAsync(
@@ -158,18 +165,18 @@ describe("dataset delete", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("DELETE");
+    expect(listCounter.calls).toBe(0);
+    expect(deleted.calls).toBe(1);
+    expect(deleted.id).toBe("abcdef1234567890");
   });
 
   it("exits with FAILURE on 404", async () => {
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: [{ id: "abc123" }] } },
-      { ok: false, status: 404, body: { status: 404 } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    usePinnedDatasetList();
+    mock.server.use(
+      http.delete("/v1/datasets/{id}", ({ response }) =>
+        response(404).text("Dataset not found")
+      )
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -191,11 +198,8 @@ describe("dataset delete", () => {
 
   it("uses correct confirmation message", async () => {
     vi.mocked(confirmOrExit).mockResolvedValue(undefined);
-    const fetchMock = makeFetchMock([
-      { ok: true, body: { data: [{ id: "abc123" }] } },
-      { ok: true, body: {} },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    usePinnedDatasetList();
+    captureDatasetDelete();
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createDatasetCommand().parseAsync(
@@ -213,8 +217,8 @@ describe("dataset delete", () => {
   it("exits with INVALID_ARGUMENT when deletes are disabled", async () => {
     vi.stubEnv(ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES, "false");
     vi.mocked(confirmOrExit).mockClear();
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const listCounter = countDatasetListCalls();
+    const deleted = captureDatasetDelete();
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
     ) => {
@@ -229,15 +233,16 @@ describe("dataset delete", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(listCounter.calls).toBe(0);
+    expect(deleted.calls).toBe(0);
     expect(vi.mocked(confirmOrExit)).not.toHaveBeenCalled();
   });
 
   it("fails before any network call when the delete env var is invalid", async () => {
     vi.stubEnv(ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES, "yes");
     vi.mocked(confirmOrExit).mockClear();
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const listCounter = countDatasetListCalls();
+    const deleted = captureDatasetDelete();
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
     ) => {
@@ -252,7 +257,8 @@ describe("dataset delete", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(listCounter.calls).toBe(0);
+    expect(deleted.calls).toBe(0);
     expect(vi.mocked(confirmOrExit)).not.toHaveBeenCalled();
   });
 });
@@ -261,12 +267,22 @@ describe("project delete", () => {
   useIsolatedProfilesDir();
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("calls DELETE /v1/projects/{project_identifier}", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured: { projectIdentifier?: string; calls: number } = {
+      calls: 0,
+    };
+    mock.server.use(
+      http.delete(
+        "/v1/projects/{project_identifier}",
+        ({ params, response }) => {
+          captured.calls += 1;
+          captured.projectIdentifier = params.project_identifier;
+          return response(204).empty();
+        }
+      )
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createProjectCommand().parseAsync(
@@ -274,19 +290,17 @@ describe("project delete", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toMatch(
-      /\/v1\/projects\/my-project/
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("DELETE");
+    expect(captured.calls).toBe(1);
+    expect(captured.projectIdentifier).toBe("my-project");
   });
 
   it("uses cascade warning message mentioning traces, spans, sessions, and annotations", async () => {
     vi.mocked(confirmOrExit).mockResolvedValue(undefined);
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    mock.server.use(
+      http.delete("/v1/projects/{project_identifier}", ({ response }) =>
+        response(204).empty()
+      )
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createProjectCommand().parseAsync(
@@ -320,13 +334,18 @@ describe("trace delete", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
     vi.unstubAllEnvs();
   });
 
   it("calls DELETE /v1/traces/{trace_identifier}", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured: { traceIdentifier?: string; calls: number } = { calls: 0 };
+    mock.server.use(
+      http.delete("/v1/traces/{trace_identifier}", ({ params, response }) => {
+        captured.calls += 1;
+        captured.traceIdentifier = params.trace_identifier;
+        return response(204).empty();
+      })
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createTraceCommand().parseAsync(
@@ -334,19 +353,17 @@ describe("trace delete", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toMatch(
-      /\/v1\/traces\/trace-abc/
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("DELETE");
+    expect(captured.calls).toBe(1);
+    expect(captured.traceIdentifier).toBe("trace-abc");
   });
 
   it("uses cascade warning message mentioning spans", async () => {
     vi.mocked(confirmOrExit).mockResolvedValue(undefined);
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    mock.server.use(
+      http.delete("/v1/traces/{trace_identifier}", ({ response }) =>
+        response(204).empty()
+      )
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createTraceCommand().parseAsync(
@@ -381,7 +398,6 @@ describe("experiment delete", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("calls deleteExperiment wrapper with the experiment ID", async () => {
@@ -447,7 +463,6 @@ describe("session delete", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("calls deleteSession wrapper with the session ID", async () => {
@@ -493,12 +508,29 @@ describe("annotation-config delete", () => {
   useIsolatedProfilesDir();
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
+  const annotationConfigFixture: componentsV1["schemas"]["CategoricalAnnotationConfig"] =
+    {
+      id: "config-789",
+      name: "quality",
+      type: "CATEGORICAL",
+      optimization_direction: "MAXIMIZE",
+      values: [{ label: "good" }, { label: "bad" }],
+    };
+
   it("calls DELETE /v1/annotation_configs/{config_id}", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured: { configId?: string; calls: number } = { calls: 0 };
+    mock.server.use(
+      http.delete(
+        "/v1/annotation_configs/{config_id}",
+        ({ params, response }) => {
+          captured.calls += 1;
+          captured.configId = params.config_id;
+          return response(200).json({ data: annotationConfigFixture });
+        }
+      )
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createAnnotationConfigCommand().parseAsync(
@@ -506,19 +538,17 @@ describe("annotation-config delete", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toMatch(
-      /\/v1\/annotation_configs\/config-789/
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("DELETE");
+    expect(captured.calls).toBe(1);
+    expect(captured.configId).toBe("config-789");
   });
 
   it("uses confirmation message without cascade warning", async () => {
     vi.mocked(confirmOrExit).mockResolvedValue(undefined);
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    mock.server.use(
+      http.delete("/v1/annotation_configs/{config_id}", ({ response }) =>
+        response(200).json({ data: annotationConfigFixture })
+      )
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createAnnotationConfigCommand().parseAsync(
@@ -538,12 +568,19 @@ describe("prompt delete", () => {
   useIsolatedProfilesDir();
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
   it("calls DELETE /v1/prompts/{prompt_identifier}", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured: { promptIdentifier?: string; calls: number } = {
+      calls: 0,
+    };
+    mock.server.use(
+      http.delete("/v1/prompts/{prompt_identifier}", ({ params, response }) => {
+        captured.calls += 1;
+        captured.promptIdentifier = params.prompt_identifier;
+        return response(204).empty();
+      })
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createPromptCommand().parseAsync(
@@ -551,19 +588,17 @@ describe("prompt delete", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toMatch(
-      /\/v1\/prompts\/my-prompt/
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("DELETE");
+    expect(captured.calls).toBe(1);
+    expect(captured.promptIdentifier).toBe("my-prompt");
   });
 
   it("uses cascade warning message mentioning versions, tags, and labels", async () => {
     vi.mocked(confirmOrExit).mockResolvedValue(undefined);
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    mock.server.use(
+      http.delete("/v1/prompts/{prompt_identifier}", ({ response }) =>
+        response(204).empty()
+      )
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createPromptCommand().parseAsync(
@@ -589,32 +624,36 @@ describe("span delete", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
     vi.unstubAllEnvs();
   });
 
+  function captureSpanDelete() {
+    const captured: { spanIdentifier?: string; calls: number } = { calls: 0 };
+    mock.server.use(
+      http.delete("/v1/spans/{span_identifier}", ({ params, response }) => {
+        captured.calls += 1;
+        captured.spanIdentifier = params.span_identifier;
+        return response(204).empty();
+      })
+    );
+    return captured;
+  }
+
   it("calls DELETE /v1/spans/{span_identifier}", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanDelete();
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createSpanCommand().parseAsync(["delete", "span-abc", ...BASE_ARGS], {
       from: "user",
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toMatch(
-      /\/v1\/spans\/span-abc/
-    );
-    expect(
-      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).toBe("DELETE");
+    expect(captured.calls).toBe(1);
+    expect(captured.spanIdentifier).toBe("span-abc");
   });
 
   it("warns that child spans are NOT deleted in confirmation message", async () => {
     vi.mocked(confirmOrExit).mockResolvedValue(undefined);
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    captureSpanDelete();
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createSpanCommand().parseAsync(
@@ -639,8 +678,7 @@ describe("span delete", () => {
   });
 
   it("writes success message to stderr", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    captureSpanDelete();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await createSpanCommand().parseAsync(["delete", "span-abc", ...BASE_ARGS], {

--- a/js/packages/phoenix-cli/test/deleteAnnotations.test.ts
+++ b/js/packages/phoenix-cli/test/deleteAnnotations.test.ts
@@ -6,16 +6,11 @@ import { createTraceAnnotationsCommand } from "../src/commands/traceAnnotations"
 import { ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES } from "../src/confirm";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
 
-const BASE_ARGS = [
-  "--endpoint",
-  "http://localhost:6006",
-  "--project",
-  "default",
-  "--no-progress",
-];
+const PROJECT_ARGS = [...BASE_ARGS, "--project", "default"];
 
 /** Pin project-name resolution to a stable project ID. */
 function useProjectResolution() {
@@ -71,8 +66,7 @@ describe("trace-annotations delete", () => {
     const captured = captureAnnotationDelete(
       "/v1/projects/{project_identifier}/trace_annotations"
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceAnnotationsCommand().parseAsync(
       [
@@ -83,7 +77,7 @@ describe("trace-annotations delete", () => {
         "-y",
         "--format",
         "raw",
-        ...BASE_ARGS,
+        ...PROJECT_ARGS,
       ],
       { from: "user" }
     );
@@ -93,7 +87,7 @@ describe("trace-annotations delete", () => {
     expect(captured.query?.get("identifier")).toBe("coding-session:demo");
     expect(captured.query?.get("delete_all")).toBe("true");
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     expect(JSON.parse(String(output))).toEqual({
       deleted: true,
       target: "trace",
@@ -106,8 +100,7 @@ describe("trace-annotations delete", () => {
     const captured = captureAnnotationDelete(
       "/v1/projects/{project_identifier}/trace_annotations"
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceAnnotationsCommand().parseAsync(
       [
@@ -119,7 +112,7 @@ describe("trace-annotations delete", () => {
         "-y",
         "--format",
         "raw",
-        ...BASE_ARGS,
+        ...PROJECT_ARGS,
       ],
       { from: "user" }
     );
@@ -128,7 +121,7 @@ describe("trace-annotations delete", () => {
     expect(captured.query?.get("end_time")).toBe("2026-01-02T00:00:00Z");
     expect(captured.query?.get("delete_all")).toBeNull();
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     expect(JSON.parse(String(output))).toEqual({
       deleted: true,
       target: "trace",
@@ -144,11 +137,7 @@ describe("trace-annotations delete", () => {
       "/v1/projects/{project_identifier}/trace_annotations"
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createTraceAnnotationsCommand().parseAsync(
@@ -159,7 +148,7 @@ describe("trace-annotations delete", () => {
           "-y",
           "--format",
           "raw",
-          ...BASE_ARGS,
+          ...PROJECT_ARGS,
         ],
         { from: "user" }
       )
@@ -178,8 +167,7 @@ describe("trace-annotations delete", () => {
     const captured = captureAnnotationDelete(
       "/v1/projects/{project_identifier}/trace_annotations"
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    captureCliOutput();
 
     await createTraceAnnotationsCommand().parseAsync(
       [
@@ -192,7 +180,7 @@ describe("trace-annotations delete", () => {
         "human",
         "--all",
         "-y",
-        ...BASE_ARGS,
+        ...PROJECT_ARGS,
       ],
       { from: "user" }
     );
@@ -209,8 +197,7 @@ describe("span-annotations delete", () => {
     const captured = captureAnnotationDelete(
       "/v1/projects/{project_identifier}/span_annotations"
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanAnnotationsCommand().parseAsync(
       [
@@ -221,7 +208,7 @@ describe("span-annotations delete", () => {
         "-y",
         "--format",
         "raw",
-        ...BASE_ARGS,
+        ...PROJECT_ARGS,
       ],
       { from: "user" }
     );
@@ -230,7 +217,7 @@ describe("span-annotations delete", () => {
     expect(captured.projectIdentifier).toBe("project-default");
     expect(captured.query?.get("delete_all")).toBe("true");
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     expect(JSON.parse(String(output))).toEqual({
       deleted: true,
       target: "span",
@@ -243,15 +230,17 @@ describe("span-annotations delete", () => {
       "/v1/projects/{project_identifier}/span_annotations"
     );
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanAnnotationsCommand().parseAsync(
-        ["delete", "--identifier", "coding-session:demo", "-y", ...BASE_ARGS],
+        [
+          "delete",
+          "--identifier",
+          "coding-session:demo",
+          "-y",
+          ...PROJECT_ARGS,
+        ],
         { from: "user" }
       )
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
@@ -267,8 +256,7 @@ describe("session-annotations delete", () => {
     const captured = captureAnnotationDelete(
       "/v1/projects/{project_identifier}/session_annotations"
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionAnnotationsCommand().parseAsync(
       [
@@ -279,7 +267,7 @@ describe("session-annotations delete", () => {
         "-y",
         "--format",
         "raw",
-        ...BASE_ARGS,
+        ...PROJECT_ARGS,
       ],
       { from: "user" }
     );
@@ -288,7 +276,7 @@ describe("session-annotations delete", () => {
     expect(captured.projectIdentifier).toBe("project-default");
     expect(captured.query?.get("delete_all")).toBe("true");
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     expect(JSON.parse(String(output))).toEqual({
       deleted: true,
       target: "session",
@@ -301,15 +289,17 @@ describe("session-annotations delete", () => {
       "/v1/projects/{project_identifier}/session_annotations"
     );
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionAnnotationsCommand().parseAsync(
-        ["delete", "--identifier", "coding-session:demo", "-y", ...BASE_ARGS],
+        [
+          "delete",
+          "--identifier",
+          "coding-session:demo",
+          "-y",
+          ...PROJECT_ARGS,
+        ],
         { from: "user" }
       )
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
@@ -324,11 +314,7 @@ describe("session-annotations delete", () => {
       "/v1/projects/{project_identifier}/session_annotations"
     );
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionAnnotationsCommand().parseAsync(
@@ -338,7 +324,7 @@ describe("session-annotations delete", () => {
           "coding-session:demo",
           "--all",
           "-y",
-          ...BASE_ARGS,
+          ...PROJECT_ARGS,
         ],
         { from: "user" }
       )

--- a/js/packages/phoenix-cli/test/deleteAnnotations.test.ts
+++ b/js/packages/phoenix-cli/test/deleteAnnotations.test.ts
@@ -5,45 +5,9 @@ import { createSpanAnnotationsCommand } from "../src/commands/spanAnnotations";
 import { createTraceAnnotationsCommand } from "../src/commands/traceAnnotations";
 import { ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES } from "../src/confirm";
 import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
 
-function makeFetchMock(
-  responses: Array<
-    | { ok: boolean; status?: number; body?: unknown; text?: string }
-    | { error: Error }
-  >
-) {
-  let callIndex = 0;
-  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
-    const response = responses[callIndex++] ?? responses[responses.length - 1];
-    if ("error" in response) {
-      return Promise.reject(response.error);
-    }
-    const status = response.status ?? (response.ok ? 200 : 500);
-    const url =
-      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
-    const body = response.body ?? {};
-    const text = response.text ?? JSON.stringify(body);
-    return Promise.resolve({
-      ok: response.ok,
-      status,
-      statusText: response.ok ? "OK" : "Error",
-      url,
-      headers: new Headers(),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(text),
-    });
-  });
-}
-
-function getFetchUrl(arg: unknown): string {
-  if (arg instanceof Request) return arg.url;
-  return String(arg);
-}
-
-function getFetchMethod(arg: unknown, init?: RequestInit): string {
-  if (arg instanceof Request) return arg.method;
-  return init?.method ?? "GET";
-}
+const mock = setupMockPhoenixServer();
 
 const BASE_ARGS = [
   "--endpoint",
@@ -53,16 +17,44 @@ const BASE_ARGS = [
   "--no-progress",
 ];
 
-const PROJECT_RESPONSE = {
-  ok: true as const,
-  body: { data: { id: "project-default" } },
-};
+/** Pin project-name resolution to a stable project ID. */
+function useProjectResolution() {
+  mock.server.use(
+    http.get("/v1/projects/{project_identifier}", ({ response }) =>
+      response(200).json({
+        data: { id: "project-default", name: "default" },
+      })
+    )
+  );
+}
 
-const DELETE_204 = {
-  ok: true as const,
-  status: 204,
-  body: {},
-} satisfies { ok: true; status: 204; body: object };
+/**
+ * Register a 204 handler for the given annotation delete endpoint and record
+ * how many times it matched plus the query string of the last request.
+ */
+function captureAnnotationDelete(
+  path:
+    | "/v1/projects/{project_identifier}/trace_annotations"
+    | "/v1/projects/{project_identifier}/span_annotations"
+    | "/v1/projects/{project_identifier}/session_annotations"
+) {
+  const captured: {
+    count: number;
+    projectIdentifier?: string;
+    query?: URLSearchParams;
+  } = { count: 0 };
+
+  mock.server.use(
+    http.delete(path, ({ params, request, response }) => {
+      captured.count += 1;
+      captured.projectIdentifier = params.project_identifier;
+      captured.query = new URL(request.url).searchParams;
+      return response(204).empty();
+    })
+  );
+
+  return captured;
+}
 
 beforeEach(() => {
   process.env[ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES] = "true";
@@ -71,13 +63,14 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env[ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES];
   vi.restoreAllMocks();
-  vi.unstubAllGlobals();
 });
 
 describe("trace-annotations delete", () => {
   it("DELETEs with delete_all=true when --all is set, then emits structured success", async () => {
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE, DELETE_204]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectResolution();
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/trace_annotations"
+    );
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -95,12 +88,10 @@ describe("trace-annotations delete", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(getFetchMethod(fetchMock.mock.calls[1][0])).toBe("DELETE");
-    const url = new URL(getFetchUrl(fetchMock.mock.calls[1][0]));
-    expect(url.pathname).toBe("/v1/projects/project-default/trace_annotations");
-    expect(url.searchParams.get("identifier")).toBe("coding-session:demo");
-    expect(url.searchParams.get("delete_all")).toBe("true");
+    expect(captured.count).toBe(1);
+    expect(captured.projectIdentifier).toBe("project-default");
+    expect(captured.query?.get("identifier")).toBe("coding-session:demo");
+    expect(captured.query?.get("delete_all")).toBe("true");
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     expect(JSON.parse(String(output))).toEqual({
@@ -111,8 +102,10 @@ describe("trace-annotations delete", () => {
   });
 
   it("DELETEs with a bounded time window when --start-time/--end-time are set", async () => {
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE, DELETE_204]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectResolution();
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/trace_annotations"
+    );
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -131,10 +124,9 @@ describe("trace-annotations delete", () => {
       { from: "user" }
     );
 
-    const url = new URL(getFetchUrl(fetchMock.mock.calls[1][0]));
-    expect(url.searchParams.get("start_time")).toBe("2026-01-01T00:00:00Z");
-    expect(url.searchParams.get("end_time")).toBe("2026-01-02T00:00:00Z");
-    expect(url.searchParams.get("delete_all")).toBeNull();
+    expect(captured.query?.get("start_time")).toBe("2026-01-01T00:00:00Z");
+    expect(captured.query?.get("end_time")).toBe("2026-01-02T00:00:00Z");
+    expect(captured.query?.get("delete_all")).toBeNull();
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     expect(JSON.parse(String(output))).toEqual({
@@ -148,8 +140,9 @@ describe("trace-annotations delete", () => {
   });
 
   it("rejects an underspecified delete before any HTTP call", async () => {
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/trace_annotations"
+    );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -173,7 +166,7 @@ describe("trace-annotations delete", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
     const stderrCall = stderrSpy.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(stderrCall));
     expect(parsed.code).toBe("INVALID_ARGUMENT");
@@ -181,8 +174,10 @@ describe("trace-annotations delete", () => {
   });
 
   it("threads narrowing filters into the DELETE query string", async () => {
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE, DELETE_204]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectResolution();
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/trace_annotations"
+    );
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -202,17 +197,18 @@ describe("trace-annotations delete", () => {
       { from: "user" }
     );
 
-    const url = new URL(getFetchUrl(fetchMock.mock.calls[1][0]));
-    expect(url.searchParams.get("name")).toBe("axial_coding_category");
-    expect(url.searchParams.get("annotator_kind")).toBe("HUMAN");
-    expect(url.searchParams.get("delete_all")).toBe("true");
+    expect(captured.query?.get("name")).toBe("axial_coding_category");
+    expect(captured.query?.get("annotator_kind")).toBe("HUMAN");
+    expect(captured.query?.get("delete_all")).toBe("true");
   });
 });
 
 describe("span-annotations delete", () => {
   it("DELETEs /span_annotations with delete_all=true and emits structured success", async () => {
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE, DELETE_204]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectResolution();
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/span_annotations"
+    );
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -230,9 +226,9 @@ describe("span-annotations delete", () => {
       { from: "user" }
     );
 
-    const url = new URL(getFetchUrl(fetchMock.mock.calls[1][0]));
-    expect(url.pathname).toBe("/v1/projects/project-default/span_annotations");
-    expect(url.searchParams.get("delete_all")).toBe("true");
+    expect(captured.count).toBe(1);
+    expect(captured.projectIdentifier).toBe("project-default");
+    expect(captured.query?.get("delete_all")).toBe("true");
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     expect(JSON.parse(String(output))).toEqual({
@@ -243,8 +239,9 @@ describe("span-annotations delete", () => {
   });
 
   it("rejects underspecified deletes for span", async () => {
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/span_annotations"
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -260,14 +257,16 @@ describe("span-annotations delete", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 });
 
 describe("session-annotations delete", () => {
   it("DELETEs /session_annotations with delete_all=true and emits structured success", async () => {
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE, DELETE_204]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectResolution();
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/session_annotations"
+    );
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -285,11 +284,9 @@ describe("session-annotations delete", () => {
       { from: "user" }
     );
 
-    const url = new URL(getFetchUrl(fetchMock.mock.calls[1][0]));
-    expect(url.pathname).toBe(
-      "/v1/projects/project-default/session_annotations"
-    );
-    expect(url.searchParams.get("delete_all")).toBe("true");
+    expect(captured.count).toBe(1);
+    expect(captured.projectIdentifier).toBe("project-default");
+    expect(captured.query?.get("delete_all")).toBe("true");
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     expect(JSON.parse(String(output))).toEqual({
@@ -300,8 +297,9 @@ describe("session-annotations delete", () => {
   });
 
   it("rejects underspecified deletes for session", async () => {
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/session_annotations"
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -317,13 +315,14 @@ describe("session-annotations delete", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 
   it("disables delete commands when the dangerous-deletes env var is unset", async () => {
     delete process.env[ENV_PHOENIX_CLI_DANGEROUSLY_ENABLE_DELETES];
-    const fetchMock = makeFetchMock([PROJECT_RESPONSE]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureAnnotationDelete(
+      "/v1/projects/{project_identifier}/session_annotations"
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -346,6 +345,6 @@ describe("session-annotations delete", () => {
     ).rejects.toThrow(/process\.exit:/);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(captured.count).toBe(0);
   });
 });

--- a/js/packages/phoenix-cli/test/experimentCommand.test.ts
+++ b/js/packages/phoenix-cli/test/experimentCommand.test.ts
@@ -5,10 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createExperimentCommand } from "../src/commands/experiment";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 // Hex string, so the CLI treats it as a dataset ID and skips name resolution.
 const DATASET_ID = "abc123";
@@ -75,8 +74,7 @@ afterEach(() => {
 describe("experiment list", () => {
   it("scopes the request to the dataset and prints experiments as raw JSON", async () => {
     const captured = captureListExperimentsRequest();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createExperimentCommand().parseAsync(
       [
@@ -97,7 +95,7 @@ describe("experiment list", () => {
     expect(captured.datasetId).toBe(DATASET_ID);
     expect(captured.limit).toBe("50");
 
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual([EXPERIMENT]);
   });
 
@@ -110,8 +108,7 @@ describe("experiment list", () => {
       })
     );
     const captured = captureListExperimentsRequest();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createExperimentCommand().parseAsync(
       ["list", "--dataset", "my-dataset", "--format", "raw", ...BASE_ARGS],
@@ -120,7 +117,7 @@ describe("experiment list", () => {
 
     expect(capturedName.name).toBe("my-dataset");
     expect(captured.datasetId).toBe(DATASET_ID);
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual([EXPERIMENT]);
   });
 
@@ -131,11 +128,7 @@ describe("experiment list", () => {
       )
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createExperimentCommand().parseAsync(
@@ -157,11 +150,7 @@ describe("experiment list", () => {
       )
     );
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createExperimentCommand().parseAsync(
@@ -177,8 +166,7 @@ describe("experiment list", () => {
     // No pinned handler: the schema-generated mock answers everything. The
     // generated pages always carry a non-null next_cursor, so --limit 1 is
     // required to stop the CLI's pagination loop.
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createExperimentCommand().parseAsync(
       [
@@ -194,7 +182,7 @@ describe("experiment list", () => {
       { from: "user" }
     );
 
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed.length).toBeGreaterThan(0);
     expect(typeof parsed[0].id).toBe("string");
@@ -225,8 +213,7 @@ describe("experiment get", () => {
         }
       )
     );
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createExperimentCommand().parseAsync(
       ["get", "exp-001", "--format", "raw", ...BASE_ARGS],
@@ -236,7 +223,7 @@ describe("experiment get", () => {
     expect(captured.count).toBe(1);
     expect(captured.experimentId).toBe("exp-001");
     // Raw mode re-serializes the payload as compact JSON.
-    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(runs));
+    expect(io.stdout).toHaveBeenCalledWith(JSON.stringify(runs));
   });
 
   it("exits FAILURE when the experiment does not exist", async () => {
@@ -246,11 +233,7 @@ describe("experiment get", () => {
       )
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createExperimentCommand().parseAsync(

--- a/js/packages/phoenix-cli/test/experimentCommand.test.ts
+++ b/js/packages/phoenix-cli/test/experimentCommand.test.ts
@@ -1,0 +1,267 @@
+import type { componentsV1 } from "@arizeai/phoenix-testing";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createExperimentCommand } from "../src/commands/experiment";
+import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
+
+const mock = setupMockPhoenixServer();
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+// Hex string, so the CLI treats it as a dataset ID and skips name resolution.
+const DATASET_ID = "abc123";
+
+const EXPERIMENT: componentsV1["schemas"]["Experiment"] = {
+  id: "exp-001",
+  dataset_id: DATASET_ID,
+  dataset_version_id: "dsv-001",
+  name: "baseline",
+  description: "baseline run",
+  repetitions: 1,
+  metadata: {},
+  project_name: "demo-project",
+  created_at: "2026-07-01T00:00:00+00:00",
+  updated_at: "2026-07-01T00:00:00+00:00",
+  example_count: 3,
+  successful_run_count: 2,
+  failed_run_count: 1,
+  missing_run_count: 0,
+};
+
+const DATASET: componentsV1["schemas"]["Dataset"] = {
+  id: DATASET_ID,
+  name: "my-dataset",
+  description: null,
+  metadata: {},
+  created_at: "2026-06-01T00:00:00+00:00",
+  updated_at: "2026-06-01T00:00:00+00:00",
+  example_count: 3,
+};
+
+/**
+ * Register a handler for GET /v1/datasets/{dataset_id}/experiments that
+ * answers with a single pinned experiment and records the requested dataset
+ * ID and query parameters.
+ */
+function captureListExperimentsRequest() {
+  const captured: {
+    datasetId?: string;
+    limit?: string | null;
+    cursor?: string | null;
+    count: number;
+  } = { count: 0 };
+  mock.server.use(
+    http.get(
+      "/v1/datasets/{dataset_id}/experiments",
+      ({ params, request, response }) => {
+        captured.count += 1;
+        captured.datasetId = params.dataset_id;
+        const searchParams = new URL(request.url).searchParams;
+        captured.limit = searchParams.get("limit");
+        captured.cursor = searchParams.get("cursor");
+        return response(200).json({ data: [EXPERIMENT], next_cursor: null });
+      }
+    )
+  );
+  return captured;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("experiment list", () => {
+  it("scopes the request to the dataset and prints experiments as raw JSON", async () => {
+    const captured = captureListExperimentsRequest();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createExperimentCommand().parseAsync(
+      [
+        "list",
+        "--dataset",
+        DATASET_ID,
+        "--limit",
+        "50",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    // A hex identifier is used as-is: exactly one request, no name lookup.
+    expect(captured.count).toBe(1);
+    expect(captured.datasetId).toBe(DATASET_ID);
+    expect(captured.limit).toBe("50");
+
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(parsed).toEqual([EXPERIMENT]);
+  });
+
+  it("resolves a dataset name via /v1/datasets before listing", async () => {
+    const capturedName: { name?: string | null } = {};
+    mock.server.use(
+      http.get("/v1/datasets", ({ request, response }) => {
+        capturedName.name = new URL(request.url).searchParams.get("name");
+        return response(200).json({ data: [DATASET], next_cursor: null });
+      })
+    );
+    const captured = captureListExperimentsRequest();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createExperimentCommand().parseAsync(
+      ["list", "--dataset", "my-dataset", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(capturedName.name).toBe("my-dataset");
+    expect(captured.datasetId).toBe(DATASET_ID);
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(parsed).toEqual([EXPERIMENT]);
+  });
+
+  it("exits FAILURE with an error message on a server error", async () => {
+    mock.server.use(
+      http.get("/v1/datasets/{dataset_id}/experiments", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 404 }))
+      )
+    );
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createExperimentCommand().parseAsync(
+        ["list", "--dataset", DATASET_ID, "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error fetching experiments")
+    );
+  });
+
+  it("exits NETWORK_ERROR when the connection fails", async () => {
+    mock.server.use(
+      http.get("/v1/datasets/{dataset_id}/experiments", () =>
+        HttpResponse.error()
+      )
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createExperimentCommand().parseAsync(
+        ["list", "--dataset", DATASET_ID, "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+  });
+
+  it("succeeds end-to-end against the generated OpenAPI handlers", async () => {
+    // No pinned handler: the schema-generated mock answers everything. The
+    // generated pages always carry a non-null next_cursor, so --limit 1 is
+    // required to stop the CLI's pagination loop.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createExperimentCommand().parseAsync(
+      [
+        "list",
+        "--dataset",
+        DATASET_ID,
+        "--limit",
+        "1",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(typeof parsed[0].id).toBe("string");
+    expect(typeof parsed[0].dataset_id).toBe("string");
+  });
+});
+
+describe("experiment get", () => {
+  it("downloads the experiment JSON by ID and prints it compact in raw mode", async () => {
+    const runs = [
+      {
+        id: "run-1",
+        example_id: "ex-1",
+        repetition_number: 1,
+        input: { question: "2+2?" },
+        output: "4",
+        error: null,
+      },
+    ];
+    const captured: { experimentId?: string; count: number } = { count: 0 };
+    mock.server.use(
+      http.get(
+        "/v1/experiments/{experiment_id}/json",
+        ({ params, response }) => {
+          captured.count += 1;
+          captured.experimentId = params.experiment_id;
+          return response(200).text(JSON.stringify(runs, null, 2));
+        }
+      )
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createExperimentCommand().parseAsync(
+      ["get", "exp-001", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(captured.count).toBe(1);
+    expect(captured.experimentId).toBe("exp-001");
+    // Raw mode re-serializes the payload as compact JSON.
+    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(runs));
+  });
+
+  it("exits FAILURE when the experiment does not exist", async () => {
+    mock.server.use(
+      http.get("/v1/experiments/{experiment_id}/json", ({ response }) =>
+        response(404).text("Experiment not found")
+      )
+    );
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createExperimentCommand().parseAsync(
+        ["get", "missing", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error fetching experiment")
+    );
+  });
+});

--- a/js/packages/phoenix-cli/test/experimentCommand.test.ts
+++ b/js/packages/phoenix-cli/test/experimentCommand.test.ts
@@ -1,5 +1,5 @@
 import type { componentsV1 } from "@arizeai/phoenix-testing";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createExperimentCommand } from "../src/commands/experiment";

--- a/js/packages/phoenix-cli/test/mockServer.ts
+++ b/js/packages/phoenix-cli/test/mockServer.ts
@@ -1,0 +1,60 @@
+import { createHttp } from "@arizeai/phoenix-testing";
+import { createMockServer, type Server } from "@arizeai/phoenix-testing/node";
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+/**
+ * Type-safe `http` namespace bound to the Phoenix OpenAPI `paths`. Handlers
+ * written with it type-check path params, request bodies, and response bodies
+ * against the API definition.
+ */
+export const http = createHttp();
+
+/**
+ * Register a mock Phoenix server for the current test file. Call at the top
+ * level of a test module — it wires `beforeAll`/`afterEach`/`afterAll` hooks
+ * so every Phoenix endpoint answers with schema-generated data, and returns a
+ * handle whose `server` can be used to pin down specific responses:
+ *
+ * ```ts
+ * const mock = setupMockPhoenixServer();
+ *
+ * it("lists projects", async () => {
+ *   mock.server.use(
+ *     http.get("/v1/projects", ({ response }) =>
+ *       response(200).json({ data: [], next_cursor: null })
+ *     )
+ *   );
+ *   // ...
+ * });
+ * ```
+ *
+ * Unhandled requests fail the test (`onUnhandledRequest: "error"`), so tests
+ * that must NOT reach the network get that assertion for free.
+ */
+export function setupMockPhoenixServer(): { readonly server: Server } {
+  let server: Server | undefined;
+
+  beforeAll(async () => {
+    server = await createMockServer();
+    server.listen({ onUnhandledRequest: "error" });
+  });
+
+  afterEach(() => {
+    server?.resetHandlers();
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  return {
+    get server(): Server {
+      if (!server) {
+        throw new Error(
+          "Mock Phoenix server is not running — setupMockPhoenixServer() handles are only usable inside tests."
+        );
+      }
+      return server;
+    },
+  };
+}

--- a/js/packages/phoenix-cli/test/notes.test.ts
+++ b/js/packages/phoenix-cli/test/notes.test.ts
@@ -5,10 +5,9 @@ import { createSpanCommand } from "../src/commands/span";
 import { createTraceCommand } from "../src/commands/trace";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 /**
  * Handler that reports the given Phoenix server version. The capability
@@ -220,8 +219,7 @@ afterEach(() => {
 describe("span add-note", () => {
   it("posts a span note and returns raw output", async () => {
     const captured = captureSpanNotePost({ id: "span-note-1" });
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -242,7 +240,7 @@ describe("span add-note", () => {
         note: "needs review",
       },
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify({
         id: "span-note-1",
         targetType: "span",
@@ -256,11 +254,7 @@ describe("span add-note", () => {
     // No handlers registered: any network call would fail via
     // onUnhandledRequest: "error".
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(["add-note", "span-123", ...BASE_ARGS], {
@@ -275,11 +269,7 @@ describe("span add-note", () => {
     // No handlers registered: any network call would fail via
     // onUnhandledRequest: "error".
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSpanCommand().parseAsync(
@@ -301,8 +291,7 @@ describe("trace add-note", () => {
   it("posts a trace note and returns json output", async () => {
     mock.server.use(serverVersionHandler("14.13.0"));
     const captured = captureTraceNotePost({ id: "trace-note-1" });
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -323,7 +312,7 @@ describe("trace add-note", () => {
         note: "needs review",
       },
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify(
         {
           id: "trace-note-1",
@@ -341,11 +330,7 @@ describe("trace add-note", () => {
     // No handlers registered: any network call would fail via
     // onUnhandledRequest: "error".
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createTraceCommand().parseAsync(["add-note", "trace-123", ...BASE_ARGS], {
@@ -360,11 +345,7 @@ describe("trace add-note", () => {
     // No handlers registered: any network call would fail via
     // onUnhandledRequest: "error".
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createTraceCommand().parseAsync(
@@ -387,8 +368,7 @@ describe("add-note --identifier round-trip", () => {
     // identifier-body capability check (>= 15.5.0)
     mock.server.use(serverVersionHandler("15.5.0"));
     const captured = captureSpanNotePost({ id: "span-note-id" });
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -418,8 +398,7 @@ describe("add-note --identifier round-trip", () => {
     // capability check (route + identifier-body both gated on this version)
     mock.server.use(serverVersionHandler("15.5.0"));
     const captured = captureTraceNotePost({ id: "trace-note-id" });
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -451,8 +430,7 @@ describe("span note readback", () => {
     useProjectHandler();
     useSpanPageHandler();
     const captured = captureSpanAnnotationsRequests(() => [SPAN_NOTE_FIXTURE]);
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -472,7 +450,7 @@ describe("span note readback", () => {
       "note"
     );
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
     expect(parsedOutput[0].notes).toEqual([
       expect.objectContaining({ id: "span-note-1", name: "note" }),
@@ -487,8 +465,7 @@ describe("span note readback", () => {
         ? [SPAN_NOTE_FIXTURE]
         : [SPAN_ANNOTATION_FIXTURE]
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -513,7 +490,7 @@ describe("span note readback", () => {
     expect(annotationsQuery).toBeDefined();
     expect(notesQuery).toBeDefined();
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
     expect(parsedOutput[0].annotations).toEqual([
       expect.objectContaining({ id: "annotation-1", name: "correctness" }),
@@ -537,8 +514,7 @@ describe("trace note readback", () => {
     const capturedSpan = captureSpanAnnotationsRequests(() => [
       SPAN_NOTE_FIXTURE,
     ]);
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -563,7 +539,7 @@ describe("trace note readback", () => {
       capturedSpan.queries[0]?.getAll("include_annotation_names")
     ).toContain("note");
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
     expect(parsedOutput.notes).toEqual([
       expect.objectContaining({ id: "trace-note-1", name: "note" }),
@@ -578,8 +554,7 @@ describe("trace note readback", () => {
     useSpanPageHandler();
     const capturedTrace = captureTraceAnnotationsRequests(() => []);
     const capturedSpan = captureSpanAnnotationsRequests(() => []);
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -602,7 +577,7 @@ describe("trace note readback", () => {
       capturedSpan.queries[0]?.getAll("exclude_annotation_names")
     ).toContain("note");
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
     expect(parsedOutput.notes).toBeUndefined();
     expect(parsedOutput.spans[0].notes).toBeUndefined();
@@ -617,8 +592,7 @@ describe("trace note readback", () => {
     const capturedSpan = captureSpanAnnotationsRequests(() => [
       SPAN_NOTE_FIXTURE,
     ]);
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -642,7 +616,7 @@ describe("trace note readback", () => {
       capturedSpan.queries[0]?.getAll("include_annotation_names")
     ).toContain("note");
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
     expect(parsedOutput[0].notes).toEqual([
       expect.objectContaining({ id: "trace-note-1", name: "note" }),

--- a/js/packages/phoenix-cli/test/notes.test.ts
+++ b/js/packages/phoenix-cli/test/notes.test.ts
@@ -1,175 +1,225 @@
+import type { componentsV1 } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createSpanCommand } from "../src/commands/span";
 import { createTraceCommand } from "../src/commands/trace";
 import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
 
-function makeFetchMock(
-  responses: Array<
-    | { ok: boolean; status?: number; body?: unknown; text?: string }
-    | { error: Error }
-  >
-) {
-  let callIndex = 0;
-  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
-    const response = responses[callIndex++] ?? responses[responses.length - 1];
-    if ("error" in response) {
-      return Promise.reject(response.error);
-    }
-    const status = response.status ?? (response.ok ? 200 : 500);
-    const url =
-      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
-    const body = response.body ?? {};
-    const text = response.text ?? JSON.stringify(body);
-    return Promise.resolve({
-      ok: response.ok,
-      status,
-      statusText: response.ok ? "OK" : "Error",
-      url,
-      headers: new Headers(),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(text),
-    });
-  });
-}
-
-function getFetchUrl(arg: unknown): string {
-  if (arg instanceof Request) return arg.url;
-  return String(arg);
-}
-
-async function getFetchBody(
-  arg: unknown,
-  init?: RequestInit
-): Promise<unknown> {
-  if (arg instanceof Request) {
-    const text = await arg.clone().text();
-    return text ? JSON.parse(text) : undefined;
-  }
-  if (typeof init?.body === "string") {
-    return JSON.parse(init.body);
-  }
-  return undefined;
-}
-
-function makeProjectResponse() {
-  return {
-    ok: true,
-    body: {
-      data: {
-        id: "project-default",
-      },
-    },
-  } as const;
-}
-
-function makeSpanPageResponse() {
-  return {
-    ok: true,
-    body: {
-      data: [
-        {
-          name: "root",
-          span_kind: "CHAIN",
-          parent_id: null,
-          status_code: "OK",
-          status_message: "",
-          start_time: "2026-01-13T10:00:00.000Z",
-          end_time: "2026-01-13T10:00:01.000Z",
-          attributes: {
-            "input.value": "hello",
-            "output.value": "world",
-          },
-          events: [],
-          context: {
-            trace_id: "trace-123",
-            span_id: "span-123",
-          },
-        },
-      ],
-      next_cursor: null,
-    },
-  } as const;
-}
-
-function makeSpanNoteResponse() {
-  return {
-    ok: true,
-    body: {
-      data: [
-        {
-          id: "span-note-1",
-          created_at: "2026-01-13T10:00:00.750Z",
-          updated_at: "2026-01-13T10:00:00.750Z",
-          source: "API",
-          user_id: null,
-          name: "note",
-          annotator_kind: "HUMAN",
-          result: {
-            explanation: "span note text",
-          },
-          metadata: null,
-          identifier: "px-span-note:1",
-          span_id: "span-123",
-        },
-      ],
-      next_cursor: null,
-    },
-  } as const;
-}
-
-function makeTraceNoteResponse() {
-  return {
-    ok: true,
-    body: {
-      data: [
-        {
-          id: "trace-note-1",
-          created_at: "2026-01-13T10:00:00.500Z",
-          updated_at: "2026-01-13T10:00:00.500Z",
-          source: "API",
-          user_id: null,
-          name: "note",
-          annotator_kind: "HUMAN",
-          result: {
-            explanation: "trace note text",
-          },
-          metadata: null,
-          identifier: "px-trace-note:1",
-          trace_id: "trace-123",
-        },
-      ],
-      next_cursor: null,
-    },
-  } as const;
-}
-
-function makeTraceAnnotationResponse() {
-  return {
-    ok: true,
-    body: {
-      data: [],
-      next_cursor: null,
-    },
-  } as const;
-}
+const mock = setupMockPhoenixServer();
 
 const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
+/**
+ * Handler that reports the given Phoenix server version. The capability
+ * guards in addSpanNote/addTraceNote resolve the server version by fetching
+ * this endpoint, and the endpoint returns the version string as plain text.
+ */
+function serverVersionHandler(version: string) {
+  return http.get("/arize_phoenix_version", ({ response }) =>
+    response.untyped(new Response(version, { status: 200 }))
+  );
+}
+
+const SPAN_FIXTURE: componentsV1["schemas"]["Span"] = {
+  name: "root",
+  span_kind: "CHAIN",
+  parent_id: null,
+  status_code: "OK",
+  status_message: "",
+  start_time: "2026-01-13T10:00:00.000Z",
+  end_time: "2026-01-13T10:00:01.000Z",
+  attributes: {
+    "input.value": "hello",
+    "output.value": "world",
+  },
+  events: [],
+  context: {
+    trace_id: "trace-123",
+    span_id: "span-123",
+  },
+};
+
+const SPAN_NOTE_FIXTURE: componentsV1["schemas"]["SpanAnnotation"] = {
+  id: "span-note-1",
+  created_at: "2026-01-13T10:00:00.750Z",
+  updated_at: "2026-01-13T10:00:00.750Z",
+  source: "API",
+  user_id: null,
+  name: "note",
+  annotator_kind: "HUMAN",
+  result: {
+    explanation: "span note text",
+  },
+  metadata: null,
+  identifier: "px-span-note:1",
+  span_id: "span-123",
+};
+
+const SPAN_ANNOTATION_FIXTURE: componentsV1["schemas"]["SpanAnnotation"] = {
+  id: "annotation-1",
+  created_at: "2026-01-13T10:00:00.250Z",
+  updated_at: "2026-01-13T10:00:00.250Z",
+  source: "API",
+  user_id: null,
+  name: "correctness",
+  annotator_kind: "HUMAN",
+  result: {
+    label: "correct",
+  },
+  metadata: null,
+  identifier: "annotation:1",
+  span_id: "span-123",
+};
+
+const TRACE_NOTE_FIXTURE: componentsV1["schemas"]["TraceAnnotation"] = {
+  id: "trace-note-1",
+  created_at: "2026-01-13T10:00:00.500Z",
+  updated_at: "2026-01-13T10:00:00.500Z",
+  source: "API",
+  user_id: null,
+  name: "note",
+  annotator_kind: "HUMAN",
+  result: {
+    explanation: "trace note text",
+  },
+  metadata: null,
+  identifier: "px-trace-note:1",
+  trace_id: "trace-123",
+};
+
+/**
+ * Pin the project-by-identifier lookup used to resolve `--project default`.
+ */
+function useProjectHandler() {
+  mock.server.use(
+    http.get("/v1/projects/{project_identifier}", ({ response }) =>
+      response(200).json({
+        data: { id: "project-default", name: "default" },
+      })
+    )
+  );
+}
+
+/**
+ * Pin the project spans page with the default span fixture.
+ */
+function useSpanPageHandler() {
+  mock.server.use(
+    http.get("/v1/projects/{project_identifier}/spans", ({ response }) =>
+      response(200).json({
+        data: [SPAN_FIXTURE],
+        next_cursor: null,
+      })
+    )
+  );
+}
+
+/**
+ * Register a handler for the project span_annotations page that records each
+ * request's path param and query string, answering with the annotations the
+ * given resolver picks for that query.
+ */
+function captureSpanAnnotationsRequests(
+  resolve: (
+    query: URLSearchParams
+  ) => componentsV1["schemas"]["SpanAnnotation"][]
+) {
+  const captured: {
+    projectIdentifier?: string;
+    queries: URLSearchParams[];
+  } = { queries: [] };
+
+  mock.server.use(
+    http.get(
+      "/v1/projects/{project_identifier}/span_annotations",
+      ({ params, request, response }) => {
+        captured.projectIdentifier = params.project_identifier;
+        const query = new URL(request.url).searchParams;
+        captured.queries.push(query);
+        return response(200).json({
+          data: resolve(query),
+          next_cursor: null,
+        });
+      }
+    )
+  );
+
+  return captured;
+}
+
+/**
+ * Register a handler for the project trace_annotations page that records each
+ * request's path param and query string, answering with the annotations the
+ * given resolver picks for that query.
+ */
+function captureTraceAnnotationsRequests(
+  resolve: (
+    query: URLSearchParams
+  ) => componentsV1["schemas"]["TraceAnnotation"][]
+) {
+  const captured: {
+    projectIdentifier?: string;
+    queries: URLSearchParams[];
+  } = { queries: [] };
+
+  mock.server.use(
+    http.get(
+      "/v1/projects/{project_identifier}/trace_annotations",
+      ({ params, request, response }) => {
+        captured.projectIdentifier = params.project_identifier;
+        const query = new URL(request.url).searchParams;
+        captured.queries.push(query);
+        return response(200).json({
+          data: resolve(query),
+          next_cursor: null,
+        });
+      }
+    )
+  );
+
+  return captured;
+}
+
+/**
+ * Register a handler for POST /v1/span_notes that records the request body.
+ */
+function captureSpanNotePost({ id }: { id: string }) {
+  const captured: { body?: unknown } = {};
+
+  mock.server.use(
+    http.post("/v1/span_notes", async ({ request, response }) => {
+      captured.body = await request.clone().json();
+      return response(200).json({ data: { id } });
+    })
+  );
+
+  return captured;
+}
+
+/**
+ * Register a handler for POST /v1/trace_notes that records the request body.
+ */
+function captureTraceNotePost({ id }: { id: string }) {
+  const captured: { body?: unknown } = {};
+
+  mock.server.use(
+    http.post("/v1/trace_notes", async ({ request, response }) => {
+      captured.body = await request.clone().json();
+      return response(200).json({ data: { id } });
+    })
+  );
+
+  return captured;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.unstubAllGlobals();
 });
 
 describe("span add-note", () => {
   it("posts a span note and returns raw output", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        body: { data: { id: "span-note-1" } },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const captured = captureSpanNotePost({ id: "span-note-1" });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -186,11 +236,7 @@ describe("span add-note", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain("/v1/span_notes");
-    await expect(
-      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
-    ).resolves.toEqual({
+    expect(captured.body).toEqual({
       data: {
         span_id: "span-123",
         note: "needs review",
@@ -207,8 +253,8 @@ describe("span add-note", () => {
   });
 
   it("fails with INVALID_ARGUMENT when --text is missing", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    // No handlers registered: any network call would fail via
+    // onUnhandledRequest: "error".
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -223,12 +269,11 @@ describe("span add-note", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("fails with INVALID_ARGUMENT when --text is blank", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    // No handlers registered: any network call would fail via
+    // onUnhandledRequest: "error".
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -244,7 +289,6 @@ describe("span add-note", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "Invalid value for --text: <empty>. Expected non-empty text."
@@ -255,17 +299,8 @@ describe("span add-note", () => {
 
 describe("trace add-note", () => {
   it("posts a trace note and returns json output", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        ok: true,
-        text: "14.13.0",
-      },
-      {
-        ok: true,
-        body: { data: { id: "trace-note-1" } },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    mock.server.use(serverVersionHandler("14.13.0"));
+    const captured = captureTraceNotePost({ id: "trace-note-1" });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -282,13 +317,7 @@ describe("trace add-note", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
-      "/v1/trace_notes"
-    );
-    await expect(
-      getFetchBody(fetchMock.mock.calls[1][0], fetchMock.mock.calls[1][1])
-    ).resolves.toEqual({
+    expect(captured.body).toEqual({
       data: {
         trace_id: "trace-123",
         note: "needs review",
@@ -309,8 +338,8 @@ describe("trace add-note", () => {
   });
 
   it("fails with INVALID_ARGUMENT when --text is missing", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    // No handlers registered: any network call would fail via
+    // onUnhandledRequest: "error".
     vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -325,12 +354,11 @@ describe("trace add-note", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("fails with INVALID_ARGUMENT when --text is blank", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    // No handlers registered: any network call would fail via
+    // onUnhandledRequest: "error".
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -346,7 +374,6 @@ describe("trace add-note", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "Invalid value for --text: <empty>. Expected non-empty text."
@@ -357,18 +384,9 @@ describe("trace add-note", () => {
 
 describe("add-note --identifier round-trip", () => {
   it("threads --identifier into the span_notes request body", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        // identifier-body capability check (>= 15.5.0)
-        ok: true,
-        text: "15.5.0",
-      },
-      {
-        ok: true,
-        body: { data: { id: "span-note-id" } },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    // identifier-body capability check (>= 15.5.0)
+    mock.server.use(serverVersionHandler("15.5.0"));
+    const captured = captureSpanNotePost({ id: "span-note-id" });
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -387,10 +405,7 @@ describe("add-note --identifier round-trip", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain("/v1/span_notes");
-    await expect(
-      getFetchBody(fetchMock.mock.calls[1][0], fetchMock.mock.calls[1][1])
-    ).resolves.toEqual({
+    expect(captured.body).toEqual({
       data: {
         span_id: "span-123",
         note: "needs review",
@@ -400,18 +415,9 @@ describe("add-note --identifier round-trip", () => {
   });
 
   it("threads --identifier into the trace_notes request body", async () => {
-    const fetchMock = makeFetchMock([
-      {
-        // capability check (route + identifier-body both gated on this version)
-        ok: true,
-        text: "15.5.0",
-      },
-      {
-        ok: true,
-        body: { data: { id: "trace-note-id" } },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    // capability check (route + identifier-body both gated on this version)
+    mock.server.use(serverVersionHandler("15.5.0"));
+    const captured = captureTraceNotePost({ id: "trace-note-id" });
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -430,12 +436,7 @@ describe("add-note --identifier round-trip", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
-      "/v1/trace_notes"
-    );
-    await expect(
-      getFetchBody(fetchMock.mock.calls[1][0], fetchMock.mock.calls[1][1])
-    ).resolves.toEqual({
+    expect(captured.body).toEqual({
       data: {
         trace_id: "trace-123",
         note: "needs review",
@@ -447,12 +448,9 @@ describe("add-note --identifier round-trip", () => {
 
 describe("span note readback", () => {
   it("includes notes in span list raw output when requested", async () => {
-    const fetchMock = makeFetchMock([
-      makeProjectResponse(),
-      makeSpanPageResponse(),
-      makeSpanNoteResponse(),
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectHandler();
+    useSpanPageHandler();
+    const captured = captureSpanAnnotationsRequests(() => [SPAN_NOTE_FIXTURE]);
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -469,11 +467,9 @@ describe("span note readback", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "/v1/projects/project-default/span_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "include_annotation_names=note"
+    expect(captured.projectIdentifier).toBe("project-default");
+    expect(captured.queries[0]?.getAll("include_annotation_names")).toContain(
+      "note"
     );
 
     const output = stdoutSpy.mock.calls[0]?.[0];
@@ -484,35 +480,13 @@ describe("span note readback", () => {
   });
 
   it("keeps note names out of annotations when both note flags are used", async () => {
-    const fetchMock = makeFetchMock([
-      makeProjectResponse(),
-      makeSpanPageResponse(),
-      {
-        ok: true,
-        body: {
-          data: [
-            {
-              id: "annotation-1",
-              created_at: "2026-01-13T10:00:00.250Z",
-              updated_at: "2026-01-13T10:00:00.250Z",
-              source: "API",
-              user_id: null,
-              name: "correctness",
-              annotator_kind: "HUMAN",
-              result: {
-                label: "correct",
-              },
-              metadata: null,
-              identifier: "annotation:1",
-              span_id: "span-123",
-            },
-          ],
-          next_cursor: null,
-        },
-      },
-      makeSpanNoteResponse(),
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectHandler();
+    useSpanPageHandler();
+    const captured = captureSpanAnnotationsRequests((query) =>
+      query.getAll("include_annotation_names").includes("note")
+        ? [SPAN_NOTE_FIXTURE]
+        : [SPAN_ANNOTATION_FIXTURE]
+    );
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -530,12 +504,14 @@ describe("span note readback", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "exclude_annotation_names=note"
+    const annotationsQuery = captured.queries.find((query) =>
+      query.getAll("exclude_annotation_names").includes("note")
     );
-    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
-      "include_annotation_names=note"
+    const notesQuery = captured.queries.find((query) =>
+      query.getAll("include_annotation_names").includes("note")
     );
+    expect(annotationsQuery).toBeDefined();
+    expect(notesQuery).toBeDefined();
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
@@ -553,13 +529,14 @@ describe("span note readback", () => {
 
 describe("trace note readback", () => {
   it("includes trace and span notes in trace get raw output when requested", async () => {
-    const fetchMock = makeFetchMock([
-      makeProjectResponse(),
-      makeSpanPageResponse(),
-      makeTraceNoteResponse(),
-      makeSpanNoteResponse(),
+    useProjectHandler();
+    useSpanPageHandler();
+    const capturedTrace = captureTraceAnnotationsRequests(() => [
+      TRACE_NOTE_FIXTURE,
     ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const capturedSpan = captureSpanAnnotationsRequests(() => [
+      SPAN_NOTE_FIXTURE,
+    ]);
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -577,19 +554,14 @@ describe("trace note readback", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "/v1/projects/project-default/trace_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "include_annotation_names=note"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
-      "/v1/projects/project-default/span_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
-      "include_annotation_names=note"
-    );
+    expect(capturedTrace.projectIdentifier).toBe("project-default");
+    expect(
+      capturedTrace.queries[0]?.getAll("include_annotation_names")
+    ).toContain("note");
+    expect(capturedSpan.projectIdentifier).toBe("project-default");
+    expect(
+      capturedSpan.queries[0]?.getAll("include_annotation_names")
+    ).toContain("note");
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
@@ -602,19 +574,10 @@ describe("trace note readback", () => {
   });
 
   it("keeps notes excluded when only --include-annotations is used", async () => {
-    const fetchMock = makeFetchMock([
-      makeProjectResponse(),
-      makeSpanPageResponse(),
-      makeTraceAnnotationResponse(),
-      {
-        ok: true,
-        body: {
-          data: [],
-          next_cursor: null,
-        },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectHandler();
+    useSpanPageHandler();
+    const capturedTrace = captureTraceAnnotationsRequests(() => []);
+    const capturedSpan = captureSpanAnnotationsRequests(() => []);
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -632,12 +595,12 @@ describe("trace note readback", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "exclude_annotation_names=note"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
-      "exclude_annotation_names=note"
-    );
+    expect(
+      capturedTrace.queries[0]?.getAll("exclude_annotation_names")
+    ).toContain("note");
+    expect(
+      capturedSpan.queries[0]?.getAll("exclude_annotation_names")
+    ).toContain("note");
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
@@ -646,13 +609,14 @@ describe("trace note readback", () => {
   });
 
   it("includes trace and span notes in trace list raw output when requested", async () => {
-    const fetchMock = makeFetchMock([
-      makeProjectResponse(),
-      makeSpanPageResponse(),
-      makeTraceNoteResponse(),
-      makeSpanNoteResponse(),
+    useProjectHandler();
+    useSpanPageHandler();
+    const capturedTrace = captureTraceAnnotationsRequests(() => [
+      TRACE_NOTE_FIXTURE,
     ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const capturedSpan = captureSpanAnnotationsRequests(() => [
+      SPAN_NOTE_FIXTURE,
+    ]);
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -669,19 +633,14 @@ describe("trace note readback", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "/v1/projects/project-default/trace_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "include_annotation_names=note"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
-      "/v1/projects/project-default/span_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
-      "include_annotation_names=note"
-    );
+    expect(capturedTrace.projectIdentifier).toBe("project-default");
+    expect(
+      capturedTrace.queries[0]?.getAll("include_annotation_names")
+    ).toContain("note");
+    expect(capturedSpan.projectIdentifier).toBe("project-default");
+    expect(
+      capturedSpan.queries[0]?.getAll("include_annotation_names")
+    ).toContain("note");
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));

--- a/js/packages/phoenix-cli/test/projectGet.test.ts
+++ b/js/packages/phoenix-cli/test/projectGet.test.ts
@@ -3,10 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createProjectCommand } from "../src/commands/project";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 function usePinnedProjectPage() {
   mock.server.use(
@@ -29,15 +28,14 @@ afterEach(() => {
 describe("project get", () => {
   it("returns the matching project as a bare object in raw mode", async () => {
     usePinnedProjectPage();
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createProjectCommand().parseAsync(
       ["get", "alpha", "--format", "raw", ...BASE_ARGS],
       { from: "user" }
     );
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(output));
     expect(parsed).toEqual({
       id: "proj-aaa",
@@ -48,15 +46,14 @@ describe("project get", () => {
 
   it("returns the matching project as a bare object in json mode", async () => {
     usePinnedProjectPage();
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createProjectCommand().parseAsync(
       ["get", "beta", "--format", "json", ...BASE_ARGS],
       { from: "user" }
     );
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(output));
     expect(parsed).toEqual({
       id: "proj-bbb",
@@ -67,13 +64,8 @@ describe("project get", () => {
 
   it("emits a StructuredError on miss and exits FAILURE", async () => {
     usePinnedProjectPage();
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const io = captureCliOutput();
+    const exitSpy = mockProcessExit();
 
     await expect(
       createProjectCommand().parseAsync(
@@ -83,7 +75,7 @@ describe("project get", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
-    const stderrCall = stderrSpy.mock.calls[0]?.[0];
+    const stderrCall = io.stderr.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(stderrCall));
     expect(parsed.error).toContain("not found");
     expect(parsed.code).toBe("FAILURE");
@@ -92,13 +84,8 @@ describe("project get", () => {
 
   it("emits a human-readable error on miss in pretty mode", async () => {
     usePinnedProjectPage();
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const io = captureCliOutput();
+    const exitSpy = mockProcessExit();
 
     await expect(
       createProjectCommand().parseAsync(["get", "nonexistent", ...BASE_ARGS], {
@@ -107,21 +94,20 @@ describe("project get", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
-    const stderrCall = stderrSpy.mock.calls[0]?.[0];
+    const stderrCall = io.stderr.mock.calls[0]?.[0];
     expect(String(stderrCall)).toContain("Project 'nonexistent' not found");
   });
 
   it("does NOT envelope the response in json mode (single-record convention)", async () => {
     usePinnedProjectPage();
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createProjectCommand().parseAsync(
       ["get", "alpha", "--format", "json", ...BASE_ARGS],
       { from: "user" }
     );
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(output));
     expect(Array.isArray(parsed)).toBe(false);
     expect(parsed.id).toBe("proj-aaa");

--- a/js/packages/phoenix-cli/test/projectGet.test.ts
+++ b/js/packages/phoenix-cli/test/projectGet.test.ts
@@ -2,58 +2,33 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createProjectCommand } from "../src/commands/project";
 import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
 
-function makeFetchMock(
-  responses: Array<
-    | { ok: boolean; status?: number; body?: unknown; text?: string }
-    | { error: Error }
-  >
-) {
-  let callIndex = 0;
-  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
-    const response = responses[callIndex++] ?? responses[responses.length - 1];
-    if ("error" in response) {
-      return Promise.reject(response.error);
-    }
-    const status = response.status ?? (response.ok ? 200 : 500);
-    const url =
-      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
-    const body = response.body ?? {};
-    const text = response.text ?? JSON.stringify(body);
-    return Promise.resolve({
-      ok: response.ok,
-      status,
-      statusText: response.ok ? "OK" : "Error",
-      url,
-      headers: new Headers(),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(text),
-    });
-  });
-}
+const mock = setupMockPhoenixServer();
 
 const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
-const PROJECT_PAGE = {
-  ok: true as const,
-  body: {
-    data: [
-      { id: "proj-aaa", name: "alpha", description: "first project" },
-      { id: "proj-bbb", name: "beta", description: null },
-    ],
-    next_cursor: null,
-  },
-};
+function usePinnedProjectPage() {
+  mock.server.use(
+    http.get("/v1/projects", ({ response }) =>
+      response(200).json({
+        data: [
+          { id: "proj-aaa", name: "alpha", description: "first project" },
+          { id: "proj-bbb", name: "beta", description: null },
+        ],
+        next_cursor: null,
+      })
+    )
+  );
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.unstubAllGlobals();
 });
 
 describe("project get", () => {
   it("returns the matching project as a bare object in raw mode", async () => {
-    const fetchMock = makeFetchMock([PROJECT_PAGE]);
-    vi.stubGlobal("fetch", fetchMock);
+    usePinnedProjectPage();
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -72,8 +47,7 @@ describe("project get", () => {
   });
 
   it("returns the matching project as a bare object in json mode", async () => {
-    const fetchMock = makeFetchMock([PROJECT_PAGE]);
-    vi.stubGlobal("fetch", fetchMock);
+    usePinnedProjectPage();
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -92,8 +66,7 @@ describe("project get", () => {
   });
 
   it("emits a StructuredError on miss and exits FAILURE", async () => {
-    const fetchMock = makeFetchMock([PROJECT_PAGE]);
-    vi.stubGlobal("fetch", fetchMock);
+    usePinnedProjectPage();
     vi.spyOn(console, "log").mockImplementation(() => {});
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
@@ -118,8 +91,7 @@ describe("project get", () => {
   });
 
   it("emits a human-readable error on miss in pretty mode", async () => {
-    const fetchMock = makeFetchMock([PROJECT_PAGE]);
-    vi.stubGlobal("fetch", fetchMock);
+    usePinnedProjectPage();
     vi.spyOn(console, "log").mockImplementation(() => {});
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
@@ -140,8 +112,7 @@ describe("project get", () => {
   });
 
   it("does NOT envelope the response in json mode (single-record convention)", async () => {
-    const fetchMock = makeFetchMock([PROJECT_PAGE]);
-    vi.stubGlobal("fetch", fetchMock);
+    usePinnedProjectPage();
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/js/packages/phoenix-cli/test/projectList.test.ts
+++ b/js/packages/phoenix-cli/test/projectList.test.ts
@@ -4,10 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createProjectCommand } from "../src/commands/project";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 const PROJECTS = [
   { id: "proj-aaa", name: "alpha", description: "first project" },
@@ -36,8 +35,7 @@ describe("project list", () => {
         return response(200).json({ data: PROJECTS, next_cursor: null });
       })
     );
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createProjectCommand().parseAsync(
       ["list", "--limit", "50", "--format", "raw", ...BASE_ARGS],
@@ -47,7 +45,7 @@ describe("project list", () => {
     expect(captured.count).toBe(1);
     expect(captured.limit).toBe("50");
     expect(captured.includeExperimentProjects).toBe("false");
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual(PROJECTS);
   });
 
@@ -66,8 +64,7 @@ describe("project list", () => {
         return response(200).json({ data: [PROJECTS[1]], next_cursor: null });
       })
     );
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createProjectCommand().parseAsync(
       ["list", "--format", "raw", ...BASE_ARGS],
@@ -75,7 +72,7 @@ describe("project list", () => {
     );
 
     expect(cursors).toEqual([null, "cursor-2"]);
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual(PROJECTS);
   });
 
@@ -86,11 +83,7 @@ describe("project list", () => {
       )
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createProjectCommand().parseAsync(
@@ -108,11 +101,7 @@ describe("project list", () => {
   it("exits NETWORK_ERROR when the connection fails", async () => {
     mock.server.use(http.get("/v1/projects", () => HttpResponse.error()));
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createProjectCommand().parseAsync(
@@ -147,15 +136,14 @@ describe("project list", () => {
         )
       )
     );
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createProjectCommand().parseAsync(
       ["list", "--format", "raw", ...BASE_ARGS],
       { from: "user" }
     );
 
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual(generatedPage.data);
   });
 });

--- a/js/packages/phoenix-cli/test/projectList.test.ts
+++ b/js/packages/phoenix-cli/test/projectList.test.ts
@@ -1,0 +1,161 @@
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createProjectCommand } from "../src/commands/project";
+import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
+
+const mock = setupMockPhoenixServer();
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+const PROJECTS = [
+  { id: "proj-aaa", name: "alpha", description: "first project" },
+  { id: "proj-bbb", name: "beta", description: null },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("project list", () => {
+  it("excludes experiment projects, propagates --limit, and prints raw JSON", async () => {
+    const captured: {
+      limit?: string | null;
+      includeExperimentProjects?: string | null;
+      count: number;
+    } = { count: 0 };
+    mock.server.use(
+      http.get("/v1/projects", ({ request, response }) => {
+        captured.count += 1;
+        const searchParams = new URL(request.url).searchParams;
+        captured.limit = searchParams.get("limit");
+        captured.includeExperimentProjects = searchParams.get(
+          "include_experiment_projects"
+        );
+        return response(200).json({ data: PROJECTS, next_cursor: null });
+      })
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProjectCommand().parseAsync(
+      ["list", "--limit", "50", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(captured.count).toBe(1);
+    expect(captured.limit).toBe("50");
+    expect(captured.includeExperimentProjects).toBe("false");
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(parsed).toEqual(PROJECTS);
+  });
+
+  it("follows next_cursor across pages and concatenates the results", async () => {
+    const cursors: (string | null)[] = [];
+    mock.server.use(
+      http.get("/v1/projects", ({ request, response }) => {
+        const cursor = new URL(request.url).searchParams.get("cursor");
+        cursors.push(cursor);
+        if (cursor === null) {
+          return response(200).json({
+            data: [PROJECTS[0]],
+            next_cursor: "cursor-2",
+          });
+        }
+        return response(200).json({ data: [PROJECTS[1]], next_cursor: null });
+      })
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProjectCommand().parseAsync(
+      ["list", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(cursors).toEqual([null, "cursor-2"]);
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(parsed).toEqual(PROJECTS);
+  });
+
+  it("exits FAILURE with an error message on a server error", async () => {
+    mock.server.use(
+      http.get("/v1/projects", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 500 }))
+      )
+    );
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createProjectCommand().parseAsync(
+        ["list", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error fetching projects")
+    );
+  });
+
+  it("exits NETWORK_ERROR when the connection fails", async () => {
+    mock.server.use(http.get("/v1/projects", () => HttpResponse.error()));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createProjectCommand().parseAsync(
+        ["list", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+  });
+
+  it("renders a schema-generated page end-to-end", async () => {
+    // `fetchProjects` paginates until next_cursor is null, and the generated
+    // OpenAPI handler always emits a non-null cursor (unlike the other list
+    // commands, `project list` has no --limit early exit), so running the CLI
+    // against the pure generated handler would never terminate. Instead,
+    // fetch one generated page directly and replay it with the cursor
+    // nulled — the payload the CLI consumes is still entirely
+    // schema-generated.
+    const generatedResponse = await fetch(
+      "http://localhost:6006/v1/projects?limit=100"
+    );
+    const generatedPage = (await generatedResponse.json()) as {
+      data: unknown[];
+      next_cursor: string | null;
+    };
+    expect(generatedPage.data.length).toBeGreaterThan(0);
+    mock.server.use(
+      http.get("/v1/projects", ({ response }) =>
+        response.untyped(
+          HttpResponse.json({ ...generatedPage, next_cursor: null })
+        )
+      )
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createProjectCommand().parseAsync(
+      ["list", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(parsed).toEqual(generatedPage.data);
+  });
+});

--- a/js/packages/phoenix-cli/test/projectList.test.ts
+++ b/js/packages/phoenix-cli/test/projectList.test.ts
@@ -1,4 +1,4 @@
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createProjectCommand } from "../src/commands/project";

--- a/js/packages/phoenix-cli/test/promptCommand.test.ts
+++ b/js/packages/phoenix-cli/test/promptCommand.test.ts
@@ -1,0 +1,187 @@
+import type { componentsV1 } from "@arizeai/phoenix-testing";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createPromptCommand } from "../src/commands/prompt";
+import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
+
+const mock = setupMockPhoenixServer();
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+const PROMPT: componentsV1["schemas"]["Prompt"] = {
+  id: "prompt-001",
+  name: "greeting",
+  description: "says hello",
+};
+
+const PROMPT_VERSION: componentsV1["schemas"]["PromptVersion"] = {
+  id: "pv-001",
+  description: "first version",
+  model_provider: "OPENAI",
+  model_name: "gpt-4o",
+  template: { type: "string", template: "Hello {{name}}" },
+  template_type: "STR",
+  template_format: "MUSTACHE",
+  invocation_parameters: { type: "openai", openai: { temperature: 0.5 } },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("prompt list", () => {
+  it("propagates --limit to the query and prints prompts as raw JSON", async () => {
+    const captured: { limit?: string | null; count: number } = { count: 0 };
+    mock.server.use(
+      http.get("/v1/prompts", ({ request, response }) => {
+        captured.count += 1;
+        captured.limit = new URL(request.url).searchParams.get("limit");
+        return response(200).json({ data: [PROMPT], next_cursor: null });
+      })
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createPromptCommand().parseAsync(
+      ["list", "--limit", "25", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(captured.count).toBe(1);
+    expect(captured.limit).toBe("25");
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(parsed).toEqual([PROMPT]);
+  });
+
+  it("exits NETWORK_ERROR when the connection fails", async () => {
+    mock.server.use(http.get("/v1/prompts", () => HttpResponse.error()));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createPromptCommand().parseAsync(
+        ["list", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+  });
+
+  it("succeeds end-to-end against the generated OpenAPI handlers", async () => {
+    // No pinned handler: the schema-generated mock answers everything. The
+    // generated pages always carry a non-null next_cursor, so --limit 1 is
+    // required to stop the CLI's pagination loop.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createPromptCommand().parseAsync(
+      ["list", "--limit", "1", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(typeof parsed[0].id).toBe("string");
+    expect(typeof parsed[0].name).toBe("string");
+  });
+});
+
+describe("prompt get", () => {
+  it("fetches the latest version by identifier and prints it as raw JSON", async () => {
+    const captured: { identifier?: string; count: number } = { count: 0 };
+    mock.server.use(
+      http.get(
+        "/v1/prompts/{prompt_identifier}/latest",
+        ({ params, response }) => {
+          captured.count += 1;
+          captured.identifier = params.prompt_identifier;
+          return response(200).json({ data: PROMPT_VERSION });
+        }
+      )
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createPromptCommand().parseAsync(
+      ["get", "greeting", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(captured.count).toBe(1);
+    expect(captured.identifier).toBe("greeting");
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(parsed).toEqual(PROMPT_VERSION);
+  });
+
+  it("routes --tag to the tag endpoint with both path params", async () => {
+    const captured: { identifier?: string; tag?: string; count: number } = {
+      count: 0,
+    };
+    mock.server.use(
+      http.get(
+        "/v1/prompts/{prompt_identifier}/tags/{tag_name}",
+        ({ params, response }) => {
+          captured.count += 1;
+          captured.identifier = params.prompt_identifier;
+          captured.tag = params.tag_name;
+          return response(200).json({ data: PROMPT_VERSION });
+        }
+      )
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createPromptCommand().parseAsync(
+      [
+        "get",
+        "greeting",
+        "--tag",
+        "production",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(captured.count).toBe(1);
+    expect(captured.identifier).toBe("greeting");
+    expect(captured.tag).toBe("production");
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(parsed).toEqual(PROMPT_VERSION);
+  });
+
+  it("exits FAILURE when the prompt is not found", async () => {
+    mock.server.use(
+      http.get("/v1/prompts/{prompt_identifier}/latest", ({ response }) =>
+        response.untyped(HttpResponse.json({}, { status: 404 }))
+      )
+    );
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createPromptCommand().parseAsync(
+        ["get", "missing", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error fetching prompt")
+    );
+  });
+});

--- a/js/packages/phoenix-cli/test/promptCommand.test.ts
+++ b/js/packages/phoenix-cli/test/promptCommand.test.ts
@@ -5,10 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPromptCommand } from "../src/commands/prompt";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 const PROMPT: componentsV1["schemas"]["Prompt"] = {
   id: "prompt-001",
@@ -41,8 +40,7 @@ describe("prompt list", () => {
         return response(200).json({ data: [PROMPT], next_cursor: null });
       })
     );
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createPromptCommand().parseAsync(
       ["list", "--limit", "25", "--format", "raw", ...BASE_ARGS],
@@ -51,18 +49,14 @@ describe("prompt list", () => {
 
     expect(captured.count).toBe(1);
     expect(captured.limit).toBe("25");
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual([PROMPT]);
   });
 
   it("exits NETWORK_ERROR when the connection fails", async () => {
     mock.server.use(http.get("/v1/prompts", () => HttpResponse.error()));
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createPromptCommand().parseAsync(
@@ -78,15 +72,14 @@ describe("prompt list", () => {
     // No pinned handler: the schema-generated mock answers everything. The
     // generated pages always carry a non-null next_cursor, so --limit 1 is
     // required to stop the CLI's pagination loop.
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createPromptCommand().parseAsync(
       ["list", "--limit", "1", "--format", "raw", ...BASE_ARGS],
       { from: "user" }
     );
 
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed.length).toBeGreaterThan(0);
     expect(typeof parsed[0].id).toBe("string");
@@ -107,8 +100,7 @@ describe("prompt get", () => {
         }
       )
     );
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createPromptCommand().parseAsync(
       ["get", "greeting", "--format", "raw", ...BASE_ARGS],
@@ -117,7 +109,7 @@ describe("prompt get", () => {
 
     expect(captured.count).toBe(1);
     expect(captured.identifier).toBe("greeting");
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual(PROMPT_VERSION);
   });
 
@@ -136,8 +128,7 @@ describe("prompt get", () => {
         }
       )
     );
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createPromptCommand().parseAsync(
       [
@@ -155,7 +146,7 @@ describe("prompt get", () => {
     expect(captured.count).toBe(1);
     expect(captured.identifier).toBe("greeting");
     expect(captured.tag).toBe("production");
-    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual(PROMPT_VERSION);
   });
 
@@ -166,11 +157,7 @@ describe("prompt get", () => {
       )
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createPromptCommand().parseAsync(

--- a/js/packages/phoenix-cli/test/promptCommand.test.ts
+++ b/js/packages/phoenix-cli/test/promptCommand.test.ts
@@ -1,5 +1,5 @@
 import type { componentsV1 } from "@arizeai/phoenix-testing";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createPromptCommand } from "../src/commands/prompt";

--- a/js/packages/phoenix-cli/test/self.test.ts
+++ b/js/packages/phoenix-cli/test/self.test.ts
@@ -13,6 +13,8 @@ vi.mock("node:child_process", () => ({
   spawnSync: spawnSyncMock,
 }));
 
+import { HttpResponse, http as mswHttp } from "@arizeai/phoenix-testing/msw";
+
 import {
   buildDenoUpdateCommand,
   buildUpdateCommand,
@@ -21,6 +23,34 @@ import {
   parseDenoInstallScript,
 } from "../src/commands/self";
 import { CLI_VERSION } from "../src/version";
+import { setupMockPhoenixServer } from "./mockServer";
+
+const mock = setupMockPhoenixServer();
+
+const NPM_LATEST_VERSION_URL =
+  "https://registry.npmjs.org/%40arizeai%2Fphoenix-cli/latest";
+
+/**
+ * Register a handler for the npm registry "latest" endpoint (external to the
+ * Phoenix OpenAPI spec, so it needs a raw msw handler) and return a capture
+ * object recording every request that reaches it.
+ */
+function useNpmLatestVersion(responseBody: Record<string, unknown>) {
+  const captured: {
+    count: number;
+    urls: string[];
+    acceptHeaders: (string | null)[];
+  } = { count: 0, urls: [], acceptHeaders: [] };
+  mock.server.use(
+    mswHttp.get("https://registry.npmjs.org/*", ({ request }) => {
+      captured.count += 1;
+      captured.urls.push(request.url);
+      captured.acceptHeaders.push(request.headers.get("accept"));
+      return HttpResponse.json(responseBody);
+    })
+  );
+  return captured;
+}
 
 describe("detectInstallPackageManager", () => {
   it("detects bun installs from the bun global root", () => {
@@ -170,32 +200,20 @@ describe("self update command", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
     process.env.PATH = originalPath;
   });
 
   it("checks for updates without invoking the installer", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ version: "99.0.0" }),
-    });
+    const registryCapture = useNpmLatestVersion({ version: "99.0.0" });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    vi.stubGlobal("fetch", fetchMock);
 
     await createSelfCommand().parseAsync(["update", "--check"], {
       from: "user",
     });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://registry.npmjs.org/%40arizeai%2Fphoenix-cli/latest",
-      expect.objectContaining({
-        headers: {
-          Accept: "application/json",
-        },
-        signal: expect.any(AbortSignal),
-      })
-    );
+    expect(registryCapture.count).toBe(1);
+    expect(registryCapture.urls[0]).toBe(NPM_LATEST_VERSION_URL);
+    expect(registryCapture.acceptHeaders[0]).toBe("application/json");
     expect(spawnSyncMock).not.toHaveBeenCalled();
     expect(stdoutSpy).toHaveBeenNthCalledWith(
       1,
@@ -208,13 +226,9 @@ describe("self update command", () => {
   });
 
   it("updates via npm when the install is owned by npm", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ version: "99.0.0" }),
-    });
+    useNpmLatestVersion({ version: "99.0.0" });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    vi.stubGlobal("fetch", fetchMock);
     execFileSyncMock.mockImplementation((command: string) => {
       if (command.startsWith("pnpm")) {
         return "/tmp/pnpm-root/node_modules";
@@ -238,13 +252,9 @@ describe("self update command", () => {
   });
 
   it("updates via pnpm when the install is owned by pnpm", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ version: "99.0.0" }),
-    });
+    useNpmLatestVersion({ version: "99.0.0" });
     vi.spyOn(console, "log").mockImplementation(() => {});
 
-    vi.stubGlobal("fetch", fetchMock);
     execFileSyncMock.mockImplementation((command: string) => {
       if (command.startsWith("pnpm")) {
         return packageParentDirectory;
@@ -263,10 +273,7 @@ describe("self update command", () => {
   });
 
   it("updates via a Deno install wrapper when no node package manager owns the install", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ version: "99.0.0" }),
-    });
+    useNpmLatestVersion({ version: "99.0.0" });
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     const denoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "px-deno-"));
@@ -284,7 +291,6 @@ describe("self update command", () => {
     );
     fs.chmodSync(denoExecutable, 0o755);
 
-    vi.stubGlobal("fetch", fetchMock);
     process.env.PATH = `${denoBinDirectory}${path.delimiter}${originalPath ?? ""}`;
     execFileSyncMock.mockImplementation(() => "/tmp/unsupported-root");
     spawnSyncMock.mockReturnValue({ status: 0 } as never);
@@ -315,13 +321,8 @@ describe("self update command", () => {
   });
 
   it("reports when the installed version is already current", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ version: CLI_VERSION }),
-    });
+    useNpmLatestVersion({ version: CLI_VERSION });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    vi.stubGlobal("fetch", fetchMock);
 
     await createSelfCommand().parseAsync(["update"], { from: "user" });
 
@@ -330,10 +331,7 @@ describe("self update command", () => {
   });
 
   it("fails with guidance for unsupported install contexts", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ version: "99.0.0" }),
-    });
+    useNpmLatestVersion({ version: "99.0.0" });
     vi.spyOn(console, "log").mockImplementation(() => {});
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
@@ -342,7 +340,6 @@ describe("self update command", () => {
       throw new Error(`process.exit:${code}`);
     }) as never);
 
-    vi.stubGlobal("fetch", fetchMock);
     execFileSyncMock.mockImplementation(() => "/tmp/unsupported-root");
 
     await expect(
@@ -364,7 +361,9 @@ describe("self update command", () => {
       throw new Error(`process.exit:${code}`);
     }) as never);
 
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("offline")));
+    mock.server.use(
+      mswHttp.get("https://registry.npmjs.org/*", () => HttpResponse.error())
+    );
 
     await expect(
       createSelfCommand().parseAsync(["update", "--check"], { from: "user" })
@@ -384,13 +383,7 @@ describe("self update command", () => {
       throw new Error(`process.exit:${code}`);
     }) as never);
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue({ version: "not-a-version" }),
-      })
-    );
+    useNpmLatestVersion({ version: "not-a-version" });
 
     await expect(
       createSelfCommand().parseAsync(["update", "--check"], { from: "user" })

--- a/js/packages/phoenix-cli/test/self.test.ts
+++ b/js/packages/phoenix-cli/test/self.test.ts
@@ -13,7 +13,7 @@ vi.mock("node:child_process", () => ({
   spawnSync: spawnSyncMock,
 }));
 
-import { HttpResponse, http as mswHttp } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse, http as mswHttp } from "@arizeai/phoenix-testing";
 
 import {
   buildDenoUpdateCommand,

--- a/js/packages/phoenix-cli/test/self.test.ts
+++ b/js/packages/phoenix-cli/test/self.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../src/commands/self";
 import { CLI_VERSION } from "../src/version";
 import { setupMockPhoenixServer } from "./mockServer";
+import { captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
 
@@ -332,13 +333,8 @@ describe("self update command", () => {
 
   it("fails with guidance for unsupported install contexts", async () => {
     useNpmLatestVersion({ version: "99.0.0" });
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const io = captureCliOutput();
+    const exitSpy = mockProcessExit();
 
     execFileSyncMock.mockImplementation(() => "/tmp/unsupported-root");
 
@@ -347,7 +343,7 @@ describe("self update command", () => {
     ).rejects.toThrow("process.exit:1");
 
     expect(spawnSyncMock).not.toHaveBeenCalled();
-    expect(stderrSpy).toHaveBeenCalledWith(
+    expect(io.stderr).toHaveBeenCalledWith(
       "Error: Automatic updates are only supported for global npm, pnpm, bun, or Deno installs of @arizeai/phoenix-cli."
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
@@ -355,11 +351,7 @@ describe("self update command", () => {
 
   it("maps fetch failures to the network exit code", async () => {
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     mock.server.use(
       mswHttp.get("https://registry.npmjs.org/*", () => HttpResponse.error())
@@ -377,11 +369,7 @@ describe("self update command", () => {
 
   it("fails when the published version is not valid semver", async () => {
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     useNpmLatestVersion({ version: "not-a-version" });
 

--- a/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
+++ b/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
@@ -1,5 +1,5 @@
 import type { componentsV1 } from "@arizeai/phoenix-testing";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createSessionCommand } from "../src/commands/session";

--- a/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
+++ b/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
@@ -5,10 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSessionCommand } from "../src/commands/session";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 const SESSION_FIXTURE: componentsV1["schemas"]["SessionData"] = {
   id: "U2Vzc2lvbjox",
@@ -150,8 +149,7 @@ describe("session annotate", () => {
         });
       })
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [
@@ -182,7 +180,7 @@ describe("session annotate", () => {
         },
       ],
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify({
         id: "session-annotation-1",
         targetType: "session",
@@ -200,11 +198,7 @@ describe("session annotate", () => {
   it("validates missing annotation names before network calls", async () => {
     const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionCommand().parseAsync(
@@ -223,11 +217,7 @@ describe("session annotate", () => {
   it("validates invalid scores before network calls", async () => {
     const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionCommand().parseAsync(
@@ -256,11 +246,7 @@ describe("session annotate", () => {
   it("validates empty annotation results before network calls", async () => {
     const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionCommand().parseAsync(
@@ -281,11 +267,7 @@ describe("session annotate", () => {
   it("validates invalid annotator kinds before network calls", async () => {
     const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionCommand().parseAsync(
@@ -326,11 +308,7 @@ describe("session annotate", () => {
       )
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionCommand().parseAsync(
@@ -365,8 +343,7 @@ describe("session add-note", () => {
         return response(200).json({ data: { id: "session-note-1" } });
       })
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [
@@ -389,7 +366,7 @@ describe("session add-note", () => {
         note: "needs review",
       },
     });
-    expect(stdoutSpy).toHaveBeenCalledWith(
+    expect(io.stdout).toHaveBeenCalledWith(
       JSON.stringify({
         id: "session-note-1",
         targetType: "session",
@@ -402,11 +379,7 @@ describe("session add-note", () => {
   it("validates blank note text before network calls", async () => {
     const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionCommand().parseAsync(
@@ -435,11 +408,7 @@ describe("session add-note", () => {
       })
     );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
-      code?: number
-    ) => {
-      throw new Error(`process.exit:${code}`);
-    }) as never);
+    const exitSpy = mockProcessExit();
 
     await expect(
       createSessionCommand().parseAsync(
@@ -470,8 +439,7 @@ describe("session annotation and note readback", () => {
     const annotationReads = useSessionAnnotationReads({
       notes: [SESSION_NOTE_FIXTURE],
     });
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [
@@ -490,7 +458,7 @@ describe("session annotation and note readback", () => {
       annotationReads.queries[0]?.getAll("include_annotation_names")
     ).toEqual(["note"]);
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
     expect(parsedOutput.session.notes).toEqual([
       expect.objectContaining({ id: "session-note-1", name: "note" }),
@@ -503,8 +471,7 @@ describe("session annotation and note readback", () => {
     const annotationReads = useSessionAnnotationReads({
       annotations: [SESSION_ANNOTATION_FIXTURE],
     });
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [
@@ -522,7 +489,7 @@ describe("session annotation and note readback", () => {
       annotationReads.queries[0]?.getAll("exclude_annotation_names")
     ).toEqual(["note"]);
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
     expect(parsedOutput.session.annotations).toEqual([
       expect.objectContaining({ id: "session-annotation-1", name: "reviewer" }),
@@ -541,8 +508,7 @@ describe("session annotation and note readback", () => {
       )
     );
     useSessionAnnotationReads();
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [
@@ -556,7 +522,7 @@ describe("session annotation and note readback", () => {
       { from: "user" }
     );
 
-    const output = String(stdoutSpy.mock.calls[0]?.[0]);
+    const output = String(io.stdout.mock.calls[0]?.[0]);
     expect(output).toContain("annotations");
     expect(output).toContain("notes");
   });
@@ -572,8 +538,7 @@ describe("session annotation and note readback", () => {
       annotations: [SESSION_ANNOTATION_FIXTURE],
       notes: [SESSION_NOTE_FIXTURE],
     });
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [
@@ -598,7 +563,7 @@ describe("session annotation and note readback", () => {
     expect(notesQuery?.getAll("session_ids")).toEqual(["session-123"]);
     expect(notesQuery?.getAll("include_annotation_names")).toEqual(["note"]);
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
     expect(parsedOutput[0].annotations).toEqual([
       expect.objectContaining({ id: "session-annotation-1", name: "reviewer" }),
@@ -630,8 +595,7 @@ describe("session annotation and note readback", () => {
       )
     );
     const annotationReads = useSessionAnnotationReads();
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [

--- a/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
+++ b/js/packages/phoenix-cli/test/sessionAnnotationsNotes.test.ts
@@ -1,187 +1,155 @@
+import type { componentsV1 } from "@arizeai/phoenix-testing";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createSessionCommand } from "../src/commands/session";
 import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
 
-function makeFetchMock(
-  responses: Array<
-    | {
-        ok: boolean;
-        status?: number;
-        body?: unknown;
-        text?: string;
-        headers?: Record<string, string>;
-      }
-    | { error: Error }
-  >
-) {
-  let callIndex = 0;
-  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
-    const response = responses[callIndex++] ?? responses[responses.length - 1];
-    if ("error" in response) {
-      return Promise.reject(response.error);
-    }
-    const status = response.status ?? (response.ok ? 200 : 500);
-    const url =
-      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
-    const body = response.body ?? {};
-    const text = response.text ?? JSON.stringify(body);
-    return Promise.resolve({
-      ok: response.ok,
-      status,
-      statusText: response.ok ? "OK" : "Error",
-      url,
-      headers: new Headers(response.headers),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(text),
-    });
-  });
-}
-
-function getFetchUrl(arg: unknown): string {
-  if (arg instanceof Request) return arg.url;
-  return String(arg);
-}
-
-function getFetchMethod(arg: unknown, init?: RequestInit): string {
-  if (arg instanceof Request) return arg.method;
-  return init?.method ?? "GET";
-}
-
-async function getFetchBody(
-  arg: unknown,
-  init?: RequestInit
-): Promise<unknown> {
-  if (arg instanceof Request) {
-    const text = await arg.clone().text();
-    return text ? JSON.parse(text) : undefined;
-  }
-  if (typeof init?.body === "string") {
-    return JSON.parse(init.body);
-  }
-  return undefined;
-}
-
-function makeProjectResponse() {
-  return {
-    ok: true,
-    body: {
-      data: {
-        id: "project-default",
-      },
-    },
-  } as const;
-}
-
-function makeSessionResponse() {
-  return {
-    ok: true,
-    body: {
-      data: {
-        id: "U2Vzc2lvbjox",
-        session_id: "session-123",
-        project_id: "project-default",
-        start_time: "2026-01-13T10:00:00.000Z",
-        end_time: "2026-01-13T10:01:00.000Z",
-        traces: [],
-      },
-    },
-  } as const;
-}
-
-function makeSessionPageResponse() {
-  return {
-    ok: true,
-    body: {
-      data: [
-        {
-          id: "U2Vzc2lvbjox",
-          session_id: "session-123",
-          project_id: "project-default",
-          start_time: "2026-01-13T10:00:00.000Z",
-          end_time: "2026-01-13T10:01:00.000Z",
-          traces: [],
-        },
-      ],
-      next_cursor: null,
-    },
-  } as const;
-}
-
-function makeSessionAnnotationResponse() {
-  return {
-    ok: true,
-    body: {
-      data: [
-        {
-          id: "session-annotation-1",
-          created_at: "2026-01-13T10:00:00.500Z",
-          updated_at: "2026-01-13T10:00:00.500Z",
-          source: "API",
-          user_id: null,
-          name: "reviewer",
-          annotator_kind: "HUMAN",
-          result: {
-            label: "pass",
-          },
-          metadata: null,
-          identifier: "",
-          session_id: "session-123",
-        },
-      ],
-      next_cursor: null,
-    },
-  } as const;
-}
-
-function makeSessionNoteResponse() {
-  return {
-    ok: true,
-    body: {
-      data: [
-        {
-          id: "session-note-1",
-          created_at: "2026-01-13T10:00:00.750Z",
-          updated_at: "2026-01-13T10:00:00.750Z",
-          source: "API",
-          user_id: null,
-          name: "note",
-          annotator_kind: "HUMAN",
-          result: {
-            explanation: "session note text",
-          },
-          metadata: null,
-          identifier: "px-session-note:1",
-          session_id: "session-123",
-        },
-      ],
-      next_cursor: null,
-    },
-  } as const;
-}
+const mock = setupMockPhoenixServer();
 
 const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
-const SERVER_VERSION_RESPONSE = {
-  ok: true,
-  text: "14.17.0",
-} as const;
+
+const SESSION_FIXTURE: componentsV1["schemas"]["SessionData"] = {
+  id: "U2Vzc2lvbjox",
+  session_id: "session-123",
+  project_id: "project-default",
+  start_time: "2026-01-13T10:00:00.000Z",
+  end_time: "2026-01-13T10:01:00.000Z",
+  traces: [],
+};
+
+const SESSION_ANNOTATION_FIXTURE: componentsV1["schemas"]["SessionAnnotation"] =
+  {
+    id: "session-annotation-1",
+    created_at: "2026-01-13T10:00:00.500Z",
+    updated_at: "2026-01-13T10:00:00.500Z",
+    source: "API",
+    user_id: null,
+    name: "reviewer",
+    annotator_kind: "HUMAN",
+    result: {
+      label: "pass",
+    },
+    metadata: null,
+    identifier: "",
+    session_id: "session-123",
+  };
+
+const SESSION_NOTE_FIXTURE: componentsV1["schemas"]["SessionAnnotation"] = {
+  id: "session-note-1",
+  created_at: "2026-01-13T10:00:00.750Z",
+  updated_at: "2026-01-13T10:00:00.750Z",
+  source: "API",
+  user_id: null,
+  name: "note",
+  annotator_kind: "HUMAN",
+  result: {
+    explanation: "session note text",
+  },
+  metadata: null,
+  identifier: "px-session-note:1",
+  session_id: "session-123",
+};
+
+/**
+ * Answer session lookups with the standard session fixture and record how
+ * many lookups happened and the last identifier requested.
+ */
+function useSessionLookup() {
+  const captured: { count: number; sessionIdentifier?: string } = { count: 0 };
+  mock.server.use(
+    http.get("/v1/sessions/{session_identifier}", ({ params, response }) => {
+      captured.count += 1;
+      captured.sessionIdentifier = params.session_identifier;
+      return response(200).json({ data: SESSION_FIXTURE });
+    })
+  );
+  return captured;
+}
+
+/**
+ * Report the given Phoenix server version. The endpoint returns the version
+ * string as plain text, which is not expressible via the typed JSON helper.
+ */
+function useServerVersion(version: string) {
+  const captured = { count: 0 };
+  mock.server.use(
+    http.get("/arize_phoenix_version", ({ response }) => {
+      captured.count += 1;
+      return response.untyped(new Response(version, { status: 200 }));
+    })
+  );
+  return captured;
+}
+
+/** Pin project-name resolution to a stable project ID. */
+function useProjectResolution() {
+  mock.server.use(
+    http.get("/v1/projects/{project_identifier}", ({ response }) =>
+      response(200).json({
+        data: { id: "project-default", name: "default" },
+      })
+    )
+  );
+}
+
+/**
+ * Answer session-annotation reads, serving `notes` when the request filters
+ * to the note annotation name and `annotations` otherwise. Records each
+ * request's project identifier and query string in arrival order.
+ */
+function useSessionAnnotationReads({
+  annotations = [],
+  notes = [],
+}: {
+  annotations?: componentsV1["schemas"]["SessionAnnotation"][];
+  notes?: componentsV1["schemas"]["SessionAnnotation"][];
+} = {}) {
+  const captured: {
+    projectIdentifiers: string[];
+    queries: URLSearchParams[];
+  } = { projectIdentifiers: [], queries: [] };
+
+  mock.server.use(
+    http.get(
+      "/v1/projects/{project_identifier}/session_annotations",
+      ({ params, request, response }) => {
+        const query = new URL(request.url).searchParams;
+        captured.projectIdentifiers.push(params.project_identifier);
+        captured.queries.push(query);
+        const isNoteRead = query
+          .getAll("include_annotation_names")
+          .includes("note");
+        return response(200).json({
+          data: isNoteRead ? notes : annotations,
+          next_cursor: null,
+        });
+      }
+    )
+  );
+
+  return captured;
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.unstubAllGlobals();
 });
 
 describe("session annotate", () => {
   it("resolves a session and posts a sync session annotation", async () => {
-    const fetchMock = makeFetchMock([
-      makeSessionResponse(),
-      SERVER_VERSION_RESPONSE,
-      {
-        ok: true,
-        body: { data: [{ id: "session-annotation-1" }] },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const sessionLookup = useSessionLookup();
+    useServerVersion("14.17.0");
+    const posted: { query?: URLSearchParams; body?: unknown } = {};
+    mock.server.use(
+      http.post("/v1/session_annotations", async ({ request, response }) => {
+        posted.query = new URL(request.url).searchParams;
+        posted.body = await request.clone().json();
+        return response(200).json({
+          data: [{ id: "session-annotation-1" }],
+        });
+      })
+    );
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -200,19 +168,9 @@ describe("session annotate", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
-      "/v1/sessions/U2Vzc2lvbjox"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "/v1/session_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain("sync=true");
-    expect(
-      getFetchMethod(fetchMock.mock.calls[2][0], fetchMock.mock.calls[2][1])
-    ).toBe("POST");
-    await expect(
-      getFetchBody(fetchMock.mock.calls[2][0], fetchMock.mock.calls[2][1])
-    ).resolves.toEqual({
+    expect(sessionLookup.sessionIdentifier).toBe("U2Vzc2lvbjox");
+    expect(posted.query?.get("sync")).toBe("true");
+    expect(posted.body).toEqual({
       data: [
         {
           session_id: "session-123",
@@ -240,8 +198,7 @@ describe("session annotate", () => {
   });
 
   it("validates missing annotation names before network calls", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -257,15 +214,14 @@ describe("session annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sessionLookup.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining("Missing required flag --name.")
     );
   });
 
   it("validates invalid scores before network calls", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -289,7 +245,7 @@ describe("session annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sessionLookup.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "Invalid value for --score: nope. Expected a finite number."
@@ -298,8 +254,7 @@ describe("session annotate", () => {
   });
 
   it("validates empty annotation results before network calls", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -315,7 +270,7 @@ describe("session annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sessionLookup.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "At least one of --label, --score, or --explanation must be provided."
@@ -324,8 +279,7 @@ describe("session annotate", () => {
   });
 
   it("validates invalid annotator kinds before network calls", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -351,23 +305,26 @@ describe("session annotate", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sessionLookup.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining("Invalid value for --annotator-kind: bot")
     );
   });
 
   it("reports API errors from session annotation", async () => {
-    const fetchMock = makeFetchMock([
-      makeSessionResponse(),
-      SERVER_VERSION_RESPONSE,
-      {
-        ok: false,
-        status: 400,
-        body: { detail: "The name 'note' is reserved for session notes." },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useSessionLookup();
+    useServerVersion("14.17.0");
+    mock.server.use(
+      // 400 is not part of the OpenAPI spec for this operation.
+      http.post("/v1/session_annotations", ({ response }) =>
+        response.untyped(
+          HttpResponse.json(
+            { detail: "The name 'note' is reserved for session notes." },
+            { status: 400 }
+          )
+        )
+      )
+    );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -399,15 +356,15 @@ describe("session annotate", () => {
 
 describe("session add-note", () => {
   it("resolves a session and posts a session note", async () => {
-    const fetchMock = makeFetchMock([
-      makeSessionResponse(),
-      SERVER_VERSION_RESPONSE,
-      {
-        ok: true,
-        body: { data: { id: "session-note-1" } },
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    const sessionLookup = useSessionLookup();
+    const serverVersion = useServerVersion("14.17.0");
+    const posted: { body?: unknown } = {};
+    mock.server.use(
+      http.post("/v1/session_notes", async ({ request, response }) => {
+        posted.body = await request.clone().json();
+        return response(200).json({ data: { id: "session-note-1" } });
+      })
+    );
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -424,18 +381,9 @@ describe("session add-note", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
-      "/v1/sessions/U2Vzc2lvbjox"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
-      "/arize_phoenix_version"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "/v1/session_notes"
-    );
-    await expect(
-      getFetchBody(fetchMock.mock.calls[2][0], fetchMock.mock.calls[2][1])
-    ).resolves.toEqual({
+    expect(sessionLookup.sessionIdentifier).toBe("U2Vzc2lvbjox");
+    expect(serverVersion.count).toBe(1);
+    expect(posted.body).toEqual({
       data: {
         session_id: "session-123",
         note: "needs review",
@@ -452,8 +400,7 @@ describe("session add-note", () => {
   });
 
   it("validates blank note text before network calls", async () => {
-    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
-    vi.stubGlobal("fetch", fetchMock);
+    const sessionLookup = useSessionLookup();
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -469,7 +416,7 @@ describe("session add-note", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sessionLookup.count).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "Invalid value for --text: <empty>. Expected non-empty text."
@@ -478,14 +425,15 @@ describe("session add-note", () => {
   });
 
   it("fails fast on older Phoenix servers", async () => {
-    const fetchMock = makeFetchMock([
-      makeSessionResponse(),
-      {
-        ok: true,
-        text: "14.16.0",
-      },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useSessionLookup();
+    useServerVersion("14.16.0");
+    let noteRequestCount = 0;
+    mock.server.use(
+      http.post("/v1/session_notes", ({ response }) => {
+        noteRequestCount += 1;
+        return response(200).json({ data: { id: "unreachable" } });
+      })
+    );
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
@@ -509,6 +457,7 @@ describe("session add-note", () => {
     ).rejects.toThrow();
 
     expect(exitSpy).toHaveBeenCalled();
+    expect(noteRequestCount).toBe(0);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining("requires Phoenix server >= 14.17.0")
     );
@@ -517,11 +466,10 @@ describe("session add-note", () => {
 
 describe("session annotation and note readback", () => {
   it("includes notes in session get raw output when requested", async () => {
-    const fetchMock = makeFetchMock([
-      makeSessionResponse(),
-      makeSessionNoteResponse(),
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useSessionLookup();
+    const annotationReads = useSessionAnnotationReads({
+      notes: [SESSION_NOTE_FIXTURE],
+    });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -537,12 +485,10 @@ describe("session annotation and note readback", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
-      "/v1/projects/project-default/session_annotations"
-    );
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
-      "include_annotation_names=note"
-    );
+    expect(annotationReads.projectIdentifiers).toEqual(["project-default"]);
+    expect(
+      annotationReads.queries[0]?.getAll("include_annotation_names")
+    ).toEqual(["note"]);
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
@@ -553,11 +499,10 @@ describe("session annotation and note readback", () => {
   });
 
   it("excludes notes from session get annotations", async () => {
-    const fetchMock = makeFetchMock([
-      makeSessionResponse(),
-      makeSessionAnnotationResponse(),
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useSessionLookup();
+    const annotationReads = useSessionAnnotationReads({
+      annotations: [SESSION_ANNOTATION_FIXTURE],
+    });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -573,9 +518,9 @@ describe("session annotation and note readback", () => {
       { from: "user" }
     );
 
-    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
-      "exclude_annotation_names=note"
-    );
+    expect(
+      annotationReads.queries[0]?.getAll("exclude_annotation_names")
+    ).toEqual(["note"]);
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
@@ -589,13 +534,13 @@ describe("session annotation and note readback", () => {
   });
 
   it("renders requested empty annotation and note columns in session list pretty output", async () => {
-    const fetchMock = makeFetchMock([
-      makeProjectResponse(),
-      makeSessionPageResponse(),
-      { ok: true, body: { data: [], next_cursor: null } },
-      { ok: true, body: { data: [], next_cursor: null } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectResolution();
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/sessions", ({ response }) =>
+        response(200).json({ data: [SESSION_FIXTURE], next_cursor: null })
+      )
+    );
+    useSessionAnnotationReads();
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -617,13 +562,16 @@ describe("session annotation and note readback", () => {
   });
 
   it("includes annotations and notes in session list raw output", async () => {
-    const fetchMock = makeFetchMock([
-      makeProjectResponse(),
-      makeSessionPageResponse(),
-      makeSessionAnnotationResponse(),
-      makeSessionNoteResponse(),
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+    useProjectResolution();
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/sessions", ({ response }) =>
+        response(200).json({ data: [SESSION_FIXTURE], next_cursor: null })
+      )
+    );
+    const annotationReads = useSessionAnnotationReads({
+      annotations: [SESSION_ANNOTATION_FIXTURE],
+      notes: [SESSION_NOTE_FIXTURE],
+    });
     const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -641,20 +589,14 @@ describe("session annotation and note readback", () => {
       { from: "user" }
     );
 
-    const annotationsUrl = new URL(getFetchUrl(fetchMock.mock.calls[2][0]));
-    const notesUrl = new URL(getFetchUrl(fetchMock.mock.calls[3][0]));
-    expect(annotationsUrl.searchParams.getAll("session_ids")).toEqual([
-      "session-123",
-    ]);
-    expect(
-      annotationsUrl.searchParams.getAll("exclude_annotation_names")
-    ).toEqual(["note"]);
-    expect(notesUrl.searchParams.getAll("session_ids")).toEqual([
-      "session-123",
-    ]);
-    expect(notesUrl.searchParams.getAll("include_annotation_names")).toEqual([
+    const annotationsQuery = annotationReads.queries[0];
+    const notesQuery = annotationReads.queries[1];
+    expect(annotationsQuery?.getAll("session_ids")).toEqual(["session-123"]);
+    expect(annotationsQuery?.getAll("exclude_annotation_names")).toEqual([
       "note",
     ]);
+    expect(notesQuery?.getAll("session_ids")).toEqual(["session-123"]);
+    expect(notesQuery?.getAll("include_annotation_names")).toEqual(["note"]);
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
@@ -671,11 +613,10 @@ describe("session annotation and note readback", () => {
       { length: 101 },
       (_, index) => `session-${index + 1}`
     );
-    const fetchMock = makeFetchMock([
-      makeProjectResponse(),
-      {
-        ok: true,
-        body: {
+    useProjectResolution();
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/sessions", ({ response }) =>
+        response(200).json({
           data: sessionIds.map((sessionId, index) => ({
             id: `U2Vzc2lvbjox${index}`,
             session_id: sessionId,
@@ -685,12 +626,10 @@ describe("session annotation and note readback", () => {
             traces: [],
           })),
           next_cursor: null,
-        },
-      },
-      { ok: true, body: { data: [], next_cursor: null } },
-      { ok: true, body: { data: [], next_cursor: null } },
-    ]);
-    vi.stubGlobal("fetch", fetchMock);
+        })
+      )
+    );
+    const annotationReads = useSessionAnnotationReads();
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -709,16 +648,9 @@ describe("session annotation and note readback", () => {
       { from: "user" }
     );
 
-    const firstAnnotationsUrl = new URL(
-      getFetchUrl(fetchMock.mock.calls[2][0])
-    );
-    const secondAnnotationsUrl = new URL(
-      getFetchUrl(fetchMock.mock.calls[3][0])
-    );
-    expect(firstAnnotationsUrl.searchParams.getAll("session_ids")).toHaveLength(
-      100
-    );
-    expect(secondAnnotationsUrl.searchParams.getAll("session_ids")).toEqual([
+    expect(annotationReads.queries).toHaveLength(2);
+    expect(annotationReads.queries[0]?.getAll("session_ids")).toHaveLength(100);
+    expect(annotationReads.queries[1]?.getAll("session_ids")).toEqual([
       "session-101",
     ]);
   });

--- a/js/packages/phoenix-cli/test/sessionCommand.test.ts
+++ b/js/packages/phoenix-cli/test/sessionCommand.test.ts
@@ -1,5 +1,5 @@
 import type { componentsV1 } from "@arizeai/phoenix-testing";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createSessionCommand } from "../src/commands/session";

--- a/js/packages/phoenix-cli/test/sessionCommand.test.ts
+++ b/js/packages/phoenix-cli/test/sessionCommand.test.ts
@@ -5,12 +5,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSessionCommand } from "../src/commands/session";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 type SessionData = componentsV1["schemas"]["SessionData"];
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 // A hex identifier is treated as a project ID directly, skipping the
 // `/v1/projects/{project_identifier}` name-resolution round-trip.
@@ -42,12 +41,6 @@ const SESSION_B: SessionData = {
   traces: [],
 };
 
-function mockProcessExit() {
-  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-    throw new Error(`process.exit:${code}`);
-  }) as never);
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -76,8 +69,7 @@ describe("session list", () => {
         }
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [
@@ -103,7 +95,7 @@ describe("session list", () => {
     expect(capturedQuery?.get("order")).toBe("asc");
     expect(capturedQuery?.get("cursor")).toBeNull();
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const sessions = JSON.parse(String(output));
     expect(sessions).toEqual([SESSION_A, SESSION_B]);
   });
@@ -130,8 +122,7 @@ describe("session list", () => {
         }
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       [
@@ -150,7 +141,7 @@ describe("session list", () => {
     // The per-page limit shrinks to the number of sessions still needed.
     expect(capturedLimits).toEqual(["2", "1"]);
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const sessions = JSON.parse(String(output));
     expect(sessions.map((s: SessionData) => s.session_id)).toEqual([
       "chat-session-001",
@@ -160,8 +151,7 @@ describe("session list", () => {
 
   it("completes end-to-end against the generated OpenAPI handlers", async () => {
     // No pinned handlers: every response comes from the schema-generated mocks.
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await createSessionCommand().parseAsync(
@@ -178,7 +168,7 @@ describe("session list", () => {
     );
 
     expect(exitSpy).not.toHaveBeenCalled();
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const sessions = JSON.parse(String(output));
     expect(Array.isArray(sessions)).toBe(true);
     expect(sessions.length).toBeGreaterThan(0);
@@ -195,8 +185,7 @@ describe("session get", () => {
         return response(200).json({ data: SESSION_A });
       })
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSessionCommand().parseAsync(
       ["get", "chat-session-001", "--format", "raw", ...BASE_ARGS],
@@ -204,7 +193,7 @@ describe("session get", () => {
     );
 
     expect(capturedIdentifier).toBe("chat-session-001");
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(output));
     expect(parsed).toEqual({ session: SESSION_A });
   });
@@ -215,8 +204,7 @@ describe("session get", () => {
         response(404).text("Session not found")
       )
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -227,7 +215,7 @@ describe("session get", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
-    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+    expect(String(io.stderr.mock.calls[0]?.[0])).toContain(
       "Error fetching session"
     );
   });
@@ -236,8 +224,7 @@ describe("session get", () => {
     mock.server.use(
       http.get("/v1/sessions/{session_identifier}", () => HttpResponse.error())
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -248,7 +235,7 @@ describe("session get", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
-    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+    expect(String(io.stderr.mock.calls[0]?.[0])).toContain(
       "Error fetching session"
     );
   });

--- a/js/packages/phoenix-cli/test/sessionCommand.test.ts
+++ b/js/packages/phoenix-cli/test/sessionCommand.test.ts
@@ -1,0 +1,255 @@
+import type { componentsV1 } from "@arizeai/phoenix-testing";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSessionCommand } from "../src/commands/session";
+import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
+
+type SessionData = componentsV1["schemas"]["SessionData"];
+
+const mock = setupMockPhoenixServer();
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+// A hex identifier is treated as a project ID directly, skipping the
+// `/v1/projects/{project_identifier}` name-resolution round-trip.
+const PROJECT_ID = "cafe0123";
+const PROJECT_ARGS = ["--project", PROJECT_ID];
+
+const SESSION_A: SessionData = {
+  id: "U2Vzc2lvbjox",
+  session_id: "chat-session-001",
+  project_id: PROJECT_ID,
+  start_time: "2026-07-01T00:00:00.000Z",
+  end_time: "2026-07-01T00:05:00.000Z",
+  traces: [
+    {
+      id: "VHJhY2U6MQ==",
+      trace_id: "0123456789abcdef0123456789abcdef",
+      start_time: "2026-07-01T00:00:00.000Z",
+      end_time: "2026-07-01T00:01:00.000Z",
+    },
+  ],
+};
+
+const SESSION_B: SessionData = {
+  id: "U2Vzc2lvbjoy",
+  session_id: "chat-session-002",
+  project_id: PROJECT_ID,
+  start_time: "2026-07-01T01:00:00.000Z",
+  end_time: "2026-07-01T01:02:00.000Z",
+  traces: [],
+};
+
+function mockProcessExit() {
+  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit:${code}`);
+  }) as never);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("session list", () => {
+  it("resolves a project name and propagates limit and order in raw mode", async () => {
+    let capturedResolutionIdentifier: string | undefined;
+    let capturedSessionsProject: string | undefined;
+    let capturedQuery: URLSearchParams | undefined;
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}", ({ params, response }) => {
+        capturedResolutionIdentifier = params.project_identifier;
+        return response(200).json({
+          data: { id: PROJECT_ID, name: "demo", description: null },
+        });
+      }),
+      http.get(
+        "/v1/projects/{project_identifier}/sessions",
+        ({ params, request, response }) => {
+          capturedSessionsProject = params.project_identifier;
+          capturedQuery = new URL(request.url).searchParams;
+          return response(200).json({
+            data: [SESSION_A, SESSION_B],
+            next_cursor: null,
+          });
+        }
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "list",
+        "--format",
+        "raw",
+        "--limit",
+        "5",
+        "--order",
+        "asc",
+        "--project",
+        "demo",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    // The non-hex project name is resolved to an ID first, and the sessions
+    // request is made against the resolved ID.
+    expect(capturedResolutionIdentifier).toBe("demo");
+    expect(capturedSessionsProject).toBe(PROJECT_ID);
+    expect(capturedQuery?.get("limit")).toBe("5");
+    expect(capturedQuery?.get("order")).toBe("asc");
+    expect(capturedQuery?.get("cursor")).toBeNull();
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const sessions = JSON.parse(String(output));
+    expect(sessions).toEqual([SESSION_A, SESSION_B]);
+  });
+
+  it("follows next_cursor across pages until --limit is reached", async () => {
+    const capturedCursors: Array<string | null> = [];
+    const capturedLimits: Array<string | null> = [];
+    let page = 0;
+    mock.server.use(
+      http.get(
+        "/v1/projects/{project_identifier}/sessions",
+        ({ request, response }) => {
+          const query = new URL(request.url).searchParams;
+          capturedCursors.push(query.get("cursor"));
+          capturedLimits.push(query.get("limit"));
+          page += 1;
+          if (page === 1) {
+            return response(200).json({
+              data: [SESSION_A],
+              next_cursor: "cursor-page-2",
+            });
+          }
+          return response(200).json({ data: [SESSION_B], next_cursor: null });
+        }
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      [
+        "list",
+        "--format",
+        "raw",
+        "--limit",
+        "2",
+        ...PROJECT_ARGS,
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(capturedCursors).toEqual([null, "cursor-page-2"]);
+    // The per-page limit shrinks to the number of sessions still needed.
+    expect(capturedLimits).toEqual(["2", "1"]);
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const sessions = JSON.parse(String(output));
+    expect(sessions.map((s: SessionData) => s.session_id)).toEqual([
+      "chat-session-001",
+      "chat-session-002",
+    ]);
+  });
+
+  it("completes end-to-end against the generated OpenAPI handlers", async () => {
+    // No pinned handlers: every response comes from the schema-generated mocks.
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await createSessionCommand().parseAsync(
+      [
+        "list",
+        "--format",
+        "raw",
+        "--limit",
+        "2",
+        ...PROJECT_ARGS,
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const sessions = JSON.parse(String(output));
+    expect(Array.isArray(sessions)).toBe(true);
+    expect(sessions.length).toBeGreaterThan(0);
+    expect(typeof sessions[0].session_id).toBe("string");
+  });
+});
+
+describe("session get", () => {
+  it("outputs the session wrapped in a `session` envelope in raw mode", async () => {
+    let capturedIdentifier: string | undefined;
+    mock.server.use(
+      http.get("/v1/sessions/{session_identifier}", ({ params, response }) => {
+        capturedIdentifier = params.session_identifier;
+        return response(200).json({ data: SESSION_A });
+      })
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSessionCommand().parseAsync(
+      ["get", "chat-session-001", "--format", "raw", ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    expect(capturedIdentifier).toBe("chat-session-001");
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsed = JSON.parse(String(output));
+    expect(parsed).toEqual({ session: SESSION_A });
+  });
+
+  it("exits FAILURE with an error on stderr when the session is not found", async () => {
+    mock.server.use(
+      http.get("/v1/sessions/{session_identifier}", ({ response }) =>
+        response(404).text("Session not found")
+      )
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createSessionCommand().parseAsync(
+        ["get", "missing-session", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+      "Error fetching session"
+    );
+  });
+
+  it("exits NETWORK_ERROR when the request fails at the network level", async () => {
+    mock.server.use(
+      http.get("/v1/sessions/{session_identifier}", () => HttpResponse.error())
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createSessionCommand().parseAsync(
+        ["get", "chat-session-001", "--format", "raw", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+      "Error fetching session"
+    );
+  });
+});

--- a/js/packages/phoenix-cli/test/spanCommand.test.ts
+++ b/js/packages/phoenix-cli/test/spanCommand.test.ts
@@ -1,16 +1,15 @@
-import type { componentsV1 } from "@arizeai/phoenix-client";
+import type { componentsV1 } from "@arizeai/phoenix-testing";
 import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createSpanCommand } from "../src/commands/span";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 type Span = componentsV1["schemas"]["Span"];
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 // A hex identifier is treated as a project ID directly, skipping the
 // `/v1/projects/{project_identifier}` name-resolution round-trip.
@@ -47,12 +46,6 @@ const TOOL_SPAN: Span = {
   events: [],
 };
 
-function mockProcessExit() {
-  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-    throw new Error(`process.exit:${code}`);
-  }) as never);
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -74,8 +67,7 @@ describe("span list", () => {
         }
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -103,7 +95,7 @@ describe("span list", () => {
     expect(capturedQuery?.getAll("trace_id")).toEqual([TRACE_ID]);
     expect(capturedQuery?.get("parent_id")).toBe("null");
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const spans = JSON.parse(String(output));
     expect(spans).toHaveLength(2);
     expect(spans[0].name).toBe("chat_completion");
@@ -134,8 +126,7 @@ describe("span list", () => {
         }
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createSpanCommand().parseAsync(
       [
@@ -151,7 +142,7 @@ describe("span list", () => {
     );
 
     expect(capturedCursors).toEqual([null, "cursor-page-2"]);
-    const spans = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const spans = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     // 3 spans came back across pages; --limit 2 truncates client-side
     expect(spans).toHaveLength(2);
     expect(spans.map((span: Span) => span.name)).toEqual([
@@ -166,8 +157,7 @@ describe("span list", () => {
         response(404).text("Project not found")
       )
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -178,7 +168,7 @@ describe("span list", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
-    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+    expect(String(io.stderr.mock.calls[0]?.[0])).toContain(
       "Error fetching spans"
     );
   });
@@ -189,8 +179,7 @@ describe("span list", () => {
         HttpResponse.error()
       )
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -201,15 +190,14 @@ describe("span list", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
-    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+    expect(String(io.stderr.mock.calls[0]?.[0])).toContain(
       "Error fetching spans"
     );
   });
 
   it("completes end-to-end against the generated OpenAPI handlers", async () => {
     // No pinned handlers: every response comes from the schema-generated mocks.
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await createSpanCommand().parseAsync(
@@ -226,7 +214,7 @@ describe("span list", () => {
     );
 
     expect(exitSpy).not.toHaveBeenCalled();
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const spans = JSON.parse(String(output));
     expect(Array.isArray(spans)).toBe(true);
     expect(spans.length).toBeGreaterThan(0);

--- a/js/packages/phoenix-cli/test/spanCommand.test.ts
+++ b/js/packages/phoenix-cli/test/spanCommand.test.ts
@@ -1,0 +1,241 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSpanCommand } from "../src/commands/span";
+import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
+
+type Span = componentsV1["schemas"]["Span"];
+
+const mock = setupMockPhoenixServer();
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+// A hex identifier is treated as a project ID directly, skipping the
+// `/v1/projects/{project_identifier}` name-resolution round-trip.
+const PROJECT_ID = "cafe0123";
+const PROJECT_ARGS = ["--project", PROJECT_ID];
+
+const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+const LLM_SPAN: Span = {
+  id: "U3BhbjoxMjM=",
+  name: "chat_completion",
+  context: { trace_id: TRACE_ID, span_id: "aaaa000000000001" },
+  span_kind: "LLM",
+  parent_id: null,
+  start_time: "2026-07-01T00:00:00.000Z",
+  end_time: "2026-07-01T00:00:01.000Z",
+  status_code: "ERROR",
+  status_message: "rate limited",
+  attributes: { "llm.model_name": "gpt-4" },
+  events: [],
+};
+
+const TOOL_SPAN: Span = {
+  id: "U3BhbjoxMjQ=",
+  name: "search_tool",
+  context: { trace_id: TRACE_ID, span_id: "aaaa000000000002" },
+  span_kind: "TOOL",
+  parent_id: "aaaa000000000001",
+  start_time: "2026-07-01T00:00:00.100Z",
+  end_time: "2026-07-01T00:00:00.400Z",
+  status_code: "OK",
+  status_message: "",
+  attributes: {},
+  events: [],
+};
+
+function mockProcessExit() {
+  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit:${code}`);
+  }) as never);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("span list", () => {
+  it("outputs pinned spans in raw mode and propagates path, limit, and filter params", async () => {
+    let capturedProjectIdentifier: string | undefined;
+    let capturedQuery: URLSearchParams | undefined;
+    mock.server.use(
+      http.get(
+        "/v1/projects/{project_identifier}/spans",
+        ({ params, request, response }) => {
+          capturedProjectIdentifier = params.project_identifier;
+          capturedQuery = new URL(request.url).searchParams;
+          return response(200).json({
+            data: [LLM_SPAN, TOOL_SPAN],
+            next_cursor: null,
+          });
+        }
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSpanCommand().parseAsync(
+      [
+        "list",
+        "--format",
+        "raw",
+        "--limit",
+        "50",
+        "--status-code",
+        "ERROR",
+        "--trace-id",
+        TRACE_ID,
+        "--parent-id",
+        "null",
+        ...PROJECT_ARGS,
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(capturedProjectIdentifier).toBe(PROJECT_ID);
+    // span list pages at min(limit, 1000), so --limit 50 is sent verbatim
+    expect(capturedQuery?.get("limit")).toBe("50");
+    expect(capturedQuery?.getAll("status_code")).toEqual(["ERROR"]);
+    expect(capturedQuery?.getAll("trace_id")).toEqual([TRACE_ID]);
+    expect(capturedQuery?.get("parent_id")).toBe("null");
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const spans = JSON.parse(String(output));
+    expect(spans).toHaveLength(2);
+    expect(spans[0].name).toBe("chat_completion");
+    expect(spans[0].status_code).toBe("ERROR");
+    expect(spans[0].attributes["llm.model_name"]).toBe("gpt-4");
+    expect(spans[1].context.span_id).toBe("aaaa000000000002");
+  });
+
+  it("follows the pagination cursor and truncates client-side to --limit", async () => {
+    const capturedCursors: (string | null)[] = [];
+    let page = 0;
+    mock.server.use(
+      http.get(
+        "/v1/projects/{project_identifier}/spans",
+        ({ request, response }) => {
+          capturedCursors.push(new URL(request.url).searchParams.get("cursor"));
+          page += 1;
+          if (page === 1) {
+            return response(200).json({
+              data: [LLM_SPAN],
+              next_cursor: "cursor-page-2",
+            });
+          }
+          return response(200).json({
+            data: [TOOL_SPAN, { ...TOOL_SPAN, name: "extra_span" }],
+            next_cursor: null,
+          });
+        }
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSpanCommand().parseAsync(
+      [
+        "list",
+        "--format",
+        "raw",
+        "--limit",
+        "2",
+        ...PROJECT_ARGS,
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(capturedCursors).toEqual([null, "cursor-page-2"]);
+    const spans = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    // 3 spans came back across pages; --limit 2 truncates client-side
+    expect(spans).toHaveLength(2);
+    expect(spans.map((span: Span) => span.name)).toEqual([
+      "chat_completion",
+      "search_tool",
+    ]);
+  });
+
+  it("exits FAILURE with an error on stderr when the server returns 404", async () => {
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/spans", ({ response }) =>
+        response(404).text("Project not found")
+      )
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createSpanCommand().parseAsync(
+        ["list", "--format", "raw", ...PROJECT_ARGS, ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+      "Error fetching spans"
+    );
+  });
+
+  it("exits NETWORK_ERROR when the request fails at the network level", async () => {
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/spans", () =>
+        HttpResponse.error()
+      )
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createSpanCommand().parseAsync(
+        ["list", "--format", "raw", ...PROJECT_ARGS, ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+      "Error fetching spans"
+    );
+  });
+
+  it("completes end-to-end against the generated OpenAPI handlers", async () => {
+    // No pinned handlers: every response comes from the schema-generated mocks.
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await createSpanCommand().parseAsync(
+      [
+        "list",
+        "--format",
+        "raw",
+        "--limit",
+        "3",
+        ...PROJECT_ARGS,
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const spans = JSON.parse(String(output));
+    expect(Array.isArray(spans)).toBe(true);
+    expect(spans.length).toBeGreaterThan(0);
+    // --limit is honored even for generated pages (client-side truncation)
+    expect(spans.length).toBeLessThanOrEqual(3);
+    for (const span of spans) {
+      expect(Array.isArray(span)).toBe(false);
+      expect(typeof span.context.trace_id).toBe("string");
+      expect(typeof span.context.span_id).toBe("string");
+    }
+  });
+});

--- a/js/packages/phoenix-cli/test/spanCommand.test.ts
+++ b/js/packages/phoenix-cli/test/spanCommand.test.ts
@@ -1,5 +1,5 @@
 import type { componentsV1 } from "@arizeai/phoenix-client";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createSpanCommand } from "../src/commands/span";

--- a/js/packages/phoenix-cli/test/testUtils.ts
+++ b/js/packages/phoenix-cli/test/testUtils.ts
@@ -1,0 +1,36 @@
+import { DEFAULT_MOCK_BASE_URL } from "@arizeai/phoenix-testing";
+import { vi } from "vitest";
+
+/**
+ * Connection args pointing a command under test at the mock Phoenix server,
+ * with progress output suppressed. Extend per-file when a command needs more:
+ * `[...BASE_ARGS, "--yes"]`.
+ */
+export const BASE_ARGS = ["--endpoint", DEFAULT_MOCK_BASE_URL, "--no-progress"];
+
+/**
+ * Replace `process.exit` with a spy that throws `process.exit:<code>` so a
+ * command's exit path can be asserted with
+ * `rejects.toThrow(`process.exit:${ExitCode.FAILURE}`)` and
+ * `expect(exitSpy).toHaveBeenCalledWith(...)`. Restored by
+ * `vi.restoreAllMocks()`.
+ */
+export function mockProcessExit() {
+  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit:${code}`);
+  }) as never);
+}
+
+/**
+ * Silence and capture the CLI's stdout/stderr for the current test. The CLI
+ * writes data to stdout via `console.log` and errors/progress to stderr via
+ * `console.error` (see `src/io.ts`), so tests assert on
+ * `io.stdout.mock.calls` / `io.stderr.mock.calls`. Restored by
+ * `vi.restoreAllMocks()`.
+ */
+export function captureCliOutput() {
+  return {
+    stdout: vi.spyOn(console, "log").mockImplementation(() => {}),
+    stderr: vi.spyOn(console, "error").mockImplementation(() => {}),
+  };
+}

--- a/js/packages/phoenix-cli/test/traceCommand.test.ts
+++ b/js/packages/phoenix-cli/test/traceCommand.test.ts
@@ -1,5 +1,5 @@
 import type { componentsV1 } from "@arizeai/phoenix-client";
-import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createTraceCommand } from "../src/commands/trace";

--- a/js/packages/phoenix-cli/test/traceCommand.test.ts
+++ b/js/packages/phoenix-cli/test/traceCommand.test.ts
@@ -1,16 +1,15 @@
-import type { componentsV1 } from "@arizeai/phoenix-client";
+import type { componentsV1 } from "@arizeai/phoenix-testing";
 import { HttpResponse } from "@arizeai/phoenix-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createTraceCommand } from "../src/commands/trace";
 import { ExitCode } from "../src/exitCodes";
 import { http, setupMockPhoenixServer } from "./mockServer";
+import { BASE_ARGS, captureCliOutput, mockProcessExit } from "./testUtils";
 
 type Span = componentsV1["schemas"]["Span"];
 
 const mock = setupMockPhoenixServer();
-
-const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
 
 // A hex identifier is treated as a project ID directly, skipping the
 // `/v1/projects/{project_identifier}` name-resolution round-trip.
@@ -47,12 +46,6 @@ const CHILD_SPAN: Span = {
   events: [],
 };
 
-function mockProcessExit() {
-  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-    throw new Error(`process.exit:${code}`);
-  }) as never);
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -74,8 +67,7 @@ describe("trace list", () => {
         }
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -99,7 +91,7 @@ describe("trace list", () => {
     expect(capturedQuery?.get("start_time")).toBe("2026-07-01T00:00:00Z");
     expect(capturedQuery?.get("cursor")).toBeNull();
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const traces = JSON.parse(String(output));
     expect(traces).toHaveLength(1);
     expect(traces[0].traceId).toBe(TRACE_ID);
@@ -116,8 +108,7 @@ describe("trace list", () => {
         response(404).text("Project not found")
       )
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -128,7 +119,7 @@ describe("trace list", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
-    const stderrCall = stderrSpy.mock.calls[0]?.[0];
+    const stderrCall = io.stderr.mock.calls[0]?.[0];
     expect(String(stderrCall)).toContain("Error fetching traces");
   });
 
@@ -138,8 +129,7 @@ describe("trace list", () => {
         HttpResponse.error()
       )
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -150,7 +140,7 @@ describe("trace list", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
-    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+    expect(String(io.stderr.mock.calls[0]?.[0])).toContain(
       "Error fetching traces"
     );
   });
@@ -158,8 +148,7 @@ describe("trace list", () => {
   it("completes end-to-end against the generated OpenAPI handlers", async () => {
     // No pinned handlers: every response comes from the schema-generated
     // mocks, proving the OpenAPI-derived data satisfies trace assembly.
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await createTraceCommand().parseAsync(
@@ -176,7 +165,7 @@ describe("trace list", () => {
     );
 
     expect(exitSpy).not.toHaveBeenCalled();
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const parsed = JSON.parse(String(output));
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed.length).toBeLessThanOrEqual(1);
@@ -196,15 +185,14 @@ describe("trace get", () => {
         })
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       ["get", TRACE_ID, "--format", "raw", ...PROJECT_ARGS, ...BASE_ARGS],
       { from: "user" }
     );
 
-    const output = stdoutSpy.mock.calls[0]?.[0];
+    const output = io.stdout.mock.calls[0]?.[0];
     const trace = JSON.parse(String(output));
     expect(Array.isArray(trace)).toBe(false);
     expect(trace.traceId).toBe(TRACE_ID);
@@ -224,8 +212,7 @@ describe("trace get", () => {
         })
       )
     );
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
 
     await createTraceCommand().parseAsync(
       [
@@ -239,7 +226,7 @@ describe("trace get", () => {
       { from: "user" }
     );
 
-    const trace = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    const trace = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(trace.traceId).toBe(TRACE_ID);
   });
 
@@ -249,8 +236,7 @@ describe("trace get", () => {
         response(200).json({ data: [], next_cursor: null })
       )
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const io = captureCliOutput();
     const exitSpy = mockProcessExit();
 
     await expect(
@@ -268,7 +254,7 @@ describe("trace get", () => {
     ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
-    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+    expect(String(io.stderr.mock.calls[0]?.[0])).toContain(
       "Trace not found: ffffffffffffffff"
     );
   });

--- a/js/packages/phoenix-cli/test/traceCommand.test.ts
+++ b/js/packages/phoenix-cli/test/traceCommand.test.ts
@@ -1,0 +1,275 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+import { HttpResponse } from "@arizeai/phoenix-testing/msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createTraceCommand } from "../src/commands/trace";
+import { ExitCode } from "../src/exitCodes";
+import { http, setupMockPhoenixServer } from "./mockServer";
+
+type Span = componentsV1["schemas"]["Span"];
+
+const mock = setupMockPhoenixServer();
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+// A hex identifier is treated as a project ID directly, skipping the
+// `/v1/projects/{project_identifier}` name-resolution round-trip.
+const PROJECT_ID = "cafe0123";
+const PROJECT_ARGS = ["--project", PROJECT_ID];
+
+const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+const ROOT_SPAN: Span = {
+  id: "U3BhbjoxMjM=",
+  name: "agent_run",
+  context: { trace_id: TRACE_ID, span_id: "aaaa000000000001" },
+  span_kind: "AGENT",
+  parent_id: null,
+  start_time: "2026-07-01T00:00:00.000Z",
+  end_time: "2026-07-01T00:00:02.000Z",
+  status_code: "OK",
+  status_message: "",
+  attributes: { "input.value": "hello", "output.value": "world" },
+  events: [],
+};
+
+const CHILD_SPAN: Span = {
+  id: "U3BhbjoxMjQ=",
+  name: "chat_completion",
+  context: { trace_id: TRACE_ID, span_id: "aaaa000000000002" },
+  span_kind: "LLM",
+  parent_id: "aaaa000000000001",
+  start_time: "2026-07-01T00:00:00.500Z",
+  end_time: "2026-07-01T00:00:01.500Z",
+  status_code: "ERROR",
+  status_message: "boom",
+  attributes: {},
+  events: [],
+};
+
+function mockProcessExit() {
+  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit:${code}`);
+  }) as never);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("trace list", () => {
+  it("outputs traces built from pinned spans in raw mode and propagates request params", async () => {
+    let capturedProjectIdentifier: string | undefined;
+    let capturedQuery: URLSearchParams | undefined;
+    mock.server.use(
+      http.get(
+        "/v1/projects/{project_identifier}/spans",
+        ({ params, request, response }) => {
+          capturedProjectIdentifier = params.project_identifier;
+          capturedQuery = new URL(request.url).searchParams;
+          return response(200).json({
+            data: [ROOT_SPAN, CHILD_SPAN],
+            next_cursor: null,
+          });
+        }
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "list",
+        "--format",
+        "raw",
+        "--limit",
+        "5",
+        "--since",
+        "2026-07-01T00:00:00Z",
+        ...PROJECT_ARGS,
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(capturedProjectIdentifier).toBe(PROJECT_ID);
+    // trace list always pages spans at 1000 regardless of --limit; the
+    // user-facing limit is applied to the assembled traces client-side.
+    expect(capturedQuery?.get("limit")).toBe("1000");
+    expect(capturedQuery?.get("start_time")).toBe("2026-07-01T00:00:00Z");
+    expect(capturedQuery?.get("cursor")).toBeNull();
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const traces = JSON.parse(String(output));
+    expect(traces).toHaveLength(1);
+    expect(traces[0].traceId).toBe(TRACE_ID);
+    expect(traces[0].spans).toHaveLength(2);
+    expect(traces[0].rootSpan.name).toBe("agent_run");
+    // A single ERROR span marks the whole trace as ERROR
+    expect(traces[0].status).toBe("ERROR");
+    expect(traces[0].duration).toBe(2000);
+  });
+
+  it("exits FAILURE with an error on stderr when the server returns 404", async () => {
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/spans", ({ response }) =>
+        response(404).text("Project not found")
+      )
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createTraceCommand().parseAsync(
+        ["list", "--format", "raw", ...PROJECT_ARGS, ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    const stderrCall = stderrSpy.mock.calls[0]?.[0];
+    expect(String(stderrCall)).toContain("Error fetching traces");
+  });
+
+  it("exits NETWORK_ERROR when the request fails at the network level", async () => {
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/spans", () =>
+        HttpResponse.error()
+      )
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createTraceCommand().parseAsync(
+        ["list", "--format", "raw", ...PROJECT_ARGS, ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+      "Error fetching traces"
+    );
+  });
+
+  it("completes end-to-end against the generated OpenAPI handlers", async () => {
+    // No pinned handlers: every response comes from the schema-generated
+    // mocks, proving the OpenAPI-derived data satisfies trace assembly.
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await createTraceCommand().parseAsync(
+      [
+        "list",
+        "--format",
+        "raw",
+        "--limit",
+        "1",
+        ...PROJECT_ARGS,
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const parsed = JSON.parse(String(output));
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeLessThanOrEqual(1);
+    for (const trace of parsed) {
+      expect(typeof trace.traceId).toBe("string");
+    }
+  });
+});
+
+describe("trace get", () => {
+  it("outputs the assembled trace as a bare object in raw mode", async () => {
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/spans", ({ response }) =>
+        response(200).json({
+          data: [ROOT_SPAN, CHILD_SPAN],
+          next_cursor: null,
+        })
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      ["get", TRACE_ID, "--format", "raw", ...PROJECT_ARGS, ...BASE_ARGS],
+      { from: "user" }
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    const trace = JSON.parse(String(output));
+    expect(Array.isArray(trace)).toBe(false);
+    expect(trace.traceId).toBe(TRACE_ID);
+    expect(trace.spans).toHaveLength(2);
+    expect(trace.spans.map((span: Span) => span.name)).toEqual([
+      "agent_run",
+      "chat_completion",
+    ]);
+  });
+
+  it("matches traces by trace ID prefix", async () => {
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/spans", ({ response }) =>
+        response(200).json({
+          data: [ROOT_SPAN, CHILD_SPAN],
+          next_cursor: null,
+        })
+      )
+    );
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "get",
+        TRACE_ID.slice(0, 8),
+        "--format",
+        "raw",
+        ...PROJECT_ARGS,
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    const trace = JSON.parse(String(stdoutSpy.mock.calls[0]?.[0]));
+    expect(trace.traceId).toBe(TRACE_ID);
+  });
+
+  it("exits FAILURE with 'Trace not found' when no spans match", async () => {
+    mock.server.use(
+      http.get("/v1/projects/{project_identifier}/spans", ({ response }) =>
+        response(200).json({ data: [], next_cursor: null })
+      )
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = mockProcessExit();
+
+    await expect(
+      createTraceCommand().parseAsync(
+        [
+          "get",
+          "ffffffffffffffff",
+          "--format",
+          "raw",
+          ...PROJECT_ARGS,
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain(
+      "Trace not found: ffffffffffffffff"
+    );
+  });
+});

--- a/js/packages/phoenix-testing/README.md
+++ b/js/packages/phoenix-testing/README.md
@@ -52,16 +52,16 @@ Handlers passed to `createMockServer({ handlers })` or registered with `server.u
 
 ## API
 
-| Export                                              | Description                                                                             |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `createMockServer({ baseUrl, handlers })` (`/node`) | MSW server for Node.js with generated handlers for every Phoenix endpoint.              |
-| `Server` (`/node`)                                  | The mock server type returned by `createMockServer`.                                    |
-| `createOpenApiHandlers({ baseUrl })`                | The generated MSW request handlers, for composing into your own setup.                  |
-| `createHttp({ baseUrl })`                           | Type-safe `http` namespace for writing custom Phoenix handler overrides.                |
-| `getOpenApiDocument({ baseUrl })`                   | A copy of the workspace's Phoenix OpenAPI document with `servers` pointed at `baseUrl`. |
-| `DEFAULT_MOCK_BASE_URL`                             | `"http://localhost:6006"` — the default base URL handlers are bound to.                 |
-| `pathsV1`, `componentsV1`, `operationsV1`           | OpenAPI types generated from the Phoenix API definition (via `openapi-typescript`).     |
-| `*` (`/msw`)                                        | Re-export of `msw` for raw (non-OpenAPI) handlers, e.g. GraphQL or third-party hosts.   |
+| Export                                              | Description                                                                               |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `createMockServer({ baseUrl, handlers })` (`/node`) | MSW server for Node.js with generated handlers for every Phoenix endpoint.                |
+| `Server` (`/node`)                                  | The mock server type returned by `createMockServer`.                                      |
+| `createOpenApiHandlers({ baseUrl })`                | The generated MSW request handlers, for composing into your own setup.                    |
+| `createHttp({ baseUrl })`                           | Type-safe `http` namespace for writing custom Phoenix handler overrides.                  |
+| `getOpenApiDocument({ baseUrl })`                   | A copy of the workspace's Phoenix OpenAPI document with `servers` pointed at `baseUrl`.   |
+| `DEFAULT_MOCK_BASE_URL`                             | `"http://localhost:6006"` — the default base URL handlers are bound to.                   |
+| `pathsV1`, `componentsV1`, `operationsV1`           | OpenAPI types generated from the Phoenix API definition (via `openapi-typescript`).       |
+| `*` (re-exported `msw`)                             | Everything from `msw`, for raw (non-OpenAPI) handlers, e.g. GraphQL or third-party hosts. |
 
 ## Regenerating the mocks
 

--- a/js/packages/phoenix-testing/README.md
+++ b/js/packages/phoenix-testing/README.md
@@ -61,6 +61,7 @@ Handlers passed to `createMockServer({ handlers })` or registered with `server.u
 | `getOpenApiDocument({ baseUrl })`                   | A copy of the workspace's Phoenix OpenAPI document with `servers` pointed at `baseUrl`. |
 | `DEFAULT_MOCK_BASE_URL`                             | `"http://localhost:6006"` — the default base URL handlers are bound to.                 |
 | `pathsV1`, `componentsV1`, `operationsV1`           | OpenAPI types generated from the Phoenix API definition (via `openapi-typescript`).     |
+| `*` (`/msw`)                                        | Re-export of `msw` for raw (non-OpenAPI) handlers, e.g. GraphQL or third-party hosts.   |
 
 ## Regenerating the mocks
 

--- a/js/packages/phoenix-testing/package.json
+++ b/js/packages/phoenix-testing/package.json
@@ -25,6 +25,11 @@
       "types": "./dist/node.d.ts",
       "import": "./dist/node.js",
       "default": "./dist/node.js"
+    },
+    "./msw": {
+      "types": "./dist/msw.d.ts",
+      "import": "./dist/msw.js",
+      "default": "./dist/msw.js"
     }
   },
   "scripts": {

--- a/js/packages/phoenix-testing/package.json
+++ b/js/packages/phoenix-testing/package.json
@@ -25,11 +25,6 @@
       "types": "./dist/node.d.ts",
       "import": "./dist/node.js",
       "default": "./dist/node.js"
-    },
-    "./msw": {
-      "types": "./dist/msw.d.ts",
-      "import": "./dist/msw.js",
-      "default": "./dist/msw.js"
     }
   },
   "scripts": {

--- a/js/packages/phoenix-testing/src/index.ts
+++ b/js/packages/phoenix-testing/src/index.ts
@@ -1,3 +1,10 @@
+// Re-export `msw` so workspace consumers can write raw (non-OpenAPI)
+// handlers — e.g. for GraphQL or third-party endpoints — without declaring
+// their own `msw` dependency and risking a duplicate interceptor version.
+// Note: msw's untyped `http` namespace is among these exports; prefer
+// `createHttp()` for Phoenix API handlers.
+export * from "msw";
+
 export { DEFAULT_MOCK_BASE_URL } from "./constants.js";
 export { createOpenApiHandlers, getOpenApiDocument } from "./openApi.js";
 export { createHttp } from "./http.js";

--- a/js/packages/phoenix-testing/src/msw.ts
+++ b/js/packages/phoenix-testing/src/msw.ts
@@ -1,7 +1,0 @@
-/**
- * Re-export of the underlying `msw` package so workspace consumers can write
- * raw (non-OpenAPI) handlers — e.g. for GraphQL or third-party endpoints —
- * without declaring their own `msw` dependency and risking a duplicate
- * interceptor version.
- */
-export * from "msw";

--- a/js/packages/phoenix-testing/src/msw.ts
+++ b/js/packages/phoenix-testing/src/msw.ts
@@ -1,0 +1,7 @@
+/**
+ * Re-export of the underlying `msw` package so workspace consumers can write
+ * raw (non-OpenAPI) handlers — e.g. for GraphQL or third-party endpoints —
+ * without declaring their own `msw` dependency and risking a duplicate
+ * interceptor version.
+ */
+export * from "msw";

--- a/js/packages/phoenix-testing/src/openApi.ts
+++ b/js/packages/phoenix-testing/src/openApi.ts
@@ -33,6 +33,36 @@ export function getOpenApiDocument({
 }
 
 /**
+ * `@mswjs/source` understands the OpenAPI `example` keyword but treats the
+ * JSON Schema `examples` keyword (an array of candidate values) as the value
+ * itself, generating an array wherever a schema declares one — e.g. a `Span`
+ * with `examples: [{...}]` yields `Span[]` in place of every `Span`. Rewrite
+ * array-form `examples` to a single `example` so generated responses conform
+ * to the schema. Map-form `examples` (OpenAPI media-type examples) are not
+ * arrays and pass through untouched.
+ */
+function normalizeSchemaExamples(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(normalizeSchemaExamples);
+  }
+  if (node === null || typeof node !== "object") {
+    return node;
+  }
+  const record: Record<string, unknown> = { ...node };
+  if (Array.isArray(record.examples)) {
+    const [firstExample] = record.examples;
+    delete record.examples;
+    if (record.example === undefined && firstExample !== undefined) {
+      record.example = firstExample;
+    }
+  }
+  for (const [key, value] of Object.entries(record)) {
+    record[key] = normalizeSchemaExamples(value);
+  }
+  return record;
+}
+
+/**
  * Create MSW request handlers for every operation in the Phoenix OpenAPI
  * definition. Responses are derived from the response schemas and examples
  * declared in the definition, so they are spec-conformant but contain
@@ -52,7 +82,9 @@ export async function createOpenApiHandlers({
 }: {
   baseUrl?: string;
 } = {}): Promise<RequestHandler[]> {
-  const document = getOpenApiDocument({ baseUrl });
+  const document = normalizeSchemaExamples(
+    getOpenApiDocument({ baseUrl })
+  ) as Record<string, unknown>;
   // The document is a runtime-validated JSON value; fromOpenApi's parameter
   // type is the openapi-types Document union, which structural typing of a
   // Record<string, unknown> cannot satisfy without a cast.

--- a/js/packages/phoenix-testing/test/node.test.ts
+++ b/js/packages/phoenix-testing/test/node.test.ts
@@ -49,6 +49,24 @@ describe("createMockServer", () => {
     expect(typeof body.data.example_count).toBe("number");
   });
 
+  it("generates single objects for schemas that declare array-form `examples`", async () => {
+    // The `Span` schema carries a JSON Schema `examples: [<span>]` array; the
+    // generator must emit one span per item, not the whole array per item.
+    const response = await fetch(`${BASE_URL}/v1/projects/test-project/spans`);
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      data: Array<{ context: { trace_id: string; span_id: string } }>;
+    };
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThan(0);
+    for (const span of body.data) {
+      expect(Array.isArray(span)).toBe(false);
+      expect(typeof span.context.trace_id).toBe("string");
+      expect(typeof span.context.span_id).toBe("string");
+    }
+  });
+
   it("lets type-safe custom handlers take precedence over generated ones", async () => {
     server.use(
       http.get("/v1/datasets/{id}", ({ params, response }) =>

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -439,6 +439,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@arizeai/phoenix-testing':
+        specifier: workspace:*
+        version: link:../phoenix-testing
       '@types/cross-spawn':
         specifier: ^6.0.6
         version: 6.0.6
@@ -6464,7 +6467,7 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -6506,7 +6509,7 @@ snapshots:
 
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
@@ -6535,7 +6538,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -6550,7 +6553,7 @@ snapshots:
 
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/traverse': 7.29.7
@@ -6581,92 +6584,92 @@ snapshots:
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -6674,7 +6677,7 @@ snapshots:
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
@@ -6685,7 +6688,7 @@ snapshots:
 
   '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
@@ -7247,7 +7250,7 @@ snapshots:
 
   '@jest/transform@30.4.1':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
       babel-plugin-istanbul: 7.0.1
@@ -7526,7 +7529,7 @@ snapshots:
 
   '@mastra/deployer@1.50.1(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.50.1(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@6.0.222(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(supports-color@10.2.2)(typescript@7.0.2)(zod@4.4.3)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
       '@hono/node-ws': 1.3.1(@hono/node-server@2.0.1(hono@4.12.18))(hono@4.12.18)
@@ -8848,7 +8851,7 @@ snapshots:
 
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@jest/transform': 30.4.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 7.0.1
@@ -8875,7 +8878,7 @@ snapshots:
 
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
@@ -8894,7 +8897,7 @@ snapshots:
 
   babel-preset-jest@30.4.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
@@ -9937,7 +9940,7 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -10023,7 +10026,7 @@ snapshots:
 
   jest-config@30.4.2(@types/node@26.1.1):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.4.0
       '@jest/test-sequencer': 30.4.1
@@ -10207,7 +10210,7 @@ snapshots:
 
   jest-snapshot@30.4.1:
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)


### PR DESCRIPTION
## Summary

Completes the phoenix-testing migration for the CLI (follow-up to #14518, which did the same for phoenix-client): every phoenix-cli test that stubbed global `fetch` with ad-hoc mocks now uses type-safe MSW handlers from `@arizeai/phoenix-testing`, and the critical command surfaces gained HTTP-level coverage they previously lacked.

### Harness
- New shared harness `test/mockServer.ts`: a typed `http` namespace (checked against the OpenAPI `paths`) plus `setupMockPhoenixServer()`, which registers schema-generated handlers for every documented endpoint with `onUnhandledRequest: "error"` — "no network call happened" assertions come for free.
- `@arizeai/phoenix-testing` added as a workspace devDependency. `msw` is deliberately **not** a direct dependency: phoenix-testing gained a `./msw` subpath re-export so raw (non-OpenAPI) handlers — the GraphQL endpoint, the npm registry — use the single workspace msw copy.

### Migrations (149 tests, zero `vi.stubGlobal("fetch")` left)
annotate, annotationConfigGetCreate, annotationConfigUpdate, api, delete, deleteAnnotations, notes, projectGet, self, sessionAnnotationsNotes. Request assertions moved into capture-in-handler helpers; method/URL checks are implicit in typed handler matching. `oauth.test.ts` / `version.test.ts` intentionally stay on injected-fetch DI (MSW would intercept oauth's real local callback server).

The typed handlers immediately caught places where the old mocks diverged from the real API (`200 {}` where the spec returns `204`, `Project` fixtures missing the required `name`, `text/plain` error bodies mocked as JSON).

### New command coverage
Eight new HTTP-level test files: `traceCommand`, `spanCommand`, `sessionCommand`, `datasetCommand`, `experimentCommand`, `promptCommand`, `projectList` (+ the existing `projectGet`). Each covers raw/json output, request propagation (project/dataset name→ID resolution, cursors, limits), 404/500 → `FAILURE`, network failure → `NETWORK_ERROR`, and one integration test running purely against the OpenAPI-generated handlers.

### phoenix-testing fix
`@mswjs/source` treats JSON-Schema `examples` arrays (declared on `Span`/`SpanContext`/`SpanEvent`) as the value itself, generating `Span[][]` and crashing `trace list`. `createOpenApiHandlers` now normalizes array-form `examples` → `example`; regression test included.

### Follow-ups observed (not addressed here)
- `session`/`dataset`/`trace`/`span`/`experiment`/`prompt` error paths emit prose instead of `StructuredError` JSON in raw mode (only `project get` conforms).
- Network failures during name resolution exit `FAILURE` rather than `NETWORK_ERROR` (`resolveProjectId`/`resolveDatasetId` wrap the `TypeError`).
- `project list` paginates unboundedly with no `--limit` escape.

## Test plan
- `pnpm vitest run` in phoenix-cli: 69 files, 851 tests passing
- phoenix-testing: 8 tests passing; phoenix-client: 460 passing against the rebuilt package
- `tsc --noEmit`, oxlint, and oxfmt clean across the workspace