### PR TITLE
feat(pytest): evaluator trace isolation and experiment metadata for the pytest plugin

### DIFF
--- a/docs/phoenix/datasets-and-experiments/how-to-experiments/eval-ci-with-pytest.mdx
+++ b/docs/phoenix/datasets-and-experiments/how-to-experiments/eval-ci-with-pytest.mdx
@@ -74,13 +74,19 @@ experiments over a fixed set of examples rather than creating duplicates.
 
 ### The Marker
 
-`@pytest.mark.phoenix` accepts three optional keyword arguments:
+`@pytest.mark.phoenix` accepts six optional keyword arguments:
 
 <Tabs>
 <Tab title="Python" icon="python">
 ```python
 @pytest.mark.phoenix(
     dataset="qa-suite",
+    dataset_description="Customer support regression cases",
+    experiment_description="GPT-4.1 with a lower temperature",
+    experiment_metadata={
+        "model": "gpt-4.1",
+        "parameters": {"temperature": 0.2},
+    },
     evaluators=[correctness],
     repetitions=3,
 )
@@ -95,6 +101,12 @@ def test_answers(question, expected): ...
   files that share a basename never collide. The full precedence is `PHOENIX_TEST_DATASET`
   (environment) > `phoenix_dataset` (`pytest.ini`) > this `dataset=` kwarg > the file-path
   default.
+- **`dataset_description`** sets the description stored on the Phoenix dataset.
+- **`experiment_description`** sets the description stored on the Phoenix experiment.
+- **`experiment_metadata`** stores a free-form mapping on the experiment. Use it to record the
+  model and invocation parameters that distinguish one run from another. The plugin adds the
+  current Git commit as `git_sha` when available; an explicit `git_sha` in this mapping takes
+  precedence.
 - **`evaluators`** is a list of evaluators that run automatically against every case.
   Each evaluator's score is recorded as an annotation alongside the `pass` annotation,
   and a failing evaluator never fails the test itself.
@@ -103,6 +115,9 @@ def test_answers(question, expected): ...
   (visible to `-k`, `pytest-xdist`, and your IDE) and recorded as a distinct run against
   the same example. A per-test value takes precedence over the `PHOENIX_TEST_REPETITIONS`
   environment variable.
+
+Tests that resolve to the same dataset must use matching non-empty descriptions and experiment
+metadata.
 
 ## Logging Outputs
 

--- a/docs/phoenix/evaluation/integrations/pytest.mdx
+++ b/docs/phoenix/evaluation/integrations/pytest.mdx
@@ -113,6 +113,12 @@ The marker is what tells the plugin which tests to record. Tests without it run 
 ```python
 @pytest.mark.phoenix(
     dataset="my-eval-suite",
+    dataset_description="Customer support regression cases",
+    experiment_description="GPT-4.1 with a lower temperature",
+    experiment_metadata={
+        "model": "gpt-4.1",
+        "parameters": {"temperature": 0.2},
+    },
     evaluators=[correctness_evaluator],
     repetitions=3,
 )
@@ -122,8 +128,13 @@ def test_my_feature(input, expected): ...
 | Argument | Description |
 |---|---|
 | `dataset` | Name of the Phoenix dataset and experiment. Defaults to the test file's relative path when omitted. |
+| `dataset_description` | Description stored on the Phoenix dataset. |
+| `experiment_description` | Description stored on the Phoenix experiment. |
+| `experiment_metadata` | Metadata stored on the experiment, such as the model and invocation parameters. |
 | `evaluators` | List of evaluators that run automatically against every case. |
 | `repetitions` | Run each case this many times to measure non-determinism. |
+
+Tests that resolve to the same dataset must use matching non-empty descriptions and experiment metadata. The plugin also adds the current Git commit as `git_sha` when it runs inside a Git checkout. Set `git_sha` in `experiment_metadata` to record a different revision, such as the commit supplied by your CI environment.
 
 ### Dataset naming
 

--- a/evals/pxi/harness/agent_task.py
+++ b/evals/pxi/harness/agent_task.py
@@ -61,6 +61,7 @@ class _NoOpEventQueue:
 
 DEFAULT_ASSISTANT_PROVIDER = "OPENAI"
 DEFAULT_ASSISTANT_MODEL = "gpt-5.4"
+DEFAULT_ASSISTANT_OPENAI_API_TYPE = "responses"
 DEFAULT_PROJECT_NODE_ID = "UHJvamVjdDox"
 ENV_ASSISTANT_PROVIDER = "PHOENIX_AGENTS_ASSISTANT_PROVIDER"
 ENV_ASSISTANT_MODEL = "PHOENIX_AGENTS_ASSISTANT_MODEL"
@@ -129,7 +130,7 @@ def _warn_placeholder_api_key(provider: str, base_url: str) -> None:
 async def _build_model() -> PydanticAIModel:
     provider = os.getenv(ENV_ASSISTANT_PROVIDER, DEFAULT_ASSISTANT_PROVIDER).upper()
     model_name = os.getenv(ENV_ASSISTANT_MODEL, DEFAULT_ASSISTANT_MODEL)
-    openai_api_type = os.getenv(ENV_ASSISTANT_OPENAI_API_TYPE, "responses")
+    openai_api_type = os.getenv(ENV_ASSISTANT_OPENAI_API_TYPE, DEFAULT_ASSISTANT_OPENAI_API_TYPE)
     if openai_api_type not in ("chat_completions", "responses"):
         raise RuntimeError(f"Unsupported {ENV_ASSISTANT_OPENAI_API_TYPE}: {openai_api_type}")
     typed_openai_api_type = cast(Literal["chat_completions", "responses"], openai_api_type)

--- a/evals/pxi/tests/test_pxi_evals.py
+++ b/evals/pxi/tests/test_pxi_evals.py
@@ -12,16 +12,27 @@ never assert -- ``gate.py`` decides pass/fail from the aggregated artifact.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from typing import Any
 
 import pytest
 
 from evals.pxi.evaluators import EVALUATORS_BY_NAME
-from evals.pxi.harness.agent_task import run_pxi_example
+from evals.pxi.harness.agent_task import (
+    DEFAULT_ASSISTANT_MODEL,
+    DEFAULT_ASSISTANT_OPENAI_API_TYPE,
+    DEFAULT_ASSISTANT_PROVIDER,
+    ENV_ASSISTANT_MODEL,
+    ENV_ASSISTANT_OPENAI_API_TYPE,
+    ENV_ASSISTANT_PROVIDER,
+    run_pxi_example,
+)
 from evals.pxi.harness.datasets import DATASETS_DIR, load_dataset
 from evals.pxi.harness.reporting import PASSING_SCORE
 from phoenix.client.pytest import evaluate, log_output
+
+EXPERIMENT_DESCRIPTION = "PXI behavioral regression evaluation run."
 
 
 @dataclass(frozen=True)
@@ -38,6 +49,13 @@ def _load_cases() -> list[Any]:
     cases: list[Any] = []
     for path in sorted(DATASETS_DIR.glob("*.yaml")):
         dataset = load_dataset(path)
+        experiment_metadata = {
+            "model": os.getenv(ENV_ASSISTANT_MODEL, DEFAULT_ASSISTANT_MODEL),
+            "provider": os.getenv(ENV_ASSISTANT_PROVIDER, DEFAULT_ASSISTANT_PROVIDER).upper(),
+            "openai_api_type": os.getenv(
+                ENV_ASSISTANT_OPENAI_API_TYPE, DEFAULT_ASSISTANT_OPENAI_API_TYPE
+            ),
+        }
         for example in dataset.examples:
             split = str(example["splits"][0])
             case = EvalCase(
@@ -60,7 +78,12 @@ def _load_cases() -> list[Any]:
                     # the repetition axis before parametrization exists -- a
                     # per-example repetitions kwarg would be silently ignored.
                     marks=[
-                        pytest.mark.phoenix(dataset=dataset.dataset_name),
+                        pytest.mark.phoenix(
+                            dataset=dataset.dataset_name,
+                            dataset_description=dataset.description,
+                            experiment_description=EXPERIMENT_DESCRIPTION,
+                            experiment_metadata=experiment_metadata,
+                        ),
                         getattr(pytest.mark, split),
                     ],
                     # Namespaced so example ids stay globally unique across

--- a/packages/phoenix-client/src/phoenix/client/pytest/plugin.py
+++ b/packages/phoenix-client/src/phoenix/client/pytest/plugin.py
@@ -179,18 +179,23 @@ def pytest_collection_modifyitems(
         external_id = stable_external_id(item)
         marker = item.get_closest_marker(MARKER_NAME)
         reps = resolve_repetitions(marker, env_default=cfg.repetitions)
-        marker_kwargs = marker.kwargs if marker is not None else {}
-        experiment_metadata = marker_kwargs.get("experiment_metadata")
-        if experiment_metadata is not None and not isinstance(experiment_metadata, Mapping):
+        marker_kwargs: Mapping[str, Any] = marker.kwargs if marker is not None else {}
+        dataset_description: Optional[str] = marker_kwargs.get("dataset_description")
+        experiment_description: Optional[str] = marker_kwargs.get("experiment_description")
+        experiment_metadata_value = marker_kwargs.get("experiment_metadata")
+        if experiment_metadata_value is not None and not isinstance(
+            experiment_metadata_value, Mapping
+        ):
             raise pytest.UsageError("phoenix marker experiment_metadata must be a mapping")
+        experiment_metadata: Optional[Mapping[str, Any]] = experiment_metadata_value
         try:
             state.register_item(
                 item,
                 dataset_name=dataset_name,
                 external_id=external_id,
                 repetitions=reps,
-                dataset_description=marker_kwargs.get("dataset_description"),
-                experiment_description=marker_kwargs.get("experiment_description"),
+                dataset_description=dataset_description,
+                experiment_description=experiment_description,
                 experiment_metadata=(
                     dict(experiment_metadata) if experiment_metadata is not None else None
                 ),

--- a/packages/phoenix-client/src/phoenix/client/pytest/plugin.py
+++ b/packages/phoenix-client/src/phoenix/client/pytest/plugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -83,7 +84,9 @@ def pytest_addoption(parser: "Parser") -> None:
 def pytest_configure(config: "Config") -> None:
     config.addinivalue_line(
         "markers",
-        "phoenix(dataset=None, evaluators=None): record this test as a Phoenix experiment run.",
+        "phoenix(dataset=None, dataset_description=None, experiment_description=None, "
+        "experiment_metadata=None, evaluators=None, repetitions=None): record this test as a "
+        "Phoenix experiment run.",
     )
 
 
@@ -170,16 +173,30 @@ def pytest_collection_modifyitems(
 
     partial = _is_partial_collection(session, config)
 
-    state = SuiteState(config=cfg, partial_collection=partial)
+    state = SuiteState(config=cfg, partial_collection=partial, rootpath=config.rootpath)
     for item in phoenix_items:
         dataset_name = resolve_dataset_name(item, override=cfg.dataset_override)
         external_id = stable_external_id(item)
-        reps = resolve_repetitions(
-            item.get_closest_marker(MARKER_NAME), env_default=cfg.repetitions
-        )
-        state.register_item(
-            item, dataset_name=dataset_name, external_id=external_id, repetitions=reps
-        )
+        marker = item.get_closest_marker(MARKER_NAME)
+        reps = resolve_repetitions(marker, env_default=cfg.repetitions)
+        marker_kwargs = marker.kwargs if marker is not None else {}
+        experiment_metadata = marker_kwargs.get("experiment_metadata")
+        if experiment_metadata is not None and not isinstance(experiment_metadata, Mapping):
+            raise pytest.UsageError("phoenix marker experiment_metadata must be a mapping")
+        try:
+            state.register_item(
+                item,
+                dataset_name=dataset_name,
+                external_id=external_id,
+                repetitions=reps,
+                dataset_description=marker_kwargs.get("dataset_description"),
+                experiment_description=marker_kwargs.get("experiment_description"),
+                experiment_metadata=(
+                    dict(experiment_metadata) if experiment_metadata is not None else None
+                ),
+            )
+        except ValueError as e:
+            raise pytest.UsageError(str(e)) from e
 
     config.stash[_STATE_KEY] = state
 

--- a/packages/phoenix-client/src/phoenix/client/pytest/plugin.py
+++ b/packages/phoenix-client/src/phoenix/client/pytest/plugin.py
@@ -469,6 +469,12 @@ def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: "Con
         write(state.summary_line())
 
 
+def pytest_unconfigure(config: "Config") -> None:
+    state = _get_state(config)
+    if state is not None:
+        state.close_tracing()
+
+
 def _chain_input(item: "Item") -> dict[str, Any]:
     """The CHAIN span input: the test's parametrized fields, or its nodeid when unparametrized."""
     callspec = getattr(item, "callspec", None)

--- a/packages/phoenix-client/src/phoenix/client/pytest/session.py
+++ b/packages/phoenix-client/src/phoenix/client/pytest/session.py
@@ -7,6 +7,10 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from httpx import HTTPStatusError
 
+from phoenix.client.resources.experiments import (
+    _TracerBundle,  # pyright: ignore[reportPrivateUsage]
+)
+
 from .config import PhoenixTestConfig
 from .context import (
     _annotator_kind_for,  # pyright: ignore[reportPrivateUsage]
@@ -16,7 +20,13 @@ from .context import (
     _RunRecord,  # pyright: ignore[reportPrivateUsage]
 )
 from .marker import REPETITION_PARAM, resolve_evaluators
-from .tracing import SpanHandle, SuiteTracer, build_suite_tracer
+from .tracing import (
+    SpanHandle,
+    SuiteTracer,
+    build_evaluator_bundle,
+    build_noop_suite_tracer,
+    build_suite_tracer,
+)
 
 if TYPE_CHECKING:
     from _pytest.nodes import Item
@@ -70,6 +80,10 @@ class SuiteState:
         self._bootstrap_error: Optional[Exception] = None
         self._bootstrapped = False
         self._tracers: dict[str, SuiteTracer] = {}
+        self._offline_tracer = build_noop_suite_tracer() if config.offline else None
+        self._evaluator_bundle: Optional[_TracerBundle] = None
+        self._owned_bundles: list[_TracerBundle] = []
+        self._tracing_closed = False
 
     def register_item(
         self, item: "Item", *, dataset_name: str, external_id: str, repetitions: int = 1
@@ -107,12 +121,25 @@ class SuiteState:
         if self.config.offline:
             return
         base_url, headers = self._tracer_endpoint()
+        if self._evaluator_bundle is None:
+            self._evaluator_bundle = build_evaluator_bundle(base_url=base_url, headers=headers)
+            if self._evaluator_bundle is not None:
+                self._owned_bundles.append(self._evaluator_bundle)
+        evaluator_bundle = self._evaluator_bundle
+        mount_evaluator_provider = evaluator_bundle is not None
+        if evaluator_bundle is None:
+            evaluator_bundle = build_noop_suite_tracer().evaluator_bundle
         for group in self._groups.values():
             tracer = build_suite_tracer(
-                project_name=group.project_name, base_url=base_url, headers=headers
+                project_name=group.project_name,
+                base_url=base_url,
+                headers=headers,
+                evaluator_bundle=evaluator_bundle,
+                mount_evaluator_provider=mount_evaluator_provider,
             )
             if tracer is not None:
                 self._tracers[group.name] = tracer
+                self._owned_bundles.append(tracer.task_bundle)
 
     def _tracer_endpoint(self) -> tuple[Optional[str], Optional[dict[str, str]]]:
         http_client = getattr(self._client, "_client", None)
@@ -121,7 +148,29 @@ class SuiteState:
         return str(http_client.base_url), dict(http_client.headers)
 
     def tracer_for(self, dataset_name: str) -> Optional[SuiteTracer]:
+        if self.config.offline:
+            return self._offline_tracer
         return self._tracers.get(dataset_name)
+
+    def close_tracing(self) -> None:
+        if self._tracing_closed:
+            return
+        self._tracing_closed = True
+        seen: set[int] = set()
+        for bundle in self._owned_bundles:
+            provider = bundle.provider
+            if id(provider) in seen:
+                continue
+            seen.add(id(provider))
+            try:
+                provider.force_flush()
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Phoenix plugin: failed to flush tracing: %s", e)
+            finally:
+                try:
+                    provider.shutdown()
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("Phoenix plugin: failed to shut down tracing: %s", e)
 
     def project_name_for(self, dataset_name: str) -> Optional[str]:
         group = self._groups.get(dataset_name)

--- a/packages/phoenix-client/src/phoenix/client/pytest/session.py
+++ b/packages/phoenix-client/src/phoenix/client/pytest/session.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
+import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from httpx import HTTPStatusError
@@ -47,6 +49,9 @@ class DatasetGroup:
     """All marked items resolving to one dataset name -> one dataset + one experiment."""
 
     name: str
+    dataset_description: Optional[str] = None
+    experiment_description: Optional[str] = None
+    experiment_metadata: Optional[dict[str, Any]] = None
     bindings: dict[str, ItemBinding] = field(default_factory=dict)
     dataset_id: Optional[str] = None
     dataset_version_id: Optional[str] = None
@@ -68,8 +73,40 @@ class RecordedRun:
     evaluations: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
+def _merge_group_value(group: DatasetGroup, field_name: str, value: Any) -> None:
+    if not value:
+        return
+    current = getattr(group, field_name)
+    if current is not None and current != value:
+        raise ValueError(f"Conflicting {field_name} values for Phoenix dataset {group.name!r}")
+    setattr(group, field_name, dict(value) if field_name == "experiment_metadata" else value)
+
+
+def _detect_git_sha(rootpath: Optional[Path]) -> Optional[str]:
+    if rootpath is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=rootpath,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
 class SuiteState:
-    def __init__(self, *, config: PhoenixTestConfig, partial_collection: bool) -> None:
+    def __init__(
+        self,
+        *,
+        config: PhoenixTestConfig,
+        partial_collection: bool,
+        rootpath: Optional[Path] = None,
+    ) -> None:
         self.config = config
         self.partial_collection = partial_collection
         self._groups: dict[str, DatasetGroup] = {}
@@ -84,11 +121,24 @@ class SuiteState:
         self._evaluator_bundle: Optional[_TracerBundle] = None
         self._owned_bundles: list[_TracerBundle] = []
         self._tracing_closed = False
+        self._rootpath = rootpath
+        self._git_sha: Optional[str] = None
 
     def register_item(
-        self, item: "Item", *, dataset_name: str, external_id: str, repetitions: int = 1
+        self,
+        item: "Item",
+        *,
+        dataset_name: str,
+        external_id: str,
+        repetitions: int = 1,
+        dataset_description: Optional[str] = None,
+        experiment_description: Optional[str] = None,
+        experiment_metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         group = self._groups.setdefault(dataset_name, DatasetGroup(name=dataset_name))
+        _merge_group_value(group, "dataset_description", dataset_description)
+        _merge_group_value(group, "experiment_description", experiment_description)
+        _merge_group_value(group, "experiment_metadata", experiment_metadata)
         group.max_repetitions = max(group.max_repetitions, repetitions)
         binding = ItemBinding(
             nodeid=item.nodeid, dataset_name=dataset_name, external_id=external_id
@@ -111,6 +161,7 @@ class SuiteState:
     def bootstrap(self, client: Any, *, pass_annotation: str) -> None:
         self._client = client
         self._bootstrapped = True
+        self._git_sha = _detect_git_sha(self._rootpath)
         for group in self._groups.values():
             self._sync_dataset(group)
             self._resolve_examples(group)
@@ -205,6 +256,7 @@ class SuiteState:
         action = "append" if self.partial_collection else "update"
         dataset = self._client.datasets._upload_json_dataset(  # noqa: SLF001
             dataset_name=group.name,
+            dataset_description=group.dataset_description,
             inputs=inputs,
             outputs=outputs,
             metadata=metadata,
@@ -245,9 +297,14 @@ class SuiteState:
     def _create_experiment(self, group: DatasetGroup) -> None:
         if group.dataset_id is None:
             return
+        experiment_metadata = dict(group.experiment_metadata or {})
+        if self._git_sha:
+            experiment_metadata.setdefault("git_sha", self._git_sha)
         experiment = self._client.experiments.create(
             dataset_id=group.dataset_id,
             dataset_version_id=group.dataset_version_id,
+            experiment_description=group.experiment_description,
+            experiment_metadata=experiment_metadata or None,
             repetitions=group.max_repetitions,
         )
         group.experiment_id = experiment["id"]

--- a/packages/phoenix-client/src/phoenix/client/pytest/tracing.py
+++ b/packages/phoenix-client/src/phoenix/client/pytest/tracing.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, contextmanager, nullcontext
 from dataclasses import dataclass
-from typing import Any, Callable, Iterator, Optional
+from typing import Any, Callable, ContextManager, Iterator, Optional
 
 from opentelemetry.context import Context
 from opentelemetry.trace import Status, StatusCode
@@ -18,8 +18,11 @@ from phoenix.client.resources.experiments import (
     OPENINFERENCE_SPAN_KIND,
     OUTPUT_MIME_TYPE,
     OUTPUT_VALUE,
-    _get_tracer,  # pyright: ignore[reportPrivateUsage]
+    _attach_global_tracer_provider,  # pyright: ignore[reportPrivateUsage]
+    _get_noop_tracer_bundle,  # pyright: ignore[reportPrivateUsage]
+    _get_tracer_bundle,  # pyright: ignore[reportPrivateUsage]
     _str_trace_id,  # pyright: ignore[reportPrivateUsage]
+    _TracerBundle,  # pyright: ignore[reportPrivateUsage]
     capture_spans,
 )
 
@@ -50,10 +53,19 @@ class SpanHandle:
 
 @dataclass
 class SuiteTracer:
-    """Process-local OpenInference tracer for one pytest worker, plus its project resource."""
+    """Task and evaluator tracing pipelines for one pytest worker."""
 
-    tracer: Any
-    resource: Any
+    task_bundle: _TracerBundle
+    evaluator_bundle: _TracerBundle
+    mount_evaluator_provider: bool = True
+
+    @property
+    def tracer(self) -> Any:
+        return self.task_bundle.tracer
+
+    @property
+    def resource(self) -> Any:
+        return self.task_bundle.resource
 
     @contextmanager
     def chain_span(
@@ -69,24 +81,43 @@ class SuiteTracer:
         close: pytest's ``hookwrapper`` captures a failing test's exception into the call
         outcome instead of raising it through the ``yield``, so the body never propagates it
         here — ``error_getter`` is how the span learns the test failed."""
-        with self._span(name, CHAIN, input_value, output_getter, error_getter) as handle:
+        with self._span(
+            self.task_bundle, name, CHAIN, input_value, output_getter, error_getter
+        ) as handle:
             yield handle
 
     @contextmanager
     def evaluator_span(self, name: str, *, input_value: Any) -> Iterator[SpanHandle]:
         """Open an EVALUATOR span around a genuine evaluator invocation. The evaluator is a
         direct call, so a failure propagates through the body and needs no ``error_getter``."""
-        with self._span(name, EVALUATOR, input_value, None, None) as handle:
-            yield handle
+        attachment: ContextManager[None] = (
+            _attach_global_tracer_provider(self.evaluator_bundle.provider)
+            if self.mount_evaluator_provider
+            else nullcontext()
+        )
+        with attachment:
+            with self._span(
+                self.evaluator_bundle,
+                name,
+                EVALUATOR,
+                input_value,
+                None,
+                None,
+                flush_provider=True,
+            ) as handle:
+                yield handle
 
     @contextmanager
     def _span(
         self,
+        bundle: _TracerBundle,
         name: str,
         span_kind: str,
         input_value: Any,
         output_getter: Optional[Callable[[], Any]],
         error_getter: Optional[Callable[[], Optional[BaseException]]],
+        *,
+        flush_provider: bool = False,
     ) -> Iterator[SpanHandle]:
         """Run the body inside a span, swallowing every tracing error so the body always runs
         and its own exception (if any) propagates. The body yields exactly once regardless.
@@ -98,8 +129,8 @@ class SuiteTracer:
         stack = ExitStack()
         span: Any = None
         try:
-            stack.enter_context(capture_spans(self.resource))
-            span = stack.enter_context(self.tracer.start_as_current_span(name, context=Context()))
+            stack.enter_context(capture_spans(bundle.resource))
+            span = stack.enter_context(bundle.tracer.start_as_current_span(name, context=Context()))
         except Exception as e:  # noqa: BLE001
             _warn_degraded(repr(e))
 
@@ -128,6 +159,9 @@ class SuiteTracer:
                         )
                     else:
                         span.set_status(Status(StatusCode.OK))
+            except Exception as e:  # noqa: BLE001
+                _warn_degraded(repr(e))
+            try:
                 stack.close()
                 if span is not None:
                     span_context = span.get_span_context()
@@ -135,10 +169,22 @@ class SuiteTracer:
                         handle.trace_id = _str_trace_id(span_context.trace_id)
             except Exception as e:  # noqa: BLE001
                 _warn_degraded(repr(e))
+            if flush_provider:
+                try:
+                    force_flush = getattr(bundle.provider, "force_flush", None)
+                    if force_flush is not None:
+                        force_flush()
+                except Exception as e:  # noqa: BLE001
+                    _warn_degraded(repr(e))
 
 
 def build_suite_tracer(
-    *, project_name: Optional[str], base_url: Optional[str], headers: Optional[dict[str, str]]
+    *,
+    project_name: Optional[str],
+    base_url: Optional[str],
+    headers: Optional[dict[str, str]],
+    evaluator_bundle: Optional[_TracerBundle] = None,
+    mount_evaluator_provider: bool = True,
 ) -> Optional[SuiteTracer]:
     """Build a process-local, non-global tracer via the experiments-runner helper.
 
@@ -148,11 +194,36 @@ def build_suite_tracer(
     if not project_name:
         return None
     try:
-        tracer, resource = _get_tracer(project_name, base_url, headers)
+        task_bundle = _get_tracer_bundle(project_name, base_url, headers)
+        if evaluator_bundle is None:
+            evaluator_bundle = _get_tracer_bundle("evaluators", base_url, headers)
     except Exception as e:  # noqa: BLE001
         _warn_degraded(repr(e))
         return None
-    return SuiteTracer(tracer=tracer, resource=resource)
+    return SuiteTracer(
+        task_bundle=task_bundle,
+        evaluator_bundle=evaluator_bundle,
+        mount_evaluator_provider=mount_evaluator_provider,
+    )
+
+
+def build_evaluator_bundle(
+    *, base_url: Optional[str], headers: Optional[dict[str, str]]
+) -> Optional[_TracerBundle]:
+    try:
+        return _get_tracer_bundle("evaluators", base_url, headers)
+    except Exception as e:  # noqa: BLE001
+        _warn_degraded(repr(e))
+        return None
+
+
+def build_noop_suite_tracer() -> SuiteTracer:
+    bundle = _get_noop_tracer_bundle()
+    return SuiteTracer(
+        task_bundle=bundle,
+        evaluator_bundle=bundle,
+        mount_evaluator_provider=False,
+    )
 
 
 def _set_io(span: Any, input_value: Any, output_value: Any) -> None:

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -40,6 +40,9 @@ from opentelemetry.trace import (
     StatusCode,
     Tracer,
 )
+from opentelemetry.util._decorator import (  # pyright: ignore[reportPrivateUsage]
+    _agnosticcontextmanager,
+)
 
 from phoenix.client.__generated__ import v1
 from phoenix.client.resources.datasets import Dataset
@@ -160,19 +163,74 @@ class _TracerBundle:
 
 
 _GLOBAL_TRACER_PROVIDER_LOCK = RLock()
+_evaluator_provider_mount_count = 0
+
+
+class _EvaluatorRoutingProvider(trace_api.TracerProvider):
+    def __init__(self, evaluator_provider: Any) -> None:
+        self._evaluator_provider = evaluator_provider
+
+    def get_tracer(
+        self,
+        instrumenting_module_name: str,
+        instrumenting_library_version: Optional[str] = None,
+        schema_url: Optional[str] = None,
+        attributes: Optional[Mapping[str, Any]] = None,
+    ) -> Tracer:
+        return _RoutingTracer(
+            self,
+            (
+                instrumenting_module_name,
+                instrumenting_library_version,
+                schema_url,
+                attributes,
+            ),
+        )
+
+
+class _RoutingTracer(Tracer):
+    def __init__(
+        self,
+        routing_provider: _EvaluatorRoutingProvider,
+        get_tracer_args: tuple[str, Optional[str], Optional[str], Optional[Mapping[str, Any]]],
+    ) -> None:
+        self._routing_provider = routing_provider
+        self._get_tracer_args = get_tracer_args
+
+    def _delegate(self) -> Tracer:
+        if _evaluator_provider_mount_count:
+            provider = self._routing_provider._evaluator_provider
+        else:
+            provider = trace_api._TRACER_PROVIDER  # pyright: ignore[reportPrivateUsage]
+            if provider is None or provider is self._routing_provider:
+                return NoOpTracerProvider().get_tracer(*self._get_tracer_args)
+        return cast(Tracer, provider.get_tracer(*self._get_tracer_args))
+
+    def start_span(self, *args: Any, **kwargs: Any) -> trace_api.Span:
+        return self._delegate().start_span(*args, **kwargs)
+
+    @_agnosticcontextmanager
+    def start_as_current_span(self, *args: Any, **kwargs: Any) -> Iterator[trace_api.Span]:
+        with self._delegate().start_as_current_span(*args, **kwargs) as span:
+            yield span
 
 
 @contextmanager
 def _attach_global_tracer_provider(provider: Any) -> Iterator[None]:
     """Temporarily mount a provider while preserving OpenTelemetry's exact prior state."""
-    # OpenTelemetry's public setter is one-shot and has no matching restore operation.
+    global _evaluator_provider_mount_count
+
+    routing_provider = _EvaluatorRoutingProvider(provider)
     with _GLOBAL_TRACER_PROVIDER_LOCK:
         previous = trace_api._TRACER_PROVIDER  # pyright: ignore[reportPrivateUsage]
-        trace_api._TRACER_PROVIDER = provider  # pyright: ignore[reportPrivateUsage]
+        _evaluator_provider_mount_count += 1
+        # ProxyTracer caches its first real tracer, so the mounted tracer must route each emission.
+        trace_api._TRACER_PROVIDER = routing_provider  # pyright: ignore[reportPrivateUsage]
         try:
             yield
         finally:
             trace_api._TRACER_PROVIDER = previous  # pyright: ignore[reportPrivateUsage]
+            _evaluator_provider_mount_count -= 1
 
 
 INPUT_VALUE = SpanAttributes.INPUT_VALUE

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -10,15 +10,16 @@ from binascii import hexlify
 from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
 from contextlib import ExitStack, contextmanager
 from contextvars import ContextVar
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from itertools import product
-from threading import Lock
+from threading import Lock, RLock
 from typing import Any, Literal, Optional, Union, cast
 from urllib.parse import urljoin
 
 import httpx
 import opentelemetry.sdk.trace as trace_sdk
+import opentelemetry.trace as trace_api
 from httpx import HTTPStatusError
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.semconv.resource import ResourceAttributes
@@ -32,7 +33,13 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource  # type: ignore[attr-defined, unused-ignore]
 from opentelemetry.sdk.trace import ReadableSpan, Span
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.trace import INVALID_SPAN_ID, Status, StatusCode, Tracer
+from opentelemetry.trace import (
+    INVALID_SPAN_ID,
+    NoOpTracerProvider,
+    Status,
+    StatusCode,
+    Tracer,
+)
 
 from phoenix.client.__generated__ import v1
 from phoenix.client.resources.datasets import Dataset
@@ -145,6 +152,29 @@ class _NoOpProcessor(trace_sdk.SpanProcessor):
         return True
 
 
+@dataclass(frozen=True)
+class _TracerBundle:
+    tracer: Tracer
+    resource: Resource
+    provider: Any
+
+
+_GLOBAL_TRACER_PROVIDER_LOCK = RLock()
+
+
+@contextmanager
+def _attach_global_tracer_provider(provider: Any) -> Iterator[None]:
+    """Temporarily mount a provider while preserving OpenTelemetry's exact prior state."""
+    # OpenTelemetry's public setter is one-shot and has no matching restore operation.
+    with _GLOBAL_TRACER_PROVIDER_LOCK:
+        previous = trace_api._TRACER_PROVIDER  # pyright: ignore[reportPrivateUsage]
+        trace_api._TRACER_PROVIDER = provider  # pyright: ignore[reportPrivateUsage]
+        try:
+            yield
+        finally:
+            trace_api._TRACER_PROVIDER = previous  # pyright: ignore[reportPrivateUsage]
+
+
 INPUT_VALUE = SpanAttributes.INPUT_VALUE
 OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
 INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
@@ -156,11 +186,11 @@ EVALUATOR = OpenInferenceSpanKindValues.EVALUATOR.value
 JSON = OpenInferenceMimeTypeValues.JSON
 
 
-def _get_tracer(
+def _get_tracer_bundle(
     project_name: Optional[str] = None,
     base_url: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
-) -> tuple[Tracer, Resource]:
+) -> _TracerBundle:
     resource = Resource({ResourceAttributes.PROJECT_NAME: project_name} if project_name else {})
     tracer_provider = trace_sdk.TracerProvider(resource=resource)
 
@@ -176,7 +206,30 @@ def _get_tracer(
         span_processor = _NoOpProcessor()
 
     tracer_provider.add_span_processor(span_processor)
-    return OITracer(tracer_provider.get_tracer(__name__), config=TraceConfig()), resource
+    return _TracerBundle(
+        tracer=OITracer(tracer_provider.get_tracer(__name__), config=TraceConfig()),
+        resource=resource,
+        provider=tracer_provider,
+    )
+
+
+def _get_noop_tracer_bundle() -> _TracerBundle:
+    resource = Resource({})
+    provider = NoOpTracerProvider()
+    return _TracerBundle(
+        tracer=OITracer(provider.get_tracer("no-op"), config=TraceConfig()),
+        resource=resource,
+        provider=provider,
+    )
+
+
+def _get_tracer(
+    project_name: Optional[str] = None,
+    base_url: Optional[str] = None,
+    headers: Optional[dict[str, str]] = None,
+) -> tuple[Tracer, Resource]:
+    bundle = _get_tracer_bundle(project_name, base_url, headers)
+    return bundle.tracer, bundle.resource
 
 
 def get_tqdm_progress_bar_formatter(title: str) -> str:

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -40,8 +40,8 @@ from opentelemetry.trace import (
     StatusCode,
     Tracer,
 )
-from opentelemetry.util._decorator import (  # pyright: ignore[reportPrivateUsage]
-    _agnosticcontextmanager,
+from opentelemetry.util._decorator import (
+    _agnosticcontextmanager,  # pyright: ignore[reportPrivateUsage]
 )
 
 from phoenix.client.__generated__ import v1
@@ -168,7 +168,7 @@ _evaluator_provider_mount_count = 0
 
 class _EvaluatorRoutingProvider(trace_api.TracerProvider):
     def __init__(self, evaluator_provider: Any) -> None:
-        self._evaluator_provider = evaluator_provider
+        self.evaluator_provider = evaluator_provider
 
     def get_tracer(
         self,
@@ -199,7 +199,7 @@ class _RoutingTracer(Tracer):
 
     def _delegate(self) -> Tracer:
         if _evaluator_provider_mount_count:
-            provider = self._routing_provider._evaluator_provider
+            provider = self._routing_provider.evaluator_provider
         else:
             provider = trace_api._TRACER_PROVIDER  # pyright: ignore[reportPrivateUsage]
             if provider is None or provider is self._routing_provider:

--- a/packages/phoenix-client/tests/client/pytest/test_plugin_integration.py
+++ b/packages/phoenix-client/tests/client/pytest/test_plugin_integration.py
@@ -7,6 +7,7 @@ offline-mode test asserts zero client construction.
 
 from __future__ import annotations
 
+import subprocess
 from typing import Any, cast
 
 import pytest
@@ -172,6 +173,127 @@ def test_end_to_end_records_runs_and_pass_annotation(pytester: pytest.Pytester) 
     assert effects["eval_names"] == ["custom", "pass"]
     # PR #13702 guard: runs key on node GlobalIDs, not external_ids (which contain "::").
     assert effects["run_examples"] == effects["node_ids"]
+
+
+def test_marker_metadata_reaches_created_dataset_and_experiment(
+    pytester: pytest.Pytester,
+) -> None:
+    pytester.makeconftest(
+        """
+        import json
+        import os
+
+        import phoenix.client.pytest.plugin as plugin
+
+        class _FakeDataset:
+            id = "Dataset:1"
+            version_id = "Version:1"
+            def __init__(self, examples):
+                self._examples = examples
+            @property
+            def examples(self):
+                return self._examples
+
+        class _FakeDatasets:
+            def __init__(self):
+                self._examples = []
+                self.dataset_description = None
+            def _upload_json_dataset(self, *, dataset_description=None, inputs, metadata,
+                                     example_ids, **kwargs):
+                self.dataset_description = dataset_description
+                self._examples = [
+                    {"id": eid, "node_id": f"DatasetExampleGID:{i}",
+                     "input": inp, "output": {}, "metadata": md}
+                    for i, (eid, inp, md) in enumerate(zip(example_ids, inputs, metadata))
+                ]
+                return _FakeDataset(self._examples)
+            def get_dataset(self, **kwargs):
+                return _FakeDataset(self._examples)
+
+        class _FakeExperiments:
+            def __init__(self):
+                self.experiment_description = None
+                self.experiment_metadata = None
+            def create(self, *, experiment_description=None, experiment_metadata=None, **kwargs):
+                self.experiment_description = experiment_description
+                self.experiment_metadata = experiment_metadata
+                return {"id": "Experiment:1"}
+            def log_run(self, **kwargs):
+                return {"id": "ExperimentRun:1"}
+            def log_evaluation(self, **kwargs):
+                return {"id": "Annotation:1"}
+            def get_experiment_summary(self, *, experiment_id, **kwargs):
+                return {"experiment_id": experiment_id, "dataset_version_id": "Version:1",
+                        "baseline_experiment_id": None, "baseline_dataset_version_id": None,
+                        "annotation_summaries": []}
+
+        class _FakeClient:
+            def __init__(self):
+                self.datasets = _FakeDatasets()
+                self.experiments = _FakeExperiments()
+
+        _CLIENT = _FakeClient()
+
+        def pytest_configure(config):
+            plugin._make_client = lambda: _CLIENT
+            config._phoenix_fake_client = _CLIENT
+
+        def pytest_unconfigure(config):
+            client = config._phoenix_fake_client
+            with open(os.path.join(str(config.rootdir), "metadata-effects.json"), "w") as f:
+                json.dump({
+                    "dataset_description": client.datasets.dataset_description,
+                    "experiment_description": client.experiments.experiment_description,
+                    "experiment_metadata": client.experiments.experiment_metadata,
+                }, f)
+        """
+    )
+    pytester.makepyfile(
+        test_metadata="""
+        import pytest
+        import phoenix.client.pytest as px
+
+        @pytest.mark.phoenix(
+            dataset="metadata-suite",
+            dataset_description="Customer support regression cases",
+            experiment_description="GPT-4.1 with a lower temperature",
+            experiment_metadata={
+                "model": "gpt-4.1",
+                "parameters": {"temperature": 0.2, "max_tokens": 512},
+            },
+        )
+        def test_answer():
+            px.log_output("A concise answer")
+            assert True
+        """
+    )
+    for command in (
+        ("git", "init", "--quiet"),
+        ("git", "config", "user.email", "phoenix@example.com"),
+        ("git", "config", "user.name", "Phoenix Tests"),
+        ("git", "add", "."),
+        ("git", "commit", "--quiet", "-m", "test fixture"),
+    ):
+        completed = subprocess.run(command, cwd=pytester.path, capture_output=True, text=True)
+        assert completed.returncode == 0, completed.stderr
+    git_sha_result = subprocess.run(
+        ("git", "rev-parse", "HEAD"), cwd=pytester.path, capture_output=True, text=True
+    )
+    assert git_sha_result.returncode == 0, git_sha_result.stderr
+
+    pytester.runpytest_subprocess("-p", "phoenix", "--no-header").assert_outcomes(passed=1)
+
+    import json
+
+    effects = json.loads((pytester.path / "metadata-effects.json").read_text())
+    assert effects["dataset_description"] == "Customer support regression cases"
+    assert effects["experiment_description"] == "GPT-4.1 with a lower temperature"
+    assert effects["experiment_metadata"]["model"] == "gpt-4.1"
+    assert effects["experiment_metadata"]["parameters"] == {
+        "temperature": 0.2,
+        "max_tokens": 512,
+    }
+    assert effects["experiment_metadata"]["git_sha"] == git_sha_result.stdout.strip()
 
 
 def test_failing_test_records_run_with_error(pytester: pytest.Pytester) -> None:

--- a/packages/phoenix-client/tests/client/pytest/test_plugin_integration.py
+++ b/packages/phoenix-client/tests/client/pytest/test_plugin_integration.py
@@ -726,13 +726,19 @@ def test_offline_builds_no_tracer(
     monkeypatch.setenv("PHOENIX_TEST_TRACKING", "false")
     pytester.makeconftest(
         """
+        import builtins
         import phoenix.client.pytest.plugin as plugin
         import phoenix.client.pytest.tracing as tracing
+        from opentelemetry import trace
 
         def pytest_configure(config):
+            original_provider = trace.NoOpTracerProvider()
+            trace._TRACER_PROVIDER = original_provider
+            builtins._phoenix_original_provider = original_provider
             def _boom(*a, **k):
                 raise AssertionError("no tracer should be built offline")
             tracing.build_suite_tracer = _boom
+            tracing._attach_global_tracer_provider = _boom
             def _no_client():
                 raise AssertionError("no client offline")
             plugin._make_client = _no_client
@@ -740,12 +746,25 @@ def test_offline_builds_no_tracer(
     )
     pytester.makepyfile(
         test_off="""
+        import builtins
         import pytest
         import phoenix.client.pytest as px
+        from opentelemetry import trace
+        from phoenix.client.pytest.context import current_run
+
+        def offline_eval(output, **_):
+            assert trace.get_tracer_provider() is builtins._phoenix_original_provider
+            return {"name": "offline", "score": 1.0}
 
         @pytest.mark.phoenix(dataset="trace-suite")
         def test_one():
             px.log_output("hi")
+            px.evaluate(offline_eval, output="hi")
+            run = current_run()
+            assert run is not None
+            assert run.trace_id is None
+            assert run.evaluations["offline"]["trace_id"] is None
+            assert trace.get_tracer_provider() is builtins._phoenix_original_provider
             assert True
         """
     )
@@ -756,26 +775,73 @@ def test_offline_builds_no_tracer(
 # ``SimpleSpanProcessor`` for the no-op one) so a test can read back the actual exported span
 # status/events. The appended ``pytest_unconfigure`` dumps spans and shadows the trace.json one.
 _SPAN_CAPTURE_HEADER = """
+import builtins
 import phoenix.client.pytest.tracing as _tracing
+from opentelemetry import trace as _trace
 from opentelemetry.sdk import trace as _trace_sdk
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor as _SSP
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter as _IMSE
 from opentelemetry.sdk.resources import Resource as _Resource
 from openinference.instrumentation import OITracer as _OITracer, TraceConfig as _TraceConfig
 from openinference.semconv.resource import ResourceAttributes as _RA
+from phoenix.client.resources.experiments import _TracerBundle
 
-_SPAN_EXPORTER = _IMSE()
+_SPAN_EXPORTERS = []
+_LIFECYCLE = []
+_trace._TRACER_PROVIDER = None
+_ORIGINAL_PROVIDER = _trace.get_tracer_provider()
+builtins._phoenix_original_provider = _ORIGINAL_PROVIDER
+builtins._phoenix_fail_flush = False
 
-def _capturing_get_tracer(project_name=None, base_url=None, headers=None):
+class _RecordingExporter(_IMSE):
+    def __init__(self, project_name):
+        super().__init__()
+        self.project_name = project_name
+
+    def export(self, spans):
+        for span in spans:
+            _LIFECYCLE.append({"event": "export", "project": self.project_name,
+                               "span": span.name})
+        return super().export(spans)
+
+class _RecordingProvider(_trace_sdk.TracerProvider):
+    def __init__(self, *, resource, project_name):
+        super().__init__(resource=resource)
+        self.project_name = project_name
+
+    def force_flush(self, *args, **kwargs):
+        _LIFECYCLE.append({"event": "flush", "project": self.project_name,
+                           "is_global": _trace.get_tracer_provider() is self})
+        if self.project_name == "evaluators" and builtins._phoenix_fail_flush:
+            builtins._phoenix_fail_flush = False
+            raise RuntimeError("flush failed")
+        return super().force_flush(*args, **kwargs)
+
+    def shutdown(self):
+        _LIFECYCLE.append({"event": "shutdown", "project": self.project_name})
+        return super().shutdown()
+
+def _capturing_get_tracer_bundle(project_name=None, base_url=None, headers=None):
     resource = _Resource({_RA.PROJECT_NAME: project_name} if project_name else {})
-    tp = _trace_sdk.TracerProvider(resource=resource)
-    tp.add_span_processor(_SSP(_SPAN_EXPORTER))
-    return _OITracer(tp.get_tracer(__name__), config=_TraceConfig()), resource
+    exporter = _RecordingExporter(project_name)
+    _SPAN_EXPORTERS.append(exporter)
+    tp = _RecordingProvider(resource=resource, project_name=project_name)
+    tp.add_span_processor(_SSP(exporter))
+    if project_name == "evaluators":
+        builtins._phoenix_evaluator_provider = tp
+    return _TracerBundle(
+        tracer=_OITracer(tp.get_tracer(__name__), config=_TraceConfig()),
+        resource=resource,
+        provider=tp,
+    )
 
-_tracing._get_tracer = _capturing_get_tracer
+_tracing._get_tracer_bundle = _capturing_get_tracer_bundle
 """
 
 _SPAN_CAPTURE_FOOTER = """
+import pytest
+
+@pytest.hookimpl(trylast=True)
 def pytest_unconfigure(config):
     import json, os
     from openinference.semconv.trace import SpanAttributes as _SA
@@ -783,20 +849,30 @@ def pytest_unconfigure(config):
         {"name": s.name, "status": s.status.status_code.name,
          "kind": s.attributes.get(_SA.OPENINFERENCE_SPAN_KIND),
          "trace_id": format(s.context.trace_id, "032x"),
+         "project": s.resource.attributes.get(_RA.PROJECT_NAME),
          "events": [e.name for e in s.events]}
-        for s in _SPAN_EXPORTER.get_finished_spans()
+        for exporter in _SPAN_EXPORTERS
+        for s in exporter.get_finished_spans()
     ]
+    client = config._c
     with open(os.path.join(str(config.rootdir), "spans.json"), "w") as f:
-        json.dump(spans, f)
+        json.dump({"spans": spans, "lifecycle": _LIFECYCLE,
+                   "restored": _trace.get_tracer_provider() is _ORIGINAL_PROVIDER,
+                   "runs": client.experiments.runs,
+                   "evals": client.experiments.evals}, f)
 """
 
 _TRACING_CAPTURE_CONFTEST = _SPAN_CAPTURE_HEADER + _TRACING_CONFTEST + _SPAN_CAPTURE_FOOTER
 
 
-def _spans(pytester: pytest.Pytester) -> list[dict[str, Any]]:
+def _span_effects(pytester: pytest.Pytester) -> dict[str, Any]:
     import json
 
-    return cast("list[dict[str, Any]]", json.loads((pytester.path / "spans.json").read_text()))
+    return cast("dict[str, Any]", json.loads((pytester.path / "spans.json").read_text()))
+
+
+def _spans(pytester: pytest.Pytester) -> list[dict[str, Any]]:
+    return cast("list[dict[str, Any]]", _span_effects(pytester)["spans"])
 
 
 def test_failing_test_records_error_chain_span(pytester: pytest.Pytester) -> None:
@@ -841,35 +917,134 @@ def test_passing_test_records_ok_chain_span(pytester: pytest.Pytester) -> None:
     assert "exception" not in chain["events"]
 
 
-def test_every_evaluation_emits_an_evaluator_span(pytester: pytest.Pytester) -> None:
-    """The test body is the lone CHAIN span; every evaluation — the auto pass/fail annotation, a
-    bare px.log_evaluation, and a hoisted marker evaluator — emits its own EVALUATOR span on a
-    trace distinct from the CHAIN trace."""
+def test_task_and_evaluator_spans_use_separate_provider_lifecycles(
+    pytester: pytest.Pytester,
+) -> None:
+    """Task and evaluator spans use distinct projects while evaluator-global tracing is scoped."""
     pytester.makeconftest(_TRACING_CAPTURE_CONFTEST)
     pytester.makepyfile(
         test_kinds="""
+        import builtins
         import pytest
         import phoenix.client.pytest as px
+        from opentelemetry import trace
+        from phoenix.client.pytest.context import current_run
+
+        def _evaluator_child(name):
+            assert trace.get_tracer_provider() is builtins._phoenix_evaluator_provider
+            with trace.get_tracer(__name__).start_as_current_span(name):
+                pass
+
+        def inline(output, **_):
+            _evaluator_child("inline child")
+            return {"name": "inline", "score": 1.0}
+        inline.name = "inline"
+
+        def nested(output, **_):
+            _evaluator_child("nested child")
+            px.evaluate(inline, output=output)
+            assert trace.get_tracer_provider() is builtins._phoenix_evaluator_provider
+            return {"name": "nested", "score": 1.0}
+        nested.name = "nested"
+
+        def broken(output, **_):
+            _evaluator_child("error child")
+            builtins._phoenix_fail_flush = True
+            raise ValueError("expected")
+        broken.name = "broken"
 
         def correctness(output, **_):
+            _evaluator_child("marker child")
             return {"name": "correctness", "score": 1.0}
 
         @pytest.mark.phoenix(dataset="trace-suite", evaluators=[correctness])
         def test_one():
             px.log_output("stable")
+            run = current_run()
+            assert run is not None and run.tracer is not None
+            with run.tracer.tracer.start_as_current_span("task child before"):
+                pass
+            assert trace.get_tracer_provider() is builtins._phoenix_original_provider
+            px.evaluate(nested, output="stable")
+            assert trace.get_tracer_provider() is builtins._phoenix_original_provider
+            with pytest.raises(ValueError, match="expected"):
+                px.evaluate(broken, output="stable")
+            assert trace.get_tracer_provider() is builtins._phoenix_original_provider
             px.log_evaluation(name="manual", score=1.0)
+            with run.tracer.tracer.start_as_current_span("task child after"):
+                pass
             assert True
         """
     )
     pytester.runpytest_subprocess("-p", "phoenix", "--no-header").assert_outcomes(passed=1)
-    spans = _spans(pytester)
+    effects = _span_effects(pytester)
+    spans = effects["spans"]
     by_name = {s["name"]: s for s in spans}
     chain = next(s for s in spans if s["name"].startswith("Test: "))
     assert chain["kind"] == "CHAIN"
-    for ev_name in ("Evaluation: pass", "Evaluation: manual", "Evaluation: correctness"):
+    assert chain["project"] == "proj-1"
+    for task_name in ("task child before", "task child after"):
+        assert by_name[task_name]["project"] == "proj-1"
+    for ev_name in (
+        "Evaluation: inline",
+        "Evaluation: nested",
+        "Evaluation: broken",
+        "Evaluation: manual",
+        "Evaluation: pass",
+        "Evaluation: correctness",
+    ):
         ev = by_name[ev_name]
         assert ev["kind"] == "EVALUATOR", ev_name
+        assert ev["project"] == "evaluators", ev_name
         assert ev["trace_id"] != chain["trace_id"], ev_name
+    for child_name in ("inline child", "nested child", "error child", "marker child"):
+        assert by_name[child_name]["project"] == "evaluators"
+    assert all(
+        not span["name"].startswith("Evaluation:")
+        and span["name"] not in {"inline child", "nested child", "error child", "marker child"}
+        for span in spans
+        if span["project"] == "proj-1"
+    )
+
+    run_trace_id = effects["runs"][0]["trace_id"]
+    for evaluation in effects["evals"]:
+        root = by_name[f"Evaluation: {evaluation['name']}"]
+        assert evaluation["trace_id"] == root["trace_id"]
+        assert evaluation["trace_id"] != run_trace_id
+    assert effects["restored"] is True
+
+    lifecycle = effects["lifecycle"]
+    for ev_name in (
+        "Evaluation: inline",
+        "Evaluation: nested",
+        "Evaluation: broken",
+        "Evaluation: manual",
+        "Evaluation: pass",
+        "Evaluation: correctness",
+    ):
+        exported = next(
+            i
+            for i, event in enumerate(lifecycle)
+            if event["event"] == "export" and event.get("span") == ev_name
+        )
+        flushed = next(
+            event
+            for event in lifecycle[exported + 1 :]
+            if event["event"] == "flush" and event["project"] == "evaluators"
+        )
+        assert flushed["is_global"] is True
+    for project in ("evaluators", "proj-1"):
+        shutdown = next(
+            i
+            for i, event in enumerate(lifecycle)
+            if event["event"] == "shutdown" and event["project"] == project
+        )
+        assert lifecycle[shutdown - 1]["event"] == "flush"
+        assert lifecycle[shutdown - 1]["project"] == project
+        assert (
+            sum(event["event"] == "shutdown" and event["project"] == project for event in lifecycle)
+            == 1
+        )
 
 
 def test_failing_test_output_carries_trace_id(pytester: pytest.Pytester) -> None:

--- a/packages/phoenix-client/tests/client/pytest/test_plugin_integration.py
+++ b/packages/phoenix-client/tests/client/pytest/test_plugin_integration.py
@@ -910,6 +910,7 @@ from phoenix.client.resources.experiments import _TracerBundle
 
 _SPAN_EXPORTERS = []
 _LIFECYCLE = []
+builtins._phoenix_span_exporters = _SPAN_EXPORTERS
 _trace._TRACER_PROVIDER = None
 _ORIGINAL_PROVIDER = _trace.get_tracer_provider()
 builtins._phoenix_original_provider = _ORIGINAL_PROVIDER
@@ -932,8 +933,10 @@ class _RecordingProvider(_trace_sdk.TracerProvider):
         self.project_name = project_name
 
     def force_flush(self, *args, **kwargs):
+        global_provider = _trace.get_tracer_provider()
         _LIFECYCLE.append({"event": "flush", "project": self.project_name,
-                           "is_global": _trace.get_tracer_provider() is self})
+                           "is_global": global_provider is not _ORIGINAL_PROVIDER,
+                           "is_raw": global_provider is self})
         if self.project_name == "evaluators" and builtins._phoenix_fail_flush:
             builtins._phoenix_fail_flush = False
             raise RuntimeError("flush failed")
@@ -1053,7 +1056,9 @@ def test_task_and_evaluator_spans_use_separate_provider_lifecycles(
         from phoenix.client.pytest.context import current_run
 
         def _evaluator_child(name):
-            assert trace.get_tracer_provider() is builtins._phoenix_evaluator_provider
+            global_provider = trace.get_tracer_provider()
+            assert global_provider is not builtins._phoenix_original_provider
+            assert global_provider is not builtins._phoenix_evaluator_provider
             with trace.get_tracer(__name__).start_as_current_span(name):
                 pass
 
@@ -1065,7 +1070,7 @@ def test_task_and_evaluator_spans_use_separate_provider_lifecycles(
         def nested(output, **_):
             _evaluator_child("nested child")
             px.evaluate(inline, output=output)
-            assert trace.get_tracer_provider() is builtins._phoenix_evaluator_provider
+            assert trace.get_tracer_provider() is not builtins._phoenix_original_provider
             return {"name": "nested", "score": 1.0}
         nested.name = "nested"
 
@@ -1155,6 +1160,7 @@ def test_task_and_evaluator_spans_use_separate_provider_lifecycles(
             if event["event"] == "flush" and event["project"] == "evaluators"
         )
         assert flushed["is_global"] is True
+        assert flushed["is_raw"] is False
     for project in ("evaluators", "proj-1"):
         shutdown = next(
             i
@@ -1167,6 +1173,64 @@ def test_task_and_evaluator_spans_use_separate_provider_lifecycles(
             sum(event["event"] == "shutdown" and event["project"] == project for event in lifecycle)
             == 1
         )
+
+
+def test_preacquired_proxy_tracer_does_not_bind_permanently_to_evaluator_provider(
+    pytester: pytest.Pytester,
+) -> None:
+    pytester.makeconftest(_TRACING_CAPTURE_CONFTEST)
+    pytester.makepyfile(
+        test_proxy="""
+        import builtins
+        import pytest
+        import phoenix.client.pytest as px
+        from openinference.semconv.resource import ResourceAttributes
+        from opentelemetry import trace
+        from opentelemetry.sdk import trace as trace_sdk
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+        trace._TRACER_PROVIDER = None
+        tracer = trace.get_tracer("preacquired.lib")
+
+        def first_emission(output, **_):
+            with tracer.start_as_current_span("proxy first evaluator span"):
+                pass
+            return {"name": "proxy", "score": 1.0}
+
+        @pytest.fixture
+        def application_provider_after_test():
+            yield
+            exporter = InMemorySpanExporter()
+            provider = trace_sdk.TracerProvider(
+                resource=Resource({ResourceAttributes.PROJECT_NAME: "application"})
+            )
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            builtins._phoenix_span_exporters.append(exporter)
+            trace._TRACER_PROVIDER = provider
+            with tracer.start_as_current_span("proxy post-evaluator span"):
+                pass
+            assert [span.name for span in exporter.get_finished_spans()] == [
+                "proxy post-evaluator span"
+            ]
+            trace._TRACER_PROVIDER = None
+            provider.shutdown()
+
+        @pytest.mark.phoenix(dataset="trace-suite")
+        def test_one(application_provider_after_test):
+            px.log_output("stable")
+            px.evaluate(first_emission, output="stable")
+        """
+    )
+    pytester.runpytest_subprocess("-p", "phoenix", "--no-header").assert_outcomes(passed=1)
+    proxy_spans = {
+        span["name"]: span
+        for span in _spans(pytester)
+        if span["name"] in {"proxy first evaluator span", "proxy post-evaluator span"}
+    }
+    assert proxy_spans["proxy first evaluator span"]["project"] == "evaluators"
+    assert proxy_spans["proxy post-evaluator span"]["project"] == "application"
 
 
 def test_failing_test_output_carries_trace_id(pytester: pytest.Pytester) -> None:


### PR DESCRIPTION
## Summary

Two ergonomics fixes for experiments run through the pytest plugin.

**Evaluator traces from pytest-run experiments now land in a dedicated `evaluators` project** (fixes #14602). Scope note: this applies to the pytest integration only — experiments run directly through the Python client's `run_experiment` / `evaluate_experiment` still emit evaluator traces into the experiment's own project, and bringing that path to the same behavior is left as a follow-up (the TypeScript client already isolates evaluator traces on its equivalent path).

Previously, evaluator traces from the pytest plugin were exported to the same project as the experiment's task traces, so the task project's trace list and cost view mixed both populations. The plugin now keeps one task provider per experiment project and one shared `evaluators` provider per process, mirroring the TypeScript client's `runExperiment` behavior: while an evaluator body runs, the global tracer provider is fronted by a routing provider that resolves each emission to the `evaluators` provider (so LLM or other spans created inside evaluators via the global tracer API are captured and routed to `evaluators` instead of being dropped by the no-op global provider), and the exact prior global provider state — including unset/proxy state — is restored afterward. The routing indirection also prevents pre-configuration `ProxyTracer` instances from permanently binding to the evaluators provider. Evaluator spans close before the provider force-flushes, restoration happens even on evaluator or flush failure, and plugin-owned providers flush before shutdown at `pytest_unconfigure`. Offline runs remain fully no-op. Experiment-level cost totals are unchanged: they were already computed per run trace, and evaluator roots remain detached traces.

**Pytest-run experiments now carry run-comparison metadata** (fixes #14550). `@pytest.mark.phoenix` accepts three new keyword arguments — `dataset_description`, `experiment_description`, and `experiment_metadata` (e.g. model and parameters) — which flow to the existing dataset-upload and experiment-creation fields. The current git commit is detected once per session and merged into experiment metadata as `git_sha` unless the caller supplies their own; git absence degrades silently. Conflicting non-empty values for the same dataset fail collection with a usage error. Both pytest guides are updated, and the PXI regression eval suite now uses these fields, tagging its experiments with the assistant model, provider, API type, and per-dataset descriptions.

## Testing

- Plugin suite: 63 passed, including a provider-lifecycle test covering project routing of evaluator roots and evaluator-created global children, nested/reentrant evaluator mounting, error and flush-failure restoration, annotation trace linkage, flush-before-shutdown ordering, and offline no-op behavior; a regression test proving a pre-acquired proxy tracer follows a later-configured application provider after evaluation; and a metadata scenario asserting all four metadata classes against a real temporary git repository.
- End-to-end against a live Phoenix server: the task project contained only the test's CHAIN trace with zero evaluator spans; the `evaluators` project contained the evaluator root and its global-API child span; evaluation annotations linked to the detached evaluator trace IDs, distinct from the run trace.
- `make format-python`, `make lint-python`, pyright, and strict mypy over the changed modules pass.

Fixes #14602
Fixes #14550