### PR TITLE
feat(evaluators): link to Settings → Sandboxes from code-evaluator empty state

### DIFF
--- a/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
+++ b/app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Flex,
   Label,
+  Link,
   ListBox,
   Popover,
   Select,
@@ -176,6 +177,15 @@ export const CodeEvaluatorSandboxField = ({
           )}
         </ListBox>
       </Popover>
+      {hasNoCompatibleConfigs && (
+        <Text slot="description">
+          No sandbox available.{" "}
+          <Link to="/settings/sandboxes">
+            Set one up in Settings → Sandboxes
+          </Link>
+          .
+        </Text>
+      )}
     </Select>
   );
 };


### PR DESCRIPTION
## Summary

When creating a code evaluator, the **Sandbox** picker shows "No sandboxes configured" / "None available" when there's no compatible sandbox configuration — but gives no way to fix it. A user with no sandbox set up hits a dead end.

This adds a description link under the sandbox field, shown only when there are no compatible configurations, pointing to **Settings → Sandboxes** so the user can set one up.

## Change

- `app/src/components/evaluators/CodeEvaluatorLanguageSandboxFields.tsx` — render a `<Text slot="description">` with an internal `<Link to="/settings/sandboxes">` when `hasNoCompatibleConfigs`.

Pairs with the docs update in #14534 (surfacing local Deno sandbox setup).

> Not locally build-verified (frontend deps weren't installed in my environment) — relying on CI typecheck/lint. Draft for that reason.