### PR TITLE
fix(server): serve HEAD on the OAuth2/OIDC discovery documents

### DIFF
--- a/src/phoenix/server/api/routers/auth_md.py
+++ b/src/phoenix/server/api/routers/auth_md.py
@@ -19,7 +19,6 @@ from phoenix.auth import (
     PHOENIX_REFRESH_TOKEN_COOKIE_NAME,
 )
 from phoenix.server.oauth2_authorization_server import public_origin
-from phoenix.server.utils import GET_HEAD
 
 router = APIRouter(include_in_schema=False)
 
@@ -44,12 +43,16 @@ def _protected_resource_metadata(request: Request, *, resource: str) -> JSONResp
     )
 
 
-@router.api_route("/.well-known/oauth-protected-resource", methods=GET_HEAD)
+# HEAD is listed explicitly on these routes: FastAPI, unlike Starlette's own
+# Route, does not add HEAD to a GET route implicitly, and an unmatched HEAD
+# falls through to the SPA mount at / and 404s. uvicorn omits the body for
+# HEAD at the protocol layer, so handlers need no special casing.
+@router.api_route("/.well-known/oauth-protected-resource", methods=["GET", "HEAD"])
 async def protected_resource_metadata(request: Request) -> JSONResponse:
     return _protected_resource_metadata(request, resource=public_origin(request))
 
 
-@router.api_route("/.well-known/oauth-protected-resource/mcp", methods=GET_HEAD)
+@router.api_route("/.well-known/oauth-protected-resource/mcp", methods=["GET", "HEAD"])
 async def mcp_protected_resource_metadata(request: Request) -> JSONResponse:
     """RFC 9728 path-inserted metadata for the MCP endpoint mounted at /mcp.
 
@@ -67,7 +70,7 @@ async def mcp_protected_resource_metadata(request: Request) -> JSONResponse:
     return _protected_resource_metadata(request, resource=f"{public_origin(request)}{mount_path}")
 
 
-@router.api_route("/auth.md", methods=GET_HEAD)
+@router.api_route("/auth.md", methods=["GET", "HEAD"])
 async def get_auth_md(request: Request) -> PlainTextResponse:
     base_url = public_origin(request)
     authentication_enabled: bool = getattr(request.app.state, "authentication_enabled", False)

--- a/src/phoenix/server/api/routers/auth_md.py
+++ b/src/phoenix/server/api/routers/auth_md.py
@@ -3,8 +3,8 @@ Endpoints for agent authentication discovery, following the auth.md
 convention: https://workos.com/auth-md/docs/apps
 
 Serves:
-  GET /auth.md                              -- human/agent-readable auth guide
-  GET /.well-known/oauth-protected-resource -- RFC 9728 Protected Resource Metadata
+  GET|HEAD /auth.md                              -- human/agent-readable auth guide
+  GET|HEAD /.well-known/oauth-protected-resource -- RFC 9728 Protected Resource Metadata
 """
 
 from textwrap import dedent
@@ -19,6 +19,7 @@ from phoenix.auth import (
     PHOENIX_REFRESH_TOKEN_COOKIE_NAME,
 )
 from phoenix.server.oauth2_authorization_server import public_origin
+from phoenix.server.utils import GET_HEAD
 
 router = APIRouter(include_in_schema=False)
 
@@ -43,12 +44,12 @@ def _protected_resource_metadata(request: Request, *, resource: str) -> JSONResp
     )
 
 
-@router.get("/.well-known/oauth-protected-resource")
+@router.api_route("/.well-known/oauth-protected-resource", methods=GET_HEAD)
 async def protected_resource_metadata(request: Request) -> JSONResponse:
     return _protected_resource_metadata(request, resource=public_origin(request))
 
 
-@router.get("/.well-known/oauth-protected-resource/mcp")
+@router.api_route("/.well-known/oauth-protected-resource/mcp", methods=GET_HEAD)
 async def mcp_protected_resource_metadata(request: Request) -> JSONResponse:
     """RFC 9728 path-inserted metadata for the MCP endpoint mounted at /mcp.
 
@@ -66,7 +67,7 @@ async def mcp_protected_resource_metadata(request: Request) -> JSONResponse:
     return _protected_resource_metadata(request, resource=f"{public_origin(request)}{mount_path}")
 
 
-@router.get("/auth.md")
+@router.api_route("/auth.md", methods=GET_HEAD)
 async def get_auth_md(request: Request) -> PlainTextResponse:
     base_url = public_origin(request)
     authentication_enabled: bool = getattr(request.app.state, "authentication_enabled", False)

--- a/src/phoenix/server/api/routers/oauth2_authorization_server.py
+++ b/src/phoenix/server/api/routers/oauth2_authorization_server.py
@@ -53,7 +53,7 @@ from phoenix.server.types import (
     TokenStore,
     UserId,
 )
-from phoenix.server.utils import prepend_root_path, strip_root_path
+from phoenix.server.utils import GET_HEAD, prepend_root_path, strip_root_path
 
 logger = logging.getLogger(__name__)
 
@@ -405,12 +405,12 @@ def _authorization_server_metadata(request: Request) -> dict[str, Any]:
     return metadata
 
 
-@router.get("/.well-known/oauth-authorization-server")
+@router.api_route("/.well-known/oauth-authorization-server", methods=GET_HEAD)
 async def authorization_server_metadata(request: Request) -> JSONResponse:
     return JSONResponse(_authorization_server_metadata(request))
 
 
-@router.get("/.well-known/openid-configuration")
+@router.api_route("/.well-known/openid-configuration", methods=GET_HEAD)
 async def openid_configuration(request: Request) -> JSONResponse:
     """Serve the authorization-server metadata at the OIDC discovery location.
 

--- a/src/phoenix/server/api/routers/oauth2_authorization_server.py
+++ b/src/phoenix/server/api/routers/oauth2_authorization_server.py
@@ -53,7 +53,7 @@ from phoenix.server.types import (
     TokenStore,
     UserId,
 )
-from phoenix.server.utils import GET_HEAD, prepend_root_path, strip_root_path
+from phoenix.server.utils import prepend_root_path, strip_root_path
 
 logger = logging.getLogger(__name__)
 
@@ -405,12 +405,16 @@ def _authorization_server_metadata(request: Request) -> dict[str, Any]:
     return metadata
 
 
-@router.api_route("/.well-known/oauth-authorization-server", methods=GET_HEAD)
+# HEAD is listed explicitly on these routes: FastAPI, unlike Starlette's own
+# Route, does not add HEAD to a GET route implicitly, and an unmatched HEAD
+# falls through to the SPA mount at / and 404s. uvicorn omits the body for
+# HEAD at the protocol layer, so handlers need no special casing.
+@router.api_route("/.well-known/oauth-authorization-server", methods=["GET", "HEAD"])
 async def authorization_server_metadata(request: Request) -> JSONResponse:
     return JSONResponse(_authorization_server_metadata(request))
 
 
-@router.api_route("/.well-known/openid-configuration", methods=GET_HEAD)
+@router.api_route("/.well-known/openid-configuration", methods=["GET", "HEAD"])
 async def openid_configuration(request: Request) -> JSONResponse:
     """Serve the authorization-server metadata at the OIDC discovery location.
 

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -148,7 +148,7 @@ from phoenix.server.types import (
     LastUpdatedAt,
     TokenStore,
 )
-from phoenix.server.utils import GET_HEAD, get_root_path, prepend_root_path
+from phoenix.server.utils import get_root_path, prepend_root_path
 from phoenix.settings import Settings
 from phoenix.trace.fixtures import (
     TracesFixture,
@@ -1117,7 +1117,7 @@ def create_app(
         app.add_api_route(
             f"/.well-known/oauth-protected-resource{host_root_path}",
             protected_resource_metadata,
-            methods=GET_HEAD,
+            methods=["GET", "HEAD"],
             include_in_schema=False,
         )
         # The MCP PRM handler 404s by itself when the mount is disabled. The /mcp
@@ -1126,7 +1126,7 @@ def create_app(
         app.add_api_route(
             f"/.well-known/oauth-protected-resource{host_root_path}/mcp",
             mcp_protected_resource_metadata,
-            methods=GET_HEAD,
+            methods=["GET", "HEAD"],
             include_in_schema=False,
         )
         if authentication_enabled:
@@ -1134,7 +1134,7 @@ def create_app(
                 app.add_api_route(
                     f"/.well-known/{well_known}{host_root_path}",
                     authorization_server_metadata,
-                    methods=GET_HEAD,
+                    methods=["GET", "HEAD"],
                     include_in_schema=False,
                     dependencies=[Depends(authorization_server_enabled)],
                 )

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -148,7 +148,7 @@ from phoenix.server.types import (
     LastUpdatedAt,
     TokenStore,
 )
-from phoenix.server.utils import get_root_path, prepend_root_path
+from phoenix.server.utils import GET_HEAD, get_root_path, prepend_root_path
 from phoenix.settings import Settings
 from phoenix.trace.fixtures import (
     TracesFixture,
@@ -1117,6 +1117,7 @@ def create_app(
         app.add_api_route(
             f"/.well-known/oauth-protected-resource{host_root_path}",
             protected_resource_metadata,
+            methods=GET_HEAD,
             include_in_schema=False,
         )
         # The MCP PRM handler 404s by itself when the mount is disabled. The /mcp
@@ -1125,6 +1126,7 @@ def create_app(
         app.add_api_route(
             f"/.well-known/oauth-protected-resource{host_root_path}/mcp",
             mcp_protected_resource_metadata,
+            methods=GET_HEAD,
             include_in_schema=False,
         )
         if authentication_enabled:
@@ -1132,6 +1134,7 @@ def create_app(
                 app.add_api_route(
                     f"/.well-known/{well_known}{host_root_path}",
                     authorization_server_metadata,
+                    methods=GET_HEAD,
                     include_in_schema=False,
                     dependencies=[Depends(authorization_server_enabled)],
                 )

--- a/src/phoenix/server/utils.py
+++ b/src/phoenix/server/utils.py
@@ -1,14 +1,5 @@
 from typing import Any, Mapping
 
-#: Method list for routes serving a document to be read rather than acted on.
-#:
-#: FastAPI, unlike Starlette's own Route, does not add HEAD to a GET route
-#: implicitly, and leaving it off does not even yield a 405: the SPA mount at /
-#: matches every method, so an unmatched HEAD lands there and gets a 404 claiming
-#: the document does not exist. Handlers need no special casing — uvicorn omits
-#: the body for HEAD at the protocol layer.
-GET_HEAD = ["GET", "HEAD"]
-
 
 def prepend_root_path(scope: Mapping[str, Any], path: str) -> str:
     """

--- a/src/phoenix/server/utils.py
+++ b/src/phoenix/server/utils.py
@@ -1,5 +1,14 @@
 from typing import Any, Mapping
 
+#: Method list for routes serving a document to be read rather than acted on.
+#:
+#: FastAPI, unlike Starlette's own Route, does not add HEAD to a GET route
+#: implicitly, and leaving it off does not even yield a 405: the SPA mount at /
+#: matches every method, so an unmatched HEAD lands there and gets a 404 claiming
+#: the document does not exist. Handlers need no special casing — uvicorn omits
+#: the body for HEAD at the protocol layer.
+GET_HEAD = ["GET", "HEAD"]
+
 
 def prepend_root_path(scope: Mapping[str, Any], path: str) -> str:
     """


### PR DESCRIPTION
resolves #14606

## Problem

The OAuth2/OIDC discovery documents answered `200` to `GET` and `404` to `HEAD`.

The routes were registered with `@router.get`, and FastAPI — unlike Starlette's own `Route` — does not add `HEAD` to a `GET` route implicitly. What makes the symptom a `404` rather than the `405` you would expect is the SPA mount: Starlette records a method mismatch as a *partial* match and keeps scanning, `Mount("/")` then matches *fully* on any method and wins, so the partial's `405` is never emitted. `StaticFiles` permits `HEAD`, so the request reaches the fallback in `Static.get_response`, which deliberately re-raises rather than masking a missing `/.well-known/` document (the RFC 8615 comment at `app.py:305`).

The net effect is that a discovery client reads "the method was wrong" as "no such document" — and `404` is exactly the signal MCP/OAuth2 clients use to abandon a candidate URL and move to the next one.

## Fix

Declare `GET` and `HEAD` together on the documents meant to be read rather than acted on:

- `/.well-known/oauth-authorization-server` and `/.well-known/openid-configuration`
- `/.well-known/oauth-protected-resource` and `/.well-known/oauth-protected-resource/mcp`
- `/auth.md`
- the RFC 8414 §3 / RFC 9728 §3.1 path-inserted aliases registered under `PHOENIX_HOST_ROOT_PATH`

The method list lives in one place as `GET_HEAD` in `phoenix/server/utils.py` so the four registration sites cannot drift.

Handlers need no special casing. Uvicorn omits the body for `HEAD` at the protocol layer (`h11_impl.py:506`), and h11 computes the response headers as though the request had been a `GET` — which is what RFC 9110 §9.3.2 asks for (`SHOULD send the same header fields... as it would have sent if the request method had been GET`).

Note that §9.3.2 does not itself require a server to support `HEAD` wherever it supports `GET`; the `MUST` in §9.1 is server-scoped, and a resource may legitimately refuse a method. So serving `HEAD` here is a choice rather than an obligation — a cheap one for small static metadata documents. What is not defensible is the `404`, which asserts the resource does not exist.

## Verification

Against a server running with `PHOENIX_ENABLE_AUTH=true` and `PHOENIX_ENABLE_OAUTH2_AUTHORIZATION_SERVER=true`:

```console
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:6006/.well-known/openid-configuration
200
$ curl -s -o /dev/null -I -w '%{http_code}\n' http://localhost:6006/.well-known/openid-configuration
200
```

`HEAD` now returns the same status and `Content-Type` as `GET` on all of the paths listed above, including the path-inserted aliases under a root path. Existing coverage in `tests/unit/server/test_well_known_path_inserted.py`, `tests/unit/server/api/routers/test_auth_md.py`, and `tests/unit/server/test_oauth2_authorization_server_flag.py` passes unchanged.

## Out of scope

This routing behavior is not unique to the discovery endpoints — every FastAPI `GET` route in the app is shadowed by the SPA mount for `HEAD`. On ordinary paths the fallback serves `index.html`, so `HEAD /healthz` and `HEAD /v1/projects` return `200 text/html` instead of the route's own response. That masking is why the bug surfaced on `/.well-known/*` first: it is the one path prefix where the fallback declines to mask. Filed separately, since addressing it means picking a policy for `HEAD` across the whole API surface.
