### PR TITLE
feat: View trace by double clicking turn in sidebar

### DIFF
--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -14,7 +14,7 @@ import {
   useDefaultLayout,
 } from "react-resizable-panels";
 import type { To } from "react-router";
-import { useLocation, useSearchParams } from "react-router";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import {
   Flex,
@@ -375,7 +375,7 @@ function SessionTurnDetail({
   );
 }
 
-type SessionTurnRow = {
+export type SessionTurnRow = {
   traceId: string;
   rootSpan: SessionTraceRootSpan;
 };
@@ -440,14 +440,16 @@ const turnListCSS = css`
   }
 `;
 
-function SessionTurnList({
+export function SessionTurnList({
   rows,
   selectedTraceId,
   onTurnClick,
+  onTurnDoubleClick,
 }: {
   rows: ReadonlyArray<SessionTurnRow>;
   selectedTraceId: string | null;
   onTurnClick: (traceId: string) => void;
+  onTurnDoubleClick: (turn: { traceId: string; spanNodeId: string }) => void;
 }) {
   const { fullTimeFormatter } = useTimeFormatters();
   const indexedRows: IndexedSessionTurnRow[] = rows.map((row, index) => ({
@@ -474,7 +476,16 @@ function SessionTurnList({
         const paddedIndex = String(row.index + 1).padStart(2, "0");
         const turnLabel = `${paddedIndex} | ${row.rootSpan.name}`;
         return (
-          <ListBoxItem id={row.traceId} textValue={turnLabel}>
+          <ListBoxItem
+            id={row.traceId}
+            textValue={turnLabel}
+            onDoubleClick={() =>
+              onTurnDoubleClick({
+                traceId: row.traceId,
+                spanNodeId: row.rootSpan.id,
+              })
+            }
+          >
             <Flex direction="column" gap="size-50">
               <Flex
                 direction="row"
@@ -666,6 +677,8 @@ export function SessionDetailsTraceList({
     storage: localStorage,
   });
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  const navigate = useNavigate();
   const selectedTraceId = searchParams.get(SELECTED_TRACE_ID_PARAM);
 
   const handleTurnClick = (traceId: string) => {
@@ -675,6 +688,23 @@ export function SessionDetailsTraceList({
         return params;
       },
       { replace: true }
+    );
+  };
+
+  const handleTurnDoubleClick = ({
+    traceId,
+    spanNodeId,
+  }: {
+    traceId: string;
+    spanNodeId: string;
+  }) => {
+    navigate(
+      getSessionTraceUrl({
+        pathname: location.pathname,
+        search: location.search,
+        traceId,
+        spanNodeId,
+      })
     );
   };
 
@@ -717,6 +747,7 @@ export function SessionDetailsTraceList({
         rows={sessionRootSpans}
         selectedTraceId={selectedTraceId}
         onTurnClick={handleTurnClick}
+        onTurnDoubleClick={handleTurnDoubleClick}
       />
     </div>
   );

--- a/app/src/pages/trace/__tests__/SessionDetailsTraceList.test.tsx
+++ b/app/src/pages/trace/__tests__/SessionDetailsTraceList.test.tsx
@@ -1,0 +1,137 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { userEvent } from "storybook/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PreferencesProvider } from "@phoenix/contexts/PreferencesContext";
+import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
+
+import {
+  SessionTurnList,
+  type SessionTurnRow,
+} from "../SessionDetailsTraceList";
+
+const rows = [
+  {
+    traceId: "trace-1",
+    rootSpan: {
+      attributes: "{}",
+      cumulativeTokenCountTotal: 3,
+      endTime: "2026-07-22T12:00:01.000Z",
+      id: "span-node-1",
+      input: null,
+      latencyMs: 1000,
+      name: "First turn",
+      output: null,
+      project: { id: "project-1" },
+      spanId: "span-1",
+      startTime: "2026-07-22T12:00:00.000Z",
+      trace: {
+        costSummary: { total: { cost: null } },
+        id: "trace-node-1",
+      },
+    },
+  },
+  {
+    traceId: "trace-2",
+    rootSpan: {
+      attributes: "{}",
+      cumulativeTokenCountTotal: 5,
+      endTime: "2026-07-22T12:01:01.000Z",
+      id: "span-node-2",
+      input: null,
+      latencyMs: 1000,
+      name: "Second turn",
+      output: null,
+      project: { id: "project-1" },
+      spanId: "span-2",
+      startTime: "2026-07-22T12:01:00.000Z",
+      trace: {
+        costSummary: { total: { cost: null } },
+        id: "trace-node-2",
+      },
+    },
+  },
+] as unknown as ReadonlyArray<SessionTurnRow>;
+
+describe("SessionTurnList", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function renderTurnList({
+    onTurnClick,
+    onTurnDoubleClick,
+  }: {
+    onTurnClick: (traceId: string) => void;
+    onTurnDoubleClick: (turn: { traceId: string; spanNodeId: string }) => void;
+  }) {
+    act(() => {
+      root.render(
+        <ThemeProvider themeMode="dark">
+          <PreferencesProvider>
+            <SessionTurnList
+              rows={rows}
+              selectedTraceId={null}
+              onTurnClick={onTurnClick}
+              onTurnDoubleClick={onTurnDoubleClick}
+            />
+          </PreferencesProvider>
+        </ThemeProvider>
+      );
+    });
+  }
+
+  it("keeps a single click scoped to turn selection", async () => {
+    const onTurnClick = vi.fn();
+    const onTurnDoubleClick = vi.fn();
+    renderTurnList({ onTurnClick, onTurnDoubleClick });
+    const turn = container.querySelectorAll<HTMLElement>('[role="option"]')[1];
+    expect(turn).toBeInstanceOf(HTMLElement);
+
+    await act(async () => {
+      await userEvent.setup().click(turn as HTMLElement);
+    });
+
+    expect(onTurnClick).toHaveBeenCalledWith("trace-2");
+    expect(onTurnDoubleClick).not.toHaveBeenCalled();
+  });
+
+  it("identifies the trace and root span when a turn is double-clicked", async () => {
+    const onTurnClick = vi.fn();
+    const onTurnDoubleClick = vi.fn();
+    renderTurnList({ onTurnClick, onTurnDoubleClick });
+    const turn = container.querySelectorAll<HTMLElement>('[role="option"]')[1];
+    expect(turn).toBeInstanceOf(HTMLElement);
+
+    await act(async () => {
+      await userEvent.setup().dblClick(turn as HTMLElement);
+    });
+
+    expect(onTurnDoubleClick).toHaveBeenCalledOnce();
+    expect(onTurnDoubleClick).toHaveBeenCalledWith({
+      traceId: "trace-2",
+      spanNodeId: "span-node-2",
+    });
+  });
+});


### PR DESCRIPTION
Formalizing a thing I kept trying to do instinctively: double click a turn in the sidebar to jump to its trace.


https://github.com/user-attachments/assets/8394a8d6-1974-4ef1-b818-ebf9cea2928b

