### PR TITLE
fix(playground): switch default model to gpt-5.6-luna

### DIFF
--- a/app/src/constants/generativeConstants.ts
+++ b/app/src/constants/generativeConstants.ts
@@ -25,7 +25,7 @@ export const DEFAULT_MODEL_PROVIDER: ModelProvider = "OPENAI";
 /**
  * The default model name
  */
-export const DEFAULT_MODEL_NAME = "gpt-5.6-sol";
+export const DEFAULT_MODEL_NAME = "gpt-5.6-luna";
 
 export const DEFAULT_CHAT_ROLE: ChatMessageRole = "user";
 


### PR DESCRIPTION
- **fix(playground): default OpenAI models to Responses API**
- **fix(playground): assume Responses API when unspecified**
- **style(ui): remove model selector chevrons**
- **fix(playground): default to gpt-5.6-sol**
- **chore: switch to luna default**

resolves #<issue-number>
