### PR TITLE
docs(skills): weekly audit — 2026-07-22

### DIFF
--- a/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
+++ b/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
@@ -24,13 +24,16 @@ import { openai } from "@ai-sdk/openai";
 const hallucinationEval = createHallucinationEvaluator({ model: openai("gpt-4o") });
 ```
 
-## Available (2.0)
+## Available
 
 | Evaluator | Type | Description |
 | --------- | ---- | ----------- |
 | `FaithfulnessEvaluator` | LLM | Is the response faithful to the context? |
 | `CorrectnessEvaluator` | LLM | Is the response correct? |
+| `ConcisenessEvaluator` | LLM | Is the response concise and free of unnecessary content? |
 | `DocumentRelevanceEvaluator` | LLM | Are retrieved documents relevant? |
+| `RefusalEvaluator` | LLM | Did the model refuse or decline to answer? |
+| `UserFrictionEvaluator` | LLM | Did the latest user message express friction with the assistant's preceding behavior? |
 | `ToolSelectionEvaluator` | LLM | Did the agent select the right tool? |
 | `ToolInvocationEvaluator` | LLM | Did the agent invoke the tool correctly? |
 | `ToolResponseHandlingEvaluator` | LLM | Did the agent handle the tool response well? |
@@ -38,10 +41,58 @@ const hallucinationEval = createHallucinationEvaluator({ model: openai("gpt-4o")
 | `PrecisionRecallFScore` | Code | Precision/recall/F-score metrics |
 | `exact_match` | Code | Exact string match |
 
+All LLM evaluators are imported from `phoenix.evals.metrics` and constructed with an
+`LLM` instance, e.g. `UserFrictionEvaluator(llm=llm)`.
+
+### `UserFrictionEvaluator` input shape
+
+Unlike single-response evaluators, `UserFrictionEvaluator` expects the conversation
+history and the target user message as **separate** fields, so the judge does not
+confuse an earlier turn with the message under evaluation:
+
+```python
+from phoenix.evals import LLM
+from phoenix.evals.metrics import UserFrictionEvaluator
+
+llm = LLM(provider="openai", model="gpt-4o-mini")
+user_friction_eval = UserFrictionEvaluator(llm=llm)
+
+scores = user_friction_eval.evaluate({
+    "conversation": (
+        "User: Show orders from this week.\n"
+        "Assistant: Here are last month's orders."
+    ),
+    "user_message": "No, I asked for this week.",
+})
+# -> Score(name='user_friction', label='friction', score=1.0, ...)
+```
+
+Labels are `friction` / `no_friction` (score 1.0 = friction). Note that `no_friction`
+does not prove satisfaction — users often abandon conversations without saying why.
+
 Legacy evaluators (`HallucinationEvaluator`, `QAEvaluator`, `RelevanceEvaluator`,
 `ToxicityEvaluator`, `SummarizationEvaluator`) are in `phoenix.evals.legacy` and deprecated.
 
-**TypeScript**: `PrecisionRecallFScore` is also available via `@arizeai/phoenix-evals/code`
+**TypeScript**: the LLM evaluators ship as factory functions from
+`@arizeai/phoenix-evals` — `createFaithfulnessEvaluator`, `createCorrectnessEvaluator`,
+`createConcisenessEvaluator`, `createDocumentRelevanceEvaluator`,
+`createRefusalEvaluator`, `createUserFrictionEvaluator`, `createToolSelectionEvaluator`,
+`createToolInvocationEvaluator`, and `createToolResponseHandlingEvaluator`. Each takes a
+`model` and returns an evaluator whose `.evaluate()` returns a classification result:
+
+```typescript
+import { createUserFrictionEvaluator } from "@arizeai/phoenix-evals";
+import { openai } from "@ai-sdk/openai";
+
+const userFriction = createUserFrictionEvaluator({ model: openai("gpt-4o-mini") });
+const result = await userFriction.evaluate({
+  conversation: "User: Show recent orders.\nAssistant: Here are last month's orders.",
+  userMessage: "No, I asked for this week.",
+});
+// result.label === "friction"
+```
+
+`PrecisionRecallFScore` is also available via `@arizeai/phoenix-evals/code`
 as `createPrecisionEvaluator`, `createRecallEvaluator`, `createF1Evaluator`,
 `createFBetaEvaluator`, and `createPrecisionRecallFScoreEvaluators` — see
 [evaluators-code-typescript.md](evaluators-code-typescript.md).

--- a/.agents/skills/phoenix-tracing/references/instrumentation-auto-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-auto-typescript.md
@@ -5,8 +5,9 @@ Automatically create spans for LLM calls without code changes.
 ## Supported Frameworks
 
 - **LLM SDKs:** OpenAI
-- **Frameworks:** LangChain
+- **Frameworks:** LangChain, Vercel AI SDK
 - **Install:** `npm install @arizeai/openinference-instrumentation-{name}`
+  (the Vercel AI SDK is traced through `@arizeai/phoenix-otel` directly — see below)
 
 ## Setup
 
@@ -36,6 +37,52 @@ registerInstrumentations({ instrumentations: [instrumentation] });
 ```
 
 **Why:** ESM imports are hoisted before `register()` runs.
+
+## Vercel AI SDK
+
+The Vercel AI SDK (v7+) emits its own OpenTelemetry spans; `@arizeai/phoenix-otel`
+processes them (via `@arizeai/openinference-vercel`) and exports them to Phoenix. No
+per-call instrumentation is needed.
+
+**Version compatibility** — the runtime is ESM-only, so match versions:
+
+| Vercel AI SDK | `@arizeai/phoenix-otel` | `@arizeai/openinference-vercel` |
+| ------------- | ----------------------- | ------------------------------- |
+| v7+           | 2.x                     | 3.x                             |
+| v6 and older  | 1.x                     | 2.x                             |
+
+AI SDK v7 telemetry requires Node.js 22+.
+
+**Install:**
+
+```bash
+npm i --save ai @ai-sdk/otel @arizeai/phoenix-otel
+```
+
+**Setup** — since AI SDK v7, telemetry only flows once you register a telemetry
+integration with `registerTelemetry`. `register()` does **not** do this for you:
+
+```typescript
+// instrumentation.ts
+import { OpenTelemetry } from "@ai-sdk/otel";
+import { register } from "@arizeai/phoenix-otel";
+import { registerTelemetry } from "ai";
+
+// Reads PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY from the environment.
+export const provider = register({ projectName: "my-ai-sdk-app" });
+
+// headers: false keeps outgoing LLM request headers (which can carry
+// credentials) off the spans. This is unrelated to Phoenix auth.
+registerTelemetry(new OpenTelemetry({ headers: false }));
+```
+
+Import this file before the rest of the program, e.g.
+`node --import ./instrumentation.ts index.ts`. After that, `generateText`,
+`streamText`, and `ToolLoopAgent` runs are traced end to end with no per-call config.
+
+**Note:** `register()` uses a batch span processor by default. In a short-lived
+script, call `await provider.shutdown()` before exit to flush queued spans, or pass
+`batch: false` to `register()` for immediate export.
 
 ## Limitations
 


### PR DESCRIPTION
# Phoenix Skills Audit — 2026-07-15 → 2026-07-22

**Audited against:** `origin/main` at `b7f2760264ae40f1ddf953ceacd5b7fdff1f2541`
**Commits analyzed:** 117 (2 user-facing edits applied, several already self-patched, rest skipped)

## Edits applied

### phoenix-evals
- `references/evaluators-pre-built.md` — added `UserFrictionEvaluator` to the pre-built
  table (new evaluator shipped in commit `1ae1a3933`, released in arize-phoenix-evals
  3.2.0 `6ce4fbd1d`). Added a dedicated subsection documenting its two-field input shape
  (`conversation` + `user_message`) and `friction`/`no_friction` labels, grounded in
  `packages/phoenix-evals/src/phoenix/evals/metrics/user_friction.py:13-89`.
- `references/evaluators-pre-built.md` — added the TypeScript mirror
  `createUserFrictionEvaluator` (shipped same PR,
  `js/packages/phoenix-evals/src/llm/createUserFrictionEvaluator.ts`), with a runnable
  example using the `conversation` / `userMessage` record from the file's own JSDoc.
- `references/evaluators-pre-built.md` — while correcting the table, added two
  pre-existing gaps (`ConcisenessEvaluator`, `RefusalEvaluator`, both present since
  `2ec192c07`, 2026-03) so the "Available" list matches
  `packages/phoenix-evals/src/phoenix/evals/metrics/__init__.py` exactly, and dropped the
  stale `(2.0)` version label (evals is now 3.2.0). Also expanded the TypeScript note to
  enumerate all factory functions exported from `js/packages/phoenix-evals/src/llm/index.ts`.

### phoenix-tracing
- `references/instrumentation-auto-typescript.md` — added a **Vercel AI SDK** section and
  listed it under "Supported Frameworks". Motivated by the breaking change in commit
  `30f082722` (`feat(js)!: upgrade phoenix-otel to openinference-vercel v3 for AI SDK v7
  spans`). The skill previously had zero Vercel AI SDK coverage. Content grounded in:
  - `js/packages/phoenix-otel/src/register.ts` (the `register()` signature/behavior),
  - `docs/phoenix/integrations/typescript/vercel/vercel-ai-sdk-tracing-js.mdx` (the v7
    `registerTelemetry(new OpenTelemetry({ headers: false }))` setup, install list, and
    version-compatibility table),
  - `js/packages/phoenix-otel/README.md` / changeset `js/.changeset/ai-sdk-7-otel.md`.
  The section includes the version-compatibility matrix (AI SDK v7+ → phoenix-otel 2.x /
  openinference-vercel 3.x; v6 and older → phoenix-otel 1.x / 2.x), the Node 22+
  requirement, and the batch-flush note (`await provider.shutdown()`).

## Candidates already reflected (no edit needed)

The CLI feature PRs self-patched `phoenix-cli/SKILL.md` when they shipped, and the current
skill was verified accurate against the code:

- `f9cd97ae3` `feat(cli): px setup mcp` — SKILL.md §"`px setup mcp`" already documents the
  six agents, `--global`/`--local` scope, OAuth/`--header` auth, and the raw output shape
  `{"endpoint","url","serverName","agent","scope","auth","file?"}`. Verified verbatim
  against `js/packages/phoenix-cli/src/setup/mcp/runSetupMcp.ts:37-46`.
- `3abafcfd5` `refactor(cli): px setup mcp polish` — no public-surface change beyond what
  the section above already describes (Codex bearer-token behavior is documented). No edit.
- `99dec5a92` `feat(cli): offer the Phoenix docs MCP server during px setup` — already
  documented in SKILL.md §`px setup` (`--docs-mcp` / `--no-docs-mcp`, lines 97-101).
- `d6b1cbb59` `feat(auth)!: add OAuth2 authorization server and CLI login` — the CLI side
  (`px auth login`, `--no-browser`, `logout`, `status`, credential-source reporting) is
  already documented in SKILL.md §Auth. The server-side OAuth2 authorization server is
  phoenix-server scope (see out-of-scope findings).
- `1f3c4b600` `fix(cli): px auth login pre-flights OAuth discovery` — internal behavior
  (pre-flight check before opening the browser); no flag/output change. No edit.

## Skipped commits (representative)

- Dep bumps / release bookkeeping: `b7f276026` (uv), `2822d7ea3` (weekly deps),
  `60e9e9b01` (mcp), `d9ea99592`/`0d196d03f` (gradio), `bc9b533e5` (skip LiteLLM on
  py3.14), `c6f72d07a`/`6ce4fbd1d`/`7435236c7`/`e9a65c216`/`803673166`/`7721c32e3`/
  `e58f6c984`/`3fa3de98f` (release-please), `ca2ee6907`/`bc2f1bed5`/`7950936ae`/
  `17ccdcc4f`/`9d027b499`/`8d14c5f39` (js version bumps).
- Frontend-only (belong to phoenix-frontend/phoenix-design): `b1a63591f` (span header
  redesign — UI), `51cf276f2`/`94456834e` (components), `2f14ce8ae`/`326ed655b`/
  `2e748ef56`/`0587fca06`/`7868a584b`/`c58854fc3`/`df56d8da3`/`20de8b972` (settings/UI),
  `59d992f05`/`ee1b6770b`/`98ea567a2` (PXI UI), assorted `fix(ui)`/`style` commits.
- Server-internal (no client/CLI-visible change): `5ae4b51c7` (IP rate limiting),
  `9e289aaed` (HEAD on OIDC discovery), `1bf160347` (HTTP/2 for OAuth), banner refactors
  `3904c49d0`/`79c1ca663`/`ccfd9f83c`/`1474c9b46`/`f457d4fff`/`676bf79b1` (cosmetic
  startup banner), playground defaults `dc1258f95`/`3476db9aa`/`3a8f36145`.
- Tests / test infra: `25cba37fd`/`969978fb2`/`618cfc551`/`92faa588f`/`f8ba0874d`
  (phoenix-testing MSW migration), `30fc98198`/`ae92a8287`/`6087d8d86`/`613c98d23` (tests).
- Docs (human-facing, not skill scope): `1e5d5f73d`, `bd9b73ecd`, `81f5a8f76`,
  `37fb24782`, `dc451a6af`, `aa17a6544`, `21a1eefb1`, `f3d7af30c`, `2c50e4836`,
  `e5764b348`, `9c6a4a4dd`, `fc9978cf0`, `ddd049d14`, `d4261fa09`, `e19317698`.
- Evals PXI harness (internal, not the `phoenix-evals` package public API):
  `2a7a87946` (PXI regression gate), `3f3d85363` (omit PXI trace metadata),
  `115d3f24c` (user-friction prompt wording — tuning only, no API change).

## Out-of-scope findings (for other skill owners)

- **REST CRUD for user/system API keys** — `50cc3db8e`, `257a77d58`, `7e30e1a0b`
  (`REST requires a human session to issue API keys`), `ea38b1bf6` (page size bounded at
  1000). These add `/v1/users/api_keys` REST endpoints. The `phoenix-cli` does **not**
  wrap them (no `api-key`/`apikey` command exists in `js/packages/phoenix-cli/src`), so
  they are out of scope for the three external skills — they belong to `phoenix-rest-api`.
- **OAuth2 authorization server** — the server half of `d6b1cbb59` (issuing/validating
  OAuth2 for the Phoenix server itself) is `phoenix-server` scope.

## Cross-runtime note

- `UserFrictionEvaluator` shipped on **both** Python and TypeScript in the same PR
  (`1ae1a3933`); both are documented.
- The AI SDK v7 / openinference-vercel v3 upgrade (`30f082722`) is **TypeScript-only** —
  there is no Python phoenix-otel mirror (the Vercel AI SDK is a JS runtime concern), so
  no Python tracing edit was warranted.
