### PR TITLE
feat(cli): improve server startup banner

### DIFF
--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from jinja2 import BaseLoader, Environment
 
-from phoenix.utilities import stdout_supports_unicode
+from phoenix.utilities import no_emojis_on_windows, stdout_supports_unicode
 
 _GITHUB_URL = "https://github.com/Arize-ai/phoenix"
 _SLACK_URL = "https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g"
@@ -145,23 +145,25 @@ class BootMessage:
             unicode_ok = stdout_supports_unicode()
         enabled_sandboxes = [name for name, enabled in self.sandbox_providers if enabled]
         disabled_sandboxes = [name for name, enabled in self.sandbox_providers if not enabled]
-        return _BOOT_MESSAGE.render(
-            **vars(self),
-            unicode_ok=unicode_ok,
-            rule="─" if unicode_ok else "-",
-            heavy_rule="━" if unicode_ok else "=",
-            arrow="▶" if unicode_ok else ">",
-            dash="—" if unicode_ok else "-",
-            enabled="✅ Enabled" if unicode_ok else "Enabled",
-            disabled="➖ Disabled" if unicode_ok else "Disabled",
-            not_configured="➖ Not configured" if unicode_ok else "Not configured",
-            enabled_marker="✅ " if unicode_ok else "Enabled: ",
-            disabled_marker="➖ " if unicode_ok else "Disabled: ",
-            enabled_sandboxes=enabled_sandboxes,
-            disabled_sandboxes=disabled_sandboxes,
-            disabled_sandbox_prefix=(" " * 20 if enabled_sandboxes else "Code sandboxes      "),
-            rocket="🚀 " if unicode_ok else "",
-            github_url=_GITHUB_URL,
-            slack_url=_SLACK_URL,
-            docs_url=_DOCS_URL,
+        return no_emojis_on_windows(
+            _BOOT_MESSAGE.render(
+                **vars(self),
+                unicode_ok=unicode_ok,
+                rule="─" if unicode_ok else "-",
+                heavy_rule="━" if unicode_ok else "=",
+                arrow="▶" if unicode_ok else ">",
+                dash="—" if unicode_ok else "-",
+                enabled="✅ Enabled" if unicode_ok else "Enabled",
+                disabled="➖ Disabled" if unicode_ok else "Disabled",
+                not_configured="➖ Not configured" if unicode_ok else "Not configured",
+                enabled_marker="✅ " if unicode_ok else "Enabled: ",
+                disabled_marker="➖ " if unicode_ok else "Disabled: ",
+                enabled_sandboxes=enabled_sandboxes,
+                disabled_sandboxes=disabled_sandboxes,
+                disabled_sandbox_prefix=(" " * 20 if enabled_sandboxes else "Code sandboxes      "),
+                rocket="🚀 " if unicode_ok else "",
+                github_url=_GITHUB_URL,
+                slack_url=_SLACK_URL,
+                docs_url=_DOCS_URL,
+            )
         )

--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -36,10 +36,6 @@ _BOOT_MESSAGE = Environment(
 {% endif %}
 Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability & Evaluation
 
-{{ header("📡", "Tracing " ~ dash ~ " send traces here", heavy=true) }}
-  {{ arrow }} OTLP over gRPC    {{ otlp_grpc_url }}
-  {{ arrow }} OTLP over HTTP    {{ otlp_http_url }}
-
 {{ header("💾", "Storage") }}
   Database            {{ database }}
 {% if database_schema %}
@@ -101,6 +97,10 @@ Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability 
 {% if read_only %}
   Mode                Read-only
 {% endif %}
+
+{{ header("📡", "Tracing " ~ dash ~ " send traces here", heavy=true) }}
+  {{ arrow }} OTLP over gRPC    {{ otlp_grpc_url }}
+  {{ arrow }} OTLP over HTTP    {{ otlp_http_url }}
 
 {{ rocket }}Phoenix is up and running {{ dash }} open {{ ui_url }} to get started.
 """

--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -1,69 +1,128 @@
-"""Startup banner for `phoenix serve`.
-
-Everything the server discloses at boot lives here: :class:`BootMessage` is a
-frozen snapshot of the effective configuration (one field per reported fact),
-and :meth:`BootMessage.render` turns it into the banner text. Auditing what the
-server prints on startup means reading this one module — the CLI only gathers
-values.
-"""
+"""Startup banner for `phoenix serve`."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional
 
+from jinja2 import BaseLoader, Environment
+
 from phoenix.utilities import stdout_supports_unicode
-
-_MESSAGE_WIDTH = 68
-_LABEL_WIDTH = 20
-
-# Joined line by line (rather than one triple-quoted block) so the padding that
-# keeps every row the same width survives trailing-whitespace lint (W291).
-_UNICODE_LOGO = "\n".join(
-    (
-        "██████╗ ██╗  ██╗ ██████╗ ███████╗███╗   ██╗██╗██╗  ██╗",
-        "██╔══██╗██║  ██║██╔═══██╗██╔════╝████╗  ██║██║╚██╗██╔╝",
-        "██████╔╝███████║██║   ██║█████╗  ██╔██╗ ██║██║ ╚███╔╝ ",
-        "██╔═══╝ ██╔══██║██║   ██║██╔══╝  ██║╚██╗██║██║ ██╔██╗ ",
-        "██║     ██║  ██║╚██████╔╝███████╗██║ ╚████║██║██╔╝ ██╗",
-        "╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝",
-    )
-)
 
 _GITHUB_URL = "https://github.com/Arize-ai/phoenix"
 _SLACK_URL = "https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g"
 _DOCS_URL = "https://arize.com/docs/phoenix"
 
+_BOOT_MESSAGE = Environment(
+    loader=BaseLoader(),
+    autoescape=False,
+    trim_blocks=True,
+    lstrip_blocks=True,
+).from_string(
+    """
+{% macro header(icon, title, heavy=false) -%}
+{% set character = heavy_rule if heavy else rule -%}
+{{ character * 2 }} {{ (icon ~ " ") if unicode_ok else "" }}{{ title }} {{ character * 48 }}
+{%- endmacro %}
+{% if unicode_ok %}
+██████╗ ██╗  ██╗ ██████╗ ███████╗███╗   ██╗██╗██╗  ██╗
+██╔══██╗██║  ██║██╔═══██╗██╔════╝████╗  ██║██║╚██╗██╔╝
+██████╔╝███████║██║   ██║█████╗  ██╔██╗ ██║██║ ╚███╔╝
+██╔═══╝ ██╔══██║██║   ██║██╔══╝  ██║╚██╗██║██║ ██╔██╗
+██║     ██║  ██║╚██████╔╝███████╗██║ ╚████║██║██╔╝ ██╗
+╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝
+
+{% endif %}
+Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability & Evaluation
+
+{{ header("🌐", "Server") }}
+  Web UI              {{ ui_url }}
+  REST API            {{ rest_api_url }}
+  GraphQL API         {{ graphql_url }}
+  MCP server          {{ mcp_url or disabled }}
+{% if read_only %}
+  Mode                Read-only
+{% endif %}
+
+{{ header("📡", "Tracing " ~ dash ~ " send traces here", heavy=true) }}
+  {{ arrow }} OTLP over gRPC    {{ otlp_grpc_url }}
+  {{ arrow }} OTLP over HTTP    {{ otlp_http_url }}
+
+{{ header("💾", "Storage") }}
+  Database            {{ database }}
+{% if database_schema %}
+  Schema              {{ database_schema }}
+{% endif %}
+{% if read_replica %}
+  Read replica        {{ read_replica }}
+{% endif %}
+{% if storage_capacity_gibibytes is not none %}
+  Capacity limit      {{ "%g" | format(storage_capacity_gibibytes) }} GiB
+{% endif %}
+{% if retention_policy_days > 0 %}
+  Default retention   {{ retention_policy_days }} days
+{% endif %}
+
+{{ header("🔐", "Auth & Security") }}
+  Authentication      {{ enabled if auth_enabled else disabled }}
+{% if auth_enabled and basic_auth_disabled %}
+  Basic auth          {{ disabled }}
+{% endif %}
+{% if oauth2_idp_names %}
+  OAuth2 providers    {{ oauth2_idp_names | join(", ") }}
+{% endif %}
+{% if ldap_enabled %}
+  LDAP                {{ enabled }}
+{% endif %}
+  TLS (HTTP)          {{ enabled if tls_enabled_for_http else disabled }}
+  TLS (gRPC)          {{ enabled if tls_enabled_for_grpc else disabled }}
+{% if tls_verify_client %}
+  mTLS client verify  {{ enabled }}
+{% endif %}
+{% if allowed_origins %}
+  Allowed origins     {{ allowed_origins | join(", ") }}
+{% endif %}
+
+{{ header("🧩", "Features") }}
+{% if enabled_sandboxes %}
+  Code sandboxes      {{ enabled_marker }}{{ enabled_sandboxes | join(", ") }}
+{% endif %}
+{% if disabled_sandboxes %}
+  {{ disabled_sandbox_prefix }}{{ disabled_marker }}{{ disabled_sandboxes | join(", ") }}
+{% endif %}
+  Agent assistant     {{ enabled if agent_assistant_enabled else disabled }}
+  Prometheus metrics  {{ enabled if prometheus_enabled else disabled }}
+  Email (SMTP)        {{ smtp_hostname or not_configured }}
+  Telemetry           {{ enabled if telemetry_enabled else disabled }}
+
+{{ header("🌎", "Community") }}
+  Star on GitHub      {{ github_url }}
+  Community Slack     {{ slack_url }}
+  Documentation       {{ docs_url }}
+  Docs MCP            {{ docs_mcp_url or disabled }}
+
+{{ rocket }}Phoenix is up and running {{ dash }} open {{ ui_url }} to get started.
+"""
+)
+
 
 @dataclass(frozen=True)
 class BootMessage:
-    """Everything the `phoenix serve` startup banner reports.
-
-    Each field corresponds to one line (or one optional line) of the banner,
-    grouped below in the order the sections are rendered.
-    """
+    """Effective server configuration displayed when `phoenix serve` starts."""
 
     version: str
-
-    # ── Server ───────────────────────────────────────────────────────────
     ui_url: str
     rest_api_url: str
     graphql_url: str
-    mcp_url: Optional[str]  # None when the MCP server is disabled
+    mcp_url: Optional[str]
     read_only: bool
-
-    # ── Tracing (highlighted) ────────────────────────────────────────────
     otlp_grpc_url: str
     otlp_http_url: str
-
-    # ── Storage ──────────────────────────────────────────────────────────
     database: str
     database_schema: Optional[str]
     read_replica: Optional[str]
     storage_capacity_gibibytes: Optional[float]
     retention_policy_days: int
-
-    # ── Auth & security ──────────────────────────────────────────────────
     auth_enabled: bool
     basic_auth_disabled: bool
     oauth2_idp_names: list[str]
@@ -72,127 +131,36 @@ class BootMessage:
     tls_enabled_for_grpc: bool
     tls_verify_client: bool
     allowed_origins: Optional[list[str]]
-
-    # ── Features ─────────────────────────────────────────────────────────
-    sandbox_providers: list[tuple[str, bool]]  # (provider name, enabled)
+    sandbox_providers: list[tuple[str, bool]]
     agent_assistant_enabled: bool
-    docs_mcp_url: Optional[str]  # None when the docs MCP connection is disabled
+    docs_mcp_url: Optional[str]
     prometheus_enabled: bool
-    smtp_hostname: str  # empty string when email is not configured
+    smtp_hostname: str
     telemetry_enabled: bool
 
     def render(self, unicode_ok: Optional[bool] = None) -> str:
+        """Render the startup banner for the active console."""
         if unicode_ok is None:
             unicode_ok = stdout_supports_unicode()
-        rule = "─" if unicode_ok else "-"
-        heavy_rule = "━" if unicode_ok else "="
-        arrow = "▶" if unicode_ok else ">"
-        on = "✅ Enabled" if unicode_ok else "Enabled"
-        off = "➖ Disabled" if unicode_ok else "Disabled"
-
-        def status(enabled: bool) -> str:
-            return on if enabled else off
-
-        def emoji(icon: str, title: str) -> str:
-            return f"{icon} {title}" if unicode_ok else title
-
-        def section(
-            title: str,
-            rows: list[tuple[str, str]],
-            rule_char: str = rule,
-        ) -> list[str]:
-            header = f"{rule_char * 2} {title} "
-            lines = [header + rule_char * max(0, _MESSAGE_WIDTH - len(header))]
-            lines.extend(f"  {label:<{_LABEL_WIDTH}}{value}".rstrip() for label, value in rows)
-            lines.append("")
-            return lines
-
-        server_rows: list[tuple[str, str]] = [
-            ("Web UI", self.ui_url),
-            ("REST API", self.rest_api_url),
-            ("GraphQL API", self.graphql_url),
-            ("MCP server", self.mcp_url or off),
-        ]
-        if self.read_only:
-            server_rows.append(("Mode", "Read-only"))
-
-        # Rendered with heavy rules and arrow markers so the endpoints to send
-        # traces to stand out from every other section.
-        tracing_rows: list[tuple[str, str]] = [
-            (f"{arrow} OTLP over gRPC", self.otlp_grpc_url),
-            (f"{arrow} OTLP over HTTP", self.otlp_http_url),
-        ]
-
-        storage_rows: list[tuple[str, str]] = [("Database", self.database)]
-        if self.database_schema:
-            storage_rows.append(("Schema", self.database_schema))
-        if self.read_replica:
-            storage_rows.append(("Read replica", self.read_replica))
-        if self.storage_capacity_gibibytes is not None:
-            storage_rows.append(("Capacity limit", f"{self.storage_capacity_gibibytes:g} GiB"))
-        if self.retention_policy_days > 0:
-            storage_rows.append(("Default retention", f"{self.retention_policy_days} days"))
-
-        security_rows: list[tuple[str, str]] = [("Authentication", status(self.auth_enabled))]
-        if self.auth_enabled and self.basic_auth_disabled:
-            security_rows.append(("Basic auth", status(False)))
-        if self.oauth2_idp_names:
-            security_rows.append(("OAuth2 providers", ", ".join(self.oauth2_idp_names)))
-        if self.ldap_enabled:
-            security_rows.append(("LDAP", status(True)))
-        security_rows.append(("TLS (HTTP)", status(self.tls_enabled_for_http)))
-        security_rows.append(("TLS (gRPC)", status(self.tls_enabled_for_grpc)))
-        if self.tls_verify_client:
-            security_rows.append(("mTLS client verify", status(True)))
-        if self.allowed_origins:
-            security_rows.append(("Allowed origins", ", ".join(self.allowed_origins)))
-
         enabled_sandboxes = [name for name, enabled in self.sandbox_providers if enabled]
         disabled_sandboxes = [name for name, enabled in self.sandbox_providers if not enabled]
-        feature_rows: list[tuple[str, str]] = []
-        if enabled_sandboxes:
-            marker = "✅ " if unicode_ok else "Enabled: "
-            feature_rows.append(("Code sandboxes", marker + ", ".join(enabled_sandboxes)))
-        if disabled_sandboxes:
-            marker = "➖ " if unicode_ok else "Disabled: "
-            label = "Code sandboxes" if not enabled_sandboxes else ""
-            feature_rows.append((label, marker + ", ".join(disabled_sandboxes)))
-        feature_rows.append(("Agent assistant", status(self.agent_assistant_enabled)))
-        feature_rows.append(("Prometheus metrics", status(self.prometheus_enabled)))
-        not_configured = "➖ Not configured" if unicode_ok else "Not configured"
-        feature_rows.append(("Email (SMTP)", self.smtp_hostname or not_configured))
-        feature_rows.append(("Telemetry", status(self.telemetry_enabled)))
-
-        # Plain labels here: emoji are double-width in most terminals and would
-        # knock these rows' value column out of alignment with the rest.
-        community_rows: list[tuple[str, str]] = [
-            ("Star on GitHub", _GITHUB_URL),
-            ("Community Slack", _SLACK_URL),
-            ("Documentation", _DOCS_URL),
-            ("Docs MCP", self.docs_mcp_url or off),
-        ]
-
-        lines: list[str] = [""]
-        if unicode_ok:
-            lines.extend((_UNICODE_LOGO, ""))
-        separator = "·" if unicode_ok else "-"
-        lines.append(f"Arize Phoenix v{self.version} {separator} AI Observability & Evaluation")
-        lines.append("")
-        dash = "—" if unicode_ok else "-"
-        lines.extend(section(emoji("🌐", "Server"), server_rows))
-        lines.extend(
-            section(
-                emoji("📡", f"Tracing {dash} send traces here"),
-                tracing_rows,
-                rule_char=heavy_rule,
-            )
+        return _BOOT_MESSAGE.render(
+            **vars(self),
+            unicode_ok=unicode_ok,
+            rule="─" if unicode_ok else "-",
+            heavy_rule="━" if unicode_ok else "=",
+            arrow="▶" if unicode_ok else ">",
+            dash="—" if unicode_ok else "-",
+            enabled="✅ Enabled" if unicode_ok else "Enabled",
+            disabled="➖ Disabled" if unicode_ok else "Disabled",
+            not_configured="➖ Not configured" if unicode_ok else "Not configured",
+            enabled_marker="✅ " if unicode_ok else "Enabled: ",
+            disabled_marker="➖ " if unicode_ok else "Disabled: ",
+            enabled_sandboxes=enabled_sandboxes,
+            disabled_sandboxes=disabled_sandboxes,
+            disabled_sandbox_prefix=(" " * 20 if enabled_sandboxes else "Code sandboxes      "),
+            rocket="🚀 " if unicode_ok else "",
+            github_url=_GITHUB_URL,
+            slack_url=_SLACK_URL,
+            docs_url=_DOCS_URL,
         )
-        lines.extend(section(emoji("💾", "Storage"), storage_rows))
-        lines.extend(section(emoji("🔐", "Auth & Security"), security_rows))
-        lines.extend(section(emoji("🧩", "Features"), feature_rows))
-        lines.extend(section(emoji("🌎", "Community"), community_rows))
-        lines.append(
-            f"{emoji('🚀', 'Phoenix')} is up and running {dash} open {self.ui_url} to get started."
-        )
-        lines.append("")
-        return "\n".join(lines)

--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -22,7 +22,8 @@ _BOOT_MESSAGE = Environment(
     """
 {% macro header(icon, title, heavy=false) -%}
 {% set character = heavy_rule if heavy else rule -%}
-{{ character * 2 }} {{ (icon ~ " ") if unicode_ok else "" }}{{ title }} {{ character * 48 }}
+{% set prefix = character * 2 ~ " " ~ ((icon ~ " ") if unicode_ok else "") ~ title ~ " " -%}
+{{ prefix }}{{ character * (68 - prefix | length) }}
 {%- endmacro %}
 {% if unicode_ok %}
 ██████╗ ██╗  ██╗ ██████╗ ███████╗███╗   ██╗██╗██╗  ██╗
@@ -34,15 +35,6 @@ _BOOT_MESSAGE = Environment(
 
 {% endif %}
 Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability & Evaluation
-
-{{ header("🌐", "Server") }}
-  Web UI              {{ ui_url }}
-  REST API            {{ rest_api_url }}
-  GraphQL API         {{ graphql_url }}
-  MCP server          {{ mcp_url or disabled }}
-{% if read_only %}
-  Mode                Read-only
-{% endif %}
 
 {{ header("📡", "Tracing " ~ dash ~ " send traces here", heavy=true) }}
   {{ arrow }} OTLP over gRPC    {{ otlp_grpc_url }}
@@ -100,6 +92,15 @@ Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability 
   Community Slack     {{ slack_url }}
   Documentation       {{ docs_url }}
   Docs MCP            {{ docs_mcp_url or disabled }}
+
+{{ header("🌐", "Server") }}
+  Web UI              {{ ui_url }}
+  REST API            {{ rest_api_url }}
+  GraphQL API         {{ graphql_url }}
+  MCP server          {{ mcp_url or disabled }}
+{% if read_only %}
+  Mode                Read-only
+{% endif %}
 
 {{ rocket }}Phoenix is up and running {{ dash }} open {{ ui_url }} to get started.
 """

--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -30,15 +30,6 @@ _UNICODE_LOGO = "\n".join(
     )
 )
 
-# Pure-ASCII fallback for consoles that cannot render block characters
-# (e.g. legacy Windows code pages).
-_ASCII_LOGO = """\
- ____  _   _  ___  _____ _   _ ___ __  __
-|  _ \\| | | |/ _ \\| ____| \\ | |_ _|\\ \\/ /
-| |_) | |_| | | | |  _| |  \\| || |  \\  /
-|  __/|  _  | |_| | |___| |\\  || |  /  \\
-|_|   |_| |_|\\___/|_____|_| \\_|___|/_/\\_\\"""
-
 _GITHUB_URL = "https://github.com/Arize-ai/phoenix"
 _SLACK_URL = "https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g"
 _DOCS_URL = "https://arize.com/docs/phoenix"
@@ -182,8 +173,8 @@ class BootMessage:
         ]
 
         lines: list[str] = [""]
-        lines.append(_UNICODE_LOGO if unicode_ok else _ASCII_LOGO)
-        lines.append("")
+        if unicode_ok:
+            lines.extend((_UNICODE_LOGO, ""))
         separator = "·" if unicode_ok else "-"
         lines.append(f"Arize Phoenix v{self.version} {separator} AI Observability & Evaluation")
         lines.append("")

--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -1,0 +1,207 @@
+"""Startup banner for `phoenix serve`.
+
+Everything the server discloses at boot lives here: :class:`BootMessage` is a
+frozen snapshot of the effective configuration (one field per reported fact),
+and :meth:`BootMessage.render` turns it into the banner text. Auditing what the
+server prints on startup means reading this one module — the CLI only gathers
+values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from phoenix.utilities import stdout_supports_unicode
+
+_MESSAGE_WIDTH = 68
+_LABEL_WIDTH = 20
+
+# Joined line by line (rather than one triple-quoted block) so the padding that
+# keeps every row the same width survives trailing-whitespace lint (W291).
+_UNICODE_LOGO = "\n".join(
+    (
+        "██████╗ ██╗  ██╗ ██████╗ ███████╗███╗   ██╗██╗██╗  ██╗",
+        "██╔══██╗██║  ██║██╔═══██╗██╔════╝████╗  ██║██║╚██╗██╔╝",
+        "██████╔╝███████║██║   ██║█████╗  ██╔██╗ ██║██║ ╚███╔╝ ",
+        "██╔═══╝ ██╔══██║██║   ██║██╔══╝  ██║╚██╗██║██║ ██╔██╗ ",
+        "██║     ██║  ██║╚██████╔╝███████╗██║ ╚████║██║██╔╝ ██╗",
+        "╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝",
+    )
+)
+
+# Pure-ASCII fallback for consoles that cannot render block characters
+# (e.g. legacy Windows code pages).
+_ASCII_LOGO = """\
+ ____  _   _  ___  _____ _   _ ___ __  __
+|  _ \\| | | |/ _ \\| ____| \\ | |_ _|\\ \\/ /
+| |_) | |_| | | | |  _| |  \\| || |  \\  /
+|  __/|  _  | |_| | |___| |\\  || |  /  \\
+|_|   |_| |_|\\___/|_____|_| \\_|___|/_/\\_\\"""
+
+_GITHUB_URL = "https://github.com/Arize-ai/phoenix"
+_SLACK_URL = "https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g"
+_DOCS_URL = "https://arize.com/docs/phoenix"
+
+
+@dataclass(frozen=True)
+class BootMessage:
+    """Everything the `phoenix serve` startup banner reports.
+
+    Each field corresponds to one line (or one optional line) of the banner,
+    grouped below in the order the sections are rendered.
+    """
+
+    version: str
+
+    # ── Server ───────────────────────────────────────────────────────────
+    ui_url: str
+    rest_api_url: str
+    graphql_url: str
+    mcp_url: Optional[str]  # None when the MCP server is disabled
+    read_only: bool
+
+    # ── Tracing (highlighted) ────────────────────────────────────────────
+    otlp_grpc_url: str
+    otlp_http_url: str
+
+    # ── Storage ──────────────────────────────────────────────────────────
+    database: str
+    database_schema: Optional[str]
+    read_replica: Optional[str]
+    storage_capacity_gibibytes: Optional[float]
+    retention_policy_days: int
+
+    # ── Auth & security ──────────────────────────────────────────────────
+    auth_enabled: bool
+    basic_auth_disabled: bool
+    oauth2_idp_names: list[str]
+    ldap_enabled: bool
+    tls_enabled_for_http: bool
+    tls_enabled_for_grpc: bool
+    tls_verify_client: bool
+    allowed_origins: Optional[list[str]]
+
+    # ── Features ─────────────────────────────────────────────────────────
+    sandbox_providers: list[tuple[str, bool]]  # (provider name, enabled)
+    agent_assistant_enabled: bool
+    docs_mcp_url: Optional[str]  # None when the docs MCP connection is disabled
+    prometheus_enabled: bool
+    smtp_hostname: str  # empty string when email is not configured
+    telemetry_enabled: bool
+
+    def render(self, unicode_ok: Optional[bool] = None) -> str:
+        if unicode_ok is None:
+            unicode_ok = stdout_supports_unicode()
+        rule = "─" if unicode_ok else "-"
+        heavy_rule = "━" if unicode_ok else "="
+        arrow = "▶" if unicode_ok else ">"
+        on = "✅ Enabled" if unicode_ok else "Enabled"
+        off = "➖ Disabled" if unicode_ok else "Disabled"
+
+        def status(enabled: bool) -> str:
+            return on if enabled else off
+
+        def emoji(icon: str, title: str) -> str:
+            return f"{icon} {title}" if unicode_ok else title
+
+        def section(
+            title: str,
+            rows: list[tuple[str, str]],
+            rule_char: str = rule,
+        ) -> list[str]:
+            header = f"{rule_char * 2} {title} "
+            lines = [header + rule_char * max(0, _MESSAGE_WIDTH - len(header))]
+            lines.extend(f"  {label:<{_LABEL_WIDTH}}{value}".rstrip() for label, value in rows)
+            lines.append("")
+            return lines
+
+        server_rows: list[tuple[str, str]] = [
+            ("Web UI", self.ui_url),
+            ("REST API", self.rest_api_url),
+            ("GraphQL API", self.graphql_url),
+            ("MCP server", self.mcp_url or off),
+        ]
+        if self.read_only:
+            server_rows.append(("Mode", "Read-only"))
+
+        # Rendered with heavy rules and arrow markers so the endpoints to send
+        # traces to stand out from every other section.
+        tracing_rows: list[tuple[str, str]] = [
+            (f"{arrow} OTLP over gRPC", self.otlp_grpc_url),
+            (f"{arrow} OTLP over HTTP", self.otlp_http_url),
+        ]
+
+        storage_rows: list[tuple[str, str]] = [("Database", self.database)]
+        if self.database_schema:
+            storage_rows.append(("Schema", self.database_schema))
+        if self.read_replica:
+            storage_rows.append(("Read replica", self.read_replica))
+        if self.storage_capacity_gibibytes is not None:
+            storage_rows.append(("Capacity limit", f"{self.storage_capacity_gibibytes:g} GiB"))
+        if self.retention_policy_days > 0:
+            storage_rows.append(("Default retention", f"{self.retention_policy_days} days"))
+
+        security_rows: list[tuple[str, str]] = [("Authentication", status(self.auth_enabled))]
+        if self.auth_enabled and self.basic_auth_disabled:
+            security_rows.append(("Basic auth", status(False)))
+        if self.oauth2_idp_names:
+            security_rows.append(("OAuth2 providers", ", ".join(self.oauth2_idp_names)))
+        if self.ldap_enabled:
+            security_rows.append(("LDAP", status(True)))
+        security_rows.append(("TLS (HTTP)", status(self.tls_enabled_for_http)))
+        security_rows.append(("TLS (gRPC)", status(self.tls_enabled_for_grpc)))
+        if self.tls_verify_client:
+            security_rows.append(("mTLS client verify", status(True)))
+        if self.allowed_origins:
+            security_rows.append(("Allowed origins", ", ".join(self.allowed_origins)))
+
+        enabled_sandboxes = [name for name, enabled in self.sandbox_providers if enabled]
+        disabled_sandboxes = [name for name, enabled in self.sandbox_providers if not enabled]
+        feature_rows: list[tuple[str, str]] = []
+        if enabled_sandboxes:
+            marker = "✅ " if unicode_ok else "Enabled: "
+            feature_rows.append(("Code sandboxes", marker + ", ".join(enabled_sandboxes)))
+        if disabled_sandboxes:
+            marker = "➖ " if unicode_ok else "Disabled: "
+            label = "Code sandboxes" if not enabled_sandboxes else ""
+            feature_rows.append((label, marker + ", ".join(disabled_sandboxes)))
+        feature_rows.append(("Agent assistant", status(self.agent_assistant_enabled)))
+        feature_rows.append(("Prometheus metrics", status(self.prometheus_enabled)))
+        not_configured = "➖ Not configured" if unicode_ok else "Not configured"
+        feature_rows.append(("Email (SMTP)", self.smtp_hostname or not_configured))
+        feature_rows.append(("Telemetry", status(self.telemetry_enabled)))
+
+        # Plain labels here: emoji are double-width in most terminals and would
+        # knock these rows' value column out of alignment with the rest.
+        community_rows: list[tuple[str, str]] = [
+            ("Star on GitHub", _GITHUB_URL),
+            ("Community Slack", _SLACK_URL),
+            ("Documentation", _DOCS_URL),
+            ("Docs MCP", self.docs_mcp_url or off),
+        ]
+
+        lines: list[str] = [""]
+        lines.append(_UNICODE_LOGO if unicode_ok else _ASCII_LOGO)
+        lines.append("")
+        separator = "·" if unicode_ok else "-"
+        lines.append(f"Arize Phoenix v{self.version} {separator} AI Observability & Evaluation")
+        lines.append("")
+        dash = "—" if unicode_ok else "-"
+        lines.extend(section(emoji("🌐", "Server"), server_rows))
+        lines.extend(
+            section(
+                emoji("📡", f"Tracing {dash} send traces here"),
+                tracing_rows,
+                rule_char=heavy_rule,
+            )
+        )
+        lines.extend(section(emoji("💾", "Storage"), storage_rows))
+        lines.extend(section(emoji("🔐", "Auth & Security"), security_rows))
+        lines.extend(section(emoji("🧩", "Features"), feature_rows))
+        lines.extend(section(emoji("🌎", "Community"), community_rows))
+        lines.append(
+            f"{emoji('🚀', 'Phoenix')} is up and running {dash} open {self.ui_url} to get started."
+        )
+        lines.append("")
+        return "\n".join(lines)

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -14,18 +14,21 @@ from urllib.parse import urljoin
 if TYPE_CHECKING:
     from argparse import _SubParsersAction
 
-from jinja2 import BaseLoader, Environment
 from uvicorn import Config, Server
 
 from phoenix.config import (
     TLSConfigVerifyClient,
     get_env_access_token_expiry,
+    get_env_allow_external_resources,
     get_env_allowed_origins,
     get_env_allowed_sandbox_providers,
     get_env_auth_settings,
+    get_env_database_allocated_storage_capacity_gibibytes,
     get_env_database_connection_str,
     get_env_database_schema,
+    get_env_default_retention_policy_days,
     get_env_disable_agent_assistant,
+    get_env_enable_mcp_server,
     get_env_enable_prometheus,
     get_env_grpc_port,
     get_env_host,
@@ -43,6 +46,7 @@ from phoenix.config import (
     get_env_smtp_port,
     get_env_smtp_username,
     get_env_smtp_validate_certs,
+    get_env_telemetry_enabled,
     get_env_tls_config,
     get_env_tls_enabled_for_grpc,
     get_env_tls_enabled_for_http,
@@ -51,12 +55,14 @@ from phoenix.config import (
 from phoenix.db import get_printable_db_url
 from phoenix.db.engines import create_engine
 from phoenix.db.insertion.types import AnnotationPrecursor
+from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
 from phoenix.server.app import (
     ScaffolderConfig,
     _db,
     create_app,
     instrument_engine_if_enabled,
 )
+from phoenix.server.cli.boot_message import BootMessage
 from phoenix.server.email.sender import SimpleEmailSender
 from phoenix.server.email.types import EmailSender
 from phoenix.server.types import DbSessionFactory
@@ -74,76 +80,26 @@ from phoenix.trace.fixtures import (
 )
 from phoenix.trace.otel import decode_otlp_span, encode_span_to_otlp
 from phoenix.trace.schemas import Span
-from phoenix.utilities import no_emojis_on_windows
 from phoenix.version import __version__ as phoenix_version
 
 logger = logging.getLogger(__name__)
 
-_WELCOME_MESSAGE = Environment(loader=BaseLoader()).from_string("""
-
-██████╗ ██╗  ██╗ ██████╗ ███████╗███╗   ██╗██╗██╗  ██╗
-██╔══██╗██║  ██║██╔═══██╗██╔════╝████╗  ██║██║╚██╗██╔╝
-██████╔╝███████║██║   ██║█████╗  ██╔██╗ ██║██║ ╚███╔╝
-██╔═══╝ ██╔══██║██║   ██║██╔══╝  ██║╚██╗██║██║ ██╔██╗
-██║     ██║  ██║╚██████╔╝███████╗██║ ╚████║██║██╔╝ ██╗
-╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝ v{{ version }}
-
-|  ⭐️⭐️⭐️ Support Open Source ⭐️⭐️⭐️
-|  ⭐️⭐️⭐️ Star on GitHub! ⭐️⭐️⭐️
-|  https://github.com/Arize-ai/phoenix
-|
-|  🌎 Join our Community 🌎
-|  https://join.slack.com/t/arize-ai/shared_invite/zt-3r07iavnk-ammtATWSlF0pSrd1DsMW7g
-|
-|  📚 Documentation 📚
-|  https://arize.com/docs/phoenix
-|
-|  🚀 Phoenix Server 🚀
-|  Phoenix UI: {{ ui_path }}
-|
-|  Authentication: {{ auth_enabled }}
-{%- if basic_auth_disabled %}
-|  Basic Auth: Disabled
-{%- endif %}
-{%- if tls_enabled_for_http or tls_enabled_for_grpc %}
-{%- if tls_enabled_for_http %}
-|  TLS: Enabled for HTTP
-{%- endif %}
-{%- if tls_enabled_for_grpc %}
-|  TLS: Enabled for gRPC
-{%- endif %}
-{%- if tls_verify_client %}
-|  TLS Client Verification: Enabled
-{%- endif %}
-{%- endif %}
-{%- if allowed_origins %}
-|  Allowed Origins: {{ allowed_origins }}
-{%- endif %}
-|  Log traces:
-|    - gRPC: {{ grpc_path }}
-|    - HTTP: {{ http_path }}
-|  Storage: {{ storage }}
-{%- if schema %}
-|    - Schema: {{ schema }}
-{%- endif %}
-|
-|  📦 Code Sandbox Providers 📦
-{%- for provider in sandbox_providers %}
-|  - {{ provider.name }}: {{ "✅ Allowed" if provider.enabled else "❌ Disabled" }}
-{%- endfor %}
-{%- if agent_assistant_disabled %}
-|
-|  Agent Assistant: Disabled
-{%- endif %}
-""")
+# Mirrors phoenix.server.mcp_server.MCP_MOUNT_PATH, which is not imported here
+# because importing that module loads fastmcp even when the mount is disabled.
+_MCP_MOUNT_PATH = "/mcp"
 
 
-def _get_sandbox_provider_statuses() -> list[dict[str, object]]:
-    """Return per-provider enabled/disabled status for the launch banner."""
+def _join_url_path(root_url: str, path: str) -> str:
+    """Append a path without dropping a configured deployment root."""
+    return urljoin(f"{root_url.rstrip('/')}/", path.lstrip("/"))
+
+
+def _get_sandbox_provider_statuses() -> list[tuple[str, bool]]:
+    """Return per-provider (name, enabled) status for the launch banner."""
     from phoenix.server.sandbox.types import SANDBOX_BACKEND_TYPES
 
     allowed = get_env_allowed_sandbox_providers()
-    return [{"name": name, "enabled": name in allowed} for name in sorted(SANDBOX_BACKEND_TYPES)]
+    return [(name, name in allowed) for name in sorted(SANDBOX_BACKEND_TYPES)]
 
 
 def _add_server_args(parser: ArgumentParser) -> None:
@@ -270,9 +226,10 @@ def run(args: Namespace) -> None:
 
         start_prometheus()
 
+    read_replica_connection_str = get_env_read_replica_url()
     factory, shutdown_callbacks = _create_db_session_factory(
         db_connection_str=db_connection_str,
-        read_replica_connection_str=get_env_read_replica_url(),
+        read_replica_connection_str=read_replica_connection_str,
         migrate=not Settings.disable_migrations,
         log_to_stdout=get_env_log_sql(),
         log_migrations=Settings.log_migrations,
@@ -291,24 +248,50 @@ def run(args: Namespace) -> None:
     display_host = "localhost" if host in ("0.0.0.0", "::") else host
     root_path = urljoin(f"{http_scheme}://{host}:{port}", host_root_path)
     display_root_path = urljoin(f"{http_scheme}://{display_host}:{port}", host_root_path)
-    msg = _WELCOME_MESSAGE.render(
+    oauth2_client_configs = get_env_oauth2_settings()
+    smtp_hostname = get_env_smtp_hostname()
+    agent_assistant_enabled = not get_env_disable_agent_assistant()
+    msg = BootMessage(
         version=phoenix_version,
-        ui_path=display_root_path,
-        grpc_path=f"{grpc_scheme}://{display_host}:{grpc_port}",
-        http_path=urljoin(display_root_path, "v1/traces"),
-        storage=get_printable_db_url(db_connection_str),
-        schema=get_env_database_schema(),
+        ui_url=display_root_path,
+        rest_api_url=_join_url_path(display_root_path, "v1"),
+        graphql_url=_join_url_path(display_root_path, "graphql"),
+        mcp_url=(
+            _join_url_path(display_root_path, _MCP_MOUNT_PATH)
+            if get_env_enable_mcp_server()
+            else None
+        ),
+        read_only=read_only,
+        otlp_grpc_url=f"{grpc_scheme}://{display_host}:{grpc_port}",
+        otlp_http_url=_join_url_path(display_root_path, "v1/traces"),
+        database=get_printable_db_url(db_connection_str),
+        database_schema=get_env_database_schema(),
+        read_replica=(
+            get_printable_db_url(read_replica_connection_str)
+            if read_replica_connection_str
+            else None
+        ),
+        storage_capacity_gibibytes=get_env_database_allocated_storage_capacity_gibibytes(),
+        retention_policy_days=get_env_default_retention_policy_days(),
         auth_enabled=auth_settings.enable_auth,
         basic_auth_disabled=auth_settings.disable_basic_auth,
+        oauth2_idp_names=[config.idp_display_name for config in oauth2_client_configs],
+        ldap_enabled=auth_settings.ldap_config is not None,
         tls_enabled_for_http=tls_enabled_for_http,
         tls_enabled_for_grpc=tls_enabled_for_grpc,
         tls_verify_client=tls_verify_client,
         allowed_origins=allowed_origins,
-        agent_assistant_disabled=get_env_disable_agent_assistant(),
         sandbox_providers=_get_sandbox_provider_statuses(),
-    )
-
-    msg = no_emojis_on_windows(msg)
+        agent_assistant_enabled=agent_assistant_enabled,
+        docs_mcp_url=(
+            MintlifyDocsMCPServer.URL
+            if agent_assistant_enabled and get_env_allow_external_resources()
+            else None
+        ),
+        prometheus_enabled=bool(enable_prometheus),
+        smtp_hostname=smtp_hostname,
+        telemetry_enabled=get_env_telemetry_enabled(),
+    ).render()
 
     scaffolder_config = ScaffolderConfig(
         db=factory,

--- a/src/phoenix/utilities/__init__.py
+++ b/src/phoenix/utilities/__init__.py
@@ -20,6 +20,18 @@ def hour_of_week(dt: datetime) -> int:
     return (weekday * 24) + dt.hour
 
 
+def stdout_supports_unicode() -> bool:
+    """Whether stdout can render the startup banner's Unicode glyphs."""
+    if sys.platform.startswith("win"):
+        return False
+    encoding = getattr(sys.stdout, "encoding", None) or "ascii"
+    try:
+        "█─━▶✅➖🗄🚀".encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
+
+
 def no_emojis_on_windows(text: str) -> str:
     if sys.platform.startswith("win"):
         return codecs.encode(text, "ascii", errors="ignore").decode("ascii").strip()

--- a/tests/unit/server/cli/commands/test_serve.py
+++ b/tests/unit/server/cli/commands/test_serve.py
@@ -14,6 +14,7 @@ from phoenix.db.insertion.types import Precursors
 from phoenix.server.cli.commands import serve
 from phoenix.server.cli.commands.serve import (
     _create_db_session_factory,
+    _join_url_path,
     _load_trace_fixture_initial_batches,
     _resolve_grpc_port,
 )
@@ -31,6 +32,19 @@ def test_resolve_grpc_port_uses_env_when_cli_flag_missing(monkeypatch: pytest.Mo
     monkeypatch.setenv("PHOENIX_GRPC_PORT", "4318")
 
     assert _resolve_grpc_port(Namespace(grpc_port=None)) == 4318
+
+
+@pytest.mark.parametrize(
+    "path, expected_url",
+    [
+        ("v1", "http://localhost:6006/phoenix/v1"),
+        ("graphql", "http://localhost:6006/phoenix/graphql"),
+        ("/mcp", "http://localhost:6006/phoenix/mcp"),
+        ("v1/traces", "http://localhost:6006/phoenix/v1/traces"),
+    ],
+)
+def test_join_url_path_preserves_deployment_root(path: str, expected_url: str) -> None:
+    assert _join_url_path("http://localhost:6006/phoenix", path) == expected_url
 
 
 async def _run_shutdown_callbacks(

--- a/tests/unit/server/cli/test_boot_message.py
+++ b/tests/unit/server/cli/test_boot_message.py
@@ -44,12 +44,13 @@ def test_render_displays_configured_urls() -> None:
     assert "http://localhost:6006/phoenix/v1/traces" in rendered
 
 
-def test_render_uses_uniform_dividers_and_places_server_section_last() -> None:
+def test_render_uses_uniform_dividers_and_places_tracing_section_last() -> None:
     rendered = _boot_message().render(unicode_ok=True)
 
     headers = [line for line in rendered.splitlines() if line.startswith(("──", "━━"))]
     assert len({len(header) for header in headers}) == 1
-    assert "Server" in headers[-1]
+    assert "Server" in headers[-2]
+    assert "Tracing" in headers[-1]
 
 
 def test_render_without_unicode_omits_logo_and_is_ascii() -> None:

--- a/tests/unit/server/cli/test_boot_message.py
+++ b/tests/unit/server/cli/test_boot_message.py
@@ -42,6 +42,14 @@ def test_render_displays_configured_urls() -> None:
     assert "http://localhost:6006/phoenix/v1/traces" in rendered
 
 
+def test_render_uses_uniform_dividers_and_places_server_section_last() -> None:
+    rendered = _boot_message().render(unicode_ok=True)
+
+    headers = [line for line in rendered.splitlines() if line.startswith(("──", "━━"))]
+    assert len({len(header) for header in headers}) == 1
+    assert "Server" in headers[-1]
+
+
 def test_render_without_unicode_omits_logo_and_is_ascii() -> None:
     rendered = _boot_message().render(unicode_ok=False)
 

--- a/tests/unit/server/cli/test_boot_message.py
+++ b/tests/unit/server/cli/test_boot_message.py
@@ -1,0 +1,50 @@
+from phoenix.server.cli.boot_message import BootMessage
+
+
+def _boot_message() -> BootMessage:
+    return BootMessage(
+        version="1.2.3",
+        ui_url="http://localhost:6006/phoenix",
+        rest_api_url="http://localhost:6006/phoenix/v1",
+        graphql_url="http://localhost:6006/phoenix/graphql",
+        mcp_url="http://localhost:6006/phoenix/mcp",
+        read_only=False,
+        otlp_grpc_url="http://localhost:4317",
+        otlp_http_url="http://localhost:6006/phoenix/v1/traces",
+        database="sqlite:///phoenix.db",
+        database_schema=None,
+        read_replica=None,
+        storage_capacity_gibibytes=None,
+        retention_policy_days=0,
+        auth_enabled=False,
+        basic_auth_disabled=False,
+        oauth2_idp_names=[],
+        ldap_enabled=False,
+        tls_enabled_for_http=False,
+        tls_enabled_for_grpc=False,
+        tls_verify_client=False,
+        allowed_origins=None,
+        sandbox_providers=[("e2b", True), ("modal", False)],
+        agent_assistant_enabled=True,
+        docs_mcp_url=None,
+        prometheus_enabled=False,
+        smtp_hostname="",
+        telemetry_enabled=True,
+    )
+
+
+def test_render_displays_configured_urls() -> None:
+    rendered = _boot_message().render(unicode_ok=True)
+
+    assert "http://localhost:6006/phoenix/v1" in rendered
+    assert "http://localhost:6006/phoenix/graphql" in rendered
+    assert "http://localhost:6006/phoenix/mcp" in rendered
+    assert "http://localhost:6006/phoenix/v1/traces" in rendered
+
+
+def test_render_without_unicode_omits_logo_and_is_ascii() -> None:
+    rendered = _boot_message().render(unicode_ok=False)
+
+    rendered.encode("ascii")
+    assert "██████" not in rendered
+    assert "Arize Phoenix v1.2.3 - AI Observability & Evaluation" in rendered

--- a/tests/unit/server/cli/test_boot_message.py
+++ b/tests/unit/server/cli/test_boot_message.py
@@ -1,3 +1,5 @@
+import pytest
+
 from phoenix.server.cli.boot_message import BootMessage
 
 
@@ -56,3 +58,14 @@ def test_render_without_unicode_omits_logo_and_is_ascii() -> None:
     rendered.encode("ascii")
     assert "██████" not in rendered
     assert "Arize Phoenix v1.2.3 - AI Observability & Evaluation" in rendered
+
+
+def test_render_sanitizes_for_windows_even_when_unicode_is_forced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("phoenix.utilities.sys.platform", "win32")
+
+    rendered = _boot_message().render(unicode_ok=True)
+
+    rendered.encode("ascii")
+    assert "██████" not in rendered


### PR DESCRIPTION
## What changed

- move the Jinja startup banner into a dedicated module with a typed configuration context
- group server, tracing, storage, security, feature, and community configuration into a scannable launch banner
- preserve configured deployment root paths in advertised REST, GraphQL, MCP, and OTLP HTTP URLs
- omit Unicode decorations on terminals that cannot render them

## Why

The existing startup output is difficult to scan and omits useful effective configuration. Keeping rendering in one module makes the advertised endpoints and runtime settings easier to audit while leaving server behavior unchanged.

## Validation

- `uv run pytest tests/unit/server/cli/test_boot_message.py tests/unit/server/cli/commands/test_serve.py tests/unit/server/test_app_docs_mcp_lifespan.py -n auto`
- `make typecheck-python`
- `uv run ruff check` and `uv run ruff format --check` on the changed Python files
