### PR TITLE
fix(agents): Move feedback from chat operations within the chat window

### DIFF
--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -18,10 +18,9 @@ import {
 } from "react-relay";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
-import { Button, Flex, Text } from "@phoenix/components";
+import { Alert, Button, Flex, Text } from "@phoenix/components";
 import { ChatSessionUsage } from "@phoenix/components/agent/ChatSessionUsage";
 import { Loading } from "@phoenix/components/core";
-import { useNotifyError } from "@phoenix/contexts";
 import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import type { AgentPosition } from "@phoenix/store/agentStore";
@@ -143,7 +142,7 @@ function AgentSessionsContent({
   const clearSessionEphemeralState = useAgentContext(
     (state) => state.clearSessionEphemeralState
   );
-  const notifyError = useNotifyError();
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const connectionId = ConnectionHandler.getConnectionID(
     "client:root",
     AGENT_SESSIONS_CONNECTION_KEY
@@ -155,6 +154,7 @@ function AgentSessionsContent({
    * message, so no empty session rows are ever written.
    */
   const startNewSession = useCallback(() => {
+    setDeleteError(null);
     const state = store.getState();
     state.setIsDraftSessionTemporary(state.defaultTemporaryChat);
     setActiveSession(DRAFT_SESSION_ID);
@@ -209,6 +209,7 @@ function AgentSessionsContent({
 
   const deleteSession = useCallback(
     (sessionId: string) => {
+      setDeleteError(null);
       if (sessionId === DRAFT_SESSION_ID) {
         // The draft has no server session; deleting it just resets its
         // ephemeral state (draft input, staged message).
@@ -240,10 +241,7 @@ function AgentSessionsContent({
             setActiveSession(sessionId);
           }
           const messages = getErrorMessagesFromRelayMutationError(error);
-          notifyError({
-            title: "Session could not be deleted",
-            message: messages?.[0] ?? error.message,
-          });
+          setDeleteError(messages?.[0] ?? error.message);
         },
       });
     },
@@ -252,7 +250,6 @@ function AgentSessionsContent({
       clearSessionEphemeralState,
       commitDelete,
       connectionId,
-      notifyError,
       runtime,
       setActiveSession,
       store,
@@ -263,6 +260,13 @@ function AgentSessionsContent({
     (session) => session.id === activeSessionId
   );
   const sessionDisplayName = activeSession?.title || EMPTY_SESSION_DISPLAY_NAME;
+  const selectSession = useCallback(
+    (sessionId: string | null) => {
+      setDeleteError(null);
+      setActiveSession(sessionId);
+    },
+    [setActiveSession]
+  );
   const panelState = useAgentChatPanelState();
   const handleMissingSession = useCallback(
     (sessionId: string) => {
@@ -305,7 +309,7 @@ function AgentSessionsContent({
         isActiveSessionTemporary={activeSession?.isTemporary}
         position={position}
         isPositionChangeDisabled={isPositionChangeDisabled}
-        onSelectSession={setActiveSession}
+        onSelectSession={selectSession}
         onDeleteSession={deleteSession}
         onCreateSession={startNewSession}
         hasNextSessionPage={hasNext}
@@ -314,6 +318,19 @@ function AgentSessionsContent({
         onPositionChange={panelState.setPosition}
         onClose={panelState.closePanel}
       />
+      {deleteError ? (
+        <div role="alert">
+          <Alert
+            banner
+            variant="danger"
+            title="Session could not be deleted"
+            dismissable
+            onDismissClick={() => setDeleteError(null)}
+          >
+            {deleteError}
+          </Alert>
+        </div>
+      ) : null}
       {activeSessionId == null ? (
         <Loading />
       ) : needsTranscriptSeed ? (
@@ -396,6 +413,9 @@ function AgentChatController({
     handleElicitationCancel,
     compactSession,
     isCompacting,
+    compactionStatus,
+    operationError,
+    clearOperationError,
     rewindToMessage,
     forkFromMessage,
   } = useAgentChat({
@@ -418,6 +438,9 @@ function AgentChatController({
       handleElicitationCancel={handleElicitationCancel}
       compactSession={compactSession}
       isCompacting={isCompacting}
+      compactionStatus={compactionStatus}
+      operationError={operationError}
+      clearOperationError={clearOperationError}
       rewindToMessage={rewindToMessage}
       forkFromMessage={forkFromMessage}
       modelMenuValue={menuValue}

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -27,6 +27,7 @@ import type {
   ElicitToolOutput,
   PendingElicitation,
 } from "@phoenix/agent/tools/elicit";
+import { Alert } from "@phoenix/components";
 import { ElicitationCarousel } from "@phoenix/components/ai/elicitation";
 import { PromptInput } from "@phoenix/components/ai/prompt-input";
 import { Shimmer } from "@phoenix/components/ai/shimmer";
@@ -73,6 +74,7 @@ import { PxiGlyph } from "./PxiGlyph";
 import { useScrollAnchor } from "./scrollAnchor";
 import { TemporaryChatToggle } from "./TemporaryChatToggle";
 import { isToolUIPart } from "./toolPartTypes";
+import type { AgentChatOperationError } from "./useAgentChat";
 
 export type { EmptyStateQuickAction } from "./ChatEmptyState";
 
@@ -296,6 +298,10 @@ const chatCSS = css`
     animation: ${chatInputFadeUp} 280ms ease-out;
   }
 
+  .chat__operation-error {
+    margin-bottom: var(--global-dimension-size-100);
+  }
+
   /* Elicitation-style surfaces (consent gate, rewind confirmation, question
      carousel) can be taller than the panel; let the input region shrink and
      scroll internally instead of clipping at the panel edge. */
@@ -417,6 +423,14 @@ function ChatCompactionProgress() {
   );
 }
 
+function ChatCompactionStatus({ children }: { children: string }) {
+  return (
+    <div className="chat__compaction-divider" role="status" aria-live="polite">
+      <span className="chat__compaction-divider-label">{children}</span>
+    </div>
+  );
+}
+
 /**
  * Pure chat view used both by the legacy mounted panel and by the headless
  * controller path that keeps streaming alive while the panel is hidden.
@@ -433,6 +447,9 @@ export function ChatView({
   handleElicitationCancel,
   compactSession,
   isCompacting = false,
+  compactionStatus,
+  operationError,
+  clearOperationError,
   rewindToMessage,
   forkFromMessage,
   modelMenuValue,
@@ -456,6 +473,9 @@ export function ChatView({
   handleElicitationCancel: () => void;
   compactSession: PromptCommandContext["compactSession"];
   isCompacting?: boolean;
+  compactionStatus?: string | null;
+  operationError?: AgentChatOperationError | null;
+  clearOperationError?: () => void;
   /**
    * Truncates the active session at a message; resolves to user text to
    * restore. Absent on read-only surfaces, which hides the rewind/branch
@@ -463,7 +483,7 @@ export function ChatView({
    */
   rewindToMessage?: (messageId: string) => Promise<string | null>;
   /** Branches a new session from a message; absent hides the branch control. */
-  forkFromMessage?: (messageId: string) => void;
+  forkFromMessage?: (messageId: string) => Promise<void>;
   modelMenuValue: ModelMenuValue;
   onModelChange: (model: ModelMenuValue) => void;
   emptyStateSubtext?: ReactNode;
@@ -556,7 +576,10 @@ export function ChatView({
   });
   const latestMessage = messages.at(-1);
   const shouldShowInterruptedMessage =
-    status === "ready" && !error && latestMessage?.role === "user";
+    status === "ready" &&
+    !error &&
+    latestMessage?.role === "user" &&
+    !isCompactionMessage(latestMessage);
   const resolvedElicitationDraft =
     pendingElicitation &&
     elicitationDraft?.toolCallId !== pendingElicitation.toolCallId
@@ -607,6 +630,9 @@ export function ChatView({
     messageId: string;
     role: MessageRewindRole;
   } | null>(null);
+  const [historyActionError, setHistoryActionError] =
+    useState<AgentChatOperationError | null>(null);
+  const [isHistoryActionPending, setIsHistoryActionPending] = useState(false);
 
   // Rewind/branch changes finalized history, so these actions are only offered
   // once the chat has settled — never mid-request.
@@ -616,7 +642,10 @@ export function ChatView({
     if (!hasChatSettled || !rewindToMessage) {
       return undefined;
     }
-    return (request) => setRewindRequest(request);
+    return (request) => {
+      setHistoryActionError(null);
+      setRewindRequest(request);
+    };
   }, [hasChatSettled, rewindToMessage]);
 
   const handleConfirmRewind = async () => {
@@ -624,17 +653,34 @@ export function ChatView({
       return;
     }
     const { mode, messageId } = rewindRequest;
-    setRewindRequest(null);
-    if (mode === "fork") {
-      // Forking switches the active session, which remounts this view; the
-      // forked session receives restored text through draftInputBySessionId.
-      forkFromMessage?.(messageId);
-    } else {
-      const restoredInput = (await rewindToMessage?.(messageId)) ?? null;
-      if (restoredInput != null) {
-        setSessionDraftInput(restoredInput);
-        textareaRef.current?.focus();
+    setHistoryActionError(null);
+    setIsHistoryActionPending(true);
+    try {
+      if (mode === "fork") {
+        // Forking switches the active session, which remounts this view; the
+        // forked session receives restored text through draftInputBySessionId.
+        await forkFromMessage?.(messageId);
+      } else {
+        const restoredInput = (await rewindToMessage?.(messageId)) ?? null;
+        if (restoredInput != null) {
+          setSessionDraftInput(restoredInput);
+          textareaRef.current?.focus();
+        }
       }
+      setRewindRequest(null);
+    } catch (error) {
+      setHistoryActionError({
+        title:
+          mode === "fork"
+            ? "Conversation could not be branched"
+            : "Conversation could not be rewound",
+        message:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred.",
+      });
+    } finally {
+      setIsHistoryActionPending(false);
     }
   };
 
@@ -648,12 +694,23 @@ export function ChatView({
     }
     // The server-side truncation must land before re-sending, or the resent
     // request would still carry the interrupted user turn.
-    const restoredInput = await rewindToMessage?.(message.id);
-    if (restoredInput == null) {
-      return;
+    setHistoryActionError(null);
+    try {
+      const restoredInput = await rewindToMessage?.(message.id);
+      if (restoredInput == null) {
+        return;
+      }
+      void scrollToBottom();
+      sendMessage({ text: messageText });
+    } catch (error) {
+      setHistoryActionError({
+        title: "Conversation could not be rewound",
+        message:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred.",
+      });
     }
-    void scrollToBottom();
-    sendMessage({ text: messageText });
   };
 
   const handleRetryInterruptedMessage = () => retryUserMessage(latestMessage);
@@ -761,6 +818,11 @@ export function ChatView({
                   );
                 })}
                 {isCompacting ? <ChatCompactionProgress /> : null}
+                {!isCompacting && compactionStatus ? (
+                  <ChatCompactionStatus>
+                    {compactionStatus}
+                  </ChatCompactionStatus>
+                ) : null}
                 {showThinkingIndicator && <Loading />}
                 {shouldShowInterruptedMessage ? (
                   <InterruptedChatMessage
@@ -789,6 +851,21 @@ export function ChatView({
           </div>
         </ChatScrollContext.Provider>
         <div className="chat__input">
+          {(operationError || (!rewindRequest && historyActionError)) && (
+            <div className="chat__operation-error" role="alert">
+              <Alert
+                variant="danger"
+                title={(operationError ?? historyActionError)?.title}
+                dismissable
+                onDismissClick={() => {
+                  clearOperationError?.();
+                  setHistoryActionError(null);
+                }}
+              >
+                {(operationError ?? historyActionError)?.message}
+              </Alert>
+            </div>
+          )}
           {!hasAcknowledgedConsent ? (
             <PromptInput status={status} isDisabled mode="elicitation">
               <AgentConsentGate />
@@ -798,8 +875,13 @@ export function ChatView({
               <MessageRewindConfirmation
                 mode={rewindRequest.mode}
                 role={rewindRequest.role}
+                error={historyActionError?.message}
+                isPending={isHistoryActionPending}
                 onConfirm={handleConfirmRewind}
-                onCancel={() => setRewindRequest(null)}
+                onCancel={() => {
+                  setHistoryActionError(null);
+                  setRewindRequest(null);
+                }}
               />
             </PromptInput>
           ) : pendingElicitation ? (

--- a/app/src/components/agent/MessageRewindDialog.tsx
+++ b/app/src/components/agent/MessageRewindDialog.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 
-import { Button, Flex, Text } from "@phoenix/components";
+import { Alert, Button, Flex, Text } from "@phoenix/components";
 
 /** Which action the confirmation is gating. */
 export type MessageRewindMode = "rewind" | "fork";
@@ -81,11 +81,15 @@ const confirmationActionsCSS = css`
 export function MessageRewindConfirmation({
   mode,
   role,
+  error,
+  isPending = false,
   onConfirm,
   onCancel,
 }: {
   mode: MessageRewindMode;
   role: MessageRewindRole;
+  error?: string | null;
+  isPending?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }) {
@@ -102,16 +106,23 @@ export function MessageRewindConfirmation({
         </Text>
         <Text color="text-700">{description}</Text>
       </div>
+      {error ? <Alert variant="danger">{error}</Alert> : null}
       <Flex direction="row" css={confirmationActionsCSS}>
-        <Button variant="default" size="S" onPress={onCancel}>
+        <Button
+          variant="default"
+          size="S"
+          isDisabled={isPending}
+          onPress={onCancel}
+        >
           Cancel
         </Button>
         <Button
           variant={mode === "rewind" ? "danger" : "primary"}
           size="S"
+          isDisabled={isPending}
           onPress={onConfirm}
         >
-          {confirmLabel}
+          {isPending ? "Working…" : confirmLabel}
         </Button>
       </Flex>
     </div>

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -92,6 +92,9 @@ function renderChatView(
     sendMessage = vi.fn<ChatViewSendMessage>(),
     compactSession = vi.fn<ChatViewCompactSession>(),
     isCompacting = false,
+    compactionStatus,
+    operationError,
+    clearOperationError,
     rewindToMessage,
     forkFromMessage,
   }: {
@@ -106,8 +109,11 @@ function renderChatView(
     sendMessage?: ChatViewSendMessage;
     compactSession?: ChatViewCompactSession;
     isCompacting?: boolean;
+    compactionStatus?: string | null;
+    operationError?: { title: string; message: string } | null;
+    clearOperationError?: () => void;
     rewindToMessage?: (messageId: string) => Promise<string | null>;
-    forkFromMessage?: (messageId: string) => void;
+    forkFromMessage?: (messageId: string) => Promise<void>;
   } = {}
 ) {
   act(() => {
@@ -159,6 +165,9 @@ function renderChatView(
             handleElicitationCancel={vi.fn()}
             compactSession={compactSession}
             isCompacting={isCompacting}
+            compactionStatus={compactionStatus}
+            operationError={operationError}
+            clearOperationError={clearOperationError}
             rewindToMessage={rewindToMessage}
             forkFromMessage={forkFromMessage}
             modelMenuValue={{ provider: "ANTHROPIC", modelName: "claude" }}
@@ -363,6 +372,20 @@ describe("ChatView", () => {
     );
   });
 
+  it("renders an already-compact result inline in the transcript", () => {
+    renderChatView(root, {
+      compactionStatus:
+        "Conversation is already compact. There are no older complete turns to compact.",
+    });
+
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      "Conversation is already compact. There are no older complete turns to compact."
+    );
+
+    renderChatView(root, { compactionStatus: null });
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
   it("renders a divider after the compacted transcript boundary", () => {
     const nextUserMessage = {
       id: "user-message-2",
@@ -452,6 +475,55 @@ describe("ChatView", () => {
     expect(summaries).toHaveLength(2);
     expect(summaries[0]?.textContent).toContain("first summary");
     expect(summaries[1]?.textContent).toContain("second summary");
+  });
+
+  it("does not treat a trailing compaction checkpoint as an interrupted turn", () => {
+    const compactionMessage = {
+      id: "compaction-message",
+      role: "user",
+      metadata: { type: "compaction" },
+      parts: [{ type: "text", text: '{"objectives":[]}' }],
+    } as AgentUIMessage;
+
+    renderChatView(root, {
+      chatMessages: [...messages, compactionMessage],
+      status: "ready",
+      rewindToMessage: vi.fn(),
+      forkFromMessage: vi.fn(),
+    });
+
+    expect(container.textContent).not.toContain("PXI did not respond.");
+    expect(container.textContent).not.toContain("Branch before message");
+    expect(
+      container.querySelector(
+        '[role="separator"][aria-label="Conversation context compacted"]'
+      )
+    ).not.toBeNull();
+  });
+
+  it("renders a dismissible operation error above the composer", () => {
+    const clearOperationError = vi.fn();
+    renderChatView(root, {
+      operationError: {
+        title: "Conversation could not be compacted",
+        message: "The compaction request failed.",
+      },
+      clearOperationError,
+    });
+
+    const operationError = container.querySelector(".chat__operation-error");
+    expect(operationError?.getAttribute("role")).toBe("alert");
+    expect(operationError?.textContent).toContain(
+      "Conversation could not be compacted"
+    );
+    expect(operationError?.textContent).toContain(
+      "The compaction request failed."
+    );
+
+    act(() => {
+      operationError?.querySelector("button")?.click();
+    });
+    expect(clearOperationError).toHaveBeenCalledOnce();
   });
 
   it("truncates and resends the last user message when retrying a failed turn", async () => {
@@ -551,7 +623,7 @@ describe("ChatView", () => {
   });
 
   it("confirms branching before an interrupted user message", () => {
-    const forkFromMessage = vi.fn(() => "branch-session");
+    const forkFromMessage = vi.fn(async () => undefined);
     renderChatView(root, {
       chatMessages: unansweredUserMessages,
       status: "ready",
@@ -610,7 +682,7 @@ describe("ChatView", () => {
   });
 
   it("confirms branching before a failed turn from the latest user message", () => {
-    const forkFromMessage = vi.fn(() => "forked-session");
+    const forkFromMessage = vi.fn(async () => undefined);
     renderChatView(root, {
       chatMessages: messages,
       error: new Error("provider unavailable"),
@@ -638,5 +710,36 @@ describe("ChatView", () => {
     });
 
     expect(forkFromMessage).toHaveBeenCalledWith("user-message");
+  });
+
+  it("keeps rewind confirmation open and shows a scoped mutation error", async () => {
+    const rewindToMessage = vi
+      .fn<(messageId: string) => Promise<string | null>>()
+      .mockRejectedValue(new Error("Session version changed."));
+    renderChatView(root, {
+      chatMessages: messages,
+      error: new Error("provider unavailable"),
+      status: "error",
+      rewindToMessage,
+      forkFromMessage: vi.fn(),
+    });
+
+    const undoButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Undo failed turn"
+    );
+    act(() => {
+      undoButton?.click();
+    });
+
+    const confirmButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Rewind conversation"
+    );
+    await act(async () => {
+      confirmButton?.click();
+    });
+
+    expect(container.querySelector('[role="alertdialog"]')).not.toBeNull();
+    expect(container.textContent).toContain("Session version changed.");
+    expect(container.textContent).toContain("Rewind conversation");
   });
 });

--- a/app/src/components/agent/__tests__/useAgentChat.test.ts
+++ b/app/src/components/agent/__tests__/useAgentChat.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+
+import { getRemovedUserMessageText } from "../useAgentChat";
+
+describe("getRemovedUserMessageText", () => {
+  it("does not restore a compaction checkpoint into the composer", () => {
+    const compactionMessage = {
+      id: "compaction-message",
+      role: "user",
+      metadata: { type: "compaction" },
+      parts: [{ type: "text", text: '{"objectives":["Understand traces"]}' }],
+    } as AgentUIMessage;
+
+    expect(
+      getRemovedUserMessageText([compactionMessage], compactionMessage.id)
+    ).toBeNull();
+  });
+
+  it("continues to restore ordinary user messages", () => {
+    const userMessage = {
+      id: "user-message",
+      role: "user",
+      parts: [{ type: "text", text: "What is a trace?" }],
+    } as AgentUIMessage;
+
+    expect(getRemovedUserMessageText([userMessage], userMessage.id)).toBe(
+      "What is a trace?"
+    );
+  });
+});

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -6,7 +6,7 @@ import {
   isTextUIPart,
   isToolUIPart,
 } from "ai";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   ConnectionHandler,
   commitLocalUpdate,
@@ -32,6 +32,7 @@ import { createTurnCompletionGate } from "@phoenix/agent/chat/turnCompletion";
 import { createTurnTraceContextManager } from "@phoenix/agent/chat/turnTraceContext";
 import {
   getAssistantMessageMetadata,
+  isCompactionMessage,
   type AgentUIMessage,
 } from "@phoenix/agent/chat/types";
 import { buildUserMessageMetadata } from "@phoenix/agent/chat/userMessageMetadata";
@@ -52,7 +53,6 @@ import { WRITE_PROMPT_TOOLS_TOOL_NAME } from "@phoenix/agent/tools/playgroundPro
 import { SAVE_PROMPT_TOOL_NAME } from "@phoenix/agent/tools/playgroundSavePrompt";
 import type { paths } from "@phoenix/api/__generated__/v1";
 import { authFetch } from "@phoenix/authFetch";
-import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
 import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import {
@@ -73,6 +73,11 @@ import {
 type TurnClientState = {
   turnTraceContext: ReturnType<typeof createTurnTraceContextManager>;
   toolTimings: ReturnType<typeof createClientToolTimingRecorder>;
+};
+
+export type AgentChatOperationError = {
+  title: string;
+  message: string;
 };
 
 const turnClientStateByChat = new WeakMap<
@@ -197,8 +202,9 @@ export function useAgentChat({
   const store = useAgentStore();
   const runtime = useAgentChatRuntime();
   const relayEnvironment = useRelayEnvironment();
-  const notifyError = useNotifyError();
-  const notifySuccess = useNotifySuccess();
+  const [operationError, setOperationError] =
+    useState<AgentChatOperationError | null>(null);
+  const [compactionStatus, setCompactionStatus] = useState<string | null>(null);
   const isDraft = sessionId == null || sessionId === DRAFT_SESSION_ID;
   const isCompacting = useAgentContext((state) =>
     sessionId
@@ -497,6 +503,7 @@ export function useAgentChat({
     if (!text || isCreatingSessionRef.current) {
       return;
     }
+    setOperationError(null);
     isCreatingSessionRef.current = true;
     commitCreateAgentSession({
       variables: {
@@ -528,7 +535,7 @@ export function useAgentChat({
         store.getState().setDraftInput(DRAFT_SESSION_ID, text);
         const errorMessages =
           getErrorMessagesFromRelayMutationError(mutationError);
-        notifyError({
+        setOperationError({
           title: "Conversation could not be started",
           message: errorMessages?.[0] ?? mutationError.message,
         });
@@ -537,6 +544,7 @@ export function useAgentChat({
   };
 
   const handleSendMessage = async (...args: Parameters<typeof sendMessage>) => {
+    setCompactionStatus(null);
     if (isDraft) {
       createSessionAndSendMessage(...args);
       return;
@@ -562,6 +570,8 @@ export function useAgentChat({
   };
 
   const compactSession = (pendingMessage?: PendingAgentMessage): void => {
+    setOperationError(null);
+    setCompactionStatus(null);
     const restorePendingMessage = () => {
       if (pendingMessage && sessionId) {
         store.getState().setDraftInput(sessionId, pendingMessage.text);
@@ -569,7 +579,7 @@ export function useAgentChat({
     };
     if (isDraft || !sessionId || !chatInstance) {
       restorePendingMessage();
-      notifyError({
+      setOperationError({
         title: "Conversation could not be compacted",
         message: "There is no persisted conversation to compact.",
       });
@@ -577,7 +587,7 @@ export function useAgentChat({
     }
     if (isRequestActive(chatInstance.status)) {
       restorePendingMessage();
-      notifyError({
+      setOperationError({
         title: "Conversation could not be compacted",
         message: "Wait for the current response to finish and try again.",
       });
@@ -585,7 +595,7 @@ export function useAgentChat({
     }
     if (store.getState().isCompactionPendingBySessionId[sessionId]) {
       restorePendingMessage();
-      notifyError({
+      setOperationError({
         title: "Conversation could not be compacted",
         message: "Conversation compaction is already in progress.",
       });
@@ -621,14 +631,11 @@ export function useAgentChat({
           environment: relayEnvironment,
           sessionId,
         });
-        notifySuccess({
-          title: wasCompacted
-            ? "Conversation compacted"
-            : "Conversation already compact",
-          message: wasCompacted
-            ? "Older turns will be represented by a durable checkpoint."
-            : "There are no older complete turns to compact.",
-        });
+        if (!wasCompacted) {
+          setCompactionStatus(
+            "Conversation is already compact. There are no older complete turns to compact."
+          );
+        }
         if (pendingMessage) {
           store.getState().setSessionCompactionPending(sessionId, false);
           await handleSendMessage(
@@ -640,7 +647,7 @@ export function useAgentChat({
         }
       } catch (error) {
         restorePendingMessage();
-        notifyError({
+        setOperationError({
           title: "Conversation could not be compacted",
           message:
             error instanceof Error
@@ -737,7 +744,7 @@ export function useAgentChat({
   // itself runs server-side (`truncateAgentSession`); the runtime chat is then
   // reset to the persisted transcript and stale tool state is released.
   // Resolves to the user message text to restore into the input (user target)
-  // or null (assistant target / no-op / failure).
+  // or null (assistant target / no-op), and rejects when persistence fails.
   const rewindToMessage = useCallback(
     (messageId: string): Promise<string | null> => {
       if (
@@ -754,7 +761,7 @@ export function useAgentChat({
         chatInstance.messages,
         messageId
       );
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         commitTruncateAgentSession({
           variables: { input: { id: sessionId, messageId } },
           onCompleted: (response) => {
@@ -773,11 +780,7 @@ export function useAgentChat({
           onError: (mutationError) => {
             const errorMessages =
               getErrorMessagesFromRelayMutationError(mutationError);
-            notifyError({
-              title: "Conversation could not be rewound",
-              message: errorMessages?.[0] ?? mutationError.message,
-            });
-            resolve(null);
+            reject(new Error(errorMessages?.[0] ?? mutationError.message));
           },
         });
       });
@@ -788,7 +791,6 @@ export function useAgentChat({
       clearError,
       commitTruncateAgentSession,
       isDraft,
-      notifyError,
       sessionId,
       setMessages,
     ]
@@ -799,9 +801,9 @@ export function useAgentChat({
   // the truncated transcript and derives the branch title; the UI seeds a
   // runtime chat from the returned transcript and activates it.
   const forkFromMessage = useCallback(
-    (messageId: string): void => {
+    (messageId: string): Promise<void> => {
       if (isDraft || !sessionId || !chatInstance) {
-        return;
+        return Promise.resolve();
       }
       clearError();
       // Branching at a user message drops it from the branch; remember its
@@ -810,41 +812,41 @@ export function useAgentChat({
         chatInstance.messages,
         messageId
       );
-      commitBranchAgentSession({
-        variables: {
-          input: { id: sessionId, messageId },
-          connections: [sessionsConnectionId],
-        },
-        onCompleted: (response) => {
-          const payload = response.branchAgentSession;
-          const branchSessionId = payload.agentSession.id;
-          const branchChatApiUrl = buildAgentChatApiUrl(branchSessionId);
-          const branchMessages = Array.isArray(payload.agentSession.messages)
-            ? (payload.agentSession.messages as AgentUIMessage[])
-            : [];
-          runtime.getOrCreateChat({
-            sessionId: branchSessionId,
-            chatApiUrl: branchChatApiUrl,
-            createChat: (previousMessages) =>
-              createChatForSession(
-                branchSessionId,
-                previousMessages ?? branchMessages
-              ),
-          });
-          const state = store.getState();
-          if (restoredInput) {
-            state.setDraftInput(branchSessionId, restoredInput);
-          }
-          state.setActiveSession(branchSessionId);
-        },
-        onError: (mutationError) => {
-          const errorMessages =
-            getErrorMessagesFromRelayMutationError(mutationError);
-          notifyError({
-            title: "Conversation could not be branched",
-            message: errorMessages?.[0] ?? mutationError.message,
-          });
-        },
+      return new Promise((resolve, reject) => {
+        commitBranchAgentSession({
+          variables: {
+            input: { id: sessionId, messageId },
+            connections: [sessionsConnectionId],
+          },
+          onCompleted: (response) => {
+            const payload = response.branchAgentSession;
+            const branchSessionId = payload.agentSession.id;
+            const branchChatApiUrl = buildAgentChatApiUrl(branchSessionId);
+            const branchMessages = Array.isArray(payload.agentSession.messages)
+              ? (payload.agentSession.messages as AgentUIMessage[])
+              : [];
+            runtime.getOrCreateChat({
+              sessionId: branchSessionId,
+              chatApiUrl: branchChatApiUrl,
+              createChat: (previousMessages) =>
+                createChatForSession(
+                  branchSessionId,
+                  previousMessages ?? branchMessages
+                ),
+            });
+            const state = store.getState();
+            if (restoredInput) {
+              state.setDraftInput(branchSessionId, restoredInput);
+            }
+            state.setActiveSession(branchSessionId);
+            resolve();
+          },
+          onError: (mutationError) => {
+            const errorMessages =
+              getErrorMessagesFromRelayMutationError(mutationError);
+            reject(new Error(errorMessages?.[0] ?? mutationError.message));
+          },
+        });
       });
     },
     [
@@ -853,7 +855,6 @@ export function useAgentChat({
       commitBranchAgentSession,
       createChatForSession,
       isDraft,
-      notifyError,
       runtime,
       sessionId,
       sessionsConnectionId,
@@ -872,6 +873,9 @@ export function useAgentChat({
     handleElicitationCancel,
     compactSession,
     isCompacting,
+    compactionStatus,
+    operationError,
+    clearOperationError: () => setOperationError(null),
     rewindToMessage,
     forkFromMessage,
   } as {
@@ -888,8 +892,11 @@ export function useAgentChat({
     handleElicitationCancel: () => void;
     compactSession: (message?: PendingAgentMessage) => void;
     isCompacting: boolean;
+    compactionStatus: string | null;
+    operationError: AgentChatOperationError | null;
+    clearOperationError: () => void;
     rewindToMessage: (messageId: string) => Promise<string | null>;
-    forkFromMessage: (messageId: string) => void;
+    forkFromMessage: (messageId: string) => Promise<void>;
   };
 }
 
@@ -912,14 +919,15 @@ function removeInterruptedToolInputParts(
 
 /**
  * The text of the user message a rewind/branch at `messageId` removes, or null
- * when the target is not a user message (assistant targets are retained).
+ * when the target is not an ordinary user message. Assistant responses and
+ * synthetic compaction checkpoints are retained without staging composer text.
  */
-function getRemovedUserMessageText(
+export function getRemovedUserMessageText(
   messages: AgentUIMessage[],
   messageId: string
 ): string | null {
   const target = messages.find((message) => message.id === messageId);
-  if (!target || target.role !== "user") {
+  if (!target || target.role !== "user" || isCompactionMessage(target)) {
     return null;
   }
   return target.parts


### PR DESCRIPTION
## Summary

- replace global chat operation notifications with persistent, scoped feedback within the chat window
- show compaction progress, no-op results, and durable checkpoints inline in the transcript
- keep rewind and branch confirmations open through pending and failure states
- prevent compaction checkpoints from appearing as interrupted turns or being staged in the composer

## Tests

- `pnpm exec vitest run src/components/agent/__tests__/Chat.test.tsx src/components/agent/__tests__/useAgentChat.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Stack

Depends on #14579.