### PR TITLE
fix(ui): preserve line breaks in user chat messages

### DIFF
--- a/app/src/components/ai/message/styles.ts
+++ b/app/src/components/ai/message/styles.ts
@@ -36,6 +36,7 @@ export const messageContentCSS = css`
     border-radius: var(--message-user-border-radius);
     padding: var(--global-dimension-size-100) var(--global-dimension-size-200);
     max-width: 75%;
+    white-space: pre-wrap;
   }
 
   [data-from="assistant"] > & {


### PR DESCRIPTION
Multi-line prompts in the PXI chat were rendering as a single blob. The text is sent and stored correctly with its newlines. The problem is purely display: the user message bubble never set `white-space`, so the browser collapsed the line breaks.

The fix sets `white-space: pre-wrap` on the user bubble, which keeps the line breaks while still wrapping long text. Assistant messages aren't affected since they render through the markdown block.

Closes #14652
