### PR TITLE
fix: focus ring token consistency

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -881,6 +881,7 @@ const baseTokensCSS = (theme: Theme) => css`
       : "var(--global-color-blue-900)"};
     --hover-background: var(--global-color-gray-100);
     --focus-ring-color: var(--global-color-primary-500);
+    --focus-ring-thickness: var(--global-border-size-thick);
     --focus-ring-offset: var(--global-dimension-size-25);
 
     --text-color-placeholder: var(--global-color-gray-400);
@@ -1528,7 +1529,7 @@ const chartCSS = css`
     outline: none;
   }
   .recharts-surface:focus-visible {
-    outline: 2px solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
   }
 `;

--- a/app/src/components/agent/AgentWebSearchToggle.tsx
+++ b/app/src/components/agent/AgentWebSearchToggle.tsx
@@ -47,7 +47,7 @@ const webSearchToggleCSS = css`
   }
 
   &[data-focus-visible] {
-    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
   }
 `;

--- a/app/src/components/agent/ResizableFloatingPanel.tsx
+++ b/app/src/components/agent/ResizableFloatingPanel.tsx
@@ -547,7 +547,7 @@ const resizeHandleCSS = css`
   touch-action: none;
 
   &:focus-visible {
-    outline: 2px solid var(--global-color-primary);
+    outline: var(--focus-ring-thickness) solid var(--global-color-primary);
     outline-offset: -2px;
   }
 

--- a/app/src/components/agent/ResizableFloatingPanel.tsx
+++ b/app/src/components/agent/ResizableFloatingPanel.tsx
@@ -547,8 +547,8 @@ const resizeHandleCSS = css`
   touch-action: none;
 
   &:focus-visible {
-    outline: var(--focus-ring-thickness) solid var(--global-color-primary);
-    outline-offset: -2px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
 
   &[data-layer="modal"] {

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -193,8 +193,8 @@ export const toolPartCSS = css`
     background: var(--global-code-block-header-background-color);
 
     &:focus-visible {
-      outline: var(--focus-ring-thickness) solid var(--global-color-primary);
-      outline-offset: -2px;
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: calc(-1 * var(--focus-ring-thickness));
     }
   }
 

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -193,7 +193,7 @@ export const toolPartCSS = css`
     background: var(--global-code-block-header-background-color);
 
     &:focus-visible {
-      outline: 2px solid var(--global-color-primary);
+      outline: var(--focus-ring-thickness) solid var(--global-color-primary);
       outline-offset: -2px;
     }
   }

--- a/app/src/components/ai/attachment/styles.ts
+++ b/app/src/components/ai/attachment/styles.ts
@@ -313,7 +313,7 @@ export const attachmentRemoveCSS = css`
 
   &[data-focus-visible] {
     opacity: 1;
-    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
   }
 

--- a/app/src/components/ai/elicitation/styles.ts
+++ b/app/src/components/ai/elicitation/styles.ts
@@ -137,8 +137,8 @@ export const elicitationOptionButtonCSS = css`
     color 0.15s ease;
 
   &:focus-visible {
-    outline: 1px solid var(--global-input-field-border-color-active);
-    outline-offset: 1px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 
   &[data-selected="true"] {

--- a/app/src/components/ai/message/styles.ts
+++ b/app/src/components/ai/message/styles.ts
@@ -96,7 +96,7 @@ export const messageActionCSS = css`
   }
 
   &[data-focus-visible] {
-    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
   }
 

--- a/app/src/components/ai/prompt-input/styles.ts
+++ b/app/src/components/ai/prompt-input/styles.ts
@@ -101,7 +101,7 @@ export const promptInputSubmitCSS = css`
   }
 
   &[data-focus-visible] {
-    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
   }
 
@@ -148,7 +148,7 @@ export const promptInputButtonCSS = css`
   }
 
   &[data-focus-visible] {
-    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
   }
 

--- a/app/src/components/ai/prompt-input/styles.ts
+++ b/app/src/components/ai/prompt-input/styles.ts
@@ -10,6 +10,8 @@ export const promptInputContainerCSS = css`
 
   &[data-input-mode="prompt"]:focus-within {
     border-color: var(--prompt-input-border-color-focus);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
 
   /* Elicitation surfaces host tall content (consent gate, question carousel,

--- a/app/src/components/chart/InteractiveLegend.tsx
+++ b/app/src/components/chart/InteractiveLegend.tsx
@@ -118,7 +118,7 @@ const legendButtonCSS = css`
   }
 
   &:focus-visible {
-    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
     border-radius: var(--global-rounding-small);
   }

--- a/app/src/components/code/CodeEditorFieldWrapper.tsx
+++ b/app/src/components/code/CodeEditorFieldWrapper.tsx
@@ -11,7 +11,9 @@ const codeEditorFormWrapperCSS = css`
     border: 1px solid var(--global-input-field-border-color-active);
   }
   &.is-focused {
-    border: 1px solid var(--global-input-field-border-color-active);
+    border-color: var(--global-input-field-border-color-active);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
   &.is-invalid {
     border: 1px solid var(--global-color-danger);

--- a/app/src/components/core/button/IconButton.tsx
+++ b/app/src/components/core/button/IconButton.tsx
@@ -95,7 +95,7 @@ const iconButtonCSS = (color: TextColorValue) => css`
   }
 
   &[data-focus-visible] {
-    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
   }
 

--- a/app/src/components/core/button/styles.tsx
+++ b/app/src/components/core/button/styles.tsx
@@ -24,8 +24,8 @@ export const buttonCSS = css`
   &[data-focus-visible],
   &:focus-visible {
     // Only show outline on focus-visible, aka only when tabbed but not clicked
-    outline: 1px solid var(--global-input-field-border-color-active);
-    outline-offset: 1px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
   &[disabled] {
     cursor: default;

--- a/app/src/components/core/checkbox/styles.ts
+++ b/app/src/components/core/checkbox/styles.ts
@@ -55,7 +55,7 @@ export const checkboxCSS = css`
 
   &[data-focus-visible] .checkbox {
     outline: var(--focus-ring-thickness) solid var(--checkbox-focus-ring-color);
-    outline-offset: 2px;
+    outline-offset: var(--focus-ring-offset);
   }
 
   &[data-selected],

--- a/app/src/components/core/checkbox/styles.ts
+++ b/app/src/components/core/checkbox/styles.ts
@@ -54,7 +54,7 @@ export const checkboxCSS = css`
   }
 
   &[data-focus-visible] .checkbox {
-    outline: 2px solid var(--checkbox-focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--checkbox-focus-ring-color);
     outline-offset: 2px;
   }
 

--- a/app/src/components/core/datetime/DateField.tsx
+++ b/app/src/components/core/datetime/DateField.tsx
@@ -40,8 +40,8 @@ const dateFieldCSS = css`
     forced-color-adjust: none;
 
     &[data-focus-within] {
-      outline: 1px solid var(--global-color-primary);
-      outline-offset: -1px;
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: calc(-1 * var(--focus-ring-thickness));
     }
 
     &[data-invalid] {

--- a/app/src/components/core/datetime/TimeField.tsx
+++ b/app/src/components/core/datetime/TimeField.tsx
@@ -29,8 +29,8 @@ const timeFieldCSS = css`
     forced-color-adjust: none;
 
     &[data-focus-within] {
-      outline: 1px solid var(--global-color-primary);
-      outline-offset: -1px;
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: calc(-1 * var(--focus-ring-thickness));
     }
   }
 

--- a/app/src/components/core/datetime/calendarStyles.ts
+++ b/app/src/components/core/datetime/calendarStyles.ts
@@ -78,7 +78,7 @@ export const calendarCSS = css`
     }
 
     &[data-focus-visible] {
-      outline: 2px solid var(--focus-ring-color);
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
       outline-offset: -2px;
     }
 

--- a/app/src/components/core/datetime/calendarStyles.ts
+++ b/app/src/components/core/datetime/calendarStyles.ts
@@ -79,7 +79,7 @@ export const calendarCSS = css`
 
     &[data-focus-visible] {
       outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
-      outline-offset: -2px;
+      outline-offset: calc(-1 * var(--focus-ring-thickness));
     }
 
     &[data-selected] {

--- a/app/src/components/core/disclosure/styles.tsx
+++ b/app/src/components/core/disclosure/styles.tsx
@@ -54,8 +54,10 @@ export const disclosureCSS = css`
       background-color: var(--global-disclosure-background-color-active);
     }
     &[data-focus-visible] {
-      outline: 1px solid var(--global-input-field-border-color-active);
-      outline-offset: -1px;
+      position: relative;
+      z-index: 1;
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: calc(-1 * var(--focus-ring-thickness));
     }
     &:not([disabled]) {
       transition: all 0.2s ease-in-out;

--- a/app/src/components/core/dropzone/styles.ts
+++ b/app/src/components/core/dropzone/styles.ts
@@ -41,6 +41,8 @@ export const fileDropZoneCSS = css`
 
   &[data-focus-visible] {
     border-color: var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
 
   &[data-drop-target] {

--- a/app/src/components/core/field/CopyInput.tsx
+++ b/app/src/components/core/field/CopyInput.tsx
@@ -78,9 +78,8 @@ function CopyInput({
           }
 
           &:focus-visible {
-            outline: var(--focus-ring-thickness) solid
-              var(--global-color-primary);
-            outline-offset: 2px;
+            outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+            outline-offset: var(--focus-ring-offset);
           }
 
           &[disabled] {

--- a/app/src/components/core/field/CopyInput.tsx
+++ b/app/src/components/core/field/CopyInput.tsx
@@ -78,7 +78,8 @@ function CopyInput({
           }
 
           &:focus-visible {
-            outline: 2px solid var(--global-color-primary);
+            outline: var(--focus-ring-thickness) solid
+              var(--global-color-primary);
             outline-offset: 2px;
           }
 

--- a/app/src/components/core/field/CredentialInput.tsx
+++ b/app/src/components/core/field/CredentialInput.tsx
@@ -72,9 +72,8 @@ function CredentialInput({
           }
 
           &:focus-visible {
-            outline: var(--focus-ring-thickness) solid
-              var(--global-color-primary);
-            outline-offset: 2px;
+            outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+            outline-offset: var(--focus-ring-offset);
           }
 
           &[disabled] {

--- a/app/src/components/core/field/CredentialInput.tsx
+++ b/app/src/components/core/field/CredentialInput.tsx
@@ -72,7 +72,8 @@ function CredentialInput({
           }
 
           &:focus-visible {
-            outline: 2px solid var(--global-color-primary);
+            outline: var(--focus-ring-thickness) solid
+              var(--global-color-primary);
             outline-offset: 2px;
           }
 

--- a/app/src/components/core/field/SearchField.tsx
+++ b/app/src/components/core/field/SearchField.tsx
@@ -96,8 +96,8 @@ const searchFieldCSS = css`
     font-size: var(--searchfield-icon-size);
 
     &[data-focus-visible] {
-      outline: 1px solid var(--global-input-field-border-color-active);
-      outline-offset: 1px;
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: var(--focus-ring-offset);
     }
 
     &:hover {

--- a/app/src/components/core/field/styles.ts
+++ b/app/src/components/core/field/styles.ts
@@ -33,11 +33,14 @@ export const fieldBaseCSS = css`
     vertical-align: middle;
 
     &[data-focused] {
-      // TODO: figure out focus ring behavior. For now the color is enough
+      // State-specific selectors below provide the visible focus treatment.
       outline: none;
     }
     &[data-focused]:not([data-invalid]) {
-      border: 1px solid var(--field-border-color-active);
+      border-color: var(--field-border-color-active);
+      outline: var(--focus-ring-thickness) solid
+        var(--field-border-color-active);
+      outline-offset: calc(-1 * var(--focus-ring-thickness));
     }
     &[data-hovered]:not([data-disabled]):not([data-invalid]) {
       border: 1px solid var(--field-border-color-active);
@@ -55,6 +58,9 @@ export const fieldBaseCSS = css`
     &:is([data-readonly], [readonly])[data-focus-visible]:not([data-invalid]) {
       background-color: var(--field-readonly-background-color-hover);
       border-color: var(--field-readonly-border-color-focus);
+      outline: var(--focus-ring-thickness) solid
+        var(--field-readonly-border-color-focus);
+      outline-offset: calc(-1 * var(--focus-ring-thickness));
     }
     &:is([data-readonly], [readonly])[data-hovered]:not([data-invalid]):not(
       [data-focus-visible]
@@ -172,12 +178,16 @@ export const textFieldCSS = css`
       var(--textfield-horizontal-padding);
     box-sizing: border-box;
     outline-offset: -1px;
-    outline: var(--global-border-size-thin) solid transparent;
+    outline: var(--focus-ring-thickness) solid transparent;
     &[data-focused]:not([data-invalid]) {
-      outline: 1px solid var(--field-border-color-active);
+      border-width: var(--global-border-size-thin);
+      outline: var(--focus-ring-thickness) solid
+        var(--field-border-color-active);
     }
     &[data-focused][data-invalid] {
-      outline: 1px solid var(--field-invalid-border-color);
+      border-width: var(--global-border-size-thin);
+      outline: var(--focus-ring-thickness) solid
+        var(--field-invalid-border-color);
     }
     // Suppress the focus outline while readonly (fieldBaseCSS handles the
     // readonly background/border), then restore it only for keyboard focus.
@@ -188,7 +198,9 @@ export const textFieldCSS = css`
       outline-color: transparent;
     }
     &:is([data-readonly], [readonly])[data-focus-visible]:not([data-invalid]) {
-      outline-color: var(--field-readonly-border-color-focus);
+      border-width: var(--global-border-size-thin);
+      outline: var(--focus-ring-thickness) solid
+        var(--field-readonly-border-color-focus);
     }
   }
 

--- a/app/src/components/core/gridlist/styles.ts
+++ b/app/src/components/core/gridlist/styles.ts
@@ -12,7 +12,7 @@ export const gridListCss = css`
   padding: var(--global-menu-item-gap);
   &:focus-visible {
     border-radius: var(--global-rounding-small);
-    outline: var(--focus-ring-thickness) solid var(--global-color-primary);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: 0px;
   }
   &[data-empty] {

--- a/app/src/components/core/gridlist/styles.ts
+++ b/app/src/components/core/gridlist/styles.ts
@@ -12,7 +12,7 @@ export const gridListCss = css`
   padding: var(--global-menu-item-gap);
   &:focus-visible {
     border-radius: var(--global-rounding-small);
-    outline: 2px solid var(--global-color-primary);
+    outline: var(--focus-ring-thickness) solid var(--global-color-primary);
     outline-offset: 0px;
   }
   &[data-empty] {

--- a/app/src/components/core/id/IDBadge.tsx
+++ b/app/src/components/core/id/IDBadge.tsx
@@ -17,8 +17,8 @@ const idBadgeCSS = css`
   display: inline-flex;
   cursor: pointer;
   &:focus-visible {
-    outline: 1px solid var(--global-input-field-border-color-active);
-    outline-offset: 1px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
     border-radius: var(--global-badge-border-radius);
   }
   &[data-hovered] .id-badge__copy-icon {

--- a/app/src/components/core/listbox/ListBox.tsx
+++ b/app/src/components/core/listbox/ListBox.tsx
@@ -15,7 +15,7 @@ const listBoxCSS = css`
   box-sizing: border-box;
 
   &[data-focus-visible] {
-    outline: 2px solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: -1px;
   }
 
@@ -41,7 +41,7 @@ const listBoxCSS = css`
     flex-direction: column;
 
     &[data-focus-visible] {
-      outline: 2px solid var(--focus-ring-color);
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
       outline-offset: -2px;
     }
 

--- a/app/src/components/core/overlay/Drawer.tsx
+++ b/app/src/components/core/overlay/Drawer.tsx
@@ -74,7 +74,7 @@ const drawerCSS = css`
   }
 
   .drawer__resize-handle:focus-visible {
-    outline: 2px solid var(--global-color-primary);
+    outline: var(--focus-ring-thickness) solid var(--global-color-primary);
     outline-offset: 2px;
   }
 

--- a/app/src/components/core/overlay/Drawer.tsx
+++ b/app/src/components/core/overlay/Drawer.tsx
@@ -74,8 +74,8 @@ const drawerCSS = css`
   }
 
   .drawer__resize-handle:focus-visible {
-    outline: var(--focus-ring-thickness) solid var(--global-color-primary);
-    outline-offset: 2px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 
   &[data-dragging="true"] {

--- a/app/src/components/core/radio/Radio.tsx
+++ b/app/src/components/core/radio/Radio.tsx
@@ -43,9 +43,8 @@ const baseRadioCSS = css(`
   }
 
   &[data-focus-visible]:before {
-    outline: var(--focus-ring-thickness) solid
-      var(--global-input-field-border-color-active);
-    outline-offset: 2px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 
   &[data-disabled] {

--- a/app/src/components/core/radio/Radio.tsx
+++ b/app/src/components/core/radio/Radio.tsx
@@ -43,7 +43,8 @@ const baseRadioCSS = css(`
   }
 
   &[data-focus-visible]:before {
-    outline: 2px solid var(--global-input-field-border-color-active);
+    outline: var(--focus-ring-thickness) solid
+      var(--global-input-field-border-color-active);
     outline-offset: 2px;
   }
 

--- a/app/src/components/core/radio/RadioGroup.tsx
+++ b/app/src/components/core/radio/RadioGroup.tsx
@@ -78,7 +78,7 @@ const baseRadioGroupCSS = css(`
 
   &:has(.radio[data-focus-visible]) {
     border-radius: var(--global-rounding-small);
-    outline: 1px solid var(--global-input-field-border-color-active);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     // display an outline offset around the radio group, accounting for the outline offset of the inner radios
     outline-offset: var(--global-dimension-size-100);
   }

--- a/app/src/components/core/slider/Slider.tsx
+++ b/app/src/components/core/slider/Slider.tsx
@@ -26,6 +26,7 @@ const sliderCSS = css`
   --slider-track-bg: var(--global-color-gray-300);
   --slider-filled-color: var(--global-color-primary);
   --slider-ring-color: var(--global-color-primary-200);
+  --slider-focus-ring-color: var(--global-color-primary);
 
   display: grid;
   grid-template-areas:
@@ -84,13 +85,14 @@ const sliderCSS = css`
     position: relative;
 
     &:hover,
-    &[data-focus-visible],
     &[data-dragging] {
       box-shadow: 0 0 0 4px var(--slider-ring-color);
     }
 
     &[data-focus-visible] {
-      outline: none;
+      box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+      outline: var(--focus-ring-thickness) solid var(--slider-focus-ring-color);
+      outline-offset: var(--focus-ring-offset);
     }
   }
 

--- a/app/src/components/core/slider/Slider.tsx
+++ b/app/src/components/core/slider/Slider.tsx
@@ -26,7 +26,7 @@ const sliderCSS = css`
   --slider-track-bg: var(--global-color-gray-300);
   --slider-filled-color: var(--global-color-primary);
   --slider-ring-color: var(--global-color-primary-200);
-  --slider-focus-ring-color: var(--global-color-primary);
+  --slider-focus-ring-color: var(--focus-ring-color);
 
   display: grid;
   grid-template-areas:

--- a/app/src/components/core/switch/Switch.tsx
+++ b/app/src/components/core/switch/Switch.tsx
@@ -72,7 +72,7 @@ const switchCSS = css`
   }
 
   &[data-focus-visible] .indicator {
-    outline: 2px solid var(--focus-ring-color);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: 2px;
   }
 

--- a/app/src/components/core/switch/Switch.tsx
+++ b/app/src/components/core/switch/Switch.tsx
@@ -73,7 +73,7 @@ const switchCSS = css`
 
   &[data-focus-visible] .indicator {
     outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
-    outline-offset: 2px;
+    outline-offset: var(--focus-ring-offset);
   }
 
   &[data-disabled] {

--- a/app/src/components/core/tabs/Tabs.tsx
+++ b/app/src/components/core/tabs/Tabs.tsx
@@ -341,7 +341,7 @@ const tabCSS = css`
     position: absolute;
     inset: var(--tab-pill-inset, var(--global-dimension-size-50));
     border-radius: var(--global-rounding-small);
-    border: 2px solid var(--focus-ring-color);
+    border: var(--focus-ring-thickness) solid var(--focus-ring-color);
   }
 `;
 

--- a/app/src/components/core/tag/Tag.tsx
+++ b/app/src/components/core/tag/Tag.tsx
@@ -21,8 +21,8 @@ const tagCSS = css`
   }
 
   &[data-focus-visible] {
-    outline: 1px solid var(--global-color-primary);
-    outline-offset: 1px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 
   &[data-selected] {

--- a/app/src/components/core/toast/Toast.tsx
+++ b/app/src/components/core/toast/Toast.tsx
@@ -7,7 +7,7 @@ import {
   UNSTABLE_ToastStateContext as ToastStateContext,
 } from "react-aria-components";
 
-import { Button } from "@phoenix/components/core/button";
+import { Button, IconButton } from "@phoenix/components/core/button";
 import { Text } from "@phoenix/components/core/content";
 import { Icon, Icons } from "@phoenix/components/core/icon";
 import { toastCSS } from "@phoenix/components/core/toast/styles";
@@ -84,12 +84,15 @@ export const Toast = <T extends QueuedToast<NotificationParams>>({
             </Text>
             <Text slot="description">{toast.content.message}</Text>
           </AriaToastContent>
-          <Button
+          <IconButton
             slot="close"
             size="S"
+            color="inherit"
             type="button"
-            leadingVisual={<Icon svg={<Icons.Close />} />}
-          />
+            aria-label="Close notification"
+          >
+            <Icon svg={<Icons.Close />} />
+          </IconButton>
         </div>
         {toast.content.action ? (
           <div className="toast-action-container">

--- a/app/src/components/core/toast/styles.ts
+++ b/app/src/components/core/toast/styles.ts
@@ -189,31 +189,4 @@ export const toastCSS = css`
       color: var(--toast-color);
     }
   }
-
-  .react-aria-Button[slot="close"] {
-    flex: 0 0 auto;
-    background: none;
-    border: none;
-    appearance: none;
-    border-radius: 50%;
-    height: 18px;
-    width: 18px;
-    border: none;
-    color: var(--toast-color);
-    padding: 0;
-    outline: none;
-
-    &[data-focus-visible] {
-      border: 1px solid var(--global-input-field-border-color-active);
-      background: var(--toast-background-color);
-    }
-
-    &[data-hovered] {
-      background: var(--toast-background-color);
-    }
-
-    &[data-pressed] {
-      background: var(--toast-background-color);
-    }
-  }
 `;

--- a/app/src/components/core/toast/styles.ts
+++ b/app/src/components/core/toast/styles.ts
@@ -144,8 +144,8 @@ export const toastCSS = css`
   }
 
   &[data-focus-visible] {
-    outline: var(--focus-ring-thickness) solid slateblue;
-    outline-offset: 2px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 
   [slot="close"][data-hovered],

--- a/app/src/components/core/toast/styles.ts
+++ b/app/src/components/core/toast/styles.ts
@@ -148,6 +148,12 @@ export const toastCSS = css`
     outline-offset: 2px;
   }
 
+  [slot="close"][data-hovered],
+  [slot="close"][data-pressed] {
+    background-color: transparent;
+    color: inherit;
+  }
+
   .toast-action-container {
     display: flex;
     align-items: center;

--- a/app/src/components/core/toast/styles.ts
+++ b/app/src/components/core/toast/styles.ts
@@ -144,7 +144,7 @@ export const toastCSS = css`
   }
 
   &[data-focus-visible] {
-    outline: 2px solid slateblue;
+    outline: var(--focus-ring-thickness) solid slateblue;
     outline-offset: 2px;
   }
 

--- a/app/src/components/core/toggleButtonGroup/ToggleButton.tsx
+++ b/app/src/components/core/toggleButtonGroup/ToggleButton.tsx
@@ -29,8 +29,11 @@ const baseToggleButtonCSS = css(
       background-color: var(--global-input-field-border-color-hover);
     }
     &[data-focus-visible] {
-      outline: 1px solid var(--global-input-field-border-color-active);
-      outline-offset: -2px;
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: calc(-1 * var(--focus-ring-thickness));
+    }
+    &[data-selected="true"][data-focus-visible] {
+      outline-color: var(--global-button-primary-foreground-color);
     }
 `
 );

--- a/app/src/components/core/toggleButtonGroup/ToggleButtonGroup.tsx
+++ b/app/src/components/core/toggleButtonGroup/ToggleButtonGroup.tsx
@@ -39,8 +39,8 @@ const baseToggleButtonGroupCSS = css(`
 
   &:has(.toggle-button[data-focus-visible]) {
     border-radius: var(--global-rounding-small);
-    outline: 1px solid var(--global-input-field-border-color-active);
-    outline-offset: 1px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 `);
 

--- a/app/src/components/core/token/Token.tsx
+++ b/app/src/components/core/token/Token.tsx
@@ -102,7 +102,7 @@ const tokenBaseCSS = css`
 
     > button {
       &:focus-visible {
-        outline: 2px solid var(--focus-ring-color);
+        outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
         border-radius: var(--global-rounding-small);
       }
     }

--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -66,9 +66,13 @@ const timeRangeSelectorCSS = css`
   /* Match the standard input field: a single border-color change for both
      hover and focus so the two states read consistently. */
   &:hover:not([data-disabled]),
-  &:focus-within:not([data-disabled]),
   &[data-presets-open]:not([data-disabled]) {
     border-color: var(--global-input-field-border-color-active);
+  }
+  &:focus-within:not([data-disabled]) {
+    border-color: var(--global-input-field-border-color-active);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
   &[data-disabled] {
     opacity: var(--global-opacity-disabled);

--- a/app/src/components/dnd/styles.ts
+++ b/app/src/components/dnd/styles.ts
@@ -43,7 +43,7 @@ export const dndHandleAppearanceCSS = css`
   }
   &:focus-visible {
     opacity: 1;
-    outline: 1px solid var(--global-color-primary);
-    outline-offset: -1px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
 `;

--- a/app/src/components/filter/styles.ts
+++ b/app/src/components/filter/styles.ts
@@ -155,9 +155,13 @@ export const dslFilterFieldCSS = css`
   background-color: var(--global-input-field-background-color);
   transition: all 0.2s ease-in-out;
   overflow-x: hidden;
-  &:hover,
+  &:hover {
+    border-color: var(--global-input-field-border-color-active);
+  }
   &[data-is-focused="true"] {
     border-color: var(--global-input-field-border-color-active);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
   /* Flag invalidity only once the user has left the field — a red border
      while they're still typing/fixing the expression is too alarming */
@@ -192,8 +196,8 @@ export const dslFilterFieldCSS = css`
       flex-shrink: 0;
     }
     &:focus-visible {
-      outline: 1px solid var(--global-input-field-border-color-active);
-      outline-offset: 1px;
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: var(--focus-ring-offset);
     }
   }
   .error-badge__message {
@@ -215,8 +219,8 @@ export const dslFilterFieldCSS = css`
       background-color: var(--global-color-gray-300);
     }
     &:focus-visible {
-      outline: 1px solid var(--global-input-field-border-color-active);
-      outline-offset: 1px;
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: var(--focus-ring-offset);
     }
   }
   &[data-has-condition="true"] .clear-button {

--- a/app/src/components/project/GradientCircleRadio.tsx
+++ b/app/src/components/project/GradientCircleRadio.tsx
@@ -40,8 +40,8 @@ const gradientCircleRadioCSS = css`
 
   /* Focus visible state */
   &[data-focus-visible] {
-    outline: var(--focus-ring-thickness) solid var(--global-color-primary);
-    outline-offset: 2px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 
   /* Disabled state */

--- a/app/src/components/project/GradientCircleRadio.tsx
+++ b/app/src/components/project/GradientCircleRadio.tsx
@@ -40,7 +40,7 @@ const gradientCircleRadioCSS = css`
 
   /* Focus visible state */
   &[data-focus-visible] {
-    outline: 2px solid var(--global-color-primary);
+    outline: var(--focus-ring-thickness) solid var(--global-color-primary);
     outline-offset: 2px;
   }
 

--- a/app/src/components/project/GradientCircleRadioGroup.tsx
+++ b/app/src/components/project/GradientCircleRadioGroup.tsx
@@ -50,8 +50,8 @@ const gradientCircleRadioGroupCSS = css`
 
   &:has(.gradient-circle-radio[data-focus-visible]) {
     border-radius: var(--global-rounding-small);
-    outline: 1px solid var(--global-color-primary);
-    outline-offset: var(--global-dimension-size-50);
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
 `;
 

--- a/app/src/components/react-resizable-panels/TitledPanel.tsx
+++ b/app/src/components/react-resizable-panels/TitledPanel.tsx
@@ -168,8 +168,8 @@ const panelTitleCSS = css`
   flex: 1 1 auto;
   min-width: 0;
   &:focus-visible {
-    outline: 1px solid var(--global-color-primary);
-    outline-offset: -1px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
   &:hover {
     cursor: pointer;

--- a/app/src/pages/datasets/ColumnAssigner/ColumnBucket.tsx
+++ b/app/src/pages/datasets/ColumnAssigner/ColumnBucket.tsx
@@ -20,8 +20,8 @@ const bucketBaseCSS = css`
   }
 
   &:focus-visible {
-    outline: 1px solid var(--global-color-primary);
-    outline-offset: -2px;
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
 `;
 

--- a/app/src/pages/project/SessionSearchField.tsx
+++ b/app/src/pages/project/SessionSearchField.tsx
@@ -1,107 +1,28 @@
-import { css } from "@emotion/react";
-import CodeMirror, { type BasicSetupOptions } from "@uiw/react-codemirror";
-import { useState } from "react";
+import { Input } from "react-aria-components";
 
-import { Flex, Icon, Icons } from "@phoenix/components";
-import { pierreDark, pierreLight } from "@phoenix/components/code";
-import { useTheme } from "@phoenix/contexts";
+import { SearchField, SearchIcon } from "@phoenix/components";
 
 import { useSessionSearchContext } from "./SessionSearchContext";
-const codeMirrorCSS = css`
-  flex: 1 1 auto;
-  .cm-content {
-    padding: var(--global-dimension-size-100) 0;
-  }
-  .cm-editor {
-    background-color: transparent !important;
-  }
-  .cm-focused {
-    outline: none;
-  }
-  .cm-selectionLayer .cm-selectionBackground {
-    background: var(--global-color-cyan-400) !important;
-  }
-`;
 
-const fieldCSS = css`
-  border-width: var(--global-border-size-thin);
-  border-style: solid;
-  border-color: var(--global-input-field-border-color);
-  border-radius: var(--global-rounding-small);
-  background-color: var(--global-input-field-background-color);
-  transition: all 0.2s ease-in-out;
-  overflow-x: hidden;
-  &:hover,
-  &[data-is-focused="true"] {
-    border-color: var(--global-input-field-border-color-active);
-    background-color: var(--global-input-field-background-color-active);
-  }
-  &[data-is-invalid="true"] {
-    border-color: var(--global-color-danger);
-  }
-  box-sizing: border-box;
-  .search-icon {
-    margin-left: var(--global-dimension-size-100);
-    margin-top: var(--global-dimension-size-100);
-  }
-`;
-
-const basicSetupOptions: BasicSetupOptions = {
-  lineNumbers: false,
-  foldGutter: false,
-  bracketMatching: false,
-  syntaxHighlighting: false,
-  highlightActiveLine: false,
-  highlightActiveLineGutter: false,
-  defaultKeymap: false,
-  searchKeymap: false,
-};
-
-type SessionsSubstringFieldProps = {
+type SessionSearchFieldProps = {
   placeholder?: string;
 };
-export function SessionSearchField(props: SessionsSubstringFieldProps) {
-  const { placeholder = "Search messages or session ID" } = props;
-  const [isFocused, setIsFocused] = useState<boolean>(false);
+
+export function SessionSearchField({
+  placeholder = "Search messages or session ID",
+}: SessionSearchFieldProps) {
   const { filterIoSubstringOrSessionId, setFilterIoSubstringOrSessionId } =
     useSessionSearchContext();
-  const { theme } = useTheme();
-  const codeMirrorTheme = theme === "light" ? pierreLight : pierreDark;
 
-  const hasSubstring = filterIoSubstringOrSessionId !== "";
   return (
-    <div
-      data-is-focused={isFocused}
-      className="sessions-substring-field"
-      css={fieldCSS}
+    <SearchField
+      aria-label="Search sessions"
+      value={filterIoSubstringOrSessionId}
+      onChange={setFilterIoSubstringOrSessionId}
+      size="S"
     >
-      <Flex direction="row">
-        <Icon svg={<Icons.Search />} className="search-icon" />
-        <CodeMirror
-          css={codeMirrorCSS}
-          indentWithTab={false}
-          basicSetup={basicSetupOptions}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          value={filterIoSubstringOrSessionId}
-          onChange={setFilterIoSubstringOrSessionId}
-          height="36px"
-          width="100%"
-          theme={codeMirrorTheme}
-          placeholder={placeholder}
-        />
-        <button
-          css={css`
-            margin-right: var(--global-dimension-size-100);
-            color: var(--global-text-color-700);
-            visibility: ${hasSubstring ? "visible" : "hidden"};
-          `}
-          onClick={() => setFilterIoSubstringOrSessionId("")}
-          className="button--reset"
-        >
-          <Icon svg={<Icons.CloseCircle />} />
-        </button>
-      </Flex>
-    </div>
+      <SearchIcon />
+      <Input placeholder={placeholder} />
+    </SearchField>
   );
 }

--- a/app/src/pages/project/SessionSearchField.tsx
+++ b/app/src/pages/project/SessionSearchField.tsx
@@ -19,7 +19,6 @@ export function SessionSearchField({
       aria-label="Search sessions"
       value={filterIoSubstringOrSessionId}
       onChange={setFilterIoSubstringOrSessionId}
-      size="S"
     >
       <SearchIcon />
       <Input placeholder={placeholder} />


### PR DESCRIPTION
Creates a dedicated focus ring thickness token. 

Updates call sites to use the dedicated token as well as the existing color and offset tokens. 

Two actual component changes:

* Toast replaces a one-off close button with a regular icon button
* Session filter bar becomes consistent with its equivalent on other pages

