### PR TITLE
feat(dsl): add `parent_span is None` root-span predicate to span filter DSL

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -142,6 +142,15 @@ _BACKWARD_COMPATIBILITY_REPLACEMENTS: typing.Mapping[str, str] = MappingProxyTyp
     }
 )
 
+# The reserved `parent_span` keyword refers to a span's parent span (the span whose
+# `span_id` equals this span's `parent_id`). Only `parent_span is None` /
+# `parent_span is not None` are supported (root-ness by parent existence); the
+# translator rewrites those into references to the names below, which are bound
+# to correlated `EXISTS` predicates in `SpanFilter.__call__`.
+_PARENT_KEYWORD = "parent_span"
+_PARENT_IS_NULL = "__parent_is_null__"
+_PARENT_IS_NOT_NULL = "__parent_is_not_null__"
+
 
 @dataclass(frozen=True)
 class SpanFilter:
@@ -184,6 +193,16 @@ class SpanFilter:
     def __call__(self, select: Select[typing.Any]) -> Select[typing.Any]:
         if not self.condition:
             return select
+        # `parent_span is None` / `parent_span is not None` select spans whose parent span does
+        # not / does exist. A correlated `NOT EXISTS` is used deliberately: it is true
+        # both when `parent_id` is NULL and when it points to a span absent from the
+        # table (an orphan), and it is the shape the existing root query uses to avoid
+        # a measured PostgreSQL regression (see `query.py`). An `OR ... parent_id IS
+        # NULL` form is intentionally NOT used here.
+        parent_span = aliased(models.Span)
+        parent_exists = (
+            sqlalchemy.select(1).where(parent_span.span_id == models.Span.parent_id).exists()
+        )
         return self._join_aliased_relations(select).where(
             eval(
                 self.compiled,
@@ -198,6 +217,8 @@ class SpanFilter:
                     "Float": sqlalchemy.Float,
                     "String": sqlalchemy.String,
                     "TextContains": models.TextContains,
+                    _PARENT_IS_NULL: ~parent_exists,
+                    _PARENT_IS_NOT_NULL: parent_exists,
                 },
             )
         )
@@ -303,6 +324,33 @@ def _is_string_constant(node: typing.Any) -> TypeGuard[ast.Constant]:
 
 def _is_uppercase_enum(node: typing.Any) -> TypeGuard[ast.Name]:
     return isinstance(node, ast.Name) and node.id in ("span_kind", "status_code")
+
+
+def _is_parent_name(node: typing.Any) -> TypeGuard[ast.Name]:
+    # the bare reserved keyword `parent_span`
+    return isinstance(node, ast.Name) and node.id == _PARENT_KEYWORD
+
+
+def _is_parent_rooted(node: typing.Any) -> bool:
+    # an attribute/subscript chain rooted at the bare `parent_span` keyword, e.g.
+    # `parent_span.span_kind`, `parent_span.a.b`, `parent_span.attributes['x']`.
+    # (Not `attributes['parent_span']`, whose root is `attributes`.)
+    while isinstance(node, (ast.Attribute, ast.Subscript)):
+        node = node.value
+    return _is_parent_name(node)
+
+
+def _parent_traversal_error(node: ast.expr) -> SyntaxError:
+    # `parent_span.<field>` traversal is not supported yet (a follow-up).
+    return SyntaxError(
+        f"`{ast.unparse(node)}` is not supported: `parent_span` traversal "
+        "(`parent_span.<field>`) is not yet available; only `parent_span is None` "
+        "and `parent_span is not None` are supported"
+    )
+
+
+def _is_none_constant(node: typing.Any) -> TypeGuard[ast.Constant]:
+    return isinstance(node, ast.Constant) and node.value is None
 
 
 def _convert_to_uppercase(node: ast.expr) -> ast.expr:
@@ -512,7 +560,61 @@ class _ProjectionTranslator(ast.NodeTransformer):
 
 
 class _FilterTranslator(_ProjectionTranslator):
+    def visit_Name(self, node: ast.Name) -> typing.Any:
+        if _is_parent_name(node):
+            # A bare `parent_span` that reaches this point is not part of a supported
+            # `parent_span is None` / `parent_span is not None` comparison (those are
+            # intercepted in visit_Compare before their operands are visited).
+            raise SyntaxError(
+                "`parent_span` can only be used as `parent_span is None` "
+                "or `parent_span is not None`"
+            )
+        return super().visit_Name(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> typing.Any:
+        self._reject_parent_traversal(node)
+        return super().visit_Attribute(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> typing.Any:
+        self._reject_parent_traversal(node)
+        return super().visit_Subscript(node)
+
+    @staticmethod
+    def _reject_parent_traversal(node: ast.expr) -> None:
+        # The `parent_span` keyword is fully reserved: `parent_span.<field>` traversal is
+        # not supported yet (a follow-up), so reject it clearly here rather than
+        # letting it fall through to the pre-existing `attributes['parent_span'][...]`
+        # attribute-path behavior, which would silently mean something else.
+        if _is_parent_rooted(node):
+            raise _parent_traversal_error(node)
+
+    def _parent_root_predicate(self, node: ast.Compare) -> typing.Optional[ast.expr]:
+        """
+        Rewrites `parent_span is None` / `parent_span == None` into a root-existence
+        predicate (and the negations into non-root). Returns ``None`` when the
+        comparison does not involve the bare `parent_span` keyword.
+        """
+        op = node.ops[0]
+        left, right = node.left, node.comparators[0]
+        if _is_parent_name(left):
+            other = right
+        elif _is_parent_name(right):
+            other = left
+        else:
+            return None
+        if not _is_none_constant(other):
+            raise SyntaxError(
+                "`parent_span` can only be compared to None (e.g. `parent_span is None`)"
+            )
+        if isinstance(op, (ast.Is, ast.Eq)):
+            return ast.Name(id=_PARENT_IS_NULL, ctx=ast.Load())
+        if isinstance(op, (ast.IsNot, ast.NotEq)):
+            return ast.Name(id=_PARENT_IS_NOT_NULL, ctx=ast.Load())
+        raise SyntaxError("`parent_span` supports only `is` / `is not` (or `==` / `!=`) with None")
+
     def visit_Compare(self, node: ast.Compare) -> typing.Any:
+        if len(node.ops) == 1 and (predicate := self._parent_root_predicate(node)) is not None:
+            return predicate
         if len(node.comparators) > 1:
             args: list[typing.Any] = []
             left = node.left
@@ -645,6 +747,12 @@ def _validate_expression(
                 or _is_annotation(node)
             ):
                 continue
+        elif isinstance(node, (ast.Attribute, ast.Subscript)) and _is_parent_rooted(node):
+            # `parent_span.<field>` traversal is not supported yet (the `parent_span`
+            # keyword is fully reserved); reject with a clear message rather than
+            # the generic "invalid expression" below. Bare `parent_span` (valid in
+            # `parent_span is None`) is a Name, not matched here.
+            raise _parent_traversal_error(node)
         elif (
             _is_subscript(node, "metadata") or _is_subscript(node, "attributes")
         ) and _get_attribute_keys_list(node) is not None:

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -2748,6 +2748,49 @@ class TestProject:
             assert [e["node"]["id"] for e in res["edges"]] == expected
             cursor = res["edges"][0]["cursor"]
 
+    async def test_parent_is_none_matches_orphan_aware_root_spans_only(
+        self,
+        _orphan_spans: _Data,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        """The DSL predicate ``filterCondition: "parent_span is None"`` selects the same
+        spans as ``rootSpansOnly: true, orphanSpanAsRootSpan: true`` — verifying the
+        correlated ``NOT EXISTS`` behaves correctly once the resolver's project
+        predicate and query structure are applied, not just in direct SpanFilter
+        execution.
+        """
+        project = _orphan_spans.projects[0]
+
+        # Orphan-aware roots computed directly from the fixture: a NULL parent, or a
+        # parent_id that references no span in the table.
+        existing_span_ids = {s.span_id for s in _orphan_spans.spans}
+        expected = {
+            _gid(s)
+            for s in _orphan_spans.spans
+            if s.parent_id is None or s.parent_id not in existing_span_ids
+        }
+        # The fixture must exercise both kinds of root, or the test proves nothing.
+        assert any(s.parent_id is None for s in _orphan_spans.spans)
+        assert any(
+            s.parent_id is not None and s.parent_id not in existing_span_ids
+            for s in _orphan_spans.spans
+        )
+
+        dsl_res = await self._node(
+            'spans(filterCondition:"parent_span is None",first:100){edges{node{id}}}',
+            project,
+            httpx_client,
+        )
+        flag_res = await self._node(
+            "spans(rootSpansOnly:true,orphanSpanAsRootSpan:true,first:100){edges{node{id}}}",
+            project,
+            httpx_client,
+        )
+        dsl_ids = {e["node"]["id"] for e in dsl_res["edges"]}
+        flag_ids = {e["node"]["id"] for e in flag_res["edges"]}
+        assert dsl_ids == expected
+        assert dsl_ids == flag_ids
+
     @pytest.fixture
     async def _time_series_data(
         self,

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -1,12 +1,13 @@
 import ast
 import sys
 from ast import unparse
+from datetime import datetime
 from typing import Any, Optional
 from unittest.mock import patch
 from uuid import UUID
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import insert, select
 
 import phoenix.trace.dsl.filter
 from phoenix.db import models
@@ -212,6 +213,28 @@ def test_get_attribute_keys_list(expression: str, expected: Optional[list[str]])
             "'err' in status_code",
             "TextContains(status_code, 'ERR')",
         ),
+        # `parent_span` root predicate: `parent_span is None` / `parent_span is not None` become
+        # references to correlated EXISTS predicates bound in SpanFilter.__call__.
+        (
+            "parent_span is None",
+            "__parent_is_null__",
+        ),
+        (
+            "parent_span is not None",
+            "__parent_is_not_null__",
+        ),
+        (
+            "parent_span == None",
+            "__parent_is_null__",
+        ),
+        (
+            "parent_span != None",
+            "__parent_is_not_null__",
+        ),
+        (
+            "not (parent_span is None)",
+            "not_(__parent_is_null__)",
+        ),
     ],
 )
 async def test_filter_translated(
@@ -388,3 +411,128 @@ class TestProjectorValidationGap:
             "code-injection vectors; instead it exposes "
             f"{len(builtins_obj) if builtins_obj else 0} builtins."
         )
+
+
+_PARENT_PREDICATE_TS = datetime.fromisoformat("2021-01-01T00:00:00.000+00:00")
+
+
+@pytest.fixture
+async def parent_predicate_project(db: DbSessionFactory) -> None:
+    """
+    A project whose single trace exercises every parent case:
+
+    - ``A`` root span (``parent_id`` is NULL)
+    - ``B`` child of ``A``
+    - ``C`` orphan (``parent_id`` ``"GHOST"`` references a span absent from the table)
+    - ``D`` child of the orphan ``C``
+    """
+    async with db() as session:
+        project_rowid = await session.scalar(
+            insert(models.Project).values(name="parent-predicate").returning(models.Project.id)
+        )
+        trace_rowid = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="trace-parent-predicate",
+                project_rowid=project_rowid,
+                start_time=_PARENT_PREDICATE_TS,
+                end_time=_PARENT_PREDICATE_TS,
+            )
+            .returning(models.Trace.id)
+        )
+        for span_id, parent_id, span_kind in (
+            ("A", None, "CHAIN"),
+            ("B", "A", "LLM"),
+            ("C", "GHOST", "LLM"),
+            ("D", "C", "LLM"),
+        ):
+            await session.execute(
+                insert(models.Span).values(
+                    trace_rowid=trace_rowid,
+                    span_id=span_id,
+                    parent_id=parent_id,
+                    name=span_id,
+                    span_kind=span_kind,
+                    start_time=_PARENT_PREDICATE_TS,
+                    end_time=_PARENT_PREDICATE_TS,
+                    attributes={},
+                    events=[],
+                    status_code="OK",
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                )
+            )
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        # `parent_span is None` is orphan-aware: both the NULL-parent root and the orphan.
+        ("parent_span is None", ["A", "C"]),
+        ("parent_span is not None", ["B", "D"]),
+        # `parent_id is None` stays strict (NULL pointer only), unchanged by this work.
+        ("parent_id is None", ["A"]),
+        ("parent_span is None and span_kind == 'LLM'", ["C"]),
+        ("parent_span is not None or parent_id is None", ["A", "B", "D"]),
+    ],
+)
+async def test_parent_root_predicate_selects_expected_spans(
+    db: DbSessionFactory,
+    parent_predicate_project: None,
+    condition: str,
+    expected: list[str],
+) -> None:
+    f = SpanFilter(condition)
+    async with db() as session:
+        span_ids = list(
+            await session.scalars(f(select(models.Span.span_id)).order_by(models.Span.span_id))
+        )
+    assert span_ids == expected
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "parent_span",  # bare keyword, not a comparison
+        "parent_span == 'LLM'",  # compared to a non-None value
+        "parent_span and span_kind == 'LLM'",  # used outside a None comparison
+        "parent_span < None",  # unsupported operator with None
+        # `parent.<field>` traversal is not supported yet; the reserved keyword is
+        # fully locked down, so these must raise rather than silently resolve to
+        # the pre-existing `attributes['parent_span'][...]` attribute path.
+        "parent_span.span_kind == 'AGENT'",
+        "parent_span.name == 'x'",
+        "parent_span.a.b.c == 'z'",
+        "parent_span.attributes['x'] == 'y'",
+        "'x' in parent_span.name",
+    ],
+)
+def test_parent_keyword_rejects_unsupported_usage(condition: str) -> None:
+    with pytest.raises(SyntaxError):
+        SpanFilter(condition)
+
+
+def test_attribute_named_parent_span_still_reachable_explicitly() -> None:
+    # Reserving `parent_span` does not remove access to a span attribute literally
+    # named `parent_span`: it is still reachable via the explicit subscript form,
+    # whose root is `attributes`, not the `parent_span` keyword.
+    SpanFilter("attributes['parent_span'] == 'x'")  # does not raise
+
+
+@pytest.mark.parametrize(
+    "sentinel",
+    ["__parent_is_null__", "__parent_is_not_null__"],
+)
+def test_parent_predicate_sentinels_unreachable_from_user_input(sentinel: str) -> None:
+    """The names bound to the root-existence predicates in the eval namespace must
+    not be reachable from user input. Because the translator rewrites every
+    non-reserved bare identifier into an ``attributes[[...]]`` subscript before
+    compilation, a user who types a sentinel name gets an ordinary attribute
+    lookup, never the injected predicate. This locks that invariant so later
+    translator changes (e.g. parent-column traversal) cannot regress it.
+    """
+    translated = unparse(SpanFilter(f"{sentinel} == 'x'").translated).strip()
+    # resolves to an attribute path, not the bare injected name
+    assert translated.startswith(f"attributes[['{sentinel}']]")


### PR DESCRIPTION
First step toward #14497, which lays out **why** root-span filtering belongs inside the span filter DSL (filter persistence, a unified condition for online evaluations, and one-string manipulation by the agent). This description is about **what was chosen** to get there.

## What already exists (unchanged)

`parent_id is None` already compiles in the DSL and selects strict roots — spans whose `parent_id` pointer column is null. This PR neither adds nor changes that.

## Choice 1: add the orphan-aware root definition

An **orphan** is a span whose `parent_id` points at a span that is absent from the table. The orphan-aware root definition treats those as roots too, and it is the one thing the DSL could not express, because it needs a correlated existence check rather than a column comparison. `parent_span is None` fills exactly that gap:

| Condition | Meaning | Status |
|-----------|---------|--------|
| `parent_id is None` | strict root (null pointer only) | already existed |
| `parent_span is None` | orphan-aware root (null pointer **or** orphan) | **new** |
| `parent_span is not None` | non-root (has a real parent span) | **new** |

Where "orphan-aware" is the default is worth being precise about, because it is not a single "UI default": the GraphQL `orphanSpanAsRootSpan` argument defaults to `true`, and the Traces / trace- detail views request it, but the main project **Spans** table defaults to strict (`treatOrphansAsRoots = false` in `projectStore.ts`). So `parent_span is None` implements the orphan-aware definition specifically — not "the UI default."

**Scope caveat.** `parent_span is None` checks for a parent span **globally**. `Trace.spans(... rootSpansOnly: true)` checks **within the trace**, so a span whose `parent_id` references a span in another trace is a root under the flag but not under `parent_span is None`. The equivalence with the flag is therefore asserted (and tested) only for `Project.spans`, not `Trace.spans`.

## Choice 2: model it as the `parent_span` relation, not an `is_root` boolean

> **Why `parent_span` and not `parent`?** The `parent_id` (id pointer) vs `parent_span` (resolved span) contrast makes the strict-vs-orphan distinction self-documenting, and `parent_span` is far less likely to collide with a real span attribute than `parent`.

**Non-goal:** `parent.<field>` traversal is **not** implemented in this PR — but the `parent_span` keyword is **fully reserved**, so every `parent.<field>` expression (`parent_span.span_kind`, `parent_span.attributes['x']`, …) raises a clear `SyntaxError` rather than silently resolving to the pre-existing `attributes['parent'][...]` attribute path. That closes the silent-footgun window: adding traversal in the follow-up is a clean error → feature change, not a change in behavior for anyone who happened to write `parent.<field>` in between.

Root-ness could have been an `is_root` keyword. An `is_root` boolean would not *prevent* adding traversal later — but it would leave root-ness and parent-column filtering as two unrelated syntaxes. Modeling `parent_span` as a **relation** (`parent_span is None` = "no parent span exists") is a consistency/extensibility choice: the same `parent_span` concept later carries traversal — `parent_span.span_kind == 'AGENT'`, `parent_span.attributes['llm.model_name'] == 'gpt-4'` — as a direct follow-up rather than a separate feature.

## Choice 3: compile to a correlated `NOT EXISTS`

`parent_span is None` compiles to a correlated `NOT EXISTS` over the spans table — true both when `parent_id` is null and when it points at an absent span. This is deliberately the shape the existing root query already uses (#6904): the "natural" `parent_id IS NULL OR NOT EXISTS(...)` form caused a **measured >10× PostgreSQL regression** on ~2.6M spans, so the `OR` is avoided.

## Choice 4: accept the breaking reinterpretation of `parent_span` (no migration)

Before this PR a bare `parent_span` resolved to the span attribute `attributes["parent_span"]`, so `parent_span is None` meant "the attribute named `parent_span` is null." After it, `parent_span` is reserved and that same expression means orphan-aware root — a genuine reinterpretation.

We accept it, for the same reason every reserved DSL name (`span_kind`, `name`, `status_code`, …) already shadows the matching `attributes[...]` key: no OpenInference/standard attribute is named `parent_span`. A span attribute literally named `parent_span` is still reachable as `attributes["parent_span"]`. Other uses of `parent_span` (bare, compared to a non-`None` value, or in a boolean op) raise a clear `SyntaxError`.

The one durable surface is the recent-filter suggestion history in `localStorage`, where a stored `parent_span is None` entry would be re-offered with the new meaning. **No history migration or cleanup is included in this PR** — this is an explicit decision, accepted as low severity because it is a typeahead suggestion the user must re-select.

## Frontend implications (why the `rootSpansOnly` flag stays)

In the interactive UI, root-ness is a **view mode**, not just a row filter, so the frontend cannot simply adopt `parent_span is None` and drop the `rootSpansOnly` flag. This PR — and the DSL work generally — therefore serves **headless** consumers (the API, the agent, persisted filters, online evaluations), while the interactive frontend keeps its boolean. The constraints, for reviewers:

- **`rootSpansOnly` drives presentation, not only the query.** In the Spans table it selects per-span versus *cumulative* token/cost columns, toggles Relay `@skip`/`@include` on those fields, swaps cell components, and sets the toggle's own state. That view-mode signal cannot be recovered by parsing an arbitrary filter string, so moving root-ness into filter text would lose it.
- **There is no single "UI default."** The Spans table defaults to strict (`treatOrphansAsRoots = false`), the Traces / trace-detail views hardcode orphan-aware, and the GraphQL argument defaults to `true`. Serializing the toggle into DSL text must choose `parent_span is None` vs `parent_id is None` per view and per setting.
- **String composition is unsafe as written.** `appendFilterCondition` is naive concatenation, so appending `and parent_span is None` to an existing `a or b` changes operator precedence. Toggling root scope in the string needs an AST-aware transform or a separate canonical root-scope value.
- **Spans and Traces share the free-text filter but not root scope** (`TracesTable` hardcodes `rootSpansOnly: true` independently of the Spans toggle), so root scope must stay a per-view value distinct from the shared condition.
- **Autocomplete** currently labels `parent_id is None` as "root spans" and should be updated to distinguish strict from orphan-aware and mention `parent_span is None`.

Consequence: the `rootSpansOnly` flag can be fully retired only after a separate frontend effort decouples query scope from view mode (or gives the agent's `set_spans_filter` tool a distinct view-mode field). That decoupling is a follow-up, not part of this PR.

## Testing

- Translation, orphan-aware row semantics, and rejected-usage cases in `tests/unit/trace/dsl/test_filter.py`, on **SQLite and PostgreSQL**.
- Resolver-level integration in `tests/unit/server/api/types/test_Project.py` asserting `Project.spans(filterCondition: "parent_span is None")` returns the same rows as `rootSpansOnly: true, orphanSpanAsRootSpan: true`.
- A guard that the internal eval sentinels are unreachable from user input.

