### PR TITLE
chore: release arize-phoenix 19.4.0

### DIFF
--- a/src/phoenix/datetime_utils.py
+++ b/src/phoenix/datetime_utils.py
@@ -23,8 +23,8 @@ def normalize_datetime(
     tz: Optional[tzinfo] = None,
 ) -> Optional[datetime]:
     """
-    If the input datetime is timezone-naive, it is localized as local timezone
-    unless tzinfo is specified.
+    If the input datetime is timezone-naive, it is localized to the local
+    timezone unless tzinfo is specified.
     """
     if not isinstance(dt, datetime):
         return None


### PR DESCRIPTION
Undoes the major bump proposed in #14572. The breaking-change marker on #14563 (`feat(js)!`) applies to the JS packages only and should not major-bump the `arize-phoenix` Python server. Forces release-please to propose 19.4.0 instead of 20.0.0.

Release-As: 19.4.0