### PR TITLE
docs: replace removed createOrGetDataset with createDataset in TypeScript docs

### DIFF
--- a/docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-typescript.mdx
+++ b/docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-typescript.mdx
@@ -148,7 +148,7 @@ In order to experiment with our agent, we first need to define a dataset for it 
 We will use a small dataset for demo purposes:
 
 ```typescript
-import { createOrGetDataset } from "@arizeai/phoenix-client/datasets";
+import { createDataset } from "@arizeai/phoenix-client/datasets";
 
 // Step 2: define the dataset of questions to ask the agent
 const DATASET = [
@@ -164,7 +164,7 @@ const DATASET = [
     "Which Batman movie should I watch?"
 ]
 
-export const dataset = await createOrGetDataset({
+export const dataset = await createDataset({
     name: "movie-rec-questions",
     description: "Questions to ask a movie recommendation agent",
     examples: DATASET.map(question => ({
@@ -175,7 +175,7 @@ export const dataset = await createOrGetDataset({
 });
 ```
 
-The `createOrGetDataset` function will either retrieve an existing dataset by name or create a new one, making it safe to re-run the setup code.
+The `createDataset` function upserts by name: re-uploading a dataset with the same name updates it in place, and an unchanged upload is a no-op. This makes it safe to re-run the setup code.
 
 <Frame>
   <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/ts-tutorial-upload-dataset.png" alt="Upload dataset in Phoenix" />

--- a/docs/phoenix/datasets-and-experiments/tutorial/defining-the-dataset.mdx
+++ b/docs/phoenix/datasets-and-experiments/tutorial/defining-the-dataset.mdx
@@ -153,9 +153,9 @@ dataset = px_client.datasets.create_dataset(
 ```
 
 ```typescript TypeScript
-import { createOrGetDataset } from "@arizeai/phoenix-client/datasets";
+import { createDataset } from "@arizeai/phoenix-client/datasets";
 
-await createOrGetDataset({
+await createDataset({
   name: "support-ticket-queries",
   description: "Support ticket queries with ground truth categories",
   examples: datasetExamples.map((item) => ({

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/datasets.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/datasets.mdx
@@ -3,14 +3,14 @@ title: "Datasets"
 description: "Create and inspect datasets with @arizeai/phoenix-client"
 ---
 
-Datasets are the foundation for experiment runs. The dataset helpers cover creation, idempotent creation, record inspection, and example appends.
+Datasets are the foundation for experiment runs. The dataset helpers cover creation (which upserts by name), record inspection, and example appends.
 
 <section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
   <h2>Relevant Source Files</h2>
   <ul>
     <li>
-      <code>src/datasets/createOrGetDataset.ts</code> for the exact return
-      shape of the idempotent helper
+      <code>src/datasets/createDataset.ts</code> for the exact return shape and
+      upsert-by-name behavior
     </li>
   </ul>
 </section>
@@ -33,18 +33,25 @@ const { datasetId } = await createDataset({
 });
 ```
 
-## Reuse Or Append
+## Upsert Or Append
+
+`createDataset()` upserts by name: re-running it with the same name updates the existing dataset to match the examples you pass, and an unchanged upload is a no-op. To keep existing examples and add more, use `appendDatasetExamples()` instead of re-running `createDataset()` with the extra examples.
 
 ```ts
 import {
   appendDatasetExamples,
-  createOrGetDataset,
+  createDataset,
 } from "@arizeai/phoenix-client/datasets";
 
-const dataset = await createOrGetDataset({
+const dataset = await createDataset({
   name: "support-eval",
   description: "Support questions with expected answers",
-  examples: [],
+  examples: [
+    {
+      input: { question: "Where is my order?" },
+      output: { answer: "Use the tracking page in your account." },
+    },
+  ],
 });
 
 await appendDatasetExamples({
@@ -58,7 +65,7 @@ await appendDatasetExamples({
 });
 ```
 
-`createOrGetDataset()` returns `{ datasetId }`, so you can pass that object directly as the dataset selector for append or experiment calls.
+`createDataset()` returns `{ datasetId }`, so you can pass that object directly as the dataset selector for append or experiment calls.
 
 ## Read Back Dataset State
 
@@ -68,7 +75,6 @@ Use `getDataset`, `getDatasetExamples`, and `getDatasetInfo` to inspect datasets
   <h2>Source Map</h2>
   <ul>
     <li><code>src/datasets/createDataset.ts</code></li>
-    <li><code>src/datasets/createOrGetDataset.ts</code></li>
     <li><code>src/datasets/appendDatasetExamples.ts</code></li>
     <li><code>src/datasets/getDataset.ts</code></li>
     <li><code>src/datasets/getDatasetExamples.ts</code></li>

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-evals/phoenix-integration.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-evals/phoenix-integration.mdx
@@ -19,14 +19,15 @@ description: "Use @arizeai/phoenix-evals with Phoenix experiments"
 ```ts
 import { openai } from "@ai-sdk/openai";
 import { createFaithfulnessEvaluator } from "@arizeai/phoenix-evals";
-import { createOrGetDataset } from "@arizeai/phoenix-client/datasets";
+import { createDataset } from "@arizeai/phoenix-client/datasets";
 import {
   asExperimentEvaluator,
   runExperiment,
 } from "@arizeai/phoenix-client/experiments";
 
-await createOrGetDataset({
+await createDataset({
   name: "support-eval",
+  description: "Support questions with expected answers",
   examples: [
     {
       input: {


### PR DESCRIPTION
## What changed

`createOrGetDataset` was removed from `@arizeai/phoenix-client` in the dataset upsert change (#11860). `createDataset` now upserts by name — re-uploading a dataset with the same name updates it in place, and an unchanged upload is a no-op — making the separate get-or-create helper unnecessary. Several TypeScript docs snippets still imported and called `createOrGetDataset`, so copying them failed with an import error.

This PR updates the docs to use `createDataset` and rewrites the surrounding prose that described get-or-create behavior to describe the new upsert semantics.

Files updated:

- `docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/datasets.mdx`
  - Renamed the **Reuse Or Append** section to **Upsert Or Append** and rewrote it to use `createDataset`. The old snippet called the helper with `examples: []` as a safe "fetch existing" no-op; that is no longer safe, because `createDataset` upserts declaratively (an empty `examples` array would clear an existing dataset). The snippet now creates with real examples and uses `appendDatasetExamples()` to add more, and the prose explains this explicitly.
  - Updated the intro line, the relevant-source-files note, the return-shape note, and the source map to point at `createDataset.ts` instead of the removed `createOrGetDataset.ts`.
- `docs/phoenix/sdk-api-reference/typescript/packages/phoenix-evals/phoenix-integration.mdx` — swapped the import/call to `createDataset` and added the now-required `description` field.
- `docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-typescript.mdx` — swapped the import/call and rewrote the trailing sentence to describe upsert semantics.
- `docs/phoenix/datasets-and-experiments/tutorial/defining-the-dataset.mdx` — swapped the import/call.

Note: `experiments.mdx` (also listed in the issue) already uses `createDataset` on `main`, so no change was needed there.

## Why

Copy-pasting the affected snippets fails at import time because `createOrGetDataset` no longer exists in the package. The fix keeps the docs working and teaches the current, correct API.

## Scope

Docs only, per the issue. The two `phoenix-client` repo examples with the same problem were fixed on `claude/ai-sdk-7-client`. The stale `js/packages/phoenix-evals/examples/phoenix_integration_example.ts` example is out of scope for this issue and is excluded from the package typecheck (`include: ["src/**/*.ts"]`), so it does not affect CI.

## How to verify

- `grep -rn "createOrGetDataset" docs/` returns no matches.
- Each snippet's usage matches the real `createDataset` signature in `js/packages/phoenix-client/src/datasets/createDataset.ts`: required `name`, `description`, and `examples`, returning `{ datasetId }`. The `appendDatasetExamples` snippet passes the returned `{ datasetId }` object as a valid `DatasetSelector`.

## Notes

- No `js/` package source was modified, so no changeset is required.
