### PR TITLE
feat(server): show dev tooling info in boot banner

### DIFF
--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -83,6 +83,22 @@ Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability 
   Email (SMTP)        {{ smtp_hostname or not_configured }}
   Telemetry           {{ enabled if telemetry_enabled else disabled }}
 
+{% if dev_mode or debug_logging or dev_vite_url or debugpy_url %}
+{{ header("🐛", "Development") }}
+{% if dev_mode %}
+  Dev mode            {{ enabled }}
+{% endif %}
+{% if debug_logging %}
+  Debug logging       {{ enabled }}
+{% endif %}
+{% if dev_vite_url %}
+  Vite dev server     {{ dev_vite_url }}
+{% endif %}
+{% if debugpy_url %}
+  debugpy             {{ debugpy_url }}
+{% endif %}
+
+{% endif %}
 {{ header("🌎", "Community") }}
   Star on GitHub      {{ github_url }}
   Community Slack     {{ slack_url }}
@@ -138,6 +154,10 @@ class BootMessage:
     prometheus_enabled: bool
     smtp_hostname: str
     telemetry_enabled: bool
+    dev_mode: bool = False
+    debug_logging: bool = False
+    dev_vite_url: Optional[str] = None
+    debugpy_url: Optional[str] = None
 
     def render(self, unicode_ok: Optional[bool] = None) -> str:
         """Render the startup banner for the active console."""

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -251,6 +251,9 @@ def run(args: Namespace) -> None:
     oauth2_client_configs = get_env_oauth2_settings()
     smtp_hostname = get_env_smtp_hostname()
     agent_assistant_enabled = not get_env_disable_agent_assistant()
+    # Dev tooling ports set by the frontend dev scripts (e.g. `pnpm dev:server`)
+    vite_port = os.getenv("VITE_PORT") or (str(args.dev_vite_port) if args.dev else None)
+    debugpy_port = os.getenv("DEBUGPY_PORT")
     msg = BootMessage(
         version=phoenix_version,
         ui_url=display_root_path,
@@ -291,6 +294,10 @@ def run(args: Namespace) -> None:
         prometheus_enabled=bool(enable_prometheus),
         smtp_hostname=smtp_hostname,
         telemetry_enabled=get_env_telemetry_enabled(),
+        dev_mode=args.dev,
+        debug_logging=args.debug,
+        dev_vite_url=f"http://localhost:{vite_port}" if vite_port else None,
+        debugpy_url=f"localhost:{debugpy_port}" if debugpy_port else None,
     ).render()
 
     scaffolder_config = ScaffolderConfig(

--- a/tests/unit/server/cli/test_boot_message.py
+++ b/tests/unit/server/cli/test_boot_message.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import pytest
 
 from phoenix.server.cli.boot_message import BootMessage
@@ -51,6 +53,40 @@ def test_render_uses_uniform_dividers_and_places_tracing_section_last() -> None:
     assert len({len(header) for header in headers}) == 1
     assert "Server" in headers[-2]
     assert "Tracing" in headers[-1]
+
+
+def test_render_omits_development_section_by_default() -> None:
+    rendered = _boot_message().render(unicode_ok=True)
+
+    assert "Development" not in rendered
+
+
+def test_render_shows_development_section_when_dev_tooling_configured() -> None:
+    message = replace(
+        _boot_message(),
+        dev_mode=True,
+        debug_logging=True,
+        dev_vite_url="http://localhost:5173",
+        debugpy_url="localhost:5678",
+    )
+
+    rendered = message.render(unicode_ok=True)
+
+    assert "Development" in rendered
+    assert "Dev mode" in rendered
+    assert "Debug logging" in rendered
+    assert "http://localhost:5173" in rendered
+    assert "localhost:5678" in rendered
+
+
+def test_render_keeps_uniform_dividers_with_development_section() -> None:
+    message = replace(_boot_message(), dev_vite_url="http://localhost:5173")
+
+    rendered = message.render(unicode_ok=True)
+
+    headers = [line for line in rendered.splitlines() if line.startswith(("──", "━━"))]
+    assert any("Development" in header for header in headers)
+    assert len({len(header) for header in headers}) == 1
 
 
 def test_render_without_unicode_omits_logo_and_is_ascii() -> None:


### PR DESCRIPTION
## Summary

When developing Phoenix, the backend boot banner gave no indication that dev tooling was active. The banner now renders a **Development** section when any dev signal is present:

- `--dev` flag → `Dev mode ✅ Enabled` plus the Vite dev server URL (from `--dev-vite-port`)
- `--debug` flag → `Debug logging ✅ Enabled`
- `VITE_PORT` env var (set by `pnpm dev:server`) → `Vite dev server http://localhost:<port>`
- `DEBUGPY_PORT` env var → `debugpy localhost:<port>`

The section is omitted entirely in normal production boots, so the banner is unchanged for end users.

```
── 🐛 Development ───────────────────────────────────────────────────
  Dev mode            ✅ Enabled
  Debug logging       ✅ Enabled
  Vite dev server     http://localhost:5173
  debugpy             localhost:5678
```

## Testing

- New unit tests: section omitted by default, all fields rendered when configured, divider width stays uniform with the new header.
- `uv run pytest tests/unit/server/cli/test_boot_message.py` — 7 passed; `mypy` clean on changed files.