### PR TITLE
fix(server): apply IP rate limiting when PHOENIX_HOST_ROOT_PATH is set

### DIFF
--- a/src/phoenix/server/rate_limiters.py
+++ b/src/phoenix/server/rate_limiters.py
@@ -12,6 +12,7 @@ from typing_extensions import ParamSpec
 
 from phoenix.config import get_env_enable_prometheus
 from phoenix.exceptions import PhoenixException
+from phoenix.server.utils import strip_root_path
 
 ParameterSpec = ParamSpec("ParameterSpec")
 GenericType = TypeVar("GenericType")
@@ -448,7 +449,11 @@ def fastapi_ip_rate_limiter(
     rate_limiter: ServerRateLimiter, paths: Iterable[str | re.Pattern[str]] | None = None
 ) -> Callable[[Request], Coroutine[Any, Any, Request]]:
     async def dependency(request: Request) -> Request:
-        if paths is None or any(path_match(request.url.path, path) for path in paths):
+        # Patterns are registered relative to the application mount point, but
+        # under PHOENIX_HOST_ROOT_PATH the request path carries the root-path
+        # prefix — strip it so the gate matches in both deployments.
+        request_path = strip_root_path(request.scope, request.url.path)
+        if paths is None or any(path_match(request_path, path) for path in paths):
             client = request.client
             if client:  # bypasses rate limiter if no client
                 client_ip = client.host

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -345,6 +345,8 @@ async def patch_grpc_server() -> AsyncIterator[None]:
 
 
 class TestBulkInserter(BulkInserter):
+    __test__ = False
+
     async def __aenter__(
         self,
     ) -> tuple[

--- a/tests/unit/server/test_oauth2_rate_limiter_wiring.py
+++ b/tests/unit/server/test_oauth2_rate_limiter_wiring.py
@@ -1,0 +1,67 @@
+"""End-to-end wiring check for the OAuth2 rate limiters.
+
+The unit tests in test_rate_limiters.py exercise the limiter dependency in
+isolation; these tests send a real request through the app to verify that the
+dependency is attached to the OAuth2 authorization-server routes and that its
+path gate matches both at the domain root and under a root path.
+
+ServerRateLimiter.make_request is patched to signal exhaustion rather than
+consuming real tokens: the module-level token buckets in
+oauth2_authorization_server.py live for the whole test session, so draining
+them here could starve unrelated tests in the same worker.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import AsyncIterator
+from unittest import mock
+
+import httpx
+import pytest
+from asgi_lifespan import LifespanManager
+from pydantic import SecretStr
+from starlette.types import ASGIApp
+
+from phoenix.server.app import create_app
+from phoenix.server.rate_limiters import ServerRateLimiter, UnavailableTokensError
+from phoenix.server.types import DbSessionFactory
+from tests.unit.conftest import TestBulkInserter, patch_grpc_server
+
+
+@contextlib.asynccontextmanager
+async def _auth_app(db: DbSessionFactory) -> AsyncIterator[ASGIApp]:
+    async with contextlib.AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_grpc_server())
+        app = create_app(
+            db=db,
+            authentication_enabled=True,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+            secret=SecretStr("test-secret-at-least-32-chars-long!!"),
+        )
+        manager = await stack.enter_async_context(LifespanManager(app))
+        yield manager.app
+
+
+@pytest.mark.parametrize(
+    "root_path",
+    [
+        pytest.param("", id="at-domain-root"),
+        pytest.param("/phoenix", id="under-root-path"),
+    ],
+)
+async def test_oauth2_register_consults_rate_limiter(
+    root_path: str,
+    db: DbSessionFactory,
+) -> None:
+    async with _auth_app(db) as app:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app, root_path=root_path),
+            base_url="http://test",
+        ) as client:
+            with mock.patch.object(
+                ServerRateLimiter, "make_request", side_effect=UnavailableTokensError
+            ):
+                response = await client.post(f"{root_path}/oauth2/register", json={})
+    assert response.status_code == 429

--- a/tests/unit/server/test_rate_limiters.py
+++ b/tests/unit/server/test_rate_limiters.py
@@ -7,6 +7,7 @@ from typing import Optional
 from unittest import mock
 
 import pytest
+from fastapi import HTTPException, Request
 
 from phoenix.server.rate_limiters import (
     AdaptiveTokenBucket,
@@ -15,6 +16,7 @@ from phoenix.server.rate_limiters import (
     ServerRateLimiter,
     TokenBucket,
     UnavailableTokensError,
+    fastapi_ip_rate_limiter,
 )
 
 
@@ -526,6 +528,78 @@ def test_rate_limiter_caches_token_buckets() -> None:
         assert token_bucket.available_tokens() == 7.5
         limiter.make_request("test_key")
         assert token_bucket.tokens == 6.5
+
+
+# --- fastapi_ip_rate_limiter tests ---
+
+
+def _build_request(path: str, root_path: str = "") -> Request:
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "root_path": root_path,
+        "query_string": b"",
+        "headers": [],
+        "client": ("192.0.2.1", 50000),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+def _single_token_server_rate_limiter() -> ServerRateLimiter:
+    return ServerRateLimiter(
+        per_second_rate_limit=0.1,
+        enforcement_window_seconds=10,
+        partition_seconds=60,
+        active_partitions=2,
+    )
+
+
+@pytest.mark.parametrize(
+    "path,root_path",
+    [
+        pytest.param("/oauth2/register", "", id="at-domain-root"),
+        # Under PHOENIX_HOST_ROOT_PATH the request path carries the root-path
+        # prefix, which an exact match against the registered pattern would
+        # silently miss, disabling rate limiting.
+        pytest.param("/phoenix/oauth2/register", "/phoenix", id="under-root-path"),
+    ],
+)
+async def test_fastapi_ip_rate_limiter_limits_matching_path(path: str, root_path: str) -> None:
+    with freeze_time():
+        dependency = fastapi_ip_rate_limiter(
+            _single_token_server_rate_limiter(), paths=["/oauth2/register"]
+        )
+        request = _build_request(path, root_path=root_path)
+        await dependency(request)
+        with pytest.raises(HTTPException) as exc_info:
+            await dependency(request)
+        assert exc_info.value.status_code == 429
+
+
+async def test_fastapi_ip_rate_limiter_ignores_non_matching_path() -> None:
+    with freeze_time():
+        dependency = fastapi_ip_rate_limiter(
+            _single_token_server_rate_limiter(), paths=["/oauth2/register"]
+        )
+        request = _build_request("/phoenix/healthz", root_path="/phoenix")
+        for _ in range(5):
+            await dependency(request)
+
+
+async def test_fastapi_ip_rate_limiter_does_not_match_root_path_prefixed_pattern_at_root() -> None:
+    # A deployment at the domain root must not rate-limit a path that merely
+    # looks like a root-path-prefixed variant of a registered pattern.
+    with freeze_time():
+        dependency = fastapi_ip_rate_limiter(
+            _single_token_server_rate_limiter(), paths=["/oauth2/register"]
+        )
+        request = _build_request("/phoenix/oauth2/register")
+        for _ in range(5):
+            await dependency(request)
 
 
 # --- BruteForceLoginRateLimiter tests ---


### PR DESCRIPTION
Fixes #14610

## Problem

`fastapi_ip_rate_limiter` gates on an exact string match between `request.url.path` and the registered patterns. The patterns are written relative to the application mount point (`/oauth2/token`, `/oauth2/revoke`, `/oauth2/register`, and the `/auth/*` login paths), but when `PHOENIX_HOST_ROOT_PATH` is set the ASGI scope path carries the root-path prefix (for example `/phoenix/oauth2/register`). The exact-equality check never matched, the dependency short-circuited, and the token bucket was never consulted — so the OAuth2 authorization-server endpoints and the login endpoints accepted unlimited requests on any deployment served under a sub-path. Deployments at the domain root were unaffected.

## Fix

Strip the root path from the request path before matching, using the existing `strip_root_path` helper. The helper returns paths without the prefix unchanged, so behavior at the domain root is identical, and it also degrades safely in the proxy-strips-the-prefix topology. Fixing the shared dependency covers both affected call sites (the OAuth2 authorization-server limiters and the `/auth/*` login limiter) at once.

## Tests

- Unit tests for the dependency's path gate: the limiter returns 429 after the burst both at the domain root and under a root path, ignores non-matching paths, and does not suffix-match a prefixed-looking path on a root deployment.
- An app-level wiring test (`test_oauth2_rate_limiter_wiring.py`) that sends a real request through `create_app` via `httpx.ASGITransport(root_path=...)` and asserts a 429, proving the dependency is attached to the route and the gate matches in both topologies. `ServerRateLimiter.make_request` is patched to signal exhaustion so the session-lived module-level buckets are not drained. The under-root-path case fails against the unfixed code.
- `tests/unit/conftest.py`: `TestBulkInserter` gains `__test__ = False` so pytest no longer warns about collecting the `Test`-prefixed helper class in modules that import it.

## Verification

Verified live in both topologies against the docker devops stack (Traefik at a sub-path with `PHOENIX_HOST_ROOT_PATH=/phoenix`) and a bare `phoenix serve --dev` instance at the domain root. In both cases `/oauth2/token` allowed exactly its burst of 12 before returning 429, and `/oauth2/register` allowed exactly its burst of 10 before returning 429, with `rate_limiter_throttles_total` advancing accordingly.

The issue's secondary observation (buckets keyed on `request.client.host`, which is the proxy address behind a reverse proxy) is intentionally out of scope, to be tracked separately.