### PR TITLE
fix(server): surface PXI API key errors to the user

### DIFF
--- a/app/src/components/agent/ChatErrorMessage.tsx
+++ b/app/src/components/agent/ChatErrorMessage.tsx
@@ -1,8 +1,24 @@
 import { css } from "@emotion/react";
 
+import { LinkButton } from "@phoenix/components";
 import { Button } from "@phoenix/components/core/button";
 
 import type { MessageRewindRequest } from "./ChatMessage";
+
+/**
+ * Matches error messages that stem from a model-provider API-key or
+ * authentication failure (missing key, invalid key, or auth rejected by the
+ * provider). Kept in sync with the server-side guidance emitted by
+ * ``build_stream_error_chunk`` and the credential errors raised by
+ * ``build_model``.
+ */
+const API_KEY_ERROR_PATTERN =
+  /api[\s_-]?key|unauthoriz|authenticat|invalid_api_key|permission[\s_-]?denied|credential/i;
+
+/** Return whether an error message looks like an API-key / auth failure. */
+export function isApiKeyError(message: string | null | undefined): boolean {
+  return message != null && API_KEY_ERROR_PATTERN.test(message);
+}
 
 const chatErrorMessageCSS = css`
   align-self: flex-start;
@@ -66,21 +82,31 @@ export function ChatErrorMessage({
 }) {
   const canRetry = onRetry != null;
   const canUndoOrFork = latestUserMessageId != null && onRewind != null;
+  const isCredentialError = isApiKeyError(error.message);
 
   return (
     <div css={chatErrorMessageCSS} role="alert">
       <div className="chat-error-message__title">
-        The assistant response failed.
+        {isCredentialError
+          ? "The model provider rejected your API key."
+          : "The assistant response failed."}
       </div>
       <p className="chat-error-message__copy">
-        You can retry the response, undo this turn, or branch before the error.
+        {isCredentialError
+          ? "The API key for the selected model is missing, invalid, or misconfigured. Add a valid key in AI provider settings, then retry."
+          : "You can retry the response, undo this turn, or branch before the error."}
       </p>
-      {canRetry || canUndoOrFork ? (
+      {canRetry || canUndoOrFork || isCredentialError ? (
         <div className="chat-error-message__actions">
+          {isCredentialError ? (
+            <LinkButton size="S" variant="primary" to="/settings/providers">
+              Open AI provider settings
+            </LinkButton>
+          ) : null}
           {canRetry ? (
             <Button
               size="S"
-              variant="primary"
+              variant={isCredentialError ? "default" : "primary"}
               onPress={() => onRetry(latestAssistantMessageId)}
             >
               Retry

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -1,5 +1,6 @@
 import { act, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
@@ -103,57 +104,59 @@ function renderChatView(
 ) {
   act(() => {
     root.render(
-      <ThemeProvider themeMode="light" disableBodyTheme>
-        <AgentProvider
-          agentsConfig={{
-            collectorEndpoint: null,
-            assistantProjectName: "assistant_agent",
-            forceTracing: false,
-            webAccessEnabled: false,
-            assistantEnabled: true,
-            allowLocalTraces: true,
-            allowRemoteExport: false,
-          }}
-          observability={{
-            storeLocalTraces: true,
-            exportRemoteTraces: false,
-            attachUserId: false,
-            acknowledgedTraceConsent: {
+      <MemoryRouter>
+        <ThemeProvider themeMode="light" disableBodyTheme>
+          <AgentProvider
+            agentsConfig={{
+              collectorEndpoint: null,
+              assistantProjectName: "assistant_agent",
+              forceTracing: false,
+              webAccessEnabled: false,
+              assistantEnabled: true,
               allowLocalTraces: true,
               allowRemoteExport: false,
-            },
-          }}
-          capabilities={{
-            "bash.retainInactiveSessions": false,
-            "graphql.mutations": false,
-            "session.storeSessions": true,
-            "subagents.enabled": false,
-            "web.access": false,
-          }}
-          {...(initialDraftInputBySessionId
-            ? { draftInputBySessionId: initialDraftInputBySessionId }
-            : {})}
-        >
-          <ChatView
-            key={chatKey ?? sessionId ?? "no-session"}
-            sessionId={sessionId}
-            messages={chatMessages}
-            sendMessage={sendMessage}
-            stop={async () => undefined}
-            status={status}
-            error={error}
-            pendingElicitation={null}
-            handleElicitationSubmit={vi.fn()}
-            handleElicitationCancel={vi.fn()}
-            retryMessage={retryMessage}
-            rewindToMessage={rewindToMessage}
-            forkFromMessage={forkFromMessage}
-            modelMenuValue={{ provider: "ANTHROPIC", modelName: "claude" }}
-            onModelChange={vi.fn()}
-            autoFocusInput={autoFocusInput}
-          />
-        </AgentProvider>
-      </ThemeProvider>
+            }}
+            observability={{
+              storeLocalTraces: true,
+              exportRemoteTraces: false,
+              attachUserId: false,
+              acknowledgedTraceConsent: {
+                allowLocalTraces: true,
+                allowRemoteExport: false,
+              },
+            }}
+            capabilities={{
+              "bash.retainInactiveSessions": false,
+              "graphql.mutations": false,
+              "session.storeSessions": true,
+              "subagents.enabled": false,
+              "web.access": false,
+            }}
+            {...(initialDraftInputBySessionId
+              ? { draftInputBySessionId: initialDraftInputBySessionId }
+              : {})}
+          >
+            <ChatView
+              key={chatKey ?? sessionId ?? "no-session"}
+              sessionId={sessionId}
+              messages={chatMessages}
+              sendMessage={sendMessage}
+              stop={async () => undefined}
+              status={status}
+              error={error}
+              pendingElicitation={null}
+              handleElicitationSubmit={vi.fn()}
+              handleElicitationCancel={vi.fn()}
+              retryMessage={retryMessage}
+              rewindToMessage={rewindToMessage}
+              forkFromMessage={forkFromMessage}
+              modelMenuValue={{ provider: "ANTHROPIC", modelName: "claude" }}
+              onModelChange={vi.fn()}
+              autoFocusInput={autoFocusInput}
+            />
+          </AgentProvider>
+        </ThemeProvider>
+      </MemoryRouter>
     );
   });
 }
@@ -315,6 +318,33 @@ describe("ChatView", () => {
     expect(retryMessage).toHaveBeenCalledWith("assistant-message");
     expect(container.textContent).toContain("Show technical details");
     expect(container.textContent).toContain("provider unavailable");
+  });
+
+  it("surfaces API key errors with remediation guidance and a settings link", () => {
+    renderChatView(root, {
+      chatMessages: messages,
+      error: new Error(
+        "The model provider rejected the request because the API key is " +
+          "missing, invalid, or misconfigured. Add a valid API key for the " +
+          "selected model in Settings, then try again.\n\n" +
+          "Provider error: 401 Unauthorized"
+      ),
+      status: "error",
+      retryMessage: vi.fn(),
+      rewindToMessage: vi.fn(),
+      forkFromMessage: vi.fn(),
+    });
+
+    expect(container.textContent).toContain(
+      "The model provider rejected your API key."
+    );
+    expect(container.textContent).toContain("AI provider settings");
+    const settingsLink = Array.from(container.querySelectorAll("a")).find(
+      (anchor) => anchor.getAttribute("href") === "/settings/providers"
+    );
+    expect(settingsLink).not.toBeUndefined();
+    // technical detail from the provider is still available
+    expect(container.textContent).toContain("Provider error: 401 Unauthorized");
   });
 
   it("shows interrupted recovery when history ends on a user message", () => {

--- a/app/src/components/agent/__tests__/ChatErrorMessage.test.tsx
+++ b/app/src/components/agent/__tests__/ChatErrorMessage.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { isApiKeyError } from "../ChatErrorMessage";
+
+describe("isApiKeyError", () => {
+  it("matches server-emitted API key guidance", () => {
+    expect(
+      isApiKeyError(
+        "The model provider rejected the request because the API key is " +
+          "missing, invalid, or misconfigured. Add a valid API key for the " +
+          "selected model in Settings, then try again."
+      )
+    ).toBe(true);
+  });
+
+  it("matches build_model credential errors", () => {
+    expect(
+      isApiKeyError(
+        "An API key is required for OpenAI models. Set the OPENAI_API_KEY " +
+          "environment variable or store it in Phoenix secrets."
+      )
+    ).toBe(true);
+  });
+
+  it("matches raw provider auth failures", () => {
+    expect(isApiKeyError("401 Unauthorized")).toBe(true);
+    expect(isApiKeyError("Invalid x-api-key header")).toBe(true);
+    expect(isApiKeyError("authentication_error: invalid token")).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isApiKeyError("provider unavailable")).toBe(false);
+    expect(isApiKeyError("connection reset by peer")).toBe(false);
+    expect(isApiKeyError(null)).toBe(false);
+    expect(isApiKeyError(undefined)).toBe(false);
+  });
+});

--- a/src/phoenix/server/agents/data_stream_protocol.py
+++ b/src/phoenix/server/agents/data_stream_protocol.py
@@ -56,6 +56,11 @@ from pydantic_ai.ui.vercel_ai.response_types import (
     ToolOutputErrorChunk,
 )
 
+from phoenix.server.agents.exceptions import (
+    ProviderConfigError,
+    ProviderCredentialsError,
+)
+
 _DEFAULT_MESSAGE_ID = "subagent-message"
 _UNKNOWN_TOOL_NAME = "unknown"
 
@@ -657,3 +662,73 @@ def _merge_provider_metadata(
     if new is None:
         return existing
     return {**existing, **new}
+
+
+# HTTP status codes a model provider returns when it rejects the API key.
+_AUTH_ERROR_STATUS_CODES = frozenset({401, 403})
+
+# Substrings that mark a provider error as an API-key / authentication failure.
+# Matched case-insensitively against the exception text as a fallback for
+# providers whose SDKs don't surface a structured HTTP status code.
+_API_KEY_ERROR_PATTERNS = (
+    "api key",
+    "api_key",
+    "apikey",
+    "x-api-key",
+    "invalid_api_key",
+    "unauthorized",
+    "authentication",
+    "authenticate",
+    "credential",
+    "permission denied",
+    "permission_denied",
+)
+
+
+def is_api_key_error(exc: BaseException) -> bool:
+    """Return ``True`` when ``exc`` looks like a model-provider API-key failure.
+
+    Covers three cases: the agent's own credential exceptions
+    (:class:`~phoenix.server.agents.exceptions.ProviderCredentialsError` and
+    :class:`~phoenix.server.agents.exceptions.ProviderConfigError`), provider
+    HTTP errors carrying a ``401``/``403`` status code (e.g. pydantic-ai's
+    ``ModelHTTPError``), and, as a fallback, exceptions whose text mentions an
+    API key or authentication problem.
+    """
+    if isinstance(exc, (ProviderCredentialsError, ProviderConfigError)):
+        return True
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int) and status_code in _AUTH_ERROR_STATUS_CODES:
+        return True
+    message = str(exc).lower()
+    return any(pattern in message for pattern in _API_KEY_ERROR_PATTERNS)
+
+
+def format_stream_error_text(exc: BaseException) -> str:
+    """Build a clear, user-facing message for a failed agent stream.
+
+    API-key / provider-authentication failures get actionable remediation
+    guidance pointing the user at their model settings; any other error falls
+    back to the underlying exception text so it is still surfaced to the user
+    instead of being silently dropped.
+    """
+    detail = str(exc).strip() or type(exc).__name__
+    if is_api_key_error(exc):
+        return (
+            "The model provider rejected the request because the API key is "
+            "missing, invalid, or misconfigured. Add a valid API key for the "
+            "selected model in Settings, then try again.\n\n"
+            f"Provider error: {detail}"
+        )
+    return detail
+
+
+def build_stream_error_chunk(exc: BaseException) -> ErrorChunk:
+    """Wrap ``exc`` in a Vercel AI :class:`ErrorChunk` for the response stream.
+
+    Emitting this chunk mid-stream ensures the client surfaces the failure in
+    the chat error banner instead of the connection closing silently, which is
+    what leaves the agent appearing to hang when, for example, an API key is
+    rejected by the provider.
+    """
+    return ErrorChunk(error_text=format_stream_error_text(exc))

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -93,6 +93,7 @@ from phoenix.server.agents.context import (
     ResolvedContexts,
     resolve_contexts,
 )
+from phoenix.server.agents.data_stream_protocol import build_stream_error_chunk
 from phoenix.server.agents.exceptions import AgentError, SummarizationError
 from phoenix.server.agents.model_factory import build_model
 from phoenix.server.agents.model_selection import AgentModelSelection
@@ -1266,6 +1267,12 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                                     emitted_at=datetime.now(timezone.utc),
                                 )
                             yield chunk
+            except Exception as exc:
+                # Surface the failure to the client as an error chunk (e.g. a
+                # rejected API key) instead of letting the connection close
+                # silently, which leaves the agent appearing to hang.
+                logger.exception("Server agent chat stream failed for session %s", session_id)
+                yield build_stream_error_chunk(exc)
             finally:
                 if tracer is not None:
                     tracer.tracer_provider.force_flush()
@@ -1570,7 +1577,16 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                         final_tool_outputs_by_tool_call_id=final_tool_outputs_by_tool_call_id,
                     ):
                         yield message_chunk
+            except Exception as exc:
+                # Surface the failure to the client as an error chunk (e.g. a
+                # rejected API key) instead of letting the connection close
+                # silently, which leaves the agent appearing to hang.
+                stream_error = exc
+                logger.exception("Agent chat stream failed for session %s", session_id)
+                yield build_stream_error_chunk(exc)
             except BaseException as exc:
+                # Cancellation and other non-``Exception`` failures propagate so
+                # client disconnects are not misreported as agent errors.
                 stream_error = exc
                 raise
             finally:

--- a/tests/unit/server/agents/test_data_stream_protocol.py
+++ b/tests/unit/server/agents/test_data_stream_protocol.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
 
+from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai.ui.vercel_ai.request_types import (
     DataUIPart,
     FileUIPart,
@@ -38,6 +39,14 @@ from pydantic_ai.ui.vercel_ai.response_types import (
 
 from phoenix.server.agents.data_stream_protocol import (
     accumulate_ui_message_chunks_to_ui_messages,
+    build_stream_error_chunk,
+    format_stream_error_text,
+    is_api_key_error,
+)
+from phoenix.server.agents.exceptions import (
+    ProviderConfigError,
+    ProviderCredentialsError,
+    SummarizationError,
 )
 
 
@@ -179,3 +188,56 @@ class TestAccumulateUIMessageChunksToUIMessages:
         assert isinstance(error_part, DataUIPart)
         assert error_part.type == "data-error"
         assert error_part.data == {"errorText": "subagent failed"}
+
+
+class TestIsApiKeyError:
+    def test_detects_credential_exceptions(self) -> None:
+        assert is_api_key_error(ProviderCredentialsError("missing key"))
+        assert is_api_key_error(ProviderConfigError("bad config"))
+
+    def test_detects_provider_http_auth_status_codes(self) -> None:
+        for status_code in (401, 403):
+            error = ModelHTTPError(
+                status_code=status_code,
+                model_name="gpt-4o",
+                body="Incorrect API key provided",
+            )
+            assert is_api_key_error(error)
+
+    def test_ignores_non_auth_http_status_codes(self) -> None:
+        error = ModelHTTPError(status_code=500, model_name="gpt-4o", body="boom")
+        assert not is_api_key_error(error)
+
+    def test_matches_message_keywords_as_fallback(self) -> None:
+        assert is_api_key_error(RuntimeError("401 Unauthorized"))
+        assert is_api_key_error(ValueError("Invalid x-api-key header"))
+        assert is_api_key_error(RuntimeError("authentication_error"))
+
+    def test_does_not_flag_unrelated_errors(self) -> None:
+        assert not is_api_key_error(RuntimeError("connection reset by peer"))
+        assert not is_api_key_error(SummarizationError("no summary produced"))
+
+
+class TestFormatStreamErrorText:
+    def test_api_key_error_includes_remediation_and_detail(self) -> None:
+        text = format_stream_error_text(ProviderCredentialsError("no OPENAI_API_KEY"))
+        assert "API key" in text
+        assert "Settings" in text
+        # underlying detail is preserved for debugging
+        assert "no OPENAI_API_KEY" in text
+
+    def test_non_api_key_error_falls_back_to_detail(self) -> None:
+        text = format_stream_error_text(RuntimeError("connection reset by peer"))
+        assert text == "connection reset by peer"
+
+    def test_empty_message_falls_back_to_exception_type(self) -> None:
+        text = format_stream_error_text(RuntimeError())
+        assert text == "RuntimeError"
+
+
+class TestBuildStreamErrorChunk:
+    def test_wraps_message_in_error_chunk(self) -> None:
+        chunk = build_stream_error_chunk(ProviderCredentialsError("no OPENAI_API_KEY"))
+        assert isinstance(chunk, ErrorChunk)
+        assert "API key" in chunk.error_text
+        assert "no OPENAI_API_KEY" in chunk.error_text


### PR DESCRIPTION
# Surface PXI API key errors to the user

Fixes #14342.

## Problem

When PXI (the Phoenix server-side agent) hit an error caused by a missing,
invalid, or misconfigured model-provider API key **during** a streaming run,
the failure was never surfaced in the UI. The agent silently stopped, leaving
the user with no indication of what went wrong or how to fix it.

The root cause is in the streaming chat endpoints added/moved by the
server-side PXI tracing work (#14215). In
`src/phoenix/server/api/routers/agents.py`, the `_stream_with_session()`
generators either had no exception handler (the `/agents/server/...` endpoint)
or caught the exception only to re-raise it for trace recording (the
`/agents/{agent_id}/...` endpoint). When the exception propagated out of the
async generator, the streaming HTTP response simply terminated — no error
event was written to the Vercel AI data stream, so the client's `useChat`
never entered its error state and the chat appeared to hang.

Pre-stream credential errors (a completely missing key) were already handled:
`build_model()` raises `ProviderCredentialsError`, which is converted to an
HTTP 400, and the frontend also runs a pre-request credential check. The gap
was the **mid-stream** case — a key that is present but rejected by the
provider (HTTP 401/403), which only fails once the request is in flight.

## What changed

### Server (`src/phoenix/server/`)

- **`agents/data_stream_protocol.py`** — added three small, unit-testable
  helpers:
  - `is_api_key_error(exc)` — classifies an exception as an API-key/auth
    failure. Recognizes the agent's own `ProviderCredentialsError` /
    `ProviderConfigError`, provider HTTP errors carrying a `401`/`403` status
    code (e.g. pydantic-ai's `ModelHTTPError`), and, as a fallback, exceptions
    whose text mentions an API key or authentication problem.
  - `format_stream_error_text(exc)` — builds a clear, user-facing message.
    API-key failures get remediation guidance ("Add a valid API key for the
    selected model in Settings, then try again.") with the underlying provider
    error appended; other errors fall back to their own text so nothing is
    dropped silently.
  - `build_stream_error_chunk(exc)` — wraps the message in a Vercel AI
    `ErrorChunk`.
- **`api/routers/agents.py`** — both streaming chat endpoints now catch
  `Exception` during the stream, log it, and `yield build_stream_error_chunk(...)`
  so an `error` event reaches the client before the stream ends. Cancellation
  and other `BaseException`s still propagate (so client disconnects are not
  misreported as agent errors), and error-trace recording is preserved.

### Frontend (`app/src/components/agent/`)

- **`ChatErrorMessage.tsx`** — exported `isApiKeyError(message)` and, when the
  error looks like a credential failure, the banner now shows a specific title
  ("The model provider rejected your API key."), visible remediation copy, and
  a primary **Open AI provider settings** link to `/settings/providers`. Other
  errors are unchanged. The raw provider detail remains under "Show technical
  details".

## How to verify

1. Configure PXI with a model provider but set an **invalid** API key
   (present, so the pre-request check passes, but rejected by the provider).
2. Open PXI and send a message.
3. Before: the agent stops with no visible error. After: the chat shows
   "The model provider rejected your API key." with guidance and a link to AI
   provider settings; the underlying provider error is available under "Show
   technical details".

## Tests

- `tests/unit/server/agents/test_data_stream_protocol.py` — covers
  `is_api_key_error`, `format_stream_error_text`, and `build_stream_error_chunk`
  (credential exceptions, 401/403 vs. non-auth HTTP status codes, keyword
  fallback, and non-matching errors).
- `app/src/components/agent/__tests__/ChatErrorMessage.test.tsx` — unit tests
  for `isApiKeyError`.
- `app/src/components/agent/__tests__/Chat.test.tsx` — new case asserting the
  credential title, guidance, and settings link render for an API-key error
  (the shared render helper now wraps the tree in a `MemoryRouter` so the
  settings link renders).

> Note: the sandboxed development environment used to author this change could
> not install the Python/Node toolchains (`uv`/`pnpm` unavailable, network
> installs blocked), so `make` test/lint/format targets were not run locally.
> The changes follow existing conventions and are expected to pass in CI.

## Changeset

No changeset added: only `app/` (the `phoenix-ui` frontend bundled into the
Python package) was modified, not a published package under `js/`.
