### PR TITLE
docs(js): use the minimal phoenix-otel path in the ai-sdk-agent example and Vercel AI SDK docs

### DIFF
--- a/docs/phoenix/integrations/typescript/vercel/vercel-ai-sdk-tracing-js.mdx
+++ b/docs/phoenix/integrations/typescript/vercel/vercel-ai-sdk-tracing-js.mdx
@@ -1,102 +1,80 @@
 ---
 title: "Vercel AI SDK Tracing (JS)"
+description: "Trace Vercel AI SDK calls with @arizeai/phoenix-otel and send spans to Phoenix for LLM and agent observability."
+keywords: ['vercel', 'ai-sdk', 'opentelemetry', 'openinference', 'typescript', 'tracing', 'observability', 'phoenix']
 ---
 
-## OpenInference Vercel
+Phoenix traces [Vercel AI SDK](https://github.com/vercel/ai) (>= 7) applications through the AI SDK's OpenTelemetry integration (`@ai-sdk/otel`). The simplest setup is [`@arizeai/phoenix-otel`](https://www.npmjs.com/package/@arizeai/phoenix-otel), which handles the OpenTelemetry provider, OpenInference span processing, and export to Phoenix in a single `register()` call.
 
-[<img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/ee7dc05f-badge.svg" />](https://badge.fury.io/js/@arizeai%2Fopeninference-vercel)
+## Version compatibility
 
-This package provides a set of utilities to ingest [Vercel AI SDK](https://github.com/vercel/ai) (>= 7) spans into platforms like [Arize AX](https://arize.com/) and [Phoenix](https://phoenix.arize.com/).
+| Vercel AI SDK | @arizeai/phoenix-otel | @arizeai/openinference-vercel |
+| ------------- | --------------------- | ----------------------------- |
+| v7+           | 2.x                   | 3.x                           |
+| v6 and older  | 1.x                   | 2.x                           |
 
-> Note: `@arizeai/openinference-vercel` v3 targets AI SDK v7 telemetry, which requires Node.js 22 or newer. For AI SDK v6 and older, use `@arizeai/openinference-vercel` v2.
+AI SDK v7 telemetry requires Node.js 22 or newer.
 
-### Installation
-
-```bash
-npm i --save @arizeai/openinference-vercel
-```
-
-You will also need to install the AI SDK telemetry package and OpenTelemetry packages into your project.
+## Installation
 
 ```bash
-npm i --save @ai-sdk/otel @arizeai/openinference-semantic-conventions @opentelemetry/api @opentelemetry/exporter-trace-otlp-proto @opentelemetry/resources @opentelemetry/sdk-trace-node @opentelemetry/semantic-conventions
+npm i --save ai @ai-sdk/otel @arizeai/phoenix-otel
 ```
 
-### Usage
+<Warning>
+Ensure your installed version of `@opentelemetry/api` matches the version installed by `@ai-sdk/otel` otherwise the AI SDK will not emit traces to the TracerProvider that you configure. If you install `ai` before the other packages, then dependency resolution in your package manager should install the correct version.
+</Warning>
 
-`@arizeai/openinference-vercel` provides a set of utilities to help you ingest Vercel AI SDK spans into OpenTelemetry compatible platforms and works in conjunction with the AI SDK's OpenTelemetry integration (`@ai-sdk/otel`). `@arizeai/openinference-vercel` works with typical node projects, as well as Next.js projects. This page will describe usage within a node project, for detailed usage instructions in Next.js follow Vercel's [guide on instrumenting Next.js](https://nextjs.org/docs/app/guides/open-telemetry#manual-opentelemetry-configuration).
+## Setup
 
-Since AI SDK v7, telemetry is emitted once you register a telemetry integration with `registerTelemetry(new OpenTelemetry(...))`. To process the resulting spans, setup a typical OpenTelemetry instrumentation boilerplate file and add a `OpenInferenceSimpleSpanProcessor` or `OpenInferenceBatchSpanProcessor` to your OpenTelemetry configuration.
+Since AI SDK v7, telemetry is emitted once you register a telemetry integration with `registerTelemetry(new OpenTelemetry(...))`. Pair that with `register()` from `@arizeai/phoenix-otel`, which processes the resulting spans and exports them to Phoenix:
 
-> Note: The `OpenInferenceSpanProcessor` alone does not handle the exporting of spans so you will need to pass it an [exporter](https://opentelemetry.io/docs/languages/js/exporters/) as a parameter.
-
-Here are two example instrumentation configurations:
-
-1. Manual instrumentation config for a Node application.
-
-2. Next.js register function utilizing `@vercel/otel` .
-
-<Tabs>
-<Tab title="Manual Instrumentation">
-
-```javascript expandable
+```typescript
 // instrumentation.ts
-// Node environment instrumentation
-// Boilerplate imports
-import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
-import { resourceFromAttributes } from "@opentelemetry/resources";
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
-// AI SDK telemetry imports
-import { registerTelemetry } from "ai";
 import { OpenTelemetry } from "@ai-sdk/otel";
-// OpenInference Vercel imports
-import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
-import { OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-vercel";
+import { register } from "@arizeai/phoenix-otel";
+import { registerTelemetry } from "ai";
 
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
-
-// e.g. http://localhost:6006
-// e.g. https://app.phoenix.arize.com/s/<your-space>
-const COLLECTOR_ENDPOINT = process.env.PHOENIX_COLLECTOR_ENDPOINT;
-// The project name that may appear in your collector's interface
-const SERVICE_NAME = "phoenix-vercel-ai-sdk-app";
-
-export const provider = new NodeTracerProvider({
-  resource: resourceFromAttributes({
-    [ATTR_SERVICE_NAME]: SERVICE_NAME,
-    [SEMRESATTRS_PROJECT_NAME]: SERVICE_NAME,
-  }),
-  spanProcessors: [
-    // In production-like environments it is recommended to use
-    // OpenInferenceBatchSpanProcessor instead
-    new OpenInferenceSimpleSpanProcessor({
-      exporter: new OTLPTraceExporter({
-        url: `${COLLECTOR_ENDPOINT}/v1/traces`,
-        // (optional) if connecting to a collector with Authentication enabled
-        headers: { Authorization: `Bearer ${process.env.PHOENIX_API_KEY}` },
-      }),
-    }),
-  ],
+// Handles all the OpenTelemetry setup and exports spans to Phoenix.
+// Reads PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY from the environment.
+export const provider = register({
+  projectName: "my-ai-sdk-app",
 });
 
-provider.register();
-
-// Register the AI SDK telemetry integration. Header capture is disabled
-// because request headers can contain credentials.
+// Point the AI SDK's telemetry at OpenTelemetry. headers: false keeps
+// outgoing LLM request headers (which can contain credentials) off of spans.
 registerTelemetry(new OpenTelemetry({ headers: false }));
-
-console.log("Provider registered");
-
-// Run this file before the rest of program execution
-// e.g node --import ./instrumentation.ts index.ts
-// or at the top of your application's entrypoint
-// e.g. import "instrumentation.ts";
 ```
 
-</Tab>
-<Tab title="@vercel/otel">
+Import this file before the rest of your program executes, e.g. `node --import ./instrumentation.ts index.ts`, or `import "./instrumentation.js"` at the top of your application's entrypoint.
+
+Once the telemetry integration is registered, AI SDK calls are traced by default; no per-call configuration is required. Use the `telemetry` option for per-call metadata such as `functionId`, or to opt out with `isEnabled: false`.
+
+```typescript
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  prompt: "Write a short story about a cat.",
+  // Optional per-call metadata:
+  telemetry: { functionId: "story-agent" },
+});
+```
+
+This applies to agents as well: a `ToolLoopAgent` run is traced end to end, with the agent, each LLM step, and every tool call captured as spans in a single trace. See the [AI SDK agent example](https://github.com/Arize-ai/phoenix/tree/main/js/examples/apps/ai-sdk-agent) for a complete runnable project.
+
+<Note>
+`register()` uses a batch span processor by default, so spans still queued when a short-lived script exits may not be exported. Call `await provider.shutdown()` before exit to flush them, or pass `batch: false` to `register()` for immediate export.
+</Note>
+
+## Next.js
+
+In a Next.js project, register the telemetry integration and `@vercel/otel` from the `register()` function in `instrumentation.ts`, using the OpenInference span processor from [`@arizeai/openinference-vercel`](https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-vercel), the same processor `@arizeai/phoenix-otel` uses under the hood:
+
+```bash
+npm i --save @arizeai/openinference-vercel @arizeai/openinference-semantic-conventions @vercel/otel @opentelemetry/api @opentelemetry/exporter-trace-otlp-proto
+```
 
 ```javascript expandable
 // instrumentation.ts
@@ -109,9 +87,6 @@ import {
   OpenInferenceSimpleSpanProcessor,
 } from "@arizeai/openinference-vercel";
 import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
-import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
-
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
 
 // e.g. http://localhost:6006
 // e.g. https://app.phoenix.arize.com/s/<your-space>
@@ -137,62 +112,29 @@ export function register() {
       new OpenInferenceSimpleSpanProcessor({
         exporter: new OTLPHttpProtoTraceExporter({
           url: `${COLLECTOR_ENDPOINT}/v1/traces`,
+          // (optional) if connecting to a collector with Authentication enabled
+          headers: { Authorization: `Bearer ${process.env.PHOENIX_API_KEY}` },
         }),
         spanFilter: isOpenInferenceSpan,
       }),
     ],
   });
-  console.log("Provider registered");
 }
 ```
 
-See Vercel's [instrumentation guide](https://nextjs.org/docs/app/guides/open-telemetry#using-vercelotel) for more details on configuring your instrumentation file and `@vercel/otel` within a Next.js project
-
-</Tab>
-</Tabs>
+See Vercel's [instrumentation guide](https://nextjs.org/docs/app/guides/open-telemetry#using-vercelotel) for more details on configuring your instrumentation file and `@vercel/otel` within a Next.js project.
 
 <Info>
 When instrumenting a Next.js application, traced spans will not be "root spans" when the OpenInference span filter is configured. This is because Next.js parents spans underneath http requests, which do not meet the requirements to be an OpenInference span.
-
 </Info>
-
-Once a telemetry integration is registered, AI SDK calls are traced by default — no per-call configuration is required. Use the `telemetry` option for per-call metadata such as `functionId`, or to opt out with `isEnabled: false`.
-
-```typescript
-import { generateText } from "ai";
-import { openai } from "@ai-sdk/openai";
-
-const result = await generateText({
-  model: openai("gpt-4o"),
-  prompt: "Write a short story about a cat.",
-  // Optional per-call metadata:
-  telemetry: { functionId: "story-agent" },
-});
-```
-
-<Warning>
-Ensure your installed version of `@opentelemetry/api` matches the version installed by `@ai-sdk/otel` otherwise the ai sdk will not emit traces to the TracerProvider that you configure. If you install `ai` before other the packages, then dependency resolution in your package manager should install the correct version.
-
-</Warning>
-
-For details on Vercel AI SDK telemetry see the [Vercel AI SDK Telemetry documentation](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
 
 <Frame>
   <iframe src="https://cdn.iframe.ly/ry2U623" width={1000} height={400} allowFullScreen scrolling="no" allow="accelerometer *; clipboard-write *; encrypted-media *; gyroscope *; picture-in-picture *; web-share *;"></iframe>
 </Frame>
 
-<Note>
-Spans may not be exported if still queued in the processor when your process exits. Use `OpenInferenceSimpleSpanProcessor` for immediate export, or call `provider.shutdown()` to explicitly flush spans before exit when using `OpenInferenceBatchSpanProcessor`.
+## Examples
 
-For simpler setup, consider using [`@arizeai/phoenix-otel`](/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel) which handles this automatically.
-</Note>
+- [AI SDK Agent](https://github.com/Arize-ai/phoenix/tree/main/js/examples/apps/ai-sdk-agent): an AI SDK v7 `ToolLoopAgent` traced with `@arizeai/phoenix-otel`
+- [Next.js OpenAI Telemetry Example](https://github.com/Arize-ai/openinference/tree/main/js/examples/next-openai-telemetry-app) in the [OpenInference repo](https://github.com/Arize-ai/openinference/tree/main/js)
 
-### Examples
-
-For a minimal runnable agent traced with `@arizeai/phoenix-otel`, see the [ai-sdk-agent example](https://github.com/Arize-ai/phoenix/tree/main/js/examples/apps/ai-sdk-agent) in the Phoenix repo.
-
-To see a Next.js example go to the [Next.js OpenAI Telemetry Example](https://github.com/Arize-ai/openinference/tree/main/js/examples/next-openai-telemetry-app) in the [OpenInference repo](https://github.com/Arize-ai/openinference/tree/main/js).
-
-For more information on Vercel OpenTelemetry support see the [Vercel AI SDK Telemetry documentation](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
-
-
+For details on Vercel AI SDK telemetry see the [Vercel AI SDK Telemetry documentation](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).

--- a/js/examples/apps/ai-sdk-agent/instrumentation.ts
+++ b/js/examples/apps/ai-sdk-agent/instrumentation.ts
@@ -1,7 +1,6 @@
 /**
- * Registers the Phoenix OpenTelemetry provider and wires it into the AI SDK's
- * process-global telemetry registry. Import this file before making any AI SDK
- * calls; every call after that is traced.
+ * Registers Phoenix tracing for the Vercel AI SDK. Import this file before
+ * making any AI SDK calls; every call after that is traced.
  */
 
 import { OpenTelemetry } from "@ai-sdk/otel";
@@ -10,20 +9,12 @@ import { registerTelemetry } from "ai";
 
 export const projectName = "ai-sdk-agent";
 
-// Register with Phoenix - this handles all the OpenTelemetry boilerplate and
-// attaches the provider as the process-global tracer provider. register()
-// reads PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY from the environment.
-// batch: false delivers spans immediately, which is ideal for short scripts.
+// Handles all the OpenTelemetry setup and exports spans to Phoenix.
+// Reads PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY from the environment.
 export const provider = register({
   projectName,
-  batch: false,
 });
 
-// AI SDK v7 telemetry registration is process-global; the AI SDK picks up the
-// global tracer provider registered above. headers: false stops the AI SDK
-// from recording outgoing LLM request headers as span attributes (they can
-// contain authorization tokens and cookies).
+// Point the AI SDK's telemetry at OpenTelemetry. headers: false keeps
+// outgoing LLM request headers (which can contain credentials) off of spans.
 registerTelemetry(new OpenTelemetry({ headers: false }));
-
-console.log("✅ Phoenix tracing enabled for the AI SDK");
-console.log(`   Project: ${projectName}`);


### PR DESCRIPTION
Update Vercel AI SDK docs examples to use the latest 7 version.