### PR TITLE
refactor(online-eval): align span evaluation context vocabulary

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2893,7 +2893,7 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  Evaluation grain. SPAN is currently executable; TRACE and SESSION are stored but remain inactive until their runtimes are available.
+  SPAN is currently executable; TRACE and SESSION are stored but remain inactive until their runtimes are available.
   """
   evaluationTarget: EvaluationTarget!
   inputMapping: EvaluatorInputMapping!

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -69,18 +69,17 @@ class HydratedWorkUnit:
 
 
 def span_eval_context(span: models.Span) -> dict[str, Any]:
-    """Span-level evaluation context. ``input`` / ``output`` surface the span's
-    IO values for direct template-variable binding; ``attributes`` exposes the
-    full attribute tree to ``path_mapping`` expressions."""
+    """Span context; ``metadata.attributes`` roots attribute ``path_mapping`` expressions."""
     return {
         "input": span.input_value,
         "output": span.output_value,
-        "metadata": span.metadata_,
-        "attributes": span.attributes,
-        "name": span.name,
-        "span_kind": span.span_kind,
-        "status_code": span.status_code,
-        "status_message": span.status_message,
+        "metadata": {
+            "attributes": span.attributes,
+            "name": span.name,
+            "span_kind": span.span_kind,
+            "status_code": span.status_code,
+            "status_message": span.status_message,
+        },
     }
 
 

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -52,6 +52,7 @@ from phoenix.server.online_eval.executor import (
     EvalExecutionError,
     HydratedWorkUnit,
     OnlineEvalExecutor,
+    span_eval_context,
 )
 from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.sandbox.types import ExecutionResult
@@ -425,6 +426,36 @@ async def _annotations(db: DbSessionFactory) -> list[models.SpanAnnotation]:
         return list(await session.scalars(select(models.SpanAnnotation)))
 
 
+async def test_span_eval_context_nests_span_fields_under_metadata(
+    db: DbSessionFactory,
+) -> None:
+    attributes = {
+        "input": {"value": "span input"},
+        "output": {"value": "span output"},
+        "metadata": {"user": "value"},
+        "custom": {"nested": "value"},
+    }
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace, attributes=attributes)
+
+        context = span_eval_context(span)
+
+    assert set(context) == {"input", "output", "metadata"}
+    assert context == {
+        "input": "span input",
+        "output": "span output",
+        "metadata": {
+            "attributes": attributes,
+            "name": span.name,
+            "span_kind": "LLM",
+            "status_code": "OK",
+            "status_message": "test_status_message",
+        },
+    }
+
+
 async def test_happy_path_claims_evaluates_annotates_and_completes(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -481,7 +512,7 @@ async def test_llm_criteria_input_mapping_override_is_used_during_execution(
         project.id,
         template_content="Question: {{question}}\nAnswer: {{answer}}",
         criteria_input_mapping=InputMapping(
-            path_mapping={"question": "attributes.remapped.question"},
+            path_mapping={"question": "metadata.attributes.remapped.question"},
             literal_mapping={"answer": "literal answer"},
         ),
     )
@@ -522,7 +553,7 @@ async def test_builtin_criteria_input_mapping_override_is_used_during_execution(
             sampling_rate=1.0,
             evaluation_target="SPAN",
             input_mapping=InputMapping(
-                path_mapping={"text": "attributes.remapped.text"},
+                path_mapping={"text": "metadata.attributes.remapped.text"},
                 literal_mapping={"words": "mapped value"},
             ),
         )
@@ -555,7 +586,7 @@ async def test_code_criteria_input_mapping_override_is_used_during_execution(
         db,
         project.id,
         criteria_input_mapping=InputMapping(
-            path_mapping={"output": "attributes.remapped.value"},
+            path_mapping={"output": "metadata.attributes.remapped.value"},
             literal_mapping={"metadata": "criteria literal"},
         ),
     )

--- a/tests/unit/server/online_eval/test_derivation.py
+++ b/tests/unit/server/online_eval/test_derivation.py
@@ -164,7 +164,7 @@ class TestConfigFingerprint:
                     ],
                 }
             ],
-            input_mapping={"input": "attributes.llm.input_messages"},
+            input_mapping={"input": "metadata.attributes.llm.input_messages"},
             evaluation_target="SPAN",
             sandbox_config_id=None,
             filter_condition="span_kind == 'LLM'",
@@ -172,7 +172,7 @@ class TestConfigFingerprint:
         )
         assert (
             config_fingerprint(resolved)
-            == "e6ca2ff2b09c452f4f1c9c6e846223e71a3955796ec86ce636c19d5215527f94"
+            == "a947137da632fef78f34554fcd4280c6a1207f96746f8667c9b578ea17ed3871"
         )
 
 


### PR DESCRIPTION
## Summary

Narrows the span evaluation context to the same binding vocabulary the session context uses: `input`, `output`, and `metadata`. Evaluator template variables and mapped inputs bind automatically only to top-level context keys, so every top-level name is implicit API surface; this change keeps that surface to the established three names for both grains.

## Changes

- `span_eval_context` now returns `input`, `output`, and a `metadata` object containing `attributes`, `name`, `span_kind`, `status_code`, and `status_message`. The previous top-level copies of those five fields are removed.
- `metadata.attributes` is the root for attribute path mappings (previously top-level `attributes`). Span metadata recorded by instrumentation remains reachable at `metadata.attributes.metadata`.
- Test input mappings and the config-fingerprint test vector are re-rooted accordingly. - Carries a one-line regeneration of `app/schema.graphql`: a stale generated description on `ProjectEvaluator.evaluationTarget` is synced with its Python source so the schema check passes against the current feature-branch tip.
No builtin evaluator relied on automatic binding to a removed key, so no evaluator contracts change.

## Notes for reviewers

- This branch has never shipped, so no user-defined mappings exist against the old shape; dev databases carrying feature-branch mappings should be recreated per the branch's migration policy.
- Zero-configuration binding behavior for `input` and `output` is unchanged on both grains.

## Testing

- Online-eval unit suites on SQLite and PostgreSQL, including an exact-shape assertion on the span context and re-rooted mapping tests exercised end to end.


