### PR TITLE
chore: re-promote typescript/consistent-return to error

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,11 +10,10 @@
     "typescript/no-require-imports": "error",
     "typescript/no-import-type-side-effects": "error",
     "typescript/prefer-ts-expect-error": "error",
-    // TODO: Re-promote consistent-return and no-unsafe-type-assertion to
-    // "error" once existing violations are fixed. They became far stricter
-    // when tsgolint (type-aware linting) was adopted and pre-existing code
-    // has not been cleaned up yet.
-    "typescript/consistent-return": "warn",
+    // TODO: Re-promote no-unsafe-type-assertion to "error" once existing
+    // violations are fixed. It became far stricter when tsgolint (type-aware
+    // linting) was adopted and pre-existing code has not been cleaned up yet.
+    "typescript/consistent-return": "error",
     "typescript/consistent-type-imports": "error",
     "typescript/no-unsafe-type-assertion": "warn",
     // "eslint/no-shadow": "warn",

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -141,7 +141,7 @@ const fetchRelay: FetchFunction = (params, variables, _cacheConfig) =>
     // throw an error to indicate to the developer what went wrong.
     (data) => {
       if (!isObject(data) || !("errors" in data)) {
-        return;
+        return undefined;
       }
       if (Array.isArray(data.errors)) {
         return new Error(
@@ -150,6 +150,7 @@ const fetchRelay: FetchFunction = (params, variables, _cacheConfig) =>
           )}': ${JSON.stringify(data.errors)}`
         );
       }
+      return undefined;
     }
   );
 

--- a/app/src/agent/chat/interruptToolCalls.ts
+++ b/app/src/agent/chat/interruptToolCalls.ts
@@ -5,6 +5,8 @@ import {
   type UIMessage,
 } from "ai";
 
+import { assertUnreachable } from "@phoenix/typeUtils";
+
 export type UnresolvedToolCall = {
   tool: string;
   toolCallId: string;
@@ -45,5 +47,7 @@ function isUnresolvedToolState(state: DynamicToolUIPart["state"]): boolean {
     case "output-error":
     case "output-denied":
       return false;
+    default:
+      return assertUnreachable(state);
   }
 }

--- a/app/src/agent/context/agentContextTypes.ts
+++ b/app/src/agent/context/agentContextTypes.ts
@@ -1,4 +1,5 @@
 import type { components } from "@phoenix/api/__generated__/v1";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 /**
  * Agent context types advertised to the PXI chat agent.
@@ -87,5 +88,7 @@ export function agentContextKey(context: AgentContext): string {
       return "web_access";
     case "subagents":
       return "subagents";
+    default:
+      return assertUnreachable(context);
   }
 }

--- a/app/src/agent/tools/annotationConfig/buildAnnotationConfigInput.ts
+++ b/app/src/agent/tools/annotationConfig/buildAnnotationConfigInput.ts
@@ -1,3 +1,5 @@
+import { assertUnreachable } from "@phoenix/typeUtils";
+
 import type { AnnotationConfigInput } from "./__generated__/createAnnotationConfigToolMutation.graphql";
 import type {
   AnnotationConfigDraft,
@@ -66,5 +68,7 @@ export function buildAnnotationConfigInput(
           upperBound: draft.upperBound ?? null,
         },
       };
+    default:
+      return assertUnreachable(draft.type);
   }
 }

--- a/app/src/agent/tools/codeEvaluatorDraft/outputConfigConverters.ts
+++ b/app/src/agent/tools/codeEvaluatorDraft/outputConfigConverters.ts
@@ -1,4 +1,5 @@
 import type { AnnotationConfig } from "@phoenix/store/evaluatorStore";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 import type { OutputConfigDraft } from "./types";
 
@@ -67,5 +68,7 @@ export function fromOutputConfigDraft(
         lowerBound: draft.lowerBound ?? null,
         upperBound: draft.upperBound ?? null,
       };
+    default:
+      return assertUnreachable(draft);
   }
 }

--- a/app/src/components/CodeBlock.tsx
+++ b/app/src/components/CodeBlock.tsx
@@ -17,6 +17,6 @@ export function CodeBlock({
         <TypeScriptBlock value={value} basicSetup={{ lineNumbers: true }} />
       );
     default:
-      assertUnreachable(language);
+      return assertUnreachable(language);
   }
 }

--- a/app/src/components/RegexField.tsx
+++ b/app/src/components/RegexField.tsx
@@ -97,10 +97,10 @@ export const RegexField = ({
 
   useEffect(() => {
     if (!validateRegex) {
-      return;
+      return undefined;
     }
     if (!debouncedValue) {
-      return;
+      return undefined;
     }
 
     const query = fetchQuery<RegexFieldQuery>(environment, regexFieldQuery, {

--- a/app/src/components/agent/AgentContextPills.tsx
+++ b/app/src/components/agent/AgentContextPills.tsx
@@ -11,6 +11,7 @@ import {
 } from "@phoenix/components/ai/attachment";
 import type { AttachmentContextData } from "@phoenix/components/ai/attachment";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 const MAX_CONDITION_CHARS = 40;
 const ID_PREFIX_CHARS = 8;
@@ -55,6 +56,8 @@ function contextLabel(context: AgentContext): string {
       return "LLM Evaluator";
     case "dataset":
       return "Dataset";
+    default:
+      return assertUnreachable(context);
   }
 }
 

--- a/app/src/components/agent/AgentFabPositioner.tsx
+++ b/app/src/components/agent/AgentFabPositioner.tsx
@@ -493,7 +493,7 @@ export function AgentFabPositioner({
   useLayoutEffect(() => {
     if (!requiresBoundary) {
       setResolvedBoundary(null);
-      return;
+      return undefined;
     }
 
     let animationFrameId: number | null = null;

--- a/app/src/components/agent/ChatEmptyShaderHero.tsx
+++ b/app/src/components/agent/ChatEmptyShaderHero.tsx
@@ -217,7 +217,7 @@ export function ChatEmptyShaderHero({
 
   useEffect(() => {
     if (typeof window === "undefined") {
-      return;
+      return undefined;
     }
 
     const updateContainerSize = () => {

--- a/app/src/components/agent/DatasetWriteApprovalCard.tsx
+++ b/app/src/components/agent/DatasetWriteApprovalCard.tsx
@@ -1,5 +1,6 @@
 import type { PendingDatasetWrite } from "@phoenix/agent/shared/pendingDatasetWrite";
 import { Flex } from "@phoenix/components";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 import {
   ToolPartApprovalActions,
@@ -144,6 +145,8 @@ function describePreview(pending: PendingDatasetWrite): PreviewDescriptor {
         },
         note: null,
       };
+    default:
+      return assertUnreachable(preview);
   }
 }
 

--- a/app/src/components/agent/PxiShaderGlyph.tsx
+++ b/app/src/components/agent/PxiShaderGlyph.tsx
@@ -43,7 +43,7 @@ export function PxiShaderGlyph(props: PxiShaderGlyphProps) {
   // chrome wants to render it as a white box during reload
   useEffect(() => {
     if (typeof window === "undefined" || typeof document === "undefined") {
-      return;
+      return undefined;
     }
 
     const hideShader = () => {

--- a/app/src/components/agent/ResizableFloatingPanel.tsx
+++ b/app/src/components/agent/ResizableFloatingPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from "@phoenix/components/core/zIndex";
 import type { AgentFabPlacement } from "@phoenix/store/agentStore";
 import type { Bounds, Point, Size } from "@phoenix/types/geometry";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 import { FAB_INSET } from "./agentFabPositioning";
 import { useModalFloatingLayerInteractivity } from "./useModalFloatingLayerInteractivity";
@@ -148,6 +149,8 @@ function getResizeHandleAriaLabel(edge: ResizeEdge) {
       return "Resize assistant from bottom left";
     case "bottom-right":
       return "Resize assistant from bottom right";
+    default:
+      return assertUnreachable(edge);
   }
 }
 
@@ -972,7 +975,7 @@ export function ResizableFloatingPanel({
   useLayoutEffect(() => {
     if (layer !== "content") {
       setResolvedBoundary(null);
-      return;
+      return undefined;
     }
 
     let animationFrameId: number | null = null;

--- a/app/src/components/agent/ToolPart.tsx
+++ b/app/src/components/agent/ToolPart.tsx
@@ -53,6 +53,7 @@ import { ADD_SPANS_TO_DATASET_TOOL_NAME } from "@phoenix/agent/tools/spansToData
 import { Icon, Icons } from "@phoenix/components";
 import type { Variant } from "@phoenix/components/core/types";
 import { MarkdownBlock } from "@phoenix/components/markdown";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 import {
   AddDatasetExamplesToolDetails,
@@ -570,6 +571,8 @@ function renderToolPartStatus(
       return (
         <ToolPartStatus variant={statusVariant}>{stateLabel}</ToolPartStatus>
       );
+    default:
+      return assertUnreachable(state);
   }
 }
 

--- a/app/src/components/agent/toolPartTypes.ts
+++ b/app/src/components/agent/toolPartTypes.ts
@@ -1,6 +1,8 @@
 import type { UIMessage } from "ai";
 import { isToolUIPart } from "ai";
 
+import { assertUnreachable } from "@phoenix/typeUtils";
+
 /**
  * Union type of all message parts.
  */
@@ -44,6 +46,8 @@ export function formatToolState(state: ToolUIPartState): string {
       return "Error";
     case "output-denied":
       return "Denied";
+    default:
+      return assertUnreachable(state);
   }
 }
 

--- a/app/src/components/agent/useModalFloatingLayerInteractivity.ts
+++ b/app/src/components/agent/useModalFloatingLayerInteractivity.ts
@@ -21,12 +21,12 @@ export function useModalFloatingLayerInteractivity(
 ) {
   useLayoutEffect(() => {
     if (!isModalLayer) {
-      return;
+      return undefined;
     }
 
     const element = ref.current;
     if (!element) {
-      return;
+      return undefined;
     }
 
     const enableInteractivity = () => {

--- a/app/src/components/ai/prompt-input/PromptInputTextarea.tsx
+++ b/app/src/components/ai/prompt-input/PromptInputTextarea.tsx
@@ -58,7 +58,7 @@ export function PromptInputTextarea({
   // via useLayoutEffect to avoid a visible flicker.
   useLayoutEffect(() => {
     const textarea = internalRef.current;
-    if (!textarea) return;
+    if (!textarea) return undefined;
 
     const resizeTextarea = () => {
       textarea.style.height = "auto";

--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -88,7 +88,7 @@ const getAnnotationValueParts = (
     case "score-and-label":
       return withFallback([labelPart, scorePart]);
     default:
-      assertUnreachable(displayPreference);
+      return assertUnreachable(displayPreference);
   }
 };
 

--- a/app/src/components/chart/ChartEmptyStateOverlay.tsx
+++ b/app/src/components/chart/ChartEmptyStateOverlay.tsx
@@ -121,7 +121,7 @@ export function ChartEmptyStateOverlay({
   useLayoutEffect(() => {
     const container = containerRef.current;
     if (!isEmpty || container == null) {
-      return;
+      return undefined;
     }
     const measure = () => {
       const nextInset = measurePlotAreaInset(container);

--- a/app/src/components/chart/ChartTooltip.tsx
+++ b/app/src/components/chart/ChartTooltip.tsx
@@ -113,6 +113,7 @@ const colorPreviewCSS = (previewShape: ColorPreviewShape) => {
       height: 8px;
     `;
   }
+  return undefined;
 };
 
 type PreviewShapeProps = {

--- a/app/src/components/chart/binning.tsx
+++ b/app/src/components/chart/binning.tsx
@@ -42,6 +42,6 @@ export function getBinName(bin: GqlBin): string {
     case "%other":
       throw new Error("Unexpected bin type %other");
     default:
-      assertUnreachable(binType);
+      return assertUnreachable(binType);
   }
 }

--- a/app/src/components/chart/useBinTimeTickFormatter.ts
+++ b/app/src/components/chart/useBinTimeTickFormatter.ts
@@ -51,7 +51,7 @@ export function useBinTimeTickFormatter({ scale }: { scale: TimeBinScale }) {
           timeZone: displayTimezone,
         });
       default: {
-        assertUnreachable(scale);
+        return assertUnreachable(scale);
       }
     }
   }, [scale, displayTimezone]);

--- a/app/src/components/core/content/ExpandableContent.tsx
+++ b/app/src/components/core/content/ExpandableContent.tsx
@@ -211,7 +211,7 @@ function useIsOverflowing({
   useEffect(() => {
     const content = contentRef.current;
     const container = containerRef.current;
-    if (!content || !container) return;
+    if (!content || !container) return undefined;
 
     const checkOverflow = () => {
       const overflowBoundary =

--- a/app/src/components/core/dropzone/FileDropZone.tsx
+++ b/app/src/components/core/dropzone/FileDropZone.tsx
@@ -65,7 +65,7 @@ export function FileDropZone({
   // DOM element so Enter/Space opens the file dialog.
   useEffect(() => {
     const el = dropZoneRef.current;
-    if (!el || isDisabled) return;
+    if (!el || isDisabled) return undefined;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();

--- a/app/src/components/core/toast/ToastRegion.tsx
+++ b/app/src/components/core/toast/ToastRegion.tsx
@@ -16,7 +16,7 @@ import { Toast } from "./Toast";
  */
 function attachToastRegion(region: HTMLElement | null) {
   if (!region) {
-    return;
+    return undefined;
   }
   const measure = () => {
     const positioners =

--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -193,7 +193,7 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   // minute or hour) so the displayed window keeps tracking "now".
   useEffect(() => {
     if (!isLastNTimeRangeKey(timeRange.timeRangeKey)) {
-      return;
+      return undefined;
     }
     const timeRangeKey = timeRange.timeRangeKey;
     const timeoutId = window.setTimeout(() => {

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -61,7 +61,7 @@ function getLastNTimeRangeDurationMs({
     case "d":
       return quantity * DAY_IN_MS;
     default:
-      assertUnreachable(unit);
+      return assertUnreachable(unit);
   }
 }
 

--- a/app/src/components/evaluators/EvaluatorOutputPreview.tsx
+++ b/app/src/components/evaluators/EvaluatorOutputPreview.tsx
@@ -265,7 +265,7 @@ export const EvaluatorOutputPreview = () => {
   const isLlmEvaluator = evaluatorKind === "LLM";
   useEffect(() => {
     if (!isLlmEvaluator) {
-      return;
+      return undefined;
     }
     const { registerClientAction, unregisterClientAction } =
       agentStore.getState();

--- a/app/src/components/evaluators/useLlmEvaluatorDraftRegistration.ts
+++ b/app/src/components/evaluators/useLlmEvaluatorDraftRegistration.ts
@@ -59,7 +59,7 @@ export const useLlmEvaluatorDraftRegistration = ({
   const draftHostRef = useRef<LlmEvaluatorDraftHost | null>(null);
   useEffect(() => {
     if (instanceId == null) {
-      return;
+      return undefined;
     }
     const buildSnapshot = (): LLMEvaluatorDraftSnapshot => {
       const state = store.getState();

--- a/app/src/components/experiment/ExperimentRunCellAnnotationsList.tsx
+++ b/app/src/components/experiment/ExperimentRunCellAnnotationsList.tsx
@@ -31,6 +31,7 @@ import { Skeleton } from "@phoenix/components/core/loading";
 import type { ExecutionState } from "@phoenix/components/core/types";
 import { ExperimentAnnotationButton } from "@phoenix/components/experiment/ExperimentAnnotationButton";
 import { ExperimentRunAnnotationFiltersList } from "@phoenix/pages/experiment/ExperimentRunAnnotationFiltersList";
+import { assertUnreachable } from "@phoenix/typeUtils";
 import { floatFormatter } from "@phoenix/utils/numberFormatUtils";
 
 const listCSS = css`
@@ -112,6 +113,8 @@ function getItemName(item: AnnotationListItem): string {
       return item.name;
     case "error":
       return item.error.evaluatorName;
+    default:
+      return assertUnreachable(item);
   }
 }
 

--- a/app/src/components/experiment/ExperimentStatus.tsx
+++ b/app/src/components/experiment/ExperimentStatus.tsx
@@ -8,6 +8,7 @@ import {
   TriggerWrap,
 } from "@phoenix/components";
 import type { BadgeVariant } from "@phoenix/components/core/badge/types";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 type ExperimentStatusValue = "RUNNING" | "COMPLETED" | "ERROR" | "STOPPED";
 
@@ -21,6 +22,8 @@ function getStatusVariant(status: ExperimentStatusValue): BadgeVariant {
       return "danger";
     case "STOPPED":
       return "warning";
+    default:
+      return assertUnreachable(status);
   }
 }
 
@@ -34,6 +37,8 @@ function getStatusIcon(status: ExperimentStatusValue) {
       return <Icons.CloseCircle />;
     case "STOPPED":
       return <Icons.StopCircle />;
+    default:
+      return assertUnreachable(status);
   }
 }
 
@@ -47,6 +52,8 @@ function getStatusLabel(status: ExperimentStatusValue): string {
       return "error";
     case "STOPPED":
       return "stopped";
+    default:
+      return assertUnreachable(status);
   }
 }
 
@@ -60,6 +67,8 @@ function getStatusTooltip(status: ExperimentStatusValue): string {
       return "Experiment encountered an error during execution";
     case "STOPPED":
       return "Experiment was manually stopped before completion";
+    default:
+      return assertUnreachable(status);
   }
 }
 

--- a/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/app/src/components/filter/DSLFilterConditionField.tsx
@@ -339,7 +339,7 @@ export function DSLFilterConditionField(props: DSLFilterConditionFieldProps) {
       startTransition(() => {
         onValidCondition("");
       });
-      return;
+      return undefined;
     }
 
     onValidationStateChange?.(false);

--- a/app/src/components/generative/ToolChoiceSelector.tsx
+++ b/app/src/components/generative/ToolChoiceSelector.tsx
@@ -86,7 +86,7 @@ const canonicalToId = (
     case "SPECIFIC_FUNCTION":
       return `${SPECIFIC_FUNCTION_PREFIX}${choice.functionName ?? ""}`;
     default:
-      assertUnreachable(choice.type);
+      return assertUnreachable(choice.type);
   }
 };
 

--- a/app/src/components/markdown/streamdownComponents.tsx
+++ b/app/src/components/markdown/streamdownComponents.tsx
@@ -364,7 +364,7 @@ function TableCopyButton({
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
-    if (!copied) return;
+    if (!copied) return undefined;
     const timeout = window.setTimeout(() => setCopied(false), 2000);
     return () => window.clearTimeout(timeout);
   }, [copied]);

--- a/app/src/components/prompt/PromptChatMessagesCard.tsx
+++ b/app/src/components/prompt/PromptChatMessagesCard.tsx
@@ -89,6 +89,7 @@ export function PromptChatMessages({
   if (template.__typename === "%other") {
     throw new Error("Unknown template type" + template.__typename);
   }
+  return null;
 }
 
 function ChatMessageContentPart({

--- a/app/src/components/search/RecentlyViewedTracker.tsx
+++ b/app/src/components/search/RecentlyViewedTracker.tsx
@@ -157,7 +157,7 @@ export function RecentlyViewedTracker() {
   useEffect(() => {
     const match = matchEntityRoute(pathname, search);
     if (!match) {
-      return;
+      return undefined;
     }
     const subscription = fetchQuery<RecentlyViewedTrackerNodeQuery>(
       environment,

--- a/app/src/components/templateEditor/templateEditorUtils.ts
+++ b/app/src/components/templateEditor/templateEditorUtils.ts
@@ -53,6 +53,6 @@ export const getTemplateFormatUtils = (
         extractVariables: () => [],
       };
     default:
-      assertUnreachable(templateFormat);
+      return assertUnreachable(templateFormat);
   }
 };

--- a/app/src/components/trace/SpanStatusBadge.tsx
+++ b/app/src/components/trace/SpanStatusBadge.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/react";
 import { Badge, Text } from "@phoenix/components";
 import type { BadgeVariant } from "@phoenix/components/core/badge/types";
 import type { TextColorValue } from "@phoenix/components/core/types/style";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 import type { SpanStatusCodeType } from "./types";
 
@@ -14,6 +15,8 @@ function getStatusVariant(statusCode: SpanStatusCodeType): BadgeVariant {
       return "danger";
     case "UNSET":
       return "default";
+    default:
+      return assertUnreachable(statusCode);
   }
 }
 
@@ -28,6 +31,8 @@ function getStatusTextColor(
       return "danger";
     case "UNSET":
       return labelVariant === "short" ? "text-300" : "text-700";
+    default:
+      return assertUnreachable(statusCode);
   }
 }
 
@@ -42,6 +47,8 @@ function getStatusLabel(
       return labelVariant === "full" ? "Error" : "ERR";
     case "UNSET":
       return labelVariant === "full" ? "Unset" : "––";
+    default:
+      return assertUnreachable(statusCode);
   }
 }
 

--- a/app/src/components/trace/useSpanStatusCodeColor.ts
+++ b/app/src/components/trace/useSpanStatusCodeColor.ts
@@ -15,6 +15,6 @@ export function useSpanStatusCodeColor(
     case "UNSET":
       return "gray-500";
     default:
-      assertUnreachable(statusCode);
+      return assertUnreachable(statusCode);
   }
 }

--- a/app/src/components/utility/PrettyText.tsx
+++ b/app/src/components/utility/PrettyText.tsx
@@ -34,5 +34,5 @@ export function PrettyText({ children, preCSS }: PrettyTextProps) {
   if (textType === "json") {
     return <JSONBlock value={text} />;
   }
-  assertUnreachable(textType);
+  return assertUnreachable(textType);
 }

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -129,7 +129,7 @@ export function ThemeProvider(
   }, []);
 
   useEffect(() => {
-    if (props.disableBodyTheme) return;
+    if (props.disableBodyTheme) return undefined;
     // When the theme changes, set a class on the body to override the default theme
     document.body.classList.add(`theme--${theme}`);
     document.body.classList.add(`theme`);

--- a/app/src/contexts/TimeRangeContext.tsx
+++ b/app/src/contexts/TimeRangeContext.tsx
@@ -162,7 +162,7 @@ function useTimeRangeMemo(timePreset: TimePreset, timeRangeBounds: TimeRange) {
         };
       }
       default:
-        assertUnreachable(timePreset);
+        return assertUnreachable(timePreset);
     }
   }, [timePreset, timeRangeBounds]);
   return timeRange;

--- a/app/src/hooks/useCurrentTime.ts
+++ b/app/src/hooks/useCurrentTime.ts
@@ -24,7 +24,7 @@ export function useCurrentTime(
   const [nowEpochMs, setNowEpochMs] = useState<number>(() => Date.now());
   useEffect(() => {
     if (typeof updateIntervalMs !== "number") {
-      return;
+      return undefined;
     }
     const interval = setInterval(() => {
       // update via state callback to avoid setting state in the effect

--- a/app/src/hooks/useDimensions.ts
+++ b/app/src/hooks/useDimensions.ts
@@ -16,7 +16,7 @@ export const useDimensions = (ref: React.RefObject<HTMLElement | null>) => {
   const [dimensions, setDimensions] = useState<MaybeDimensions>(null);
 
   useEffect(() => {
-    if (!ref.current) return;
+    if (!ref.current) return undefined;
 
     const resizeObserver = new ResizeObserver((entries) => {
       if (!entries || entries.length === 0) return;

--- a/app/src/hooks/useHasOpenModal.ts
+++ b/app/src/hooks/useHasOpenModal.ts
@@ -179,7 +179,7 @@ export function useActiveDrawerWidth() {
 
   useEffect(() => {
     if (!drawer) {
-      return;
+      return undefined;
     }
 
     const measureDrawer = () => {

--- a/app/src/hooks/useInterval.ts
+++ b/app/src/hooks/useInterval.ts
@@ -16,7 +16,7 @@ export function useInterval(callback: Callback, delay: number | null) {
   }, [callback]);
 
   useEffect(() => {
-    if (typeof delay !== "number") return;
+    if (typeof delay !== "number") return undefined;
 
     const intervalMs = delay;
 

--- a/app/src/pages/example/ExampleExperimentRunsTable.tsx
+++ b/app/src/pages/example/ExampleExperimentRunsTable.tsx
@@ -210,6 +210,7 @@ export function ExampleExperimentRunsTable({
             />
           );
         }
+        return undefined;
       },
     },
   ];

--- a/app/src/pages/playground/ChatMessageToolCallsEditor.tsx
+++ b/app/src/pages/playground/ChatMessageToolCallsEditor.tsx
@@ -15,6 +15,7 @@ import {
   selectPlaygroundInstance,
   selectPlaygroundInstanceMessage,
 } from "@phoenix/store/playground/selectors";
+import { assertUnreachable } from "@phoenix/typeUtils";
 import { isJSONString, safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
 /**
@@ -107,6 +108,8 @@ export function ChatMessageToolCallsEditor({
       // TODO(apowell): #5348 Add Google tool calls schema
       case "GOOGLE":
         return null;
+      default:
+        return assertUnreachable(instance.model.provider);
     }
   }, [instance.model.provider]);
 

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -586,7 +586,7 @@ function PlaygroundContent() {
     const { registerClientAction, unregisterClientAction } =
       agentStore.getState();
     if (!datasetId) {
-      return;
+      return undefined;
     }
     registerClientAction(
       OPEN_CODE_EVALUATOR_FORM_TOOL_NAME,
@@ -732,6 +732,7 @@ function PlaygroundContent() {
         window.removeEventListener("beforeunload", handleBeforeUnload);
       };
     }
+    return undefined;
   }, [isRunning]);
 
   // The mounted panel set varies by mode; passing panelIds keys each mode's

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -1060,7 +1060,7 @@ export function PlaygroundDatasetExamplesTable({
           case "%other":
             return;
           default:
-            return assertUnreachable(chatCompletion);
+            assertUnreachable(chatCompletion);
         }
       },
     [
@@ -1081,7 +1081,7 @@ export function PlaygroundDatasetExamplesTable({
 
   useEffect(() => {
     if (!hasSomeRunIds) {
-      return;
+      return undefined;
     }
     const { instances } = playgroundStore.getState();
     setApiError(null);

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -303,7 +303,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
 
   useEffect(() => {
     if (!runInProgress) {
-      return;
+      return undefined;
     }
     setApiError(null);
     const input = getChatCompletionInput({

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -153,7 +153,7 @@ export function processAttributeToolCalls({
   provider: ModelProvider;
 }): ChatMessage["toolCalls"] {
   if (toolCalls == null) {
-    return;
+    return undefined;
   }
   return toolCalls
     .map(({ tool_call }) => {
@@ -210,7 +210,7 @@ export function processAttributeToolCalls({
             },
           } as JSONLiteral;
         default:
-          assertUnreachable(provider);
+          return assertUnreachable(provider);
       }
     })
     .filter((toolCall): toolCall is NonNullable<typeof toolCall> => {
@@ -1388,7 +1388,7 @@ export const createToolCallForProvider = (
     case "GOOGLE":
       return createOpenAIToolCall();
     default:
-      assertUnreachable(provider);
+      return assertUnreachable(provider);
   }
 };
 
@@ -2046,6 +2046,8 @@ export function toCanonicalToolChoice(
       return { oneOrMore: true };
     case "SPECIFIC_FUNCTION":
       return { functionName: toolChoice.functionName ?? "" };
+    default:
+      return assertUnreachable(toolChoice.type);
   }
 }
 

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -262,7 +262,7 @@ export function SessionsTable(props: SessionsTableProps) {
   const setSessionSequence = useSessionPagination()?.setSessionSequence;
   useEffect(() => {
     if (!setSessionSequence) {
-      return;
+      return undefined;
     }
     setSessionSequence(
       data.sessions.edges.map(({ session }) => ({

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -337,7 +337,7 @@ export function SpansTable(props: SpansTableProps) {
   const setTraceSequence = pagination?.setTraceSequence;
   useEffect(() => {
     if (!setTraceSequence) {
-      return;
+      return undefined;
     }
     setTraceSequence(
       data.spans.edges.map(({ span }) => ({

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -954,7 +954,7 @@ export function TracesTable(props: TracesTableProps) {
   const setTraceSequence = pagination?.setTraceSequence;
   useEffect(() => {
     if (!setTraceSequence) {
-      return;
+      return undefined;
     }
     setTraceSequence(
       data.rootSpans.edges.map(({ rootSpan }) => ({

--- a/app/src/pages/prompt/PromptCodeExportCard.tsx
+++ b/app/src/pages/prompt/PromptCodeExportCard.tsx
@@ -227,6 +227,6 @@ function CodeBlock({
         <TypeScriptBlock value={value} basicSetup={{ lineNumbers: true }} />
       );
     default:
-      assertUnreachable(language);
+      return assertUnreachable(language);
   }
 }

--- a/app/src/pages/settings/CustomProviderForm.tsx
+++ b/app/src/pages/settings/CustomProviderForm.tsx
@@ -886,6 +886,7 @@ function SDKFieldsRenderer({
       // without updating this switch statement
       const exhaustiveCheck: never = sdk;
       invariant(false, `Unsupported SDK type: ${exhaustiveCheck}`);
+      return null;
     }
   }
 }

--- a/app/src/pages/settings/RetentionPolicyForm.tsx
+++ b/app/src/pages/settings/RetentionPolicyForm.tsx
@@ -170,6 +170,7 @@ export function RetentionPolicyForm(props: RetentionPolicyFormProps) {
                       ? error.message
                       : "Invalid cron expression";
                   }
+                  return undefined;
                 },
               }}
               render={({ field, fieldState }) => (

--- a/app/src/pages/settings/customProviderFormUtils.ts
+++ b/app/src/pages/settings/customProviderFormUtils.ts
@@ -120,6 +120,7 @@ export function createDefaultFormData(
         `Unknown SDK type "${String(_exhaustive)}" received. ` +
           `The frontend may need to be updated to support this SDK type.`
       );
+      return _exhaustive;
     }
   }
 }
@@ -253,6 +254,7 @@ export function transformConfigToFormValues(
         `Unknown SDK type "${String(_exhaustive)}" received from backend. ` +
           `The frontend may need to be updated to support this SDK type.`
       );
+      return _exhaustive;
     }
   }
 }
@@ -307,8 +309,9 @@ export function buildClientConfig(
       // Build auth method based on selected type
       // Note: We don't use compressObject here because the GraphQL types require
       // specific fields to be non-optional
+      const azureAuthMethod = formData.azure_auth_method;
       const authMethod: AzureOpenAIAuthenticationMethodInput = (() => {
-        switch (formData.azure_auth_method) {
+        switch (azureAuthMethod) {
           case "default_credentials":
             return { defaultCredentials: true };
           case "ad_token_provider":
@@ -338,11 +341,14 @@ export function buildClientConfig(
               "Azure API key is required when using API key authentication"
             );
             return { apiKey: formData.azure_api_key };
-          default:
+          default: {
+            const _exhaustive: never = azureAuthMethod;
             invariant(
               false,
-              `Unknown Azure auth method: ${formData.azure_auth_method}`
+              `Unknown Azure auth method: ${String(_exhaustive)}`
             );
+            return _exhaustive;
+          }
         }
       })();
 
@@ -392,8 +398,9 @@ export function buildClientConfig(
       );
 
       // Build auth method based on selected type
+      const awsAuthMethodInput = formData.aws_auth_method;
       const awsAuthMethod = (() => {
-        switch (formData.aws_auth_method) {
+        switch (awsAuthMethodInput) {
           case "default_credentials":
             return { defaultCredentials: true as const };
           case "access_keys":
@@ -414,11 +421,11 @@ export function buildClientConfig(
                 }),
               },
             };
-          default:
-            invariant(
-              false,
-              `Unknown AWS auth method: ${formData.aws_auth_method}`
-            );
+          default: {
+            const _exhaustive: never = awsAuthMethodInput;
+            invariant(false, `Unknown AWS auth method: ${String(_exhaustive)}`);
+            return _exhaustive;
+          }
         }
       })();
 
@@ -456,7 +463,7 @@ export function buildClientConfig(
       };
     }
     default: {
-      assertUnreachable(formData);
+      return assertUnreachable(formData);
     }
   }
 }
@@ -586,7 +593,7 @@ function hasConfigChanged(
       );
     }
     default: {
-      assertUnreachable(formData);
+      return assertUnreachable(formData);
     }
   }
 }

--- a/app/src/pages/settings/sandboxes/utils.tsx
+++ b/app/src/pages/settings/sandboxes/utils.tsx
@@ -82,7 +82,7 @@ export function hostingTypeLabel(hostingType: HostingType) {
     case "HOSTED":
       return "Hosted";
     default:
-      assertUnreachable(hostingType);
+      return assertUnreachable(hostingType);
   }
 }
 
@@ -137,7 +137,7 @@ export function statusLabel(status: BackendInfo["status"]) {
     case "DISABLED":
       return "Disabled";
     default:
-      assertUnreachable(status);
+      return assertUnreachable(status);
   }
 }
 

--- a/app/src/pages/trace/span/MimeTypeCodeBlock.tsx
+++ b/app/src/pages/trace/span/MimeTypeCodeBlock.tsx
@@ -15,6 +15,6 @@ export function MimeTypeCodeBlock({ value, mimeType }: SpanIOValue) {
     case "text":
       return <ConnectedMarkdownBlock>{value}</ConnectedMarkdownBlock>;
     default:
-      assertUnreachable(mimeType);
+      return assertUnreachable(mimeType);
   }
 }

--- a/app/src/schemas/toolCallSchemas.ts
+++ b/app/src/schemas/toolCallSchemas.ts
@@ -265,7 +265,7 @@ export const toOpenAIToolCall = (
     case "UNKNOWN":
       return null;
     default:
-      assertUnreachable(provider);
+      return assertUnreachable(provider);
   }
 };
 
@@ -304,7 +304,7 @@ export const fromOpenAIToolCall = <T extends ModelProvider>({
     case "GOOGLE":
       return toolCall as ProviderToToolCallMap[T];
     default:
-      assertUnreachable(targetProvider);
+      return assertUnreachable(targetProvider);
   }
 };
 

--- a/app/src/store/credentialsStore.tsx
+++ b/app/src/store/credentialsStore.tsx
@@ -100,6 +100,7 @@ export const createCredentialsStore = (
         if (isV0CredentialsProps(state)) {
           return migrateV0CredentialsProps(state);
         }
+        return undefined;
       },
     })
   );

--- a/app/src/store/playground/playgroundStoreUtils.ts
+++ b/app/src/store/playground/playgroundStoreUtils.ts
@@ -16,7 +16,7 @@ export const convertMessageToolCallsToProvider = ({
   provider: ModelProvider;
 }): ChatMessage["toolCalls"] => {
   if (toolCalls == null) {
-    return;
+    return undefined;
   }
   return toolCalls.map((toolCall) => {
     switch (provider) {
@@ -55,7 +55,7 @@ export const convertMessageToolCallsToProvider = ({
       case "GOOGLE":
         return toolCall;
       default:
-        assertUnreachable(provider);
+        return assertUnreachable(provider);
     }
   });
 };

--- a/app/src/utils/generativeUtils.ts
+++ b/app/src/utils/generativeUtils.ts
@@ -55,7 +55,7 @@ export function getProviderName(provider: ModelProvider): string {
     case "TOGETHER":
       return "Together";
     default:
-      assertUnreachable(provider);
+      return assertUnreachable(provider);
   }
 }
 
@@ -95,6 +95,6 @@ export function getSemConvProvider(provider: ModelProvider): string {
     case "TOGETHER":
       return "together"; // TODO: Add support for Together to semantic conventions
     default:
-      assertUnreachable(provider);
+      return assertUnreachable(provider);
   }
 }

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -238,7 +238,13 @@ function formatCredentialSource(
       return "oauth";
     case "none":
       return "none";
+    default:
+      return assertNever(source);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${String(value)}`);
 }
 
 function formatAuthOutput(
@@ -287,6 +293,8 @@ function exitCodeForResult(result: FetchViewerResult): ExitCode {
       return ExitCode.NETWORK_ERROR;
     case "unknown_error":
       return ExitCode.FAILURE;
+    default:
+      return assertNever(result);
   }
 }
 
@@ -304,7 +312,7 @@ async function verifyViewerOrExit(config: PhoenixConfig): Promise<ViewerUser> {
     process.exit(ExitCode.NETWORK_ERROR);
   }
   writeError({ message: `Could not verify login: ${result.message}` });
-  process.exit(ExitCode.FAILURE);
+  return process.exit(ExitCode.FAILURE);
 }
 
 /**

--- a/js/packages/phoenix-cli/src/oauthCallbackPage.ts
+++ b/js/packages/phoenix-cli/src/oauthCallbackPage.ts
@@ -51,7 +51,13 @@ function getCallbackPageContent(
         title: "Something went wrong",
         body: `${escapeHtml(result.message)} Return to your terminal and try running px auth login again.`,
       };
+    default:
+      return assertNever(result);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported callback status: ${String(value)}`);
 }
 
 /**

--- a/js/packages/phoenix-cli/src/pxi/toolProgress.ts
+++ b/js/packages/phoenix-cli/src/pxi/toolProgress.ts
@@ -77,7 +77,13 @@ function getStatusText(state: ToolProgressState): string {
       return "Failed";
     case "output-denied":
       return "Denied";
+    default:
+      return assertNever(state);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unknown tool progress state: ${String(value)}`);
 }
 
 /**

--- a/js/packages/phoenix-client/src/prompts/createPrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/createPrompt.ts
@@ -301,6 +301,6 @@ export function promptVersion(params: PromptVersionInput): PromptVersionData {
         },
       };
     default:
-      assertUnreachable(model_provider);
+      return assertUnreachable(model_provider);
   }
 }

--- a/js/packages/phoenix-client/src/prompts/sdks/toSDK.ts
+++ b/js/packages/phoenix-client/src/prompts/sdks/toSDK.ts
@@ -42,7 +42,7 @@ const getTargetSDK = <SDK extends SupportedSDK>(sdk: SDK) => {
     case "ai":
       return PROVIDER_TO_SDK.ai;
     default:
-      assertUnreachable(sdk);
+      return assertUnreachable(sdk);
   }
 };
 

--- a/js/packages/phoenix-client/src/schemas/llm/converters.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/converters.ts
@@ -294,7 +294,7 @@ export const fromOpenAIToolCall = <
         toolCall
       ) as ReturnType;
     default:
-      assertUnreachable(targetProvider);
+      return assertUnreachable(targetProvider);
   }
 };
 
@@ -328,7 +328,7 @@ export const toOpenAIToolChoice = (
         validatedToolChoice
       );
     default:
-      assertUnreachable(provider);
+      return assertUnreachable(provider);
   }
 };
 
@@ -373,7 +373,7 @@ export const fromOpenAIToolChoice = <
         toolChoice
       ) as ReturnType;
     default:
-      assertUnreachable(targetProvider);
+      return assertUnreachable(targetProvider);
   }
 };
 
@@ -406,7 +406,7 @@ export const toOpenAIToolDefinition = (
     case null:
       return null;
     default:
-      assertUnreachable(provider);
+      return assertUnreachable(provider);
   }
 };
 
@@ -447,7 +447,7 @@ export const fromOpenAIToolDefinition = <
         toolDefinition
       ) as ReturnType;
     default:
-      assertUnreachable(targetProvider);
+      return assertUnreachable(targetProvider);
   }
 };
 

--- a/js/packages/phoenix-client/src/schemas/llm/openai/converters.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/openai/converters.ts
@@ -324,7 +324,7 @@ export const openAIMessageToVercelAI = openAIMessageSchema.transform(
           content: [],
         };
       default:
-        assertUnreachable(role);
+        return assertUnreachable(role);
     }
   }
 );
@@ -354,7 +354,7 @@ export const openAIToolChoiceToAnthropic = openAIToolChoiceSchema.transform(
       case "required":
         return { type: "any" };
       default:
-        assertUnreachable(openAI);
+        return assertUnreachable(openAI);
     }
   }
 );
@@ -372,7 +372,7 @@ export const openAIToolChoiceToVercelAI = openAIToolChoiceSchema.transform(
       case "required":
         return "required";
       default:
-        assertUnreachable(openAI);
+        return assertUnreachable(openAI);
     }
   }
 );

--- a/js/packages/phoenix-client/src/schemas/llm/phoenixPrompt/converters.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/phoenixPrompt/converters.ts
@@ -172,6 +172,8 @@ export const phoenixToolChoiceToOpenAI = phoenixToolChoiceSchema.transform(
         return "required";
       case "specific_function":
         return { type: "function", function: { name: phoenix.function_name } };
+      default:
+        return assertUnreachable(phoenix);
     }
   }
 );

--- a/js/packages/phoenix-client/src/utils/serverVersionUtils.ts
+++ b/js/packages/phoenix-client/src/utils/serverVersionUtils.ts
@@ -20,6 +20,7 @@
 
 import type { PhoenixClient } from "../client";
 import type { CapabilityRequirement } from "../types/serverRequirements";
+import { assertUnreachable } from "./assertUnreachable";
 import { formatVersion, satisfiesMinVersion } from "./semverUtils";
 
 // ---------------------------------------------------------------------------
@@ -37,6 +38,8 @@ export function capabilityLabel(req: CapabilityRequirement): string {
       return `The ${req.method} ${req.path} route`;
     case "parameter":
       return `The '${req.parameterName}' ${req.parameterLocation} parameter on ${req.route}`;
+    default:
+      return assertUnreachable(req);
   }
 }
 

--- a/js/packages/phoenix-config/src/env.ts
+++ b/js/packages/phoenix-config/src/env.ts
@@ -225,11 +225,11 @@ export function resetCrossTierEndpointWarningsForTesting(): void {
 export function getIntFromEnvironment(envKey: string) {
   const value = readEnvValue(envKey);
   if (!value) {
-    return;
+    return undefined;
   }
   const parsed = parseInt(value);
   if (Number.isNaN(parsed)) {
-    return;
+    return undefined;
   }
   return parsed;
 }
@@ -343,11 +343,11 @@ export function parseHeaders(value: string | undefined): Headers | undefined {
   try {
     const parsed = JSON.parse(value);
     if (!isHeaders(parsed)) {
-      return;
+      return undefined;
     }
     return parsed;
   } catch {
-    return;
+    return undefined;
   }
 }
 


### PR DESCRIPTION
Re-promotes `typescript/consistent-return` from `warn` back to `error` and fixes the remaining violations across `app/` and `js/`. All changes are behavior-neutral:

- bare `return;` → `return undefined;` where other paths return a value (mostly `useEffect` cleanup paths)
- exhaustive switches that fall off the end get `default: return assertUnreachable(...)` (or the local `assertNever`/`_exhaustive` pattern already used in the file)
- prepend `return` to existing bare `assertUnreachable()` default calls

**Verification:** `lint` passes in both `app/` and `js/` with the rule as `error`.