### PR TITLE
feat(playground): add Gemini 3.6 Flash and 3.5 Flash-lite support

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -3042,7 +3042,9 @@ class Gemini25GoogleStreamingClient(GoogleStreamingClient):
 
 
 GEMINI_3_MODELS = [
+    "gemini-3.6-flash",
     "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
     "gemini-3.1-pro-preview",
     "gemini-3-pro-preview",
     "gemini-3-flash-preview",


### PR DESCRIPTION
## Summary

- Registers `gemini-3.6-flash` and `gemini-3.5-flash-lite` in `GEMINI_3_MODELS` (`src/phoenix/server/api/helpers/playground_clients.py`) so they are selectable as Google-provider models in the Playground.
- The Playground's model dropdown is populated dynamically from `PLAYGROUND_CLIENT_REGISTRY` via GraphQL, so no frontend changes are needed for the models to appear.
- Cost/pricing entries for both models already existed in `src/phoenix/server/cost_tracking/model_cost_manifest.json`, so no changes were needed there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBy1UEysq76NXtqbpmQepr)_