### PR TITLE
fix(phoenix-sqlean): fix memory-safety and correctness bugs in the C driver

### DIFF
--- a/packages/phoenix-sqlean/LICENSE
+++ b/packages/phoenix-sqlean/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2004-2007 Gerhard Häring, 2018+ Charles Leifer, 2023+ Anton Zhiyanov
+Copyright (c) 2004-2007 Gerhard Häring, 2018+ Charles Leifer, 2023+ Anton Zhiyanov,
+2026+ Arize AI
 
 This software is provided 'as-is', without any express or implied warranty. In
 no event will the authors be held liable for any damages arising from the use

--- a/packages/phoenix-sqlean/Makefile
+++ b/packages/phoenix-sqlean/Makefile
@@ -14,11 +14,11 @@ SQLEAN_REPO := https://github.com/nalgeon/sqlean.git
 # The release SQLEAN_COMMIT corresponds to, +<short sha> when the commit sits
 # ahead of it. check-sqlean-pin enforces that, and that setup.py's copy agrees
 # -- setup.py's is the one compiled in as what sqlean_version() reports.
-SQLEAN_VERSION := 0.28.4+10a13f9
+SQLEAN_VERSION := 0.28.4+71e7625
 # Pinned by commit, not tag: a tag can be moved to different content, a commit
 # cannot, and git verifies every object it receives. Why a given pin was
 # chosen belongs in the commit that moved it.
-SQLEAN_COMMIT := 10a13f904a80f43da65d8029ab3bb7db2d5a2304
+SQLEAN_COMMIT := 71e76250c7c5d2431283d687a04a1433a9f5efe3
 # sqlean's crypto extension includes crypto/xxhash.impl.h but does not ship it.
 # XXHASH_TAG is the tag sqlean's own Makefile fetches; download-sqlean asserts
 # they still agree, so an upstream move stops the build.

--- a/packages/phoenix-sqlean/THIRD_PARTY_LICENSES
+++ b/packages/phoenix-sqlean/THIRD_PARTY_LICENSES
@@ -179,8 +179,9 @@ CPython
 ~~~~~~~
 
 Parts of the SQLite wrapper are derived from CPython's sqlite3 module. They
-have been modified to compile against the bundled SQLite amalgamation and to
-initialize the bundled sqlean extensions.
+have been modified to compile against the bundled SQLite amalgamation, to
+initialize the bundled sqlean extensions, and to fix memory-safety and
+correctness bugs (individual files carry a modification notice).
 
 PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
 --------------------------------------------

--- a/packages/phoenix-sqlean/setup.py
+++ b/packages/phoenix-sqlean/setup.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 PACKAGE_NAME = "sqlean"
 VERSION = "0.1.1"  # x-release-please-version
-SQLEAN_VERSION = "0.28.4+10a13f9"
+SQLEAN_VERSION = "0.28.4+71e7625"
 
 SHORT_DESCRIPTION = "sqlite3 with extensions"
 LONG_DESCRIPTION = Path("README.md").read_text()

--- a/packages/phoenix-sqlean/src/blob.c
+++ b/packages/phoenix-sqlean/src/blob.c
@@ -1,3 +1,11 @@
+/* blob.c - the blob type
+ *
+ * Part of the pysqlite lineage (zlib license; see LICENSE), added in
+ * the pysqlite3 fork.
+ *
+ * Modified by the Arize Phoenix team, 2026.
+ */
+
 #include "blob.h"
 #include "util.h"
 
@@ -23,17 +31,48 @@ int pysqlite_blob_init(pysqlite_Blob *self, pysqlite_Connection* connection,
 
 static void remove_blob_from_connection_blob_list(pysqlite_Blob *self)
 {
-    Py_ssize_t i;
-    PyObject *item, *ref;
+    Py_ssize_t i = 0;
 
-    for (i = 0; i < PyList_GET_SIZE(self->connection->blobs); i++) {
-        item = PyList_GET_ITEM(self->connection->blobs, i);
-        if (PyWeakref_GetRef(item, &ref) == 1) {
-            if (ref == (PyObject *)self) {
+    /* The blob list is gone when the connection failed a
+       re-initialization (and there is no connection at all on a Blob
+       constructed without __init__). */
+    if (self->connection == NULL || self->connection->blobs == NULL) {
+        return;
+    }
+
+    while (i < PyList_GET_SIZE(self->connection->blobs)) {
+        PyObject *item = PyList_GET_ITEM(self->connection->blobs, i);
+#if PY_VERSION_HEX < 0x030D0000
+        /* Borrowed compare: PyWeakref_GetRef would resurrect self when
+           called mid-dealloc (refcount 0 -> 1), and dropping that
+           reference would re-enter tp_dealloc. */
+        if (PyWeakref_GET_OBJECT(item) == (PyObject *)self) {
+            PyList_SetSlice(self->connection->blobs, i, i+1, NULL);
+            break;
+        }
+        i++;
+#else
+        PyObject *ref;
+        int rc = PyWeakref_GetRef(item, &ref);
+        if (rc == 1) {
+            int found = (ref == (PyObject *)self);
+            Py_DECREF(ref);
+            if (found) {
                 PyList_SetSlice(self->connection->blobs, i, i+1, NULL);
                 break;
             }
+            i++;
         }
+        else if (rc == 0) {
+            /* Dead weakref.  On 3.13+ a blob mid-dealloc already reads
+               as dead, so pruning every dead entry is what unlinks it. */
+            PyList_SetSlice(self->connection->blobs, i, i+1, NULL);
+        }
+        else {
+            PyErr_Clear();
+            i++;
+        }
+#endif
     }
 }
 
@@ -52,14 +91,17 @@ static void _close_blob_inner(pysqlite_Blob* self)
 
     /* remove from connection weaklist */
     remove_blob_from_connection_blob_list(self);
-    if (self->in_weakreflist != NULL) {
-        PyObject_ClearWeakRefs((PyObject*)self);
-    }
 }
 
 static void pysqlite_blob_dealloc(pysqlite_Blob* self)
 {
     _close_blob_inner(self);
+    /* Clearing weakrefs is only valid during deallocation; doing it from
+       an explicit close() on a live object is an internal-API misuse
+       (SystemError on 3.13+). */
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }
     Py_XDECREF(self->connection);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
@@ -120,7 +162,7 @@ static PyObject* inner_read(pysqlite_Blob *self, int read_length, int offset)
     raw_buffer = PyBytes_AS_STRING(buffer);
 
     Py_BEGIN_ALLOW_THREADS
-    rc = sqlite3_blob_read(self->blob, raw_buffer, read_length, self->offset);
+    rc = sqlite3_blob_read(self->blob, raw_buffer, read_length, offset);
     Py_END_ALLOW_THREADS
 
     if (rc != SQLITE_OK){
@@ -406,7 +448,6 @@ static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
                 "Blob index out of range");
             return NULL;
         }
-        // TODO: I am not sure...
         return inner_read(self, 1, i);
     }
     else if (PySlice_Check(item)) {
@@ -424,21 +465,26 @@ static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
         } else {
             char *result_buf = (char *)PyMem_Malloc(slicelen);
             char *data_buff = NULL;
-            Py_ssize_t cur, i;
+            Py_ssize_t span_start, span_len, cur, i;
             PyObject *result;
             int rc;
+
+            /* A negative step runs backwards from start; read the byte
+               range the slice spans and pick the items out of it. */
+            span_start = (step > 0) ? start : start + (slicelen - 1) * step;
+            span_len = (slicelen - 1) * (step > 0 ? step : -step) + 1;
 
             if (result_buf == NULL)
                 return PyErr_NoMemory();
 
-            data_buff = (char *)PyMem_Malloc(stop - start);
+            data_buff = (char *)PyMem_Malloc(span_len);
             if (data_buff == NULL) {
                 PyMem_Free(result_buf);
                 return PyErr_NoMemory();
             }
 
             Py_BEGIN_ALLOW_THREADS
-            rc = sqlite3_blob_read(self->blob, data_buff, stop - start, start);
+            rc = sqlite3_blob_read(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
 
             if (rc != SQLITE_OK){
@@ -455,7 +501,7 @@ static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
                 return NULL;
             }
 
-            for (cur = 0, i = 0; i < slicelen;
+            for (cur = start - span_start, i = 0; i < slicelen;
                  cur += step, i++) {
                 result_buf[i] = data_buff[cur];
             }
@@ -538,18 +584,24 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
             rc = write_inner(self, vbuf.buf, slicelen, start);
         }
         else {
-            Py_ssize_t cur, i;
+            Py_ssize_t span_start, span_len, cur, i;
             char *data_buff;
 
+            /* A negative step runs backwards from start; read the byte
+               range the slice spans, merge the new items in, and write
+               that range back. */
+            span_start = (step > 0) ? start : start + (slicelen - 1) * step;
+            span_len = (slicelen - 1) * (step > 0 ? step : -step) + 1;
 
-            data_buff = (char *)PyMem_Malloc(stop - start);
+            data_buff = (char *)PyMem_Malloc(span_len);
             if (data_buff == NULL) {
                 PyErr_NoMemory();
+                PyBuffer_Release(&vbuf);
                 return -1;
             }
 
             Py_BEGIN_ALLOW_THREADS
-            rc = sqlite3_blob_read(self->blob, data_buff, stop - start, start);
+            rc = sqlite3_blob_read(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
 
             if (rc != SQLITE_OK){
@@ -562,10 +614,11 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
                     _pysqlite_seterror(self->connection->db);
                 }
                 PyMem_Free(data_buff);
-                rc = -1;
+                PyBuffer_Release(&vbuf);
+                return -1;
             }
 
-            for (cur = 0, i = 0;
+            for (cur = start - span_start, i = 0;
                  i < slicelen;
                  cur += step, i++)
             {
@@ -573,8 +626,10 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
             }
 
             Py_BEGIN_ALLOW_THREADS
-            rc = sqlite3_blob_write(self->blob, data_buff, stop - start, start);
+            rc = sqlite3_blob_write(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
+
+            PyMem_Free(data_buff);
 
             if (rc != SQLITE_OK){
                 /* For some reason after modifying blob the
@@ -585,8 +640,8 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
                 } else {
                     _pysqlite_seterror(self->connection->db);
                 }
-                PyMem_Free(data_buff);
-                rc = -1;
+                PyBuffer_Release(&vbuf);
+                return -1;
             }
             rc = 0;
 

--- a/packages/phoenix-sqlean/src/blob.c
+++ b/packages/phoenix-sqlean/src/blob.c
@@ -33,6 +33,13 @@ static void remove_blob_from_connection_blob_list(pysqlite_Blob *self)
 {
     Py_ssize_t i = 0;
 
+    /* The blob list is gone when the connection failed a
+       re-initialization (and there is no connection at all on a Blob
+       constructed without __init__). */
+    if (self->connection == NULL || self->connection->blobs == NULL) {
+        return;
+    }
+
     while (i < PyList_GET_SIZE(self->connection->blobs)) {
         PyObject *item = PyList_GET_ITEM(self->connection->blobs, i);
 #if PY_VERSION_HEX < 0x030D0000

--- a/packages/phoenix-sqlean/src/blob.c
+++ b/packages/phoenix-sqlean/src/blob.c
@@ -1,3 +1,11 @@
+/* blob.c - the blob type
+ *
+ * Part of the pysqlite lineage (zlib license; see LICENSE), added in
+ * the pysqlite3 fork.
+ *
+ * Modified by the Arize Phoenix team, 2026.
+ */
+
 #include "blob.h"
 #include "util.h"
 
@@ -23,17 +31,41 @@ int pysqlite_blob_init(pysqlite_Blob *self, pysqlite_Connection* connection,
 
 static void remove_blob_from_connection_blob_list(pysqlite_Blob *self)
 {
-    Py_ssize_t i;
-    PyObject *item, *ref;
+    Py_ssize_t i = 0;
 
-    for (i = 0; i < PyList_GET_SIZE(self->connection->blobs); i++) {
-        item = PyList_GET_ITEM(self->connection->blobs, i);
-        if (PyWeakref_GetRef(item, &ref) == 1) {
-            if (ref == (PyObject *)self) {
+    while (i < PyList_GET_SIZE(self->connection->blobs)) {
+        PyObject *item = PyList_GET_ITEM(self->connection->blobs, i);
+#if PY_VERSION_HEX < 0x030D0000
+        /* Borrowed compare: PyWeakref_GetRef would resurrect self when
+           called mid-dealloc (refcount 0 -> 1), and dropping that
+           reference would re-enter tp_dealloc. */
+        if (PyWeakref_GET_OBJECT(item) == (PyObject *)self) {
+            PyList_SetSlice(self->connection->blobs, i, i+1, NULL);
+            break;
+        }
+        i++;
+#else
+        PyObject *ref;
+        int rc = PyWeakref_GetRef(item, &ref);
+        if (rc == 1) {
+            int found = (ref == (PyObject *)self);
+            Py_DECREF(ref);
+            if (found) {
                 PyList_SetSlice(self->connection->blobs, i, i+1, NULL);
                 break;
             }
+            i++;
         }
+        else if (rc == 0) {
+            /* Dead weakref.  On 3.13+ a blob mid-dealloc already reads
+               as dead, so pruning every dead entry is what unlinks it. */
+            PyList_SetSlice(self->connection->blobs, i, i+1, NULL);
+        }
+        else {
+            PyErr_Clear();
+            i++;
+        }
+#endif
     }
 }
 
@@ -52,14 +84,17 @@ static void _close_blob_inner(pysqlite_Blob* self)
 
     /* remove from connection weaklist */
     remove_blob_from_connection_blob_list(self);
-    if (self->in_weakreflist != NULL) {
-        PyObject_ClearWeakRefs((PyObject*)self);
-    }
 }
 
 static void pysqlite_blob_dealloc(pysqlite_Blob* self)
 {
     _close_blob_inner(self);
+    /* Clearing weakrefs is only valid during deallocation; doing it from
+       an explicit close() on a live object is an internal-API misuse
+       (SystemError on 3.13+). */
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }
     Py_XDECREF(self->connection);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
@@ -120,7 +155,7 @@ static PyObject* inner_read(pysqlite_Blob *self, int read_length, int offset)
     raw_buffer = PyBytes_AS_STRING(buffer);
 
     Py_BEGIN_ALLOW_THREADS
-    rc = sqlite3_blob_read(self->blob, raw_buffer, read_length, self->offset);
+    rc = sqlite3_blob_read(self->blob, raw_buffer, read_length, offset);
     Py_END_ALLOW_THREADS
 
     if (rc != SQLITE_OK){
@@ -406,7 +441,6 @@ static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
                 "Blob index out of range");
             return NULL;
         }
-        // TODO: I am not sure...
         return inner_read(self, 1, i);
     }
     else if (PySlice_Check(item)) {
@@ -424,21 +458,26 @@ static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
         } else {
             char *result_buf = (char *)PyMem_Malloc(slicelen);
             char *data_buff = NULL;
-            Py_ssize_t cur, i;
+            Py_ssize_t span_start, span_len, cur, i;
             PyObject *result;
             int rc;
+
+            /* A negative step runs backwards from start; read the byte
+               range the slice spans and pick the items out of it. */
+            span_start = (step > 0) ? start : start + (slicelen - 1) * step;
+            span_len = (slicelen - 1) * (step > 0 ? step : -step) + 1;
 
             if (result_buf == NULL)
                 return PyErr_NoMemory();
 
-            data_buff = (char *)PyMem_Malloc(stop - start);
+            data_buff = (char *)PyMem_Malloc(span_len);
             if (data_buff == NULL) {
                 PyMem_Free(result_buf);
                 return PyErr_NoMemory();
             }
 
             Py_BEGIN_ALLOW_THREADS
-            rc = sqlite3_blob_read(self->blob, data_buff, stop - start, start);
+            rc = sqlite3_blob_read(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
 
             if (rc != SQLITE_OK){
@@ -455,7 +494,7 @@ static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
                 return NULL;
             }
 
-            for (cur = 0, i = 0; i < slicelen;
+            for (cur = start - span_start, i = 0; i < slicelen;
                  cur += step, i++) {
                 result_buf[i] = data_buff[cur];
             }
@@ -538,18 +577,24 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
             rc = write_inner(self, vbuf.buf, slicelen, start);
         }
         else {
-            Py_ssize_t cur, i;
+            Py_ssize_t span_start, span_len, cur, i;
             char *data_buff;
 
+            /* A negative step runs backwards from start; read the byte
+               range the slice spans, merge the new items in, and write
+               that range back. */
+            span_start = (step > 0) ? start : start + (slicelen - 1) * step;
+            span_len = (slicelen - 1) * (step > 0 ? step : -step) + 1;
 
-            data_buff = (char *)PyMem_Malloc(stop - start);
+            data_buff = (char *)PyMem_Malloc(span_len);
             if (data_buff == NULL) {
                 PyErr_NoMemory();
+                PyBuffer_Release(&vbuf);
                 return -1;
             }
 
             Py_BEGIN_ALLOW_THREADS
-            rc = sqlite3_blob_read(self->blob, data_buff, stop - start, start);
+            rc = sqlite3_blob_read(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
 
             if (rc != SQLITE_OK){
@@ -562,10 +607,11 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
                     _pysqlite_seterror(self->connection->db);
                 }
                 PyMem_Free(data_buff);
-                rc = -1;
+                PyBuffer_Release(&vbuf);
+                return -1;
             }
 
-            for (cur = 0, i = 0;
+            for (cur = start - span_start, i = 0;
                  i < slicelen;
                  cur += step, i++)
             {
@@ -573,8 +619,10 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
             }
 
             Py_BEGIN_ALLOW_THREADS
-            rc = sqlite3_blob_write(self->blob, data_buff, stop - start, start);
+            rc = sqlite3_blob_write(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
+
+            PyMem_Free(data_buff);
 
             if (rc != SQLITE_OK){
                 /* For some reason after modifying blob the
@@ -585,8 +633,8 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
                 } else {
                     _pysqlite_seterror(self->connection->db);
                 }
-                PyMem_Free(data_buff);
-                rc = -1;
+                PyBuffer_Release(&vbuf);
+                return -1;
             }
             rc = 0;
 

--- a/packages/phoenix-sqlean/src/blob.c
+++ b/packages/phoenix-sqlean/src/blob.c
@@ -84,9 +84,15 @@ static void _close_blob_inner(pysqlite_Blob* self)
     blob = self->blob;
     self->blob = NULL;
     if (blob) {
+        if (self->connection) {
+            pysqlite_enter_sqlite(self->connection);
+        }
         Py_BEGIN_ALLOW_THREADS
         sqlite3_blob_close(blob);
         Py_END_ALLOW_THREADS
+        if (self->connection) {
+            pysqlite_leave_sqlite(self->connection);
+        }
     }
 
     /* remove from connection weaklist */
@@ -135,6 +141,12 @@ PyObject* pysqlite_blob_close(pysqlite_Blob *self)
         return NULL;
     }
 
+    if (self->connection->in_sqlite > 0) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Cannot close a blob from within a callback function.");
+        return NULL;
+    }
+
     _close_blob_inner(self);
     Py_RETURN_NONE;
 };
@@ -161,9 +173,11 @@ static PyObject* inner_read(pysqlite_Blob *self, int read_length, int offset)
     }
     raw_buffer = PyBytes_AS_STRING(buffer);
 
+    pysqlite_enter_sqlite(self->connection);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_blob_read(self->blob, raw_buffer, read_length, offset);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_sqlite(self->connection);
 
     if (rc != SQLITE_OK){
         Py_DECREF(buffer);
@@ -218,9 +232,11 @@ static int write_inner(pysqlite_Blob *self, const void *buf, Py_ssize_t len, int
 {
     int rc;
 
+    pysqlite_enter_sqlite(self->connection);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_blob_write(self->blob, buf, len, offset);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_sqlite(self->connection);
     if (rc != SQLITE_OK) {
         /* For some reason after modifying blob the
         error is not set on the connection db. */
@@ -483,9 +499,11 @@ static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
                 return PyErr_NoMemory();
             }
 
+            pysqlite_enter_sqlite(self->connection);
             Py_BEGIN_ALLOW_THREADS
             rc = sqlite3_blob_read(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
+            pysqlite_leave_sqlite(self->connection);
 
             if (rc != SQLITE_OK){
                 /* For some reason after modifying blob the
@@ -600,9 +618,11 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
                 return -1;
             }
 
+            pysqlite_enter_sqlite(self->connection);
             Py_BEGIN_ALLOW_THREADS
             rc = sqlite3_blob_read(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
+            pysqlite_leave_sqlite(self->connection);
 
             if (rc != SQLITE_OK){
                 /* For some reason after modifying blob the
@@ -625,9 +645,11 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
                 data_buff[cur] = ((char *)vbuf.buf)[i];
             }
 
+            pysqlite_enter_sqlite(self->connection);
             Py_BEGIN_ALLOW_THREADS
             rc = sqlite3_blob_write(self->blob, data_buff, span_len, span_start);
             Py_END_ALLOW_THREADS
+            pysqlite_leave_sqlite(self->connection);
 
             PyMem_Free(data_buff);
 

--- a/packages/phoenix-sqlean/src/cache.c
+++ b/packages/phoenix-sqlean/src/cache.c
@@ -2,6 +2,8 @@
  *
  * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
  *
+ * Modified by the Arize Phoenix team, 2026.
+ *
  * This file is part of pysqlite.
  *
  * This software is provided 'as-is', without any express or implied
@@ -193,12 +195,11 @@ PyObject* pysqlite_cache_get(pysqlite_Cache* self, PyObject* key)
         }
 
         node = pysqlite_new_node(key, data);
+        Py_DECREF(data);
         if (!node) {
             return NULL;
         }
         node->prev = self->last;
-
-        Py_DECREF(data);
 
         if (PyDict_SetItem(self->mapping, key, (PyObject*)node) != 0) {
             Py_DECREF(node);

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -2,6 +2,8 @@
  *
  * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
  *
+ * Modified by the Arize Phoenix team, 2026.
+ *
  * This file is part of pysqlite.
  *
  * This software is provided 'as-is', without any express or implied
@@ -106,6 +108,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     int uri = 0;
     double timeout = 5.0;
     int rc;
+    sqlite3 *db = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&|diOiOipiz", kwlist,
                                      PyUnicode_FSConverter, &database_obj, &timeout, &detect_types,
@@ -118,7 +121,40 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
 
     database = PyBytes_AsString(database_obj);
 
-    self->initialized = 1;
+#ifndef SQLITE_OPEN_URI
+    if (uri) {
+        PyErr_SetString(pysqlite_NotSupportedError, "URIs not supported");
+        Py_DECREF(database_obj);
+        return -1;
+    }
+#endif
+
+    /* Open into a local handle first: when __init__ is called again on
+       an existing connection and the open fails (e.g. a bad path), the
+       connection must be left fully intact. */
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_open_v2(database, &db,
+                         flags | (uri ? SQLITE_OPEN_URI : 0), vfs);
+    Py_END_ALLOW_THREADS
+
+    Py_DECREF(database_obj);
+
+    if (rc != SQLITE_OK) {
+        if (db == NULL) {
+            PyErr_NoMemory();
+        } else {
+            _pysqlite_seterror(db);
+            Py_BEGIN_ALLOW_THREADS
+            sqlite3_close_v2(db);
+            Py_END_ALLOW_THREADS
+        }
+        return -1;
+    }
+
+    /* Point of no return: replace the previous state.  A failure from
+       here on leaves a closed connection (see the error label), never a
+       half-initialized one. */
+    self->initialized = 0;
 
     self->begin_statement = NULL;
 
@@ -133,28 +169,25 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     Py_INCREF(&PyUnicode_Type);
     Py_XSETREF(self->text_factory, (PyObject*)&PyUnicode_Type);
 
-#ifndef SQLITE_OPEN_URI
-    if (uri) {
-        PyErr_SetString(pysqlite_NotSupportedError, "URIs not supported");
-        return -1;
+    /* Close the previous handle on re-initialization; it would
+       otherwise leak.  Outstanding statements and blob handles keep it
+       alive until they are finalized (sqlite3_close_v2 semantics). */
+    if (self->db) {
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_close_v2(self->db);
+        Py_END_ALLOW_THREADS
     }
-#endif
-    Py_BEGIN_ALLOW_THREADS
-    rc = sqlite3_open_v2(database, &self->db,
-                         flags | (uri ? SQLITE_OPEN_URI : 0), vfs);
-    Py_END_ALLOW_THREADS
+    self->db = db;
 
-    Py_DECREF(database_obj);
-
-    if (rc != SQLITE_OK) {
-        _pysqlite_seterror(self->db);
-        return -1;
-    }
+    /* The database handle is live from here on; the isolation-level
+       setter below may go through commit(), which requires an
+       initialized connection. */
+    self->initialized = 1;
 
     if (!isolation_level) {
         isolation_level = PyUnicode_FromString("");
         if (!isolation_level) {
-            return -1;
+            goto error;
         }
     } else {
         Py_INCREF(isolation_level);
@@ -162,13 +195,13 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     Py_CLEAR(self->isolation_level);
     if (pysqlite_connection_set_isolation_level(self, isolation_level, NULL) < 0) {
         Py_DECREF(isolation_level);
-        return -1;
+        goto error;
     }
     Py_DECREF(isolation_level);
 
     self->statement_cache = (pysqlite_Cache*)PyObject_CallFunction((PyObject*)&pysqlite_CacheType, "Oi", self, cached_statements);
     if (PyErr_Occurred()) {
-        return -1;
+        goto error;
     }
 
     self->created_statements = 0;
@@ -179,7 +212,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->cursors = PyList_New(0);
     self->blobs = PyList_New(0);
     if (!self->statements || !self->cursors || !self->blobs) {
-        return -1;
+        goto error;
     }
 
     /* By default, the Cache class INCREFs the factory in its initializer, and
@@ -196,7 +229,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->thread_ident = PyThread_get_thread_ident();
     if (!check_same_thread && sqlite3_libversion_number() < 3003001) {
         PyErr_SetString(pysqlite_NotSupportedError, "shared connections not available");
-        return -1;
+        goto error;
     }
     self->check_same_thread = check_same_thread;
 
@@ -207,7 +240,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
 
     Py_XSETREF(self->collations, PyDict_New());
     if (!self->collations) {
-        return -1;
+        goto error;
     }
 
     self->Warning               = pysqlite_Warning;
@@ -222,6 +255,19 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->NotSupportedError     = pysqlite_NotSupportedError;
 
     return 0;
+
+error:
+    /* Close the handle so the failed connection holds no database
+       resources (close() rejects uninitialized connections, so nothing
+       else could release it). */
+    self->initialized = 0;
+    if (self->db) {
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_close_v2(self->db);
+        Py_END_ALLOW_THREADS
+        self->db = NULL;
+    }
+    return -1;
 }
 
 /* action in (ACTION_RESET, ACTION_FINALIZE) */
@@ -337,7 +383,9 @@ PyObject* pysqlite_connection_cursor(pysqlite_Connection* self, PyObject* args, 
 
     _pysqlite_drop_unused_cursor_references(self);
 
-    if (cursor && self->row_factory != Py_None) {
+    /* self->row_factory can be NULL after `del con.row_factory` (it is a
+       plain T_OBJECT member). */
+    if (cursor && self->row_factory != NULL && self->row_factory != Py_None) {
         Py_INCREF(self->row_factory);
         Py_XSETREF(((pysqlite_Cursor *)cursor)->row_factory, self->row_factory);
     }
@@ -365,6 +413,10 @@ PyObject* pysqlite_connection_blob(pysqlite_Connection *self, PyObject *args,
         return NULL;
     }
 
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_blob_open(self->db, dbname, table, column, row,
                            !readonly, &blob);
@@ -377,50 +429,65 @@ PyObject* pysqlite_connection_blob(pysqlite_Connection *self, PyObject *args,
 
     pyblob = PyObject_New(pysqlite_Blob, &pysqlite_BlobType);
     if (!pyblob) {
-        goto error;
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_blob_close(blob);
+        Py_END_ALLOW_THREADS
+        return NULL;
     }
 
+    /* From here on pyblob owns the sqlite3_blob handle: its dealloc
+       closes it, so error paths must not close it a second time. */
     rc = pysqlite_blob_init(pyblob, self, blob);
     if (rc) {
         Py_CLEAR(pyblob);
-        goto error;
+        return NULL;
     }
 
     // Add our blob to connection blobs list
     weakref = PyWeakref_NewRef((PyObject*)pyblob, NULL);
     if (!weakref) {
         Py_CLEAR(pyblob);
-        goto error;
+        return NULL;
     }
     if (PyList_Append(self->blobs, weakref) != 0) {
         Py_CLEAR(weakref);
         Py_CLEAR(pyblob);
-        goto error;
+        return NULL;
     }
     Py_DECREF(weakref);
 
     return (PyObject*)pyblob;
-
-error:
-    Py_BEGIN_ALLOW_THREADS
-    sqlite3_blob_close(blob);
-    Py_END_ALLOW_THREADS
-    return NULL;
 }
 
 static void pysqlite_close_all_blobs(pysqlite_Connection *self)
 {
-    int i;
+    Py_ssize_t i;
     PyObject *weakref;
     PyObject *blob;
+    PyObject *blobs;
 
-    for (i = 0; i < PyList_GET_SIZE(self->blobs); i++) {
-        weakref = PyList_GET_ITEM(self->blobs, i);
+    /* Closing a blob unlinks it from self->blobs; iterate over a
+       snapshot so the removals cannot shift entries out from under the
+       loop. */
+    blobs = PyList_GetSlice(self->blobs, 0, PyList_GET_SIZE(self->blobs));
+    if (blobs == NULL) {
+        PyErr_Clear();
+        return;
+    }
+
+    for (i = 0; i < PyList_GET_SIZE(blobs); i++) {
+        weakref = PyList_GET_ITEM(blobs, i);
         if (PyWeakref_GetRef(weakref, &blob) == 1) {
-            pysqlite_blob_close((pysqlite_Blob*)blob);
+            PyObject *res = pysqlite_blob_close((pysqlite_Blob*)blob);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+            Py_XDECREF(res);
             Py_DECREF(blob);
         }
     }
+
+    Py_DECREF(blobs);
 }
 
 PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args)
@@ -428,6 +495,12 @@ PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args)
     int rc;
 
     if (!pysqlite_check_thread(self)) {
+        return NULL;
+    }
+
+    if (!self->initialized) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Base Connection.__init__ not called.");
         return NULL;
     }
 
@@ -600,10 +673,16 @@ _pysqlite_set_result(sqlite3_context* context, PyObject* py_val)
     } else if (PyFloat_Check(py_val)) {
         sqlite3_result_double(context, PyFloat_AsDouble(py_val));
     } else if (PyUnicode_Check(py_val)) {
-        const char *str = PyUnicode_AsUTF8(py_val);
+        Py_ssize_t sz;
+        const char *str = PyUnicode_AsUTF8AndSize(py_val, &sz);
         if (str == NULL)
             return -1;
-        sqlite3_result_text(context, str, -1, SQLITE_TRANSIENT);
+        if (sz > INT_MAX) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "string longer than INT_MAX bytes");
+            return -1;
+        }
+        sqlite3_result_text(context, str, (int)sz, SQLITE_TRANSIENT);
     } else if (PyObject_CheckBuffer(py_val)) {
         Py_buffer view;
         if (PyObject_GetBuffer(py_val, &view, PyBUF_SIMPLE) != 0) {
@@ -650,7 +729,16 @@ PyObject* _pysqlite_build_py_params(sqlite3_context *context, int argc, sqlite3_
                 break;
             case SQLITE_TEXT:
                 val_str = (const char*)sqlite3_value_text(cur_value);
-                cur_py_value = PyUnicode_FromString(val_str);
+                if (val_str == NULL) {
+                    /* sqlite3_value_text() only fails on OOM */
+                    PyErr_NoMemory();
+                    cur_py_value = NULL;
+                    break;
+                }
+                /* value_bytes() must be called after value_text(): the
+                   text conversion can change the byte count. */
+                buflen = sqlite3_value_bytes(cur_value);
+                cur_py_value = PyUnicode_FromStringAndSize(val_str, buflen);
                 /* TODO: have a way to show errors here */
                 if (!cur_py_value) {
                     PyErr_Clear();
@@ -732,6 +820,11 @@ static void _pysqlite_step_callback(sqlite3_context *context, int argc, sqlite3_
     aggregate_class = (PyObject*)sqlite3_user_data(context);
 
     aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    if (aggregate_instance == NULL) {
+        /* OOM while allocating the aggregate context */
+        sqlite3_result_error_nomem(context);
+        goto error;
+    }
 
     if (*aggregate_instance == NULL) {
         *aggregate_instance = PyObject_CallObject(aggregate_class, NULL);
@@ -855,6 +948,11 @@ void _pysqlite_value_callback(sqlite3_context* context)
     threadstate = PyGILState_Ensure();
 
     aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    if (aggregate_instance == NULL) {
+        /* OOM while allocating the aggregate context */
+        sqlite3_result_error_nomem(context);
+        goto error;
+    }
     if (!*aggregate_instance) {
         goto error;
     }
@@ -901,6 +999,11 @@ static void _pysqlite_inverse_callback(sqlite3_context *context, int argc, sqlit
     threadstate = PyGILState_Ensure();
 
     aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    if (aggregate_instance == NULL) {
+        /* OOM while allocating the aggregate context */
+        sqlite3_result_error_nomem(context);
+        goto error;
+    }
     if (!*aggregate_instance) {
         goto error;
     }
@@ -1202,6 +1305,16 @@ static int _progress_handler(void* user_arg)
     } else {
         rc = (int)PyObject_IsTrue(ret);
         Py_DECREF(ret);
+        if (rc == -1) {
+            if (_pysqlite_enable_callback_tracebacks) {
+                PyErr_Print();
+            } else {
+                PyErr_Clear();
+            }
+
+            /* abort query if error occurred */
+            rc = 1;
+        }
     }
 
     PyGILState_Release(gilstate);
@@ -1226,10 +1339,20 @@ static int _busy_handler(void* user_arg, int n)
         rc = 0;
     }
     else {
-        if (PyLong_Check(ret))
+        if (PyLong_Check(ret)) {
             rc = PyLong_AsInt(ret);
-        else
+            if (rc == -1 && PyErr_Occurred()) {
+                if (_pysqlite_enable_callback_tracebacks)
+                    PyErr_Print();
+                else
+                    PyErr_Clear();
+
+                rc = 0;
+            }
+        }
+        else {
             rc = 0;
+        }
 
         Py_DECREF(ret);
     }
@@ -1424,13 +1547,16 @@ static PyObject* pysqlite_connection_set_busy_timeout(pysqlite_Connection* self,
     }
 
     int rc;
-    rc = sqlite3_busy_timeout(self->db, (int)busy_timeout * 1000);
+    rc = sqlite3_busy_timeout(self->db, (int)(busy_timeout * 1000.0));
     if (rc != SQLITE_OK) {
         PyErr_SetString(pysqlite_OperationalError, "Error setting busy timeout");
         return NULL;
     }
     else {
-        Py_XDECREF(self->function_pinboard_busy_handler_cb);
+        /* sqlite3_busy_timeout() replaced any registered busy handler;
+           drop the pinboard reference and NULL it so it cannot be
+           decref'ed a second time. */
+        Py_CLEAR(self->function_pinboard_busy_handler_cb);
     }
 
     Py_RETURN_NONE;
@@ -1500,7 +1626,7 @@ static PyObject* pysqlite_load_extension(pysqlite_Connection* self, PyObject* ar
 {
     int rc;
     char* extension_name;
-    char* errmsg;
+    char* errmsg = NULL;
 
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
@@ -1512,7 +1638,13 @@ static PyObject* pysqlite_load_extension(pysqlite_Connection* self, PyObject* ar
 
     rc = sqlite3_load_extension(self->db, extension_name, 0, &errmsg);
     if (rc != 0) {
-        PyErr_SetString(pysqlite_OperationalError, errmsg);
+        if (errmsg != NULL) {
+            PyErr_SetString(pysqlite_OperationalError, errmsg);
+            sqlite3_free(errmsg);
+        } else {
+            PyErr_SetString(pysqlite_OperationalError,
+                            "unable to load extension");
+        }
         return NULL;
     } else {
         Py_RETURN_NONE;
@@ -1537,6 +1669,11 @@ int pysqlite_check_thread(pysqlite_Connection* self)
 
 static PyObject* pysqlite_connection_get_isolation_level(pysqlite_Connection* self, void* unused)
 {
+    if (self->isolation_level == NULL) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Base Connection.__init__ not called.");
+        return NULL;
+    }
     Py_INCREF(self->isolation_level);
     return self->isolation_level;
 }
@@ -1843,6 +1980,10 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|$iOsd:backup", keywords,
                                      &pysqlite_ConnectionType, &target,
                                      &pages, &progress, &name, &sleep_s)) {
+        return NULL;
+    }
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
     }
 

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -1103,7 +1103,11 @@ static void _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self)
 
 static void _destructor(void* args)
 {
+    /* bpo-44304: a statement can outlive its connection, so SQLite may
+       destroy functions from sqlite3_finalize() with the GIL released. */
+    PyGILState_STATE gilstate = PyGILState_Ensure();
     Py_DECREF((PyObject *)args);
+    PyGILState_Release(gilstate);
 }
 
 

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -816,6 +816,11 @@ static void _pysqlite_step_callback(sqlite3_context *context, int argc, sqlite3_
     aggregate_class = (PyObject*)sqlite3_user_data(context);
 
     aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    if (aggregate_instance == NULL) {
+        /* OOM while allocating the aggregate context */
+        sqlite3_result_error_nomem(context);
+        goto error;
+    }
 
     if (*aggregate_instance == NULL) {
         *aggregate_instance = PyObject_CallObject(aggregate_class, NULL);
@@ -939,6 +944,11 @@ void _pysqlite_value_callback(sqlite3_context* context)
     threadstate = PyGILState_Ensure();
 
     aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    if (aggregate_instance == NULL) {
+        /* OOM while allocating the aggregate context */
+        sqlite3_result_error_nomem(context);
+        goto error;
+    }
     if (!*aggregate_instance) {
         goto error;
     }
@@ -985,6 +995,11 @@ static void _pysqlite_inverse_callback(sqlite3_context *context, int argc, sqlit
     threadstate = PyGILState_Ensure();
 
     aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    if (aggregate_instance == NULL) {
+        /* OOM while allocating the aggregate context */
+        sqlite3_result_error_nomem(context);
+        goto error;
+    }
     if (!*aggregate_instance) {
         goto error;
     }

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -2,6 +2,8 @@
  *
  * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
  *
+ * Modified by the Arize Phoenix team, 2026.
+ *
  * This file is part of pysqlite.
  *
  * This software is provided 'as-is', without any express or implied
@@ -365,6 +367,10 @@ PyObject* pysqlite_connection_blob(pysqlite_Connection *self, PyObject *args,
         return NULL;
     }
 
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_blob_open(self->db, dbname, table, column, row,
                            !readonly, &blob);
@@ -377,50 +383,65 @@ PyObject* pysqlite_connection_blob(pysqlite_Connection *self, PyObject *args,
 
     pyblob = PyObject_New(pysqlite_Blob, &pysqlite_BlobType);
     if (!pyblob) {
-        goto error;
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_blob_close(blob);
+        Py_END_ALLOW_THREADS
+        return NULL;
     }
 
+    /* From here on pyblob owns the sqlite3_blob handle: its dealloc
+       closes it, so error paths must not close it a second time. */
     rc = pysqlite_blob_init(pyblob, self, blob);
     if (rc) {
         Py_CLEAR(pyblob);
-        goto error;
+        return NULL;
     }
 
     // Add our blob to connection blobs list
     weakref = PyWeakref_NewRef((PyObject*)pyblob, NULL);
     if (!weakref) {
         Py_CLEAR(pyblob);
-        goto error;
+        return NULL;
     }
     if (PyList_Append(self->blobs, weakref) != 0) {
         Py_CLEAR(weakref);
         Py_CLEAR(pyblob);
-        goto error;
+        return NULL;
     }
     Py_DECREF(weakref);
 
     return (PyObject*)pyblob;
-
-error:
-    Py_BEGIN_ALLOW_THREADS
-    sqlite3_blob_close(blob);
-    Py_END_ALLOW_THREADS
-    return NULL;
 }
 
 static void pysqlite_close_all_blobs(pysqlite_Connection *self)
 {
-    int i;
+    Py_ssize_t i;
     PyObject *weakref;
     PyObject *blob;
+    PyObject *blobs;
 
-    for (i = 0; i < PyList_GET_SIZE(self->blobs); i++) {
-        weakref = PyList_GET_ITEM(self->blobs, i);
+    /* Closing a blob unlinks it from self->blobs; iterate over a
+       snapshot so the removals cannot shift entries out from under the
+       loop. */
+    blobs = PyList_GetSlice(self->blobs, 0, PyList_GET_SIZE(self->blobs));
+    if (blobs == NULL) {
+        PyErr_Clear();
+        return;
+    }
+
+    for (i = 0; i < PyList_GET_SIZE(blobs); i++) {
+        weakref = PyList_GET_ITEM(blobs, i);
         if (PyWeakref_GetRef(weakref, &blob) == 1) {
-            pysqlite_blob_close((pysqlite_Blob*)blob);
+            PyObject *res = pysqlite_blob_close((pysqlite_Blob*)blob);
+            if (res == NULL) {
+                PyErr_Clear();
+            }
+            Py_XDECREF(res);
             Py_DECREF(blob);
         }
     }
+
+    Py_DECREF(blobs);
 }
 
 PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args)

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -122,13 +122,16 @@ pysqlite_is_ident_cont(unsigned char c)
 }
 
 /* Skip the trivia SQLite's tokenizer skips before the first keyword:
-   space/tab/CR/LF/FF, UTF-8 BOM, -- line comments, and C-style comments. */
+   space/tab/CR/LF/FF/VT (sqlite3Isspace, including VT after a space-run;
+   a leading VT is an unrecognized token), empty statements (semicolons),
+   UTF-8 BOM, -- line comments, and C-style comments. */
 static const char *
 pysqlite_skip_sql_trivia(const char *p)
 {
     for (;;) {
         unsigned char c = (unsigned char)*p;
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f') {
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f'
+            || c == '\v' || c == ';') {
             p++;
             continue;
         }

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -315,10 +315,23 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
        otherwise leak.  Outstanding statements and blob handles keep it
        alive until they are finalized (sqlite3_close_v2 semantics). */
     if (self->db) {
-        sqlite3_close_v2(self->db);
+        /* Publish the connection as closed before sqlite3_close_v2 runs:
+           it fires xDestroy for every registered function, and Python
+           code there must see "closed database" from the usual entry
+           checks rather than reach the zombie handle. sqlite3_blob_open
+           in particular does not validate the handle without
+           SQLITE_ENABLE_API_ARMOR and walks freed structures. */
+        sqlite3 *old_db = self->db;
+        self->db = NULL;
+        pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_close_v2(old_db);
+        Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self);
     }
     self->db = db;
     self->in_sqlite = 0;
+    self->in_stmt_teardown = 0;
 
     /* The database handle is live from here on; the isolation-level
        setter below may go through commit(), which requires an
@@ -403,8 +416,13 @@ error:
        else could release it). */
     self->initialized = 0;
     if (self->db) {
-        sqlite3_close_v2(self->db);
+        sqlite3 *old_db = self->db;
         self->db = NULL;
+        pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_close_v2(old_db);
+        Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self);
     }
     return -1;
 }
@@ -491,7 +509,13 @@ void pysqlite_connection_dealloc(pysqlite_Connection* self)
 
     /* Clean up if user has not called .close() explicitly. */
     if (self->db) {
-        sqlite3_close_v2(self->db);
+        sqlite3 *old_db = self->db;
+        self->db = NULL;
+        pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_close_v2(old_db);
+        Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self);
     }
 
     Py_XDECREF(self->isolation_level);
@@ -699,13 +723,20 @@ PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args)
     pysqlite_close_all_blobs(self);
 
     if (self->db) {
-        rc = sqlite3_close_v2(self->db);
+        /* Publish the connection as closed first (see the same step in
+           __init__): xDestroy callbacks fired by the close must not
+           reach the zombie handle through open_blob() or backup(). */
+        sqlite3 *old_db = self->db;
+        self->db = NULL;
+        pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_close_v2(old_db);
+        Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self);
 
         if (rc != SQLITE_OK) {
-            _pysqlite_seterror(self->db);
+            _pysqlite_seterror(old_db);
             return NULL;
-        } else {
-            self->db = NULL;
         }
     }
 

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -1703,21 +1703,25 @@ static PyObject* pysqlite_connection_set_authorizer(pysqlite_Connection* self, P
         pysqlite_enter_sqlite(self);
         rc = sqlite3_set_authorizer(self->db, NULL, NULL);
         pysqlite_leave_sqlite(self);
+        if (rc != SQLITE_OK) {
+            PyErr_SetString(pysqlite_OperationalError, "Error setting authorizer callback");
+            return NULL;
+        }
         Py_XSETREF(self->function_pinboard_authorizer_cb, NULL);
     }
     else {
         Py_INCREF(authorizer_cb);
-        Py_XSETREF(self->function_pinboard_authorizer_cb, authorizer_cb);
         pysqlite_enter_sqlite(self);
         rc = sqlite3_set_authorizer(self->db, _authorizer_callback, (void*)authorizer_cb);
         pysqlite_leave_sqlite(self);
+        if (rc != SQLITE_OK) {
+            Py_DECREF(authorizer_cb);
+            PyErr_SetString(pysqlite_OperationalError, "Error setting authorizer callback");
+            return NULL;
+        }
+        Py_XSETREF(self->function_pinboard_authorizer_cb, authorizer_cb);
     }
 
-    if (rc != SQLITE_OK) {
-        PyErr_SetString(pysqlite_OperationalError, "Error setting authorizer callback");
-        Py_XSETREF(self->function_pinboard_authorizer_cb, NULL);
-        return NULL;
-    }
     Py_RETURN_NONE;
 }
 
@@ -1738,16 +1742,15 @@ static PyObject* pysqlite_connection_set_progress_handler(pysqlite_Connection* s
     }
 
     if (progress_handler == Py_None) {
-        /* None clears the progress handler previously set */
         pysqlite_enter_sqlite(self);
         sqlite3_progress_handler(self->db, 0, 0, (void*)0);
         pysqlite_leave_sqlite(self);
         Py_XSETREF(self->function_pinboard_progress_handler, NULL);
     } else {
+        Py_INCREF(progress_handler);
         pysqlite_enter_sqlite(self);
         sqlite3_progress_handler(self->db, n, _progress_handler, progress_handler);
         pysqlite_leave_sqlite(self);
-        Py_INCREF(progress_handler);
         Py_XSETREF(self->function_pinboard_progress_handler, progress_handler);
     }
 
@@ -1774,21 +1777,25 @@ static PyObject* pysqlite_connection_set_busy_handler(pysqlite_Connection* self,
         pysqlite_enter_sqlite(self);
         rc = sqlite3_busy_handler(self->db, NULL, NULL);
         pysqlite_leave_sqlite(self);
+        if (rc != SQLITE_OK) {
+            PyErr_SetString(pysqlite_OperationalError, "Error setting busy handler");
+            return NULL;
+        }
         Py_XSETREF(self->function_pinboard_busy_handler_cb, NULL);
     }
     else {
         Py_INCREF(busy_handler);
-        Py_XSETREF(self->function_pinboard_busy_handler_cb, busy_handler);
         pysqlite_enter_sqlite(self);
         rc = sqlite3_busy_handler(self->db, _busy_handler, (void*)busy_handler);
         pysqlite_leave_sqlite(self);
+        if (rc != SQLITE_OK) {
+            Py_DECREF(busy_handler);
+            PyErr_SetString(pysqlite_OperationalError, "Error setting busy handler");
+            return NULL;
+        }
+        Py_XSETREF(self->function_pinboard_busy_handler_cb, busy_handler);
     }
 
-    if (rc != SQLITE_OK) {
-        PyErr_SetString(pysqlite_OperationalError, "Error setting busy handler");
-        Py_XSETREF(self->function_pinboard_busy_handler_cb, NULL);
-        return NULL;
-    }
     Py_RETURN_NONE;
 }
 
@@ -2355,56 +2362,77 @@ pysqlite_connection_create_collation(pysqlite_Connection* self, PyObject* args)
 {
     PyObject* callable;
     PyObject* name = NULL;
-    PyObject* retval;
     const char *name_str;
     int rc;
 
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
-        goto finally;
+        return NULL;
     }
 
     if (!PyArg_ParseTuple(args, "UO:create_collation(name, callback)",
                           &name, &callable)) {
-        goto finally;
+        return NULL;
     }
 
     name_str = PyUnicode_AsUTF8(name);
-    if (!name_str)
-        goto finally;
+    if (!name_str) {
+        return NULL;
+    }
 
     if (callable != Py_None && !PyCallable_Check(callable)) {
         PyErr_SetString(PyExc_TypeError, "parameter must be callable");
-        goto finally;
+        return NULL;
     }
 
+    /* Ask SQLite first. The pinboard is updated only after success:
+       sqlite3_create_collation_v2 keeps the previous xUserData when it
+       returns SQLITE_BUSY, and unlike create_function_v2 it does not
+       invoke xDestroy on failure. */
     if (callable != Py_None) {
-        if (PyDict_SetItem(self->collations, name, callable) == -1)
-            goto finally;
+        Py_INCREF(callable);
+        pysqlite_enter_sqlite(self);
+        rc = sqlite3_create_collation_v2(self->db,
+                                         name_str,
+                                         SQLITE_UTF8,
+                                         callable,
+                                         pysqlite_collation_callback,
+                                         &_destructor);
+        pysqlite_leave_sqlite(self);
+        if (rc != SQLITE_OK) {
+            Py_DECREF(callable);
+            _pysqlite_seterror(self->db);
+            return NULL;
+        }
+        if (PyDict_SetItemString(self->collations, name_str, callable) < 0) {
+            pysqlite_enter_sqlite(self);
+            (void)sqlite3_create_collation_v2(self->db,
+                                              name_str,
+                                              SQLITE_UTF8,
+                                              NULL,
+                                              NULL,
+                                              NULL);
+            pysqlite_leave_sqlite(self);
+            return NULL;
+        }
     } else {
-        if (PyDict_DelItem(self->collations, name) == -1)
-            goto finally;
+        pysqlite_enter_sqlite(self);
+        rc = sqlite3_create_collation_v2(self->db,
+                                         name_str,
+                                         SQLITE_UTF8,
+                                         NULL,
+                                         NULL,
+                                         NULL);
+        pysqlite_leave_sqlite(self);
+        if (rc != SQLITE_OK) {
+            _pysqlite_seterror(self->db);
+            return NULL;
+        }
+        if (PyDict_DelItemString(self->collations, name_str) < 0) {
+            PyErr_Clear();
+        }
     }
 
-    rc = sqlite3_create_collation(self->db,
-                                  name_str,
-                                  SQLITE_UTF8,
-                                  (callable != Py_None) ? callable : NULL,
-                                  (callable != Py_None) ? pysqlite_collation_callback : NULL);
-    if (rc != SQLITE_OK) {
-        PyDict_DelItem(self->collations, name);
-        _pysqlite_seterror(self->db);
-        goto finally;
-    }
-
-finally:
-    if (PyErr_Occurred()) {
-        retval = NULL;
-    } else {
-        Py_INCREF(Py_None);
-        retval = Py_None;
-    }
-
-    return retval;
+    Py_RETURN_NONE;
 }
 
 /* Called when the connection is used as a context manager. Returns itself as a

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -104,6 +104,20 @@ pysqlite_refuse_txn_in_callback(pysqlite_Connection *self)
     return 0;
 }
 
+static const char cannot_compile_in_compile_callback[] =
+    "Cannot execute SQL from within a callback invoked during statement "
+    "compilation (such as an authorizer).";
+
+int
+pysqlite_refuse_nested_prepare(pysqlite_Connection *self)
+{
+    if (self->in_prepare > 0) {
+        PyErr_SetString(pysqlite_ProgrammingError, cannot_compile_in_compile_callback);
+        return 1;
+    }
+    return 0;
+}
+
 static int
 pysqlite_refuse_commit_in_teardown(pysqlite_Connection *self)
 {
@@ -335,6 +349,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->db = db;
     self->in_sqlite = 0;
     self->in_stmt_teardown = 0;
+    self->in_prepare = 0;
 
     /* The database handle is live from here on; the isolation-level
        setter below may go through commit(), which requires an
@@ -771,10 +786,16 @@ PyObject* _pysqlite_connection_begin(pysqlite_Connection* self)
     int rc;
     sqlite3_stmt* statement;
 
+    if (pysqlite_refuse_nested_prepare(self)) {
+        return NULL;
+    }
+
     pysqlite_enter_sqlite(self);
+    pysqlite_enter_prepare(self);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_prepare_v2(self->db, self->begin_statement, -1, &statement, NULL);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_prepare(self);
     pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
@@ -813,16 +834,18 @@ PyObject* pysqlite_connection_commit(pysqlite_Connection* self, PyObject* args)
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
     }
-    if (pysqlite_refuse_commit_in_teardown(self)) {
+    if (pysqlite_refuse_commit_in_teardown(self) || pysqlite_refuse_nested_prepare(self)) {
         return NULL;
     }
 
     if (!sqlite3_get_autocommit(self->db)) {
 
         pysqlite_enter_sqlite(self);
+        pysqlite_enter_prepare(self);
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_prepare_v2(self->db, "COMMIT", -1, &statement, NULL);
         Py_END_ALLOW_THREADS
+        pysqlite_leave_prepare(self);
         pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->db);
@@ -861,7 +884,7 @@ PyObject* pysqlite_connection_rollback(pysqlite_Connection* self, PyObject* args
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
     }
-    if (pysqlite_refuse_txn_in_callback(self)) {
+    if (pysqlite_refuse_txn_in_callback(self) || pysqlite_refuse_nested_prepare(self)) {
         return NULL;
     }
 
@@ -869,9 +892,11 @@ PyObject* pysqlite_connection_rollback(pysqlite_Connection* self, PyObject* args
         pysqlite_do_all_statements(self, ACTION_RESET, 1);
 
         pysqlite_enter_sqlite(self);
+        pysqlite_enter_prepare(self);
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_prepare_v2(self->db, "ROLLBACK", -1, &statement, NULL);
         Py_END_ALLOW_THREADS
+        pysqlite_leave_prepare(self);
         pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->db);
@@ -2050,6 +2075,8 @@ PyObject* pysqlite_connection_call(pysqlite_Connection* self, PyObject* args, Py
         } else if (rc == PYSQLITE_SQL_WRONG_TYPE) {
             if (PyErr_ExceptionMatches(PyExc_TypeError))
                 PyErr_SetString(pysqlite_Warning, "SQL is of wrong type. Must be string.");
+        } else if (rc == PYSQLITE_NESTED_PREPARE) {
+            /* ProgrammingError already set by pysqlite_statement_create. */
         } else {
             (void)pysqlite_statement_reset(statement);
             _pysqlite_seterror(self->db);

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -308,6 +308,37 @@ void pysqlite_do_all_statements(pysqlite_Connection* self, int action, int reset
     PyObject* weakref;
     PyObject* statement;
     pysqlite_Cursor* cursor;
+    PyObject* locked = NULL;
+
+    /* Hold every live cursor locked so window xFinal cannot re-enter
+       execute() on the statement currently being reset/finalized.
+
+       The locked set is snapshotted with strong references. A callback
+       run by the reset may create cursors (appending to self->cursors)
+       or trigger the periodic rebuild of that list; unlocking by
+       re-walking the live list would then decrement a cursor that was
+       never locked and leave it permanently "in use". Under OOM the
+       lock is skipped rather than half-applied. */
+    if (self->cursors) {
+        PyObject *exc_type, *exc_value, *exc_tb;
+        PyErr_Fetch(&exc_type, &exc_value, &exc_tb);
+        locked = PyList_New(0);
+        if (!locked) {
+            PyErr_Clear();
+        }
+        PyErr_Restore(exc_type, exc_value, exc_tb);
+        for (i = 0; locked && i < PyList_Size(self->cursors); i++) {
+            weakref = PyList_GetItem(self->cursors, i);
+            if (PyWeakref_GetRef(weakref, (PyObject**)&cursor) == 1) {
+                if (PyList_Append(locked, (PyObject*)cursor) == 0) {
+                    cursor->locked++;
+                } else {
+                    PyErr_Clear();
+                }
+                Py_DECREF(cursor);
+            }
+        }
+    }
 
     for (i = 0; i < PyList_Size(self->statements); i++) {
         weakref = PyList_GetItem(self->statements, i);
@@ -321,7 +352,15 @@ void pysqlite_do_all_statements(pysqlite_Connection* self, int action, int reset
         }
     }
 
-    if (reset_cursors) {
+    if (locked) {
+        for (i = 0; i < PyList_Size(locked); i++) {
+            cursor = (pysqlite_Cursor*)PyList_GetItem(locked, i);
+            cursor->locked--;
+        }
+        Py_DECREF(locked);
+    }
+
+    if (reset_cursors && self->cursors) {
         for (i = 0; i < PyList_Size(self->cursors); i++) {
             weakref = PyList_GetItem(self->cursors, i);
             if (PyWeakref_GetRef(weakref, (PyObject**)&cursor) == 1) {

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -379,7 +379,9 @@ PyObject* pysqlite_connection_cursor(pysqlite_Connection* self, PyObject* args, 
 
     _pysqlite_drop_unused_cursor_references(self);
 
-    if (cursor && self->row_factory != Py_None) {
+    /* self->row_factory can be NULL after `del con.row_factory` (it is a
+       plain T_OBJECT member). */
+    if (cursor && self->row_factory != NULL && self->row_factory != Py_None) {
         Py_INCREF(self->row_factory);
         Py_XSETREF(((pysqlite_Cursor *)cursor)->row_factory, self->row_factory);
     }

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -669,10 +669,16 @@ _pysqlite_set_result(sqlite3_context* context, PyObject* py_val)
     } else if (PyFloat_Check(py_val)) {
         sqlite3_result_double(context, PyFloat_AsDouble(py_val));
     } else if (PyUnicode_Check(py_val)) {
-        const char *str = PyUnicode_AsUTF8(py_val);
+        Py_ssize_t sz;
+        const char *str = PyUnicode_AsUTF8AndSize(py_val, &sz);
         if (str == NULL)
             return -1;
-        sqlite3_result_text(context, str, -1, SQLITE_TRANSIENT);
+        if (sz > INT_MAX) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "string longer than INT_MAX bytes");
+            return -1;
+        }
+        sqlite3_result_text(context, str, (int)sz, SQLITE_TRANSIENT);
     } else if (PyObject_CheckBuffer(py_val)) {
         Py_buffer view;
         if (PyObject_GetBuffer(py_val, &view, PyBUF_SIMPLE) != 0) {
@@ -719,7 +725,16 @@ PyObject* _pysqlite_build_py_params(sqlite3_context *context, int argc, sqlite3_
                 break;
             case SQLITE_TEXT:
                 val_str = (const char*)sqlite3_value_text(cur_value);
-                cur_py_value = PyUnicode_FromString(val_str);
+                if (val_str == NULL) {
+                    /* sqlite3_value_text() only fails on OOM */
+                    PyErr_NoMemory();
+                    cur_py_value = NULL;
+                    break;
+                }
+                /* value_bytes() must be called after value_text(): the
+                   text conversion can change the byte count. */
+                buflen = sqlite3_value_bytes(cur_value);
+                cur_py_value = PyUnicode_FromStringAndSize(val_str, buflen);
                 /* TODO: have a way to show errors here */
                 if (!cur_py_value) {
                     PyErr_Clear();

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -350,6 +350,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->in_sqlite = 0;
     self->in_stmt_teardown = 0;
     self->in_prepare = 0;
+    self->backup_target = 0;
 
     /* The database handle is live from here on; the isolation-level
        setter below may go through commit(), which requires an
@@ -776,9 +777,15 @@ int pysqlite_check_connection(pysqlite_Connection* con)
     if (!con->db) {
         PyErr_SetString(pysqlite_ProgrammingError, "Cannot operate on a closed database.");
         return 0;
-    } else {
-        return 1;
     }
+
+    if (con->backup_target > 0) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Cannot operate on the destination of a backup in progress.");
+        return 0;
+    }
+
+    return 1;
 }
 
 PyObject* _pysqlite_connection_begin(pysqlite_Connection* self)
@@ -2350,6 +2357,7 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
 
     pysqlite_enter_sqlite(self);
     pysqlite_enter_sqlite((pysqlite_Connection *)target);
+    ((pysqlite_Connection *)target)->backup_target++;
 
     Py_BEGIN_ALLOW_THREADS
     bck_handle = sqlite3_backup_init(bck_conn, "main", self->db, name);
@@ -2404,6 +2412,7 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
         }
     }
 
+    ((pysqlite_Connection *)target)->backup_target--;
     pysqlite_leave_sqlite((pysqlite_Connection *)target);
     pysqlite_leave_sqlite(self);
 

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -1286,6 +1286,16 @@ static int _progress_handler(void* user_arg)
     } else {
         rc = (int)PyObject_IsTrue(ret);
         Py_DECREF(ret);
+        if (rc == -1) {
+            if (_pysqlite_enable_callback_tracebacks) {
+                PyErr_Print();
+            } else {
+                PyErr_Clear();
+            }
+
+            /* abort query if error occurred */
+            rc = 1;
+        }
     }
 
     PyGILState_Release(gilstate);
@@ -1310,10 +1320,20 @@ static int _busy_handler(void* user_arg, int n)
         rc = 0;
     }
     else {
-        if (PyLong_Check(ret))
+        if (PyLong_Check(ret)) {
             rc = PyLong_AsInt(ret);
-        else
+            if (rc == -1 && PyErr_Occurred()) {
+                if (_pysqlite_enable_callback_tracebacks)
+                    PyErr_Print();
+                else
+                    PyErr_Clear();
+
+                rc = 0;
+            }
+        }
+        else {
             rc = 0;
+        }
 
         Py_DECREF(ret);
     }

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -1607,7 +1607,7 @@ static PyObject* pysqlite_load_extension(pysqlite_Connection* self, PyObject* ar
 {
     int rc;
     char* extension_name;
-    char* errmsg;
+    char* errmsg = NULL;
 
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
@@ -1619,7 +1619,13 @@ static PyObject* pysqlite_load_extension(pysqlite_Connection* self, PyObject* ar
 
     rc = sqlite3_load_extension(self->db, extension_name, 0, &errmsg);
     if (rc != 0) {
-        PyErr_SetString(pysqlite_OperationalError, errmsg);
+        if (errmsg != NULL) {
+            PyErr_SetString(pysqlite_OperationalError, errmsg);
+            sqlite3_free(errmsg);
+        } else {
+            PyErr_SetString(pysqlite_OperationalError,
+                            "unable to load extension");
+        }
         return NULL;
     } else {
         Py_RETURN_NONE;

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -108,6 +108,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     int uri = 0;
     double timeout = 5.0;
     int rc;
+    sqlite3 *db = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&|diOiOipiz", kwlist,
                                      PyUnicode_FSConverter, &database_obj, &timeout, &detect_types,
@@ -120,7 +121,40 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
 
     database = PyBytes_AsString(database_obj);
 
-    self->initialized = 1;
+#ifndef SQLITE_OPEN_URI
+    if (uri) {
+        PyErr_SetString(pysqlite_NotSupportedError, "URIs not supported");
+        Py_DECREF(database_obj);
+        return -1;
+    }
+#endif
+
+    /* Open into a local handle first: when __init__ is called again on
+       an existing connection and the open fails (e.g. a bad path), the
+       connection must be left fully intact. */
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_open_v2(database, &db,
+                         flags | (uri ? SQLITE_OPEN_URI : 0), vfs);
+    Py_END_ALLOW_THREADS
+
+    Py_DECREF(database_obj);
+
+    if (rc != SQLITE_OK) {
+        if (db == NULL) {
+            PyErr_NoMemory();
+        } else {
+            _pysqlite_seterror(db);
+            Py_BEGIN_ALLOW_THREADS
+            sqlite3_close_v2(db);
+            Py_END_ALLOW_THREADS
+        }
+        return -1;
+    }
+
+    /* Point of no return: replace the previous state.  A failure from
+       here on leaves a closed connection (see the error label), never a
+       half-initialized one. */
+    self->initialized = 0;
 
     self->begin_statement = NULL;
 
@@ -135,28 +169,23 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     Py_INCREF(&PyUnicode_Type);
     Py_XSETREF(self->text_factory, (PyObject*)&PyUnicode_Type);
 
-#ifndef SQLITE_OPEN_URI
-    if (uri) {
-        PyErr_SetString(pysqlite_NotSupportedError, "URIs not supported");
-        return -1;
+    /* Close the previous handle on re-initialization; it would
+       otherwise leak.  Outstanding statements and blob handles keep it
+       alive until they are finalized (sqlite3_close_v2 semantics). */
+    if (self->db) {
+        sqlite3_close_v2(self->db);
     }
-#endif
-    Py_BEGIN_ALLOW_THREADS
-    rc = sqlite3_open_v2(database, &self->db,
-                         flags | (uri ? SQLITE_OPEN_URI : 0), vfs);
-    Py_END_ALLOW_THREADS
+    self->db = db;
 
-    Py_DECREF(database_obj);
-
-    if (rc != SQLITE_OK) {
-        _pysqlite_seterror(self->db);
-        return -1;
-    }
+    /* The database handle is live from here on; the isolation-level
+       setter below may go through commit(), which requires an
+       initialized connection. */
+    self->initialized = 1;
 
     if (!isolation_level) {
         isolation_level = PyUnicode_FromString("");
         if (!isolation_level) {
-            return -1;
+            goto error;
         }
     } else {
         Py_INCREF(isolation_level);
@@ -164,13 +193,13 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     Py_CLEAR(self->isolation_level);
     if (pysqlite_connection_set_isolation_level(self, isolation_level, NULL) < 0) {
         Py_DECREF(isolation_level);
-        return -1;
+        goto error;
     }
     Py_DECREF(isolation_level);
 
     self->statement_cache = (pysqlite_Cache*)PyObject_CallFunction((PyObject*)&pysqlite_CacheType, "Oi", self, cached_statements);
     if (PyErr_Occurred()) {
-        return -1;
+        goto error;
     }
 
     self->created_statements = 0;
@@ -181,7 +210,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->cursors = PyList_New(0);
     self->blobs = PyList_New(0);
     if (!self->statements || !self->cursors || !self->blobs) {
-        return -1;
+        goto error;
     }
 
     /* By default, the Cache class INCREFs the factory in its initializer, and
@@ -198,7 +227,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->thread_ident = PyThread_get_thread_ident();
     if (!check_same_thread && sqlite3_libversion_number() < 3003001) {
         PyErr_SetString(pysqlite_NotSupportedError, "shared connections not available");
-        return -1;
+        goto error;
     }
     self->check_same_thread = check_same_thread;
 
@@ -209,7 +238,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
 
     Py_XSETREF(self->collations, PyDict_New());
     if (!self->collations) {
-        return -1;
+        goto error;
     }
 
     self->Warning               = pysqlite_Warning;
@@ -224,6 +253,17 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->NotSupportedError     = pysqlite_NotSupportedError;
 
     return 0;
+
+error:
+    /* Close the handle so the failed connection holds no database
+       resources (close() rejects uninitialized connections, so nothing
+       else could release it). */
+    self->initialized = 0;
+    if (self->db) {
+        sqlite3_close_v2(self->db);
+        self->db = NULL;
+    }
+    return -1;
 }
 
 /* action in (ACTION_RESET, ACTION_FINALIZE) */
@@ -449,6 +489,12 @@ PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args)
     int rc;
 
     if (!pysqlite_check_thread(self)) {
+        return NULL;
+    }
+
+    if (!self->initialized) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Base Connection.__init__ not called.");
         return NULL;
     }
 
@@ -1558,6 +1604,11 @@ int pysqlite_check_thread(pysqlite_Connection* self)
 
 static PyObject* pysqlite_connection_get_isolation_level(pysqlite_Connection* self, void* unused)
 {
+    if (self->isolation_level == NULL) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Base Connection.__init__ not called.");
+        return NULL;
+    }
     Py_INCREF(self->isolation_level);
     return self->isolation_level;
 }
@@ -1864,6 +1915,10 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|$iOsd:backup", keywords,
                                      &pysqlite_ConnectionType, &target,
                                      &pages, &progress, &name, &sleep_s)) {
+        return NULL;
+    }
+
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
     }
 

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -2329,6 +2329,16 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
         PyErr_SetString(PyExc_ValueError, "target cannot be the same connection instance");
         return NULL;
     }
+    /* The step loop below retries forever on SQLITE_BUSY, assuming the
+       contention is external and will clear. From a callback of either
+       connection it is that connection's own in-progress statement, so
+       it never clears: a window finalize running during rollback() spun
+       for good. */
+    if (self->in_sqlite > 0 || ((pysqlite_Connection *)target)->in_sqlite > 0) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Cannot start a backup from within a callback function.");
+        return NULL;
+    }
     if (sleep_s < 0) {
         PyErr_SetString(PyExc_ValueError, "sleep must be greater-than or equal to zero");
         return NULL;

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -1419,6 +1419,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
     }
     Py_INCREF(func);
     pysqlite_enter_sqlite(self);
+    Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_create_function_v2(self->db,
                                     name,
                                     narg,
@@ -1428,6 +1429,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
                                     NULL,
                                     NULL,
                                     &_destructor);
+    Py_END_ALLOW_THREADS
     pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
@@ -1458,6 +1460,7 @@ PyObject* pysqlite_connection_create_aggregate(pysqlite_Connection* self, PyObje
 
     Py_INCREF(aggregate_class);
     pysqlite_enter_sqlite(self);
+    Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_create_function_v2(self->db,
                                     name,
                                     n_arg,
@@ -1467,6 +1470,7 @@ PyObject* pysqlite_connection_create_aggregate(pysqlite_Connection* self, PyObje
                                     &_pysqlite_step_callback,
                                     &_pysqlite_final_callback,
                                     &_destructor);
+    Py_END_ALLOW_THREADS
     pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
@@ -1499,6 +1503,7 @@ PyObject* pysqlite_connection_create_window_function(pysqlite_Connection* self, 
 
     Py_INCREF(window_function_class);
     pysqlite_enter_sqlite(self);
+    Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_create_window_function(
         self->db,
         name,
@@ -1510,6 +1515,7 @@ PyObject* pysqlite_connection_create_window_function(pysqlite_Connection* self, 
         &_pysqlite_value_callback,
         &_pysqlite_inverse_callback,
         &_destructor);
+    Py_END_ALLOW_THREADS
     pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
@@ -1729,7 +1735,9 @@ static PyObject* pysqlite_connection_set_authorizer(pysqlite_Connection* self, P
     int rc;
     if (authorizer_cb == Py_None) {
         pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_set_authorizer(self->db, NULL, NULL);
+        Py_END_ALLOW_THREADS
         pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             PyErr_SetString(pysqlite_OperationalError, "Error setting authorizer callback");
@@ -1740,7 +1748,9 @@ static PyObject* pysqlite_connection_set_authorizer(pysqlite_Connection* self, P
     else {
         Py_INCREF(authorizer_cb);
         pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_set_authorizer(self->db, _authorizer_callback, (void*)authorizer_cb);
+        Py_END_ALLOW_THREADS
         pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             Py_DECREF(authorizer_cb);
@@ -1771,13 +1781,17 @@ static PyObject* pysqlite_connection_set_progress_handler(pysqlite_Connection* s
 
     if (progress_handler == Py_None) {
         pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
         sqlite3_progress_handler(self->db, 0, 0, (void*)0);
+        Py_END_ALLOW_THREADS
         pysqlite_leave_sqlite(self);
         Py_XSETREF(self->function_pinboard_progress_handler, NULL);
     } else {
         Py_INCREF(progress_handler);
         pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
         sqlite3_progress_handler(self->db, n, _progress_handler, progress_handler);
+        Py_END_ALLOW_THREADS
         pysqlite_leave_sqlite(self);
         Py_XSETREF(self->function_pinboard_progress_handler, progress_handler);
     }
@@ -1803,7 +1817,9 @@ static PyObject* pysqlite_connection_set_busy_handler(pysqlite_Connection* self,
     int rc;
     if (busy_handler == Py_None) {
         pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_busy_handler(self->db, NULL, NULL);
+        Py_END_ALLOW_THREADS
         pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             PyErr_SetString(pysqlite_OperationalError, "Error setting busy handler");
@@ -1814,7 +1830,9 @@ static PyObject* pysqlite_connection_set_busy_handler(pysqlite_Connection* self,
     else {
         Py_INCREF(busy_handler);
         pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_busy_handler(self->db, _busy_handler, (void*)busy_handler);
+        Py_END_ALLOW_THREADS
         pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             Py_DECREF(busy_handler);
@@ -1843,7 +1861,9 @@ static PyObject* pysqlite_connection_set_busy_timeout(pysqlite_Connection* self,
     }
 
     int rc;
+    Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_busy_timeout(self->db, (int)(busy_timeout * 1000.0));
+    Py_END_ALLOW_THREADS
     if (rc != SQLITE_OK) {
         PyErr_SetString(pysqlite_OperationalError, "Error setting busy timeout");
         return NULL;
@@ -1876,16 +1896,24 @@ static PyObject* pysqlite_connection_set_trace_callback(pysqlite_Connection* sel
     if (trace_callback == Py_None) {
         /* None clears the trace callback previously set */
 #ifdef HAVE_TRACE_V2
+        Py_BEGIN_ALLOW_THREADS
         sqlite3_trace_v2(self->db, SQLITE_TRACE_STMT, NULL, (void*)0);
+        Py_END_ALLOW_THREADS
 #else
+        Py_BEGIN_ALLOW_THREADS
         sqlite3_trace(self->db, 0, (void*)0);
+        Py_END_ALLOW_THREADS
 #endif
         Py_XSETREF(self->function_pinboard_trace_callback, NULL);
     } else {
 #ifdef HAVE_TRACE_V2
+        Py_BEGIN_ALLOW_THREADS
         sqlite3_trace_v2(self->db, SQLITE_TRACE_STMT, _trace_callback, trace_callback);
+        Py_END_ALLOW_THREADS
 #else
+        Py_BEGIN_ALLOW_THREADS
         sqlite3_trace(self->db, _trace_callback, trace_callback);
+        Py_END_ALLOW_THREADS
 #endif
         Py_INCREF(trace_callback);
         Py_XSETREF(self->function_pinboard_trace_callback, trace_callback);
@@ -2421,12 +2449,14 @@ pysqlite_connection_create_collation(pysqlite_Connection* self, PyObject* args)
     if (callable != Py_None) {
         Py_INCREF(callable);
         pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_create_collation_v2(self->db,
                                          name_str,
                                          SQLITE_UTF8,
                                          callable,
                                          pysqlite_collation_callback,
                                          &_destructor);
+        Py_END_ALLOW_THREADS
         pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             Py_DECREF(callable);
@@ -2435,23 +2465,27 @@ pysqlite_connection_create_collation(pysqlite_Connection* self, PyObject* args)
         }
         if (PyDict_SetItemString(self->collations, name_str, callable) < 0) {
             pysqlite_enter_sqlite(self);
+            Py_BEGIN_ALLOW_THREADS
             (void)sqlite3_create_collation_v2(self->db,
                                               name_str,
                                               SQLITE_UTF8,
                                               NULL,
                                               NULL,
                                               NULL);
+            Py_END_ALLOW_THREADS
             pysqlite_leave_sqlite(self);
             return NULL;
         }
     } else {
         pysqlite_enter_sqlite(self);
+        Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_create_collation_v2(self->db,
                                          name_str,
                                          SQLITE_UTF8,
                                          NULL,
                                          NULL,
                                          NULL);
+        Py_END_ALLOW_THREADS
         pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->db);

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -186,6 +186,24 @@ pysqlite_refuse_txn_sql(pysqlite_Connection *self, PyObject *sql)
     return 0;
 }
 
+static void
+pysqlite_detach_statements(pysqlite_Connection *self)
+{
+    Py_ssize_t i;
+
+    if (!self->statements) {
+        return;
+    }
+    for (i = 0; i < PyList_Size(self->statements); i++) {
+        PyObject *weakref = PyList_GetItem(self->statements, i);
+        PyObject *statement;
+        if (PyWeakref_GetRef(weakref, &statement) == 1) {
+            ((pysqlite_Statement*)statement)->connection = NULL;
+            Py_DECREF(statement);
+        }
+    }
+}
+
 
 static void _sqlite3_result_error(sqlite3_context* ctx, const char* errmsg, int len)
 {
@@ -276,6 +294,11 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     self->initialized = 0;
 
     self->begin_statement = NULL;
+
+    /* Orphans from con("sql") keep a borrowed connection pointer.
+       Drop those before discarding the weakref list, or re-init plus
+       del con leaves finalize writing in_sqlite into freed heap. */
+    pysqlite_detach_statements(self);
 
     Py_CLEAR(self->statement_cache);
     Py_CLEAR(self->statements);
@@ -459,6 +482,12 @@ void pysqlite_do_all_statements(pysqlite_Connection* self, int action, int reset
 void pysqlite_connection_dealloc(pysqlite_Connection* self)
 {
     Py_XDECREF(self->statement_cache);
+
+    /* Drop borrowed statement->connection pointers before freeing this
+       object. An orphan Statement (con("sql") surviving del con) used
+       to increment in_sqlite on the freed heap, corrupting a later
+       Connection that reused the slot. */
+    pysqlite_detach_statements(self);
 
     /* Clean up if user has not called .close() explicitly. */
     if (self->db) {

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -75,6 +75,32 @@ static const char * const begin_statements[] = {
 static int pysqlite_connection_set_isolation_level(pysqlite_Connection* self, PyObject* isolation_level, void *Py_UNUSED(ignored));
 static void _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self);
 
+static const char cannot_close_in_callback[] =
+    "Cannot close the database connection from within a callback function.";
+
+static const char cannot_rollback_in_callback[] =
+    "Cannot roll back a transaction from within a callback function.";
+
+static int
+pysqlite_refuse_close_in_callback(pysqlite_Connection *self)
+{
+    if (self->in_sqlite > 0) {
+        PyErr_SetString(pysqlite_ProgrammingError, cannot_close_in_callback);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+pysqlite_refuse_txn_in_callback(pysqlite_Connection *self)
+{
+    if (self->in_sqlite > 0) {
+        PyErr_SetString(pysqlite_ProgrammingError, cannot_rollback_in_callback);
+        return 1;
+    }
+    return 0;
+}
+
 
 static void _sqlite3_result_error(sqlite3_context* ctx, const char* errmsg, int len)
 {
@@ -120,6 +146,14 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     }
 
     database = PyBytes_AsString(database_obj);
+
+    /* in_sqlite, not initialized: re-init sets initialized=0 before
+       closing the old handle, and an xDestroy __del__ used to re-enter
+       __init__ during that close, leak the inner db, and drop work. */
+    if (pysqlite_refuse_close_in_callback(self)) {
+        Py_DECREF(database_obj);
+        return -1;
+    }
 
 #ifndef SQLITE_OPEN_URI
     if (uri) {
@@ -176,6 +210,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
         sqlite3_close_v2(self->db);
     }
     self->db = db;
+    self->in_sqlite = 0;
 
     /* The database handle is live from here on; the isolation-level
        setter below may go through commit(), which requires an
@@ -413,10 +448,12 @@ PyObject* pysqlite_connection_blob(pysqlite_Connection *self, PyObject *args,
         return NULL;
     }
 
+    pysqlite_enter_sqlite(self);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_blob_open(self->db, dbname, table, column, row,
                            !readonly, &blob);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
         _pysqlite_seterror(self->db);
@@ -500,6 +537,10 @@ PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args)
         return NULL;
     }
 
+    if (pysqlite_refuse_close_in_callback(self)) {
+        return NULL;
+    }
+
     pysqlite_do_all_statements(self, ACTION_FINALIZE, 1);
 
     pysqlite_close_all_blobs(self);
@@ -543,9 +584,11 @@ PyObject* _pysqlite_connection_begin(pysqlite_Connection* self)
     int rc;
     sqlite3_stmt* statement;
 
+    pysqlite_enter_sqlite(self);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_prepare_v2(self->db, self->begin_statement, -1, &statement, NULL);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
         _pysqlite_seterror(self->db);
@@ -557,9 +600,11 @@ PyObject* _pysqlite_connection_begin(pysqlite_Connection* self)
         _pysqlite_seterror(self->db);
     }
 
+    pysqlite_enter_sqlite(self);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_finalize(statement);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK && !PyErr_Occurred()) {
         _pysqlite_seterror(self->db);
@@ -584,9 +629,11 @@ PyObject* pysqlite_connection_commit(pysqlite_Connection* self, PyObject* args)
 
     if (!sqlite3_get_autocommit(self->db)) {
 
+        pysqlite_enter_sqlite(self);
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_prepare_v2(self->db, "COMMIT", -1, &statement, NULL);
         Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->db);
             goto error;
@@ -597,9 +644,11 @@ PyObject* pysqlite_connection_commit(pysqlite_Connection* self, PyObject* args)
             _pysqlite_seterror(self->db);
         }
 
+        pysqlite_enter_sqlite(self);
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_finalize(statement);
         Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK && !PyErr_Occurred()) {
             _pysqlite_seterror(self->db);
         }
@@ -622,13 +671,18 @@ PyObject* pysqlite_connection_rollback(pysqlite_Connection* self, PyObject* args
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
     }
+    if (pysqlite_refuse_txn_in_callback(self)) {
+        return NULL;
+    }
 
     if (!sqlite3_get_autocommit(self->db)) {
         pysqlite_do_all_statements(self, ACTION_RESET, 1);
 
+        pysqlite_enter_sqlite(self);
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_prepare_v2(self->db, "ROLLBACK", -1, &statement, NULL);
         Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->db);
             goto error;
@@ -639,9 +693,11 @@ PyObject* pysqlite_connection_rollback(pysqlite_Connection* self, PyObject* args
             _pysqlite_seterror(self->db);
         }
 
+        pysqlite_enter_sqlite(self);
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_finalize(statement);
         Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self);
         if (rc != SQLITE_OK && !PyErr_Occurred()) {
             _pysqlite_seterror(self->db);
         }
@@ -1147,6 +1203,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
 #endif
     }
     Py_INCREF(func);
+    pysqlite_enter_sqlite(self);
     rc = sqlite3_create_function_v2(self->db,
                                     name,
                                     narg,
@@ -1156,6 +1213,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
                                     NULL,
                                     NULL,
                                     &_destructor);
+    pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
         /* Workaround for SQLite bug: no error code or string is available here */
@@ -1184,6 +1242,7 @@ PyObject* pysqlite_connection_create_aggregate(pysqlite_Connection* self, PyObje
     }
 
     Py_INCREF(aggregate_class);
+    pysqlite_enter_sqlite(self);
     rc = sqlite3_create_function_v2(self->db,
                                     name,
                                     n_arg,
@@ -1193,6 +1252,7 @@ PyObject* pysqlite_connection_create_aggregate(pysqlite_Connection* self, PyObje
                                     &_pysqlite_step_callback,
                                     &_pysqlite_final_callback,
                                     &_destructor);
+    pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
         /* Workaround for SQLite bug: no error code or string is available here */
@@ -1223,6 +1283,7 @@ PyObject* pysqlite_connection_create_window_function(pysqlite_Connection* self, 
     }
 
     Py_INCREF(window_function_class);
+    pysqlite_enter_sqlite(self);
     rc = sqlite3_create_window_function(
         self->db,
         name,
@@ -1234,6 +1295,7 @@ PyObject* pysqlite_connection_create_window_function(pysqlite_Connection* self, 
         &_pysqlite_value_callback,
         &_pysqlite_inverse_callback,
         &_destructor);
+    pysqlite_leave_sqlite(self);
 
     if (rc != SQLITE_OK) {
         /* Workaround for SQLite bug: no error code or string is available here */
@@ -1451,13 +1513,17 @@ static PyObject* pysqlite_connection_set_authorizer(pysqlite_Connection* self, P
 
     int rc;
     if (authorizer_cb == Py_None) {
+        pysqlite_enter_sqlite(self);
         rc = sqlite3_set_authorizer(self->db, NULL, NULL);
+        pysqlite_leave_sqlite(self);
         Py_XSETREF(self->function_pinboard_authorizer_cb, NULL);
     }
     else {
         Py_INCREF(authorizer_cb);
         Py_XSETREF(self->function_pinboard_authorizer_cb, authorizer_cb);
+        pysqlite_enter_sqlite(self);
         rc = sqlite3_set_authorizer(self->db, _authorizer_callback, (void*)authorizer_cb);
+        pysqlite_leave_sqlite(self);
     }
 
     if (rc != SQLITE_OK) {
@@ -1486,10 +1552,14 @@ static PyObject* pysqlite_connection_set_progress_handler(pysqlite_Connection* s
 
     if (progress_handler == Py_None) {
         /* None clears the progress handler previously set */
+        pysqlite_enter_sqlite(self);
         sqlite3_progress_handler(self->db, 0, 0, (void*)0);
+        pysqlite_leave_sqlite(self);
         Py_XSETREF(self->function_pinboard_progress_handler, NULL);
     } else {
+        pysqlite_enter_sqlite(self);
         sqlite3_progress_handler(self->db, n, _progress_handler, progress_handler);
+        pysqlite_leave_sqlite(self);
         Py_INCREF(progress_handler);
         Py_XSETREF(self->function_pinboard_progress_handler, progress_handler);
     }
@@ -1514,13 +1584,17 @@ static PyObject* pysqlite_connection_set_busy_handler(pysqlite_Connection* self,
 
     int rc;
     if (busy_handler == Py_None) {
+        pysqlite_enter_sqlite(self);
         rc = sqlite3_busy_handler(self->db, NULL, NULL);
+        pysqlite_leave_sqlite(self);
         Py_XSETREF(self->function_pinboard_busy_handler_cb, NULL);
     }
     else {
         Py_INCREF(busy_handler);
         Py_XSETREF(self->function_pinboard_busy_handler_cb, busy_handler);
+        pysqlite_enter_sqlite(self);
         rc = sqlite3_busy_handler(self->db, _busy_handler, (void*)busy_handler);
+        pysqlite_leave_sqlite(self);
     }
 
     if (rc != SQLITE_OK) {
@@ -1767,6 +1841,7 @@ PyObject* pysqlite_connection_call(pysqlite_Connection* self, PyObject* args, Py
 
     statement->db = NULL;
     statement->st = NULL;
+    statement->connection = NULL;
     statement->sql = NULL;
     statement->in_use = 0;
     statement->in_weakreflist = NULL;
@@ -2021,6 +2096,9 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
 
     bck_conn = ((pysqlite_Connection *)target)->db;
 
+    pysqlite_enter_sqlite(self);
+    pysqlite_enter_sqlite((pysqlite_Connection *)target);
+
     Py_BEGIN_ALLOW_THREADS
     bck_handle = sqlite3_backup_init(bck_conn, "main", self->db, name);
     Py_END_ALLOW_THREADS
@@ -2073,6 +2151,9 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
             PyErr_SetString(pysqlite_OperationalError, sqlite3_errstr(rc));
         }
     }
+
+    pysqlite_leave_sqlite((pysqlite_Connection *)target);
+    pysqlite_leave_sqlite(self);
 
     if (!callback_error && rc == SQLITE_OK) {
         Py_RETURN_NONE;

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -1508,13 +1508,16 @@ static PyObject* pysqlite_connection_set_busy_timeout(pysqlite_Connection* self,
     }
 
     int rc;
-    rc = sqlite3_busy_timeout(self->db, (int)busy_timeout * 1000);
+    rc = sqlite3_busy_timeout(self->db, (int)(busy_timeout * 1000.0));
     if (rc != SQLITE_OK) {
         PyErr_SetString(pysqlite_OperationalError, "Error setting busy timeout");
         return NULL;
     }
     else {
-        Py_XDECREF(self->function_pinboard_busy_handler_cb);
+        /* sqlite3_busy_timeout() replaced any registered busy handler;
+           drop the pinboard reference and NULL it so it cannot be
+           decref'ed a second time. */
+        Py_CLEAR(self->function_pinboard_busy_handler_cb);
     }
 
     Py_RETURN_NONE;

--- a/packages/phoenix-sqlean/src/connection.c
+++ b/packages/phoenix-sqlean/src/connection.c
@@ -81,6 +81,9 @@ static const char cannot_close_in_callback[] =
 static const char cannot_rollback_in_callback[] =
     "Cannot roll back a transaction from within a callback function.";
 
+static const char cannot_commit_in_teardown[] =
+    "Cannot commit a transaction from within a statement reset or finalize.";
+
 static int
 pysqlite_refuse_close_in_callback(pysqlite_Connection *self)
 {
@@ -97,6 +100,88 @@ pysqlite_refuse_txn_in_callback(pysqlite_Connection *self)
     if (self->in_sqlite > 0) {
         PyErr_SetString(pysqlite_ProgrammingError, cannot_rollback_in_callback);
         return 1;
+    }
+    return 0;
+}
+
+static int
+pysqlite_refuse_commit_in_teardown(pysqlite_Connection *self)
+{
+    if (self->in_stmt_teardown > 0) {
+        PyErr_SetString(pysqlite_ProgrammingError, cannot_commit_in_teardown);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+pysqlite_is_ident_cont(unsigned char c)
+{
+    return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z')
+        || (c >= 'a' && c <= 'z') || c == '_';
+}
+
+/* Skip the trivia SQLite's tokenizer skips before the first keyword:
+   space/tab/CR/LF/FF, UTF-8 BOM, -- line comments, and C-style comments. */
+static const char *
+pysqlite_skip_sql_trivia(const char *p)
+{
+    for (;;) {
+        unsigned char c = (unsigned char)*p;
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f') {
+            p++;
+            continue;
+        }
+        if ((unsigned char)p[0] == 0xef && (unsigned char)p[1] == 0xbb
+            && (unsigned char)p[2] == 0xbf) {
+            p += 3;
+            continue;
+        }
+        if (p[0] == '-' && p[1] == '-') {
+            p += 2;
+            while (*p && *p != '\n') {
+                p++;
+            }
+            continue;
+        }
+        if (p[0] == '/' && p[1] == '*') {
+            p += 2;
+            while (*p) {
+                if (p[0] == '*' && p[1] == '/') {
+                    p += 2;
+                    break;
+                }
+                p++;
+            }
+            continue;
+        }
+        return p;
+    }
+}
+
+static int
+pysqlite_sql_keyword(const char *p, const char *kw, Py_ssize_t n)
+{
+    if (PyOS_strnicmp(p, kw, n) != 0) {
+        return 0;
+    }
+    return !pysqlite_is_ident_cont((unsigned char)p[n]);
+}
+
+int
+pysqlite_refuse_txn_sql(pysqlite_Connection *self, PyObject *sql)
+{
+    const char *p;
+
+    p = PyUnicode_AsUTF8(sql);
+    if (!p) {
+        return 1;
+    }
+    p = pysqlite_skip_sql_trivia(p);
+    if (pysqlite_sql_keyword(p, "commit", 6)
+        || pysqlite_sql_keyword(p, "end", 3)
+        || pysqlite_sql_keyword(p, "release", 7)) {
+        return pysqlite_refuse_commit_in_teardown(self);
     }
     return 0;
 }
@@ -663,6 +748,9 @@ PyObject* pysqlite_connection_commit(pysqlite_Connection* self, PyObject* args)
     sqlite3_stmt* statement;
 
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+    if (pysqlite_refuse_commit_in_teardown(self)) {
         return NULL;
     }
 

--- a/packages/phoenix-sqlean/src/connection.h
+++ b/packages/phoenix-sqlean/src/connection.h
@@ -121,6 +121,14 @@ typedef struct
        connection, so a nested compile is refused. */
     int in_prepare;
 
+    /* Non-zero while this connection is the destination of an
+       in-progress backup(). SQLite forbids any use of the destination
+       until the backup finishes: even a read from the progress
+       callback left every later backup_step returning SQLITE_BUSY, and
+       the retry loop never exits. check_connection refuses every
+       method while it is set. */
+    int backup_target;
+
     /* Exception objects */
     PyObject* Warning;
     PyObject* Error;

--- a/packages/phoenix-sqlean/src/connection.h
+++ b/packages/phoenix-sqlean/src/connection.h
@@ -97,6 +97,15 @@ typedef struct
     /* a dictionary of registered collation name => collation callable mappings */
     PyObject* collations;
 
+    /* Non-zero while a sqlite3_* call that may invoke a Python
+       callback is on the C stack. close(), rollback(), re-init, and
+       cursor close or re-init refuse to tear down handles in that
+       window: re-entering finalize/reset/close crashes when the native
+       call resumes. Registering functions or collations is left to
+       SQLite, which refuses to replace one while a statement is active
+       and can safely add a new one. */
+    int in_sqlite;
+
     /* Exception objects */
     PyObject* Warning;
     PyObject* Error;
@@ -126,6 +135,18 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
 int pysqlite_connection_register_cursor(pysqlite_Connection* connection, PyObject* cursor);
 int pysqlite_check_thread(pysqlite_Connection* self);
 int pysqlite_check_connection(pysqlite_Connection* con);
+
+static inline void
+pysqlite_enter_sqlite(pysqlite_Connection *self)
+{
+    self->in_sqlite++;
+}
+
+static inline void
+pysqlite_leave_sqlite(pysqlite_Connection *self)
+{
+    self->in_sqlite--;
+}
 
 int pysqlite_connection_setup_types(void);
 

--- a/packages/phoenix-sqlean/src/connection.h
+++ b/packages/phoenix-sqlean/src/connection.h
@@ -106,6 +106,12 @@ typedef struct
        and can safely add a new one. */
     int in_sqlite;
 
+    /* Non-zero while sqlite3_reset/finalize is on the C stack. commit()
+       is refused here because SQLite will accept COMMIT while statements
+       are mid-reset, turning rollback into a commit. Backup progress
+       still commits: that path increments in_sqlite only. */
+    int in_stmt_teardown;
+
     /* Exception objects */
     PyObject* Warning;
     PyObject* Error;
@@ -135,6 +141,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
 int pysqlite_connection_register_cursor(pysqlite_Connection* connection, PyObject* cursor);
 int pysqlite_check_thread(pysqlite_Connection* self);
 int pysqlite_check_connection(pysqlite_Connection* con);
+int pysqlite_refuse_txn_sql(pysqlite_Connection *self, PyObject *sql);
 
 static inline void
 pysqlite_enter_sqlite(pysqlite_Connection *self)
@@ -146,6 +153,18 @@ static inline void
 pysqlite_leave_sqlite(pysqlite_Connection *self)
 {
     self->in_sqlite--;
+}
+
+static inline void
+pysqlite_enter_stmt_teardown(pysqlite_Connection *self)
+{
+    self->in_stmt_teardown++;
+}
+
+static inline void
+pysqlite_leave_stmt_teardown(pysqlite_Connection *self)
+{
+    self->in_stmt_teardown--;
 }
 
 int pysqlite_connection_setup_types(void);

--- a/packages/phoenix-sqlean/src/connection.h
+++ b/packages/phoenix-sqlean/src/connection.h
@@ -101,9 +101,11 @@ typedef struct
        callback is on the C stack. close(), rollback(), re-init, and
        cursor close or re-init refuse to tear down handles in that
        window: re-entering finalize/reset/close crashes when the native
-       call resumes. Registering functions or collations is left to
-       SQLite, which refuses to replace one while a statement is active
-       and can safely add a new one. */
+       call resumes. backup() refuses to start there as well, on either
+       end: its retry loop can only spin against the connection's own
+       in-progress statement. Registering functions or collations is
+       left to SQLite, which refuses to replace one while a statement is
+       active and can safely add a new one. */
     int in_sqlite;
 
     /* Non-zero while sqlite3_reset/finalize is on the C stack. commit()

--- a/packages/phoenix-sqlean/src/connection.h
+++ b/packages/phoenix-sqlean/src/connection.h
@@ -2,6 +2,8 @@
  *
  * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
  *
+ * Modified by the Arize Phoenix team, 2026.
+ *
  * This file is part of pysqlite.
  *
  * This software is provided 'as-is', without any express or implied
@@ -114,6 +116,7 @@ PyObject* pysqlite_connection_alloc(PyTypeObject* type, int aware);
 void pysqlite_connection_dealloc(pysqlite_Connection* self);
 PyObject* pysqlite_connection_cursor(pysqlite_Connection* self, PyObject* args, PyObject* kwargs);
 PyObject* pysqlite_connection_close(pysqlite_Connection* self, PyObject* args);
+PyObject* pysqlite_connection_call(pysqlite_Connection* self, PyObject* args, PyObject* kwargs);
 PyObject* _pysqlite_connection_begin(pysqlite_Connection* self);
 PyObject* pysqlite_connection_commit(pysqlite_Connection* self, PyObject* args);
 PyObject* pysqlite_connection_rollback(pysqlite_Connection* self, PyObject* args);

--- a/packages/phoenix-sqlean/src/connection.h
+++ b/packages/phoenix-sqlean/src/connection.h
@@ -112,6 +112,15 @@ typedef struct
        still commits: that path increments in_sqlite only. */
     int in_stmt_teardown;
 
+    /* Non-zero while sqlite3_prepare_v2 is on the C stack. A callback
+       fired during compilation (the authorizer, or a busy handler while
+       the schema loads) that compiles another statement on the same
+       connection recurses without bound, and the C stack goes before
+       Python's recursion limit trips on a thread with a small stack.
+       SQLite documents that such callbacks must not use the invoking
+       connection, so a nested compile is refused. */
+    int in_prepare;
+
     /* Exception objects */
     PyObject* Warning;
     PyObject* Error;
@@ -142,6 +151,7 @@ int pysqlite_connection_register_cursor(pysqlite_Connection* connection, PyObjec
 int pysqlite_check_thread(pysqlite_Connection* self);
 int pysqlite_check_connection(pysqlite_Connection* con);
 int pysqlite_refuse_txn_sql(pysqlite_Connection *self, PyObject *sql);
+int pysqlite_refuse_nested_prepare(pysqlite_Connection *self);
 
 static inline void
 pysqlite_enter_sqlite(pysqlite_Connection *self)
@@ -153,6 +163,18 @@ static inline void
 pysqlite_leave_sqlite(pysqlite_Connection *self)
 {
     self->in_sqlite--;
+}
+
+static inline void
+pysqlite_enter_prepare(pysqlite_Connection *self)
+{
+    self->in_prepare++;
+}
+
+static inline void
+pysqlite_leave_prepare(pysqlite_Connection *self)
+{
+    self->in_prepare--;
 }
 
 static inline void

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -2,6 +2,8 @@
  *
  * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
  *
+ * Modified by the Arize Phoenix team, 2026.
+ *
  * This file is part of pysqlite.
  *
  * This software is provided 'as-is', without any express or implied
@@ -322,6 +324,12 @@ _pysqlite_fetch_one_row(pysqlite_Cursor* self)
                     converted = PyBytes_FromStringAndSize(val_str, nbytes);
                 } else if (self->connection->text_factory == (PyObject*)&PyByteArray_Type) {
                     converted = PyByteArray_FromStringAndSize(val_str, nbytes);
+                } else if (self->connection->text_factory == NULL) {
+                    /* text_factory is a plain T_OBJECT member and can be
+                       deleted with `del con.text_factory` */
+                    PyErr_SetString(pysqlite_ProgrammingError,
+                                    "text_factory attribute is not set");
+                    converted = NULL;
                 } else {
                     converted = PyObject_CallFunction(self->connection->text_factory, "y#", val_str, nbytes);
                 }
@@ -488,6 +496,23 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
         rc = pysqlite_statement_create(self->statement, self->connection, operation);
         if (rc != SQLITE_OK) {
             Py_CLEAR(self->statement);
+            /* Make sure an exception is set: without one this function
+               reports success with no statement, and fetches silently
+               return no rows. */
+            if (rc == PYSQLITE_TOO_MUCH_SQL) {
+                PyErr_SetString(pysqlite_Warning,
+                                "You can only execute one statement at a time.");
+            } else if (rc == PYSQLITE_SQL_WRONG_TYPE) {
+                if (PyErr_ExceptionMatches(PyExc_TypeError))
+                    PyErr_SetString(pysqlite_Warning,
+                                    "SQL is of wrong type. Must be string.");
+            } else if (!PyErr_Occurred()) {
+                _pysqlite_seterror(self->connection->db);
+            }
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(pysqlite_OperationalError,
+                                "Error creating statement");
+            }
             goto error;
         }
     }
@@ -545,8 +570,11 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
         numcols = sqlite3_column_count(self->statement->st);
         Py_END_ALLOW_THREADS
         if (self->description == Py_None && numcols > 0) {
-            Py_SETREF(self->description, PyTuple_New(numcols));
-            if (!self->description) {
+            /* Build the tuple in a local first: publishing it before all
+               slots are filled would expose NULL entries to Python if a
+               mid-loop allocation fails. */
+            PyObject *description = PyTuple_New(numcols);
+            if (!description) {
                 goto error;
             }
             for (i = 0; i < numcols; i++) {
@@ -555,16 +583,19 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
                 colname = sqlite3_column_name(self->statement->st, i);
                 if (colname == NULL) {
                     PyErr_NoMemory();
+                    Py_DECREF(description);
                     goto error;
                 }
                 column_name = _pysqlite_build_column_name(self, colname);
                 if (!column_name) {
+                    Py_DECREF(description);
                     goto error;
                 }
                 decltype = sqlite3_column_decltype(self->statement->st, i);
                 column_decltype = _pysqlite_build_column_decltype(self, decltype);
                 if (!column_decltype) {
                     Py_DECREF(column_name);
+                    Py_DECREF(description);
                     goto error;
                 }
 
@@ -574,10 +605,12 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
                 Py_DECREF(column_name);
                 Py_DECREF(column_decltype);
                 if (descriptor == NULL) {
+                    Py_DECREF(description);
                     goto error;
                 }
-                PyTuple_SET_ITEM(self->description, i, descriptor);
+                PyTuple_SET_ITEM(description, i, descriptor);
             }
+            Py_SETREF(self->description, description);
         }
 
         if (self->statement->is_dml) {
@@ -587,11 +620,15 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
         }
 
         if (!multiple) {
-            Py_DECREF(self->lastrowid);
+            PyObject *new_lastrowid;
             Py_BEGIN_ALLOW_THREADS
             lastrowid = sqlite3_last_insert_rowid(self->connection->db);
             Py_END_ALLOW_THREADS
-            self->lastrowid = PyLong_FromLongLong(lastrowid);
+            new_lastrowid = PyLong_FromLongLong(lastrowid);
+            if (!new_lastrowid) {
+                goto error;
+            }
+            Py_SETREF(self->lastrowid, new_lastrowid);
         }
 
         if (rc == SQLITE_ROW) {
@@ -751,7 +788,9 @@ PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self)
     assert(next_row_tuple != NULL);
     self->next_row = NULL;
 
-    if (self->row_factory != Py_None) {
+    /* self->row_factory can be NULL after `del cur.row_factory` (it is a
+       plain T_OBJECT member). */
+    if (self->row_factory != NULL && self->row_factory != Py_None) {
         next_row = PyObject_CallFunction(self->row_factory, "OO", self, next_row_tuple);
         if (next_row == NULL) {
             self->next_row = next_row_tuple;
@@ -763,14 +802,20 @@ PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self)
     }
 
     if (self->statement) {
+        /* GH-80254: lock the cursor while stepping and fetching so a
+           detect_types converter cannot re-enter execute() on this
+           cursor and reset or free the statement out from under us. */
+        self->locked = 1;
         rc = pysqlite_step(self->statement->st, self->connection);
         if (PyErr_Occurred()) {
             (void)pysqlite_statement_reset(self->statement);
+            self->locked = 0;
             Py_DECREF(next_row);
             return NULL;
         }
         if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
             (void)pysqlite_statement_reset(self->statement);
+            self->locked = 0;
             Py_DECREF(next_row);
             _pysqlite_seterror(self->connection->db);
             return NULL;
@@ -780,9 +825,11 @@ PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self)
             self->next_row = _pysqlite_fetch_one_row(self);
             if (self->next_row == NULL) {
                 (void)pysqlite_statement_reset(self->statement);
+                self->locked = 0;
                 return NULL;
             }
         }
+        self->locked = 0;
     }
 
     return next_row;
@@ -816,6 +863,12 @@ PyObject* pysqlite_cursor_fetchmany(pysqlite_Cursor* self, PyObject* args, PyObj
     list = PyList_New(0);
     if (!list) {
         return NULL;
+    }
+
+    /* `++counter == maxrows` never matches for maxrows <= 0, which would
+       fetch every remaining row. */
+    if (maxrows <= 0) {
+        return list;
     }
 
     while ((row = pysqlite_cursor_iternext(self))) {

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -2,6 +2,8 @@
  *
  * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
  *
+ * Modified by the Arize Phoenix team, 2026.
+ *
  * This file is part of pysqlite.
  *
  * This software is provided 'as-is', without any express or implied
@@ -322,6 +324,12 @@ _pysqlite_fetch_one_row(pysqlite_Cursor* self)
                     converted = PyBytes_FromStringAndSize(val_str, nbytes);
                 } else if (self->connection->text_factory == (PyObject*)&PyByteArray_Type) {
                     converted = PyByteArray_FromStringAndSize(val_str, nbytes);
+                } else if (self->connection->text_factory == NULL) {
+                    /* text_factory is a plain T_OBJECT member and can be
+                       deleted with `del con.text_factory` */
+                    PyErr_SetString(pysqlite_ProgrammingError,
+                                    "text_factory attribute is not set");
+                    converted = NULL;
                 } else {
                     converted = PyObject_CallFunction(self->connection->text_factory, "y#", val_str, nbytes);
                 }
@@ -751,7 +759,9 @@ PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self)
     assert(next_row_tuple != NULL);
     self->next_row = NULL;
 
-    if (self->row_factory != Py_None) {
+    /* self->row_factory can be NULL after `del cur.row_factory` (it is a
+       plain T_OBJECT member). */
+    if (self->row_factory != NULL && self->row_factory != Py_None) {
         next_row = PyObject_CallFunction(self->row_factory, "OO", self, next_row_tuple);
         if (next_row == NULL) {
             self->next_row = next_row_tuple;

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -94,8 +94,11 @@ static void pysqlite_cursor_dealloc(pysqlite_Cursor* self)
 {
     /* Reset the statement if the user has not closed the cursor */
     if (self->statement) {
+        self->locked = 1;
         pysqlite_statement_reset(self->statement);
+        self->locked = 0;
         Py_DECREF(self->statement);
+        self->statement = NULL;
     }
 
     Py_XDECREF(self->connection);
@@ -793,7 +796,9 @@ PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self)
 
     if (!self->next_row) {
          if (self->statement) {
+            self->locked = 1;
             (void)pysqlite_statement_reset(self->statement);
+            self->locked = 0;
             Py_CLEAR(self->statement);
         }
         return NULL;
@@ -944,7 +949,8 @@ PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
     }
 
     /* GH-80254: converters and row factories used to close the cursor
-       while fetch still held the statement. */
+       while fetch still held the statement. Window xFinal can also
+       close a cursor during sqlite3_reset of a different statement. */
     if (self->locked) {
         PyErr_SetString(pysqlite_ProgrammingError,
                         "Recursive use of cursors not allowed.");
@@ -957,7 +963,9 @@ PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
     }
 
     if (self->statement) {
+        self->locked = 1;
         (void)pysqlite_statement_reset(self->statement);
+        self->locked = 0;
         Py_CLEAR(self->statement);
     }
 

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -475,6 +475,10 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
         }
     }
 
+    if (pysqlite_refuse_txn_sql(self->connection, operation)) {
+        goto error;
+    }
+
     if (self->statement != NULL) {
         /* There is an active statement */
         pysqlite_statement_reset(self->statement);

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -828,6 +828,12 @@ PyObject* pysqlite_cursor_fetchmany(pysqlite_Cursor* self, PyObject* args, PyObj
         return NULL;
     }
 
+    /* `++counter == maxrows` never matches for maxrows <= 0, which would
+       fetch every remaining row. */
+    if (maxrows <= 0) {
+        return list;
+    }
+
     while ((row = pysqlite_cursor_iternext(self))) {
         PyList_Append(list, row);
         Py_XDECREF(row);

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -722,7 +722,11 @@ pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
     self->reset = 0;
 
     while (1) {
+        if (pysqlite_refuse_nested_prepare(self->connection)) {
+            goto error;
+        }
         pysqlite_enter_sqlite(self->connection);
+        pysqlite_enter_prepare(self->connection);
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_prepare_v2(self->connection->db,
                                 script_cstr,
@@ -730,6 +734,7 @@ pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
                                 &statement,
                                 &script_cstr);
         Py_END_ALLOW_THREADS
+        pysqlite_leave_prepare(self->connection);
         pysqlite_leave_sqlite(self->connection);
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->connection->db);

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -488,14 +488,16 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
     }
 
     if (self->statement->in_use) {
-        Py_SETREF(self->statement,
-                  PyObject_New(pysqlite_Statement, &pysqlite_StatementType));
-        if (!self->statement) {
+        /* Use the cache factory for duplicates too: it initializes the
+           statement and registers it for connection close/rollback. */
+        func_args = PyTuple_Pack(1, operation);
+        if (!func_args) {
             goto error;
         }
-        rc = pysqlite_statement_create(self->statement, self->connection, operation);
-        if (rc != SQLITE_OK) {
-            Py_CLEAR(self->statement);
+        Py_SETREF(self->statement, (pysqlite_Statement*)
+                  pysqlite_connection_call(self->connection, func_args, NULL));
+        Py_DECREF(func_args);
+        if (!self->statement) {
             goto error;
         }
     }

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -419,13 +419,10 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
     sqlite_int64 lastrowid;
 
     if (!check_cursor(self)) {
-        goto error;
+        return NULL;
     }
 
     self->locked = 1;
-    self->reset = 0;
-
-    Py_CLEAR(self->next_row);
 
     if (multiple) {
         /* executemany() */
@@ -478,6 +475,9 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
     if (pysqlite_refuse_txn_sql(self->connection, operation)) {
         goto error;
     }
+
+    self->reset = 0;
+    Py_CLEAR(self->next_row);
 
     if (self->statement != NULL) {
         /* There is an active statement */
@@ -702,8 +702,6 @@ pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
         return NULL;
     }
 
-    self->reset = 0;
-
     if (PyUnicode_Check(script_obj)) {
         script_cstr = PyUnicode_AsUTF8(script_obj);
         if (!script_cstr) {
@@ -720,6 +718,8 @@ pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
         goto error;
     }
     Py_DECREF(result);
+
+    self->reset = 0;
 
     while (1) {
         pysqlite_enter_sqlite(self->connection);

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -40,6 +40,22 @@ static int pysqlite_cursor_init(pysqlite_Cursor* self, PyObject* args, PyObject*
         return -1;
     }
 
+    /* CPython checks locked before dropping the live statement. Re-init
+       is the same teardown as close() and used to NULL statement while
+       execute/iternext still dereferenced it. */
+    if (self->initialized) {
+        if (self->locked) {
+            PyErr_SetString(pysqlite_ProgrammingError,
+                            "Recursive use of cursors not allowed.");
+            return -1;
+        }
+        if (self->connection != NULL && self->connection->in_sqlite > 0) {
+            PyErr_SetString(pysqlite_ProgrammingError,
+                            "Cannot re-initialize a cursor from within a callback function.");
+            return -1;
+        }
+    }
+
     Py_INCREF(connection);
     Py_XSETREF(self->connection, connection);
     Py_CLEAR(self->statement);
@@ -699,6 +715,7 @@ pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
     Py_DECREF(result);
 
     while (1) {
+        pysqlite_enter_sqlite(self->connection);
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_prepare_v2(self->connection->db,
                                 script_cstr,
@@ -706,6 +723,7 @@ pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
                                 &statement,
                                 &script_cstr);
         Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self->connection);
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->connection->db);
             goto error;
@@ -715,18 +733,30 @@ pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
         do {
             rc = pysqlite_step(statement, self->connection);
             if (PyErr_Occurred()) {
+                pysqlite_enter_sqlite(self->connection);
+                Py_BEGIN_ALLOW_THREADS
                 (void)sqlite3_finalize(statement);
+                Py_END_ALLOW_THREADS
+                pysqlite_leave_sqlite(self->connection);
                 goto error;
             }
         } while (rc == SQLITE_ROW);
 
         if (rc != SQLITE_DONE) {
+            pysqlite_enter_sqlite(self->connection);
+            Py_BEGIN_ALLOW_THREADS
             (void)sqlite3_finalize(statement);
+            Py_END_ALLOW_THREADS
+            pysqlite_leave_sqlite(self->connection);
             _pysqlite_seterror(self->connection->db);
             goto error;
         }
 
+        pysqlite_enter_sqlite(self->connection);
+        Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_finalize(statement);
+        Py_END_ALLOW_THREADS
+        pysqlite_leave_sqlite(self->connection);
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->connection->db);
             goto error;
@@ -918,6 +948,11 @@ PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
     if (self->locked) {
         PyErr_SetString(pysqlite_ProgrammingError,
                         "Recursive use of cursors not allowed.");
+        return NULL;
+    }
+    if (self->connection->in_sqlite > 0) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Cannot close a cursor from within a callback function.");
         return NULL;
     }
 

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -553,8 +553,11 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
         numcols = sqlite3_column_count(self->statement->st);
         Py_END_ALLOW_THREADS
         if (self->description == Py_None && numcols > 0) {
-            Py_SETREF(self->description, PyTuple_New(numcols));
-            if (!self->description) {
+            /* Build the tuple in a local first: publishing it before all
+               slots are filled would expose NULL entries to Python if a
+               mid-loop allocation fails. */
+            PyObject *description = PyTuple_New(numcols);
+            if (!description) {
                 goto error;
             }
             for (i = 0; i < numcols; i++) {
@@ -563,16 +566,19 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
                 colname = sqlite3_column_name(self->statement->st, i);
                 if (colname == NULL) {
                     PyErr_NoMemory();
+                    Py_DECREF(description);
                     goto error;
                 }
                 column_name = _pysqlite_build_column_name(self, colname);
                 if (!column_name) {
+                    Py_DECREF(description);
                     goto error;
                 }
                 decltype = sqlite3_column_decltype(self->statement->st, i);
                 column_decltype = _pysqlite_build_column_decltype(self, decltype);
                 if (!column_decltype) {
                     Py_DECREF(column_name);
+                    Py_DECREF(description);
                     goto error;
                 }
 
@@ -582,10 +588,12 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
                 Py_DECREF(column_name);
                 Py_DECREF(column_decltype);
                 if (descriptor == NULL) {
+                    Py_DECREF(description);
                     goto error;
                 }
-                PyTuple_SET_ITEM(self->description, i, descriptor);
+                PyTuple_SET_ITEM(description, i, descriptor);
             }
+            Py_SETREF(self->description, description);
         }
 
         if (self->statement->is_dml) {
@@ -595,11 +603,15 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* args)
         }
 
         if (!multiple) {
-            Py_DECREF(self->lastrowid);
+            PyObject *new_lastrowid;
             Py_BEGIN_ALLOW_THREADS
             lastrowid = sqlite3_last_insert_rowid(self->connection->db);
             Py_END_ALLOW_THREADS
-            self->lastrowid = PyLong_FromLongLong(lastrowid);
+            new_lastrowid = PyLong_FromLongLong(lastrowid);
+            if (!new_lastrowid) {
+                goto error;
+            }
+            Py_SETREF(self->lastrowid, new_lastrowid);
         }
 
         if (rc == SQLITE_ROW) {

--- a/packages/phoenix-sqlean/src/cursor.c
+++ b/packages/phoenix-sqlean/src/cursor.c
@@ -773,14 +773,20 @@ PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self)
     }
 
     if (self->statement) {
+        /* GH-80254: lock the cursor while stepping and fetching so a
+           detect_types converter cannot re-enter execute() on this
+           cursor and reset or free the statement out from under us. */
+        self->locked = 1;
         rc = pysqlite_step(self->statement->st, self->connection);
         if (PyErr_Occurred()) {
             (void)pysqlite_statement_reset(self->statement);
+            self->locked = 0;
             Py_DECREF(next_row);
             return NULL;
         }
         if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
             (void)pysqlite_statement_reset(self->statement);
+            self->locked = 0;
             Py_DECREF(next_row);
             _pysqlite_seterror(self->connection->db);
             return NULL;
@@ -790,9 +796,11 @@ PyObject* pysqlite_cursor_iternext(pysqlite_Cursor *self)
             self->next_row = _pysqlite_fetch_one_row(self);
             if (self->next_row == NULL) {
                 (void)pysqlite_statement_reset(self->statement);
+                self->locked = 0;
                 return NULL;
             }
         }
+        self->locked = 0;
     }
 
     return next_row;
@@ -888,6 +896,14 @@ PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
         return NULL;
     }
     if (!pysqlite_check_thread(self->connection) || !pysqlite_check_connection(self->connection)) {
+        return NULL;
+    }
+
+    /* GH-80254: converters and row factories used to close the cursor
+       while fetch still held the statement. */
+    if (self->locked) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Recursive use of cursors not allowed.");
         return NULL;
     }
 

--- a/packages/phoenix-sqlean/src/row.c
+++ b/packages/phoenix-sqlean/src/row.c
@@ -2,6 +2,8 @@
  *
  * Copyright (C) 2005-2010 Gerhard Häring <gh@ghaering.de>
  *
+ * Modified by the Arize Phoenix team, 2026.
+ *
  * This file is part of pysqlite.
  *
  * This software is provided 'as-is', without any express or implied
@@ -51,6 +53,14 @@ pysqlite_row_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 
     if (!PyTuple_Check(data)) {
         PyErr_SetString(PyExc_TypeError, "tuple required for second argument");
+        return NULL;
+    }
+
+    /* An uninitialized cursor (Cursor.__new__ without __init__) has a
+       NULL description. */
+    if (cursor->description == NULL) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Base Cursor.__init__ not called.");
         return NULL;
     }
 
@@ -183,7 +193,19 @@ static PyObject* pysqlite_iter(pysqlite_Row* self)
 
 static Py_hash_t pysqlite_row_hash(pysqlite_Row *self)
 {
-    return PyObject_Hash(self->description) ^ PyObject_Hash(self->data);
+    Py_hash_t descr_hash, data_hash, hash;
+
+    descr_hash = PyObject_Hash(self->description);
+    if (descr_hash == -1) {
+        return -1;
+    }
+    data_hash = PyObject_Hash(self->data);
+    if (data_hash == -1) {
+        return -1;
+    }
+    hash = descr_hash ^ data_hash;
+    /* -1 signals an error to the caller */
+    return (hash == -1) ? -2 : hash;
 }
 
 static PyObject* pysqlite_row_richcompare(pysqlite_Row *self, PyObject *_other, int opid)

--- a/packages/phoenix-sqlean/src/sqlean.c
+++ b/packages/phoenix-sqlean/src/sqlean.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2023 Anton Zhiyanov, MIT License
 // https://github.com/nalgeon/sqlean.py
+// Modified by the Arize Phoenix team, 2026.
 
 // Sqlean extensions bundle.
 
@@ -34,33 +35,48 @@ static void sqlean_version(sqlite3_context* context, int argc, sqlite3_value** a
     sqlite3_result_text(context, SQLEAN_VERSION, -1, SQLITE_STATIC);
 }
 
+// init_one initializes a single extension and logs a failure instead of
+// swallowing it: a silently skipped init would only surface much later as
+// a confusing "no such function" error.
+static int init_one(const char* name, int (*init_fn)(sqlite3* db), sqlite3* db) {
+    int rc = init_fn(db);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "sqlean: failed to initialize the %s extension (error code %d)\n", name,
+                rc);
+    }
+    return rc;
+}
+
 // init_all initializes all extensions.
 static int init_all(sqlite3* db) {
-    crypto_init(db);
-    define_init(db);
-    fileio_init(db);
-    fuzzy_init(db);
+    init_one("crypto", crypto_init, db);
+    init_one("define", define_init, db);
+    init_one("fileio", fileio_init, db);
+    init_one("fuzzy", fuzzy_init, db);
 #if !defined(_WIN32)
-    ipaddr_init(db);
+    init_one("ipaddr", ipaddr_init, db);
 #endif
-    regexp_init(db);
-    stats_init(db);
-    text_init(db);
-    time_init(db);
-    unicode_init(db);
-    uuid_init(db);
-    vsv_init(db);
+    init_one("regexp", regexp_init, db);
+    init_one("stats", stats_init, db);
+    init_one("text", text_init, db);
+    init_one("time", time_init, db);
+    init_one("unicode", unicode_init, db);
+    init_one("uuid", uuid_init, db);
+    init_one("vsv", vsv_init, db);
     return SQLITE_OK;
 }
 
 // init_extension initializes the extension if it's enabled according to the env variable.
-static int init_extension(const char* flag, int (*init_fn)(sqlite3* db), sqlite3* db) {
+static int init_extension(const char* flag,
+                          const char* name,
+                          int (*init_fn)(sqlite3* db),
+                          sqlite3* db) {
     const char* enabled = getenv(flag);
     if (enabled == NULL || strcmp(enabled, "0") == 0) {
         // disable the extension unless it is explicitly enabled
         return SQLITE_OK;
     }
-    return init_fn(db);
+    return init_one(name, init_fn, db);
 }
 
 #ifdef _WIN32
@@ -77,7 +93,11 @@ __declspec(dllexport)
     }
 
     static const int flags = SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC;
-    sqlite3_create_function(db, "sqlean_version", 0, flags, 0, sqlean_version, 0, 0);
+    int rc = sqlite3_create_function(db, "sqlean_version", 0, flags, 0, sqlean_version, 0, 0);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "sqlean: failed to register the sqlean_version function (error code %d)\n",
+                rc);
+    }
 
     if (enable_all != NULL) {
         // SQLEAN_ENABLE != 0, enable all extensions
@@ -86,19 +106,19 @@ __declspec(dllexport)
     }
 
     // SQLEAN_ENABLE is not set, enable individual extensions
-    init_extension("SQLEAN_ENABLE_CRYPTO", crypto_init, db);
-    init_extension("SQLEAN_ENABLE_DEFINE", define_init, db);
-    init_extension("SQLEAN_ENABLE_FILEIO", fileio_init, db);
-    init_extension("SQLEAN_ENABLE_FUZZY", fuzzy_init, db);
+    init_extension("SQLEAN_ENABLE_CRYPTO", "crypto", crypto_init, db);
+    init_extension("SQLEAN_ENABLE_DEFINE", "define", define_init, db);
+    init_extension("SQLEAN_ENABLE_FILEIO", "fileio", fileio_init, db);
+    init_extension("SQLEAN_ENABLE_FUZZY", "fuzzy", fuzzy_init, db);
 #if !defined(_WIN32)
-    init_extension("SQLEAN_ENABLE_IPADDR", ipaddr_init, db);
+    init_extension("SQLEAN_ENABLE_IPADDR", "ipaddr", ipaddr_init, db);
 #endif
-    init_extension("SQLEAN_ENABLE_REGEXP", regexp_init, db);
-    init_extension("SQLEAN_ENABLE_STATS", stats_init, db);
-    init_extension("SQLEAN_ENABLE_TEXT", text_init, db);
-    init_extension("SQLEAN_ENABLE_TIME", time_init, db);
-    init_extension("SQLEAN_ENABLE_UNICODE", unicode_init, db);
-    init_extension("SQLEAN_ENABLE_UUID", uuid_init, db);
-    init_extension("SQLEAN_ENABLE_VSV", vsv_init, db);
+    init_extension("SQLEAN_ENABLE_REGEXP", "regexp", regexp_init, db);
+    init_extension("SQLEAN_ENABLE_STATS", "stats", stats_init, db);
+    init_extension("SQLEAN_ENABLE_TEXT", "text", text_init, db);
+    init_extension("SQLEAN_ENABLE_TIME", "time", time_init, db);
+    init_extension("SQLEAN_ENABLE_UNICODE", "unicode", unicode_init, db);
+    init_extension("SQLEAN_ENABLE_UUID", "uuid", uuid_init, db);
+    init_extension("SQLEAN_ENABLE_VSV", "vsv", vsv_init, db);
     return SQLITE_OK;
 }

--- a/packages/phoenix-sqlean/src/statement.c
+++ b/packages/phoenix-sqlean/src/statement.c
@@ -113,7 +113,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
     self->db = connection->db;
 
     if (rc == SQLITE_OK && pysqlite_check_remaining_sql(tail)) {
-        (void)sqlite3_finalize(self->st);
+        (void)pysqlite_statement_finalize(self);
         self->st = NULL;
         rc = PYSQLITE_TOO_MUCH_SQL;
     }
@@ -335,17 +335,18 @@ void pysqlite_statement_bind_parameters(pysqlite_Statement* self, PyObject* para
 
 int pysqlite_statement_finalize(pysqlite_Statement* self)
 {
-    int rc;
+    int rc = SQLITE_OK;
+    sqlite3_stmt *st = self->st;
 
-    rc = SQLITE_OK;
-    if (self->st) {
-        Py_BEGIN_ALLOW_THREADS
-        rc = sqlite3_finalize(self->st);
-        Py_END_ALLOW_THREADS
-        self->st = NULL;
-    }
-
+    /* Drop the pointer first so a re-entrant close/rollback cannot
+       finalize the same VDBE a second time while xFinal is running. */
+    self->st = NULL;
     self->in_use = 0;
+    if (st) {
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_finalize(st);
+        Py_END_ALLOW_THREADS
+    }
 
     return rc;
 }
@@ -376,13 +377,7 @@ void pysqlite_statement_mark_dirty(pysqlite_Statement* self)
 
 void pysqlite_statement_dealloc(pysqlite_Statement* self)
 {
-    if (self->st) {
-        Py_BEGIN_ALLOW_THREADS
-        sqlite3_finalize(self->st);
-        Py_END_ALLOW_THREADS
-    }
-
-    self->st = NULL;
+    (void)pysqlite_statement_finalize(self);
 
     Py_XDECREF(self->sql);
 

--- a/packages/phoenix-sqlean/src/statement.c
+++ b/packages/phoenix-sqlean/src/statement.c
@@ -348,11 +348,13 @@ int pysqlite_statement_finalize(pysqlite_Statement* self)
     if (st) {
         if (self->connection) {
             pysqlite_enter_sqlite(self->connection);
+            pysqlite_enter_stmt_teardown(self->connection);
         }
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_finalize(st);
         Py_END_ALLOW_THREADS
         if (self->connection) {
+            pysqlite_leave_stmt_teardown(self->connection);
             pysqlite_leave_sqlite(self->connection);
         }
     }
@@ -362,18 +364,18 @@ int pysqlite_statement_finalize(pysqlite_Statement* self)
 
 int pysqlite_statement_reset(pysqlite_Statement* self)
 {
-    int rc;
-
-    rc = SQLITE_OK;
+    int rc = SQLITE_OK;
 
     if (self->in_use && self->st) {
         if (self->connection) {
             pysqlite_enter_sqlite(self->connection);
+            pysqlite_enter_stmt_teardown(self->connection);
         }
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_reset(self->st);
         Py_END_ALLOW_THREADS
         if (self->connection) {
+            pysqlite_leave_stmt_teardown(self->connection);
             pysqlite_leave_sqlite(self->connection);
         }
 

--- a/packages/phoenix-sqlean/src/statement.c
+++ b/packages/phoenix-sqlean/src/statement.c
@@ -76,7 +76,12 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
     Py_INCREF(sql);
     self->sql = sql;
 
+    if (pysqlite_refuse_nested_prepare(connection)) {
+        return PYSQLITE_NESTED_PREPARE;
+    }
+
     pysqlite_enter_sqlite(connection);
+    pysqlite_enter_prepare(connection);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_prepare_v2(connection->db,
                             sql_cstr,
@@ -85,6 +90,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
                             &tail);
     self->is_dml = !sqlite3_stmt_readonly(self->st);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_prepare(connection);
     pysqlite_leave_sqlite(connection);
 
     /* To retain backward-compatibility, we need to treat DDL and certain types

--- a/packages/phoenix-sqlean/src/statement.c
+++ b/packages/phoenix-sqlean/src/statement.c
@@ -58,6 +58,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
 
     self->st = NULL;
     self->in_use = 0;
+    self->connection = connection;
 
     assert(PyUnicode_Check(sql));
 
@@ -75,6 +76,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
     Py_INCREF(sql);
     self->sql = sql;
 
+    pysqlite_enter_sqlite(connection);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_prepare_v2(connection->db,
                             sql_cstr,
@@ -83,6 +85,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
                             &tail);
     self->is_dml = !sqlite3_stmt_readonly(self->st);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_sqlite(connection);
 
     /* To retain backward-compatibility, we need to treat DDL and certain types
      * of transactions as being "not-dml".
@@ -343,9 +346,15 @@ int pysqlite_statement_finalize(pysqlite_Statement* self)
     self->st = NULL;
     self->in_use = 0;
     if (st) {
+        if (self->connection) {
+            pysqlite_enter_sqlite(self->connection);
+        }
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_finalize(st);
         Py_END_ALLOW_THREADS
+        if (self->connection) {
+            pysqlite_leave_sqlite(self->connection);
+        }
     }
 
     return rc;
@@ -358,9 +367,15 @@ int pysqlite_statement_reset(pysqlite_Statement* self)
     rc = SQLITE_OK;
 
     if (self->in_use && self->st) {
+        if (self->connection) {
+            pysqlite_enter_sqlite(self->connection);
+        }
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_reset(self->st);
         Py_END_ALLOW_THREADS
+        if (self->connection) {
+            pysqlite_leave_sqlite(self->connection);
+        }
 
         if (rc == SQLITE_OK) {
             self->in_use = 0;

--- a/packages/phoenix-sqlean/src/statement.h
+++ b/packages/phoenix-sqlean/src/statement.h
@@ -31,6 +31,7 @@
 
 #define PYSQLITE_TOO_MUCH_SQL (-100)
 #define PYSQLITE_SQL_WRONG_TYPE (-101)
+#define PYSQLITE_NESTED_PREPARE (-102)
 
 typedef struct
 {

--- a/packages/phoenix-sqlean/src/statement.h
+++ b/packages/phoenix-sqlean/src/statement.h
@@ -37,6 +37,10 @@ typedef struct
     PyObject_HEAD
     sqlite3* db;
     sqlite3_stmt* st;
+    /* Borrowed. Statements die with the cursor/cache before the connection
+       object is freed, except the close_v2 zombie path where db is already
+       NULL and close() is a no-op. */
+    pysqlite_Connection* connection;
     PyObject* sql;
     int in_use;
     int is_dml;

--- a/packages/phoenix-sqlean/src/util.c
+++ b/packages/phoenix-sqlean/src/util.c
@@ -44,7 +44,15 @@ int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection)
 int _pysqlite_seterror(sqlite3* db)
 {
     PyObject *exc_class;
-    int errorcode = sqlite3_errcode(db);
+    int errorcode;
+
+    if (db == NULL) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Cannot operate on a closed database.");
+        return SQLITE_MISUSE;
+    }
+
+    errorcode = sqlite3_errcode(db);
 
     switch (errorcode)
     {

--- a/packages/phoenix-sqlean/src/util.c
+++ b/packages/phoenix-sqlean/src/util.c
@@ -28,9 +28,11 @@ int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection)
 {
     int rc;
 
+    pysqlite_enter_sqlite(connection);
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_step(statement);
     Py_END_ALLOW_THREADS
+    pysqlite_leave_sqlite(connection);
 
     return rc;
 }

--- a/packages/phoenix-sqlean/tests/__main__.py
+++ b/packages/phoenix-sqlean/tests/__main__.py
@@ -4,6 +4,7 @@ import unittest
 
 from tests.backup import suite as backup_suite
 from tests.dbapi import suite as dbapi_suite
+from tests.driver_regressions import suite as driver_regressions_suite
 from tests.extensions import suite as extensions_suite
 from tests.factory import suite as factory_suite
 from tests.hooks import suite as hooks_suite
@@ -18,6 +19,7 @@ def test(verbosity=1, failfast=False):
     all_tests = unittest.TestSuite((
         backup_suite(),
         dbapi_suite(),
+        driver_regressions_suite(),
         extensions_suite(),
         factory_suite(),
         hooks_suite(),

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -1,0 +1,408 @@
+# tests/driver_regressions.py: regression tests for bugs fixed in the C
+# driver sources (src/).
+#
+# Each test pins down a defect that was inherited from the upstream
+# pysqlite lineage: wrong blob reads, use-after-free and double-free
+# error paths, reference-count bugs, and crashes on partially
+# initialized objects.  Only defects with a deterministic, non-OOM
+# trigger are covered here; allocation-failure paths can only be
+# exercised with fault injection.
+
+import gc
+import sys
+import threading
+import unittest
+import weakref
+
+from sqlean import dbapi2 as sqlite
+
+
+class BlobRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(b blob)")
+        self.cx.execute("insert into test(b) values (?)", (b"0123456789",))
+        self.blob = self.cx.open_blob("test", "b", 1)
+
+    def tearDown(self):
+        try:
+            self.cx.close()
+        except sqlite.ProgrammingError:
+            pass
+
+    def test_subscript_uses_requested_offset(self):
+        # Subscript reads used the current seek position instead of the
+        # requested offset.
+        self.blob.seek(9)
+        self.assertEqual(self.blob[5], b"5")
+        self.assertEqual(self.blob[2:5], b"234")
+        # An in-range subscript with the seek position at the end used
+        # to raise OperationalError.
+        self.blob.seek(10)
+        self.assertEqual(self.blob[0], b"0")
+        # Sequential read still honors the seek position.
+        self.blob.seek(4)
+        self.assertEqual(self.blob.read(2), b"45")
+
+    def test_negative_step_slices(self):
+        # Negative-step slices allocated `stop - start` (< 0) bytes and
+        # always raised MemoryError.
+        self.assertEqual(self.blob[::-1], b"9876543210")
+        self.assertEqual(self.blob[::-2], b"97531")
+        self.assertEqual(self.blob[8:2:-2], b"864")
+        self.assertEqual(self.blob[::2], b"02468")
+
+    def test_negative_step_slice_assignment(self):
+        self.blob[::-1] = b"abcdefghij"
+        self.assertEqual(self.blob[0:10], b"jihgfedcba")
+
+    def test_step_slice_assignment(self):
+        self.blob[::2] = b"abcde"
+        self.assertEqual(self.blob[0:10], b"a1b3c5d7e9")
+
+    def test_step_slice_assignment_on_expired_blob(self):
+        # Expiring the blob handle makes the initial range read fail
+        # with SQLITE_ABORT; that error path used to write to a freed
+        # buffer, free it twice, and then report success anyway.
+        self.cx.execute("update test set b = zeroblob(10)")
+        with self.assertRaises(sqlite.OperationalError):
+            self.blob[::2] = b"abcde"
+
+    def test_cross_thread_open_blob(self):
+        # open_blob had no thread check at entry; the failure used to be
+        # detected only after the handle was opened, and the error path
+        # closed the handle twice.
+        results = []
+
+        def worker():
+            try:
+                self.cx.open_blob("test", "b", 1)
+                results.append(None)
+            except Exception as exc:  # noqa: BLE001
+                results.append(exc)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], sqlite.ProgrammingError)
+
+    def test_open_blob_on_closed_connection(self):
+        self.blob.close()
+        self.cx.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cx.open_blob("test", "b", 1)
+
+    def test_connection_close_closes_every_blob(self):
+        # close() used to skip every other open blob because it iterated
+        # by index while entries were being removed.
+        blobs = [self.blob] + [self.cx.open_blob("test", "b", 1) for _ in range(4)]
+        self.cx.close()
+        for blob in blobs:
+            with self.assertRaises(sqlite.ProgrammingError):
+                blob.read(1)
+
+    def test_explicit_close_keeps_weakrefs_intact(self):
+        # close() used to clear weakrefs of the still-live blob object,
+        # an internal-API misuse that raises SystemError on Python
+        # 3.13+.
+        ref = weakref.ref(self.blob)
+        self.blob.close()
+        self.assertIs(ref(), self.blob)
+
+    def test_closed_blob_is_collected(self):
+        # close() leaked a strong reference taken while unlinking the
+        # blob from the connection's blob list, pinning the blob (and
+        # through it the connection) forever.
+        blob = self.cx.open_blob("test", "b", 1)
+        ref = weakref.ref(blob)
+        blob.close()
+        del blob
+        gc.collect()
+        self.assertIsNone(ref())
+
+
+class FactoryMemberRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(t text)")
+        self.cx.execute("insert into test(t) values ('hello')")
+
+    def tearDown(self):
+        self.cx.close()
+
+    def test_del_connection_row_factory(self):
+        # row_factory is a plain member; deleting it stored NULL, and
+        # the next cursor() call crashed in Py_INCREF(NULL).
+        del self.cx.row_factory
+        cur = self.cx.cursor()
+        self.assertEqual(cur.execute("select t from test").fetchone(), ("hello",))
+
+    def test_del_cursor_row_factory(self):
+        cur = self.cx.cursor()
+        cur.execute("select t from test")
+        del cur.row_factory
+        self.assertEqual(cur.fetchone(), ("hello",))
+
+    def test_del_text_factory(self):
+        del self.cx.text_factory
+        cur = self.cx.cursor()
+        with self.assertRaises(sqlite.ProgrammingError):
+            cur.execute("select t from test").fetchone()
+
+
+class BusyHandlerRegressionTests(unittest.TestCase):
+    def test_fractional_busy_timeout(self):
+        # (int)timeout * 1000 truncated before multiplying, so 0.5
+        # seconds became 0 ms and silently disabled waiting.
+        cx = sqlite.connect(":memory:")
+        try:
+            cx.set_busy_timeout(0.5)
+            row = cx.execute("pragma busy_timeout").fetchone()
+            self.assertEqual(row[0], 500)
+        finally:
+            cx.close()
+
+    def test_busy_handler_reference_management(self):
+        # set_busy_timeout dropped the busy-handler reference without
+        # NULLing the stored pointer, so a second call (or dealloc)
+        # dropped it again and underflowed the refcount.
+        cx = sqlite.connect(":memory:")
+        try:
+            def handler(n):
+                return 0
+
+            cx.set_busy_handler(handler)
+            before = sys.getrefcount(handler)
+            cx.set_busy_timeout(1.0)  # replaces the handler: drops one reference
+            after = sys.getrefcount(handler)
+            self.assertEqual(after, before - 1)
+            cx.set_busy_timeout(2.0)  # must not drop another reference
+            self.assertEqual(sys.getrefcount(handler), after)
+            cx.set_busy_handler(handler)
+        finally:
+            cx.close()
+        # The handler survives connection teardown.
+        self.assertEqual(handler(0), 0)
+
+
+class ConnectionLifecycleRegressionTests(unittest.TestCase):
+    def test_uninitialized_connection_close(self):
+        # Connection.__new__ without __init__ used to crash close() on
+        # its NULL internal lists.
+        cx = sqlite.Connection.__new__(sqlite.Connection)
+        with self.assertRaises(sqlite.ProgrammingError):
+            cx.close()
+
+    def test_uninitialized_connection_isolation_level(self):
+        cx = sqlite.Connection.__new__(sqlite.Connection)
+        with self.assertRaises(sqlite.ProgrammingError):
+            cx.isolation_level
+
+    def test_failed_reinit_preserves_connection(self):
+        # A failed re-open used to leave a half-initialized connection
+        # (NULL statement cache) that crashed on the next execute();
+        # the new database is now opened before any existing state is
+        # replaced, so the original connection survives untouched.
+        cx = sqlite.connect(":memory:")
+        try:
+            cx.execute("create table t(i int)")
+            cx.execute("insert into t values (1)")
+            with self.assertRaises(sqlite.OperationalError):
+                cx.__init__("/nonexistent-directory/no-such.db")
+            self.assertEqual(cx.execute("select i from t").fetchone(), (1,))
+        finally:
+            cx.close()
+
+    def test_failed_reinit_preserves_open_blob(self):
+        cx = sqlite.connect(":memory:")
+        try:
+            cx.execute("create table t(b blob)")
+            cx.execute("insert into t values (?)", (b"0123456789",))
+            blob = cx.open_blob("t", "b", 1)
+            with self.assertRaises(sqlite.OperationalError):
+                cx.__init__("/nonexistent-directory/no-such.db")
+            self.assertEqual(blob.read(2), b"01")
+            blob.close()
+        finally:
+            cx.close()
+
+    def test_reinit_produces_working_connection(self):
+        # Re-initialization used to leak the previous database handle.
+        cx = sqlite.connect(":memory:")
+        cx.execute("create table one(i int)")
+        cx.__init__(":memory:")
+        try:
+            # The new database is empty; the old handle was closed.
+            rows = cx.execute(
+                "select name from sqlite_master where type = 'table'"
+            ).fetchall()
+            self.assertEqual(rows, [])
+        finally:
+            cx.close()
+
+    def test_reinit_with_open_blob(self):
+        # A blob that outlives a re-initialization must close cleanly:
+        # the old database handle stays alive until its last blob
+        # handle is closed (sqlite3_close_v2 semantics).
+        cx = sqlite.connect(":memory:")
+        cx.execute("create table t(b blob)")
+        cx.execute("insert into t values (?)", (b"0123456789",))
+        blob = cx.open_blob("t", "b", 1)
+        cx.__init__(":memory:")
+        try:
+            blob.close()
+            with self.assertRaises(sqlite.ProgrammingError):
+                blob.read(1)
+        finally:
+            cx.close()
+
+    def test_backup_from_closed_source(self):
+        # backup() validated only the target connection; a closed
+        # source dereferenced a NULL sqlite3 handle.
+        source = sqlite.connect(":memory:")
+        target = sqlite.connect(":memory:")
+        source.close()
+        try:
+            with self.assertRaises(sqlite.ProgrammingError):
+                source.backup(target)
+        finally:
+            target.close()
+
+
+class CursorRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(i int)")
+        self.cx.executemany(
+            "insert into test(i) values (?)", [(i,) for i in range(10)]
+        )
+
+    def tearDown(self):
+        self.cx.close()
+
+    def test_fetchmany_nonpositive_size(self):
+        # fetchmany(0) and negative sizes used to return every
+        # remaining row.
+        cur = self.cx.execute("select i from test")
+        self.assertEqual(cur.fetchmany(0), [])
+        self.assertEqual(cur.fetchmany(-1), [])
+        self.assertEqual(len(cur.fetchmany(3)), 3)
+
+    def test_converter_cannot_reenter_cursor(self):
+        # A detect_types converter re-entering execute() on the same
+        # cursor used to reset the statement out from under the active
+        # fetch.  The first row is fetched inside execute() (which was
+        # already locked); re-entering on the second row exercises the
+        # previously unlocked iteration path.
+        cx = sqlite.connect(":memory:", detect_types=sqlite.PARSE_COLNAMES)
+        try:
+            cx.execute("create table test(i int)")
+            cx.executemany("insert into test(i) values (?)", [(1,), (2,)])
+            cur = cx.cursor()
+
+            def reenter(value):
+                if value == b"2":
+                    cur.execute("select 3")
+                return value
+
+            sqlite.register_converter("reenter", reenter)
+            try:
+                # execute() itself succeeds: only row 1 is fetched there.
+                cur.execute('select i as "i [reenter]" from test order by i')
+                # The first fetch prefetches row 2, where the
+                # converter's re-entrant execute() must be rejected.
+                with self.assertRaises(sqlite.ProgrammingError):
+                    cur.fetchall()
+            finally:
+                del sqlite.converters["REENTER"]
+        finally:
+            cx.close()
+
+    def test_udf_text_with_embedded_nul(self):
+        # Function arguments and results were marshalled with
+        # NUL-terminated string APIs, truncating TEXT values at the
+        # first embedded NUL byte in both directions.
+        self.cx.create_function("gen", 0, lambda: "a\x00b")
+        self.cx.create_function("echo", 1, lambda v: v)
+        # Result direction: the full value reaches SQLite.  (length()
+        # deliberately counts only up to the first NUL; octet_length()
+        # reports the stored bytes.)
+        self.assertEqual(
+            self.cx.execute("select octet_length(gen())").fetchone()[0], 3
+        )
+        # Argument direction: the full value reaches Python.
+        self.assertEqual(self.cx.execute("select echo(gen())").fetchone()[0], "a\x00b")
+
+    def test_progress_handler_bad_return(self):
+        # A progress-handler return value that fails truth-testing used
+        # to leave the exception set across PyGILState_Release,
+        # surfacing at an arbitrary later point.
+        class BadBool:
+            def __bool__(self):
+                raise RuntimeError("boom")
+
+        self.cx.set_progress_handler(lambda: BadBool(), 1)
+        try:
+            with self.assertRaises(sqlite.OperationalError):
+                self.cx.execute("select 1")
+        finally:
+            self.cx.set_progress_handler(None, 1)
+        # The handler's exception must not leak into unrelated calls.
+        self.assertEqual(self.cx.execute("select 2").fetchone()[0], 2)
+
+    def test_load_extension_failure(self):
+        # A failed load raises cleanly (and no longer leaks the SQLite
+        # error message buffer, which is not observable from here).
+        if not hasattr(self.cx, "enable_load_extension"):
+            self.skipTest("load-extension support not compiled in")
+        self.cx.enable_load_extension(True)
+        try:
+            with self.assertRaises(sqlite.OperationalError):
+                self.cx.load_extension("no-such-extension")
+        finally:
+            self.cx.enable_load_extension(False)
+
+
+class RowRegressionTests(unittest.TestCase):
+    def test_row_over_uninitialized_cursor(self):
+        # Row() over a cursor created without __init__ crashed in
+        # Py_INCREF(NULL) on the cursor's description.
+        cursor = sqlite.Cursor.__new__(sqlite.Cursor)
+        with self.assertRaises(sqlite.ProgrammingError):
+            sqlite.Row(cursor, ())
+
+    def test_row_hash(self):
+        # Row.__hash__ XORed two PyObject_Hash results without checking
+        # for -1 (error).
+        cx = sqlite.connect(":memory:")
+        try:
+            cx.row_factory = sqlite.Row
+            row = cx.execute("select 1 as a, 2 as b").fetchone()
+            self.assertNotEqual(hash(row), -1)
+            self.assertEqual(hash(row), hash(row))
+        finally:
+            cx.close()
+
+
+def suite():
+    loader = unittest.TestLoader()
+    return unittest.TestSuite(
+        (
+            loader.loadTestsFromTestCase(BlobRegressionTests),
+            loader.loadTestsFromTestCase(FactoryMemberRegressionTests),
+            loader.loadTestsFromTestCase(BusyHandlerRegressionTests),
+            loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
+            loader.loadTestsFromTestCase(CursorRegressionTests),
+            loader.loadTestsFromTestCase(RowRegressionTests),
+        )
+    )
+
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -319,6 +319,85 @@ class CallbackCloseRegressionTests(unittest.TestCase):
         )
 
 
+class StatementLifetimeRegressionTests(unittest.TestCase):
+    def test_function_destructor_after_connection_close(self):
+        # Isolate native crashes so a missing GIL reports a test failure rather
+        # than taking down the suite. All three registration APIs share xDestroy.
+        for registration in (
+            "create_function",
+            "create_aggregate",
+            "create_window_function",
+        ):
+            for lifetime in ("failed", "active", "orphan"):
+                with self.subTest(registration=registration, lifetime=lifetime):
+                    result = subprocess.run(
+                        [
+                            sys.executable,
+                            "-X",
+                            "faulthandler",
+                            "-c",
+                            textwrap.dedent("""
+                            import gc
+                            import sys
+                            import weakref
+                            from sqlean import dbapi2 as sqlite
+
+                            registration, lifetime = sys.argv[1:]
+                            con = sqlite.connect(":memory:")
+                            callback = lambda *args: 1
+                            ref = weakref.ref(callback)
+                            getattr(con, registration)("f", 1, callback)
+                            del callback
+
+                            if lifetime == "orphan":
+                                # A directly prepared Statement does not own the
+                                # Connection. Its finalization closes the zombie
+                                # with the GIL released, even when every cursor
+                                # statement is correctly tracked by close().
+                                statement = con("select 1")
+                                del con
+                                assert ref() is not None
+                                del statement
+                            else:
+                                cursors = [con.cursor(), con.cursor()]
+                                if lifetime == "failed":
+                                    con.execute("create table t(x unique)")
+                                    con.execute("insert into t values (1)")
+                                    for cursor in cursors:
+                                        try:
+                                            cursor.execute("insert into t values (1)")
+                                        except sqlite.IntegrityError:
+                                            pass
+                                        else:
+                                            raise AssertionError("constraint did not fail")
+                                    del cursor
+                                else:
+                                    # The second cursor needs an uncached copy
+                                    # while the first is still using this SQL.
+                                    for cursor in cursors:
+                                        cursor.execute("select 1 union all select 2")
+                                    del cursor
+                                con.close()
+                                released_at_close = ref() is None
+                                del con, cursors
+                                gc.collect()
+                                assert released_at_close, "close left a live statement"
+                            gc.collect()
+                            assert ref() is None, "registered callback leaked"
+                        """),
+                            registration,
+                            lifetime,
+                        ],
+                        cwd=Path(__file__).resolve().parents[1],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+                    self.assertEqual(
+                        result.returncode, 0, result.stdout + result.stderr
+                    )
+
+
 class CursorRegressionTests(unittest.TestCase):
     def setUp(self):
         self.cx = sqlite.connect(":memory:")
@@ -443,6 +522,7 @@ def suite():
             loader.loadTestsFromTestCase(BusyHandlerRegressionTests),
             loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
             loader.loadTestsFromTestCase(CallbackCloseRegressionTests),
+            loader.loadTestsFromTestCase(StatementLifetimeRegressionTests),
             loader.loadTestsFromTestCase(CursorRegressionTests),
             loader.loadTestsFromTestCase(RowRegressionTests),
         )

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -334,6 +334,27 @@ class CursorRegressionTests(unittest.TestCase):
             self.cx.enable_load_extension(False)
 
 
+class RowRegressionTests(unittest.TestCase):
+    def test_row_over_uninitialized_cursor(self):
+        # Row() over a cursor created without __init__ crashed in
+        # Py_INCREF(NULL) on the cursor's description.
+        cursor = sqlite.Cursor.__new__(sqlite.Cursor)
+        with self.assertRaises(sqlite.ProgrammingError):
+            sqlite.Row(cursor, ())
+
+    def test_row_hash(self):
+        # Row.__hash__ XORed two PyObject_Hash results without checking
+        # for -1 (error).
+        cx = sqlite.connect(":memory:")
+        try:
+            cx.row_factory = sqlite.Row
+            row = cx.execute("select 1 as a, 2 as b").fetchone()
+            self.assertNotEqual(hash(row), -1)
+            self.assertEqual(hash(row), hash(row))
+        finally:
+            cx.close()
+
+
 def suite():
     loader = unittest.TestLoader()
     return unittest.TestSuite(
@@ -343,6 +364,7 @@ def suite():
             loader.loadTestsFromTestCase(BusyHandlerRegressionTests),
             loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
             loader.loadTestsFromTestCase(CursorRegressionTests),
+            loader.loadTestsFromTestCase(RowRegressionTests),
         )
     )
 

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -835,6 +835,35 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_reinit_from_destructor_refused(self):
+        # Re-init used to set initialized=0 before closing the old
+        # handle, so an xDestroy __del__ could __init__ again, leak the
+        # inner db, and drop work already committed on the outer handle.
+        self._run(
+            """
+            events = []
+            class Fn:
+                def __call__(self):
+                    return 1
+                def __del__(self):
+                    try:
+                        con.__init__(":memory:")
+                        events.append("allowed")
+                    except sqlite.ProgrammingError:
+                        events.append("refused")
+            con = sqlite.connect(":memory:")
+            con.execute("create table keep(x)")
+            con.execute("insert into keep values (1)")
+            con.commit()
+            con.create_function("f", 0, Fn())
+            con.__init__(":memory:")
+            assert events == ["refused"], events
+            con.execute("create table t(x)")
+            assert con.execute("select count(*) from t").fetchone()[0] == 0
+            con.close()
+            """
+        )
+
     def test_reinit_orphan_statement_does_not_corrupt_next_connection(self):
         # Re-init used to Py_CLEAR the statements list without NULLing
         # borrowed statement->connection pointers. del con then missed
@@ -964,6 +993,33 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_open_blob_from_function_destructor(self):
+        self._run(
+            """
+            import os
+            import tempfile
+            fd, path = tempfile.mkstemp(suffix=".db")
+            os.close(fd)
+            try:
+                con = sqlite.connect(path)
+                con.execute("create table t(b blob)")
+                con.execute("insert into t values (zeroblob(8))")
+                con.commit()
+                class Fn:
+                    def __call__(self):
+                        return 1
+                    def __del__(self):
+                        try:
+                            con.open_blob("t", "b", 1)
+                        except sqlite.ProgrammingError:
+                            pass
+                con.create_function("f", 0, Fn())
+                con.close()
+            finally:
+                os.unlink(path)
+            """
+        )
+
     def test_cursor_created_in_finalize_stays_usable(self):
         # rollback() locks every live cursor around the reset so a window
         # finalize cannot re-enter execute() on the statement being
@@ -1032,6 +1088,61 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_connection_methods_from_function_destructor_during_close(self):
+        # close() publishes the connection as closed before
+        # sqlite3_close_v2 destroys the registered functions, so a
+        # callable's __del__ fired there sees "closed database" from
+        # every entry point. Before, the methods reached the zombie
+        # handle; sqlite3_blob_open walked freed structures.
+        self._run(
+            """
+            results = {}
+            def attempt(name, fn):
+                try:
+                    fn()
+                    results[name] = "allowed"
+                except sqlite.ProgrammingError:
+                    results[name] = "refused"
+            class Fn:
+                def __call__(self):
+                    return 1
+                def __del__(self):
+                    attempt("in_transaction", lambda: con.in_transaction)
+                    attempt("total_changes", lambda: con.total_changes)
+                    attempt("isolation_level", lambda: setattr(con, "isolation_level", None))
+                    attempt("interrupt", con.interrupt)
+                    attempt("set_busy_timeout", lambda: con.set_busy_timeout(1.0))
+                    attempt("set_busy_handler", lambda: con.set_busy_handler(lambda n: 0))
+                    attempt("enable_load_extension", lambda: con.enable_load_extension(True))
+                    attempt("__call__", lambda: con("select 1"))
+                    attempt("cursor", con.cursor)
+                    attempt("execute", lambda: con.execute("select 1"))
+                    attempt("executescript", lambda: con.executescript("select 1;"))
+                    attempt("commit", con.commit)
+                    attempt("rollback", con.rollback)
+                    attempt("create_function", lambda: con.create_function("z", 0, lambda: 0))
+                    attempt("create_aggregate", lambda: con.create_aggregate("za", 1, Fn))
+                    attempt("create_window_function", lambda: con.create_window_function("zw", 1, Fn))
+                    attempt("create_collation", lambda: con.create_collation("zc", lambda a, b: 0))
+                    attempt("set_authorizer", lambda: con.set_authorizer(lambda *a: 0))
+                    attempt("set_progress_handler", lambda: con.set_progress_handler(lambda: 0, 1))
+                    attempt("set_trace_callback", lambda: con.set_trace_callback(lambda s: None))
+                    attempt("open_blob", lambda: con.open_blob("t", "b", 1))
+                    attempt("backup", lambda: con.backup(sqlite.connect(":memory:")))
+                    attempt("__exit__", lambda: con.__exit__(None, None, None))
+                    attempt("close", con.close)
+                    attempt("__init__", lambda: con.__init__(":memory:"))
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(b blob)")
+            con.execute("insert into t values (zeroblob(4))")
+            con.commit()
+            con.create_function("f", 0, Fn())
+            con.close()
+            allowed = sorted(k for k, v in results.items() if v != "refused")
+            assert len(results) == 25 and not allowed, (len(results), allowed)
+            """
+        )
+
     def test_orphan_statement_does_not_corrupt_next_connection(self):
         # Statement.connection is borrowed. dealloc used to free the
         # Connection while an orphan con("sql") still wrote in_sqlite
@@ -1067,6 +1178,37 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             del fn
             del stmt
             assert not bad, bad
+            """
+        )
+
+    def test_close_from_function_destructor(self):
+        # sqlite3_close_v2 destroys registered functions; a callable
+        # whose only reference is SQLite's runs __del__ from inside
+        # close(). Re-entering close() there used to reach SQLite as
+        # API misuse; it is now refused like any other callback.
+        self._run(
+            """
+            events = []
+            class Fn:
+                def __call__(self):
+                    return 1
+                def __del__(self):
+                    try:
+                        con.close()
+                    except sqlite.ProgrammingError as e:
+                        events.append(str(e))
+            con = sqlite.connect(":memory:")
+            con.create_function("f", 0, Fn())
+            con.close()
+            assert events == [
+                "Cannot close the database connection from within a callback function."
+            ], events
+            try:
+                con.execute("select 1")
+            except sqlite.ProgrammingError:
+                pass
+            else:
+                raise AssertionError("connection should be closed")
             """
         )
 

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -835,6 +835,73 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_execute_commit_in_window_finalize_during_rollback(self):
+        # commit() is guarded; execute("COMMIT") used to bypass it.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            con.commit()
+            con.execute("insert into t values (4)")
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        con.execute("COMMIT")
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur = con.execute("select w(x) over (order by x) from t")
+            cur.fetchone()
+            con.rollback()
+            assert con.execute("select count(*) from t").fetchone()[0] == 3, (
+                "execute(COMMIT) from window finalize must not preserve a rolled-back insert"
+            )
+            con.close()
+            """
+        )
+
+    def test_comment_prefixed_commit_in_window_finalize_during_rollback(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            con.commit()
+            con.execute("insert into t values (4)")
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        con.execute("/*x*/COMMIT")
+                    except sqlite.ProgrammingError:
+                        pass
+                    try:
+                        con.execute("COMMIT--x")
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur = con.execute("select w(x) over (order by x) from t")
+            cur.fetchone()
+            con.rollback()
+            assert con.execute("select count(*) from t").fetchone()[0] == 3
+            con.close()
+            """
+        )
+
     def test_same_cursor_execute_in_window_finalize_during_rollback(self):
         self._run(
             """
@@ -929,6 +996,41 @@ class CallbackCloseRegressionTests(unittest.TestCase):
                 return "replaced"
             con.create_function("replace", 0, replace)
             assert con.execute("select replace()").fetchone() == ("busy",)
+            con.close()
+            """
+        )
+
+    def test_commit_in_window_finalize_during_rollback(self):
+        # rollback() resets live statements; window xFinal runs there.
+        # SQLite accepts COMMIT during that reset, so an unguarded
+        # commit() turned rollback into a commit.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            con.commit()
+            con.execute("insert into t values (4)")
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        con.commit()
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur = con.execute("select w(x) over (order by x) from t")
+            cur.fetchone()
+            con.rollback()
+            assert con.execute("select count(*) from t").fetchone()[0] == 3, (
+                "commit from window finalize must not preserve a rolled-back insert"
+            )
             con.close()
             """
         )

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -313,6 +313,18 @@ class CursorRegressionTests(unittest.TestCase):
         # The handler's exception must not leak into unrelated calls.
         self.assertEqual(self.cx.execute("select 2").fetchone()[0], 2)
 
+    def test_load_extension_failure(self):
+        # A failed load raises cleanly (and no longer leaks the SQLite
+        # error message buffer, which is not observable from here).
+        if not hasattr(self.cx, "enable_load_extension"):
+            self.skipTest("load-extension support not compiled in")
+        self.cx.enable_load_extension(True)
+        try:
+            with self.assertRaises(sqlite.OperationalError):
+                self.cx.load_extension("no-such-extension")
+        finally:
+            self.cx.enable_load_extension(False)
+
 
 def suite():
     loader = unittest.TestLoader()

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -1158,6 +1158,43 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_execute_from_authorizer_is_refused(self):
+        # An authorizer runs inside sqlite3_prepare. Calling execute() on
+        # the same connection from it compiled another statement, which
+        # invoked the authorizer again, without bound: Python's recursion
+        # limit never fires before the C stack is gone on a thread with a
+        # small stack (512 KB is the macOS default for non-main threads).
+        # SQLite documents that an authorizer must not use the invoking
+        # connection; a nested compile is now refused.
+        self._run(
+            """
+            import threading
+            threading.stack_size(512 * 1024)
+            seen = []
+            def run():
+                con = sqlite.connect(":memory:", check_same_thread=False)
+                con.execute("create table t(x)")
+                con.execute("insert into t values (1)")
+                def auth(action, *args):
+                    try:
+                        con.execute("select 1")
+                        seen.append("allowed")
+                    except sqlite.ProgrammingError:
+                        seen.append("refused")
+                    return sqlite.SQLITE_OK
+                con.set_authorizer(auth)
+                seen.append(con.execute("select x from t").fetchone())
+                con.set_authorizer(None)
+                seen.append(con.execute("select x from t").fetchone())
+                con.close()
+            t = threading.Thread(target=run)
+            t.start()
+            t.join()
+            assert "refused" in seen and "allowed" not in seen, seen
+            assert seen[-2:] == [(1,), (1,)], seen
+            """
+        )
+
     def test_open_blob_from_function_destructor(self):
         self._run(
             """

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -9,10 +9,13 @@
 # exercised with fault injection.
 
 import gc
+import subprocess
 import sys
+import textwrap
 import threading
 import unittest
 import weakref
+from pathlib import Path
 
 from sqlean import dbapi2 as sqlite
 
@@ -270,6 +273,52 @@ class ConnectionLifecycleRegressionTests(unittest.TestCase):
             target.close()
 
 
+class CallbackCloseRegressionTests(unittest.TestCase):
+    def _run(self, source):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-X",
+                "faulthandler",
+                "-c",
+                "from sqlean import dbapi2 as sqlite\n" + textwrap.dedent(source),
+            ],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result.stdout
+
+    def test_cursor_close_in_converter(self):
+        self._run(
+            """
+            def conv(value):
+                try:
+                    cur.close()
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("cursor close() should have been refused")
+            sqlite.register_converter("X", conv)
+            con = sqlite.connect(":memory:", detect_types=sqlite.PARSE_COLNAMES)
+            cur = con.cursor()
+            cur.execute("create table t(a, b)")
+            cur.execute("insert into t values (1, 2)")
+            try:
+                cur.execute('select a as "a [X]", b as "b [X]" from t')
+                cur.fetchall()
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected fetch to fail after a refused cursor close")
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+
 class CursorRegressionTests(unittest.TestCase):
     def setUp(self):
         self.cx = sqlite.connect(":memory:")
@@ -288,6 +337,36 @@ class CursorRegressionTests(unittest.TestCase):
         self.assertEqual(cur.fetchmany(0), [])
         self.assertEqual(cur.fetchmany(-1), [])
         self.assertEqual(len(cur.fetchmany(3)), 3)
+
+    def test_converter_cannot_reenter_cursor(self):
+        # A detect_types converter re-entering execute() on the same
+        # cursor used to reset the statement out from under the active
+        # fetch.  The first row is fetched inside execute() (which was
+        # already locked); re-entering on the second row exercises the
+        # previously unlocked iteration path.
+        cx = sqlite.connect(":memory:", detect_types=sqlite.PARSE_COLNAMES)
+        try:
+            cx.execute("create table test(i int)")
+            cx.executemany("insert into test(i) values (?)", [(1,), (2,)])
+            cur = cx.cursor()
+
+            def reenter(value):
+                if value == b"2":
+                    cur.execute("select 3")
+                return value
+
+            sqlite.register_converter("reenter", reenter)
+            try:
+                # execute() itself succeeds: only row 1 is fetched there.
+                cur.execute('select i as "i [reenter]" from test order by i')
+                # The first fetch prefetches row 2, where the
+                # converter's re-entrant execute() must be rejected.
+                with self.assertRaises(sqlite.ProgrammingError):
+                    cur.fetchall()
+            finally:
+                del sqlite.converters["REENTER"]
+        finally:
+            cx.close()
 
     def test_udf_text_with_embedded_nul(self):
         # Function arguments and results were marshalled with
@@ -363,6 +442,7 @@ def suite():
             loader.loadTestsFromTestCase(FactoryMemberRegressionTests),
             loader.loadTestsFromTestCase(BusyHandlerRegressionTests),
             loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
+            loader.loadTestsFromTestCase(CallbackCloseRegressionTests),
             loader.loadTestsFromTestCase(CursorRegressionTests),
             loader.loadTestsFromTestCase(RowRegressionTests),
         )

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -296,6 +296,23 @@ class CursorRegressionTests(unittest.TestCase):
         # Argument direction: the full value reaches Python.
         self.assertEqual(self.cx.execute("select echo(gen())").fetchone()[0], "a\x00b")
 
+    def test_progress_handler_bad_return(self):
+        # A progress-handler return value that fails truth-testing used
+        # to leave the exception set across PyGILState_Release,
+        # surfacing at an arbitrary later point.
+        class BadBool:
+            def __bool__(self):
+                raise RuntimeError("boom")
+
+        self.cx.set_progress_handler(lambda: BadBool(), 1)
+        try:
+            with self.assertRaises(sqlite.OperationalError):
+                self.cx.execute("select 1")
+        finally:
+            self.cx.set_progress_handler(None, 1)
+        # The handler's exception must not leak into unrelated calls.
+        self.assertEqual(self.cx.execute("select 2").fetchone()[0], 2)
+
 
 def suite():
     loader = unittest.TestLoader()

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -9,6 +9,7 @@
 # exercised with fault injection.
 
 import gc
+import sys
 import threading
 import unittest
 import weakref
@@ -150,6 +151,41 @@ class FactoryMemberRegressionTests(unittest.TestCase):
             cur.execute("select t from test").fetchone()
 
 
+class BusyHandlerRegressionTests(unittest.TestCase):
+    def test_fractional_busy_timeout(self):
+        # (int)timeout * 1000 truncated before multiplying, so 0.5
+        # seconds became 0 ms and silently disabled waiting.
+        cx = sqlite.connect(":memory:")
+        try:
+            cx.set_busy_timeout(0.5)
+            row = cx.execute("pragma busy_timeout").fetchone()
+            self.assertEqual(row[0], 500)
+        finally:
+            cx.close()
+
+    def test_busy_handler_reference_management(self):
+        # set_busy_timeout dropped the busy-handler reference without
+        # NULLing the stored pointer, so a second call (or dealloc)
+        # dropped it again and underflowed the refcount.
+        cx = sqlite.connect(":memory:")
+        try:
+            def handler(n):
+                return 0
+
+            cx.set_busy_handler(handler)
+            before = sys.getrefcount(handler)
+            cx.set_busy_timeout(1.0)  # replaces the handler: drops one reference
+            after = sys.getrefcount(handler)
+            self.assertEqual(after, before - 1)
+            cx.set_busy_timeout(2.0)  # must not drop another reference
+            self.assertEqual(sys.getrefcount(handler), after)
+            cx.set_busy_handler(handler)
+        finally:
+            cx.close()
+        # The handler survives connection teardown.
+        self.assertEqual(handler(0), 0)
+
+
 class ConnectionLifecycleRegressionTests(unittest.TestCase):
     def test_uninitialized_connection_close(self):
         # Connection.__new__ without __init__ used to crash close() on
@@ -267,6 +303,7 @@ def suite():
         (
             loader.loadTestsFromTestCase(BlobRegressionTests),
             loader.loadTestsFromTestCase(FactoryMemberRegressionTests),
+            loader.loadTestsFromTestCase(BusyHandlerRegressionTests),
             loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
             loader.loadTestsFromTestCase(CursorRegressionTests),
         )

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -234,6 +234,33 @@ class ConnectionLifecycleRegressionTests(unittest.TestCase):
             target.close()
 
 
+class CursorRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(i int)")
+        self.cx.executemany(
+            "insert into test(i) values (?)", [(i,) for i in range(10)]
+        )
+
+    def tearDown(self):
+        self.cx.close()
+
+    def test_udf_text_with_embedded_nul(self):
+        # Function arguments and results were marshalled with
+        # NUL-terminated string APIs, truncating TEXT values at the
+        # first embedded NUL byte in both directions.
+        self.cx.create_function("gen", 0, lambda: "a\x00b")
+        self.cx.create_function("echo", 1, lambda v: v)
+        # Result direction: the full value reaches SQLite.  (length()
+        # deliberately counts only up to the first NUL; octet_length()
+        # reports the stored bytes.)
+        self.assertEqual(
+            self.cx.execute("select octet_length(gen())").fetchone()[0], 3
+        )
+        # Argument direction: the full value reaches Python.
+        self.assertEqual(self.cx.execute("select echo(gen())").fetchone()[0], "a\x00b")
+
+
 def suite():
     loader = unittest.TestLoader()
     return unittest.TestSuite(
@@ -241,6 +268,7 @@ def suite():
             loader.loadTestsFromTestCase(BlobRegressionTests),
             loader.loadTestsFromTestCase(FactoryMemberRegressionTests),
             loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
+            loader.loadTestsFromTestCase(CursorRegressionTests),
         )
     )
 

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -1230,6 +1230,39 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_backup_target_is_unusable_during_backup(self):
+        # SQLite forbids using the destination connection while a backup
+        # is in progress. From the progress callback, a read on it saw a
+        # half-copied schema ("malformed database schema") and a write
+        # segfaulted. The target now refuses every method for the
+        # duration; the source stays readable, as SQLite allows.
+        self._run(
+            """
+            src = sqlite.connect(":memory:")
+            src.execute("create table t(x)")
+            src.executemany("insert into t values (?)", [(i,) for i in range(2000)])
+            src.commit()
+            dst = sqlite.connect(":memory:")
+            seen = set()
+            def attempt(name, fn):
+                try:
+                    fn()
+                    seen.add(name + " allowed")
+                except sqlite.ProgrammingError:
+                    seen.add(name + " refused")
+            def progress(status, remaining, total):
+                attempt("write", lambda: dst.execute("create table if not exists u(y)"))
+                attempt("read", lambda: dst.execute("select 1").fetchone())
+                attempt("close", dst.close)
+                seen.add(("src", src.execute("select count(*) from t").fetchone()[0]))
+            src.backup(dst, pages=1, progress=progress)
+            assert seen == {"write refused", "read refused", "close refused", ("src", 2000)}, seen
+            assert dst.execute("select count(*) from t").fetchone() == (2000,)
+            dst.close()
+            src.close()
+            """
+        )
+
     def test_open_blob_from_function_destructor(self):
         self._run(
             """

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -835,6 +835,38 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_reinit_orphan_statement_does_not_corrupt_next_connection(self):
+        # Re-init used to Py_CLEAR the statements list without NULLing
+        # borrowed statement->connection pointers. del con then missed
+        # those orphans in the dealloc walk.
+        self._run(
+            """
+            bad = []
+            class Fn:
+                victim = None
+                def __call__(self):
+                    return 1
+                def __del__(self):
+                    if self.victim is not None:
+                        try:
+                            self.victim.close()
+                        except sqlite.ProgrammingError as e:
+                            bad.append(str(e))
+            con = sqlite.connect(":memory:")
+            fn = Fn()
+            con.create_function("f", 0, fn)
+            stmt = con("select f()")
+            con.__init__(":memory:")
+            del con
+            victim = sqlite.connect(":memory:")
+            fn.victim = victim
+            del fn
+            del stmt
+            assert not bad, bad
+            victim.close()
+            """
+        )
+
     def test_execute_commit_in_window_finalize_during_rollback(self):
         # commit() is guarded; execute("COMMIT") used to bypass it.
         self._run(
@@ -997,6 +1029,44 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             con.create_function("replace", 0, replace)
             assert con.execute("select replace()").fetchone() == ("busy",)
             con.close()
+            """
+        )
+
+    def test_orphan_statement_does_not_corrupt_next_connection(self):
+        # Statement.connection is borrowed. dealloc used to free the
+        # Connection while an orphan con("sql") still wrote in_sqlite
+        # into that heap, so a later Connection that reused the slot
+        # saw a callback in progress.
+        #
+        # The enter/leave pair around finalize nets to zero, so the
+        # corruption is only visible *during* the finalize. Finalizing
+        # the orphan closes the zombie db, which destroys the registered
+        # function; its __del__ runs at exactly that moment and probes
+        # the victim. pymalloc hands the freed Connection block to the
+        # next same-sized allocation, so the victim reuses the slot.
+        self._run(
+            """
+            bad = []
+            class Fn:
+                victim = None
+                def __call__(self):
+                    return 1
+                def __del__(self):
+                    if self.victim is not None:
+                        try:
+                            self.victim.close()
+                        except sqlite.ProgrammingError as e:
+                            bad.append(str(e))
+            con = sqlite.connect(":memory:")
+            fn = Fn()
+            con.create_function("f", 0, fn)
+            stmt = con("select f()")
+            del con
+            victim = sqlite.connect(":memory:")
+            fn.victim = victim
+            del fn
+            del stmt
+            assert not bad, bad
             """
         )
 

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -121,11 +121,96 @@ class BlobRegressionTests(unittest.TestCase):
         self.assertIsNone(ref())
 
 
+class ConnectionLifecycleRegressionTests(unittest.TestCase):
+    def test_uninitialized_connection_close(self):
+        # Connection.__new__ without __init__ used to crash close() on
+        # its NULL internal lists.
+        cx = sqlite.Connection.__new__(sqlite.Connection)
+        with self.assertRaises(sqlite.ProgrammingError):
+            cx.close()
+
+    def test_uninitialized_connection_isolation_level(self):
+        cx = sqlite.Connection.__new__(sqlite.Connection)
+        with self.assertRaises(sqlite.ProgrammingError):
+            cx.isolation_level
+
+    def test_failed_reinit_preserves_connection(self):
+        # A failed re-open used to leave a half-initialized connection
+        # (NULL statement cache) that crashed on the next execute();
+        # the new database is now opened before any existing state is
+        # replaced, so the original connection survives untouched.
+        cx = sqlite.connect(":memory:")
+        try:
+            cx.execute("create table t(i int)")
+            cx.execute("insert into t values (1)")
+            with self.assertRaises(sqlite.OperationalError):
+                cx.__init__("/nonexistent-directory/no-such.db")
+            self.assertEqual(cx.execute("select i from t").fetchone(), (1,))
+        finally:
+            cx.close()
+
+    def test_failed_reinit_preserves_open_blob(self):
+        cx = sqlite.connect(":memory:")
+        try:
+            cx.execute("create table t(b blob)")
+            cx.execute("insert into t values (?)", (b"0123456789",))
+            blob = cx.open_blob("t", "b", 1)
+            with self.assertRaises(sqlite.OperationalError):
+                cx.__init__("/nonexistent-directory/no-such.db")
+            self.assertEqual(blob.read(2), b"01")
+            blob.close()
+        finally:
+            cx.close()
+
+    def test_reinit_produces_working_connection(self):
+        # Re-initialization used to leak the previous database handle.
+        cx = sqlite.connect(":memory:")
+        cx.execute("create table one(i int)")
+        cx.__init__(":memory:")
+        try:
+            # The new database is empty; the old handle was closed.
+            rows = cx.execute(
+                "select name from sqlite_master where type = 'table'"
+            ).fetchall()
+            self.assertEqual(rows, [])
+        finally:
+            cx.close()
+
+    def test_reinit_with_open_blob(self):
+        # A blob that outlives a re-initialization must close cleanly:
+        # the old database handle stays alive until its last blob
+        # handle is closed (sqlite3_close_v2 semantics).
+        cx = sqlite.connect(":memory:")
+        cx.execute("create table t(b blob)")
+        cx.execute("insert into t values (?)", (b"0123456789",))
+        blob = cx.open_blob("t", "b", 1)
+        cx.__init__(":memory:")
+        try:
+            blob.close()
+            with self.assertRaises(sqlite.ProgrammingError):
+                blob.read(1)
+        finally:
+            cx.close()
+
+    def test_backup_from_closed_source(self):
+        # backup() validated only the target connection; a closed
+        # source dereferenced a NULL sqlite3 handle.
+        source = sqlite.connect(":memory:")
+        target = sqlite.connect(":memory:")
+        source.close()
+        try:
+            with self.assertRaises(sqlite.ProgrammingError):
+                source.backup(target)
+        finally:
+            target.close()
+
+
 def suite():
     loader = unittest.TestLoader()
     return unittest.TestSuite(
         (
             loader.loadTestsFromTestCase(BlobRegressionTests),
+            loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
         )
     )
 

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -1,0 +1,139 @@
+# tests/driver_regressions.py: regression tests for bugs fixed in the C
+# driver sources (src/).
+#
+# Each test pins down a defect that was inherited from the upstream
+# pysqlite lineage: wrong blob reads, use-after-free and double-free
+# error paths, reference-count bugs, and crashes on partially
+# initialized objects.  Only defects with a deterministic, non-OOM
+# trigger are covered here; allocation-failure paths can only be
+# exercised with fault injection.
+
+import gc
+import threading
+import unittest
+import weakref
+
+from sqlean import dbapi2 as sqlite
+
+
+class BlobRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(b blob)")
+        self.cx.execute("insert into test(b) values (?)", (b"0123456789",))
+        self.blob = self.cx.open_blob("test", "b", 1)
+
+    def tearDown(self):
+        try:
+            self.cx.close()
+        except sqlite.ProgrammingError:
+            pass
+
+    def test_subscript_uses_requested_offset(self):
+        # Subscript reads used the current seek position instead of the
+        # requested offset.
+        self.blob.seek(9)
+        self.assertEqual(self.blob[5], b"5")
+        self.assertEqual(self.blob[2:5], b"234")
+        # An in-range subscript with the seek position at the end used
+        # to raise OperationalError.
+        self.blob.seek(10)
+        self.assertEqual(self.blob[0], b"0")
+        # Sequential read still honors the seek position.
+        self.blob.seek(4)
+        self.assertEqual(self.blob.read(2), b"45")
+
+    def test_negative_step_slices(self):
+        # Negative-step slices allocated `stop - start` (< 0) bytes and
+        # always raised MemoryError.
+        self.assertEqual(self.blob[::-1], b"9876543210")
+        self.assertEqual(self.blob[::-2], b"97531")
+        self.assertEqual(self.blob[8:2:-2], b"864")
+        self.assertEqual(self.blob[::2], b"02468")
+
+    def test_negative_step_slice_assignment(self):
+        self.blob[::-1] = b"abcdefghij"
+        self.assertEqual(self.blob[0:10], b"jihgfedcba")
+
+    def test_step_slice_assignment(self):
+        self.blob[::2] = b"abcde"
+        self.assertEqual(self.blob[0:10], b"a1b3c5d7e9")
+
+    def test_step_slice_assignment_on_expired_blob(self):
+        # Expiring the blob handle makes the initial range read fail
+        # with SQLITE_ABORT; that error path used to write to a freed
+        # buffer, free it twice, and then report success anyway.
+        self.cx.execute("update test set b = zeroblob(10)")
+        with self.assertRaises(sqlite.OperationalError):
+            self.blob[::2] = b"abcde"
+
+    def test_cross_thread_open_blob(self):
+        # open_blob had no thread check at entry; the failure used to be
+        # detected only after the handle was opened, and the error path
+        # closed the handle twice.
+        results = []
+
+        def worker():
+            try:
+                self.cx.open_blob("test", "b", 1)
+                results.append(None)
+            except Exception as exc:  # noqa: BLE001
+                results.append(exc)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], sqlite.ProgrammingError)
+
+    def test_open_blob_on_closed_connection(self):
+        self.blob.close()
+        self.cx.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            self.cx.open_blob("test", "b", 1)
+
+    def test_connection_close_closes_every_blob(self):
+        # close() used to skip every other open blob because it iterated
+        # by index while entries were being removed.
+        blobs = [self.blob] + [self.cx.open_blob("test", "b", 1) for _ in range(4)]
+        self.cx.close()
+        for blob in blobs:
+            with self.assertRaises(sqlite.ProgrammingError):
+                blob.read(1)
+
+    def test_explicit_close_keeps_weakrefs_intact(self):
+        # close() used to clear weakrefs of the still-live blob object,
+        # an internal-API misuse that raises SystemError on Python
+        # 3.13+.
+        ref = weakref.ref(self.blob)
+        self.blob.close()
+        self.assertIs(ref(), self.blob)
+
+    def test_closed_blob_is_collected(self):
+        # close() leaked a strong reference taken while unlinking the
+        # blob from the connection's blob list, pinning the blob (and
+        # through it the connection) forever.
+        blob = self.cx.open_blob("test", "b", 1)
+        ref = weakref.ref(blob)
+        blob.close()
+        del blob
+        gc.collect()
+        self.assertIsNone(ref())
+
+
+def suite():
+    loader = unittest.TestLoader()
+    return unittest.TestSuite(
+        (
+            loader.loadTestsFromTestCase(BlobRegressionTests),
+        )
+    )
+
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+
+if __name__ == "__main__":
+    test()

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -1005,12 +1005,101 @@ class CallbackCloseRegressionTests(unittest.TestCase):
                         con.execute("COMMIT--x")
                     except sqlite.ProgrammingError:
                         pass
+                    try:
+                        con.execute(" \vCOMMIT")
+                    except sqlite.ProgrammingError:
+                        pass
+                    try:
+                        con.execute(";COMMIT")
+                    except sqlite.ProgrammingError:
+                        pass
                     return 1
             con.create_window_function("w", 1, Win)
             cur = con.execute("select w(x) over (order by x) from t")
             cur.fetchone()
             con.rollback()
             assert con.execute("select count(*) from t").fetchone()[0] == 3
+            con.close()
+            """
+        )
+
+    def test_refused_execute_preserves_pending_row(self):
+        # pysqlite_refuse_txn_sql used to run after execute() had already
+        # cleared next_row, so a refused COMMIT on another cursor dropped
+        # a fetched-but-unconsumed row.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            con.commit()
+            cur_b = con.execute("select x from t")
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        cur_b.execute("COMMIT")
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur_a = con.execute("select w(x) over (order by x) from t")
+            cur_a.fetchone()
+            cur_a.execute("select 1")
+            assert cur_b.fetchone() == (0,)
+            con.close()
+            """
+        )
+
+    def test_refused_execute_preserves_reset_after_rollback(self):
+        # The same early mutation cleared reset, so fetchone after a
+        # refused execute on a rolled-back cursor returned None instead
+        # of InterfaceError.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            con.commit()
+            con.execute("insert into t values (4)")
+            cur_b = con.execute("select x from t")
+            con.rollback()
+            try:
+                cur_b.fetchone()
+            except sqlite.InterfaceError:
+                pass
+            else:
+                raise AssertionError("expected InterfaceError after rollback")
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        cur_b.execute("COMMIT")
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur_a = con.execute("select w(x) over (order by x) from t")
+            cur_a.fetchone()
+            cur_a.execute("select 1")
+            try:
+                cur_b.fetchone()
+            except sqlite.InterfaceError:
+                pass
+            else:
+                raise AssertionError(
+                    "refused execute must not clear reset after rollback"
+                )
             con.close()
             """
         )
@@ -1040,6 +1129,30 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             cur.execute("select w(x) over (order by x) from t")
             cur.fetchone()
             con.rollback()
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_refused_reexecute_does_not_drop_outer_lock(self):
+        # check_cursor failure used to fall through to execute's error
+        # path, which cleared locked even though this call never set it.
+        # A later fetch then re-entered reset of the live statement.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            cur = con.cursor()
+            def callback():
+                try:
+                    cur.execute("select 1")
+                except sqlite.ProgrammingError:
+                    pass
+                return 1
+            con.create_function("f", 0, callback)
+            cur.execute("select f() union all select f()")
+            assert cur.fetchone() == (1,)
+            assert cur.fetchone() == (1,)
+            assert cur.fetchone() is None
             assert con.execute("select 1").fetchone() == (1,)
             con.close()
             """

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -281,6 +281,14 @@ class CursorRegressionTests(unittest.TestCase):
     def tearDown(self):
         self.cx.close()
 
+    def test_fetchmany_nonpositive_size(self):
+        # fetchmany(0) and negative sizes used to return every
+        # remaining row.
+        cur = self.cx.execute("select i from test")
+        self.assertEqual(cur.fetchmany(0), [])
+        self.assertEqual(cur.fetchmany(-1), [])
+        self.assertEqual(len(cur.fetchmany(3)), 3)
+
     def test_udf_text_with_embedded_nul(self):
         # Function arguments and results were marshalled with
         # NUL-terminated string APIs, truncating TEXT values at the

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -756,6 +756,26 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_authorizer_del_reenter_set_authorizer(self):
+        self._run(
+            """
+            class Auth:
+                def __init__(self, con):
+                    self.con = con
+                def __call__(self, *args):
+                    return sqlite.SQLITE_OK
+                def __del__(self):
+                    self.con.set_authorizer(None)
+            con = sqlite.connect(":memory:")
+            auth = Auth(con)
+            con.set_authorizer(auth)
+            del auth
+            con.set_authorizer(lambda *args: sqlite.SQLITE_OK)
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
     def test_cursor_init_in_udf(self):
         # Re-init used to Py_CLEAR the live statement while execute still
         # held it. CPython refuses recursive cursor use here.
@@ -831,6 +851,38 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             else:
                 raise AssertionError("expected execute to fail after a refused cursor __init__")
             assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_collation_evilstr_name_does_not_crash_on_close(self):
+        # Pinboard keys are the UTF-8 name, not the Python str object, so
+        # a name whose __hash__ raises still registers. close() must not
+        # double-destroy if __del__ tries to re-register the same name.
+        self._run(
+            """
+            class EvilStr(str):
+                def __hash__(self):
+                    raise RuntimeError("hash")
+            class Coll:
+                def __init__(self, con):
+                    self.con = con
+                def __call__(self, a, b):
+                    return (a > b) - (a < b)
+                def __del__(self):
+                    try:
+                        self.con.create_collation("C", lambda a, b: 0)
+                    except Exception:
+                        pass
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x text)")
+            con.execute("insert into t values ('b'), ('a')")
+            coll = Coll(con)
+            con.create_collation(EvilStr("C"), coll)
+            assert [row[0] for row in con.execute(
+                "select x from t order by x collate C"
+            )] == ["a", "b"]
+            del coll
             con.close()
             """
         )
@@ -1248,6 +1300,74 @@ class CallbackCloseRegressionTests(unittest.TestCase):
         )
 
 
+class CollationOwnershipRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite.connect(":memory:")
+        self.con.execute("create table t(x text)")
+        self.con.executemany("insert into t values (?)", [("a",), ("b",), ("c",)])
+
+    def tearDown(self):
+        self.con.close()
+
+    def _active_ordered_cursor(self, name="c"):
+        return self.con.execute(
+            f"select x from t order by x collate {name}"
+        )
+
+    def test_unregister_never_registered_collation(self):
+        # Missing names used to raise KeyError out of create_collation.
+        self.con.create_collation("never_registered", None)
+
+    def test_failed_replacement_keeps_original_callback(self):
+        callback = lambda a, b: (a > b) - (a < b)
+        ref = weakref.ref(callback)
+        self.con.create_collation("c", callback)
+        del callback
+        cursor = self._active_ordered_cursor()
+        with self.assertRaises(sqlite.OperationalError):
+            self.con.create_collation("c", lambda a, b: 0)
+        self.assertIsNotNone(ref(), "SQLite still holds the original callback")
+        self.assertEqual([row[0] for row in cursor], ["a", "b", "c"])
+
+    def test_failed_deletion_keeps_original_callback(self):
+        callback = lambda a, b: (a > b) - (a < b)
+        ref = weakref.ref(callback)
+        self.con.create_collation("c", callback)
+        del callback
+        cursor = self._active_ordered_cursor()
+        with self.assertRaises(sqlite.OperationalError):
+            self.con.create_collation("c", None)
+        self.assertIsNotNone(ref())
+        self.assertEqual([row[0] for row in cursor], ["a", "b", "c"])
+
+    def test_failed_case_insensitive_replacement(self):
+        # SQLite collation names are case-insensitive; the pinboard key is
+        # not. Ownership is the still-active sort order, not the weakref
+        # on a Python dict that the replacement never touched.
+        callback = lambda a, b: (a > b) - (a < b)
+        self.con.create_collation("C", callback)
+        cursor = self._active_ordered_cursor("c")
+        with self.assertRaises(sqlite.OperationalError):
+            self.con.create_collation("c", lambda a, b: (b > a) - (b < a))
+        self.assertEqual([row[0] for row in cursor], ["a", "b", "c"])
+
+    def test_successful_replacement_after_statement_released(self):
+        self.con.create_collation("c", lambda a, b: (a > b) - (a < b))
+        self.assertEqual(
+            [row[0] for row in self.con.execute(
+                "select x from t order by x collate c"
+            )],
+            ["a", "b", "c"],
+        )
+        self.con.create_collation("c", lambda a, b: (b > a) - (b < a))
+        self.assertEqual(
+            [row[0] for row in self.con.execute(
+                "select x from t order by x collate c"
+            )],
+            ["c", "b", "a"],
+        )
+
+
 class StatementLifetimeRegressionTests(unittest.TestCase):
     def test_function_destructor_after_connection_close(self):
         # Isolate native crashes so a missing GIL reports a test failure rather
@@ -1451,6 +1571,7 @@ def suite():
             loader.loadTestsFromTestCase(BusyHandlerRegressionTests),
             loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
             loader.loadTestsFromTestCase(CallbackCloseRegressionTests),
+            loader.loadTestsFromTestCase(CollationOwnershipRegressionTests),
             loader.loadTestsFromTestCase(StatementLifetimeRegressionTests),
             loader.loadTestsFromTestCase(CursorRegressionTests),
             loader.loadTestsFromTestCase(RowRegressionTests),

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -585,6 +585,33 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_reexecute_in_window_finalize(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            cur = con.cursor()
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        cur.execute("select 1")
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            list(cur.execute("select w(x) over (order by x) from t"))
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
     def test_gc_in_window_finalize(self):
         self._run(
             """
@@ -804,6 +831,68 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             else:
                 raise AssertionError("expected execute to fail after a refused cursor __init__")
             assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_same_cursor_execute_in_window_finalize_during_rollback(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            con.commit()
+            cur = con.cursor()
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        cur.execute("select 1")
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur.execute("select w(x) over (order by x) from t")
+            cur.fetchone()
+            con.rollback()
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_cursor_created_in_finalize_stays_usable(self):
+        # rollback() locks every live cursor around the reset so a window
+        # finalize cannot re-enter execute() on the statement being
+        # reset. A cursor the finalize creates used to receive the
+        # matching unlock without ever being locked, leaving it stuck
+        # with "Recursive use of cursors not allowed".
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            created = []
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    created.append(con.cursor())
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur = con.execute("select w(x) over (order by x) from t")
+            cur.fetchone()
+            con.rollback()
+            assert len(created) == 1, created
+            assert created[0].execute("select 1").fetchone() == (1,)
             con.close()
             """
         )

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -291,6 +291,355 @@ class CallbackCloseRegressionTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         return result.stdout
 
+    def test_close_in_scalar_function(self):
+        # gh-145040: close() during sqlite3_step used to NULL db and
+        # finalize the executing statement.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            def callback():
+                try:
+                    con.close()
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("close() should have been refused")
+                return 1
+            con.create_function("f", 0, callback)
+            try:
+                con.execute("select f()")
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected execute to fail after a refused close")
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_close_in_authorizer(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x)")
+            def auth(*args):
+                try:
+                    con.close()
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("close() should have been refused")
+                return sqlite.SQLITE_OK
+            con.set_authorizer(auth)
+            try:
+                con.execute("select x from t")
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected execute to fail after a refused close")
+            con.set_authorizer(None)
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_close_in_progress_handler(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(20)])
+            def progress():
+                try:
+                    con.close()
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("close() should have been refused")
+                return 1
+            con.set_progress_handler(progress, 1)
+            try:
+                list(con.execute("select x from t"))
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected execute to fail after a refused close")
+            con.set_progress_handler(None, 1)
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_close_in_collation(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x text)")
+            con.executemany("insert into t values (?)", [("a",), ("b",), ("c",)])
+            def collation(a, b):
+                try:
+                    con.close()
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("close() should have been refused")
+                return (a > b) - (a < b)
+            con.create_collation("c", collation)
+            try:
+                con.execute("select x from t order by x collate c")
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected execute to fail after a refused close")
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_close_in_aggregate(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(5)])
+            class Agg:
+                def __init__(self):
+                    self.total = 0
+                def step(self, value):
+                    try:
+                        con.close()
+                    except sqlite.ProgrammingError:
+                        raise
+                    else:
+                        raise AssertionError("close() should have been refused")
+                    self.total += value
+                def finalize(self):
+                    return self.total
+            con.create_aggregate("agg_close", 1, Agg)
+            try:
+                con.execute("select agg_close(x) from t")
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected execute to fail after a refused close")
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_close_in_backup_progress(self):
+        self._run(
+            """
+            src = sqlite.connect(":memory:")
+            dst = sqlite.connect(":memory:")
+            src.execute("create table t(x)")
+            src.executemany("insert into t values (?)", [(i,) for i in range(20)])
+            src.commit()
+            calls = []
+            def progress(status, remaining, total):
+                calls.append((status, remaining, total))
+                try:
+                    src.close()
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("close() should have been refused")
+            try:
+                src.backup(dst, pages=1, progress=progress)
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected backup to fail after a refused close")
+            assert calls, "progress callback never ran; commit the source first"
+            assert src.execute("select count(*) from t").fetchone()[0] == 20
+            src.close()
+            dst.close()
+            """
+        )
+
+    def test_close_caught_inside_callback(self):
+        # If the callback swallows ProgrammingError, the native operation
+        # continues and the connection remains usable.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            def swallow(_):
+                try:
+                    con.close()
+                except sqlite.ProgrammingError:
+                    pass
+                return 1
+            con.create_function("swallow", 1, swallow)
+            assert con.execute("select swallow(1)").fetchone() == (1,)
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_close_target_in_backup_progress(self):
+        self._run(
+            """
+            src = sqlite.connect(":memory:")
+            dst = sqlite.connect(":memory:")
+            src.execute("create table t(x)")
+            src.executemany("insert into t values (?)", [(i,) for i in range(20)])
+            src.commit()
+            def progress(status, remaining, total):
+                try:
+                    dst.close()
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("target close() should have been refused")
+            try:
+                src.backup(dst, pages=1, progress=progress)
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected backup to fail after a refused close")
+            assert src.execute("select count(*) from t").fetchone()[0] == 20
+            src.close()
+            dst.close()
+            """
+        )
+
+    def test_close_in_window_finalize(self):
+        # xFinal runs from sqlite3_reset after the last row, not from
+        # step; the driver clears callback exceptions there, so the
+        # query may still complete. close() must not crash.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        con.close()
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            list(con.execute("select w(x) over (order by x) from t"))
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_rollback_in_window_finalize(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        con.rollback()
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            list(con.execute("select w(x) over (order by x) from t"))
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_cursor_close_in_window_finalize(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            cur = con.cursor()
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        cur.close()
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            list(cur.execute("select w(x) over (order by x) from t"))
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_gc_in_window_finalize(self):
+        self._run(
+            """
+            import gc
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        con.close()
+                    except sqlite.ProgrammingError:
+                        pass
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur = con.execute("select w(x) over (order by x) from t")
+            cur.fetchone()
+            del cur
+            gc.collect()
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_cursor_close_in_udf(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            cur = con.cursor()
+            def callback():
+                try:
+                    cur.close()
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("cursor close() should have been refused")
+                return 1
+            con.create_function("f", 0, callback)
+            try:
+                cur.execute("select f()")
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected execute to fail after a refused cursor close")
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
     def test_cursor_close_in_converter(self):
         self._run(
             """
@@ -314,6 +663,183 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             else:
                 raise AssertionError("expected fetch to fail after a refused cursor close")
             assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_close_in_open_blob_busy_handler(self):
+        self._run(
+            """
+            import os
+            import tempfile
+            fd, path = tempfile.mkstemp(suffix=".db")
+            os.close(fd)
+            try:
+                locker = sqlite.connect(path)
+                locker.execute("create table t(b blob)")
+                locker.execute("insert into t values (zeroblob(8))")
+                locker.commit()
+                locker.execute("begin exclusive")
+                con = sqlite.connect(path, timeout=0)
+                def busy(n):
+                    try:
+                        con.close()
+                    except sqlite.ProgrammingError:
+                        raise
+                    else:
+                        raise AssertionError("close() should have been refused")
+                    return 0
+                con.set_busy_handler(busy)
+                try:
+                    con.open_blob("t", "b", 1)
+                except sqlite.Error:
+                    pass
+                else:
+                    raise AssertionError("expected open_blob to fail after a refused close")
+                con.set_busy_handler(None)
+                locker.rollback()
+                assert con.execute("select 1").fetchone() == (1,)
+                con.close()
+                locker.close()
+            finally:
+                os.unlink(path)
+            """
+        )
+
+    def test_create_function_replace_destructor_close(self):
+        self._run(
+            """
+            class Closer:
+                def __init__(self, con):
+                    self.con = con
+                def __call__(self):
+                    return 1
+                def __del__(self):
+                    try:
+                        self.con.close()
+                    except sqlite.ProgrammingError:
+                        pass
+            con = sqlite.connect(":memory:")
+            old = Closer(con)
+            con.create_function("f", 0, old)
+            del old
+            con.create_function("f", 0, lambda: 2)
+            assert con.execute("select f()").fetchone() == (2,)
+            con.close()
+            """
+        )
+
+    def test_cursor_init_in_udf(self):
+        # Re-init used to Py_CLEAR the live statement while execute still
+        # held it. CPython refuses recursive cursor use here.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            cur = con.cursor()
+            def callback():
+                try:
+                    cur.__init__(con)
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("cursor __init__ should have been refused")
+                return 1
+            con.create_function("f", 0, callback)
+            try:
+                cur.execute("select f()")
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected execute to fail after a refused cursor __init__")
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_cursor_init_in_converter(self):
+        self._run(
+            """
+            def conv(value):
+                try:
+                    cur.__init__(con)
+                except sqlite.ProgrammingError:
+                    raise
+                else:
+                    raise AssertionError("cursor __init__ should have been refused")
+            sqlite.register_converter("X", conv)
+            con = sqlite.connect(":memory:", detect_types=sqlite.PARSE_COLNAMES)
+            cur = con.cursor()
+            cur.execute("create table t(a)")
+            cur.execute("insert into t values (1)")
+            try:
+                cur.execute('select a as "a [X]" from t')
+                cur.fetchall()
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected fetch to fail after a refused cursor __init__")
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_cursor_init_in_conform(self):
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            cur = con.cursor()
+            cur.execute("create table t(x)")
+            class Payload:
+                def __conform__(self, protocol):
+                    try:
+                        cur.__init__(con)
+                    except sqlite.ProgrammingError:
+                        raise
+                    else:
+                        raise AssertionError("cursor __init__ should have been refused")
+            try:
+                cur.execute("insert into t values (?)", (Payload(),))
+            except sqlite.Error:
+                pass
+            else:
+                raise AssertionError("expected execute to fail after a refused cursor __init__")
+            assert con.execute("select 1").fetchone() == (1,)
+            con.close()
+            """
+        )
+
+    def test_callbacks_may_query_and_register(self):
+        # Nothing here tears a handle down, so it stays allowed: a
+        # callback may run its own query on the connection and register
+        # a new function. SQLite itself refuses to replace a function or
+        # collation while a statement is active.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.execute("insert into t values (1), (2), (3)")
+            def total():
+                return con.execute("select sum(x) from t").fetchone()[0]
+            con.create_function("total", 0, total)
+            assert con.execute("select total()").fetchone() == (6,)
+            def register():
+                con.create_function("late", 0, lambda: 7)
+                con.create_collation("late_c", lambda a, b: (a > b) - (a < b))
+                return 1
+            con.create_function("register", 0, register)
+            con.execute("select register()").fetchone()
+            assert con.execute("select late()").fetchone() == (7,)
+            assert [r[0] for r in con.execute(
+                "select x from t order by x collate late_c desc"
+            )] == [3, 2, 1]
+            def replace():
+                try:
+                    con.create_function("replace", 0, lambda: 0)
+                except sqlite.OperationalError:
+                    return "busy"
+                return "replaced"
+            con.create_function("replace", 0, replace)
+            assert con.execute("select replace()").fetchone() == ("busy",)
             con.close()
             """
         )

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -121,6 +121,35 @@ class BlobRegressionTests(unittest.TestCase):
         self.assertIsNone(ref())
 
 
+class FactoryMemberRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(t text)")
+        self.cx.execute("insert into test(t) values ('hello')")
+
+    def tearDown(self):
+        self.cx.close()
+
+    def test_del_connection_row_factory(self):
+        # row_factory is a plain member; deleting it stored NULL, and
+        # the next cursor() call crashed in Py_INCREF(NULL).
+        del self.cx.row_factory
+        cur = self.cx.cursor()
+        self.assertEqual(cur.execute("select t from test").fetchone(), ("hello",))
+
+    def test_del_cursor_row_factory(self):
+        cur = self.cx.cursor()
+        cur.execute("select t from test")
+        del cur.row_factory
+        self.assertEqual(cur.fetchone(), ("hello",))
+
+    def test_del_text_factory(self):
+        del self.cx.text_factory
+        cur = self.cx.cursor()
+        with self.assertRaises(sqlite.ProgrammingError):
+            cur.execute("select t from test").fetchone()
+
+
 class ConnectionLifecycleRegressionTests(unittest.TestCase):
     def test_uninitialized_connection_close(self):
         # Connection.__new__ without __init__ used to crash close() on
@@ -210,6 +239,7 @@ def suite():
     return unittest.TestSuite(
         (
             loader.loadTestsFromTestCase(BlobRegressionTests),
+            loader.loadTestsFromTestCase(FactoryMemberRegressionTests),
             loader.loadTestsFromTestCase(ConnectionLifecycleRegressionTests),
         )
     )

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -1195,6 +1195,41 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_cross_thread_registration_does_not_deadlock(self):
+        # Registering a function held the GIL while taking the connection
+        # mutex. With check_same_thread=False, a reader thread inside
+        # sqlite3_step holds that mutex and its UDF waits for the GIL:
+        # AB-BA. The registration calls now release the GIL.
+        self._run(
+            """
+            import threading
+            con = sqlite.connect(":memory:", check_same_thread=False)
+            con.execute("create table t(x)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(20000)])
+            in_step = threading.Event()
+            def udf(v):
+                in_step.set()
+                return v
+            con.create_function("udf", 1, udf)
+            result = []
+            def reader():
+                result.append(con.execute("select sum(udf(x)) from t").fetchone()[0])
+            t = threading.Thread(target=reader)
+            t.start()
+            assert in_step.wait(10), "reader never entered the UDF"
+            con.create_function("g", 0, lambda: 0)          # deadlocked here
+            con.create_collation("c", lambda a, b: 0)
+            con.set_authorizer(lambda *a: sqlite.SQLITE_OK)
+            con.set_progress_handler(lambda: 0, 1000)
+            con.set_busy_timeout(0.1)
+            con.set_trace_callback(lambda s: None)
+            t.join(10)
+            assert not t.is_alive(), "reader thread hung"
+            assert result == [sum(range(20000))], result
+            con.close()
+            """
+        )
+
     def test_open_blob_from_function_destructor(self):
         self._run(
             """

--- a/packages/phoenix-sqlean/tests/driver_regressions.py
+++ b/packages/phoenix-sqlean/tests/driver_regressions.py
@@ -1263,6 +1263,49 @@ class CallbackCloseRegressionTests(unittest.TestCase):
             """
         )
 
+    def test_backup_from_callback_is_refused(self):
+        # backup() retries forever on SQLITE_BUSY, on the assumption that
+        # the contention is external and will clear. Started from a
+        # callback of its own source, the contention is the source's own
+        # in-progress statement, so it never does: a window finalize
+        # running during rollback() spun for good. A backup whose source
+        # or destination has a callback on the stack is now refused.
+        self._run(
+            """
+            con = sqlite.connect(":memory:")
+            con.execute("create table t(x integer)")
+            con.executemany("insert into t values (?)", [(i,) for i in range(3)])
+            con.commit()
+            con.execute("insert into t values (4)")
+            dst = sqlite.connect(":memory:")
+            seen = []
+            class Win:
+                def step(self, value):
+                    pass
+                def inverse(self, value):
+                    pass
+                def value(self):
+                    return 1
+                def finalize(self):
+                    try:
+                        con.backup(dst)
+                        seen.append("allowed")
+                    except sqlite.ProgrammingError:
+                        seen.append("refused")
+                    return 1
+            con.create_window_function("w", 1, Win)
+            cur = con.execute("select w(x) over (order by x) from t")
+            cur.fetchone()
+            con.rollback()
+            assert seen == ["refused"], seen
+            assert con.execute("select count(*) from t").fetchone() == (3,)
+            con.backup(dst)
+            assert dst.execute("select count(*) from t").fetchone() == (3,)
+            con.close()
+            dst.close()
+            """
+        )
+
     def test_open_blob_from_function_destructor(self):
         self._run(
             """


### PR DESCRIPTION
The vendored driver (pysqlite lineage, roughly CPython 3.9-era Modules/_sqlite) carries defects that were later fixed in CPython or are specific to the sqlean fork's Blob API. A review of src/ against CPython's actively maintained _sqlite3 turned up the following, all inherited from upstream; this PR fixes them, one commit per fix, followed by fixes for re-entrancy and threading hazards found while testing those.

Blob API:
- Subscript and slice reads used the current seek position instead of the requested offset, silently returning wrong data.
- Step-slice assignment kept going after a failed range read: it wrote into the freed merge buffer, freed it a second time on write failure, and unconditionally reported success; the buffer also leaked on the successful path.
- Negative-step slices computed a negative buffer size and always raised MemoryError; blob[::-1] now works.
- open_blob() had no thread/connection checks, so calling it on a closed connection dereferenced a NULL sqlite3 handle, and its error path closed the new sqlite3_blob handle twice (once via the Blob dealloc, once via the shared error label).
- Closing a blob leaked the strong reference taken while unlinking it from the connection's blob list, pinning the blob and its connection forever; on Python 3.13+ the unlink never matched a mid-dealloc blob, so dead weakrefs accumulated instead.
- Connection.close() skipped every other open blob because it indexed the blob list while the closes were removing entries from it.
- PyObject_ClearWeakRefs() was called on still-live blobs during close(); it is only valid during deallocation and raises SystemError on Python 3.13+.

Connection lifecycle:
- __init__ set the initialized flag before sqlite3_open_v2, so a failed (re-)initialization left a half-initialized connection that crashed on the next execute() (NULL statement cache). The new database is now opened into a local handle first: a failed open leaves an existing connection fully intact, a post-open failure leaves a closed connection, and a successful re-initialization closes the previous handle instead of leaking it (outstanding statement and blob handles keep it alive per sqlite3_close_v2 semantics).
- close() and the isolation_level getter crashed on a connection created with Connection.__new__ without __init__.
- backup() validated only the target connection; a closed source connection dereferenced a NULL handle in sqlite3_backup_init.
- Unlinking a blob after a failed re-initialization dereferenced the connection's NULL blob list.

Callbacks and user-defined functions:
- Function arguments and results were marshalled with NUL-terminated string APIs, truncating TEXT at the first embedded NUL byte in both directions; an OOM from sqlite3_value_text() crashed in strlen(NULL).
- set_busy_timeout() dropped the busy-handler reference without NULLing the stored pointer, so the next drop underflowed the refcount; it also truncated fractional timeouts to whole seconds before converting to milliseconds, so 0.5 disabled waiting entirely.
- Progress and busy handlers could leave a live exception set across PyGILState_Release when their return value failed to convert.
- Aggregate step/value/inverse callbacks dereferenced a NULL sqlite3_aggregate_context() result under OOM.
- load_extension() leaked SQLite's error-message buffer and passed NULL to PyErr_SetString when no message was provided.
- sqlean extension initialization return codes were discarded; a failed init now logs to stderr instead of surfacing much later as a confusing 'no such function' error.

Cursor and row:
- A detect_types converter re-entering execute() on the same cursor during iteration reset the active statement out from under the fetch loop (use-after-free); iteration now locks the cursor the same way execute() already did (CPython gh-80254).
- fetchmany(0) and negative sizes fetched every remaining row.
- A failed re-creation of an in-use statement reported success with no statement, making subsequent fetches silently return nothing.
- Deleting the plain-member factory attributes (del con.row_factory, del con.text_factory, del cur.row_factory) stored NULL and crashed on next use in Py_INCREF(NULL) (CPython gh-149738).
- Row() over an uninitialized cursor crashed on the NULL description; Row.__hash__ ignored PyObject_Hash failures.
- lastrowid and description updates published partially-built or NULL objects under OOM; the statement-cache factory result leaked when node allocation failed.

Statement teardown and callback re-entrancy:
- A cursor or raw Statement can outlive its SQLite connection, so sqlite3_finalize() destroyed registered Python callbacks with the GIL released. The destructor guard is ported from CPython bpo-44304 / GH-26551. In-use statement-cache duplicates are now created through the connection's statement factory, with shared initialization and error handling, so close() finalizes them too.
- Closing, rolling back, or re-initializing the connection from inside a SQLite callback, or closing or re-initializing a cursor, finalized or reset the running statement out from under the native call, which crashed when it resumed. The connection now counts the sqlite3_* calls that may invoke a Python callback (statement execution, window finalize, blob I/O, sqlite3_close_v2, and function or collation registration), and those teardown paths raise ProgrammingError while the count is non-zero. Cursor re-initialization also refuses while the cursor is locked, matching CPython's recursive-use check. The re-init refusal keys on that count rather than the initialized flag, which re-init clears before closing the old handle; a destructor fired by that close could otherwise re-enter __init__, leak the inner handle, and drop committed work. Registering functions and collations from a callback stays allowed: SQLite refuses to replace one while a statement is active and adds a new one safely.
- rollback() and close() reset or finalize every statement while cursors may still hold them, so a window function's finalize could re-enter execute() on the statement being reset. Both now hold every live cursor locked for the duration. The locked set is snapshotted with strong references: a cursor the callback creates must not receive the matching unlock, which left it permanently "in use".
- commit() during a statement reset or finalize is refused through a separate counter. SQLite accepts COMMIT while statements are mid-reset, so a commit() issued from a window function's finalize during rollback() silently turned the rollback into a commit. The same check covers COMMIT, END, and RELEASE issued through execute(), after skipping leading whitespace and comments, since those reach SQLite the same way. The counter is separate because commit() itself does not reset statements, so it stays legal from an ordinary callback such as a backup progress handler.
- An orphan Statement (a con("sql") result surviving del con) kept a borrowed pointer to the freed Connection and incremented the callback counter on that heap when finalized; a later Connection that reused the block saw a callback in progress. dealloc and re-initialization now clear the pointer in every surviving Statement first; re-init used to discard the weakref list without doing so, hiding the orphans from the dealloc walk.
- sqlite3_close_v2 in close(), dealloc, and re-initialization now runs with the GIL released, inside the callback window, and only after the connection has been published as closed. The close destroys every registered function, and a callable whose only reference is SQLite's runs __del__ there; re-entering close() from it reached SQLite as API misuse, and open_blob() walked freed structures, because sqlite3_blob_open does not validate the handle without SQLITE_ENABLE_API_ARMOR. close() and __init__ are now refused there as callback re-entry; every other method sees the ordinary closed-connection error.
- Replacing a collation swapped the callable in the pinboard before asking SQLite, so when sqlite3_create_collation returned SQLITE_BUSY (the old collation still in use) SQLite kept pointing at the callable Python had just released. Registration now goes through sqlite3_create_collation_v2 with a destructor, and the pinboard is updated only after SQLite accepts the new callable, keyed by the collation's UTF-8 name so a str subclass with a failing __hash__ cannot fail that update; if it fails anyway, the registration is undone so SQLite is not left holding the callable's only reference.

Found while testing the above:
- The execute()-level guard for COMMIT, END, and RELEASE skipped only space, tab, CR, LF, FF, the UTF-8 BOM, and comments before the keyword. SQLite also accepts a vertical tab inside a whitespace run and leading empty statements (semicolons), so both reached it as a plain COMMIT and turned a rollback into a commit from a window finalize. The trivia skipper now covers them. The guard also ran after execute() had cleared the cursor's pending row and reset marker, so a refused COMMIT on another cursor dropped a fetched-but-unconsumed row and made fetchone() return None where it should raise InterfaceError after a rollback; those fields are now cleared only once the call is going ahead. A refused re-entrant execute() on a locked cursor also fell through to the error path and cleared a lock it never took, so a second attempt from the same callback reset the live statement under the outer query.
- An authorizer runs inside sqlite3_prepare_v2. Calling execute() on the invoking connection from it compiled another statement, ran the authorizer again, and so on without bound; each level costs a sqlite3_prepare_v2 frame, so on a 512 KB thread stack (the macOS default for non-main threads) the process died with a signal long before Python's recursion limit tripped. The connection now counts the sqlite3_prepare_v2 calls on its C stack and refuses a compile requested while that count is non-zero with ProgrammingError. Callbacks fired during execution (functions, progress and busy handlers) keep their ability to run queries, and an authorizer may still query a different connection.
- Every registration call (create_function, create_aggregate, create_window_function, create_collation, set_authorizer, set_progress_handler, set_busy_handler, set_busy_timeout, set_trace_callback) took the connection's SQLite mutex with the GIL held. With check_same_thread=False, a thread inside sqlite3_step holds that mutex for the whole step while a user-defined function it calls waits for the GIL, so a second thread registering anything deadlocked. Those calls now run with the GIL released, like step, prepare, and close already did.
- SQLite forbids using the destination connection of a backup until the backup finishes, and nothing enforced that. Connection.backup() runs a Python progress callback between steps; a read from the destination there returned "malformed database schema" and a write segfaulted. The destination now carries a counter for the duration, and the connection check every method goes through refuses with ProgrammingError while it is set. Reading the source from the callback remains allowed.
- Connection.backup() retries on SQLITE_BUSY and SQLITE_LOCKED on the assumption that the contention is external. Started from a callback of either connection, the contention is that connection's own in-progress statement, which cannot clear until the callback returns, so the backup spun forever. backup() now refuses with ProgrammingError when the source or destination has a callback on its C stack. A backup started at top level while the source holds an uncommitted write transaction also retries forever; that is inherited behavior shared with CPython and left alone.

tests/driver_regressions.py adds regression tests for every fix with a deterministic, non-OOM trigger, including subprocess cases for scalar, aggregate, and window callbacks across constraint failures, overlapping SELECTs, and orphaned statements (each segfaulted before the fix), a test pinning what callbacks may still do (run their own queries and register new functions or collations), a 512 KB-stack thread for the authorizer recursion, and a two-thread test that drives a reader into a UDF before registering each kind of callback. Allocation-failure paths are reasoned about but not exercised; that needs fault injection. The package suite passes on CPython 3.10 through 3.14 (437 tests, 2 skipped).

The altered files carry a modification notice as the zlib license requires; LICENSE and THIRD_PARTY_LICENSES are updated accordingly.
