### PR TITLE
docs: surface local (Deno) sandbox setup for code evaluators

### DIFF
--- a/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
+++ b/docs/phoenix/evaluation/server-evals/code-evaluators.mdx
@@ -57,7 +57,7 @@ flowchart LR
 
 From authoring to results, you'll work through five steps:
 
-1. **Create the evaluator** — From a dataset's **Evaluators** tab, choose **Add evaluator → Create new code evaluator**. Pick a language (Python or TypeScript) and a sandbox configuration.
+1. **Create the evaluator** — From a dataset's **Evaluators** tab, choose **Add evaluator → Create new code evaluator**. Pick a language (Python or TypeScript) and a sandbox configuration. *(No sandbox configuration yet? Create one under [Settings → Sandboxes](/docs/phoenix/settings/sandboxes) — for local TypeScript, use the [Deno](/docs/phoenix/settings/sandboxes/deno) sandbox; for local Python, [WebAssembly](/docs/phoenix/settings/sandboxes/wasm).)*
 2. **Write `evaluate(...)`** — The editor opens pre-populated with an `evaluate(...)` function. Its parameters become the evaluator's inputs.
 3. **Configure the annotation** — Pick an optimization direction (maximize vs. minimize) and, optionally, a threshold for pass/fail coloring.
 4. **Map inputs** — Bind each parameter to a path on the [evaluation parameters](/docs/phoenix/evaluation/server-evals/input-mapping#evaluation-parameters) (`input`, `output`, `reference`, `metadata`) or to a literal value.

--- a/docs/phoenix/settings/sandboxes/deno.mdx
+++ b/docs/phoenix/settings/sandboxes/deno.mdx
@@ -14,6 +14,19 @@ The **Deno** sandbox is a **local sandbox** for **simple TypeScript evaluators**
 
 Configure it from [Settings → Sandboxes](/docs/phoenix/settings/sandboxes).
 
+## Setup
+
+The `deno` binary ships **inside the `arizephoenix/phoenix` container**, so there's nothing to install there. If you run Phoenix another way — for example `pip install arize-phoenix` — install Deno yourself so the `deno` binary is on the `PATH` of the process running Phoenix:
+
+```bash
+# macOS
+brew install deno
+# or, any platform:
+curl -fsSL https://deno.land/install.sh | sh
+```
+
+Restart Phoenix, then open [**Settings → Sandboxes**](/docs/phoenix/settings/sandboxes). The **Deno** row should read **Available**. If it shows *"Unavailable — Deno binary isn't installed,"* the Phoenix process can't find `deno` on its `PATH`. For the full platform details, see [Sandbox Backends](/docs/phoenix/self-hosting/features/sandbox-runtimes#deno).
+
 ## What it supports
 
 The Deno sandbox runs your TypeScript in a locked-down local process. It is intentionally limited to **self-contained code**:


### PR DESCRIPTION
## Summary

Setting up a local TypeScript (Deno) code evaluator on a non-container Phoenix (e.g. `pip install arize-phoenix`) requires the `deno` binary, but that requirement isn't stated on the Deno provider page — it lives only in the self-hosting *Sandbox Backends* page, which isn't discoverable from the evaluator flow. First-time users hit "Unavailable — Deno binary isn't installed" with no next step on the page they're looking at.

## Changes

- **`settings/sandboxes/deno.mdx`** — add a **Setup** section: install the `deno` binary for non-container deployments, how to confirm the Deno row reads **Available**, and a link to *Sandbox Backends* for platform details.
- **`evaluation/server-evals/code-evaluators.mdx`** — add a "no sandbox configuration yet?" link from step 1 to Settings → Sandboxes (and the Deno / WebAssembly pages), so readers without a configuration know where to set one up.

Docs-only; no code changes.