### PR TITLE
feat(js): add AI SDK 7 / ESM validation example apps

### DIFF
--- a/js/examples/apps/ai-sdk-quickstart/README.md
+++ b/js/examples/apps/ai-sdk-quickstart/README.md
@@ -1,0 +1,44 @@
+# AI SDK v7 Quickstart
+
+A minimal ESM app that validates the Phoenix TypeScript packages against the
+[Vercel AI SDK](https://ai-sdk.dev/) v7:
+
+- **Tracing** — `@arizeai/phoenix-otel` + `@ai-sdk/otel` via the AI SDK's
+  process-global `registerTelemetry` API
+- **Tool calling** — a multi-step `generateText` run with a weather tool
+- **Evals** — `@arizeai/phoenix-evals` (which runs on AI SDK v7 internally)
+  judging the response
+
+## Prerequisites
+
+- Node.js >= 22.12
+- A running Phoenix instance (defaults to `http://localhost:6006`)
+- `OPENAI_API_KEY` set in your environment
+
+```shell
+# From the js/ directory
+pnpm install
+
+# Start Phoenix if you don't have one running
+# see https://arize.com/docs/phoenix/self-hosting
+```
+
+## Run
+
+```shell
+export OPENAI_API_KEY=sk-...
+pnpm start
+```
+
+The script makes a tool-calling LLM request, evaluates the response with an
+LLM-as-a-judge classifier, and prints the result. Open
+[http://localhost:6006](http://localhost:6006) to see the traces for both the
+agent run and the evaluator in the `ai-sdk-quickstart` project.
+
+## Configuration
+
+| Environment variable         | Description                          | Default                 |
+| ---------------------------- | ------------------------------------ | ----------------------- |
+| `OPENAI_API_KEY`             | OpenAI API key (agent + judge)       | required                |
+| `PHOENIX_COLLECTOR_ENDPOINT` | Phoenix OTLP endpoint                | `http://localhost:6006` |
+| `PHOENIX_API_KEY`            | Phoenix API key (if auth is enabled) | none                    |

--- a/js/examples/apps/ai-sdk-quickstart/instrumentation.ts
+++ b/js/examples/apps/ai-sdk-quickstart/instrumentation.ts
@@ -1,0 +1,30 @@
+/**
+ * AI SDK v7 Quickstart - Instrumentation Setup
+ *
+ * Registers the Phoenix OpenTelemetry provider and wires it into the AI SDK's
+ * process-global telemetry registry. Import this file before making any AI SDK
+ * calls.
+ */
+
+import { OpenTelemetry } from "@ai-sdk/otel";
+import { register } from "@arizeai/phoenix-otel";
+import { registerTelemetry } from "ai";
+
+// Register with Phoenix - this handles all the OpenTelemetry boilerplate.
+// batch: false delivers spans immediately, which is ideal for short scripts.
+export const provider = register({
+  projectName: "ai-sdk-quickstart",
+  batch: false,
+});
+
+// AI SDK v7 telemetry registration is process-global. Request-header capture
+// is disabled because headers can contain authorization tokens and cookies.
+registerTelemetry(
+  new OpenTelemetry({
+    tracer: provider.getTracer("ai-sdk-quickstart"),
+    headers: false,
+  })
+);
+
+console.log("✅ Phoenix tracing enabled for the AI SDK");
+console.log("   Project: ai-sdk-quickstart");

--- a/js/examples/apps/ai-sdk-quickstart/instrumentation.ts
+++ b/js/examples/apps/ai-sdk-quickstart/instrumentation.ts
@@ -10,10 +10,12 @@ import { OpenTelemetry } from "@ai-sdk/otel";
 import { register } from "@arizeai/phoenix-otel";
 import { registerTelemetry } from "ai";
 
+export const projectName = "ai-sdk-quickstart";
+
 // Register with Phoenix - this handles all the OpenTelemetry boilerplate.
 // batch: false delivers spans immediately, which is ideal for short scripts.
 export const provider = register({
-  projectName: "ai-sdk-quickstart",
+  projectName,
   batch: false,
 });
 
@@ -21,10 +23,10 @@ export const provider = register({
 // is disabled because headers can contain authorization tokens and cookies.
 registerTelemetry(
   new OpenTelemetry({
-    tracer: provider.getTracer("ai-sdk-quickstart"),
+    tracer: provider.getTracer(projectName),
     headers: false,
   })
 );
 
 console.log("✅ Phoenix tracing enabled for the AI SDK");
-console.log("   Project: ai-sdk-quickstart");
+console.log(`   Project: ${projectName}`);

--- a/js/examples/apps/ai-sdk-quickstart/instrumentation.ts
+++ b/js/examples/apps/ai-sdk-quickstart/instrumentation.ts
@@ -17,10 +17,16 @@ export const projectName = "ai-sdk-quickstart";
 export const provider = register({
   projectName,
   batch: false,
+  // Authenticates trace export when Phoenix has auth enabled. register()
+  // reads PHOENIX_API_KEY on its own; it is passed explicitly here to make
+  // the wiring visible.
+  apiKey: process.env.PHOENIX_API_KEY,
 });
 
-// AI SDK v7 telemetry registration is process-global. Request-header capture
-// is disabled because headers can contain authorization tokens and cookies.
+// AI SDK v7 telemetry registration is process-global. headers: false only
+// stops the AI SDK from recording outgoing LLM request headers as span
+// attributes (they can contain authorization tokens and cookies) — it is
+// unrelated to the Phoenix API key above.
 registerTelemetry(
   new OpenTelemetry({
     tracer: provider.getTracer(projectName),

--- a/js/examples/apps/ai-sdk-quickstart/main.ts
+++ b/js/examples/apps/ai-sdk-quickstart/main.ts
@@ -53,7 +53,7 @@ Is the response helpful or unhelpful?
 async function main() {
   const prompt = "What's the weather like in Tokyo right now?";
 
-  console.log(`\n🤖 Asking: ${prompt}\n`);
+  console.log(`\n💬 Asking: ${prompt}\n`);
 
   const result = await generateText({
     model: openai("gpt-4o-mini"),
@@ -64,7 +64,7 @@ async function main() {
     stopWhen: stepCountIs(3),
   });
 
-  console.log(`💬 Response: ${result.text}\n`);
+  console.log(`🤖 Response: ${result.text}\n`);
 
   const evaluation = await helpfulnessEvaluator.evaluate({
     input: prompt,

--- a/js/examples/apps/ai-sdk-quickstart/main.ts
+++ b/js/examples/apps/ai-sdk-quickstart/main.ts
@@ -14,7 +14,7 @@ import { generateText, stepCountIs, tool } from "ai";
 import { z } from "zod";
 
 // Importing this module registers Phoenix tracing before any LLM calls run
-import { provider } from "./instrumentation.js";
+import { projectName, provider } from "./instrumentation.js";
 
 const weatherTool = tool({
   description: "Get the current weather for a city",
@@ -79,7 +79,16 @@ async function main() {
   }
 
   await provider.shutdown();
-  console.log("\n✅ Done - view the trace at http://localhost:6006");
+
+  // The redirect route resolves the project by name, so the link works
+  // without knowing the project id
+  const phoenixBaseUrl =
+    process.env.PHOENIX_COLLECTOR_ENDPOINT ?? "http://localhost:6006";
+  const projectUrl = new URL(
+    `redirects/projects/${encodeURIComponent(projectName)}`,
+    phoenixBaseUrl.endsWith("/") ? phoenixBaseUrl : `${phoenixBaseUrl}/`
+  );
+  console.log(`\n✅ Done - view the trace at ${projectUrl}`);
 }
 
 main().catch((error) => {

--- a/js/examples/apps/ai-sdk-quickstart/main.ts
+++ b/js/examples/apps/ai-sdk-quickstart/main.ts
@@ -1,0 +1,88 @@
+/**
+ * AI SDK v7 Quickstart
+ *
+ * A minimal agent built on the Vercel AI SDK v7 that validates the
+ * ESM-only Phoenix packages end to end:
+ *
+ * 1. Traces a tool-calling generateText run to Phoenix via @arizeai/phoenix-otel
+ * 2. Judges the response with @arizeai/phoenix-evals (which runs on AI SDK v7)
+ */
+
+import { openai } from "@ai-sdk/openai";
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+import { generateText, stepCountIs, tool } from "ai";
+import { z } from "zod";
+
+// Importing this module registers Phoenix tracing before any LLM calls run
+import { provider } from "./instrumentation.js";
+
+const weatherTool = tool({
+  description: "Get the current weather for a city",
+  inputSchema: z.object({
+    city: z.string().describe("The city to look up"),
+  }),
+  execute: async ({ city }) => {
+    // Canned data keeps the example deterministic and offline-friendly
+    return {
+      city,
+      temperatureCelsius: 22,
+      conditions: "partly cloudy",
+    };
+  },
+});
+
+const helpfulnessEvaluator = createClassificationEvaluator({
+  name: "helpfulness",
+  model: openai("gpt-4o-mini"),
+  choices: {
+    helpful: 1,
+    unhelpful: 0,
+  },
+  promptTemplate: `You are evaluating whether an assistant's response is helpful for the user's request.
+
+A response is HELPFUL if it directly answers the request with accurate, relevant information.
+A response is UNHELPFUL if it is off-topic, incomplete, or does not address the request.
+
+[Request]: {{input}}
+[Response]: {{output}}
+
+Is the response helpful or unhelpful?
+`,
+});
+
+async function main() {
+  const prompt = "What's the weather like in Tokyo right now?";
+
+  console.log(`\n🤖 Asking: ${prompt}\n`);
+
+  const result = await generateText({
+    model: openai("gpt-4o-mini"),
+    prompt,
+    tools: {
+      getWeather: weatherTool,
+    },
+    stopWhen: stepCountIs(3),
+  });
+
+  console.log(`💬 Response: ${result.text}\n`);
+
+  const evaluation = await helpfulnessEvaluator.evaluate({
+    input: prompt,
+    output: result.text,
+  });
+
+  console.log(
+    `📊 Helpfulness: ${evaluation.label} (score: ${evaluation.score})`
+  );
+  if (evaluation.explanation) {
+    console.log(`   ${evaluation.explanation}`);
+  }
+
+  await provider.shutdown();
+  console.log("\n✅ Done - view the trace at http://localhost:6006");
+}
+
+main().catch((error) => {
+  console.error("❌ Example failed:", error);
+  process.exit(1);
+});

--- a/js/examples/apps/ai-sdk-quickstart/package.json
+++ b/js/examples/apps/ai-sdk-quickstart/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ai-sdk-quickstart",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Validates Phoenix tracing and evals against the Vercel AI SDK v7 in an ESM app",
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^4.0.0",
+    "@ai-sdk/otel": "^1.0.0",
+    "@arizeai/phoenix-evals": "workspace:*",
+    "@arizeai/phoenix-otel": "workspace:*",
+    "ai": "^7.0.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2"
+  }
+}

--- a/js/examples/apps/ai-sdk-quickstart/tsconfig.json
+++ b/js/examples/apps/ai-sdk-quickstart/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/js/examples/apps/anthropic-quickstart/README.md
+++ b/js/examples/apps/anthropic-quickstart/README.md
@@ -1,0 +1,44 @@
+# Anthropic SDK Quickstart
+
+A minimal ESM app that validates the Phoenix TypeScript packages against the
+raw [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-typescript):
+
+- **Tracing** — `@arizeai/phoenix-otel` +
+  `@arizeai/openinference-instrumentation-anthropic` using manual ESM
+  instrumentation (`manuallyInstrument`)
+- **Evals** — `@arizeai/phoenix-evals` (which runs on AI SDK v7 internally)
+  judging the response with an Anthropic model
+
+## Prerequisites
+
+- Node.js >= 22.12
+- A running Phoenix instance (defaults to `http://localhost:6006`)
+- `ANTHROPIC_API_KEY` set in your environment
+
+```shell
+# From the js/ directory
+pnpm install
+
+# Start Phoenix if you don't have one running
+# see https://arize.com/docs/phoenix/self-hosting
+```
+
+## Run
+
+```shell
+export ANTHROPIC_API_KEY=sk-ant-...
+pnpm start
+```
+
+The script makes a messages request, evaluates the response with an
+LLM-as-a-judge classifier, and prints the result. Open
+[http://localhost:6006](http://localhost:6006) to see the traces in the
+`anthropic-quickstart` project.
+
+## Configuration
+
+| Environment variable         | Description                          | Default                 |
+| ---------------------------- | ------------------------------------ | ----------------------- |
+| `ANTHROPIC_API_KEY`          | Anthropic API key (app + judge)      | required                |
+| `PHOENIX_COLLECTOR_ENDPOINT` | Phoenix OTLP endpoint                | `http://localhost:6006` |
+| `PHOENIX_API_KEY`            | Phoenix API key (if auth is enabled) | none                    |

--- a/js/examples/apps/anthropic-quickstart/instrumentation.ts
+++ b/js/examples/apps/anthropic-quickstart/instrumentation.ts
@@ -1,0 +1,27 @@
+/**
+ * Anthropic SDK Quickstart - Instrumentation Setup
+ *
+ * Registers the Phoenix OpenTelemetry provider and manually instruments the
+ * Anthropic SDK. ESM apps cannot rely on require-hook auto-instrumentation,
+ * so the module is patched explicitly with manuallyInstrument.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { AnthropicInstrumentation } from "@arizeai/openinference-instrumentation-anthropic";
+import { register } from "@arizeai/phoenix-otel";
+
+const instrumentation = new AnthropicInstrumentation();
+
+// Register with Phoenix - this handles all the OpenTelemetry boilerplate.
+// batch: false delivers spans immediately, which is ideal for short scripts.
+export const provider = register({
+  projectName: "anthropic-quickstart",
+  batch: false,
+  instrumentations: [instrumentation],
+});
+
+// Manual instrumentation is required in ESM environments
+instrumentation.manuallyInstrument(Anthropic);
+
+console.log("✅ Phoenix tracing enabled for the Anthropic SDK");
+console.log("   Project: anthropic-quickstart");

--- a/js/examples/apps/anthropic-quickstart/main.ts
+++ b/js/examples/apps/anthropic-quickstart/main.ts
@@ -1,0 +1,75 @@
+/**
+ * Anthropic SDK Quickstart
+ *
+ * A minimal app built on the raw Anthropic SDK that validates the ESM-only
+ * Phoenix packages end to end:
+ *
+ * 1. Traces a messages.create call to Phoenix via manual ESM instrumentation
+ * 2. Judges the response with @arizeai/phoenix-evals (which runs on AI SDK v7)
+ */
+
+import { anthropic as anthropicJudge } from "@ai-sdk/anthropic";
+import Anthropic from "@anthropic-ai/sdk";
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+
+// Importing this module registers Phoenix tracing before any LLM calls run
+import { provider } from "./instrumentation.js";
+
+const client = new Anthropic();
+
+const correctnessEvaluator = createClassificationEvaluator({
+  name: "correctness",
+  model: anthropicJudge("claude-haiku-4-5"),
+  choices: {
+    correct: 1,
+    incorrect: 0,
+  },
+  promptTemplate: `You are evaluating whether an assistant's answer to a question is factually correct.
+
+An answer is CORRECT if the facts it states are accurate and it addresses the question.
+An answer is INCORRECT if it contains factual errors or fails to answer the question.
+
+[Question]: {{input}}
+[Answer]: {{output}}
+
+Is the answer correct or incorrect?
+`,
+});
+
+async function main() {
+  const question = "In one sentence, what does OpenTelemetry do?";
+
+  console.log(`\n🤖 Asking: ${question}\n`);
+
+  const message = await client.messages.create({
+    model: "claude-haiku-4-5",
+    max_tokens: 1024,
+    messages: [{ role: "user", content: question }],
+  });
+
+  const answer = message.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+  console.log(`💬 Response: ${answer}\n`);
+
+  const evaluation = await correctnessEvaluator.evaluate({
+    input: question,
+    output: answer,
+  });
+
+  console.log(
+    `📊 Correctness: ${evaluation.label} (score: ${evaluation.score})`
+  );
+  if (evaluation.explanation) {
+    console.log(`   ${evaluation.explanation}`);
+  }
+
+  await provider.shutdown();
+  console.log("\n✅ Done - view the trace at http://localhost:6006");
+}
+
+main().catch((error) => {
+  console.error("❌ Example failed:", error);
+  process.exit(1);
+});

--- a/js/examples/apps/anthropic-quickstart/package.json
+++ b/js/examples/apps/anthropic-quickstart/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "anthropic-quickstart",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Validates Phoenix tracing and evals against the raw Anthropic SDK in an ESM app",
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^4.0.0",
+    "@anthropic-ai/sdk": "^0.112.0",
+    "@arizeai/openinference-instrumentation-anthropic": "^0.1.15",
+    "@arizeai/phoenix-evals": "workspace:*",
+    "@arizeai/phoenix-otel": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2"
+  }
+}

--- a/js/examples/apps/anthropic-quickstart/tsconfig.json
+++ b/js/examples/apps/anthropic-quickstart/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/js/examples/apps/mastra-tracing/README.md
+++ b/js/examples/apps/mastra-tracing/README.md
@@ -1,0 +1,49 @@
+# Mastra Tracing Example
+
+A minimal ESM app that validates the Phoenix TypeScript packages against a
+[Mastra](https://mastra.ai/) agent:
+
+- **Tracing** — Mastra `Observability` + `@mastra/arize` exporting agent
+  traces to Phoenix
+- **AI SDK v7 providers** — the agent's model comes from `@ai-sdk/openai` v4
+  (the AI SDK v7 provider line)
+- **Evals** — `@arizeai/phoenix-evals` (which runs on AI SDK v7 internally)
+  judging the response
+
+Unlike the `mastra-agent` and `mastra-quickstart` examples, this app runs the
+agent in-process with a single script — no Mastra dev server required.
+
+## Prerequisites
+
+- Node.js >= 22.13
+- A running Phoenix instance (defaults to `http://localhost:6006`)
+- `OPENAI_API_KEY` set in your environment
+
+```shell
+# From the js/ directory
+pnpm install
+
+# Start Phoenix if you don't have one running
+# see https://arize.com/docs/phoenix/self-hosting
+```
+
+## Run
+
+```shell
+export OPENAI_API_KEY=sk-...
+pnpm start
+```
+
+The script runs a tool-calling weather agent, evaluates the response with an
+LLM-as-a-judge classifier, and prints the result. Open
+[http://localhost:6006](http://localhost:6006) to see the traces in the
+`mastra-tracing` project.
+
+## Configuration
+
+| Environment variable         | Description                          | Default                 |
+| ---------------------------- | ------------------------------------ | ----------------------- |
+| `OPENAI_API_KEY`             | OpenAI API key (agent + judge)       | required                |
+| `PHOENIX_COLLECTOR_ENDPOINT` | Phoenix OTLP endpoint                | `http://localhost:6006` |
+| `PHOENIX_API_KEY`            | Phoenix API key (if auth is enabled) | none                    |
+| `PHOENIX_PROJECT_NAME`       | Phoenix project for traces           | `mastra-tracing`        |

--- a/js/examples/apps/mastra-tracing/main.ts
+++ b/js/examples/apps/mastra-tracing/main.ts
@@ -1,0 +1,66 @@
+/**
+ * Mastra Tracing Example
+ *
+ * A minimal Mastra agent that validates the ESM-only Phoenix packages
+ * end to end:
+ *
+ * 1. Runs a tool-calling Mastra agent whose model is an AI SDK v7 provider
+ * 2. Exports the agent trace to Phoenix via @mastra/arize
+ * 3. Judges the response with @arizeai/phoenix-evals (which runs on AI SDK v7)
+ */
+
+import { openai } from "@ai-sdk/openai";
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+
+import { mastra } from "./mastra.js";
+
+const helpfulnessEvaluator = createClassificationEvaluator({
+  name: "helpfulness",
+  model: openai("gpt-4o-mini"),
+  choices: {
+    helpful: 1,
+    unhelpful: 0,
+  },
+  promptTemplate: `You are evaluating whether an assistant's response is helpful for the user's request.
+
+A response is HELPFUL if it directly answers the request with accurate, relevant information.
+A response is UNHELPFUL if it is off-topic, incomplete, or does not address the request.
+
+[Request]: {{input}}
+[Response]: {{output}}
+
+Is the response helpful or unhelpful?
+`,
+});
+
+async function main() {
+  const prompt = "What's the weather like in Tokyo right now?";
+
+  console.log(`\n🤖 Asking: ${prompt}\n`);
+
+  const agent = mastra.getAgent("weatherAgent");
+  const result = await agent.generate(prompt);
+
+  console.log(`💬 Response: ${result.text}\n`);
+
+  const evaluation = await helpfulnessEvaluator.evaluate({
+    input: prompt,
+    output: result.text,
+  });
+
+  console.log(
+    `📊 Helpfulness: ${evaluation.label} (score: ${evaluation.score})`
+  );
+  if (evaluation.explanation) {
+    console.log(`   ${evaluation.explanation}`);
+  }
+
+  // Flush pending trace exports before the process exits
+  await mastra.shutdown();
+  console.log("\n✅ Done - view the trace at http://localhost:6006");
+}
+
+main().catch((error) => {
+  console.error("❌ Example failed:", error);
+  process.exit(1);
+});

--- a/js/examples/apps/mastra-tracing/mastra.ts
+++ b/js/examples/apps/mastra-tracing/mastra.ts
@@ -1,0 +1,60 @@
+/**
+ * Mastra Tracing Example - Agent and Observability Setup
+ *
+ * Defines a small tool-calling Mastra agent whose model comes from an
+ * AI SDK v7 provider, with traces exported to Phoenix via @mastra/arize.
+ */
+
+import { openai } from "@ai-sdk/openai";
+import { ArizeExporter } from "@mastra/arize";
+import { Agent } from "@mastra/core/agent";
+import { Mastra } from "@mastra/core/mastra";
+import { createTool } from "@mastra/core/tools";
+import { Observability } from "@mastra/observability";
+import { z } from "zod";
+
+const PROJECT_NAME = process.env.PHOENIX_PROJECT_NAME || "mastra-tracing";
+
+const weatherTool = createTool({
+  id: "get-weather",
+  description: "Get the current weather for a city",
+  inputSchema: z.object({
+    city: z.string().describe("The city to look up"),
+  }),
+  execute: async ({ city }) => {
+    // Canned data keeps the example deterministic and offline-friendly
+    return {
+      city,
+      temperatureCelsius: 22,
+      conditions: "partly cloudy",
+    };
+  },
+});
+
+export const weatherAgent = new Agent({
+  id: "weather-agent",
+  name: "Weather Assistant",
+  instructions:
+    "You are a helpful weather assistant. Use the get-weather tool to look up current conditions before answering.",
+  model: openai("gpt-4o-mini"),
+  tools: { weatherTool },
+});
+
+export const mastra = new Mastra({
+  agents: { weatherAgent },
+  observability: new Observability({
+    configs: {
+      arize: {
+        serviceName: PROJECT_NAME,
+        exporters: [
+          new ArizeExporter({
+            endpoint:
+              process.env.PHOENIX_COLLECTOR_ENDPOINT || "http://localhost:6006",
+            apiKey: process.env.PHOENIX_API_KEY,
+            projectName: PROJECT_NAME,
+          }),
+        ],
+      },
+    },
+  }),
+});

--- a/js/examples/apps/mastra-tracing/package.json
+++ b/js/examples/apps/mastra-tracing/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "mastra-tracing",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Validates Phoenix tracing and evals against a Mastra agent using AI SDK v7 providers",
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^4.0.0",
+    "@arizeai/phoenix-evals": "workspace:*",
+    "@mastra/arize": "^1.3.4",
+    "@mastra/core": "^1.51.0",
+    "@mastra/observability": "^1.16.1",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/js/examples/apps/mastra-tracing/tsconfig.json
+++ b/js/examples/apps/mastra-tracing/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/js/examples/apps/openai-quickstart/README.md
+++ b/js/examples/apps/openai-quickstart/README.md
@@ -1,0 +1,44 @@
+# OpenAI SDK Quickstart
+
+A minimal ESM app that validates the Phoenix TypeScript packages against the
+raw [OpenAI Node SDK](https://github.com/openai/openai-node):
+
+- **Tracing** — `@arizeai/phoenix-otel` +
+  `@arizeai/openinference-instrumentation-openai` using manual ESM
+  instrumentation (`manuallyInstrument`)
+- **Evals** — `@arizeai/phoenix-evals` (which runs on AI SDK v7 internally)
+  judging the response
+
+## Prerequisites
+
+- Node.js >= 22.12
+- A running Phoenix instance (defaults to `http://localhost:6006`)
+- `OPENAI_API_KEY` set in your environment
+
+```shell
+# From the js/ directory
+pnpm install
+
+# Start Phoenix if you don't have one running
+# see https://arize.com/docs/phoenix/self-hosting
+```
+
+## Run
+
+```shell
+export OPENAI_API_KEY=sk-...
+pnpm start
+```
+
+The script makes a chat completion request, evaluates the response with an
+LLM-as-a-judge classifier, and prints the result. Open
+[http://localhost:6006](http://localhost:6006) to see the traces in the
+`openai-quickstart` project.
+
+## Configuration
+
+| Environment variable         | Description                          | Default                 |
+| ---------------------------- | ------------------------------------ | ----------------------- |
+| `OPENAI_API_KEY`             | OpenAI API key (app + judge)         | required                |
+| `PHOENIX_COLLECTOR_ENDPOINT` | Phoenix OTLP endpoint                | `http://localhost:6006` |
+| `PHOENIX_API_KEY`            | Phoenix API key (if auth is enabled) | none                    |

--- a/js/examples/apps/openai-quickstart/instrumentation.ts
+++ b/js/examples/apps/openai-quickstart/instrumentation.ts
@@ -1,0 +1,27 @@
+/**
+ * OpenAI SDK Quickstart - Instrumentation Setup
+ *
+ * Registers the Phoenix OpenTelemetry provider and manually instruments the
+ * OpenAI SDK. ESM apps cannot rely on require-hook auto-instrumentation, so
+ * the module is patched explicitly with manuallyInstrument.
+ */
+
+import { OpenAIInstrumentation } from "@arizeai/openinference-instrumentation-openai";
+import { register } from "@arizeai/phoenix-otel";
+import OpenAI from "openai";
+
+const instrumentation = new OpenAIInstrumentation();
+
+// Register with Phoenix - this handles all the OpenTelemetry boilerplate.
+// batch: false delivers spans immediately, which is ideal for short scripts.
+export const provider = register({
+  projectName: "openai-quickstart",
+  batch: false,
+  instrumentations: [instrumentation],
+});
+
+// Manual instrumentation is required in ESM environments
+instrumentation.manuallyInstrument(OpenAI);
+
+console.log("✅ Phoenix tracing enabled for the OpenAI SDK");
+console.log("   Project: openai-quickstart");

--- a/js/examples/apps/openai-quickstart/main.ts
+++ b/js/examples/apps/openai-quickstart/main.ts
@@ -1,0 +1,71 @@
+/**
+ * OpenAI SDK Quickstart
+ *
+ * A minimal app built on the raw OpenAI SDK that validates the ESM-only
+ * Phoenix packages end to end:
+ *
+ * 1. Traces a chat completion to Phoenix via manual ESM instrumentation
+ * 2. Judges the response with @arizeai/phoenix-evals (which runs on AI SDK v7)
+ */
+
+import { openai as openaiJudge } from "@ai-sdk/openai";
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+import OpenAI from "openai";
+
+// Importing this module registers Phoenix tracing before any LLM calls run
+import { provider } from "./instrumentation.js";
+
+const client = new OpenAI();
+
+const correctnessEvaluator = createClassificationEvaluator({
+  name: "correctness",
+  model: openaiJudge("gpt-4o-mini"),
+  choices: {
+    correct: 1,
+    incorrect: 0,
+  },
+  promptTemplate: `You are evaluating whether an assistant's answer to a question is factually correct.
+
+An answer is CORRECT if the facts it states are accurate and it addresses the question.
+An answer is INCORRECT if it contains factual errors or fails to answer the question.
+
+[Question]: {{input}}
+[Answer]: {{output}}
+
+Is the answer correct or incorrect?
+`,
+});
+
+async function main() {
+  const question = "In one sentence, what does OpenTelemetry do?";
+
+  console.log(`\n🤖 Asking: ${question}\n`);
+
+  const completion = await client.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: question }],
+  });
+
+  const answer = completion.choices[0]?.message?.content ?? "";
+  console.log(`💬 Response: ${answer}\n`);
+
+  const evaluation = await correctnessEvaluator.evaluate({
+    input: question,
+    output: answer,
+  });
+
+  console.log(
+    `📊 Correctness: ${evaluation.label} (score: ${evaluation.score})`
+  );
+  if (evaluation.explanation) {
+    console.log(`   ${evaluation.explanation}`);
+  }
+
+  await provider.shutdown();
+  console.log("\n✅ Done - view the trace at http://localhost:6006");
+}
+
+main().catch((error) => {
+  console.error("❌ Example failed:", error);
+  process.exit(1);
+});

--- a/js/examples/apps/openai-quickstart/package.json
+++ b/js/examples/apps/openai-quickstart/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "openai-quickstart",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Validates Phoenix tracing and evals against the raw OpenAI SDK in an ESM app",
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^4.0.0",
+    "@arizeai/openinference-instrumentation-openai": "^4.1.5",
+    "@arizeai/phoenix-evals": "workspace:*",
+    "@arizeai/phoenix-otel": "workspace:*",
+    "openai": "^6.48.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2"
+  }
+}

--- a/js/examples/apps/openai-quickstart/tsconfig.json
+++ b/js/examples/apps/openai-quickstart/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -102,6 +102,65 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  examples/apps/ai-sdk-quickstart:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^4.0.0
+        version: 4.0.16(zod@4.4.3)
+      '@ai-sdk/otel':
+        specifier: ^1.0.0
+        version: 1.0.31(zod@4.4.3)
+      '@arizeai/phoenix-evals':
+        specifier: workspace:*
+        version: link:../../../packages/phoenix-evals
+      '@arizeai/phoenix-otel':
+        specifier: workspace:*
+        version: link:../../../packages/phoenix-otel
+      ai:
+        specifier: ^7.0.0
+        version: 7.0.31(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
+  examples/apps/anthropic-quickstart:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^4.0.0
+        version: 4.0.16(zod@4.4.3)
+      '@anthropic-ai/sdk':
+        specifier: ^0.112.0
+        version: 0.112.3(zod@4.4.3)
+      '@arizeai/openinference-instrumentation-anthropic':
+        specifier: ^0.1.15
+        version: 0.1.15
+      '@arizeai/phoenix-evals':
+        specifier: workspace:*
+        version: link:../../../packages/phoenix-evals
+      '@arizeai/phoenix-otel':
+        specifier: workspace:*
+        version: link:../../../packages/phoenix-otel
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   examples/apps/cli-agent-starter-kit:
     dependencies:
       '@ai-sdk/anthropic':
@@ -152,7 +211,7 @@ importers:
         version: 3.0.86(zod@4.4.3)
       '@arizeai/openinference-instrumentation-openai':
         specifier: ^4.1.5
-        version: 4.1.5(supports-color@10.2.2)
+        version: 4.1.5
       '@arizeai/phoenix-client':
         specifier: workspace:*
         version: link:../../../packages/phoenix-client
@@ -373,11 +432,70 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  examples/apps/mastra-tracing:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^4.0.0
+        version: 4.0.16(zod@4.4.3)
+      '@arizeai/phoenix-evals':
+        specifier: workspace:*
+        version: link:../../../packages/phoenix-evals
+      '@mastra/arize':
+        specifier: ^1.3.4
+        version: 1.3.4(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(@opentelemetry/api@1.9.1)(zod@4.4.3)
+      '@mastra/core':
+        specifier: ^1.51.0
+        version: 1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+      '@mastra/observability':
+        specifier: ^1.16.1
+        version: 1.16.1(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
+  examples/apps/openai-quickstart:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^4.0.0
+        version: 4.0.16(zod@4.4.3)
+      '@arizeai/openinference-instrumentation-openai':
+        specifier: ^4.1.5
+        version: 4.1.5
+      '@arizeai/phoenix-evals':
+        specifier: workspace:*
+        version: link:../../../packages/phoenix-evals
+      '@arizeai/phoenix-otel':
+        specifier: workspace:*
+        version: link:../../../packages/phoenix-otel
+      openai:
+        specifier: ^6.48.0
+        version: 6.48.0(ws@8.21.1)(zod@4.4.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   examples/apps/phoenix-experiment-runner:
     dependencies:
       '@arizeai/openinference-instrumentation-openai':
         specifier: ^4.1.5
-        version: 4.1.5(supports-color@10.2.2)
+        version: 4.1.5
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.5.0
         version: 2.5.0
@@ -637,7 +755,7 @@ importers:
         version: 4.0.16(zod@4.4.3)
       '@arizeai/openinference-instrumentation-openai':
         specifier: ^4.1.5
-        version: 4.1.5(supports-color@10.2.2)
+        version: 4.1.5
       '@opentelemetry/sdk-trace-node':
         specifier: ^2.9.0
         version: 2.9.0(@opentelemetry/api@1.9.1)
@@ -800,6 +918,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/anthropic@4.0.16':
+    resolution: {integrity: sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.153':
     resolution: {integrity: sha512-R5r567od2Olqze/lL2dVS4wVOVyVqG6sJ3cEUI/kW12XQJYKf8fetyxWPYS0ZFe87QPcsh3Z3sDnrMAtAIiS3Q==}
     engines: {node: '>=18'}
@@ -921,6 +1045,15 @@ packages:
       zod:
         optional: true
 
+  '@anthropic-ai/sdk@0.112.3':
+    resolution: {integrity: sha512-wjcozJlitVIuBEw9cj/xBuRznwkhcLmXmNzlFoeHbh4AvrDG3HGZrdvEOTTmobcbhjGkfOpKbmDTCQ4s9LQvCg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@arizeai/openinference-core@2.4.0':
     resolution: {integrity: sha512-F4FgdLj9dCp/f2C0GZ6w3qpd4rsNC8/Rr4ikOvQcIBsn0hjn1jyWA2/9x3TF4Xf8H53ckoGoQv4uhexgwbtCNw==}
 
@@ -935,6 +1068,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0'
       '@opentelemetry/semantic-conventions': '>=1.41.1'
+
+  '@arizeai/openinference-instrumentation-anthropic@0.1.15':
+    resolution: {integrity: sha512-YdTjEevjp3wtajdPWWUwmbRvcx3nrPYwZDDcXwPoZAtpnUeNR3uzjhYOESZGvpX69VVejtclVVrKI76gphqcrQ==}
 
   '@arizeai/openinference-instrumentation-langchain@4.0.14':
     resolution: {integrity: sha512-SvgIqIJu0bBOGYx8btqnqH97/sBEDlTNLRjD79GDPNyh2HVO9oPfngA9pyhL00zDOfT7nwb3XWclO7DD1VpdUw==}
@@ -5288,7 +5424,6 @@ packages:
 
   openai@6.48.0:
     resolution: {integrity: sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==}
-    hasBin: true
     peerDependencies:
       '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
       '@smithy/hash-node': '>=4.3.0 <5'
@@ -6624,6 +6759,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/anthropic@4.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.153(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
@@ -6761,6 +6902,13 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  '@anthropic-ai/sdk@0.112.3(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
+
   '@arizeai/openinference-core@2.4.0':
     dependencies:
       '@arizeai/openinference-semantic-conventions': 2.5.0
@@ -6779,6 +6927,16 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
 
+  '@arizeai/openinference-instrumentation-anthropic@0.1.15':
+    dependencies:
+      '@arizeai/openinference-core': 2.4.0
+      '@arizeai/openinference-semantic-conventions': 2.5.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@arizeai/openinference-instrumentation-langchain@4.0.14(@langchain/core@1.2.2(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.48.0(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))':
     dependencies:
       '@arizeai/openinference-core': 2.4.0
@@ -6786,17 +6944,17 @@ snapshots:
       '@langchain/core': 1.2.2(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(openai@6.48.0(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@arizeai/openinference-instrumentation-openai@4.1.5(supports-color@10.2.2)':
+  '@arizeai/openinference-instrumentation-openai@4.1.5':
     dependencies:
       '@arizeai/openinference-core': 2.4.0
       '@arizeai/openinference-semantic-conventions': 2.5.0
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8203,12 +8361,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.46.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
+  '@opentelemetry/instrumentation@0.46.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.7.1
-      require-in-the-middle: 7.5.2(supports-color@10.2.2)
+      require-in-the-middle: 7.5.2
       semver: 7.8.5
       shimmer: 1.2.1
     transitivePeerDependencies:
@@ -12027,7 +12185,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@7.5.2(supports-color@10.2.2):
+  require-in-the-middle@7.5.2:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       module-details-from-path: 1.0.4


### PR DESCRIPTION
Four minimal example apps under js/examples/apps that validate the AI SDK v7
and ESM upgrade of the Phoenix TypeScript packages end to end:

- ai-sdk-quickstart: raw Vercel AI SDK v7 with process-global registerTelemetry
- openai-quickstart: raw OpenAI SDK with manual ESM instrumentation
- anthropic-quickstart: raw Anthropic SDK with manual ESM instrumentation
- mastra-tracing: in-process Mastra agent on AI SDK v7 providers

Each app traces to Phoenix via phoenix-otel (or @mastra/arize) and judges the
response with phoenix-evals, and has a typecheck script so CI validates module
resolution against the upgraded packages.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>