### PR TITLE
docs: simplify Eve tracing setup to use phoenix-otel

### DIFF
--- a/docs/phoenix/integrations/typescript/vercel/eve-tracing.mdx
+++ b/docs/phoenix/integrations/typescript/vercel/eve-tracing.mdx
@@ -4,7 +4,7 @@ description: "Trace Vercel Eve agents with OpenInference and send AI SDK spans t
 keywords: ['vercel', 'eve', 'agents', 'ai-sdk', 'opentelemetry', 'openinference', 'typescript', 'tracing', 'observability', 'phoenix']
 ---
 
-[Eve](https://eve.dev/) is Vercel's filesystem-first TypeScript framework for durable backend AI agents. You define an agent as files under an `agent/` directory and Eve compiles it into an app that runs on Vercel Functions. Eve emits [Vercel AI SDK](https://github.com/vercel/ai) OpenTelemetry spans for every turn, model call, and tool execution. Phoenix captures them by registering the [`@arizeai/openinference-vercel`](https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-vercel) span processor in Eve's `agent/instrumentation.ts`.
+[Eve](https://eve.dev/) is Vercel's filesystem-first TypeScript framework for durable backend AI agents. You define an agent as files under an `agent/` directory and Eve compiles it into an app that runs on Vercel Functions. Eve emits [Vercel AI SDK](https://github.com/vercel/ai) OpenTelemetry spans for every turn, model call, and tool execution. Phoenix captures them with a single [`@arizeai/phoenix-otel`](/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel) `register()` call in Eve's `agent/instrumentation.ts`.
 
 ## Prerequisites
 
@@ -14,19 +14,15 @@ keywords: ['vercel', 'eve', 'agents', 'ai-sdk', 'opentelemetry', 'openinference'
 
 ## Install
 
-In your Eve project, add the Arize OpenInference processor and the OpenTelemetry packages it exports through:
+In your Eve project, install `@arizeai/phoenix-otel` — it bundles the OTLP exporter and the AI SDK span processor:
 
 ```bash
-npm install @arizeai/openinference-vercel@^3.1 \
-  @arizeai/openinference-semantic-conventions \
-  @vercel/otel \
-  @opentelemetry/api \
-  @opentelemetry/exporter-trace-otlp-proto
+npm install @arizeai/phoenix-otel
 ```
 
 ## Connect to Phoenix
 
-Run a [self-hosted Phoenix instance](/docs/phoenix/self-hosting), a local terminal, Kubernetes, etc., then point Eve at it by adding the following to your environment variables.
+Run a [self-hosted Phoenix instance](/docs/phoenix/self-hosting). A local Phoenix at `http://localhost:6006` needs no configuration; otherwise set:
 
 ```bash .local.env
 PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"
@@ -34,46 +30,39 @@ PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"
 # optional; defaults to the agent name
 PHOENIX_PROJECT_NAME="weather-agent"
 
-# optional; use if using Vercel's AI Gateway with Eve
-# AI_GATEWAY_API_KEY="<your-ai-gateway-key>"
+# only if your Phoenix has auth enabled
+# PHOENIX_API_KEY="<your-phoenix-api-key>"
 ```
 
 ## Setup tracing
 
-Eve auto-discovers `agent/instrumentation.ts` and runs it once at server startup, before any agent code. Create or edit this file to register an OpenTelemetry provider in the `setup` callback like so:
+Eve auto-discovers `agent/instrumentation.ts` and runs it once at server startup. Call `register()` in the `setup` callback:
 
 ```typescript agent/instrumentation.ts
-import { defineInstrumentation } from "eve/instrumentation";
-import { registerOTel } from "@vercel/otel";
+import {
+  ensureCollectorEndpoint,
+  OTLPTraceExporter,
+  register,
+} from "@arizeai/phoenix-otel";
 import {
   isOpenInferenceSpan,
   OpenInferenceSimpleSpanProcessor,
-} from "@arizeai/openinference-vercel";
-import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+} from "@arizeai/phoenix-otel/vercel";
+import { defineInstrumentation } from "eve/instrumentation";
 
 export default defineInstrumentation({
   setup: ({ agentName }) => {
-    // Bail out if the collector endpoint is missing. This callback runs at server
-    // startup, so throwing here (an unset endpoint makes an unparseable exporter URL)
-    // would crash the agent runner with a "Runner did not become ready in time" error
-    // that never mentions Phoenix.
-    const endpoint = process.env.PHOENIX_COLLECTOR_ENDPOINT;
-    if (!endpoint) {
-      console.warn("PHOENIX_COLLECTOR_ENDPOINT not set — skipping Phoenix tracing");
-      return;
-    }
-    // Route to the project named by PHOENIX_PROJECT_NAME, falling back to the agent
-    // name. Without a project name, spans land in Phoenix's "default" project.
-    const projectName = process.env.PHOENIX_PROJECT_NAME ?? agentName;
-    return registerOTel({
-      serviceName: projectName,
-      attributes: { [SEMRESATTRS_PROJECT_NAME]: projectName },
+    register({
+      projectName: process.env.PHOENIX_PROJECT_NAME ?? agentName,
       spanProcessors: [
+        // The simple (non-batched) processor delivers each span as it ends,
+        // which is safe on the short-lived serverless functions Eve deploys to.
         new OpenInferenceSimpleSpanProcessor({
           exporter: new OTLPTraceExporter({
-            url: `${endpoint}/v1/traces`,
-            // Only needed when your self-hosted Phoenix has auth enabled.
+            url: ensureCollectorEndpoint(
+              process.env.PHOENIX_COLLECTOR_ENDPOINT ?? "http://localhost:6006"
+            ),
+            // Only needed when Phoenix has auth enabled.
             headers: process.env.PHOENIX_API_KEY
               ? { Authorization: `Bearer ${process.env.PHOENIX_API_KEY}` }
               : undefined,
@@ -88,23 +77,17 @@ export default defineInstrumentation({
 ```
 
 <Accordion title="What the spanFilter and reparentOrphanedSpans options do">
-Both options act client-side, before spans are exported, and control which spans reach Phoenix and how each trace is rooted:
-
-- **`spanFilter: isOpenInferenceSpan`** keeps only the AI spans and drops the rest — the raw HTTP/fetch spans and Eve's Vercel Workflow spans — so your Phoenix **Traces** view isn't cluttered with non-AI spans.
-- **`reparentOrphanedSpans: true`** re-roots any AI span left orphaned when the filter drops its parent, so it no longer points at a parent that was never exported (which would otherwise show up orphaned on the Phoenix **Traces** tab). It also recognizes Eve's `ai.eve.turn` wrapper as an AI-like root and tags it `openinference.span.kind = AGENT`, so each turn shows up as a single clean **agent** root with its steps nested underneath.
+- **`spanFilter: isOpenInferenceSpan`** keeps only the AI spans, dropping the raw HTTP/fetch spans and Eve's workflow-engine spans.
+- **`reparentOrphanedSpans: true`** re-roots the AI spans left orphaned by the filter and promotes Eve's `ai.eve.turn` wrapper to an **agent** root, so each turn is one clean trace.
 </Accordion>
 
 <Note>
-`OpenInferenceSimpleSpanProcessor` exports each span synchronously as it ends, so it is safe on the short-lived serverless functions Eve runs on (no process-exit `forceFlush` to call). `@arizeai/openinference-vercel` translates the AI SDK spans into OpenInference before export.
-</Note>
-
-<Note>
-[`@arizeai/phoenix-otel`](/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel) can host this processor instead of `@vercel/otel`: pass it through `register()`'s `spanProcessors` option and `register()` handles the provider, project-name resource attribute, and global wiring — see the runnable [eve-agent example](https://github.com/Arize-ai/phoenix/tree/main/js/examples/apps/eve-agent) in the Phoenix repo.
+This setup is runnable end to end as the [eve-agent example](https://github.com/Arize-ai/phoenix/tree/main/js/examples/apps/eve-agent) in the Phoenix repo.
 </Note>
 
 ## Run Eve
 
-Start the Eve dev server, then open a session against the built-in HTTP channel:
+Start the Eve dev server:
 
 ```bash
 npm run dev
@@ -134,40 +117,32 @@ curl http://127.0.0.1:2000/eve/v1/session/<sessionId>/stream
 
 ## Observe in Phoenix
 
-New to reading traces in Phoenix? Here's how to make sense of what Eve sends, step by step.
-
-1. **Open your project.** Go to [localhost:6006](http://localhost:6006/) and click the project named `weather-agent` (or whatever you set in `PHOENIX_PROJECT_NAME`). That opens the project's **Spans** table. New spans show up within ~30 seconds of a turn. By default, only "Root spans" are shown. You can toggle on "All" to see all the spans.
-1. **Open a trace.** Navigate to the "Traces" tab. Each row in the Traces table is one _trace_: a full agent turn, from the incoming message to the final reply. Click a row to open a _span tree_. Each **span** is one unit of work inside the turn (a model call, a tool run, a reasoning step), nested to show what ran inside what.
-1. **Read a span by its name and its _kind_.** Eve registers the AI SDK's [`@ai-sdk/otel`](https://ai-sdk.dev/docs/ai-sdk-core/telemetry) telemetry adapter, which names spans per OpenTelemetry's GenAI conventions — `invoke_agent gpt-4o-mini`, `step 1`, `chat gpt-4o-mini`, `execute_tool get_weather` — and `@arizeai/openinference-vercel` translates their attributes to OpenInference on export. Alongside the name, each span carries a **span kind**, a colored label Phoenix adds to denote what it is:
+1. **Open your project.** Go to [localhost:6006](http://localhost:6006/) and click the project named `weather-agent` (or whatever you set in `PHOENIX_PROJECT_NAME`). New spans show up within ~30 seconds of a turn.
+1. **Open a trace.** Navigate to the "Traces" tab — each row is one full agent turn, from the incoming message to the final reply. Click a row to open the span tree; each **span** is one unit of work (a model call, a tool run), nested to show what ran inside what.
+1. **Read a span by its name and its _kind_.** Eve registers the AI SDK's [`@ai-sdk/otel`](https://ai-sdk.dev/docs/ai-sdk-core/telemetry) telemetry adapter, which names spans per OpenTelemetry's GenAI conventions — `invoke_agent gpt-4o-mini`, `step 1`, `chat gpt-4o-mini`, `execute_tool get_weather` — and the OpenInference span processor translates their attributes to OpenInference on export. Alongside the name, each span carries a **span kind**, a colored label Phoenix adds to denote what it is:
     - **agent** a step of the agent's turn (its reasoning and orchestration).
     - **llm** a model request (the `chat` span). Open it to see the prompt, the response, and token usage.
     - **tool** a tool execution (the `execute_tool` span), carrying a `tool.name` attribute such as `get_weather`.
 1. **Find the session context.** Click any span and open its **Attributes** panel. Eve attaches session identifiers under the `ai.settings.context.eve.*` prefix — `ai.settings.context.eve.session.id`, `ai.settings.context.eve.turn.id`, `ai.settings.context.eve.step.index`, and `ai.settings.context.eve.channel.kind` — so you can trace any span back to the session and turn it came from.
-1. **Read the tree top-down.** At the top sits Eve's `ai.eve.turn` span, shown as an **agent** root — `reparentOrphanedSpans` is promoting Eve's turn wrapper to a clean root, one per turn. Beneath it sits one `invoke_agent` span (kind **agent**) per step Eve took in the turn, each wrapping a span named `step 1` (kind **chain**) that holds the actual model request — a `chat` span of kind **llm**. Eve makes exactly one model call per step, so the AI SDK's per-call step counter always reads `1`; count the `invoke_agent` spans to count steps. If the step ran a tool, that shows up as an `execute_tool` span of kind **tool** carrying `tool.name`.
-
-    <Note>
-    If you turn off `spanFilter`/`reparentOrphanedSpans` in **instrumentation.ts**, this tree will be cluttered with raw HTTP spans, or with the `gen_ai` spans floating loose under no root; see the accordion under [Setup tracing](#setup-tracing).
-    </Note>
-
+1. **Read the tree top-down.** At the top sits Eve's `ai.eve.turn` span, an **agent** root, one per turn. Beneath it sits one `invoke_agent` span (kind **agent**) per step Eve took, each wrapping a `step 1` span (kind **chain**) that holds the model request — a `chat` span of kind **llm**. If the step ran a tool, an `execute_tool` span of kind **tool** carries `tool.name`.
 1. If no traces appear at all, see [Troubleshooting](#troubleshooting).
 
-<Frame caption="A Vercel Eve turn trace in Phoenix. With reparentOrphanedSpans enabled, ai.eve.turn becomes an agent root over the per-step agent, llm, and tool spans.">
+<Frame caption="A Vercel Eve turn trace in Phoenix: the ai.eve.turn agent root over the per-step agent, llm, and tool spans.">
 ![Phoenix trace view of a Vercel Eve agent turn, showing the ai.eve.turn agent root span with nested agent, llm, and tool spans for each step](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/screen_phoenix-eve.jpg)
 </Frame>
 
 ## Troubleshooting
 
-- **No traces in Phoenix.** Confirm the file is exactly `agent/instrumentation.ts` (Eve discovers it by path), and that `PHOENIX_COLLECTOR_ENDPOINT` is set in the shell running `npm run dev`. If your Phoenix has auth enabled, also set `PHOENIX_API_KEY`. Enable OpenTelemetry debug logs with `export OTEL_LOG_LEVEL=debug` and re-run.
+- **No traces in Phoenix.** Confirm the file is exactly `agent/instrumentation.ts` (Eve discovers it by path), and that `PHOENIX_COLLECTOR_ENDPOINT` points at your Phoenix (it defaults to `http://localhost:6006` in the snippet above). If your Phoenix has auth enabled, also set `PHOENIX_API_KEY`. Enable OpenTelemetry debug logs with `export OTEL_LOG_LEVEL=debug` and re-run.
 - **Traces land in the wrong project.** Phoenix routes spans to a project by the project-name resource attribute. Set `PHOENIX_PROJECT_NAME` (or rely on the agent-name fallback above); without it, spans land in Phoenix's `default` project.
 - **Model auth errors.** Eve routes models through AI Gateway, so set `AI_GATEWAY_API_KEY`, or run `vercel link` to use a `VERCEL_OIDC_TOKEN`. To skip the gateway, switch the agent to a direct provider model (e.g. `@ai-sdk/openai` with `OPENAI_API_KEY`). A brand-new AI Gateway key also fails until you add a payment method. The turn errors with `GatewayInternalServerError: AI Gateway requires a valid credit card on file to service requests`, even if you only plan to use the free credits. Add a card in your Vercel **AI Gateway** dashboard to unlock them.
-- **Version mismatch.** Pin the OpenTelemetry packages to Eve's `@vercel/otel` major: `@vercel/otel@1.x` requires `@opentelemetry/*` `1.x`; `@vercel/otel@2.x` requires `2.x`. Mismatches surface as silently missing traces.
-- **`gen_ai` spans orphaned on the Traces tab.** This happens when `spanFilter: isOpenInferenceSpan` drops Eve's `ai.eve.turn` workflow span without re-rooting its children, leaving the per-step `gen_ai` spans with no parent. Set `reparentOrphanedSpans: true` as shown in [Setup tracing](#setup-tracing) for a single clean agent root per turn, and confirm `@arizeai/openinference-vercel` is **3.0.0 or later** (the v3 major maps Eve's v7 GenAI-convention spans and carries the `ai.eve.turn` reparenting fix first shipped in 2.8.1).
 
 ## Resources
 
 <CardGroup>
   <Card icon="signal-stream" href="/docs/phoenix/integrations/typescript/vercel/vercel-ai-sdk-tracing-js" title="Vercel AI SDK Tracing (JS)" horizontal />
+  <Card icon="wrench" href="/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel" title="Setup Tracing with phoenix-otel" horizontal />
+  <Card icon="terminal" href="https://github.com/Arize-ai/phoenix/tree/main/js/examples/apps/eve-agent" title="Runnable Eve Agent Example" horizontal />
   <Card icon="book-open" href="https://vercel.com/docs/eve/observability" title="Eve Observability Docs" horizontal />
-  <Card icon="terminal" href="https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-vercel" title="OpenInference Vercel Span Processor" horizontal />
   <Card icon="robot" href="https://eve.dev/docs/getting-started" title="Eve Getting Started" horizontal />
 </CardGroup>

--- a/docs/phoenix/integrations/typescript/vercel/eve-tracing.mdx
+++ b/docs/phoenix/integrations/typescript/vercel/eve-tracing.mdx
@@ -14,10 +14,10 @@ keywords: ['vercel', 'eve', 'agents', 'ai-sdk', 'opentelemetry', 'openinference'
 
 ## Install
 
-In your Eve project, install `@arizeai/phoenix-otel` — it bundles the OTLP exporter and the AI SDK span processor:
+In your Eve project, install `@arizeai/phoenix-otel` and the OpenInference span processor for the AI SDK:
 
 ```bash
-npm install @arizeai/phoenix-otel
+npm install @arizeai/phoenix-otel @arizeai/openinference-vercel
 ```
 
 ## Connect to Phoenix
@@ -40,14 +40,10 @@ Eve auto-discovers `agent/instrumentation.ts` and runs it once at server startup
 
 ```typescript agent/instrumentation.ts
 import {
-  ensureCollectorEndpoint,
-  OTLPTraceExporter,
-  register,
-} from "@arizeai/phoenix-otel";
-import {
   isOpenInferenceSpan,
   OpenInferenceSimpleSpanProcessor,
-} from "@arizeai/phoenix-otel/vercel";
+} from "@arizeai/openinference-vercel";
+import { OTLPTraceExporter, register } from "@arizeai/phoenix-otel";
 import { defineInstrumentation } from "eve/instrumentation";
 
 export default defineInstrumentation({
@@ -57,11 +53,10 @@ export default defineInstrumentation({
       spanProcessors: [
         // The simple (non-batched) processor delivers each span as it ends,
         // which is safe on the short-lived serverless functions Eve deploys to.
+        // Swap in OpenInferenceBatchSpanProcessor if you prefer batching.
         new OpenInferenceSimpleSpanProcessor({
           exporter: new OTLPTraceExporter({
-            url: ensureCollectorEndpoint(
-              process.env.PHOENIX_COLLECTOR_ENDPOINT ?? "http://localhost:6006"
-            ),
+            url: `${process.env.PHOENIX_COLLECTOR_ENDPOINT ?? "http://localhost:6006"}/v1/traces`,
             // Only needed when Phoenix has auth enabled.
             headers: process.env.PHOENIX_API_KEY
               ? { Authorization: `Bearer ${process.env.PHOENIX_API_KEY}` }

--- a/js/examples/apps/eve-agent/agent/instrumentation.ts
+++ b/js/examples/apps/eve-agent/agent/instrumentation.ts
@@ -14,14 +14,10 @@
  */
 
 import {
-  ensureCollectorEndpoint,
-  OTLPTraceExporter,
-  register,
-} from "@arizeai/phoenix-otel";
-import {
   isOpenInferenceSpan,
   OpenInferenceSimpleSpanProcessor,
-} from "@arizeai/phoenix-otel/vercel";
+} from "@arizeai/openinference-vercel";
+import { OTLPTraceExporter, register } from "@arizeai/phoenix-otel";
 import { defineInstrumentation } from "eve/instrumentation";
 
 export default defineInstrumentation({
@@ -31,11 +27,10 @@ export default defineInstrumentation({
       spanProcessors: [
         // The simple (non-batched) processor delivers each span as it ends,
         // which is safe on the short-lived serverless functions Eve deploys to.
+        // Swap in OpenInferenceBatchSpanProcessor if you prefer batching.
         new OpenInferenceSimpleSpanProcessor({
           exporter: new OTLPTraceExporter({
-            url: ensureCollectorEndpoint(
-              process.env.PHOENIX_COLLECTOR_ENDPOINT ?? "http://localhost:6006"
-            ),
+            url: `${process.env.PHOENIX_COLLECTOR_ENDPOINT ?? "http://localhost:6006"}/v1/traces`,
             // Only needed when Phoenix has auth enabled.
             headers: process.env.PHOENIX_API_KEY
               ? { Authorization: `Bearer ${process.env.PHOENIX_API_KEY}` }

--- a/js/examples/apps/eve-agent/package.json
+++ b/js/examples/apps/eve-agent/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^4.0.0",
+    "@arizeai/openinference-vercel": "^3.1.0",
     "@arizeai/phoenix-otel": "workspace:*",
     "ai": "^7.0.26",
     "eve": "^0.25.1",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^4.0.0
         version: 4.0.16(zod@4.4.3)
+      '@arizeai/openinference-vercel':
+        specifier: ^3.1.0
+        version: 3.1.0(@ai-sdk/otel@1.0.31(zod@4.4.3))(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.31(zod@4.4.3))
       '@arizeai/phoenix-otel':
         specifier: workspace:*
         version: link:../../../packages/phoenix-otel
@@ -362,7 +365,7 @@ importers:
         version: 26.1.1
       mastra:
         specifier: ^1.19.0
-        version: 1.19.0(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@7.0.2)(zod@4.4.3)
+        version: 1.19.0(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(supports-color@10.2.2)(typescript@7.0.2)(zod@4.4.3)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -6859,26 +6862,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@7.29.7(supports-color@10.2.2)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/generator@7.29.7':
     dependencies:
       '@babel/parser': 7.29.7
@@ -6898,19 +6881,6 @@ snapshots:
       browserslist: 4.28.6
       lru-cache: 5.1.1
       semver: 6.3.1
-
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -6941,15 +6911,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -6964,15 +6925,6 @@ snapshots:
       '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.29.7': {}
-
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -7040,11 +6992,6 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -7090,40 +7037,16 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -7135,17 +7058,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -7991,45 +7903,6 @@ snapshots:
       - utf-8-validate
 
   '@mastra/deployer@1.51.0(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(supports-color@10.2.2)(typescript@7.0.2)(zod@4.4.3)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/traverse': 7.29.7
-      '@hono/node-ws': 1.3.1(@hono/node-server@2.0.1(hono@4.12.18))(hono@4.12.18)
-      '@mastra/core': 1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
-      '@mastra/server': 1.51.0(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(zod@4.4.3)
-      '@optimize-lodash/rollup-plugin': 5.1.0(rollup@4.62.2)
-      '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
-      '@rollup/plugin-commonjs': 29.0.2(rollup@4.62.2)
-      '@rollup/plugin-esm-shim': 0.1.8(rollup@4.62.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
-      '@rollup/plugin-virtual': 3.0.2(rollup@4.62.2)
-      '@sindresorhus/slugify': 2.2.1
-      '@types/babel__traverse': 7.28.0
-      empathic: 2.0.1
-      esbuild: 0.28.1
-      find-workspaces: 0.3.1
-      fs-extra: 11.3.6
-      gray-matter: 4.0.3
-      hono: 4.12.18
-      local-pkg: 1.2.1
-      resolve.exports: 2.0.3
-      rollup: 4.62.2
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@10.2.2)
-      strip-json-comments: 5.0.3
-      tinyglobby: 0.2.17
-      typescript-paths: 1.5.2(typescript@7.0.2)
-      ws: 8.21.1
-    transitivePeerDependencies:
-      - '@hono/node-server'
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@mastra/deployer@1.51.0(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@7.0.2)(zod@4.4.3)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
@@ -11132,44 +11005,6 @@ snapshots:
       '@expo/devcert': 1.2.1
       '@mastra/core': 1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
       '@mastra/deployer': 1.51.0(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(supports-color@10.2.2)(typescript@7.0.2)(zod@4.4.3)
-      '@mastra/loggers': 1.2.0(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))
-      archiver: 8.0.0
-      commander: 14.0.3
-      dotenv: 17.4.2
-      execa: 9.6.1
-      fs-extra: 11.3.6
-      get-port: 7.2.0
-      local-pkg: 1.2.1
-      openapi-fetch: 0.17.0
-      picocolors: 1.1.1
-      posthog-node: 5.45.2
-      semver: 7.8.5
-      serve: 14.2.6
-      serve-handler: 6.1.7
-      shell-quote: 1.10.0
-      strip-json-comments: 5.0.3
-      tinyglobby: 0.2.17
-      yocto-spinner: 1.2.2
-    transitivePeerDependencies:
-      - '@hono/node-server'
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
-      - rxjs
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-
-  mastra@1.19.0(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@7.0.2)(zod@4.4.3):
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@clack/prompts': 1.7.0
-      '@expo/devcert': 1.2.1
-      '@mastra/core': 1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
-      '@mastra/deployer': 1.51.0(@hono/node-server@2.0.1(hono@4.12.18))(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@7.0.2)(zod@4.4.3)
       '@mastra/loggers': 1.2.0(@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.31(zod@4.4.3))(express@5.2.1)(zod@4.4.3))
       archiver: 8.0.0
       commander: 14.0.3


### PR DESCRIPTION
## Summary

Rewrites the Vercel Eve integration page (`docs/phoenix/integrations/typescript/vercel/eve-tracing.mdx`) to use `@arizeai/phoenix-otel`'s `register()`, matching the runnable [eve-agent example](https://github.com/Arize-ai/phoenix/tree/main/js/examples/apps/eve-agent) added in #14589, and trims the prose. The example app is updated in the same PR so the two stay identical.
