### PR TITLE
fix: preserve keyboard navigation around message editors

### DIFF
--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -2,7 +2,8 @@ import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { css } from "@emotion/react";
-import { useCallback, useMemo, useState } from "react";
+import type { EditorView } from "@uiw/react-codemirror";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   Alert,
@@ -56,6 +57,15 @@ import type { PlaygroundInstanceProps } from "./types";
  * that would clip autocomplete dropdowns.
  */
 const DRAGGING_MESSAGE_Z_INDEX = 10;
+
+const messageEditorInteractionCSS = css`
+  outline: none;
+
+  &:focus-visible {
+    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--global-border-size-thick));
+  }
+`;
 
 interface PlaygroundChatTemplateProps extends PlaygroundInstanceProps {
   appendedMessagesPath?: string | null;
@@ -172,6 +182,10 @@ function MessageEditor({
   // Track whether to show validation alerts - becomes true on first blur
   // and stays true so errors remain visible until fixed
   const [showValidation, setShowValidation] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const editorViewRef = useRef<EditorView | null>(null);
+  const messageEditorRef = useRef<HTMLDivElement>(null);
+  const shouldRestoreMessageFocusRef = useRef(false);
 
   const onChange = useCallback(
     (val: string) => {
@@ -179,7 +193,25 @@ function MessageEditor({
     },
     [updateMessage]
   );
-  const onBlur = useCallback(() => setShowValidation(true), []);
+  const onBlur = useCallback(() => {
+    setShowValidation(true);
+    setIsEditing(false);
+  }, []);
+  const startEditing = useCallback(() => setIsEditing(true), []);
+  const stopEditing = useCallback(() => {
+    shouldRestoreMessageFocusRef.current = true;
+    setIsEditing(false);
+  }, []);
+  useEffect(() => {
+    if (isEditing) {
+      editorViewRef.current?.focus();
+      return;
+    }
+    if (shouldRestoreMessageFocusRef.current) {
+      shouldRestoreMessageFocusRef.current = false;
+      messageEditorRef.current?.focus();
+    }
+  }, [isEditing]);
   const sectionValidation = useMemo(() => {
     if (templateFormat !== TemplateFormats.Mustache) {
       return null;
@@ -240,27 +272,61 @@ function MessageEditor({
   }
 
   return (
-    <TemplateEditorWrap>
-      {showValidation && sectionValidation?.errors.length ? (
-        <Alert variant="danger" banner title="Invalid mustache sections">
-          {sectionValidation.errors.join(", ")}
-        </Alert>
-      ) : null}
-      {showValidation && sectionValidation?.warnings.length ? (
-        <Alert variant="warning" banner title="Unclosed mustache sections">
-          {sectionValidation.warnings.join(", ")}
-        </Alert>
-      ) : null}
-      <TemplateEditor
-        height="100%"
-        defaultValue={message.content || ""}
-        aria-label="Message content"
-        templateFormat={templateFormat}
-        onChange={onChange}
-        onBlur={onBlur}
-        availablePaths={availablePaths}
-      />
-    </TemplateEditorWrap>
+    <div
+      ref={messageEditorRef}
+      role={isEditing ? undefined : "button"}
+      tabIndex={isEditing ? -1 : 0}
+      aria-label={isEditing ? undefined : "Edit message content"}
+      css={messageEditorInteractionCSS}
+      onClick={() => {
+        if (!isEditing) {
+          startEditing();
+        }
+      }}
+      onKeyDown={(event) => {
+        if (isEditing && event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          stopEditing();
+          return;
+        }
+        if (
+          !isEditing &&
+          event.currentTarget === event.target &&
+          (event.key === "Enter" || event.key === " ")
+        ) {
+          event.preventDefault();
+          startEditing();
+        }
+      }}
+    >
+      <TemplateEditorWrap>
+        {showValidation && sectionValidation?.errors.length ? (
+          <Alert variant="danger" banner title="Invalid mustache sections">
+            {sectionValidation.errors.join(", ")}
+          </Alert>
+        ) : null}
+        {showValidation && sectionValidation?.warnings.length ? (
+          <Alert variant="warning" banner title="Unclosed mustache sections">
+            {sectionValidation.warnings.join(", ")}
+          </Alert>
+        ) : null}
+        <TemplateEditor
+          height="100%"
+          defaultValue={message.content || ""}
+          aria-label="Message content"
+          aria-hidden={!isEditing}
+          templateFormat={templateFormat}
+          editable={isEditing}
+          onCreateEditor={(editorView) => {
+            editorViewRef.current = editorView;
+          }}
+          onChange={onChange}
+          onBlur={onBlur}
+          availablePaths={availablePaths}
+        />
+      </TemplateEditorWrap>
+    </div>
   );
 }
 

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -1,3 +1,4 @@
+import { Transaction } from "@codemirror/state";
 import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
@@ -290,11 +291,29 @@ function MessageEditor({
           stopEditing();
           return;
         }
-        if (
-          !isEditing &&
-          event.currentTarget === event.target &&
-          (event.key === "Enter" || event.key === " ")
-        ) {
+        if (!isEditing && event.currentTarget === event.target) {
+          const hasCommandModifier =
+            event.ctrlKey || event.metaKey || event.altKey;
+          const isPrintableCharacter =
+            event.key.length === 1 &&
+            !hasCommandModifier &&
+            !event.nativeEvent.isComposing;
+          if (isPrintableCharacter) {
+            const editorView = editorViewRef.current;
+            if (!editorView) {
+              return;
+            }
+            event.preventDefault();
+            editorView.dispatch({
+              ...editorView.state.replaceSelection(event.key),
+              annotations: Transaction.userEvent.of("input.type"),
+            });
+            startEditing();
+            return;
+          }
+          if (event.key !== "Enter") {
+            return;
+          }
           event.preventDefault();
           startEditing();
         }

--- a/app/tests/playground.spec.ts
+++ b/app/tests/playground.spec.ts
@@ -177,6 +177,53 @@ test.describe("Playground", () => {
     await expect(messageStop).toBeFocused();
   });
 
+  test("types printable characters directly into inactive message editors", async ({
+    page,
+  }) => {
+    await page.goto("/playground");
+    await expect(
+      page.getByRole("heading", { name: "Playground" })
+    ).toBeVisible();
+
+    const messageItems = page.locator("li").filter({
+      has: page.getByRole("button", { name: "Reorder message" }),
+    });
+    const systemMessage = messageItems.first();
+    const systemMessageStop = systemMessage.getByRole("button", {
+      name: "Edit message content",
+    });
+    const systemMessageContent = systemMessage.locator(".cm-content");
+
+    await systemMessageStop.focus();
+    await page.keyboard.press("Control+x");
+    await expect(systemMessageStop).toBeFocused();
+    await expect(systemMessageContent).toHaveText("You are a chatbot");
+
+    await page.keyboard.press("x");
+    await expect(
+      systemMessage.getByRole("textbox", { name: "Message content" })
+    ).toBeFocused();
+    await expect(systemMessageContent).toHaveText("xYou are a chatbot");
+
+    await page.keyboard.press("Escape");
+    await page.keyboard.press(" ");
+    await expect(systemMessageContent).toHaveText("x You are a chatbot");
+
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("?");
+    await expect(systemMessageContent).toHaveText("x ?You are a chatbot");
+
+    await page.keyboard.press("Escape");
+    const userMessage = messageItems.nth(1);
+    await userMessage
+      .getByRole("button", { name: "Edit message content" })
+      .focus();
+    await page.keyboard.press("z");
+    await expect(userMessage.locator(".cm-content")).toHaveText(
+      "z{{question}}"
+    );
+  });
+
   test("preserves prompt selection in the URL across page reloads", async ({
     page,
   }) => {

--- a/app/tests/playground.spec.ts
+++ b/app/tests/playground.spec.ts
@@ -73,10 +73,10 @@ test.describe("Playground", () => {
 
     await expect(reorderButtons).toHaveCount(2);
     await expect(messageItems).toHaveCount(2);
-    await expect(messageItems.nth(0).getByRole("textbox")).toContainText(
+    await expect(messageItems.nth(0).locator(".cm-content")).toContainText(
       "You are a chatbot"
     );
-    await expect(messageItems.nth(1).getByRole("textbox")).toContainText(
+    await expect(messageItems.nth(1).locator(".cm-content")).toContainText(
       "{{question}}"
     );
 
@@ -103,12 +103,78 @@ test.describe("Playground", () => {
       .toBeGreaterThanOrEqual(1);
     await page.mouse.up();
 
-    await expect(messageItems.nth(0).getByRole("textbox")).toContainText(
+    await expect(messageItems.nth(0).locator(".cm-content")).toContainText(
       "{{question}}"
     );
-    await expect(messageItems.nth(1).getByRole("textbox")).toContainText(
+    await expect(messageItems.nth(1).locator(".cm-content")).toContainText(
       "You are a chatbot"
     );
+  });
+
+  test("moves keyboard focus through message editors until editing is intentional", async ({
+    page,
+  }) => {
+    await page.goto("/playground");
+    await expect(
+      page.getByRole("heading", { name: "Playground" })
+    ).toBeVisible();
+
+    const messageItems = page.locator("li").filter({
+      has: page.getByRole("button", { name: "Reorder message" }),
+    });
+    const systemMessageItem = messageItems.first();
+    const userMessageItem = messageItems.nth(1);
+    const reorderButton = systemMessageItem.getByRole("button", {
+      name: "Reorder message",
+    });
+    const messageStop = systemMessageItem.getByRole("button", {
+      name: "Edit message content",
+    });
+    const messageTextbox = systemMessageItem.getByRole("textbox", {
+      name: "Message content",
+    });
+    const messageContent = systemMessageItem.locator(".cm-content");
+
+    await expect(
+      page.getByRole("button", { name: "Edit message content" })
+    ).toHaveCount(2);
+
+    await reorderButton.focus();
+    await page.keyboard.press("Tab");
+    await expect(messageStop).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await expect(
+      userMessageItem.getByRole("button", { name: "user message" })
+    ).toBeFocused();
+    await page.keyboard.press("Shift+Tab");
+    await expect(messageStop).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await expect(messageTextbox).toBeFocused();
+    await page.keyboard.press("End");
+    await page.keyboard.insertText("x");
+    await expect(messageTextbox).toContainText("You are a chatbotx");
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await expect(messageTextbox).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(messageStop).toBeFocused();
+
+    await messageContent.click();
+    await expect(messageTextbox).toBeFocused();
+    const modelParametersButton = page.getByRole("button", {
+      name: "Configure model parameters",
+    });
+    await modelParametersButton.focus();
+    await expect(modelParametersButton).toBeFocused();
+    await expect(messageStop).toBeVisible();
+
+    await messageContent.click();
+    await expect(messageTextbox).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(messageStop).toBeFocused();
   });
 
   test("preserves prompt selection in the URL across page reloads", async ({


### PR DESCRIPTION
resolves #14630

## Summary

- add an explicit message-level focus stop before Playground prompt editors enter edit mode
- preserve intentional CodeMirror indentation while letting Escape restore normal Tab and Shift+Tab navigation
- cover keyboard, pointer, blur, and repeated edit transitions in the Playground E2E suite

https://github.com/user-attachments/assets/302f973c-a8d3-41dd-a725-c2ac6eccbf9b


