### PR TITLE
fix: close time range selector after focus leaves

### DIFF
--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -255,8 +255,9 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
         return;
       }
       setIsEditing(false);
+      closePresets();
     });
-  }, [getFocusedElementWithin]);
+  }, [closePresets, getFocusedElementWithin]);
   const blurFocusedTimeRangeElement = useCallback(() => {
     getFocusedElementWithin()?.blur();
   }, [getFocusedElementWithin]);
@@ -526,6 +527,7 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
                 <Input
                   ref={searchInputRef}
                   placeholder='Search or type "25m"'
+                  onBlur={closeEditingIfFocusOutside}
                 />
               </SearchField>
               <ListBox

--- a/app/src/components/datetime/__tests__/TimeRangeSelector.test.tsx
+++ b/app/src/components/datetime/__tests__/TimeRangeSelector.test.tsx
@@ -140,4 +140,23 @@ describe("TimeRangeSelector", () => {
       "Last 12 Hours",
     ]);
   });
+
+  it("returns to the compact value when focus leaves the presets", async () => {
+    await renderSelector(() => undefined);
+    const searchInput = await openPresets();
+    const externalButton = document.createElement("button");
+    document.body.appendChild(externalButton);
+
+    await act(async () => {
+      externalButton.focus();
+      vi.runAllTimers();
+    });
+
+    expect(searchInput.isConnected).toBe(false);
+    expect(container.querySelector(".time-range-selector__fields")).toBeNull();
+    expect(
+      container.querySelector(".time-range-selector__value")
+    ).not.toBeNull();
+    externalButton.remove();
+  });
 });


### PR DESCRIPTION
resolves #14627

## Summary

- Close the time range selector's editing and preset state when focus leaves the preset search.
- Add regression coverage for returning to the compact value after focus exits.


### Before: behavior is inconsistent when tabbing into and out of the time range selector. 

https://github.com/user-attachments/assets/4d5d76a6-07ab-473e-906b-09c761ceaec4



### After: consistent

https://github.com/user-attachments/assets/04743be6-1e6f-4bab-97f7-b81c1d7dc3c5



