### PR TITLE
fix(agents): omit trace metadata for PXI turns when tracing is off

### DIFF
--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1476,10 +1476,15 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             if isinstance(result.output, str):
                 turn_is_terminal = True
                 turn_final_output_text = result.output.strip() or None
+            # Only advertise a trace when the tracer is actually recording
             span_context = (
-                agent_span_recorder.span_context
-                if agent_span_recorder and agent_span_recorder.span_context is not None
-                else request_parent_span_context
+                (
+                    agent_span_recorder.span_context
+                    if agent_span_recorder and agent_span_recorder.span_context is not None
+                    else request_parent_span_context
+                )
+                if tracer is not None
+                else None
             )
             yield _build_message_metadata_chunk(
                 span_context=span_context,

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -7,7 +7,14 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from jinja2 import Template
+from opentelemetry.trace import (
+    SpanContext,
+    TraceFlags,
+    format_span_id,
+    format_trace_id,
+)
 from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, ToolOutputAvailableChunk
+from pydantic_ai.usage import RunUsage
 from sqlalchemy import func, select
 
 from phoenix.db import models
@@ -18,6 +25,8 @@ from phoenix.server.agents.types import (
     SandboxAvailability,
 )
 from phoenix.server.api.routers.agents import (
+    TurnTraceContext,
+    _build_message_metadata_chunk,
     _interleave_agent_and_subagent_message_chunks,
     _load_phoenix_user_email,
     _load_sandbox_availability,
@@ -129,6 +138,57 @@ class TestPersistDbTracesAndEmitEvent:
             assert project_session is not None
             assert project_session.start_time == start_time
             assert project_session.end_time == start_time + timedelta(seconds=3)
+
+
+class TestBuildMessageMetadataChunk:
+    @staticmethod
+    def _span_context() -> SpanContext:
+        return SpanContext(
+            trace_id=0x0123456789ABCDEF0123456789ABCDEF,
+            span_id=0x0123456789ABCDEF,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+
+    def test_omits_trace_when_no_span_or_turn_context(self) -> None:
+        # When tracing is off, `_on_complete` passes no span context and no turn
+        # trace context. The chunk must then advertise no trace so the UI does
+        # not render feedback/trace actions pointing at a nonexistent trace.
+        chunk = _build_message_metadata_chunk(
+            span_context=None,
+            turn_trace_context=None,
+            session_id="session-1",
+            usage=RunUsage(),
+        )
+        assert chunk.message_metadata.trace is None
+
+    def test_uses_turn_trace_context_when_present(self) -> None:
+        turn_trace_context = TurnTraceContext(
+            trace_id="0123456789abcdef0123456789abcdef",
+            root_span_id="0123456789abcdef",
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        chunk = _build_message_metadata_chunk(
+            span_context=self._span_context(),
+            turn_trace_context=turn_trace_context,
+            session_id="session-1",
+            usage=RunUsage(),
+        )
+        assert chunk.message_metadata.trace is not None
+        assert chunk.message_metadata.trace.trace_id == turn_trace_context.trace_id
+        assert chunk.message_metadata.trace.root_span_id == turn_trace_context.root_span_id
+
+    def test_falls_back_to_span_context_when_no_turn_context(self) -> None:
+        span_context = self._span_context()
+        chunk = _build_message_metadata_chunk(
+            span_context=span_context,
+            turn_trace_context=None,
+            session_id="session-1",
+            usage=RunUsage(),
+        )
+        assert chunk.message_metadata.trace is not None
+        assert chunk.message_metadata.trace.trace_id == format_trace_id(span_context.trace_id)
+        assert chunk.message_metadata.trace.root_span_id == format_span_id(span_context.span_id)
 
 
 class TestLoadSandboxAvailability:


### PR DESCRIPTION
## Problem

When chatting with PXI while tracing is turned off (the default settings), the thumbs-up / thumbs-down and "Trace" buttons rendered below PXI's response but didn't work — there was no trace to annotate or open.

## Root cause

The frontend gates those actions on `metadata?.trace != null` (`app/src/components/agent/AssistantMessageActions.tsx`), treating a non-null `trace` as "a persisted trace exists." But the server was populating `metadata.trace` even when nothing was recorded.

In the `/chat` handler (`src/phoenix/server/api/routers/agents.py`), every turn mints a trace/span identity up front (`_resolve_turn_trace_ids` → `request_parent_span_context`) so multi-turn conversations can share a trace when tracing is on. With tracing off, `tracer` and `agent_span_recorder` are `None`, but `_on_complete` still fell back to `request_parent_span_context` as the message's `span_context`. `_build_message_metadata_chunk` then stamped `metadata.trace` with that freshly-minted id — a trace that was never written to the DB.

That fallback is only ever *consumed* when tracing is off (when tracing is on, `turn_trace_context` takes precedence and `span_context` is ignored), so its only observable effect was advertising a phantom trace.

## Fix

Gate the `span_context` fallback on the tracer actually recording. When tracing is off, the turn now reports `trace: null`, so the frontend correctly hides the feedback/trace actions. Behavior is unchanged when tracing is on. This also matches the sibling `/run` endpoint, which already passes `span_context=None` when the tracer is off.

## Tests

Added `TestBuildMessageMetadataChunk` covering the metadata builder contract:
- no span context + no turn context → `trace is None` (tracing-off case)
- turn context present → uses turn context ids
- span context only → falls back to span context ids

All tests in `tests/unit/server/api/routers/test_agents.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)