### PR TITLE
fix(ui): commit column reorder during drag so headers stay in sync with body

### DIFF
--- a/app/src/components/table/columnOrdering/ColumnOrderingProvider.tsx
+++ b/app/src/components/table/columnOrdering/ColumnOrderingProvider.tsx
@@ -1,11 +1,54 @@
 import { move } from "@dnd-kit/helpers";
-import { DragDropProvider } from "@dnd-kit/react";
+import {
+  DragDropProvider,
+  KeyboardSensor,
+  PointerSensor,
+} from "@dnd-kit/react";
+import { useRef } from "react";
 import type { ReactNode } from "react";
+
+/**
+ * Elements inside a sortable header that own their own pointer interactions
+ * and must never start a column drag: the column resize grip and interactive
+ * elements such as a contextual-help trigger. Sort toggles are plain divs and
+ * are intentionally draggable — a click on them still sorts because a press
+ * outside the drag handle only becomes a drag once the pointer travels.
+ */
+const nonDraggableSelector = [
+  ".resizer",
+  "input",
+  "select",
+  "textarea",
+  "button",
+  "a[href]",
+  "[contenteditable]",
+].join(", ");
+
+const sensors = [
+  PointerSensor.configure({
+    // Activate from anywhere on the header cell, not only the drag handle.
+    // Presses on the handle start a drag immediately; presses elsewhere fall
+    // back to dnd-kit's default distance/delay constraints so clicks (e.g.
+    // toggling the sort) keep working.
+    activatorElements: (source) => [source.element],
+    preventActivation: (event, source) => {
+      const { target } = event;
+      if (!(target instanceof Element)) {
+        return false;
+      }
+      if (source.handle != null && source.handle.contains(target)) {
+        return false;
+      }
+      return target.closest(nonDraggableSelector) != null;
+    },
+  }),
+  KeyboardSensor,
+];
 
 export interface ColumnOrderingProviderProps {
   /** Ids of sortable columns in current display order. Every sortable inside must appear here with a matching index. */
   columnOrder: string[];
-  /** Called with the new order when a drag completes and the order changed. */
+  /** Called with the new order as it changes during a drag and when a canceled drag restores the original order. */
   onColumnOrderChange: (columnOrder: string[]) => void;
   children: ReactNode;
 }
@@ -19,14 +62,38 @@ export function ColumnOrderingProvider({
   onColumnOrderChange,
   children,
 }: ColumnOrderingProviderProps) {
+  // The order when the current drag started, restored if the drag is canceled
+  const initialColumnOrderRef = useRef<string[] | null>(null);
   return (
     <DragDropProvider
-      onDragEnd={(event) => {
+      sensors={sensors}
+      onDragStart={() => {
+        initialColumnOrderRef.current = columnOrder;
+      }}
+      onDragOver={(event) => {
+        // Commit each reorder as the drag previews it so the column bodies
+        // move with the headers. Committing state here also makes dnd-kit's
+        // optimistic-sorting plugin defer to React: without a state update it
+        // reorders the header cells directly in the DOM, and a drag released
+        // outside every header (e.g. past the far left of the table) then
+        // left the headers permanently out of sync with the cells (#14609).
         const newColumnOrder = move(columnOrder, event);
         if (newColumnOrder === columnOrder) {
           return;
         }
         onColumnOrderChange(newColumnOrder);
+      }}
+      onDragEnd={(event) => {
+        const initialColumnOrder = initialColumnOrderRef.current;
+        initialColumnOrderRef.current = null;
+        // The order the user saw was already committed during the drag;
+        // re-applying move() here would shift the column a second time.
+        if (!event.canceled) {
+          return;
+        }
+        if (initialColumnOrder != null) {
+          onColumnOrderChange(initialColumnOrder);
+        }
       }}
     >
       {children}


### PR DESCRIPTION
Fixes #14609

## Problem

Dragging a column to the far left of the table moved the column header but the body didn't adjust ([video in issue](https://github.com/Arize-ai/phoenix/issues/14609)).

Root cause: dnd-kit 0.5's `OptimisticSortingPlugin` physically reorders the header `<th>` elements in the DOM (via `insertAdjacentElement`) during a drag, and only restores them when the drag is *canceled*. Our `ColumnOrderingProvider` committed the new order only in `onDragEnd` via `move()`, which bails out when the drop has no target. Releasing a drag where the pointer has left every droppable header — past the table's far-left edge, or over the traces table's non-draggable checkbox column — produced `target: null, canceled: false`: nothing committed, nothing restored. The header cells stayed physically reordered behind React's back while the body and persisted order never changed.

## Fix

- **Commit the order on every `onDragOver`** instead of on drop. The optimistic plugin detects the React commit (its `hasChanged` check) and stops mutating the DOM itself, so the desync mechanism is gone entirely — and the column bodies now follow the headers live during the drag. Wherever you release, you get exactly what the preview showed.
- **`onDragEnd` no longer re-applies `move()`** (that would double-shift against a stale target); it only restores the drag-start order when the drag is canceled, so Escape properly reverts.
- **The whole header cell is now a drag activator**, not just the tiny hover-revealed handle. dnd-kit's default activation constraints keep clicks working (handle presses drag immediately; elsewhere needs ~5px movement or a 200ms hold), and `preventActivation` excludes the resize grip and interactive elements.

Benefits every table sharing this machinery: sessions, traces, spans, datasets, experiments, prompts.

## Testing

- `tsc --noEmit`, `oxlint`, `oxfmt --check`, and the existing columnOrdering unit tests pass.
- Verified with scripted real-input (Playwright) drags against a dev server, on both the sessions and traces tables:
  - far-left release **off the table** commits the previewed order with header/body/localStorage in sync (the issue repro)
  - far-left release **over the traces checkbox column** lands the column first among orderable columns, body in sync
  - body follows headers mid-drag and the drop matches the preview
  - Escape cancels and restores the pre-drag order
  - click on a sortable header still toggles sorting; the resize grip resizes without starting a drag; dragging via the handle still works