### PR TITLE
feat(dsl): analyze root-span scope, stop applying it twice

### DIFF
--- a/.agents/skills/phoenix-evals/references/common-mistakes-python.md
+++ b/.agents/skills/phoenix-evals/references/common-mistakes-python.md
@@ -106,13 +106,15 @@ nothing. Use `limit=` to control result size instead.
 ## Not Filtering Spans Appropriately
 
 ```python
+from phoenix.client.types.spans import SpanQuery
+
 # WRONG — fetches all spans including internal LLM calls, retrievers, etc.
 df = client.spans.get_spans_dataframe(project_identifier="my-project")
 
 # RIGHT for end-to-end evaluation — filter to top-level spans
 df = client.spans.get_spans_dataframe(
     project_identifier="my-project",
-    root_spans_only=True,
+    query=SpanQuery().where("parent_id is None"),
 )
 
 # RIGHT for RAG evaluation — fetch child spans for retriever/LLM metrics
@@ -123,7 +125,10 @@ retriever_spans = all_spans[all_spans["span_kind"] == "RETRIEVER"]
 llm_spans = all_spans[all_spans["span_kind"] == "LLM"]
 ```
 
-**Why**: For end-to-end evaluation (e.g., overall answer quality), use `root_spans_only=True`.
+**Why**: For end-to-end evaluation (e.g., overall answer quality), scope the query to root
+spans with `SpanQuery().where("parent_id is None")` — the `root_spans_only=True` argument is
+deprecated. Use `parent_span is None` instead if you also want orphans (spans whose parent is
+absent) counted as roots.
 For RAG systems, you often need child spans separately — retriever spans for
 DocumentRelevance and LLM spans for Faithfulness. Choose the right span level
 for your evaluation target.

--- a/.agents/skills/phoenix-evals/references/observe-tracing-setup.md
+++ b/.agents/skills/phoenix-evals/references/observe-tracing-setup.md
@@ -41,13 +41,14 @@ span.set_attribute("metadata.query_category", "billing")
 
 ```python
 from phoenix.client import Client
+from phoenix.client.types.spans import SpanQuery
 
 # Client() works for local Phoenix (falls back to env vars or localhost:6006)
 # For remote/cloud: Client(base_url="https://app.phoenix.arize.com", api_key="...")
 client = Client()
 spans_df = client.spans.get_spans_dataframe(
     project_identifier="my-app",  # NOT project_name= (deprecated)
-    root_spans_only=True,
+    query=SpanQuery().where("parent_id is None"),  # top-level spans only
 )
 
 dataset = client.datasets.create_dataset(

--- a/.agents/skills/phoenix-evals/references/production-continuous.md
+++ b/.agents/skills/phoenix-evals/references/production-continuous.md
@@ -39,13 +39,15 @@ Build a continuous monitoring loop:
 from phoenix.client import Client
 from datetime import datetime, timedelta
 
+from phoenix.client.types.spans import SpanQuery
+
 client = Client()
 
 # 1. Sample recent spans (includes full attributes for evaluation)
 spans_df = client.spans.get_spans_dataframe(
     project_identifier="my-app",
     start_time=datetime.now() - timedelta(hours=1),
-    root_spans_only=True,
+    query=SpanQuery().where("parent_id is None"),  # top-level spans only
     limit=100,
 )
 

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2843,6 +2843,11 @@ type Project implements Node {
   documentEvaluationSummary(evaluationName: String!, timeRange: TimeRange, filterCondition: String): DocumentEvaluationSummary
   streamingLastUpdatedAt: DateTime
   validateSpanFilterCondition(condition: String!): ValidationResult!
+
+  """
+  Parses a span filter condition and reports how it relates to root-span scoping, so a client can tell whether a filtered view is root-scoped without parsing the expression itself. Structural only: it does not validate the condition, so a condition reported as root-scoped may still be rejected when the query runs. Use validateSpanFilterCondition to check validity.
+  """
+  analyzeSpanFilterCondition(condition: String!): SpanFilterConditionAnalysis!
   annotationConfigs(first: Int = 50, last: Int = null, after: String = null, before: String = null): AnnotationConfigConnection!
   traceRetentionPolicy: ProjectTraceRetentionPolicy!
   createdAt: DateTime!
@@ -4166,6 +4171,15 @@ type SpanEvent {
   message: String!
   timestamp: DateTime!
   attributes: JSON!
+}
+
+type SpanFilterConditionAnalysis {
+  """
+  Whether the condition is established to match only root spans -- that is, whether a root predicate (`parent_span is None` or `parent_id is None`) binds every row the condition can match. A conjunct qualifies; a branch of an `or` qualifies only if every other branch is root-scoped too, since a row need satisfy just one of them.
+  
+  `false` means this could not be established, not that the condition admits non-root spans. Recognition covers the boolean structure of the expression, so a root-only condition written in a form that would require reasoning about the predicates themselves -- a branch that silently contradicts itself, say -- reports `false`. `true` is always a guarantee; `false` is the absence of one.
+  """
+  selectsRootSpansOnly: Boolean!
 }
 
 type SpanIOValue {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2845,7 +2845,7 @@ type Project implements Node {
   validateSpanFilterCondition(condition: String!): ValidationResult!
 
   """
-  Parses a span filter condition and reports how it relates to root-span scoping, so a client can tell whether a filtered view is root-scoped without parsing the expression itself. Structural only: it does not validate the condition, so a condition reported as root-scoped may still be rejected when the query runs. Use validateSpanFilterCondition to check validity.
+  How a span filter condition relates to root-span scoping, so clients need not parse the DSL. Structural only; use `validateSpanFilterCondition` to check validity.
   """
   analyzeSpanFilterCondition(condition: String!): SpanFilterConditionAnalysis!
   annotationConfigs(first: Int = 50, last: Int = null, after: String = null, before: String = null): AnnotationConfigConnection!
@@ -4175,9 +4175,7 @@ type SpanEvent {
 
 type SpanFilterConditionAnalysis {
   """
-  Whether the condition is established to match only root spans -- that is, whether a root predicate (`parent_span is None` or `parent_id is None`) binds every row the condition can match. A conjunct qualifies; a branch of an `or` qualifies only if every other branch is root-scoped too, since a row need satisfy just one of them.
-  
-  `false` means this could not be established, not that the condition admits non-root spans. Recognition covers the boolean structure of the expression, so a root-only condition written in a form that would require reasoning about the predicates themselves -- a branch that silently contradicts itself, say -- reports `false`. `true` is always a guarantee; `false` is the absence of one.
+  Whether a root predicate (`parent_span is None` or `parent_id is None`) binds every row the condition can match. `true` is a guarantee; `false` means not established, not that non-root spans are admitted.
   """
   selectsRootSpansOnly: Boolean!
 }

--- a/docs/phoenix/sdk-api-reference/python/arize-phoenix-client.mdx
+++ b/docs/phoenix/sdk-api-reference/python/arize-phoenix-client.mdx
@@ -194,11 +194,13 @@ Query for spans and annotations from your projects for custom evaluation and ann
 ```python 
 from datetime import datetime, timedelta
 
+from phoenix.client.types.spans import SpanQuery
+
 # Get spans as pandas DataFrame for analysis
 spans_df = client.spans.get_spans_dataframe(
     project_identifier="my-llm-app",
     limit=1000,
-    root_spans_only=True,  # Only get top-level spans
+    query=SpanQuery().where("parent_id is None"),  # Only top-level spans
     start_time=datetime.now() - timedelta(hours=24)
 )
 

--- a/packages/phoenix-client/README.md
+++ b/packages/phoenix-client/README.md
@@ -305,6 +305,7 @@ Query for spans and annotations from your projects for custom evaluation and ann
 
 ```python
 from phoenix.client import Client
+from phoenix.client.types.spans import SpanQuery
 from datetime import datetime, timedelta
 
 client = Client()
@@ -313,7 +314,7 @@ client = Client()
 spans_df = client.spans.get_spans_dataframe(
     project_identifier="my-llm-app",
     limit=1000,
-    root_spans_only=True,  # Only get top-level spans
+    query=SpanQuery().where("parent_id is None"),  # Only top-level spans
     start_time=datetime.now() - timedelta(hours=24)
 )
 

--- a/packages/phoenix-client/docs/source/index.md
+++ b/packages/phoenix-client/docs/source/index.md
@@ -155,7 +155,7 @@ for span in trace_spans:
 spans_df = client.spans.get_spans_dataframe(
     project_identifier="my-llm-app",
     limit=1000,
-    root_spans_only=True,  # Only get top-level spans
+    query=SpanQuery().where("parent_id is None"),  # Only top-level spans
     start_time=datetime.now() - timedelta(hours=24)
 )
 

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -188,6 +188,10 @@ class Spans:
             end_time (Optional[datetime]): Optional end time for filtering.
             limit (int): Maximum number of spans to return. Defaults to 1000.
             root_spans_only (Optional[bool]): Whether to return only root spans.
+                Deprecated: express root-span scoping in the query instead, e.g.
+                `SpanQuery().where("parent_span is None")` to match root spans
+                including orphans (spans whose parent is absent), or
+                `parent_id is None` to match only spans with no parent id.
             project_name (Optional[str]): Optional project name to filter by. Deprecated,
                 use `project_identifier` to also specify by the project id.
             project_identifier (Optional[str]): Optional project identifier (name or id)
@@ -1464,6 +1468,10 @@ class AsyncSpans:
             end_time (Optional[datetime]): Optional end time for filtering.
             limit (int): Maximum number of spans to return. Defaults to 1000.
             root_spans_only (Optional[bool]): Whether to return only root spans.
+                Deprecated: express root-span scoping in the query instead, e.g.
+                `SpanQuery().where("parent_span is None")` to match root spans
+                including orphans (spans whose parent is absent), or
+                `parent_id is None` to match only spans with no parent id.
             project_name (Optional[str]): Optional project name to filter by. Deprecated,
                 use `project_identifier` to also specify by the project id.
             project_identifier (Optional[str]): Optional project identifier (name or id)

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -154,8 +154,28 @@ class QuerySpansRequestBody(V1RoutesBaseModel):
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None
     limit: int = DEFAULT_SPAN_LIMIT
-    root_spans_only: Optional[bool] = None
-    orphan_span_as_root_span: bool = True
+    root_spans_only: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Restrict the results to root spans. "
+            "This parameter has been deprecated, express root-span scoping in the query's "
+            "filter condition instead: `parent_span is None` matches root spans including "
+            "orphans (spans whose parent is absent), and `parent_id is None` matches only "
+            "spans with no parent id. Putting it in the filter keeps the whole query in one "
+            "expression that can be composed with other clauses."
+        ),
+        deprecated=True,
+    )
+    orphan_span_as_root_span: bool = Field(
+        default=True,
+        description=(
+            "Whether an orphan span (one whose parent is absent) counts as a root span. "
+            "This parameter has been deprecated along with `root_spans_only`; choose the "
+            "behavior with the filter condition instead — `parent_span is None` treats "
+            "orphans as roots, `parent_id is None` does not."
+        ),
+        deprecated=True,
+    )
     project_name: Optional[str] = Field(
         default=None,
         description=(

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -50,12 +50,16 @@ from phoenix.server.api.types.ProjectSession import ProjectSession
 from phoenix.server.api.types.SortDir import SortDir
 from phoenix.server.api.types.Span import Span
 from phoenix.server.api.types.SpanCostSummary import SpanCostSummary
+from phoenix.server.api.types.SpanFilterConditionAnalysis import (
+    SpanFilterConditionAnalysis,
+)
 from phoenix.server.api.types.TimeSeries import TimeSeries, TimeSeriesDataPoint
 from phoenix.server.api.types.Trace import Trace
 from phoenix.server.api.types.ValidationResult import ValidationResult
 from phoenix.server.session_filters import get_filtered_session_rowids_subquery
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.dsl import SpanFilter
+from phoenix.trace.dsl.filter import RootSpanScope, root_span_scope
 
 DEFAULT_PAGE_SIZE = 30
 _TOKEN_COUNT_DETAIL_EPSILON = 1e-9
@@ -505,9 +509,11 @@ class Project(Node):
                 stmt = stmt.where(time_range.start <= models.Span.start_time)
             if time_range.end:
                 stmt = stmt.where(models.Span.start_time < time_range.end)
+        filter_root_scope: Optional[RootSpanScope] = None
         if filter_condition:
             span_filter = SpanFilter(condition=filter_condition)
             stmt = span_filter(stmt)
+            filter_root_scope = span_filter.root_scope
         sort_config: Optional[SpanSortConfig] = None
         cursor_rowid_column: Any = models.Span.id
         if sort:
@@ -533,6 +539,15 @@ class Project(Node):
             else:
                 stmt = stmt.where(models.Span.id > cursor.rowid)
         stmt = stmt.order_by(cursor_rowid_column)
+        # The flag is redundant when the condition already restricts at least as
+        # narrowly, and applying both would add a second correlated subquery (plus,
+        # in the orphan-aware branch, a CTE over `spans`) selecting the same rows.
+        if (
+            root_spans_only
+            and filter_root_scope is not None
+            and (orphan_span_as_root_span or filter_root_scope == "strict")
+        ):
+            root_spans_only = False
         if root_spans_only:
             # A root span is either a span with no parent_id or an orphan span
             # (a span whose parent_id references a span that doesn't exist in the database)
@@ -1099,6 +1114,24 @@ class Project(Node):
                 is_valid=False,
                 error_message=str(e),
             )
+
+    @strawberry.field(
+        description=(
+            "Parses a span filter condition and reports how it relates to root-span "
+            "scoping, so a client can tell whether a filtered view is root-scoped "
+            "without parsing the expression itself. Structural only: it does not "
+            "validate the condition, so a condition reported as root-scoped may "
+            "still be rejected when the query runs. Use validateSpanFilterCondition "
+            "to check validity."
+        )
+    )  # type: ignore
+    def analyze_span_filter_condition(
+        self,
+        condition: str,
+    ) -> SpanFilterConditionAnalysis:
+        return SpanFilterConditionAnalysis(
+            selects_root_spans_only=root_span_scope(condition) is not None,
+        )
 
     @strawberry.field
     async def annotation_configs(

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -1117,12 +1117,9 @@ class Project(Node):
 
     @strawberry.field(
         description=(
-            "Parses a span filter condition and reports how it relates to root-span "
-            "scoping, so a client can tell whether a filtered view is root-scoped "
-            "without parsing the expression itself. Structural only: it does not "
-            "validate the condition, so a condition reported as root-scoped may "
-            "still be rejected when the query runs. Use validateSpanFilterCondition "
-            "to check validity."
+            "How a span filter condition relates to root-span scoping, so clients "
+            "need not parse the DSL. Structural only; use "
+            "`validateSpanFilterCondition` to check validity."
         )
     )  # type: ignore
     def analyze_span_filter_condition(

--- a/src/phoenix/server/api/types/SpanFilterConditionAnalysis.py
+++ b/src/phoenix/server/api/types/SpanFilterConditionAnalysis.py
@@ -18,19 +18,13 @@ class SpanFilterConditionAnalysis:
     the analysis stay useful for an expression that is still being edited.
     """
 
+    # Kept short deliberately: schema descriptions are shipped to the agent as
+    # context, so the reasoning behind this lives in the class docstring above
+    # (which strawberry does not export) rather than here.
     selects_root_spans_only: bool = strawberry.field(
         description=(
-            "Whether the condition is established to match only root spans -- that "
-            "is, whether a root predicate (`parent_span is None` or `parent_id is "
-            "None`) binds every row the condition can match. A conjunct qualifies; a "
-            "branch of an `or` qualifies only if every other branch is root-scoped "
-            "too, since a row need satisfy just one of them."
-            "\n\n"
-            "`false` means this could not be established, not that the condition "
-            "admits non-root spans. Recognition covers the boolean structure of the "
-            "expression, so a root-only condition written in a form that would "
-            "require reasoning about the predicates themselves -- a branch that "
-            "silently contradicts itself, say -- reports `false`. `true` is always a "
-            "guarantee; `false` is the absence of one."
+            "Whether a root predicate (`parent_span is None` or `parent_id is None`) "
+            "binds every row the condition can match. `true` is a guarantee; `false` "
+            "means not established, not that non-root spans are admitted."
         )
     )

--- a/src/phoenix/server/api/types/SpanFilterConditionAnalysis.py
+++ b/src/phoenix/server/api/types/SpanFilterConditionAnalysis.py
@@ -1,0 +1,36 @@
+import strawberry
+
+
+@strawberry.type
+class SpanFilterConditionAnalysis:
+    """
+    Structural facts about a span filter condition, derived by parsing it as
+    the Python expression the filter DSL is built on.
+
+    This exists so clients can read filter semantics (notably root-span
+    scoping) without reimplementing that parsing themselves, which would be a
+    second grammar free to drift from the real one.
+
+    The analysis is purely structural and does not validate the condition --
+    use `validateSpanFilterCondition` for that. A condition can be reported as
+    root-scoped and still be rejected when the query runs, e.g. because it
+    references an unsupported construct. Keeping the two separate is what lets
+    the analysis stay useful for an expression that is still being edited.
+    """
+
+    selects_root_spans_only: bool = strawberry.field(
+        description=(
+            "Whether the condition is established to match only root spans -- that "
+            "is, whether a root predicate (`parent_span is None` or `parent_id is "
+            "None`) binds every row the condition can match. A conjunct qualifies; a "
+            "branch of an `or` qualifies only if every other branch is root-scoped "
+            "too, since a row need satisfy just one of them."
+            "\n\n"
+            "`false` means this could not be established, not that the condition "
+            "admits non-root spans. Recognition covers the boolean structure of the "
+            "expression, so a root-only condition written in a form that would "
+            "require reasoning about the predicates themselves -- a branch that "
+            "silently contradicts itself, say -- reports `false`. `true` is always a "
+            "guarantee; `false` is the absence of one."
+        )
+    )

--- a/src/phoenix/server/api/types/SpanFilterConditionAnalysis.py
+++ b/src/phoenix/server/api/types/SpanFilterConditionAnalysis.py
@@ -18,9 +18,6 @@ class SpanFilterConditionAnalysis:
     the analysis stay useful for an expression that is still being edited.
     """
 
-    # Kept short deliberately: schema descriptions are shipped to the agent as
-    # context, so the reasoning behind this lives in the class docstring above
-    # (which strawberry does not export) rather than here.
     selects_root_spans_only: bool = strawberry.field(
         description=(
             "Whether a root predicate (`parent_span is None` or `parent_id is None`) "

--- a/src/phoenix/server/api/types/Trace.py
+++ b/src/phoenix/server/api/types/Trace.py
@@ -36,6 +36,7 @@ from phoenix.server.api.types.SpanCostDetailSummaryEntry import SpanCostDetailSu
 from phoenix.server.api.types.SpanCostSummary import SpanCostSummary
 from phoenix.server.api.types.TraceAnnotation import TraceAnnotation
 from phoenix.trace.dsl import SpanFilter
+from phoenix.trace.dsl.filter import RootSpanScope
 
 if TYPE_CHECKING:
     from phoenix.server.api.types.Project import Project
@@ -311,9 +312,20 @@ class Trace(Node):
             base_query = base_query.where(models.Span.id < cursor.rowid)
         # Narrow by SpanFilter DSL (e.g. `span_kind == 'LLM'`, `status_code == 'ERROR'`)
         # before any root-span CTE wrapping, so the filter applies to the candidate set.
+        filter_root_scope: Optional[RootSpanScope] = None
         if filter_condition:
             span_filter = SpanFilter(condition=filter_condition)
             base_query = span_filter(base_query)
+            filter_root_scope = span_filter.root_scope
+        # The flag is redundant when the condition already restricts at least as
+        # narrowly, and applying both would add a second correlated subquery (plus,
+        # in the orphan-aware branch, a CTE over `spans`) selecting the same rows.
+        if (
+            root_spans_only
+            and filter_root_scope is not None
+            and (orphan_span_as_root_span or filter_root_scope == "strict")
+        ):
+            root_spans_only = False
         # Build final query based on filtering requirements
         if root_spans_only:
             if orphan_span_as_root_span:

--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -151,6 +151,18 @@ _PARENT_KEYWORD = "parent_span"
 _PARENT_IS_NULL = "__parent_is_null__"
 _PARENT_IS_NOT_NULL = "__parent_is_not_null__"
 
+_STRICT_ROOT_KEYWORD = "parent_id"
+
+
+RootSpanScope = typing.Literal["strict", "orphan_aware"]
+"""Which definition of "root span" a filter condition restricts to.
+
+The two are nested rather than alternatives, and the order matters when
+comparing them: ``"strict"`` (`parent_id is None` -- only spans with no parent
+pointer) selects a subset of ``"orphan_aware"`` (`parent_span is None` -- no
+parent pointer, or a pointer to a span absent from the table).
+"""
+
 
 @dataclass(frozen=True)
 class SpanFilter:
@@ -158,6 +170,7 @@ class SpanFilter:
     valid_eval_names: typing.Optional[typing.Sequence[str]] = None
     translated: ast.Expression = field(init=False, repr=False)
     compiled: typing.Any = field(init=False, repr=False)
+    root_scope: typing.Optional[RootSpanScope] = field(init=False, repr=False)
     _aliased_annotation_relations: tuple[AliasedAnnotationRelation] = field(init=False, repr=False)
     _aliased_annotation_attributes: dict[str, Mapped[typing.Any]] = field(init=False, repr=False)
 
@@ -165,21 +178,37 @@ class SpanFilter:
         return bool(self.condition)
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "root_scope", None)
         if not (source := self.condition):
             return
-        root = ast.parse(source, mode="eval")
-        _validate_expression(root, valid_eval_names=self.valid_eval_names)
-        source, aliased_annotation_relations = _apply_eval_aliasing(source)
-        root = ast.parse(source, mode="eval")
-        translated = _FilterTranslator(
-            reserved_keywords=(
-                alias
-                for aliased_annotation in aliased_annotation_relations
-                for alias, _ in aliased_annotation.attributes
-            ),
-        ).visit(root)
-        ast.fix_missing_locations(translated)
-        compiled = compile(translated, filename="", mode="eval")
+        try:
+            root = ast.parse(source, mode="eval")
+            _validate_expression(root, valid_eval_names=self.valid_eval_names)
+            # Derived from the tree parsed just above rather than from the source
+            # again, so a caller holding a filter is spared a parse of its own.
+            # Taken after validation so that a filter which escapes this
+            # constructor always carries the scope of a condition known to be
+            # valid, and so that invalid input is not analyzed for nothing.
+            object.__setattr__(self, "root_scope", _scope_or_none(root.body))
+            source, aliased_annotation_relations = _apply_eval_aliasing(source)
+            root = ast.parse(source, mode="eval")
+            translated = _FilterTranslator(
+                reserved_keywords=(
+                    alias
+                    for aliased_annotation in aliased_annotation_relations
+                    for alias, _ in aliased_annotation.attributes
+                ),
+            ).visit(root)
+            ast.fix_missing_locations(translated)
+            compiled = compile(translated, filename="", mode="eval")
+        except RecursionError:
+            # Input nested deeply enough to exhaust the stack, which every stage
+            # above is vulnerable to -- the parser, the translator, and
+            # `compile` all recurse. A condition arrives from the API, so this
+            # has to read as a malformed filter like any other rather than
+            # escaping as a crash from whichever stage happened to run out
+            # first.
+            raise SyntaxError("filter condition is nested too deeply") from None
         aliased_annotation_attributes = {
             alias: attribute
             for aliased_annotation in aliased_annotation_relations
@@ -266,6 +295,170 @@ class SpanFilter:
                 ),
             )
         return stmt
+
+
+def root_span_scope(condition: str) -> typing.Optional[RootSpanScope]:
+    """
+    The root-span restriction `condition` imposes, or ``None`` if it imposes
+    none.
+
+    The test is whether a root predicate binds every row the condition can
+    match, not where it sits in the expression. A conjunct qualifies; so does a
+    branch of an `or` when every other branch is root-scoped too, since a row
+    need satisfy only one of them; so does a predicate under `not` whose
+    negation restricts (`not (parent_id is not None)`). Where several
+    restrictions apply, conjoined ones compound to the narrowest and disjoined
+    ones union to the widest.
+
+    Recognition is deliberately incomplete: it covers the boolean structure of
+    the expression and nothing more, so equivalent-but-unrecognized rewritings
+    fall to ``None``. That is the safe direction -- see the note on soundness
+    below. An unparseable condition, an expression still being typed say, also
+    yields ``None`` rather than raising.
+
+    Soundness is the invariant that matters: a non-``None`` answer is a
+    guarantee that every matching row is a root span, never a guess.
+
+    This answers one question, from the condition alone: what does this
+    condition decide? Callers layer their own question on top. A client asking
+    "is this view root-scoped?" -- to choose between cumulative and per-span
+    metric columns, say -- only needs to know whether the answer is ``None``. A
+    query builder that also has a `root_spans_only` flag compares the two and
+    can drop its flag when this scope is at least as narrow, which is worth
+    doing because applying both means paying for two correlated subqueries
+    (and, in the orphan-aware branch, a CTE over `spans`) that select what one
+    of them already selects.
+    """
+    if not condition.strip():
+        return None
+    try:
+        body = ast.parse(condition, mode="eval").body
+    except SyntaxError:
+        return None
+    except RecursionError:
+        # Deeply nested input, e.g. a long chain of `not`. Both the parser and
+        # the walk below recurse, and this entry point takes arbitrary strings
+        # straight from the API, so exhausting the stack has to read as "cannot
+        # tell" rather than escaping to the caller.
+        return None
+    return _scope_or_none(body)
+
+
+def _scope_or_none(body: ast.expr) -> typing.Optional[RootSpanScope]:
+    """`_scope` with stack exhaustion folded into the unrecognized case."""
+    try:
+        return _scope(body, negated=False)
+    except RecursionError:
+        return None
+
+
+def _scope(node: ast.expr, *, negated: bool) -> typing.Optional[RootSpanScope]:
+    """The restriction imposed by `node`, or by ``not node`` when `negated`.
+
+    Carrying the polarity down the walk is negation-normal form applied lazily:
+    rather than rewriting every `not` toward the leaves and then traversing the
+    result, the traversal itself flips sense as it passes a `not`. Under a
+    flipped sense `and` and `or` trade places -- which is De Morgan -- so each
+    connective's rule is stated once rather than once per polarity.
+    """
+    if (scope := _leaf_scope(node, negated=negated)) is not None:
+        return scope
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return _scope(node.operand, negated=not negated)
+    if isinstance(node, ast.Compare) and len(node.ops) > 1:
+        # A chained comparison is a conjunction of its links: `a is b is c` is
+        # `(a is b) and (b is c)`, which is how the translator compiles it too.
+        return _combine(_comparison_links(node), negated=negated, conjunction=not negated)
+    if isinstance(node, ast.BoolOp):
+        conjunction = isinstance(node.op, ast.And) is not negated
+        return _combine(node.values, negated=negated, conjunction=conjunction)
+    return None
+
+
+def _combine(
+    parts: typing.Sequence[ast.expr],
+    *,
+    negated: bool,
+    conjunction: bool,
+) -> typing.Optional[RootSpanScope]:
+    """Folds the restrictions of `parts` under one connective."""
+    scopes = [_scope(part, negated=negated) for part in parts]
+    if conjunction:
+        # One restricting part bounds the whole, since a conjunction only
+        # narrows, so an unrestricting part drops out rather than disqualifying
+        # the result. Where several restrict, they compound to the narrowest.
+        restricting = [scope for scope in scopes if scope is not None]
+        if not restricting:
+            return None
+        return "strict" if "strict" in restricting else "orphan_aware"
+    # A row need satisfy only one part, so every part must restrict or the
+    # result admits unrestricted rows. What remains unions, so the widest wins.
+    if any(scope is None for scope in scopes):
+        return None
+    return "orphan_aware" if "orphan_aware" in scopes else "strict"
+
+
+def _comparison_links(node: ast.Compare) -> list[ast.Compare]:
+    """Splits a chained comparison into its pairwise links."""
+    links = []
+    left = node.left
+    for op, comparator in zip(node.ops, node.comparators):
+        links.append(ast.Compare(left=left, ops=[op], comparators=[comparator]))
+        left = comparator
+    return links
+
+
+def _leaf_scope(node: ast.expr, *, negated: bool) -> typing.Optional[RootSpanScope]:
+    if _matches_no_rows(node, negated=negated):
+        # An expression that can never be TRUE returns nothing, and every row of
+        # an empty result is vacuously a root span. `"strict"` is the narrowest
+        # such claim and so the strongest sound one, which is also what makes
+        # constant folding unnecessary: a never-TRUE branch of an `or` cannot
+        # widen anything and so drops out on its own, and a never-TRUE conjunct
+        # makes the whole conjunction empty.
+        return "strict"
+    return _root_predicate_scope(node, negated=negated)
+
+
+def _matches_no_rows(node: ast.expr, *, negated: bool) -> bool:
+    """Whether `node` -- or ``not node`` when `negated` -- is a literal that can
+    never be TRUE, and so returns no rows.
+
+    `False` and `None` are both never TRUE, but they diverge under negation:
+    `not False` is always TRUE, while `not None` is NULL, which is still never
+    TRUE. So `None` returns nothing in either sense, and `True`/`False` swap.
+    """
+    if not isinstance(node, ast.Constant):
+        return False
+    if node.value is None:
+        return True
+    return node.value is (True if negated else False)
+
+
+_ROOT_PREDICATE_SCOPES: typing.Mapping[str, RootSpanScope] = {
+    _PARENT_KEYWORD: "orphan_aware",
+    _STRICT_ROOT_KEYWORD: "strict",
+}
+
+
+def _root_predicate_scope(
+    node: ast.expr,
+    *,
+    negated: bool = False,
+) -> typing.Optional[RootSpanScope]:
+    # `parent_span is None` / `parent_id is None` (and the `==` spellings), in
+    # either operand order. Under `negated`, the inverted spellings are matched
+    # instead, so a predicate under `not` maps to the scope it restricts to.
+    if not isinstance(node, ast.Compare) or len(node.ops) != 1:
+        return None
+    accepted = (ast.IsNot, ast.NotEq) if negated else (ast.Is, ast.Eq)
+    if not isinstance(node.ops[0], accepted):
+        return None
+    left, right = node.left, node.comparators[0]
+    for name, other in ((left, right), (right, left)):
+        if isinstance(name, ast.Name) and name.id in _ROOT_PREDICATE_SCOPES:
+            return _ROOT_PREDICATE_SCOPES[name.id] if _is_none_constant(other) else None
+    return None
 
 
 _VALID_PROJECTION_NODE_TYPES: tuple[type, ...] = (

--- a/src/phoenix/trace/dsl/query.py
+++ b/src/phoenix/trace/dsl/query.py
@@ -525,10 +525,15 @@ class SpanQuery(_HasTmpSuffix):
             end_time (datetime, optional): The end time for the query range. Default None.
             limit (int, optional): Maximum number of spans to return. Defaults to DEFAULT_SPAN_LIMIT.
             root_spans_only (bool, optional): If True, only root spans are returned. Default None.
+                Deprecated. Express root-span scoping in the filter condition instead, via
+                `.where("parent_span is None")` (roots including orphans) or
+                `.where("parent_id is None")` (only spans with no parent id), so the whole
+                query lives in one expression that composes with other clauses.
             stop_time (datetime, optional): Deprecated. Use end_time instead. Default None.
             orphan_span_as_root_span (bool): If True, orphan spans are treated as root spans. An
                 orphan span has a non-null `parent_id` but a span with that ID is currently not
-                found in the database. Default True.
+                found in the database. Default True. Deprecated along with `root_spans_only`;
+                `parent_span is None` treats orphans as roots, `parent_id is None` does not.
 
         Returns:
             pd.DataFrame: A DataFrame containing the query results. The structure of the DataFrame
@@ -552,6 +557,18 @@ class SpanQuery(_HasTmpSuffix):
                 DeprecationWarning,
             )
             end_time = end_time or stop_time
+        # `orphan_span_as_root_span` defaults to True, so an explicit True is
+        # indistinguishable from the default (and is a no-op without
+        # `root_spans_only` anyway); an explicit False is detectable and warns.
+        if root_spans_only is not None or orphan_span_as_root_span is not True:
+            # Deprecated. Raise a warning
+            warnings.warn(
+                "root_spans_only and orphan_span_as_root_span are deprecated. Express "
+                'root-span scoping in the filter condition instead: .where("parent_span '
+                'is None") for roots including orphans, or .where("parent_id is None") '
+                "for only spans with no parent id.",
+                DeprecationWarning,
+            )
         if not (self._select or self._explode or self._concat):
             return _get_spans_dataframe(
                 session,
@@ -580,6 +597,16 @@ class SpanQuery(_HasTmpSuffix):
             stmt = stmt.where(models.Span.start_time < end_time)
         if limit is not None:
             stmt = stmt.limit(limit)
+        # The flag is redundant when the filter already restricts at least as
+        # narrowly; applying both pays for two correlated subqueries selecting
+        # the same rows.
+        filter_root_scope = self._filter.root_scope if self._filter else None
+        if (
+            root_spans_only
+            and filter_root_scope is not None
+            and (orphan_span_as_root_span or filter_root_scope == "strict")
+        ):
+            root_spans_only = False
         if root_spans_only:
             # A root span is either a span with no parent_id or an orphan span
             # (a span whose parent_id references a span that doesn't exist in the database)
@@ -809,6 +836,16 @@ def _get_spans_dataframe(
         stmt = stmt.where(models.Span.start_time < end_time)
     # Default newest-first ordering by start_time, with id as a stable tiebreaker
     stmt = stmt.order_by(models.Span.start_time.desc(), models.Span.id.desc())
+    # The flag is redundant when the filter already restricts at least as
+    # narrowly; applying both pays for two correlated subqueries selecting the
+    # same rows.
+    filter_root_scope = span_filter.root_scope if span_filter else None
+    if (
+        root_spans_only
+        and filter_root_scope is not None
+        and (orphan_span_as_root_span or filter_root_scope == "strict")
+    ):
+        root_spans_only = False
     if root_spans_only:
         # A root span is either a span with no parent_id or an orphan span
         # (a span whose parent_id references a span that doesn't exist in the database)

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -2791,6 +2791,149 @@ class TestProject:
         assert dsl_ids == expected
         assert dsl_ids == flag_ids
 
+    @pytest.mark.parametrize(
+        "condition,orphan_span_as_root_span",
+        [
+            pytest.param("parent_span is None", True, id="orphan-aware-both"),
+            pytest.param("parent_id is None", True, id="strict-condition-orphan-aware-flag"),
+            pytest.param("parent_id is None", False, id="strict-both"),
+            pytest.param("parent_span is None", False, id="orphan-aware-condition-strict-flag"),
+            # Disjunction where every branch is strict-scoped: the flag skip now
+            # fires off an `or`, so the rows must still match the flag alone.
+            pytest.param(
+                "(parent_id is None and '1' in input.value)"
+                " or (parent_id is None and '3' in input.value)",
+                True,
+                id="disjunction-all-strict-orphan-flag",
+            ),
+            pytest.param(
+                "(parent_id is None and '1' in input.value)"
+                " or (parent_id is None and '3' in input.value)",
+                False,
+                id="disjunction-all-strict-strict-flag",
+            ),
+            # Negated root predicate: `not (parent_id is not None)` is strict-scoped,
+            # so the skip fires off a `not` and must not change the result.
+            pytest.param(
+                "not (parent_id is not None) and '1' in input.value",
+                True,
+                id="negated-predicate-strict-orphan-flag",
+            ),
+            pytest.param(
+                "not (parent_id is not None) and '1' in input.value",
+                False,
+                id="negated-predicate-strict-strict-flag",
+            ),
+            # A form the analyzer does *not* recognize (De Morgan over a compound):
+            # it under-claims, so the flag's scoping is applied as well. Pinned
+            # because an under-claim must stay harmless -- redundant SQL, same rows.
+            pytest.param(
+                "not (parent_id is not None or '9' in input.value)",
+                True,
+                id="unrecognized-form-flag-still-applied",
+            ),
+            # Disjunction whose branches mix strict and orphan-aware: scoped to
+            # orphan-aware (the wider), so it may skip the orphan-aware flag but
+            # not the strict one.
+            pytest.param(
+                "(parent_span is None and '1' in input.value)"
+                " or (parent_id is None and '3' in input.value)",
+                True,
+                id="disjunction-mixed-orphan-flag",
+            ),
+            pytest.param(
+                "(parent_span is None and '1' in input.value)"
+                " or (parent_id is None and '3' in input.value)",
+                False,
+                id="disjunction-mixed-strict-flag",
+            ),
+        ],
+    )
+    async def test_root_predicate_and_flag_together_match_the_flag_alone(
+        self,
+        _orphan_spans: _Data,
+        httpx_client: httpx.AsyncClient,
+        condition: str,
+        orphan_span_as_root_span: bool,
+    ) -> None:
+        """Sending `rootSpansOnly` *and* a root predicate must not change the result.
+
+        The resolver drops the flag's scoping when the condition already implies
+        it, so this pins that the optimization is semantics-preserving. The
+        strict-flag/orphan-aware-condition case is the one that must NOT be
+        optimized away: skipping a strict flag there would admit orphans.
+        """
+        project = _orphan_spans.projects[0]
+        orphan_arg = str(orphan_span_as_root_span).lower()
+
+        async def span_ids(field: str) -> set[str]:
+            result = await self._node(field, project, httpx_client)
+            return {e["node"]["id"] for e in result["edges"]}
+
+        both = await span_ids(
+            f"spans(rootSpansOnly:true,orphanSpanAsRootSpan:{orphan_arg},"
+            f'filterCondition:"{condition}",first:100){{edges{{node{{id}}}}}}'
+        )
+        flag_only = await span_ids(
+            f"spans(rootSpansOnly:true,orphanSpanAsRootSpan:{orphan_arg},"
+            "first:100){edges{node{id}}}"
+        )
+        condition_only = await span_ids(
+            f'spans(filterCondition:"{condition}",first:100){{edges{{node{{id}}}}}}'
+        )
+        # Combining them is the intersection, which is what the flag alone gives
+        # whenever the condition is at least as strict.
+        assert both == flag_only & condition_only
+        assert both
+
+    async def test_analyze_span_filter_condition_tracks_actual_query_scope(
+        self,
+        _orphan_spans: _Data,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        """``analyzeSpanFilterCondition`` tells a client whether a filtered view is
+        root-scoped, which is what decides between cumulative and per-span metric
+        columns. Its answer has to match what the query actually returns, so this
+        checks the verdict against the rows for both a scoped and an unscoped
+        condition.
+        """
+        project = _orphan_spans.projects[0]
+        user_condition = "'2' in input.value"
+        root_scoped = f"parent_span is None and {user_condition}"
+
+        async def analyze(condition: str) -> bool:
+            result = await self._node(
+                f'analyzeSpanFilterCondition(condition:"{condition}"){{selectsRootSpansOnly}}',
+                project,
+                httpx_client,
+            )
+            return bool(result["selectsRootSpansOnly"])
+
+        async def span_ids(condition: str) -> set[str]:
+            result = await self._node(
+                f'spans(filterCondition:"{condition}",first:100){{edges{{node{{id}}}}}}',
+                project,
+                httpx_client,
+            )
+            return {e["node"]["id"] for e in result["edges"]}
+
+        assert await analyze(user_condition) is False
+        assert await analyze(root_scoped) is True
+
+        scoped_ids = await span_ids(root_scoped)
+        unscoped_ids = await span_ids(user_condition)
+        # The verdict is only meaningful if the predicate actually narrowed the
+        # result; a silently dropped predicate would make these equal.
+        assert scoped_ids < unscoped_ids
+        # ...and it narrows to exactly what the boolean arguments selected.
+        flag_res = await self._node(
+            "spans(rootSpansOnly:true,orphanSpanAsRootSpan:true,"
+            f'filterCondition:"{user_condition}",first:100){{edges{{node{{id}}}}}}',
+            project,
+            httpx_client,
+        )
+        assert scoped_ids == {e["node"]["id"] for e in flag_res["edges"]}
+
     @pytest.fixture
     async def _time_series_data(
         self,

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -1,6 +1,9 @@
 import ast
+import random
 import sys
+import typing
 from ast import unparse
+from collections import Counter
 from datetime import datetime
 from typing import Any, Optional
 from unittest.mock import patch
@@ -14,9 +17,11 @@ from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.dsl.filter import (
     Projector,
+    RootSpanScope,
     SpanFilter,
     _apply_eval_aliasing,
     _get_attribute_keys_list,
+    root_span_scope,
 )
 
 
@@ -536,3 +541,423 @@ def test_parent_predicate_sentinels_unreachable_from_user_input(sentinel: str) -
     translated = unparse(SpanFilter(f"{sentinel} == 'x'").translated).strip()
     # resolves to an attribute path, not the bare injected name
     assert translated.startswith(f"attributes[['{sentinel}']]")
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        pytest.param("", None, id="empty"),
+        pytest.param("parent_span is None", "orphan_aware", id="orphan-aware"),
+        pytest.param("parent_id is None", "strict", id="strict"),
+        pytest.param("parent_span == None", "orphan_aware", id="eq-spelling"),
+        pytest.param("None is parent_span", "orphan_aware", id="reversed-operands"),
+        pytest.param("span_kind == 'LLM'", None, id="unrelated-condition"),
+        pytest.param(
+            "parent_span is None and span_kind == 'LLM'",
+            "orphan_aware",
+            id="leading-conjunct",
+        ),
+        pytest.param(
+            "span_kind == 'LLM' and parent_id is None",
+            "strict",
+            id="trailing-conjunct",
+        ),
+        pytest.param(
+            "(span_kind == 'LLM' and parent_span is None) and latency_ms > 5",
+            "orphan_aware",
+            id="nested-conjunct",
+        ),
+        # Conjoined restrictions compound, so the narrower one is what the
+        # condition actually selects.
+        pytest.param(
+            "parent_span is None and parent_id is None",
+            "strict",
+            id="both-predicates-narrowest-wins",
+        ),
+        # A root predicate under `or` leaves non-root spans in the result set,
+        # so the condition imposes no root restriction at all.
+        pytest.param("parent_span is None or span_kind == 'LLM'", None, id="disjunction"),
+        pytest.param("not (parent_span is None)", None, id="negation"),
+        pytest.param("parent_span is not None", None, id="non-root-predicate"),
+        # An in-progress edit must not raise.
+        pytest.param("span_kind == 'LLM' and", None, id="unparseable"),
+    ],
+)
+def test_root_span_scope_reports_what_the_condition_restricts_to(
+    condition: str,
+    expected: typing.Optional[RootSpanScope],
+) -> None:
+    assert root_span_scope(condition) == expected
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        # Every branch of the disjunction is root-scoped, so every matching row
+        # is a root span even though no single conjunct binds the whole
+        # expression.
+        pytest.param(
+            "(parent_id is None and span_kind == 'LLM') or (parent_id is None and latency_ms > 5)",
+            "strict",
+            id="all-branches-strict",
+        ),
+        # Branch scopes union rather than intersect, so the widest wins: a row
+        # from the orphan-aware branch need not satisfy the strict one.
+        pytest.param(
+            "(parent_id is None and a == 1) or (parent_span is None and b == 2)",
+            "orphan_aware",
+            id="all-branches-widest-wins",
+        ),
+        # One unscoped branch admits non-root rows, so the whole is unscoped.
+        pytest.param(
+            "(parent_id is None and a == 1) or b == 2",
+            None,
+            id="one-branch-unscoped",
+        ),
+        # `not (x is not None)` is the double negative of a root predicate.
+        pytest.param("not (parent_id is not None)", "strict", id="negated-is-not-none"),
+        pytest.param("not (parent_span is not None)", "orphan_aware", id="negated-orphan-aware"),
+        # Negating a root predicate selects non-root spans, the opposite.
+        pytest.param("not (parent_id is None)", None, id="negated-root-predicate"),
+    ],
+)
+def test_root_span_scope_handles_disjunctions_and_negations(
+    condition: str,
+    expected: typing.Optional[RootSpanScope],
+) -> None:
+    assert root_span_scope(condition) == expected
+
+
+# `root_span_scope` has two consumers with two different failure modes, so it
+# owes two separate guarantees.
+#
+# SOUNDNESS, covered here: a non-None answer must be true. The query builders
+# drop the `root_spans_only` flag's SQL on the strength of it, so an over-claim
+# readmits the rows that flag would have excluded -- the only failure mode that
+# changes a result set.
+#
+# COMPLETENESS, covered by the scope tests above: supported root-only forms must
+# return a scope. This is *not* merely an optimization concern.
+# `analyzeSpanFilterCondition` surfaces the same answer to the frontend, which
+# reads None as "not root-scoped" and picks per-span rather than cumulative
+# metric columns. So under-claiming cannot change which rows come back, but it
+# is user-visible, and unsupported forms are a known gap rather than a
+# non-issue.
+#
+# Below: conditions that admit at least one non-root span, all of which must
+# return None.
+_CONDITIONS_ADMITTING_NON_ROOT_SPANS = [
+    "span_kind == 'LLM'",
+    "parent_id is not None",
+    "parent_span is not None",
+    "not (parent_id is None)",
+    "not (parent_span is None)",
+    # compared to something other than None
+    "parent_id == 'abc'",
+    "parent_id != None",
+    "'x' in parent_id",
+    # an *attribute* that happens to be named parent_id is a different thing
+    "attributes['parent_id'] is None",
+    # one unscoped branch is enough to admit non-root rows
+    "parent_id is None or span_kind == 'LLM'",
+    "parent_id is None or True",
+    "(parent_id is None and span_kind == 'CHAIN') or span_kind == 'LLM'",
+    "parent_span is None or parent_id is not None",
+    # a tautology matches everything, root or not
+    "parent_id is None or parent_id is not None",
+    # De Morgan: `parent_id is not None or span_kind != 'LLM'`, which admits
+    # any span whose kind is not LLM, root or not.
+    "not (parent_id is None and span_kind == 'LLM')",
+]
+
+
+@pytest.mark.parametrize("condition", _CONDITIONS_ADMITTING_NON_ROOT_SPANS)
+def test_root_span_scope_never_over_claims_on_non_root_conditions(condition: str) -> None:
+    assert root_span_scope(condition) is None
+
+
+# Conditions restricting to orphan-aware roots but *not* to strict roots: they
+# match spans whose parent_id is set but absent from the table. Reporting
+# "strict" for any of these would let a caller drop a strict `root_spans_only`
+# flag, readmitting the orphans that flag exists to exclude.
+_ORPHAN_AWARE_BUT_NOT_STRICT_CONDITIONS = [
+    "parent_span is None",
+    "parent_span == None",
+    "None is parent_span",
+    "parent_span is None and span_kind == 'CHAIN'",
+    "(parent_span is None and span_kind == 'CHAIN') or (parent_span is None and latency_ms > 5)",
+    "not (parent_span is not None)",
+]
+
+
+@pytest.mark.parametrize("condition", _ORPHAN_AWARE_BUT_NOT_STRICT_CONDITIONS)
+def test_root_span_scope_never_over_claims_strictness(condition: str) -> None:
+    assert root_span_scope(condition) != "strict"
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        # Double negation is the identity on which rows come back.
+        pytest.param("not not (parent_id is None)", "strict", id="double-negation"),
+        pytest.param("not not (parent_span is None)", "orphan_aware", id="double-negation-orphan"),
+        # A chained comparison is a conjunction of its links.
+        pytest.param("None is parent_id is None", "strict", id="chained-comparison"),
+        pytest.param("None is parent_span is None", "orphan_aware", id="chained-comparison-orphan"),
+        # ...so an unscoped link drops out rather than disqualifying the chain.
+        pytest.param(
+            "span_kind == 'CHAIN' and None is parent_id is None",
+            "strict",
+            id="chained-comparison-in-conjunction",
+        ),
+    ],
+)
+def test_root_span_scope_classifies_equivalent_rewrites(
+    condition: str,
+    expected: typing.Optional[RootSpanScope],
+) -> None:
+    """Forms that mean the same thing as a plain root predicate must classify the
+    same way, since the frontend picks metric columns off this answer."""
+    assert root_span_scope(condition) == expected
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        # `not (A or B)` is `not A and not B`: one restricting conjunct bounds
+        # the whole, so an unrestricting sibling drops out.
+        pytest.param(
+            "not (parent_id is not None or span_kind == 'LLM')",
+            "strict",
+            id="not-or-strict",
+        ),
+        pytest.param(
+            "not (parent_span is not None or span_kind == 'LLM')",
+            "orphan_aware",
+            id="not-or-orphan-aware",
+        ),
+        # `not (A and B)` is `not A or not B`: a disjunction, so *every* negated
+        # branch has to restrict.
+        pytest.param(
+            "not (parent_id is not None and parent_span is not None)",
+            "orphan_aware",
+            id="not-and-both-negated-branches-restrict",
+        ),
+        pytest.param(
+            "not (parent_id is not None and span_kind == 'LLM')",
+            None,
+            id="not-and-one-branch-unrestricting",
+        ),
+        # Nested polarity: two negations restore the original sense.
+        pytest.param(
+            "not (not (parent_id is None) and span_kind == 'LLM')",
+            None,
+            id="nested-negation-disjunction",
+        ),
+        pytest.param(
+            "not (not (parent_id is None) or span_kind == 'LLM')",
+            "strict",
+            id="nested-negation-conjunction",
+        ),
+        # A literal-True conjunct negates to a literal-False branch, which
+        # contributes no rows and folds out of the disjunction.
+        pytest.param(
+            "not (parent_id is not None and True)",
+            "strict",
+            id="not-and-true-folds",
+        ),
+        # ...whereas negating a literal-False conjunct yields a branch matching
+        # everything, so nothing is restricted.
+        pytest.param(
+            "not (parent_id is not None and False)",
+            None,
+            id="not-and-false-does-not-fold",
+        ),
+    ],
+)
+def test_root_span_scope_applies_de_morgan(
+    condition: str,
+    expected: typing.Optional[RootSpanScope],
+) -> None:
+    """Negation is handled by flipping polarity during the descent, so `and` and
+    `or` swap roles under a `not`. These pin both directions, including the ones
+    that must stay unrestricted -- a swapped rule would over-claim there."""
+    assert root_span_scope(condition) == expected
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        # A literal that can never be TRUE returns nothing, and an empty result
+        # is vacuously root-scoped -- so such a branch cannot widen a disjunction
+        # and drops out of one on its own.
+        pytest.param("parent_id is None or False", "strict", id="or-false"),
+        pytest.param("parent_id is None or None", "strict", id="or-null"),
+        pytest.param("parent_id is None or not True", "strict", id="or-not-true"),
+        pytest.param("not (parent_id is not None and None)", "strict", id="not-and-null"),
+        pytest.param(
+            "parent_span is None or (False and span_kind == 'LLM')",
+            "orphan_aware",
+            id="or-never-true-conjunction",
+        ),
+        # `None` is never TRUE in either sense -- `not NULL` is NULL, still not
+        # TRUE -- whereas `not False` is always TRUE and restricts nothing.
+        pytest.param("parent_id is None or not None", "strict", id="or-not-null"),
+        pytest.param("parent_id is None or not False", None, id="or-not-false"),
+        pytest.param("parent_id is None or True", None, id="or-true"),
+        # A never-TRUE conjunct empties the whole conjunction, which is
+        # vacuously root-scoped.
+        pytest.param("span_kind == 'LLM' and False", "strict", id="and-false"),
+        # ...but as a disjunct it leaves the other branch's rows, which are not
+        # root-scoped.
+        pytest.param("span_kind == 'LLM' or False", None, id="or-false-unscoped-sibling"),
+    ],
+)
+def test_root_span_scope_treats_never_true_literals_as_vacuously_scoped(
+    condition: str,
+    expected: typing.Optional[RootSpanScope],
+) -> None:
+    """Constant folding is not special-cased: mapping a never-TRUE leaf to the
+    narrowest scope makes it fall out of the same lattice rules as everything
+    else."""
+    assert root_span_scope(condition) == expected
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        pytest.param("not " * 2000 + "(parent_id is None)", id="deep-negation"),
+        pytest.param("(" * 2000 + "parent_id is None" + ")" * 2000, id="deep-grouping"),
+        pytest.param(" or ".join(["parent_id is None"] * 2000), id="wide-disjunction"),
+    ],
+)
+def test_root_span_scope_survives_pathologically_nested_input(condition: str) -> None:
+    """The analyzer is reachable from the API with an arbitrary string, so input
+    deep enough to exhaust the stack has to read as "cannot tell" rather than
+    escaping as a RecursionError."""
+    assert root_span_scope(condition) in (None, "strict")
+
+
+# Atoms for the generated corpus below. The root predicates appear in both
+# spellings and both polarities; the ordinary predicates discriminate among the
+# fixture's spans without saying anything about parentage; the constants exist
+# to exercise the never-TRUE folding.
+_CORPUS_ATOMS = (
+    "parent_id is None",
+    "parent_id is not None",
+    "parent_span is None",
+    "parent_span is not None",
+    "span_kind == 'LLM'",
+    "name == 'A'",
+    "name == 'C'",
+    "status_code == 'OK'",
+    "True",
+    "False",
+    "None",
+)
+
+
+def _generate_expression(rand: random.Random, depth: int) -> str:
+    if depth <= 0:
+        return rand.choice(_CORPUS_ATOMS)
+    kind = rand.choice(("atom", "atom", "and", "or", "not"))
+    if kind == "atom":
+        return rand.choice(_CORPUS_ATOMS)
+    if kind == "not":
+        return f"not ({_generate_expression(rand, depth - 1)})"
+    joiner = " and " if kind == "and" else " or "
+    operands = [_generate_expression(rand, depth - 1) for _ in range(rand.randint(2, 3))]
+    return "(" + joiner.join(operands) + ")"
+
+
+async def test_root_span_scope_never_over_claims_against_generated_expressions(
+    db: DbSessionFactory,
+    parent_predicate_project: None,
+) -> None:
+    """Checks soundness against the database rather than against expectations.
+
+    Every other test here asserts a hand-authored answer, which only ever
+    confirms the cases someone thought of. This one generates boolean
+    expressions, and wherever the analyzer commits to a scope it runs the
+    condition as SQL and requires that every row actually returned satisfies
+    that scope. So the analyzer is checked against the translator and the
+    database's own three-valued logic, not against a second model of them.
+
+    Only over-claiming is a failure. A ``None`` verdict is allowed for anything,
+    since under-claiming is the safe direction.
+    """
+    rand = random.Random(14497)
+    # `A` is the only strict root; `C` is an orphan, a root only in the wider
+    # sense; `B` and `D` have parents present in the table.
+    allowed_by_scope = {"strict": {"A"}, "orphan_aware": {"A", "C"}}
+
+    exercised: Counter[str] = Counter()
+    async with db() as session:
+        for _ in range(400):
+            condition = _generate_expression(rand, depth=3)
+            scope = root_span_scope(condition)
+            if scope is None:
+                continue
+            try:
+                span_filter = SpanFilter(condition)
+            except SyntaxError:
+                # e.g. a bare constant, which the DSL rejects as a whole condition
+                continue
+            returned = set(await session.scalars(span_filter(select(models.Span.span_id))))
+            assert returned <= allowed_by_scope[scope], (
+                f"{condition!r} was reported as {scope!r} but returned {sorted(returned)}"
+            )
+            exercised[scope] += 1
+            if "not " in condition:
+                exercised["negated"] += 1
+            if any(literal in condition for literal in ("True", "False", "None")):
+                exercised["with_literal"] += 1
+            if returned:
+                # The assertion above is vacuously satisfied by an empty result,
+                # so at least some verdicts have to be checked against rows that
+                # were actually returned.
+                exercised["returned_rows"] += 1
+
+    # Without this the assertions above could pass on a corpus that had
+    # degenerated -- into expressions that never commit to a scope, that only
+    # ever reach one verdict, or that all match nothing.
+    minimums = {
+        "strict": 5,
+        "orphan_aware": 3,
+        "negated": 3,
+        "with_literal": 3,
+        "returned_rows": 5,
+    }
+    missing = {k: (exercised[k], n) for k, n in minimums.items() if exercised[k] < n}
+    assert not missing, f"corpus under-exercised (got, wanted): {missing}; all: {dict(exercised)}"
+
+
+@pytest.mark.parametrize(
+    "condition,expected_message",
+    [
+        pytest.param(
+            "not " * 500 + "(parent_id is None)",
+            "nested too deeply",
+            id="deep-negation",
+        ),
+        # CPython's parser rejects deeply nested grouping on its own, before any
+        # stack is exhausted, so this arrives as a SyntaxError already. Its
+        # wording belongs to the interpreter and varies by version, so only the
+        # type is asserted -- the invariant is the same either way.
+        pytest.param(
+            "(" * 500 + "parent_id is None" + ")" * 500,
+            None,
+            id="deep-grouping",
+        ),
+    ],
+)
+def test_span_filter_reports_deeply_nested_input_as_malformed(
+    condition: str,
+    expected_message: typing.Optional[str],
+) -> None:
+    """Every stage of construction recurses -- the parser, the validator, the
+    translator, `compile` -- and conditions arrive from the API, so input deep
+    enough to exhaust the stack has to surface as a malformed filter rather than
+    as a RecursionError escaping from whichever stage ran out first."""
+    with pytest.raises(SyntaxError, match=expected_message):
+        SpanFilter(condition)

--- a/tests/unit/trace/dsl/test_query.py
+++ b/tests/unit/trace/dsl/test_query.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 from typing import Any
 
@@ -1399,3 +1400,39 @@ async def test_explode_and_concat_on_same_array_with_non_ascii_kwargs(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
     )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"root_spans_only": True}, id="root-spans-only"),
+        pytest.param({"root_spans_only": False}, id="root-spans-only-false"),
+        # Deprecated even on its own: it is a no-op without `root_spans_only`,
+        # but a caller passing it is still using a deprecated argument.
+        pytest.param({"orphan_span_as_root_span": False}, id="orphan-flag-alone"),
+        pytest.param({"root_spans_only": True, "orphan_span_as_root_span": False}, id="both"),
+    ],
+)
+async def test_root_span_flags_warn_as_deprecated(
+    db: DbSessionFactory,
+    abc_project: Any,
+    kwargs: dict[str, Any],
+) -> None:
+    """The root-span flags are deprecated in favor of expressing the scoping in
+    the filter condition, and must say so the way `stop_time` already does."""
+    sq = SpanQuery()
+    async with db() as session:
+        with pytest.warns(DeprecationWarning, match="root_spans_only"):
+            await session.run_sync(sq, project_name="abc", **kwargs)
+
+
+async def test_no_deprecation_warning_without_the_root_span_flags(
+    db: DbSessionFactory,
+    abc_project: Any,
+) -> None:
+    """The migrated path -- root scoping inside the condition -- stays quiet."""
+    sq = SpanQuery().where("parent_id is None")
+    async with db() as session:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            await session.run_sync(sq, project_name="abc")


### PR DESCRIPTION
**Stack 2/3** — under #14553, over #14599.

Second step toward #14497. #14553 added the `parent_span is None` predicate; this PR makes the server able to *read* root-span scoping back out of a filter condition, and uses that to stop applying the scoping twice.

## What this adds

`root_span_scope(condition)` answers one question, from the condition alone: does this condition restrict the result set to root spans, and under which definition?

| Answer | Meaning |
|--------|---------|
| `"strict"` | every matching row has a null `parent_id` |
| `"orphan_aware"` | every matching row has no parent *in the table* — null pointer or orphan |
| `None` | not established |

It is exposed as `Project.analyzeSpanFilterCondition` for clients, and cached on `SpanFilter` so query paths that already hold a filter do not parse the condition again.

## Choice 1: answer it on the server, not in the client

The frontend needs this to choose between cumulative and per-span token/cost columns — a cumulative rollup is only meaningful on a root span, since on a nested span it double-counts against its ancestors' rows. Answering it in TypeScript would mean a second parser for the filter DSL, free to drift from the real one.

It also cannot be done by substring matching, which is the tempting shortcut. `parent_id is None or span_kind == 'LLM'` contains the predicate and is **not** root-scoped; `(parent_id is None and A) or (parent_id is None and B)` never contains it as a conjunct and **is**. The question is whether the predicate binds every row the condition can match, which is structural rather than textual.

## Choice 2: sound, deliberately incomplete

A non-`None` answer is a guarantee — every matching row is a root span. `None` means "not established", **not** "definitely unscoped". Recognition covers the boolean structure of the expression (conjunction, disjunction, negation including De Morgan, chained comparisons, never-true literals) and stops there. A root-only condition written in a form that would need reasoning about the predicates themselves — a branch that silently contradicts itself, say — reports `None`.

Deciding it completely would take more than boolean reasoning. Treating each predicate as an opaque atom is enough to *prove* root-scoping in the structural cases, but not to see that `span_kind == 'LLM' and span_kind != 'LLM'` is unsatisfiable — that needs the theory behind the atoms (equality, string containment, arithmetic), which is a solver's job rather than a parser's.

The two consumers want different things from that, and it is worth separating them:

- **The query optimization needs only soundness.** It drops the `root_spans_only` flag on the strength of a non-`None` answer, so an over-claim would return wrong rows while an under-claim merely leaves a redundant subquery in place.
- **The frontend also benefits from completeness.** `analyzeSpanFilterCondition` picks cumulative versus per-span columns, so an under-claim is user-visible — a genuinely root-scoped view written in an unrecognized form gets per-span columns. Harmless to the data, wrong to the eye.

Recognition is therefore pushed as far as boolean structure goes, and stops where a solver would be required.

## Redundant work this removes

`Project.spans`, `Trace.spans`, and both `SpanQuery` execution paths take a `root_spans_only` flag **and** a filter condition, and today apply both. The rows are correct either way, since the two restrictions simply intersect — but when the condition already carries a root predicate, the statement pays for two correlated subqueries returning what one of them already returned, and the flag's orphan-aware branch is the expensive one, adding a CTE plus a derived table over `spans`. Reachable on `main` today with `spans(rootSpansOnly: true, filterCondition: "parent_id is None")`.

Inspected in the compiled PostgreSQL statement — this is SQL shape, not timings:

| condition + flag | before | after |
|------------------|--------|-------|
| `parent_span is None` + orphan-aware | 2 `EXISTS`, 1 CTE | 1 `EXISTS`, 0 CTE |
| `parent_id is None` + orphan-aware | 1 `EXISTS`, 1 CTE | 0 `EXISTS`, 0 CTE |

Each site now drops the flag when the condition implies it. **Strictness is directional** and the code respects it, because `parent_id is None` selects a subset of `parent_span is None`:

| condition says | flag says | skip the flag? |
|----------------|-----------|----------------|
| strict | either | yes |
| orphan-aware | orphan-aware | yes |
| orphan-aware | strict | **no** — skipping would readmit the orphans the caller asked to exclude |

## Deprecation

`root_spans_only` and `orphan_span_as_root_span` are deprecated in favor of expressing the scoping in the condition: on the REST span-query body, on `SpanQuery.__call__` (which now warns, matching the neighbouring `stop_time`), and in the docs and examples that taught them.

That last part is why `.agents/skills/phoenix-evals/references/*` appears in the diff and looks unrelated: three of those references recommended `root_spans_only=True` as the way to fetch top-level spans for evaluation, so they now show `SpanQuery().where("parent_id is None")` instead. Same for the client README, the Sphinx index, and the SDK reference page.

Worth knowing for reviewers: both routes carrying that request body are `include_in_schema=False`, so the deprecation reaches the field descriptions and a runtime `DeprecationWarning` but **not** the published OpenAPI schema or the generated clients.

## Testing

Beyond the structural cases, there is a generated corpus — random boolean expressions over both root predicates, ordinary predicates, and literals, each executed as SQL against a fixture holding a strict root, an orphan, and a child. Wherever the analyzer commits to a scope, every row actually returned must satisfy it. That checks the guarantee against real SQL and three-valued `NULL` semantics rather than against hand-authored expectations, and it is what would catch a polarity slip in the negation handling.

Deeply nested input — a long chain of `not`, say — now surfaces as a malformed filter rather than escaping as a `RecursionError` from whichever construction stage exhausts the stack first.

Both dialects are exercised, since the analyzer's guarantee is about SQL semantics rather than Python's:

```
uv run pytest --db sqlite     tests/unit/trace/dsl tests/unit/server/api/types
uv run pytest --db postgresql tests/unit/trace/dsl tests/unit/server/api/types
```