### PR TITLE
docs: add semantic headings to evaluation quickstarts

### DIFF
--- a/docs/phoenix/evaluation/python-quickstart.mdx
+++ b/docs/phoenix/evaluation/python-quickstart.mdx
@@ -6,7 +6,8 @@ sidebarTitle: "Python Quickstart"
 Now that you have Phoenix up and running, and sent traces to your first project, the next step you can take is running **evaluations** of your Python application. Evaluations let you measure and monitor the quality of your application by scoring traces against metrics like accuracy, relevance, or custom checks.
 
 <Steps>
-  <Step title={<span className="step-title">Launch Phoenix</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Launch Phoenix</h2>
     Before running evals, make sure Phoenix is running & you have sent traces in your project. For more step by step instructions, check out this [Get Started guide](/docs/phoenix/get-started) & [Get Started with Tracing guide](/docs/phoenix/get-started/get-started-tracing).
 
     <Tabs>
@@ -39,7 +40,8 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     </Tabs>
   </Step>
 
-  <Step title={<span className="step-title">Install Phoenix Evals</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Install Phoenix Evals</h2>
     You'll need to install the evals library that's apart of Phoenix.
 
     ```bash
@@ -48,7 +50,8 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     ```
   </Step>
 
-  <Step title={<span className="step-title">Pull down your Trace Data</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Pull down your Trace Data</h2>
     Since, we are running our evaluations on our trace data from our first project, we'll need to pull that data into our code.
 
     ```python
@@ -59,7 +62,8 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     ```
   </Step>
 
-  <Step title={<span className="step-title">Set Up Evaluations</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Set Up Evaluations</h2>
     In this example, we will define, create, and run our own evaluator. There's a number of different evaluators you can run, but this quick start will go through an LLM as a Judge Model.
 
     **1) Define your LLM Judge Model**
@@ -119,7 +123,8 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     ```
   </Step>
 
-  <Step title={<span className="step-title">Run Evaluation</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Run Evaluation</h2>
     Now that we have defined our evaluator, we're ready to evaluate our traces.
 
     ```python
@@ -133,7 +138,8 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     ```
   </Step>
 
-  <Step title={<span className="step-title">Log results to Visualize in Phoenix</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Log results to Visualize in Phoenix</h2>
     You'll now be able to log your evaluations in your project view.
 
     First, format the evaluation results for logging using the `to_annotation_dataframe` utility:

--- a/docs/phoenix/evaluation/typescript-quickstart.mdx
+++ b/docs/phoenix/evaluation/typescript-quickstart.mdx
@@ -17,7 +17,8 @@ If you'd like to follow along with this evaluation example, you can check out th
 </Info>
 
 <Steps>
-  <Step title={<span className="step-title">Set up and Connect to Phoenix</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Set up and Connect to Phoenix</h2>
     Before running your experiment and evaluations, make sure your environment is set up by installing the required dependencies and connecting your application to [Phoenix Cloud](https://app.arize.com/auth/phoenix/).
 
     ```bash
@@ -32,7 +33,8 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
-  <Step title={<span className="step-title">Define a Task</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Define a Task</h2>
     Simply put, the task defines how your application should behave. The task specifies exactly which input fields to pass in and how the application should process that input. By standardizing execution across examples, tasks ensure that evaluations are consistent, repeatable, and comparable as your application evolves.
 
     This example assumes the `task` function is calling the [`spaceKnowledgeApplication`](https://github.com/Arize-ai/phoenix/blob/main/js/examples/apps/demo-document-relevancy-experiment/app.ts#L57) that retrieves context from a knowledge base to answer questions:
@@ -46,7 +48,8 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
-  <Step title={<span className="step-title">Define a Dataset</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Define a Dataset</h2>
     A meaningful evaluation starts with a well-constructed dataset. This dataset should contain a diverse set of examples that capture both typical success cases and realistic failure modes.
 
     Each row in your dataset represents a single scenario the application or agent will encounter, including the _input_ and, when applicable, the _expected output._ The goal is to build a small but representative slice of the real world your application is meant to handle. A thoughtfully designed dataset ensures that the evaluation results are meaningful and aligned with the application's capabilities.
@@ -87,7 +90,8 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
-  <Step title={<span className="step-title">Create an Evaluator</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Create an Evaluator</h2>
     Once a task and dataset are defined, the final piece of the experimentation workflow is the evaluator.
 
     Evaluators determine whether the task output for each example is "good," "bad," or somewhere in between. You can use Phoenix pre-built evaluators or define custom evaluators that give you full control over the metrics and logic used to judge application behavior. The evaluator you choose should align with the specific quality or capability you want to measure.
@@ -118,7 +122,8 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
-  <Step title={<span className="step-title">Run the Experiment</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">Run the Experiment</h2>
     An experiment ties the dataset, task, and evaluator together into an end-to-end process.
 
     When you run an experiment, each dataset example is passed through the task, generating outputs that are then automatically scored by the evaluator. Experiments provide a structured, repeatable framework for testing the application's performance and collecting metrics at scale. Running the experiment produces a full set of scores, explanations, and traces for analysis.
@@ -136,7 +141,8 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
-  <Step title={<span className="step-title">View Results in Phoenix Cloud</span>}>
+  <Step title="">
+    <h2 className="step-semantic-heading">View Results in Phoenix Cloud</h2>
     After the experiment completes, the results provide a detailed breakdown of how the application performed across all examples. You can quickly identify success cases, pinpoint failure modes, and analyze patterns across the dataset.
 
     For LLM-as-a-Judge evaluators, the _explanation_ field is especially valuable—it highlights why the evaluator scored a response a certain way. These explanations often reveal actionable insights, such as missing reasoning steps, misinterpretations, or opportunities to refine prompts. By reviewing these results holistically, you can iteratively improve your application and build confidence in its performance.

--- a/docs/style.css
+++ b/docs/style.css
@@ -32,6 +32,14 @@ table {
     font-size: 1.5rem !important;
 }
 
+[data-component-part="step-title"]:empty {
+    display: none;
+}
+
+.step-semantic-heading {
+    margin-top: 0.5rem !important;
+}
+
 /* Invert monochrome-black logos in dark mode (e.g. vendor SVGs with hardcoded fill="#000"). */
 .dark .invert-on-dark {
     filter: invert(1);


### PR DESCRIPTION
resolves #14442

Adds real h2 headings to the Python and TypeScript evaluation quickstart steps so they appear in the table of contents and expose proper document semantics, while preserving the numbered step layout.

Validation:
- Both changed MDX files compile with @mdx-js/mdx
- git diff --check passes