### PR TITLE
feat(components): make IDBadge the consolidated click-to-copy ID element

### DIFF
--- a/app/src/components/core/id/IDBadge.tsx
+++ b/app/src/components/core/id/IDBadge.tsx
@@ -1,7 +1,34 @@
+import { css } from "@emotion/react";
+import copy from "copy-to-clipboard";
+import { useState } from "react";
+import { Button as AriaButton } from "react-aria-components";
+
 import { Badge } from "@phoenix/components/core/badge";
 import { Text } from "@phoenix/components/core/content";
 import { Icon } from "@phoenix/components/core/icon";
+import { Tooltip, TooltipTrigger } from "@phoenix/components/core/tooltip";
 import type { ComponentSize } from "@phoenix/components/core/types";
+
+const SHOW_COPIED_TIMEOUT_MS = 2000;
+
+const idBadgeCSS = css`
+  all: unset;
+  display: inline-flex;
+  cursor: pointer;
+  &:focus-visible {
+    outline: 1px solid var(--global-input-field-border-color-active);
+    outline-offset: 1px;
+    border-radius: var(--global-badge-border-radius);
+  }
+  &[data-hovered] .id-badge__copy-icon {
+    color: var(--global-text-color-900);
+  }
+  .id-badge__copy-icon {
+    font-size: 12px;
+    color: var(--global-text-color-500);
+    transition: color 0.2s;
+  }
+`;
 
 interface IDBadgeProps {
   /**
@@ -13,15 +40,51 @@ interface IDBadgeProps {
    * @default 'S'
    */
   size?: ComponentSize;
+  /**
+   * The text to display in the copy tooltip.
+   * @default "Copy ID"
+   */
+  tooltipText?: string;
 }
 
-export const IDBadge = ({ id, size = "S" }: IDBadgeProps) => {
+/**
+ * A badge that displays an entity's ID and copies it to the clipboard when
+ * pressed — the single, consolidated click-to-copy ID element. No separate
+ * copy button is needed alongside it.
+ */
+export const IDBadge = ({
+  id,
+  size = "S",
+  tooltipText = "Copy ID",
+}: IDBadgeProps) => {
+  const [isCopied, setIsCopied] = useState(false);
+
   return (
-    <Badge size={size}>
-      <Icon svgKey="ID" />
-      <Text fontFamily="mono" size="S" color="text-700">
-        {id}
-      </Text>
-    </Badge>
+    <TooltipTrigger>
+      <AriaButton
+        css={idBadgeCSS}
+        aria-label={`${tooltipText} ${id}`}
+        onPress={() => {
+          copy(id);
+          setIsCopied(true);
+          setTimeout(() => {
+            setIsCopied(false);
+          }, SHOW_COPIED_TIMEOUT_MS);
+        }}
+      >
+        <Badge size={size}>
+          <Icon svgKey="ID" />
+          <Text fontFamily="mono" size="S" color="text-700">
+            {id}
+          </Text>
+          <Icon
+            className="id-badge__copy-icon"
+            color={isCopied ? "success" : "inherit"}
+            svgKey={isCopied ? "Checkmark" : "Duplicate"}
+          />
+        </Badge>
+      </AriaButton>
+      <Tooltip offset={1}>{isCopied ? "Copied" : tooltipText}</Tooltip>
+    </TooltipTrigger>
   );
 };

--- a/app/src/components/core/id/TitleWithID.tsx
+++ b/app/src/components/core/id/TitleWithID.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
 import { Heading } from "@phoenix/components/core/content";
-import { CopyToClipboardButton } from "@phoenix/components/core/copy";
 import { Flex } from "@phoenix/components/core/layout";
 
 import { IDBadge } from "./IDBadge";
@@ -22,7 +21,6 @@ export const TitleWithID = ({ title, id }: TitleWithIDProps) => {
     <Flex direction="row" gap="size-100" alignItems="center">
       <Heading>{title}</Heading>
       <IDBadge size="S" id={id} />
-      <CopyToClipboardButton variant="quiet" size="S" text={id} />
     </Flex>
   );
 };

--- a/app/src/pages/experiment/TraceDetailsDialog.tsx
+++ b/app/src/pages/experiment/TraceDetailsDialog.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 
 import {
-  CopyToClipboardButton,
   Dialog,
   DialogCloseButton,
   Flex,
@@ -32,12 +31,7 @@ export function TraceDetailsDialog({
         <DialogHeader>
           <Flex direction="row" gap="size-100" alignItems="center" minWidth={0}>
             <DialogTitle>{title}</DialogTitle>
-            <IDBadge id={traceId} />
-            <CopyToClipboardButton
-              size="S"
-              text={traceId}
-              tooltipText="Copy Trace ID"
-            />
+            <IDBadge id={traceId} tooltipText="Copy Trace ID" />
           </Flex>
           <DialogTitleExtra>
             <LinkButton

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -34,7 +34,6 @@ import {
 } from "@phoenix/components";
 import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/AnnotationSummaryGroup";
 import { TraceAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/TraceAnnotationSummaryGroup";
-import { CopyToClipboardButton } from "@phoenix/components/core/copy";
 import { DynamicContent } from "@phoenix/components/DynamicContent";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { EditSpanAnnotationsDialog } from "@phoenix/components/trace/EditSpanAnnotationsDialog";
@@ -332,14 +331,7 @@ function SessionTurnDivider({
       >
         Trace
       </LinkButton>
-      <IDBadge id={traceId} />
-      <CopyToClipboardButton
-        text={traceId}
-        size="S"
-        variant="quiet"
-        tooltipText="Copy trace ID"
-        aria-label="Copy trace ID"
-      />
+      <IDBadge id={traceId} tooltipText="Copy Trace ID" />
     </Flex>
   );
 }

--- a/app/stories/IDBadge.stories.tsx
+++ b/app/stories/IDBadge.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { IDBadge } from "@phoenix/components";
+
+/**
+ * A badge that displays an entity's ID and copies it to the clipboard when
+ * pressed — the single, consolidated click-to-copy ID element. Clicking the
+ * badge copies the ID and briefly shows a checkmark; no separate copy button
+ * is needed alongside it.
+ */
+const meta = {
+  title: "Core/IDBadge",
+  component: IDBadge,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof IDBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    id: "c5b943dba87507a2",
+  },
+};
+
+/**
+ * The tooltip can name the entity being copied.
+ */
+export const CustomTooltip: Story = {
+  args: {
+    id: "c5b943dba87507a2",
+    tooltipText: "Copy Span ID",
+  },
+};


### PR DESCRIPTION
IDBadge now always copies its ID to the clipboard when pressed, with an inline copy icon, tooltip, and checkmark feedback — one consolidated UI element wherever an ID is displayed.

The separate `CopyToClipboardButton` that sat next to every IDBadge usage is removed:
- `TitleWithID` (used by trace, session, prompt version, experiment, and example detail pages)
- session details trace list
- experiment trace details dialog

Includes Storybook stories (default + custom tooltip).