### PR TITLE
feat(evaluators): bind existing code evaluators to projects

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -70,6 +70,21 @@ input AddExamplesToDatasetInput {
   datasetVersionMetadata: JSON
 }
 
+input AddProjectCodeEvaluatorInput {
+  projectId: ID!
+  evaluatorId: ID!
+  name: Identifier!
+  samplingRate: Float!
+  evaluationTarget: EvaluationTarget!
+
+  """
+  Project-specific CODE input mapping. Null inherits the evaluator input mapping; an object overrides it.
+  """
+  inputMapping: EvaluatorInputMappingInput = null
+  filterCondition: String! = ""
+  enabled: Boolean! = true
+}
+
 input AddSpansToDatasetInput {
   datasetId: ID!
   spanIds: [ID!]!
@@ -2467,12 +2482,17 @@ type Mutation {
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  """
+  addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
+
+  """
   Create a CODE project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
   deleteProjectEvaluators(input: DeleteProjectEvaluatorsInput!): DeleteProjectEvaluatorsPayload!

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -435,6 +435,24 @@ class UpdateProjectLLMEvaluatorInput:
 
 
 @strawberry.input
+class AddProjectCodeEvaluatorInput:
+    project_id: GlobalID
+    evaluator_id: GlobalID
+    name: Identifier
+    sampling_rate: float
+    evaluation_target: EvaluationTarget
+    input_mapping: Optional[EvaluatorInputMappingInput] = strawberry.field(
+        default=None,
+        description=(
+            "Project-specific CODE input mapping. Null inherits the evaluator input mapping; "
+            "an object overrides it."
+        ),
+    )
+    filter_condition: str = ""
+    enabled: bool = True
+
+
+@strawberry.input
 class CreateProjectCodeEvaluatorInput:
     project_id: GlobalID
     name: Identifier
@@ -781,6 +799,62 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
+            "Bind an existing CODE evaluator to a project. The evaluator's configuration is "
+            "shared with every project and dataset it is bound to. SPAN is executable; TRACE "
+            "and SESSION are stored but inactive until their runtimes are available."
+        ),
+    )  # type: ignore
+    async def add_project_code_evaluator(
+        self, info: Info[Context, None], input: AddProjectCodeEvaluatorInput
+    ) -> ProjectEvaluatorMutationPayload:
+        try:
+            project_id = from_global_id_with_expected_type(input.project_id, Project.__name__)
+        except ValueError:
+            raise BadRequest(f"Invalid project id: {input.project_id}")
+        try:
+            evaluator_id, evaluator_kind = _parse_evaluator_id(input.evaluator_id)
+        except ValueError as error:
+            raise BadRequest(f"Invalid evaluator id: {input.evaluator_id}. {error}")
+        if evaluator_kind != "CODE":
+            raise BadRequest("Evaluator must be a CODE evaluator")
+        try:
+            name = IdentifierModel.model_validate(input.name)
+        except ValidationError as error:
+            raise BadRequest(str(error))
+        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_sampling_rate(input.sampling_rate)
+
+        try:
+            async with info.context.db() as session:
+                if await session.get(models.Project, project_id) is None:
+                    raise NotFound(f"Project not found: {input.project_id}")
+                if await session.get(models.CodeEvaluator, evaluator_id) is None:
+                    raise BadRequest("CODE evaluator not found")
+                criteria = models.ProjectEvaluatorCriteria(
+                    project_id=project_id,
+                    evaluator_id=evaluator_id,
+                    name=name,
+                    filter_condition=input.filter_condition,
+                    sampling_rate=input.sampling_rate,
+                    evaluation_target=input.evaluation_target.value,
+                    input_mapping=(
+                        input.input_mapping.to_orm() if input.input_mapping is not None else None
+                    ),
+                    enabled=input.enabled,
+                )
+                session.add(criteria)
+                await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise Conflict("A project evaluator with this name already exists for this project")
+
+        return ProjectEvaluatorMutationPayload(
+            evaluator=ProjectEvaluator(id=criteria.id, db_record=criteria),
+            query=Query(),
+        )
+
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
+        description=(
             "Create a CODE project evaluator. SPAN is executable; TRACE and SESSION "
             "are stored but inactive until their runtimes are available."
         ),
@@ -866,8 +940,9 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
-            "Update a CODE project evaluator. SPAN is executable; TRACE and SESSION "
-            "are stored but inactive until their runtimes are available."
+            "Update a CODE project evaluator. Editing changes the underlying evaluator, which "
+            "applies to every project and dataset it is bound to. SPAN is executable; TRACE and "
+            "SESSION are stored but inactive until their runtimes are available."
         ),
     )  # type: ignore
     async def update_project_code_evaluator(

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -17,6 +17,7 @@ evaluationTarget
 enabled
 inputMapping { literalMapping pathMapping }
 evaluator {
+  id
   kind
   name
   ... on CodeEvaluator { currentVersion { sourceCode } }
@@ -27,6 +28,14 @@ evaluator {
 _CREATE_CODE = f"""
 mutation($input: CreateProjectCodeEvaluatorInput!) {{
   createProjectCodeEvaluator(input: $input) {{
+    evaluator {{ {_PROJECT_EVALUATOR_FIELDS} }}
+  }}
+}}
+"""
+
+_ADD_CODE = f"""
+mutation($input: AddProjectCodeEvaluatorInput!) {{
+  addProjectCodeEvaluator(input: $input) {{
     evaluator {{ {_PROJECT_EVALUATOR_FIELDS} }}
   }}
 }}
@@ -110,6 +119,24 @@ def _code_create_input(
         "inputMapping": None,
         "filterCondition": filter_condition,
         "enabled": True,
+    }
+
+
+def _code_add_input(
+    project: models.Project,
+    evaluator_id: str,
+    *,
+    name: str = "attached-code",
+) -> dict[str, Any]:
+    return {
+        "projectId": str(GlobalID("Project", str(project.id))),
+        "evaluatorId": evaluator_id,
+        "name": name,
+        "samplingRate": 0.25,
+        "evaluationTarget": "SESSION",
+        "inputMapping": _mapping(context="override"),
+        "filterCondition": "span_kind == 'LLM'",
+        "enabled": False,
     }
 
 
@@ -282,6 +309,149 @@ async def test_project_code_evaluator_crud_and_connection(
     assert delete_result.data["deleteProjectEvaluators"]["projectEvaluatorIds"] == [created["id"]]
     async with db() as session:
         assert await session.get(models.Project, project.id) is not None
+
+
+async def test_add_project_code_evaluator_binds_existing_core(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    source_project = await _add_project(db)
+    create_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(source_project, sandbox_config)},
+    )
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
+    core_id = created["evaluator"]["id"]
+
+    async with db() as session:
+        evaluator_count_before = await session.scalar(
+            select(func.count()).select_from(models.Evaluator)
+        )
+        version_count_before = await session.scalar(
+            select(func.count()).select_from(models.CodeEvaluatorVersion)
+        )
+
+    add_result = await gql_client.execute(
+        _ADD_CODE,
+        {"input": _code_add_input(source_project, core_id)},
+    )
+    assert add_result.data and not add_result.errors
+    attached = add_result.data["addProjectCodeEvaluator"]["evaluator"]
+    assert attached["evaluator"]["id"] == core_id
+    assert attached["name"] == "attached-code"
+    assert attached["samplingRate"] == 0.25
+    assert attached["evaluationTarget"] == "SESSION"
+    assert attached["inputMapping"] == _mapping(context="override")
+    assert attached["filterCondition"] == "span_kind == 'LLM'"
+    assert attached["enabled"] is False
+
+    project_result = await gql_client.execute(
+        _PROJECT_EVALUATORS,
+        {"id": str(GlobalID("Project", str(source_project.id)))},
+    )
+    assert project_result.data and not project_result.errors
+    nodes = [edge["node"] for edge in project_result.data["node"]["evaluators"]["edges"]]
+    assert {node["id"] for node in nodes} == {created["id"], attached["id"]}
+
+    async with db() as session:
+        criteria_id = int(GlobalID.from_id(attached["id"]).node_id)
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.evaluator_id == int(GlobalID.from_id(core_id).node_id)
+        assert await session.scalar(select(func.count()).select_from(models.Evaluator)) == (
+            evaluator_count_before
+        )
+        assert (
+            await session.scalar(select(func.count()).select_from(models.CodeEvaluatorVersion))
+            == version_count_before
+        )
+
+
+async def test_add_project_code_evaluator_rejects_non_code_evaluator(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    source_project = await _add_project(db)
+    target_project = await _add_project(db)
+    create_result = await gql_client.execute(
+        _CREATE_LLM,
+        {"input": _llm_input(source_project, name="shared-llm", text="Evaluate {{input}}")},
+    )
+    assert create_result.data and not create_result.errors
+    evaluator_id = create_result.data["createProjectLlmEvaluator"]["evaluator"]["evaluator"]["id"]
+    criteria_count_before = await _project_evaluator_criteria_count(db)
+
+    result = await gql_client.execute(
+        _ADD_CODE,
+        {"input": _code_add_input(target_project, evaluator_id)},
+    )
+
+    assert result.errors
+    assert result.errors[0].message == "Evaluator must be a CODE evaluator"
+    assert await _project_evaluator_criteria_count(db) == criteria_count_before
+
+
+async def test_add_project_code_evaluator_rejects_missing_evaluator(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    project = await _add_project(db)
+    criteria_count_before = await _project_evaluator_criteria_count(db)
+
+    result = await gql_client.execute(
+        _ADD_CODE,
+        {
+            "input": _code_add_input(
+                project,
+                str(GlobalID("CodeEvaluator", "999999999")),
+            )
+        },
+    )
+
+    assert result.errors
+    assert result.errors[0].message == "CODE evaluator not found"
+    assert await _project_evaluator_criteria_count(db) == criteria_count_before
+
+
+async def test_delete_project_binding_preserves_core_attached_to_another_project(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    source_project = await _add_project(db)
+    target_project = await _add_project(db)
+    create_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(source_project, sandbox_config)},
+    )
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
+    core_id = created["evaluator"]["id"]
+
+    add_result = await gql_client.execute(
+        _ADD_CODE,
+        {"input": _code_add_input(target_project, core_id)},
+    )
+    assert add_result.data and not add_result.errors
+    attached = add_result.data["addProjectCodeEvaluator"]["evaluator"]
+
+    delete_result = await gql_client.execute(
+        _DELETE,
+        {"input": {"projectEvaluatorIds": [created["id"]]}},
+    )
+    assert delete_result.data and not delete_result.errors
+
+    async with db() as session:
+        core_rowid = int(GlobalID.from_id(core_id).node_id)
+        created_criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+        attached_criteria_id = int(GlobalID.from_id(attached["id"]).node_id)
+        assert await session.get(models.ProjectEvaluatorCriteria, created_criteria_id) is None
+        attached_criteria = await session.get(models.ProjectEvaluatorCriteria, attached_criteria_id)
+        assert attached_criteria is not None
+        assert attached_criteria.evaluator_id == core_rowid
+        assert await session.get(models.CodeEvaluator, core_rowid) is not None
 
 
 async def test_project_llm_evaluator_create_update_delete(
@@ -559,3 +729,11 @@ async def _row_counts(db: DbSessionFactory) -> dict[str, int]:
             or 0
             for model_type in model_types
         }
+
+
+async def _project_evaluator_criteria_count(db: DbSessionFactory) -> int:
+    async with db() as session:
+        return (
+            await session.scalar(select(func.count()).select_from(models.ProjectEvaluatorCriteria))
+            or 0
+        )


### PR DESCRIPTION
## Summary

Lets a project bind an **existing** CODE evaluator instead of always creating a new one. Evaluators already live in one shared registry with per-binding policy rows — dataset bindings could attach an existing CODE evaluator, but project bindings could only mint a fresh copy. This closes that gap, so an evaluator can be built and validated against a dataset and then deployed online to one or more projects as the same shared resource.

## Changes

- New mutation `addProjectCodeEvaluator`: binds an existing CODE evaluator to a project by creating only a `project_evaluator_criteria` row — binding references (`projectId`, `evaluatorId`) plus the criteria-owned policy fields (`name`, `filterCondition`, `samplingRate`, `evaluationTarget`, `inputMapping` override, `enabled`). No evaluator or evaluator version is created.
- **Shared semantics are stated, not implied:** the new mutation's description says the evaluator configuration is shared with every binding, and `updateProjectCodeEvaluator`'s description now notes that edits change the underlying evaluator wherever it is bound (projects and datasets). Evaluator edits already version immutably and roll into online work prospectively via config fingerprints.
- The same evaluator may be bound to one project multiple times under distinct binding names/policies (e.g., different filters), matching the dataset-binding precedent.
- Validation reuses the existing create-path helpers (filter, sampling rate) and returns caller-actionable errors for missing or non-CODE evaluator ids.
- Existing cross-binding garbage collection already covers the new path: deleting one binding preserves the evaluator while any other project or dataset binding references it (now pinned by a test).
- Regenerating the GraphQL schema also synced one stale generated description on `ProjectEvaluator.evaluationTarget` with its Python source.

## Out of scope

- LLM evaluators (prompt-level sharing already exists through the prompt system) and BUILTIN project bindings.
- Frontend evaluator picker for this flow (tracked separately).

## Testing

- Mutation tests on SQLite and PostgreSQL: attach happy path (no new evaluator/version rows, visible via `Project.evaluators`), repeat-binding, kind mismatch, missing evaluator, and shared-core GC preservation.
- Online-eval suites on both dialects; GraphQL permission check and schema/codegen regeneration clean.

Supersedes #14560, which GitHub closed permanently when its base branch was deleted mid-stack.
