### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -86,6 +86,7 @@
 ### Overview
 
 - [LLM Evals](https://arize.com/docs/phoenix/evaluation/llm-evals): LLM-as-judge evaluation with pre-built and custom evaluators
+- [Evals Quickstart](https://arize.com/docs/phoenix/evaluation/evals): Evaluate data from your LLM application with arize-phoenix-evals
 
 ### How-to
 
@@ -97,6 +98,8 @@
 - [Code Evaluator Output Shapes](https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluator-output-shapes): All accepted return shapes, multi-output routing, and explanation field semantics
 - [Batch Evaluations](https://arize.com/docs/phoenix/evaluation/how-to-evals/batch-evaluations): Run evaluations at scale with automatic concurrency
 - [Using Evals with Phoenix](https://arize.com/docs/phoenix/evaluation/how-to-evals/using-evals-with-phoenix): Run evals on traces, datasets, or custom data sources
+- [Executors](https://arize.com/docs/phoenix/evaluation/llm-evals/executors): Speed up large eval runs with concurrent executors in arize-phoenix-evals
+- [Evaluator Traces](https://arize.com/docs/phoenix/evaluation/llm-evals/evaluator-traces): Trace every evaluator run to inspect LLM reasoning and align evals with human judgment
 
 ### Running Evals as Tests
 
@@ -120,6 +123,7 @@
 - [Code Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/code-evaluators): Write custom Python or TypeScript evaluators that Phoenix runs in a managed sandbox
 - [Server Eval Input Mapping](https://arize.com/docs/phoenix/evaluation/server-evals/input-mapping): Map span attributes to server-side evaluator input variables
 - [Server Pre-Built Metrics](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics): All server-side code metrics — contains, exact match, regex, JSON distance, Levenshtein, tool
+- [Server Built-in Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/builtin-evaluators): Label and score experiment outputs server-side with code evaluators — no LLM or API keys required
 
 
 ### Pre-Built Metrics — Individual Pages
@@ -141,6 +145,7 @@
 - [Tool Response Handling](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-response-handling): Evaluate whether AI agents correctly process tool results, including error handling, data extraction, and
 - [Tool Selection](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-selection): Evaluate whether LLMs select the correct tools for given tasks
 - [Toxicity](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/toxicity): Legacy evaluator — detect toxic, harmful, or offensive content in LLM responses
+- [User Friction](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/user-friction): Detect when a user expresses friction or frustration with an assistant's preceding response
 
 - [Contains](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/contains): Check whether a text contains one or more specified words
 - [Correctness](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/correctness): Evaluate whether LLM responses are generally correct and complete using a Phoenix-managed judge model
@@ -163,6 +168,7 @@
 
 ## Datasets & Experiments
 
+- [Datasets & Experiments Quickstart](https://arize.com/docs/phoenix/datasets-and-experiments/quickstart-datasets): Create a dataset and run your first experiment to evaluate and iteratively improve performance
 
 ### Tutorial
 
@@ -437,6 +443,11 @@
 ### Evaluation
 
 - [LLM as a Judge](https://arize.com/docs/phoenix/evaluation/concepts-evals/llm-as-a-judge): LLM-based evaluation best practices
+- [Evaluators](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluators): Understand the evaluator abstraction, evaluator types, and the Score object
+- [Eval Data Types](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluation-types): Understand evaluation output types — categorical labels, continuous scores, and more
+- [Input Mapping](https://arize.com/docs/phoenix/evaluation/concepts-evals/input-mapping): Map and transform nested input data into the shape an evaluator's schema expects
+- [Custom Task Evaluation](https://arize.com/docs/phoenix/evaluation/concepts-evals/building-your-own-evals): Build custom LLM-as-judge eval templates for any task with arize-phoenix-evals
+- [Evaluating Multi-Agent Systems](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluating-multi-agent-systems): Evaluate multi-agent architectures with strategies for routing, coordination, and handoffs
 
 ## Resources
 
@@ -795,6 +806,8 @@
 - [06.26.2026 Evals as Tests — pytest and Vitest/Jest](https://arize.com/docs/phoenix/release-notes/06-2026/06-26-2026-eval-ci-pytest-vitest-jest): Write LLM evaluations as pytest, Vitest, or Jest tests that record every run to Phoenix and gate CI
 - [06.30.2026 PXI Terminal Client and Annotation Summary](https://arize.com/docs/phoenix/release-notes/06-2026/06-30-2026-pxi-terminal-client-and-annotation-summary): Run PXI as an interactive terminal chat from the CLI; review and bulk-delete annotations from project settings
 - [07.07.2026: Metric Charts, Trace Search, and REST API Expansion](https://arize.com/docs/phoenix/release-notes/07-2026/07-07-2026-metric-charts-trace-search-and-rest-api): Pin metric charts above data tables, search the trace tree, manage labels and annotation configs over REST, and use Claude Sonnet 5 in the Playground
+- [07.14.2026: Command Palette, Session Tools, and Table Customization](https://arize.com/docs/phoenix/release-notes/07-2026/07-14-2026-command-palette-sessions-and-tables): Jump anywhere with the ⌘K command palette, reorder table columns, inspect session stats, and use the GPT 5.6 family in the Playground
+- [07.17.2026: OAuth2 Authorization Server & Remote MCP](https://arize.com/docs/phoenix/release-notes/07-2026/07-17-2026-oauth2-authorization-server): Phoenix 19 becomes its own OAuth2 server with browser-based px CLI login, a built-in Remote MCP server, and REST API-key management
 
 ### 2025
 


### PR DESCRIPTION
## Audit `llms.txt` for coverage against the docs tree

Traversed the full docs tree (intersection of `docs.json` nav and on-disk `.mdx` files) and reconciled it against `docs/phoenix/llms.txt`.

### Coverage

| | Before | After |
|---|---|---|
| Published nav pages | 681 | 681 |
| Indexed in llms.txt | 658 | 671 |
| **Coverage** | **96.6%** | **98.5%** |

Well above the AFDocs ≥ 90% target. The remaining 10 unindexed pages are all intentional exclusions (see below).

### Added (13 pages)

**Evaluation**
- `evaluation/evals` — Evals Quickstart
- `evaluation/llm-evals/executors` — Executors
- `evaluation/llm-evals/evaluator-traces` — Evaluator Traces
- `evaluation/server-evals/builtin-evaluators` — Server Built-in Evaluators
- `evaluation/pre-built-metrics/user-friction` — User Friction (pre-built metric)

**Concepts → Evaluation**
- `evaluation/concepts-evals/evaluators` — Evaluators
- `evaluation/concepts-evals/evaluation-types` — Eval Data Types
- `evaluation/concepts-evals/input-mapping` — Input Mapping
- `evaluation/concepts-evals/building-your-own-evals` — Custom Task Evaluation
- `evaluation/concepts-evals/evaluating-multi-agent-systems` — Evaluating Multi-Agent Systems

**Datasets & Experiments**
- `datasets-and-experiments/quickstart-datasets` — Datasets & Experiments Quickstart

**Release Notes (2026)**
- `07-2026/07-14-2026-command-palette-sessions-and-tables`
- `07-2026/07-17-2026-oauth2-authorization-server`

### Removed (0)

No stale entries. Three URLs initially flagged as stale were false positives from the audit regex (slugs containing `.` / `+`); the corresponding `.mdx` files were verified to exist and were kept:
- `.../09-29-2025-day-0-support-for-claude-sonnet-4.5`
- `.../11-19-2025-expanded-provider-support-with-openai-5-1-+-gemini-3`
- `.../open-source-langsmith-alternative-arize-phoenix-vs.-langsmith`

### Excluded (10 pages, per skill rules)

- `agent-assisted-setup` — for AI coding agents, not doc consumers
- `documentation/jp`, `documentation/zh` — translated pages
- `end-to-end-features-notebook` — Colab notebook
- `phoenix-demo` — interactive demo
- `resources/github`, `resources/openinference` — bare external-link stubs (raw github.com), no docs page behind them
- `resources/python-api`, `resources/typescript-api` — redirect stubs pointing to already-indexed SDK reference pages
- `evaluation/how-to-evals/configuring-the-llm/prompt-formats` — duplicate content of the already-indexed `evaluation/how-to-evals/prompt-formats`

### Notes

- All new descriptions are action-oriented, 5–20 words, and name relevant packages (`arize-phoenix-evals`) where applicable.
- No new duplicate titles introduced.
- All 677 link lines remain well-formed per the llmstxt.org spec.
