### PR TITLE
increase Phoenix pod resources to handle load tests and production traffic

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 # Replica count
 # -- Number of Phoenix pod replicas
-replicaCount: 1
+replicaCount: 3
 
 # Deployment strategy
 deployment:
@@ -171,7 +171,7 @@ server:
   # -- Maximum number of spans to hold in the processing queue before rejecting new requests (PHOENIX_MAX_SPANS_QUEUE_SIZE)
   # This is a heuristic to prevent memory issues when spans accumulate faster than they can be written to the database.
   # Memory usage: ~50KiB per span means 20,000 spans = ~1GiB. Adjust based on available memory and database throughput.
-  maxSpansQueueSize: 20000
+  maxSpansQueueSize: 50000
 
   # -- Comma-separated list of model provider names to display in the playground UI (PHOENIX_ALLOWED_PROVIDERS)
   # When unset, all providers are shown. Set to "NONE" to hide all providers.
@@ -708,11 +708,10 @@ image:
 # -- Resource configuration
 resources:
   limits:
-    cpu: "1000m"
-    memory: "2Gi"
+    memory: "8Gi"
   requests:
-    cpu: "500m"
-    memory: "1Gi"
+    cpu: "4000m"
+    memory: "8Gi"
 
 # -- Security context configuration
 securityContext:


### PR DESCRIPTION
## Summary

Phoenix pods were crashing under load test traffic due to OOM kills and kubelet eviction. This PR increases pod resources so Phoenix can absorb production + load test burst traffic without restarts.

Three changes in `helm/values.yaml`:

1. **`replicaCount`: 1 → 3** — single-replica means one OOM restart = full Phoenix outage for the team. 3 replicas provides availability during pod churn.
2. **Memory: `requests == limits = 8Gi` (Guaranteed QoS)** — previously `requests=1Gi / limits=2Gi` put Phoenix in Burstable QoS class, making it the kubelet's first eviction target under node memory pressure. Setting `requests == limits` gives Guaranteed QoS — the last class to be evicted.
3. **CPU: remove limit, set `request=4000m`** — CPU limits cause throttling (not kills), but throttling on the span ingestion gRPC path creates timeout cascades. Removing the limit lets Phoenix burst freely; the request guarantees baseline scheduling.
4. **`maxSpansQueueSize`: 20000 → 50000** — doubles the in-memory buffer to absorb larger bursts. At ~50KiB/span, the full queue is ~2.5Gi, well within the 8Gi limit.

## Before / After

| | Before | After |
|---|---|---|
| `replicaCount` | `1` | `3` |
| CPU request | `500m` | `4000m` |
| CPU limit | `1000m` | *(removed)* |
| Memory request | `1Gi` | `8Gi` |
| Memory limit | `2Gi` | `8Gi` |
| QoS class | Burstable | **Guaranteed** |
| `maxSpansQueueSize` | `20000` | `50000` |

## Test Plan

- [ ] Deploy to stag and run a load test — confirm no pod restarts (`kubectl get pods -w`)
- [ ] Verify Guaranteed QoS: `kubectl get pod <phoenix-pod> -o jsonpath='{.status.qosClass}'` → `Guaranteed`
- [ ] Confirm Phoenix UI and trace ingestion remain responsive under load

---
*Generated by Claude Code using the `/create-pr` skill*