### PR TITLE
feat: span analytics MCP surface with typed discovery and aggregation

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -414,6 +414,7 @@ jobs:
           sparse-checkout: |
             Makefile
             scripts/ci/
+            scripts/span_analytics_seeds/
             requirements/
             src/
             packages/

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -70,6 +70,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             requirements/
+            scripts/span_analytics_seeds/
             src/phoenix/
             packages/phoenix-evals/
             evals/

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -138,6 +138,45 @@ describe("datetime utils", () => {
     ).toBeNull();
   });
 
+  it("accepts deep-link start/end aliases when canonical bounds are absent", () => {
+    // Server-generated deep links carry short `start`/`end` params.
+    const aliased = getTimeRangeFromSearchParams(
+      new URLSearchParams(
+        "start=2026-06-09T09%3A00%3A00.000Z&end=2026-06-09T10%3A00%3A00.000Z"
+      )
+    );
+    expect(aliased).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T09:00:00.000Z"),
+      end: new Date("2026-06-09T10:00:00.000Z"),
+    });
+
+    // Canonical bounds win over aliases when both are present.
+    const canonicalWins = getTimeRangeFromSearchParams(
+      new URLSearchParams(
+        "timeRangeStart=2026-06-09T08%3A00%3A00.000Z&timeRangeEnd=2026-06-09T09%3A00%3A00.000Z&start=2026-06-09T01%3A00%3A00.000Z&end=2026-06-09T02%3A00%3A00.000Z"
+      )
+    );
+    expect(canonicalWins).toEqual({
+      timeRangeKey: "custom",
+      start: new Date("2026-06-09T08:00:00.000Z"),
+      end: new Date("2026-06-09T09:00:00.000Z"),
+    });
+
+    // Invalid or inverted aliases are unusable, so callers fall back to the
+    // stored preference rather than crashing.
+    expect(
+      getTimeRangeFromSearchParams(new URLSearchParams("start=not-a-date"))
+    ).toBeNull();
+    expect(
+      getTimeRangeFromSearchParams(
+        new URLSearchParams(
+          "start=2026-06-09T10%3A00%3A00.000Z&end=2026-06-09T09%3A00%3A00.000Z"
+        )
+      )
+    ).toBeNull();
+  });
+
   it("serializes selected time ranges to URL search params", () => {
     const searchParams = new URLSearchParams(
       "timeRangeKey=7d&selectedSpanNodeId=span-1"
@@ -172,6 +211,27 @@ describe("datetime utils", () => {
     expect(presetParams.get("timeRangeStart")).toBeNull();
     expect(presetParams.get("timeRangeEnd")).toBeNull();
     expect(presetParams.get("selectedSpanNodeId")).toBe("span-1");
+  });
+
+  it("clears deep-link start/end aliases when a new range is written", () => {
+    const deepLinkParams = new URLSearchParams(
+      "start=2026-06-09T09%3A00%3A00.000Z&end=2026-06-09T10%3A00%3A00.000Z&filter=span_kind+%3D%3D+%27LLM%27"
+    );
+    const nextParams = setTimeRangeSearchParams({
+      searchParams: deepLinkParams,
+      timeRange: {
+        timeRangeKey: "1h",
+        ...getTimeRangeFromLastNTimeRangeKey(
+          "1h",
+          new Date("2026-06-09T10:20:30.000Z").getTime()
+        ),
+      },
+    });
+    // The superseded aliases are dropped; unrelated params are preserved.
+    expect(nextParams.get("start")).toBeNull();
+    expect(nextParams.get("end")).toBeNull();
+    expect(nextParams.get("timeRangeKey")).toBe("1h");
+    expect(nextParams.get("filter")).toBe("span_kind == 'LLM'");
   });
 });
 

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -9,8 +9,10 @@ import {
 import type { DateValue } from "react-aria-components";
 
 import {
+  TIME_RANGE_END_ALIAS_PARAM,
   TIME_RANGE_END_PARAM,
   TIME_RANGE_KEY_PARAM,
+  TIME_RANGE_START_ALIAS_PARAM,
   TIME_RANGE_START_PARAM,
 } from "@phoenix/constants/searchParams";
 import { assertUnreachable } from "@phoenix/typeUtils";
@@ -144,6 +146,11 @@ function getDateFromSearchParamValue(value: string | null) {
  * key is present, which also means a legacy URL carrying both is read as a live
  * preset. Invalid or incomplete params return null so callers can fall back to
  * the user's stored preference.
+ *
+ * Each bound also accepts a short inbound alias
+ * ({@link TIME_RANGE_START_ALIAS_PARAM}/{@link TIME_RANGE_END_ALIAS_PARAM}),
+ * used by server-generated deep links, consulted only when the corresponding
+ * canonical param is absent.
  */
 export function getTimeRangeFromSearchParams(
   searchParams: URLSearchParams,
@@ -157,10 +164,12 @@ export function getTimeRangeFromSearchParams(
     };
   }
   const start = getDateFromSearchParamValue(
-    searchParams.get(TIME_RANGE_START_PARAM)
+    searchParams.get(TIME_RANGE_START_PARAM) ??
+      searchParams.get(TIME_RANGE_START_ALIAS_PARAM)
   );
   const end = getDateFromSearchParamValue(
-    searchParams.get(TIME_RANGE_END_PARAM)
+    searchParams.get(TIME_RANGE_END_PARAM) ??
+      searchParams.get(TIME_RANGE_END_ALIAS_PARAM)
   );
   // Non-parseable bounds, no bounds at all, or an inverted window are unusable.
   if (start === undefined || end === undefined) {
@@ -195,6 +204,10 @@ export function setTimeRangeSearchParams({
   timeRange: OpenTimeRangeWithKey;
 }): URLSearchParams {
   const nextSearchParams = new URLSearchParams(searchParams);
+  // Inbound deep-link aliases are superseded by whatever range is being
+  // written, so drop them rather than leaving stale bounds in the URL.
+  nextSearchParams.delete(TIME_RANGE_START_ALIAS_PARAM);
+  nextSearchParams.delete(TIME_RANGE_END_ALIAS_PARAM);
   const setOrDelete = (param: string, value: Date | null | undefined) => {
     if (value != null) {
       nextSearchParams.set(param, value.toISOString());

--- a/app/src/constants/searchParams.ts
+++ b/app/src/constants/searchParams.ts
@@ -44,6 +44,31 @@ export const TIME_RANGE_START_PARAM = "timeRangeStart";
 export const TIME_RANGE_END_PARAM = "timeRangeEnd";
 
 /**
+ * Short inbound alias for {@link TIME_RANGE_START_PARAM}, accepted on
+ * server-generated deep links (e.g. `?start=...&end=...`). Only consulted
+ * when the canonical param is absent, and cleared whenever a new time range
+ * is written to the URL.
+ */
+export const TIME_RANGE_START_ALIAS_PARAM = "start";
+
+/**
+ * Short inbound alias for {@link TIME_RANGE_END_PARAM}, accepted on
+ * server-generated deep links (e.g. `?start=...&end=...`). Only consulted
+ * when the canonical param is absent, and cleared whenever a new time range
+ * is written to the URL.
+ */
+export const TIME_RANGE_END_ALIAS_PARAM = "end";
+
+/**
+ * The search param that carries a span filter condition (the same DSL the
+ * filter condition field accepts) into the spans and traces tables. Inbound
+ * links (e.g. server-generated cohort permalinks) seed the filter field from
+ * it, and the last valid condition typed into the field is mirrored back so
+ * any filtered view is shareable as a URL.
+ */
+export const SPAN_FILTER_CONDITION_PARAM = "filter";
+
+/**
  * The search param that holds the label ids used to filter a list of resources
  * (e.g. prompts or datasets). Stored as a repeated param so multiple labels can
  * be selected, e.g. `?labelId=a&labelId=b`. Persisting to the URL makes the

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -1,5 +1,6 @@
 import type { Completion } from "@codemirror/autocomplete";
 import { useCallback, useDeferredValue, useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
 import { fetchQuery, graphql } from "relay-runtime";
 
 import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
@@ -10,6 +11,7 @@ import {
   type DSLFilterSnippet,
   useDSLFilterConditionHistory,
 } from "@phoenix/components/filter";
+import { SPAN_FILTER_CONDITION_PARAM } from "@phoenix/constants/searchParams";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import environment from "@phoenix/RelayEnvironment";
 
@@ -285,12 +287,33 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
     [recentSearchesCompletionSource]
   );
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const handleValidCondition = useCallback(
     (condition: string) => {
       recordValidCondition(condition);
       onValidCondition(condition);
+      // Mirror the validated condition into the URL so any filtered view is
+      // shareable as a link. Only validated conditions are written (edits are
+      // debounced upstream), the write replaces rather than pushes so typing
+      // does not spam history, and an already-in-sync URL (including the
+      // no-filter, no-param case) is left untouched.
+      if ((searchParams.get(SPAN_FILTER_CONDITION_PARAM) ?? "") !== condition) {
+        setSearchParams(
+          (prevSearchParams) => {
+            const nextSearchParams = new URLSearchParams(prevSearchParams);
+            if (condition) {
+              nextSearchParams.set(SPAN_FILTER_CONDITION_PARAM, condition);
+            } else {
+              nextSearchParams.delete(SPAN_FILTER_CONDITION_PARAM);
+            }
+            return nextSearchParams;
+          },
+          { replace: true }
+        );
+      }
     },
-    [recordValidCondition, onValidCondition]
+    [recordValidCondition, onValidCondition, searchParams, setSearchParams]
   );
 
   // Advertise a project context that carries the current spanFilter while

--- a/app/src/pages/project/SpanFiltersContext.tsx
+++ b/app/src/pages/project/SpanFiltersContext.tsx
@@ -8,11 +8,13 @@ import {
   useEffectEvent,
   useState,
 } from "react";
+import { useSearchParams } from "react-router";
 
 import {
   SET_SPANS_FILTER_TOOL_NAME,
   type SetSpansFilterInput,
 } from "@phoenix/agent/tools/spansFilter";
+import { SPAN_FILTER_CONDITION_PARAM } from "@phoenix/constants/searchParams";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import type { AgentClientActionResult } from "@phoenix/store/agentStore";
@@ -46,7 +48,14 @@ export function useSpanFilters() {
 }
 
 export function SpanFiltersProvider(props: PropsWithChildren) {
-  const [filterCondition, _setFilterCondition] = useState<string>("");
+  const [searchParams] = useSearchParams();
+  // Seed the filter from the URL so server-generated deep links (e.g. cohort
+  // permalinks carrying `?filter=...`) open the table pre-filtered. The
+  // search param arrives URL-decoded from useSearchParams, so the condition
+  // lands in the field verbatim.
+  const [filterCondition, _setFilterCondition] = useState<string>(
+    () => searchParams.get(SPAN_FILTER_CONDITION_PARAM) ?? ""
+  );
   const [rootSpansOnly, _setRootSpansOnly] = useState<boolean>(true);
 
   const setFilterCondition = useCallback((condition: string) => {

--- a/app/tests/span-deep-link.spec.ts
+++ b/app/tests/span-deep-link.spec.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "crypto";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+/**
+ * URL deep-linking for the project spans table.
+ *
+ * A link of the form
+ * `/projects/{projectId}/spans?filter=<condition>&start=<ISO>&end=<ISO>`
+ * must open the spans table with the filter condition seeded into the filter
+ * field, the rows narrowed to spans matching the condition, and the time
+ * range set to the given custom window.
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+
+// The tenant value deliberately carries a quote so the round-trip through URL
+// encoding into the filter field is exercised. The condition uses the grammar
+// the filter field accepts (a Python expression), where a value containing a
+// single quote is written as a double-quoted string.
+const TENANT = "o'brien-corp";
+const FILTER_CONDITION = `metadata['tenant'] == "o'brien-corp"`;
+
+function randomHex(length: number): string {
+  let hex = "";
+  while (hex.length < length) {
+    hex += randomUUID().replaceAll("-", "");
+  }
+  return hex.slice(0, length);
+}
+
+function makeSpan({
+  name,
+  tenant,
+  time,
+}: {
+  name: string;
+  tenant: string;
+  time: Date;
+}) {
+  return {
+    name,
+    context: {
+      trace_id: randomHex(32),
+      span_id: randomHex(16),
+    },
+    span_kind: "LLM",
+    start_time: time.toISOString(),
+    end_time: new Date(time.getTime() + 1000).toISOString(),
+    status_code: "OK",
+    status_message: "",
+    attributes: {
+      metadata: { tenant },
+    },
+    events: [],
+  };
+}
+
+/**
+ * Seeds a fresh project with three spans against a [2h ago, 1h ago] window:
+ * one matching both the tenant filter and the window, one inside the window
+ * with a different tenant (excluded by the filter), and one matching the
+ * filter but outside the window (excluded by the time range).
+ */
+async function seedProject(request: APIRequestContext) {
+  const runId = randomUUID().slice(0, 8);
+  const projectName = `deep-link-${runId}`;
+  const spanNamePrefix = `deeplink-${runId}`;
+
+  const now = Date.now();
+  const windowStart = new Date(now - 2 * HOUR_MS);
+  const windowEnd = new Date(now - HOUR_MS);
+  const insideWindow = new Date(now - 90 * MINUTE_MS);
+  const outsideWindow = new Date(now - 10 * MINUTE_MS);
+
+  const spans = [
+    makeSpan({
+      name: `${spanNamePrefix}-match`,
+      tenant: TENANT,
+      time: insideWindow,
+    }),
+    makeSpan({
+      name: `${spanNamePrefix}-other-tenant`,
+      tenant: "acme",
+      time: insideWindow,
+    }),
+    makeSpan({
+      name: `${spanNamePrefix}-outside-window`,
+      tenant: TENANT,
+      time: outsideWindow,
+    }),
+  ];
+
+  const createResponse = await request.post(
+    `/v1/projects/${encodeURIComponent(projectName)}/spans`,
+    { data: { data: spans } }
+  );
+  expect(createResponse.ok()).toBe(true);
+
+  // Span insertion is queued; poll until every span is visible via the API.
+  await expect
+    .poll(async () => {
+      const listResponse = await request.get(
+        `/v1/projects/${encodeURIComponent(projectName)}/spans`
+      );
+      if (!listResponse.ok()) {
+        return 0;
+      }
+      const body = (await listResponse.json()) as { data?: unknown[] };
+      return body.data?.length ?? 0;
+    })
+    .toBe(spans.length);
+
+  const projectResponse = await request.get(
+    `/v1/projects/${encodeURIComponent(projectName)}`
+  );
+  expect(projectResponse.ok()).toBe(true);
+  const projectBody = (await projectResponse.json()) as {
+    data: { id: string };
+  };
+
+  return {
+    projectId: projectBody.data.id,
+    spanNamePrefix,
+    windowStart,
+    windowEnd,
+  };
+}
+
+function seededSpanLinks(page: Page, spanNamePrefix: string) {
+  return page.getByRole("link", { name: new RegExp(spanNamePrefix) });
+}
+
+test.describe("Span deep links", () => {
+  test("opens the spans table with the filter and time range applied", async ({
+    page,
+    request,
+  }) => {
+    const { projectId, spanNamePrefix, windowStart, windowEnd } =
+      await seedProject(request);
+    const search = new URLSearchParams({
+      filter: FILTER_CONDITION,
+      start: windowStart.toISOString(),
+      end: windowEnd.toISOString(),
+    });
+    await page.goto(`/projects/${projectId}/spans?${search.toString()}`);
+
+    // The condition lands in the filter field verbatim, quotes intact.
+    const filterField = page.getByRole("textbox", { name: "Filter spans" });
+    await expect(filterField).toContainText(FILTER_CONDITION);
+    // The condition passes validation — an invalid one would flag the field
+    // with an error affordance (and would never filter the rows below).
+    await expect(page.getByLabel("Filter condition error")).not.toBeVisible();
+
+    // The time range reflects the params: the selector shows a custom range
+    // rather than a last-N preset.
+    await expect(
+      page.getByRole("group", { name: "Time range" }).getByText("Custom")
+    ).toBeVisible();
+
+    // Only the span matching both the filter and the window remains.
+    await expect(
+      page.getByRole("link", { name: `${spanNamePrefix}-match` })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: `${spanNamePrefix}-other-tenant` })
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("link", { name: `${spanNamePrefix}-outside-window` })
+    ).not.toBeVisible();
+    await expect(seededSpanLinks(page, spanNamePrefix)).toHaveCount(1);
+  });
+
+  test("shows all spans and an empty filter without deep-link params", async ({
+    page,
+    request,
+  }) => {
+    const { projectId, spanNamePrefix } = await seedProject(request);
+    await page.goto(`/projects/${projectId}/spans`);
+
+    // Default view: no filter, default (last-N) time range, all rows shown —
+    // a different row count than the filtered deep-link view.
+    await expect(seededSpanLinks(page, spanNamePrefix)).toHaveCount(3);
+    // The filter field is empty (it shows only its placeholder, which the
+    // CodeMirror editor renders inside the content element).
+    await expect(
+      page.getByRole("textbox", { name: "Filter spans" })
+    ).not.toContainText("metadata");
+    await expect(
+      page.getByRole("group", { name: "Time range" }).getByText("Custom")
+    ).not.toBeVisible();
+  });
+});

--- a/scripts/span_analytics_seeds/README.md
+++ b/scripts/span_analytics_seeds/README.md
@@ -1,0 +1,141 @@
+# Span analytics seeds
+
+Deterministic database seeds for the span-analytics surface's demos and
+dogfooding sessions — unlike `scripts/fixtures/` (notebook example data)
+and `scripts/analytics/` (usage analytics), these write directly into a
+Phoenix database to create known, queryable workloads.
+
+Two scripts fill a Phoenix database with synthetic span data for
+dogfooding sessions. Both are deterministic (same `--now` and `--seed`
+produce the same data), work on SQLite and PostgreSQL, and are safe to
+re-run with `--replace`.
+
+| Script | Project(s) | Purpose |
+|---|---|---|
+| `seed_incident.py` | `payments-agent`, `payments-agent-dev` | Scripted exercises: a planted release regression with a known answer key |
+| `seed_support_copilot.py` | `support-copilot` | Organic questioning: a realistic workload with **no** answer key, by design |
+
+## Prerequisites
+
+- A running Phoenix server (the normal case), **or** a bare database you
+  want initialized (`--migrate`).
+- Repository dependencies installed (`uv sync` or equivalent); run the
+  commands below from the repository root.
+
+The scripts write directly to Phoenix's database. Point them at the same
+database your Phoenix server uses:
+
+- **SQLite (default Phoenix setup):** with no `--database-url`, the scripts
+  read the standard Phoenix environment configuration and resolve the same
+  `phoenix.db` file a locally running default-config server uses. If your
+  server runs with a custom `PHOENIX_WORKING_DIR` or
+  `PHOENIX_SQL_DATABASE_URL`, export the same variables first.
+- **PostgreSQL:** pass the server's database URL explicitly.
+
+## Seeding
+
+SQLite (default environment):
+
+```sh
+uv run python scripts/span_analytics_seeds/seed_incident.py --now 2026-07-23T12:00:00Z
+uv run python scripts/span_analytics_seeds/seed_support_copilot.py
+```
+
+PostgreSQL:
+
+```sh
+uv run python scripts/span_analytics_seeds/seed_incident.py --now 2026-07-23T12:00:00Z \
+    --database-url postgresql://user:password@localhost:5432/phoenix
+uv run python scripts/span_analytics_seeds/seed_support_copilot.py \
+    --database-url postgresql://user:password@localhost:5432/phoenix
+```
+
+Notes:
+
+- `seed_incident.py` requires `--now` (the incident timeline is anchored to
+  it); a recent timestamp keeps the data inside default time windows.
+- `seed_support_copilot.py` defaults `--now` to the current time and
+  backdates its sessions over the trailing 24 hours.
+- Neither script runs database migrations by default — a running server
+  owns its database, and migrating under it is unsafe. For an **empty**
+  database (no Phoenix server has used it yet), add `--migrate` once to
+  initialize the schema.
+
+## What success looks like
+
+Each script prints one confirmation line per project, for example:
+
+```
+Seeded project "payments-agent": 1925 spans, 960 traces, 36 annotations, 959 cost records
+Seeded project "payments-agent-dev": 240 spans, 120 traces, 0 annotations, 120 cost records
+```
+
+```
+Seeded project "support-copilot": 3147 spans, 909 traces, 300 sessions, 274 annotations, 798 cost records
+```
+
+Then open the Phoenix UI and check the projects appear in the projects
+list with spans in them.
+
+## Re-running
+
+Generated ids are deterministic, so running a script twice against the
+same database collides. The scripts detect this and stop with a message;
+re-seed intentionally with:
+
+```sh
+uv run python scripts/span_analytics_seeds/seed_incident.py --now 2026-07-23T12:00:00Z --replace
+uv run python scripts/span_analytics_seeds/seed_support_copilot.py --replace
+```
+
+`--replace` deletes only that script's own projects (by name) before
+inserting, cascading to their sessions, traces, spans, and annotations.
+Other projects are untouched.
+
+## Which project to use for what
+
+- **`payments-agent`** (with its decoy `payments-agent-dev`) is for
+  scripted exercises: something specific went wrong in this data, and a
+  ground-truth answer key exists to check conclusions against.
+  **Do not run `--answer-key` before participating** — reading the key
+  first spoils the exercise. Facilitators can print it afterwards:
+
+  ```sh
+  uv run python scripts/span_analytics_seeds/seed_incident.py --now <same-timestamp> --dry-run --answer-key
+  ```
+
+  (`--dry-run` prints without writing; use the same `--now` and `--seed`
+  as the original seeding run.)
+
+- **`support-copilot`** is for organic questioning. There is no planted
+  anomaly and no answer key — explore it the way you would a production
+  project: what are users asking about, which model is slower, where do
+  errors cluster, what do the retrieval scores look like, which turns got
+  poor helpfulness scores.
+
+## Participant exercises
+
+A few starting points once seeding is done (all through the MCP span
+analytics tools):
+
+1. Discover the fields of a project before querying it, and use only
+   identifiers discovery returned.
+2. `payments-agent`: find what changed, when it changed, and where the
+   change is concentrated. Name the single worst request and pull up its
+   full prompt, response, and exception.
+3. `support-copilot`: pick any question you would ask of a production
+   assistant — busiest hours, error clustering, token spend by model,
+   plans or channels that struggle — and answer it end to end.
+4. **The annotation loop** — result rows carry stable span identities
+   precisely so findings can become actions:
+   (a) use the analytics tools to find the five worst spans in
+   `support-copilot` by a criterion of your choosing (slowest, most
+   tokens, lowest retrieval scores, ...);
+   (b) annotate them via `annotateSpans`, using the `span_id` every
+   result row carries;
+   (c) read your annotations back via `listSpanAnnotationsBySpanIds`.
+
+One honest boundary to try on purpose: aggregate eval analytics — say,
+"average helpfulness by model" — is intentionally refused today; run it
+and read the rejection's reason. Per-span annotation *reads* go through
+the annotation tools, not the analytics surface.

--- a/scripts/span_analytics_seeds/README.md
+++ b/scripts/span_analytics_seeds/README.md
@@ -5,8 +5,8 @@ dogfooding sessions — unlike `scripts/fixtures/` (notebook example data)
 and `scripts/analytics/` (usage analytics), these write directly into a
 Phoenix database to create known, queryable workloads.
 
-Two scripts fill a Phoenix database with synthetic span data for
-dogfooding sessions. Both are deterministic (same `--now` and `--seed`
+Three scripts fill a Phoenix database with synthetic span data for
+dogfooding sessions. All are deterministic (same `--now` and `--seed`
 produce the same data), work on SQLite and PostgreSQL, and are safe to
 re-run with `--replace`.
 
@@ -14,6 +14,7 @@ re-run with `--replace`.
 |---|---|---|
 | `seed_incident.py` | `payments-agent`, `payments-agent-dev` | Scripted exercises: a planted release regression with a known answer key |
 | `seed_support_copilot.py` | `support-copilot` | Organic questioning: a realistic workload with **no** answer key, by design |
+| `seed_eval_quality.py` | `assistant-quality`, `assistant-quality-dev` | Scripted exercises on *eval scores*: a quality drop that is mostly a shift in who was measuring, with an answer key |
 
 ## Prerequisites
 
@@ -39,6 +40,7 @@ SQLite (default environment):
 ```sh
 uv run python scripts/span_analytics_seeds/seed_incident.py --now 2026-07-23T12:00:00Z
 uv run python scripts/span_analytics_seeds/seed_support_copilot.py
+uv run python scripts/span_analytics_seeds/seed_eval_quality.py --now 2026-07-29T12:00:00Z
 ```
 
 PostgreSQL:
@@ -48,12 +50,15 @@ uv run python scripts/span_analytics_seeds/seed_incident.py --now 2026-07-23T12:
     --database-url postgresql://user:password@localhost:5432/phoenix
 uv run python scripts/span_analytics_seeds/seed_support_copilot.py \
     --database-url postgresql://user:password@localhost:5432/phoenix
+uv run python scripts/span_analytics_seeds/seed_eval_quality.py --now 2026-07-29T12:00:00Z \
+    --database-url postgresql://user:password@localhost:5432/phoenix
 ```
 
 Notes:
 
-- `seed_incident.py` requires `--now` (the incident timeline is anchored to
-  it); a recent timestamp keeps the data inside default time windows.
+- `seed_incident.py` and `seed_eval_quality.py` require `--now` (their
+  timelines are anchored to it); a recent timestamp keeps the data inside
+  default time windows.
 - `seed_support_copilot.py` defaults `--now` to the current time and
   backdates its sessions over the trailing 24 hours.
 - Neither script runs database migrations by default — a running server
@@ -74,6 +79,11 @@ Seeded project "payments-agent-dev": 240 spans, 120 traces, 0 annotations, 120 c
 Seeded project "support-copilot": 3147 spans, 909 traces, 300 sessions, 274 annotations, 798 cost records
 ```
 
+```
+Seeded project "assistant-quality": 972 spans, 480 traces, 780 annotations
+Seeded project "assistant-quality-dev": 162 spans, 80 traces, 80 annotations
+```
+
 Then open the Phoenix UI and check the projects appear in the projects
 list with spans in them.
 
@@ -86,6 +96,7 @@ re-seed intentionally with:
 ```sh
 uv run python scripts/span_analytics_seeds/seed_incident.py --now 2026-07-23T12:00:00Z --replace
 uv run python scripts/span_analytics_seeds/seed_support_copilot.py --replace
+uv run python scripts/span_analytics_seeds/seed_eval_quality.py --now 2026-07-29T12:00:00Z --replace
 ```
 
 `--replace` deletes only that script's own projects (by name) before
@@ -113,6 +124,14 @@ Other projects are untouched.
   errors cluster, what do the retrieval scores look like, which turns got
   poor helpfulness scores.
 
+- **`assistant-quality`** (with its decoy `assistant-quality-dev`) is the
+  eval-score counterpart of `payments-agent`: the measured quantity is
+  `correctness`, not errors or latency. A prompt-version cut sits at the
+  midpoint of its 24 hours, and the naive average of `correctness` drops
+  about twelve points across it. Most of that drop is not a quality
+  change — it is a change in who was measuring. Its answer key prints the
+  decomposition, and the same do-not-read-it-first rule applies.
+
 ## Participant exercises
 
 A few starting points once seeding is done (all through the MCP span
@@ -135,7 +154,20 @@ analytics tools):
    result row carries;
    (c) read your annotations back via `listSpanAnnotationsBySpanIds`.
 
-One honest boundary to try on purpose: aggregate eval analytics — say,
-"average helpfulness by model" — is intentionally refused today; run it
-and read the rejection's reason. Per-span annotation *reads* go through
-the annotation tools, not the analytics surface.
+5. **The annotator-mix trap** — in `assistant-quality`, ask what happened
+   to `correctness` across the prompt-version cut. Answer it twice: once
+   with `from: "annotations"` (one row per annotation), and once on the
+   spans grain with `annotations["correctness"].score`. The two numbers
+   differ, and neither is wrong — they answer different questions. Then
+   break the annotations down by `annotator_kind` and decide how much of
+   the drop is a quality change at all. The response tells you which
+   reduction produced any enriched value, and how many annotations of each
+   kind stand behind it; the decomposition is the finding.
+
+One honest boundary to try on purpose: on the annotations grain you cannot
+group by a property of the annotated span — "average correctness by model"
+is not expressible there, because the row is an annotation and the model
+belongs to its parent. Run it, read the rejection, and take its route: ask
+the same question on the spans grain, where the span is the subject and
+its annotations reduce to a value. Per-span annotation *writes* still go
+through the annotation tools, not the analytics surface.

--- a/scripts/span_analytics_seeds/seed_eval_quality.py
+++ b/scripts/span_analytics_seeds/seed_eval_quality.py
@@ -1,0 +1,901 @@
+"""Seed a deterministic quality-regression narrative into a Phoenix database.
+
+Generates two projects of synthetic assistant traces whose *eval scores*,
+not their error rates, are the measured quantity:
+
+- ``assistant-quality`` — 24 hours of traces split by a prompt-version cut
+  from ``pv-14`` to ``pv-15`` at the midpoint, every trace carrying a root
+  span scored under the ``correctness`` annotation name.
+- ``assistant-quality-dev`` — a decoy project with the same annotation
+  names and different values, for verifying project isolation on the
+  annotations grain.
+
+**What the fixture engineers, said out loud.** The naive average of
+``correctness`` drops about twelve points across the cut. Most of that drop
+is not a quality change: it is a change in *who was measuring*. The LLM
+judge scores every trace in both versions; the human reviewers scored a
+tenth of ``pv-14`` and three quarters of ``pv-15``, concentrating on the
+traces the judge scored lowest. Humans are harsher than the judge by
+construction, so raising their share drags the blended mean down on its
+own. Within each annotator kind the drop is four points — a real but modest
+regression.
+
+The two score populations are authored directly rather than simulated:
+each kind's scores in each version cycle through a fixed symmetric offset
+pattern around a target mean, so the per-kind means are exact. Which spans
+the humans reviewed is what the version cut changes, and the answer key
+prints the realized values computed from the generated records, special
+rows included.
+
+Also present, for semantics that only annotations can exercise:
+
+- one trace whose root span carries three annotators in strong
+  disagreement (0.92, 0.55, 0.15), one with an explanation long enough to
+  be clipped to a preview;
+- a ``tone`` annotation carrying labels and no scores at all, so
+  ``avg(score)`` over it is NULL everywhere rather than zero;
+- ``resolution`` annotations on traces and ``relevance`` annotations on
+  retrieval documents, so ``target`` is a real dimension with more than one
+  value.
+
+LLM spans carry OpenInference input/output values and token counts; no cost
+records are generated (the incident fixture covers cost).
+
+The generator is a pure function of ``(--now, --seed)``: two runs produce
+byte-identical data.
+
+Usage:
+    python scripts/span_analytics_seeds/seed_eval_quality.py --now 2026-07-29T12:00:00Z \
+        [--seed 11] [--database-url sqlite:///path/to/phoenix.db] \
+        [--migrate] [--replace] [--answer-key] [--dry-run]
+
+Without ``--database-url`` the standard Phoenix environment configuration
+is used. The target database is normally a running Phoenix's (no migration
+attempted); ``--migrate`` initializes an empty database instead. Re-runs
+require ``--replace``, which deletes and re-seeds this script's projects.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import random
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+MAIN_PROJECT_NAME = "assistant-quality"
+DECOY_PROJECT_NAME = "assistant-quality-dev"
+
+DEFAULT_SEED = 11
+
+#: Hours per prompt version; the cut sits at ``--now`` minus this many.
+HOURS_PER_VERSION = 12
+TRACES_PER_HOUR = 20
+
+OLD_VERSION = "pv-14"
+NEW_VERSION = "pv-15"
+
+TENANTS = ("northwind", "contoso", "fabrikam", "tailspin")
+MODELS = ("gpt-4o", "claude-sonnet")
+
+ROOT_SPAN_NAME = "answer_question"
+LLM_SPAN_NAME = "generate_answer"
+RETRIEVER_SPAN_NAME = "search_knowledge_base"
+
+ANNOTATION_NAME = "correctness"
+TONE_ANNOTATION_NAME = "tone"
+TRACE_ANNOTATION_NAME = "resolution"
+DOCUMENT_ANNOTATION_NAME = "relevance"
+
+JUDGE_IDENTIFIER = "llm-judge"
+HUMAN_IDENTIFIER = "human-reviewer"
+
+#: Target mean of each annotator kind's scores, per version. The per-kind
+#: regression is four points in both kinds; everything larger that shows up
+#: in a blended average is composition, not quality.
+JUDGE_MEANS = {OLD_VERSION: 0.80, NEW_VERSION: 0.76}
+HUMAN_MEANS = {OLD_VERSION: 0.56, NEW_VERSION: 0.52}
+
+#: Symmetric offsets applied around each target mean, cycled in order.
+#: They sum to zero, so any population whose size is a multiple of four
+#: realizes its target mean exactly.
+SCORE_OFFSETS = (-0.20, -0.08, 0.08, 0.20)
+
+#: How many of each version's traces the humans reviewed. The shift from a
+#: tenth to three quarters is the artifact the demo exists to expose.
+HUMAN_REVIEW_COUNTS = {OLD_VERSION: 24, NEW_VERSION: 180}
+
+#: Score at or above which an annotation is labeled 'correct'.
+CORRECT_THRESHOLD = 0.5
+
+#: Every nth trace gets a retriever span with two documents.
+RETRIEVER_EVERY = 40
+DOCUMENTS_PER_RETRIEVER = 2
+
+#: Every nth root span carries a label-only 'tone' annotation.
+TONE_EVERY = 12
+
+#: Every nth trace carries a trace-level 'resolution' annotation.
+TRACE_ANNOTATION_EVERY = 16
+
+LONG_EXPLANATION_CHARS = 1_200
+
+QUESTIONS = (
+    "How do I change the billing address on my account?",
+    "Why was my subscription downgraded last night?",
+    "Can you explain the difference between the team and business plans?",
+    "My export finished but the file is empty — what happened?",
+    "How long does a refund take to appear on the statement?",
+)
+
+
+@dataclass
+class SpanRecord:
+    span_id: str
+    trace_id: str
+    parent_id: Optional[str]
+    name: str
+    span_kind: str
+    start_time: datetime
+    end_time: datetime
+    attributes: dict[str, Any]
+    status_code: str
+
+    @property
+    def latency_ms(self) -> float:
+        return (self.end_time - self.start_time).total_seconds() * 1000
+
+
+@dataclass
+class TraceRecord:
+    trace_id: str
+    start_time: datetime
+    end_time: datetime
+    prompt_version: str
+
+
+@dataclass
+class AnnotationRecord:
+    """One annotation, on whichever target it belongs to.
+
+    ``target`` is 'span', 'trace', or 'document'; ``target_key`` is the
+    span id or trace id it attaches to, and ``document_position`` is set
+    only for document annotations.
+    """
+
+    target: str
+    target_key: str
+    name: str
+    score: Optional[float]
+    label: Optional[str]
+    explanation: Optional[str]
+    annotator_kind: str
+    identifier: str
+    document_position: Optional[int] = None
+
+
+@dataclass
+class ProjectData:
+    name: str
+    traces: list[TraceRecord] = field(default_factory=list)
+    spans: list[SpanRecord] = field(default_factory=list)
+    annotations: list[AnnotationRecord] = field(default_factory=list)
+
+
+@dataclass
+class EvalQuality:
+    now: datetime
+    seed: int
+    main: ProjectData
+    decoy: ProjectData
+    cut: datetime
+
+
+def _label(score: Optional[float]) -> Optional[str]:
+    if score is None:
+        return None
+    return "correct" if score >= CORRECT_THRESHOLD else "incorrect"
+
+
+def _scores_around(mean: float, count: int) -> list[float]:
+    """``count`` scores cycling the symmetric offsets around ``mean``.
+
+    Rounded to two decimals, which the offsets preserve exactly; for counts
+    that are a multiple of the offset cycle the realized mean is the target.
+    """
+    return [round(mean + SCORE_OFFSETS[index % len(SCORE_OFFSETS)], 2) for index in range(count)]
+
+
+def _build_project(
+    rng: random.Random,
+    name: str,
+    now: datetime,
+    id_prefix: str,
+    versions: tuple[str, str],
+    tenants: tuple[str, ...],
+    models: tuple[str, ...],
+    hours_per_version: int,
+) -> ProjectData:
+    """Build one project's traces and spans, oldest first."""
+    project = ProjectData(name=name)
+    total_hours = hours_per_version * 2
+    counter = 0
+    for hour_index in range(total_hours):
+        hour_start = now - timedelta(hours=total_hours - hour_index)
+        version = versions[0] if hour_index < hours_per_version else versions[1]
+        for slot in range(TRACES_PER_HOUR):
+            counter += 1
+            trace_id = f"{id_prefix}t{counter:014x}"
+            root_id = f"{id_prefix}{counter * 4:015x}"
+            llm_id = f"{id_prefix}{counter * 4 + 1:015x}"
+            start = hour_start + timedelta(seconds=slot * (3600 // TRACES_PER_HOUR))
+            latency_ms = rng.randint(400, 2_600)
+            end = start + timedelta(milliseconds=latency_ms)
+            question = QUESTIONS[counter % len(QUESTIONS)]
+            tenant = tenants[counter % len(tenants)]
+            model = models[counter % len(models)]
+            project.traces.append(
+                TraceRecord(
+                    trace_id=trace_id, start_time=start, end_time=end, prompt_version=version
+                )
+            )
+            project.spans.append(
+                SpanRecord(
+                    span_id=root_id,
+                    trace_id=trace_id,
+                    parent_id=None,
+                    name=ROOT_SPAN_NAME,
+                    span_kind="AGENT",
+                    start_time=start,
+                    end_time=end,
+                    attributes={
+                        "input": {"value": question},
+                        "output": {"value": f"Here is what I found about that ({version})."},
+                        "metadata": {"prompt_version": version, "tenant": tenant},
+                    },
+                    status_code="OK",
+                )
+            )
+            llm_start = start + timedelta(milliseconds=latency_ms // 4)
+            project.spans.append(
+                SpanRecord(
+                    span_id=llm_id,
+                    trace_id=trace_id,
+                    parent_id=root_id,
+                    name=LLM_SPAN_NAME,
+                    span_kind="LLM",
+                    start_time=llm_start,
+                    end_time=end,
+                    attributes={
+                        "input": {"value": question},
+                        "output": {"value": "Here is what I found about that."},
+                        "llm": {
+                            "model_name": model,
+                            "token_count": {"total": rng.randint(300, 1_800)},
+                        },
+                        "metadata": {"prompt_version": version, "tenant": tenant},
+                    },
+                    status_code="OK",
+                )
+            )
+            if counter % RETRIEVER_EVERY == 0:
+                retriever_id = f"{id_prefix}{counter * 4 + 2:015x}"
+                project.spans.append(
+                    SpanRecord(
+                        span_id=retriever_id,
+                        trace_id=trace_id,
+                        parent_id=root_id,
+                        name=RETRIEVER_SPAN_NAME,
+                        span_kind="RETRIEVER",
+                        start_time=start,
+                        end_time=llm_start,
+                        attributes={
+                            "input": {"value": question},
+                            "retrieval": {
+                                "documents": [
+                                    {
+                                        "document": {
+                                            "id": f"doc-{counter}-{position}",
+                                            "content": (
+                                                f"Knowledge base article {counter}-{position}."
+                                            ),
+                                        }
+                                    }
+                                    for position in range(DOCUMENTS_PER_RETRIEVER)
+                                ]
+                            },
+                            "metadata": {"prompt_version": version, "tenant": tenant},
+                        },
+                        status_code="OK",
+                    )
+                )
+    return project
+
+
+def _root_spans_by_version(project: ProjectData) -> dict[str, list[SpanRecord]]:
+    version_by_trace = {trace.trace_id: trace.prompt_version for trace in project.traces}
+    grouped: dict[str, list[SpanRecord]] = defaultdict(list)
+    for span in project.spans:
+        if span.name == ROOT_SPAN_NAME:
+            grouped[version_by_trace[span.trace_id]].append(span)
+    return grouped
+
+
+def _build_correctness_annotations(project: ProjectData, versions: tuple[str, str]) -> None:
+    """Score every root span with the judge, a subset with humans.
+
+    The judge covers everything in both versions. The humans review a tenth
+    of the old version and three quarters of the new one, chosen as the
+    traces the judge scored lowest — the concentration on failures that
+    makes the reviewer share move. Each kind's scores are authored around
+    its own per-version target, so the human mean is a property of the
+    fixture rather than of which spans were selected.
+    """
+    grouped = _root_spans_by_version(project)
+    for version in versions:
+        root_spans = grouped[version]
+        judge_scores = _scores_around(JUDGE_MEANS[version], len(root_spans))
+        for span, score in zip(root_spans, judge_scores):
+            project.annotations.append(
+                AnnotationRecord(
+                    target="span",
+                    target_key=span.span_id,
+                    name=ANNOTATION_NAME,
+                    score=score,
+                    label=_label(score),
+                    explanation=(
+                        f"The answer under {version} addressed the question and cited the "
+                        "right article."
+                        if score >= CORRECT_THRESHOLD
+                        else f"The answer under {version} missed the account context and "
+                        "cited an unrelated article."
+                    ),
+                    annotator_kind="LLM",
+                    identifier=JUDGE_IDENTIFIER,
+                )
+            )
+        # Reviewers work the judge's worst traces first; ties break on span
+        # id so the selection is deterministic on both backends.
+        reviewed = sorted(
+            zip(root_spans, judge_scores), key=lambda pair: (pair[1], pair[0].span_id)
+        )[: HUMAN_REVIEW_COUNTS[version]]
+        human_scores = _scores_around(HUMAN_MEANS[version], len(reviewed))
+        for (span, _), score in zip(reviewed, human_scores):
+            project.annotations.append(
+                AnnotationRecord(
+                    target="span",
+                    target_key=span.span_id,
+                    name=ANNOTATION_NAME,
+                    score=score,
+                    label=_label(score),
+                    explanation=(
+                        "Reviewed after the judge flagged it; the answer is usable but "
+                        "vague about the billing cycle."
+                    ),
+                    annotator_kind="HUMAN",
+                    identifier=HUMAN_IDENTIFIER,
+                )
+            )
+
+
+def _apply_special_rows(project: ProjectData, now: datetime, versions: tuple[str, str]) -> None:
+    """The rows that exercise semantics the bulk population cannot.
+
+    They are added after the engineered populations, so the answer key's
+    realized means differ slightly from the target means — deliberately:
+    the key is computed from the records, never from the design intent.
+    """
+    grouped = _root_spans_by_version(project)
+
+    # Three annotators, one span, strong disagreement — and an explanation
+    # long enough that a row query clips it to a preview. The judge's row
+    # comes from the bulk population above (uniqueness is name + span +
+    # identifier, so a second judge row under the same identifier would be
+    # rejected by the database, not merely redundant); these two reviewers
+    # are what turn its score into a disagreement.
+    disputed = grouped[versions[1]][-1]
+    for identifier, kind, score, explanation in (
+        (
+            "human-reviewer-a",
+            "HUMAN",
+            0.15,
+            "The answer is confidently wrong: it describes the legacy refund window, "
+            "which changed two releases ago, and the customer would act on it. "
+            + "Detail: "
+            * (LONG_EXPLANATION_CHARS // 8),
+        ),
+        (
+            "human-reviewer-b",
+            "HUMAN",
+            0.55,
+            "Partially correct — right article, wrong emphasis.",
+        ),
+    ):
+        project.annotations.append(
+            AnnotationRecord(
+                target="span",
+                target_key=disputed.span_id,
+                name=ANNOTATION_NAME,
+                score=score,
+                label=_label(score),
+                explanation=explanation,
+                annotator_kind=kind,
+                identifier=identifier,
+            )
+        )
+
+    # A label-only annotation: no scores anywhere under this name, so an
+    # average over it is NULL rather than zero.
+    for version in versions:
+        for index, span in enumerate(grouped[version]):
+            if index % TONE_EVERY:
+                continue
+            project.annotations.append(
+                AnnotationRecord(
+                    target="span",
+                    target_key=span.span_id,
+                    name=TONE_ANNOTATION_NAME,
+                    score=None,
+                    label="warm" if index % (TONE_EVERY * 2) == 0 else "curt",
+                    explanation=None,
+                    annotator_kind="CODE",
+                    identifier="tone-classifier",
+                )
+            )
+
+    # Trace- and document-target annotations, so `target` has more than one
+    # value and the polymorphic grain is exercised by real rows.
+    for index, trace in enumerate(project.traces):
+        if index % TRACE_ANNOTATION_EVERY:
+            continue
+        score = 1.0 if index % (TRACE_ANNOTATION_EVERY * 2) == 0 else 0.0
+        project.annotations.append(
+            AnnotationRecord(
+                target="trace",
+                target_key=trace.trace_id,
+                name=TRACE_ANNOTATION_NAME,
+                score=score,
+                label="resolved" if score else "unresolved",
+                explanation=None,
+                annotator_kind="CODE",
+                identifier="resolution-checker",
+            )
+        )
+    for span in project.spans:
+        if span.name != RETRIEVER_SPAN_NAME:
+            continue
+        for position in range(DOCUMENTS_PER_RETRIEVER):
+            score = 0.9 if position == 0 else 0.3
+            project.annotations.append(
+                AnnotationRecord(
+                    target="document",
+                    target_key=span.span_id,
+                    name=DOCUMENT_ANNOTATION_NAME,
+                    score=score,
+                    label="relevant" if score >= CORRECT_THRESHOLD else "irrelevant",
+                    explanation=None,
+                    annotator_kind="LLM",
+                    identifier="relevance-judge",
+                    document_position=position,
+                )
+            )
+    del now
+
+
+def build_eval_quality(now: datetime, seed: int = DEFAULT_SEED) -> EvalQuality:
+    """Build the full dataset. Pure function of (now, seed)."""
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    now = now.astimezone(timezone.utc)
+    rng = random.Random(seed)
+    versions = (OLD_VERSION, NEW_VERSION)
+    main = _build_project(
+        rng,
+        name=MAIN_PROJECT_NAME,
+        now=now,
+        id_prefix="c",
+        versions=versions,
+        tenants=TENANTS,
+        models=MODELS,
+        hours_per_version=HOURS_PER_VERSION,
+    )
+    _build_correctness_annotations(main, versions)
+    _apply_special_rows(main, now, versions)
+    decoy = _build_project(
+        rng,
+        name=DECOY_PROJECT_NAME,
+        now=now,
+        id_prefix="d",
+        versions=versions,
+        tenants=("wayne", "tyrell"),
+        models=("gpt-4o-mini",),
+        hours_per_version=2,
+    )
+    # The decoy carries the same annotation name with unmistakably
+    # different values, so a leak across projects shows up as a wrong
+    # number rather than as an empty result.
+    for span in decoy.spans:
+        if span.name != ROOT_SPAN_NAME:
+            continue
+        decoy.annotations.append(
+            AnnotationRecord(
+                target="span",
+                target_key=span.span_id,
+                name=ANNOTATION_NAME,
+                score=0.01,
+                label="incorrect",
+                explanation="Decoy project annotation.",
+                annotator_kind="LLM",
+                identifier="decoy-judge",
+            )
+        )
+    return EvalQuality(
+        now=now,
+        seed=seed,
+        main=main,
+        decoy=decoy,
+        cut=now - timedelta(hours=HOURS_PER_VERSION),
+    )
+
+
+def _mean(values: list[float]) -> Optional[float]:
+    return sum(values) / len(values) if values else None
+
+
+def correctness_ground_truth(data: EvalQuality) -> dict[str, dict[str, Any]]:
+    """The three means of ``correctness``, per version, computed from records.
+
+    They are three different questions, and they do not agree:
+
+    - ``by_kind`` — the mean per annotator kind, the decomposed truth.
+    - ``annotation_weighted`` — the mean over annotation rows, which is what
+      the annotations grain computes and what the annotator mix moves.
+    - ``span_reduced`` — the mean over spans of each span's own mean, which
+      is what the spans grain's declared reduction computes.
+    """
+    version_by_trace = {trace.trace_id: trace.prompt_version for trace in data.main.traces}
+    trace_by_span = {span.span_id: span.trace_id for span in data.main.spans}
+    result: dict[str, dict[str, Any]] = {}
+    for version in (OLD_VERSION, NEW_VERSION):
+        scores_by_kind: dict[str, list[float]] = defaultdict(list)
+        by_span: dict[str, list[float]] = defaultdict(list)
+        for annotation in data.main.annotations:
+            if annotation.target != "span" or annotation.name != ANNOTATION_NAME:
+                continue
+            if annotation.score is None:
+                continue
+            if version_by_trace[trace_by_span[annotation.target_key]] != version:
+                continue
+            scores_by_kind[annotation.annotator_kind].append(annotation.score)
+            by_span[annotation.target_key].append(annotation.score)
+        every = [score for scores in scores_by_kind.values() for score in scores]
+        result[version] = {
+            "annotations": len(every),
+            "by_kind": {kind: _mean(scores) for kind, scores in sorted(scores_by_kind.items())},
+            "counts_by_kind": {
+                kind: len(scores) for kind, scores in sorted(scores_by_kind.items())
+            },
+            "annotation_weighted": _mean(every),
+            "span_reduced": _mean([sum(s) / len(s) for s in by_span.values()]),
+            "spans_scored": len(by_span),
+        }
+    return result
+
+
+def render_ground_truth(data: EvalQuality) -> str:
+    """The answer key: deterministic text derived from the generated records."""
+    truth = correctness_ground_truth(data)
+    old, new = truth[OLD_VERSION], truth[NEW_VERSION]
+    lines = [
+        "GROUND TRUTH — assistant-quality",
+        f"cut at {data.cut.isoformat()} ({OLD_VERSION} before, {NEW_VERSION} after)",
+        "",
+        "correctness, three ways:",
+    ]
+    for label, key in (
+        ("annotation-weighted (annotations grain)", "annotation_weighted"),
+        ("span-reduced mean (spans grain)", "span_reduced"),
+    ):
+        delta = (new[key] - old[key]) * 100
+        lines.append(f"  {label}: {old[key]:.4f} -> {new[key]:.4f}  ({delta:+.2f} points)")
+    for kind in sorted(set(old["by_kind"]) | set(new["by_kind"])):
+        old_value, new_value = old["by_kind"].get(kind), new["by_kind"].get(kind)
+        if old_value is None or new_value is None:
+            continue
+        delta = (new_value - old_value) * 100
+        lines.append(
+            f"  kind {kind}: {old_value:.4f} -> {new_value:.4f}  ({delta:+.2f} points), "
+            f"n {old['counts_by_kind'][kind]} -> {new['counts_by_kind'][kind]}"
+        )
+    lines += [
+        "",
+        f"scored spans: {old['spans_scored']} -> {new['spans_scored']}",
+        f"scored annotations: {old['annotations']} -> {new['annotations']}",
+        "",
+    ]
+    targets = Counter(annotation.target for annotation in data.main.annotations)
+    names = Counter(annotation.name for annotation in data.main.annotations)
+    lines.append(f"annotations by target: {dict(sorted(targets.items()))}")
+    lines.append(f"annotations by name: {dict(sorted(names.items()))}")
+    disputed = [
+        annotation
+        for annotation in data.main.annotations
+        if annotation.name == ANNOTATION_NAME and annotation.identifier == "human-reviewer-b"
+    ]
+    if disputed:
+        span_id = disputed[0].target_key
+        scores = sorted(
+            annotation.score
+            for annotation in data.main.annotations
+            if annotation.target_key == span_id
+            and annotation.name == ANNOTATION_NAME
+            and annotation.score is not None
+        )
+        lines.append(f"three-annotator disagreement on span {span_id}: scores {scores}")
+    lines.append(
+        f"label-only annotation name {TONE_ANNOTATION_NAME!r}: "
+        f"{names[TONE_ANNOTATION_NAME]} rows, no scores"
+    )
+    return "\n".join(lines)
+
+
+async def insert_eval_quality(session: Any, data: EvalQuality) -> None:
+    """Insert both projects with plain ORM-table inserts.
+
+    ``session`` is an ``AsyncSession`` bound to a migrated Phoenix
+    database (either backend).
+    """
+    from sqlalchemy import insert, select
+
+    from phoenix.db import models
+
+    for project_data in (data.main, data.decoy):
+        project_rowid = await session.scalar(
+            insert(models.Project).values(name=project_data.name).returning(models.Project.id)
+        )
+        await session.execute(
+            insert(models.Trace),
+            [
+                {
+                    "project_rowid": project_rowid,
+                    "trace_id": trace.trace_id,
+                    "start_time": trace.start_time,
+                    "end_time": trace.end_time,
+                }
+                for trace in project_data.traces
+            ],
+        )
+        trace_rowids = dict(
+            (
+                await session.execute(
+                    select(models.Trace.trace_id, models.Trace.id).where(
+                        models.Trace.project_rowid == project_rowid
+                    )
+                )
+            ).all()
+        )
+        await session.execute(
+            insert(models.Span),
+            [
+                {
+                    "span_id": span.span_id,
+                    "trace_rowid": trace_rowids[span.trace_id],
+                    "parent_id": span.parent_id,
+                    "name": span.name,
+                    "span_kind": span.span_kind,
+                    "start_time": span.start_time,
+                    "end_time": span.end_time,
+                    "attributes": span.attributes,
+                    "events": [],
+                    "status_code": span.status_code,
+                    "status_message": "",
+                    "cumulative_error_count": 0,
+                    "cumulative_llm_token_count_prompt": 0,
+                    "cumulative_llm_token_count_completion": 0,
+                }
+                for span in project_data.spans
+            ],
+        )
+        span_rowids = dict(
+            (
+                await session.execute(
+                    select(models.Span.span_id, models.Span.id)
+                    .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+                    .where(models.Trace.project_rowid == project_rowid)
+                )
+            ).all()
+        )
+        common: dict[str, Any] = {"metadata_": {}, "source": "API", "user_id": None}
+        span_annotations = [a for a in project_data.annotations if a.target == "span"]
+        if span_annotations:
+            await session.execute(
+                insert(models.SpanAnnotation),
+                [
+                    {
+                        "span_rowid": span_rowids[annotation.target_key],
+                        "name": annotation.name,
+                        "label": annotation.label,
+                        "score": annotation.score,
+                        "explanation": annotation.explanation,
+                        "annotator_kind": annotation.annotator_kind,
+                        "identifier": annotation.identifier,
+                        **common,
+                    }
+                    for annotation in span_annotations
+                ],
+            )
+        trace_annotations = [a for a in project_data.annotations if a.target == "trace"]
+        if trace_annotations:
+            await session.execute(
+                insert(models.TraceAnnotation),
+                [
+                    {
+                        "trace_rowid": trace_rowids[annotation.target_key],
+                        "name": annotation.name,
+                        "label": annotation.label,
+                        "score": annotation.score,
+                        "explanation": annotation.explanation,
+                        "annotator_kind": annotation.annotator_kind,
+                        "identifier": annotation.identifier,
+                        **common,
+                    }
+                    for annotation in trace_annotations
+                ],
+            )
+        document_annotations = [a for a in project_data.annotations if a.target == "document"]
+        if document_annotations:
+            await session.execute(
+                insert(models.DocumentAnnotation),
+                [
+                    {
+                        "span_rowid": span_rowids[annotation.target_key],
+                        "document_position": annotation.document_position,
+                        "name": annotation.name,
+                        "label": annotation.label,
+                        "score": annotation.score,
+                        "explanation": annotation.explanation,
+                        "annotator_kind": annotation.annotator_kind,
+                        "identifier": annotation.identifier,
+                        **common,
+                    }
+                    for annotation in document_annotations
+                ],
+            )
+
+
+async def open_seed_engine(connection_str: str, migrate: bool) -> Any:
+    """Open the target database, initializing the schema only on request.
+
+    Running migrations unconditionally fails against a database a running
+    Phoenix owns: SQLite holds a write lock, and the PostgreSQL migration
+    path takes an advisory lock a live server can contend for. Seeding
+    targets are usually live servers, so the default probes for an
+    existing migrated schema (the ``alembic_version`` table) and skips
+    migration entirely; ``--migrate`` opts in for an empty database.
+    """
+    import sqlalchemy
+
+    from phoenix.db.engines import create_engine
+
+    engine = create_engine(connection_str, migrate=False)
+    async with engine.connect() as connection:
+        tables = await connection.run_sync(
+            lambda sync_connection: sqlalchemy.inspect(sync_connection).get_table_names()
+        )
+    if "alembic_version" in tables:
+        return engine
+    if not migrate:
+        await engine.dispose()
+        raise SystemExit(
+            "The target database has no Phoenix schema. Start Phoenix against it "
+            "first, or pass --migrate to initialize an empty database."
+        )
+    await engine.dispose()
+    return create_engine(connection_str, migrate=True)
+
+
+async def replace_or_reject_existing(session: Any, names: list[str], replace: bool) -> None:
+    """Delete this script's projects when ``--replace`` is given; otherwise
+    refuse to seed alongside an existing copy, which would silently double
+    every count."""
+    from sqlalchemy import delete, select
+
+    from phoenix.db import models
+
+    existing = list(
+        (
+            await session.execute(select(models.Project.name).where(models.Project.name.in_(names)))
+        ).scalars()
+    )
+    if not existing:
+        return
+    if not replace:
+        raise SystemExit(
+            f"Project(s) already exist: {', '.join(sorted(existing))}. "
+            "Pass --replace to delete and re-seed them."
+        )
+    await session.execute(delete(models.Project).where(models.Project.name.in_(existing)))
+
+
+def _print_confirmation(data: EvalQuality, wrote: bool) -> None:
+    for project_data in (data.main, data.decoy):
+        print(
+            f'{"Seeded" if wrote else "Would seed"} project "{project_data.name}": '
+            f"{len(project_data.spans)} spans, {len(project_data.traces)} traces, "
+            f"{len(project_data.annotations)} annotations"
+        )
+    if wrote:
+        print("Open the Phoenix UI and check that both projects appear.")
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--now",
+        required=True,
+        help="Anchor timestamp, ISO-8601 (e.g. 2026-07-29T12:00:00Z); naive means UTC.",
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="SQLAlchemy database URL; defaults to the Phoenix environment configuration.",
+    )
+    parser.add_argument(
+        "--migrate",
+        action="store_true",
+        help=(
+            "Initialize the Phoenix schema if the database is empty. Off by default: "
+            "seeding a running Phoenix must not attempt migrations against a "
+            "database the server owns."
+        ),
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Delete this script's projects (if present) and re-seed them.",
+    )
+    parser.add_argument(
+        "--answer-key",
+        action="store_true",
+        help=(
+            "Print the ground-truth answer key. Off by default: reading it before "
+            "investigating the data spoils the exercise."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the dataset and print the confirmation without writing anywhere.",
+    )
+    args = parser.parse_args()
+    now = datetime.fromisoformat(str(args.now).replace("Z", "+00:00"))
+    data = build_eval_quality(now, int(args.seed))
+
+    if not args.dry_run:
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        from phoenix.config import get_env_database_connection_str
+
+        connection_str = args.database_url or get_env_database_connection_str()
+        engine = await open_seed_engine(connection_str, migrate=bool(args.migrate))
+        async with AsyncSession(engine) as session:
+            async with session.begin():
+                await replace_or_reject_existing(
+                    session,
+                    [data.main.name, data.decoy.name],
+                    replace=bool(args.replace),
+                )
+                await insert_eval_quality(session, data)
+        await engine.dispose()
+
+    _print_confirmation(data, wrote=not args.dry_run)
+    if args.answer_key:
+        print()
+        print(render_ground_truth(data))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/scripts/span_analytics_seeds/seed_incident.py
+++ b/scripts/span_analytics_seeds/seed_incident.py
@@ -1,0 +1,785 @@
+"""Seed a deterministic release-regression incident into a Phoenix database.
+
+Generates two projects of synthetic payment-agent traces:
+
+- ``payments-agent`` — ~2,000 spans over 48 hours. A release cut from
+  ``v41`` to ``v42`` happens 20 hours before ``--now``; the span error rate
+  jumps from ~2% to ~18% after the cut, concentrated in the ``acme``
+  tenant. Includes a handful of orphan spans (parent never received), one
+  span whose ``llm.token_count.total`` is a string instead of a number
+  (exercising type-guarded numeric extraction), and one failed LLM span
+  with a ~20KB input payload (exercising preview clipping and full
+  recovery).
+- ``payments-agent-dev`` — a decoy project with identical span names and
+  attribute keys but different values, for verifying project isolation.
+
+LLM spans carry OpenInference input/output message lists (system + user,
+one assistant reply) and, when their recorded token count is usable, a
+deterministic cost record priced from a per-model table — the
+string-typed token span has no cost record, so cost absence is itself
+queryable.
+
+The generator is a pure function of ``(--now, --seed)``: two runs produce
+byte-identical data. A ground-truth answer key exists (error rate and count
+by release and hour, the five slowest failed LLM calls, the worst span id)
+but is printed only with ``--answer-key`` — reading it before investigating
+the data spoils the exercise.
+
+Usage:
+    python scripts/span_analytics_seeds/seed_incident.py --now 2026-07-23T12:00:00Z \
+        [--seed 7] [--database-url sqlite:///path/to/phoenix.db] \
+        [--migrate] [--replace] [--answer-key] [--dry-run]
+
+Without ``--database-url`` the standard Phoenix environment configuration
+is used. The target database is normally a running Phoenix's (no migration
+attempted); ``--migrate`` initializes an empty database instead. Re-runs
+require ``--replace``, which deletes and re-seeds this script's projects.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import random
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+MAIN_PROJECT_NAME = "payments-agent"
+DECOY_PROJECT_NAME = "payments-agent-dev"
+
+DEFAULT_SEED = 7
+HOURS = 48
+TRACES_PER_HOUR = 20
+DECOY_HOURS = 6
+RELEASE_CUT_HOURS_AGO = 20
+
+TENANTS = ("acme", "globex", "initech", "umbrella", "stark")
+MODELS = ("gpt-4o", "claude-sonnet", "llama-3-70b")
+ERROR_TENANT = "acme"
+
+DECOY_TENANTS = ("wayne", "tyrell", "cyberdyne", "weyland", "oscorp")
+DECOY_MODELS = ("gpt-4o-mini", "claude-haiku", "mistral-small")
+
+#: USD per one million tokens, (prompt rate, completion rate). Costs are
+#: computed deterministically from these at build time; LLM spans whose
+#: recorded token count is unusable (the string-typed row) get no cost
+#: record — cost absence stays a real, queryable fact.
+MODEL_PRICES: dict[str, tuple[float, float]] = {
+    "gpt-4o": (2.50, 10.00),
+    "claude-sonnet": (3.00, 15.00),
+    "llama-3-70b": (0.60, 0.80),
+    "gpt-4o-mini": (0.15, 0.60),
+    "claude-haiku": (0.80, 4.00),
+    "mistral-small": (0.20, 0.60),
+}
+
+#: Fraction of a span's total tokens attributed to the prompt when only a
+#: total is recorded (this workload records totals, not the split).
+PROMPT_TOKEN_FRACTION = 0.8
+
+SYSTEM_PROMPT = (
+    "You are the payments support assistant. Classify the intent of each "
+    "charge request and answer in one line."
+)
+
+PRE_CUT_FAILURE_RATE = 0.02
+POST_CUT_FAILURE_RATE_ERROR_TENANT = 0.50
+POST_CUT_FAILURE_RATE_OTHER = 0.10
+
+ROOT_SPAN_NAME = "process_payment"
+LLM_SPAN_NAME = "classify_intent"
+ORPHAN_SPAN_NAME = "retry_settlement"
+
+LARGE_INPUT_CHARS = 20_000
+LARGE_INPUT_LATENCY_MS = 30_000
+
+
+@dataclass
+class SpanRecord:
+    span_id: str
+    trace_id: str
+    parent_id: Optional[str]
+    name: str
+    span_kind: str
+    start_time: datetime
+    end_time: datetime
+    attributes: dict[str, Any]
+    events: list[dict[str, Any]]
+    status_code: str
+    status_message: str
+
+    @property
+    def latency_ms(self) -> float:
+        return (self.end_time - self.start_time).total_seconds() * 1000
+
+
+@dataclass
+class TraceRecord:
+    trace_id: str
+    start_time: datetime
+    end_time: datetime
+
+
+@dataclass
+class AnnotationRecord:
+    span_id: str
+    name: str
+    score: float
+    label: str
+    annotator_kind: str
+    identifier: str
+
+
+@dataclass
+class CostRecord:
+    span_id: str
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    prompt_cost: float
+    completion_cost: float
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+    @property
+    def total_cost(self) -> float:
+        return self.prompt_cost + self.completion_cost
+
+
+def _cost_record(span_id: str, model: str, total_tokens: int) -> CostRecord:
+    prompt_tokens = round(total_tokens * PROMPT_TOKEN_FRACTION)
+    completion_tokens = total_tokens - prompt_tokens
+    prompt_rate, completion_rate = MODEL_PRICES[model]
+    return CostRecord(
+        span_id=span_id,
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        prompt_cost=prompt_tokens * prompt_rate / 1_000_000,
+        completion_cost=completion_tokens * completion_rate / 1_000_000,
+    )
+
+
+@dataclass
+class ProjectData:
+    name: str
+    traces: list[TraceRecord] = field(default_factory=list)
+    spans: list[SpanRecord] = field(default_factory=list)
+    annotations: list[AnnotationRecord] = field(default_factory=list)
+    costs: list[CostRecord] = field(default_factory=list)
+
+
+@dataclass
+class Incident:
+    now: datetime
+    seed: int
+    main: ProjectData
+    decoy: ProjectData
+
+
+def _exception_event(kind: str, message: str, at: datetime) -> dict[str, Any]:
+    return {
+        "name": "exception",
+        "timestamp": at.isoformat(),
+        "attributes": {
+            "exception.type": kind,
+            "exception.message": message,
+            "exception.stacktrace": (
+                "Traceback (most recent call last):\n"
+                '  File "payment_agent/llm.py", line 88, in classify_intent\n'
+                "    response = await client.complete(prompt)\n"
+                f"{kind}: {message}"
+            ),
+        },
+    }
+
+
+def _large_input_payload() -> str:
+    lines = [
+        f'{{"line_item": {i}, "sku": "SKU-{i:05d}", "description": "{"x" * 28}"}}'
+        for i in range(LARGE_INPUT_CHARS // 64)
+    ]
+    return '{"order_manifest": [' + ",".join(lines) + "]}"
+
+
+def _build_project(
+    rng: random.Random,
+    *,
+    name: str,
+    now: datetime,
+    hours: int,
+    id_prefix: str,
+    tenants: tuple[str, ...],
+    models: tuple[str, ...],
+    with_incident: bool,
+) -> ProjectData:
+    project = ProjectData(name=name)
+    cut = now - timedelta(hours=RELEASE_CUT_HOURS_AGO)
+    counter = 0
+
+    def span_id() -> str:
+        nonlocal counter
+        counter += 1
+        return f"{id_prefix}{counter:015x}"
+
+    for hour in range(hours):
+        hour_start = now - timedelta(hours=hours - hour)
+        for _ in range(TRACES_PER_HOUR):
+            trace_start = hour_start + timedelta(seconds=rng.uniform(0, 3599))
+            release = "v42" if trace_start >= cut else "v41"
+            tenant = rng.choice(tenants)
+            model = rng.choice(models)
+            if with_incident and release == "v42":
+                failure_rate = (
+                    POST_CUT_FAILURE_RATE_ERROR_TENANT
+                    if tenant == ERROR_TENANT
+                    else POST_CUT_FAILURE_RATE_OTHER
+                )
+            else:
+                failure_rate = PRE_CUT_FAILURE_RATE
+            failed = rng.random() < failure_rate
+
+            trace_id = f"{id_prefix}{len(project.traces) + 1:031x}"
+            root_id, llm_id = span_id(), span_id()
+            llm_latency_ms = int(rng.uniform(400, 2500) * (rng.uniform(3, 8) if failed else 1))
+            root_overhead_ms = int(rng.uniform(20, 80))
+            metadata = {
+                "release": release,
+                "tenant": tenant,
+                "build.version": f"{release}.{hour}",
+            }
+            order_ref = f"order-{trace_id[-8:]}"
+            prompt = (
+                f"Classify the payment intent for {order_ref} from tenant {tenant}: "
+                '"please charge my saved card for the renewal"'
+            )
+            tokens: Any = rng.randint(200, 3000)
+            exception_kind = rng.choice(("UpstreamTimeoutError", "RateLimitError"))
+            exception_message = f"{exception_kind.removesuffix('Error')} while calling {model}"
+
+            llm_start = trace_start + timedelta(milliseconds=30)
+            llm_end = llm_start + timedelta(milliseconds=llm_latency_ms)
+            root_end = llm_end + timedelta(milliseconds=root_overhead_ms)
+            status = "ERROR" if failed else "OK"
+            project.spans.append(
+                SpanRecord(
+                    span_id=root_id,
+                    trace_id=trace_id,
+                    parent_id=None,
+                    name=ROOT_SPAN_NAME,
+                    span_kind="CHAIN",
+                    start_time=trace_start,
+                    end_time=root_end,
+                    attributes={
+                        "input": {"value": f"charge request {order_ref}"},
+                        "output": {"value": "declined" if failed else "settled"},
+                        "metadata": dict(metadata),
+                    },
+                    events=[],
+                    status_code=status,
+                    status_message=exception_message if failed else "",
+                )
+            )
+            llm_output = "intent: renewal_charge" if not failed else ""
+            project.spans.append(
+                SpanRecord(
+                    span_id=llm_id,
+                    trace_id=trace_id,
+                    parent_id=root_id,
+                    name=LLM_SPAN_NAME,
+                    span_kind="LLM",
+                    start_time=llm_start,
+                    end_time=llm_end,
+                    attributes={
+                        "llm": {
+                            "model_name": model,
+                            "token_count": {"total": tokens},
+                            # The ingested (nested) form of the OpenInference
+                            # message convention: a list of {"message": {...}}.
+                            "input_messages": [
+                                {"message": {"role": "system", "content": SYSTEM_PROMPT}},
+                                {"message": {"role": "user", "content": prompt}},
+                            ],
+                            "output_messages": [
+                                {"message": {"role": "assistant", "content": llm_output}},
+                            ],
+                        },
+                        "input": {"value": prompt},
+                        "output": {"value": llm_output},
+                        "metadata": dict(metadata),
+                    },
+                    events=[_exception_event(exception_kind, exception_message, llm_end)]
+                    if failed
+                    else [],
+                    status_code=status,
+                    status_message=exception_message if failed else "",
+                )
+            )
+            project.costs.append(_cost_record(llm_id, model, int(tokens)))
+            project.traces.append(
+                TraceRecord(trace_id=trace_id, start_time=trace_start, end_time=root_end)
+            )
+    return project
+
+
+def _apply_special_rows(rng: random.Random, project: ProjectData, now: datetime) -> None:
+    """Deterministically plant the special rows in the main project."""
+    cut = now - timedelta(hours=RELEASE_CUT_HOURS_AGO)
+    post_cut_llm = [
+        s
+        for s in project.spans
+        if s.span_kind == "LLM" and s.start_time >= cut and s.status_code == "ERROR"
+    ]
+    # One failed LLM span whose recorded token count is a string, not a
+    # number: numeric extraction must read it as NULL instead of failing
+    # the whole query or coercing it to zero.
+    mixed_type_span = post_cut_llm[3]
+    mixed_type_span.attributes["llm"]["token_count"]["total"] = "n/a"
+    # Its recorded token count is unusable, so it carries no cost record —
+    # cost absence is a real fact, not a synthetic zero.
+    project.costs = [c for c in project.costs if c.span_id != mixed_type_span.span_id]
+    # It also carries a single input message (no system prompt): the
+    # second-message fields must read as NULL, not fail.
+    mixed_type_span.attributes["llm"]["input_messages"] = [
+        {
+            "message": {
+                "role": "user",
+                "content": mixed_type_span.attributes["input"]["value"],
+            }
+        },
+    ]
+
+    # One failed LLM span with a ~20KB input and the slowest latency in the
+    # dataset: large enough to demonstrate preview clipping, recovered in
+    # full through the drill-down path.
+    large_span = next(
+        s
+        for s in post_cut_llm
+        if s.attributes["metadata"]["tenant"] == ERROR_TENANT and s is not mixed_type_span
+    )
+    large_span.attributes["input"]["value"] = _large_input_payload()
+    # The user message mirrors input.value, so the oversized payload also
+    # exercises message-content clipping.
+    large_span.attributes["llm"]["input_messages"][1]["message"]["content"] = large_span.attributes[
+        "input"
+    ]["value"]
+    large_span.end_time = large_span.start_time + timedelta(milliseconds=LARGE_INPUT_LATENCY_MS)
+    for trace in project.traces:
+        if trace.trace_id == large_span.trace_id:
+            trace.end_time = max(trace.end_time, large_span.end_time)
+    for sibling in project.spans:
+        if sibling.trace_id == large_span.trace_id and sibling.parent_id is None:
+            sibling.end_time = large_span.end_time + timedelta(milliseconds=40)
+
+    # A few orphan spans: their parent id references a span that was never
+    # received, so they surface as roots flagged orphan in trace trees.
+    for index in range(5):
+        orphan_trace = project.traces[10 + index * 7]
+        start = orphan_trace.start_time + timedelta(milliseconds=5)
+        end = start + timedelta(milliseconds=int(rng.uniform(50, 400)))
+        project.spans.append(
+            SpanRecord(
+                span_id=f"c{index + 1:015x}",
+                trace_id=orphan_trace.trace_id,
+                parent_id=f"feedbeef{index:08x}",
+                name=ORPHAN_SPAN_NAME,
+                span_kind="TOOL",
+                start_time=start,
+                end_time=end,
+                attributes={"input": {"value": "settlement retry"}},
+                events=[],
+                status_code="OK",
+                status_message="",
+            )
+        )
+
+
+def _build_annotations(rng: random.Random, project: ProjectData) -> None:
+    """Attach ``correctness`` eval scores to a couple dozen LLM spans.
+
+    Two annotator identifiers score under the same annotation name — one
+    LLM judge and one human reviewer — so a span can legitimately carry
+    multiple rows for one annotation name. That multiplicity is exactly why
+    joining spans to annotations inside a span-grain aggregate would corrupt
+    counts and sums without declared reduction semantics.
+    """
+    llm_spans = [s for s in project.spans if s.span_kind == "LLM"][:24]
+    for index, span in enumerate(llm_spans):
+        judge_score = round(rng.uniform(0.1, 1.0), 2)
+        project.annotations.append(
+            AnnotationRecord(
+                span_id=span.span_id,
+                name="correctness",
+                score=judge_score,
+                label="correct" if judge_score >= 0.5 else "incorrect",
+                annotator_kind="LLM",
+                identifier="llm-judge-1",
+            )
+        )
+        if index % 2 == 0:
+            human_score = round(rng.uniform(0.0, 1.0), 2)
+            project.annotations.append(
+                AnnotationRecord(
+                    span_id=span.span_id,
+                    name="correctness",
+                    score=human_score,
+                    label="correct" if human_score >= 0.5 else "incorrect",
+                    annotator_kind="HUMAN",
+                    identifier="human-review",
+                )
+            )
+
+
+def build_incident(now: datetime, seed: int = DEFAULT_SEED) -> Incident:
+    """Build the full dataset. Pure function of (now, seed)."""
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    now = now.astimezone(timezone.utc)
+    rng = random.Random(seed)
+    main = _build_project(
+        rng,
+        name=MAIN_PROJECT_NAME,
+        now=now,
+        hours=HOURS,
+        id_prefix="a",
+        tenants=TENANTS,
+        models=MODELS,
+        with_incident=True,
+    )
+    _apply_special_rows(rng, main, now)
+    decoy = _build_project(
+        rng,
+        name=DECOY_PROJECT_NAME,
+        now=now,
+        hours=DECOY_HOURS,
+        id_prefix="b",
+        tenants=DECOY_TENANTS,
+        models=DECOY_MODELS,
+        with_incident=False,
+    )
+    _build_annotations(rng, main)
+    return Incident(now=now, seed=seed, main=main, decoy=decoy)
+
+
+def render_ground_truth(incident: Incident) -> str:
+    """The answer key: deterministic text derived from the generated spans."""
+    main = incident.main
+    lines: list[str] = []
+    lines.append(f"# Ground truth for {main.name} (seed={incident.seed})")
+    lines.append(f"now={incident.now.isoformat()}")
+    lines.append(f"spans={len(main.spans)} traces={len(main.traces)}")
+    lines.append(f"decoy {incident.decoy.name}: spans={len(incident.decoy.spans)}")
+    lines.append("")
+    lines.append("## Error rate and count by release and hour (all spans)")
+    by_bucket: Counter[tuple[str, str]] = Counter()
+    errors_by_bucket: Counter[tuple[str, str]] = Counter()
+    for span in main.spans:
+        release = span.attributes.get("metadata", {}).get("release", "(none)")
+        hour = span.start_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:00:00+00:00")
+        by_bucket[(release, hour)] += 1
+        if span.status_code == "ERROR":
+            errors_by_bucket[(release, hour)] += 1
+    for (release, hour), count in sorted(by_bucket.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+        errors = errors_by_bucket[(release, hour)]
+        lines.append(f"{hour} {release} count={count} errors={errors} rate={errors / count:.4f}")
+    lines.append("")
+    lines.append("## Totals by release (all spans)")
+    for release in sorted({r for r, _ in by_bucket}):
+        count = sum(c for (r, _), c in by_bucket.items() if r == release)
+        errors = sum(c for (r, _), c in errors_by_bucket.items() if r == release)
+        lines.append(f"{release} count={count} errors={errors} rate={errors / count:.4f}")
+    lines.append("")
+    lines.append("## Five slowest failed LLM calls")
+    failed_llm = [s for s in main.spans if s.span_kind == "LLM" and s.status_code == "ERROR"]
+    slowest = sorted(failed_llm, key=lambda s: (-s.latency_ms, s.span_id))[:5]
+    for span in slowest:
+        tenant = span.attributes["metadata"]["tenant"]
+        release = span.attributes["metadata"]["release"]
+        lines.append(
+            f"{span.span_id} latency_ms={span.latency_ms:.1f} tenant={tenant} release={release}"
+        )
+    lines.append("")
+    lines.append(f"## Worst span: {slowest[0].span_id}")
+    lines.append("")
+    lines.append("## Top 10 spans by cost")
+    priciest = sorted(main.costs, key=lambda c: (-c.total_cost, c.span_id))[:10]
+    for cost in priciest:
+        lines.append(f"{cost.span_id} cost={cost.total_cost:.6f} model={cost.model}")
+    total_cost = sum(c.total_cost for c in main.costs)
+    lines.append(
+        f"cost records={len(main.costs)} (LLM spans with usable token counts) "
+        f"total_cost={total_cost:.6f}"
+    )
+    lines.append("")
+    lines.append("## Spans with correctness < 0.5 (any annotator)")
+    low_spans = sorted(
+        {a.span_id for a in main.annotations if a.name == "correctness" and a.score < 0.5}
+    )
+    lines.append(f"distinct spans={len(low_spans)}")
+    cost_by_span = {c.span_id: c for c in main.costs}
+    priciest_low = sorted(
+        (cost_by_span[sid] for sid in low_spans if sid in cost_by_span),
+        key=lambda c: (-c.total_cost, c.span_id),
+    )[:10]
+    lines.append("top 10 by cost:")
+    for cost in priciest_low:
+        lines.append(f"{cost.span_id} cost={cost.total_cost:.6f}")
+    incorrect_spans = sorted(
+        {a.span_id for a in main.annotations if a.name == "correctness" and a.label == "incorrect"}
+    )
+    lines.append(f"distinct spans labeled incorrect={len(incorrect_spans)}")
+    return "\n".join(lines)
+
+
+async def insert_incident(session: Any, incident: Incident) -> None:
+    """Insert both projects with plain ORM-table inserts.
+
+    ``session`` is an ``AsyncSession`` bound to a migrated Phoenix
+    database (either backend).
+    """
+    from sqlalchemy import insert, select
+
+    from phoenix.db import models
+
+    for project_data in (incident.main, incident.decoy):
+        project_rowid = await session.scalar(
+            insert(models.Project).values(name=project_data.name).returning(models.Project.id)
+        )
+        await session.execute(
+            insert(models.Trace),
+            [
+                {
+                    "project_rowid": project_rowid,
+                    "trace_id": trace.trace_id,
+                    "start_time": trace.start_time,
+                    "end_time": trace.end_time,
+                }
+                for trace in project_data.traces
+            ],
+        )
+        trace_rowids = dict(
+            (
+                await session.execute(
+                    select(models.Trace.trace_id, models.Trace.id).where(
+                        models.Trace.project_rowid == project_rowid
+                    )
+                )
+            ).all()
+        )
+        await session.execute(
+            insert(models.Span),
+            [
+                {
+                    "span_id": span.span_id,
+                    "trace_rowid": trace_rowids[span.trace_id],
+                    "parent_id": span.parent_id,
+                    "name": span.name,
+                    "span_kind": span.span_kind,
+                    "start_time": span.start_time,
+                    "end_time": span.end_time,
+                    "attributes": span.attributes,
+                    "events": span.events,
+                    "status_code": span.status_code,
+                    "status_message": span.status_message,
+                    "cumulative_error_count": 1 if span.status_code == "ERROR" else 0,
+                    "cumulative_llm_token_count_prompt": 0,
+                    "cumulative_llm_token_count_completion": 0,
+                }
+                for span in project_data.spans
+            ],
+        )
+        if project_data.annotations or project_data.costs:
+            span_rowids = dict(
+                (
+                    await session.execute(
+                        select(models.Span.span_id, models.Span.id)
+                        .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+                        .where(models.Trace.project_rowid == project_rowid)
+                    )
+                ).all()
+            )
+        if project_data.annotations:
+            await session.execute(
+                insert(models.SpanAnnotation),
+                [
+                    {
+                        "span_rowid": span_rowids[annotation.span_id],
+                        "name": annotation.name,
+                        "label": annotation.label,
+                        "score": annotation.score,
+                        "explanation": None,
+                        "metadata_": {},
+                        "annotator_kind": annotation.annotator_kind,
+                        "identifier": annotation.identifier,
+                        "source": "API",
+                        "user_id": None,
+                    }
+                    for annotation in project_data.annotations
+                ],
+            )
+        if project_data.costs:
+            span_by_id = {span.span_id: span for span in project_data.spans}
+            await session.execute(
+                insert(models.SpanCost),
+                [
+                    {
+                        "span_rowid": span_rowids[cost.span_id],
+                        "trace_rowid": trace_rowids[span_by_id[cost.span_id].trace_id],
+                        "span_start_time": span_by_id[cost.span_id].start_time,
+                        # The generative-model link is optional; keeping it
+                        # unset keeps seeding self-contained and re-runnable.
+                        "model_id": None,
+                        "total_cost": cost.total_cost,
+                        "total_tokens": float(cost.total_tokens),
+                        "prompt_cost": cost.prompt_cost,
+                        "prompt_tokens": float(cost.prompt_tokens),
+                        "completion_cost": cost.completion_cost,
+                        "completion_tokens": float(cost.completion_tokens),
+                    }
+                    for cost in project_data.costs
+                ],
+            )
+
+
+async def open_seed_engine(connection_str: str, migrate: bool) -> Any:
+    """Open the target database, initializing the schema only on request.
+
+    Running migrations unconditionally fails against a database a running
+    Phoenix owns: SQLite holds a write lock, and the PostgreSQL migration
+    path takes an advisory lock a live server can contend for. Seeding
+    targets are usually live servers, so the default probes for an
+    existing migrated schema (the ``alembic_version`` table) and skips
+    migration entirely; ``--migrate`` opts in for an empty database.
+    """
+    import sqlalchemy
+
+    from phoenix.db.engines import create_engine
+
+    engine = create_engine(connection_str, migrate=False, log_migrations=False)
+    async with engine.connect() as conn:
+        has_schema = await conn.run_sync(
+            lambda sync_conn: bool(sqlalchemy.inspect(sync_conn).has_table("alembic_version"))
+        )
+    if has_schema:
+        return engine
+    await engine.dispose()
+    if not migrate:
+        raise SystemExit(
+            "The target database has no Phoenix schema. Point --database-url at a "
+            "running Phoenix's database, or pass --migrate to initialize an empty one."
+        )
+    return create_engine(connection_str, migrate=True, log_migrations=False)
+
+
+async def replace_or_reject_existing(session: Any, names: list[str], replace: bool) -> None:
+    """Make re-runs safe: the generated ids are deterministic, so inserting
+    over a previous run collides. ``--replace`` deletes this script's own
+    projects (by name; the schema cascades to sessions, traces, spans, and
+    annotations) before re-seeding; without it, an existing project is
+    reported up front instead of failing midway on an id collision.
+    """
+    from sqlalchemy import delete, select
+
+    from phoenix.db import models
+
+    existing = list(
+        (
+            await session.execute(select(models.Project.name).where(models.Project.name.in_(names)))
+        ).scalars()
+    )
+    if not existing:
+        return
+    if replace:
+        await session.execute(delete(models.Project).where(models.Project.name.in_(names)))
+        return
+    raise SystemExit(
+        f"Project(s) already seeded: {', '.join(sorted(existing))}. "
+        "Re-run with --replace to delete and re-seed them."
+    )
+
+
+def _print_confirmation(incident: Incident, wrote: bool) -> None:
+    for project_data in (incident.main, incident.decoy):
+        print(
+            f'{"Seeded" if wrote else "Would seed"} project "{project_data.name}": '
+            f"{len(project_data.spans)} spans, {len(project_data.traces)} traces, "
+            f"{len(project_data.annotations)} annotations, "
+            f"{len(project_data.costs)} cost records"
+        )
+    if wrote:
+        print("Open the Phoenix UI and check that both projects appear.")
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--now",
+        required=True,
+        help="Anchor timestamp, ISO-8601 (e.g. 2026-07-23T12:00:00Z); naive means UTC.",
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="SQLAlchemy database URL; defaults to the Phoenix environment configuration.",
+    )
+    parser.add_argument(
+        "--migrate",
+        action="store_true",
+        help=(
+            "Initialize the Phoenix schema if the database is empty. Off by default: "
+            "seeding a running Phoenix must not attempt migrations against a "
+            "database the server owns."
+        ),
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Delete this script's projects (if present) and re-seed them.",
+    )
+    parser.add_argument(
+        "--answer-key",
+        action="store_true",
+        help=(
+            "Print the ground-truth answer key. Off by default: reading it before "
+            "investigating the data spoils the exercise."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the dataset and print the confirmation without writing anywhere.",
+    )
+    args = parser.parse_args()
+    now = datetime.fromisoformat(str(args.now).replace("Z", "+00:00"))
+    incident = build_incident(now, int(args.seed))
+
+    if not args.dry_run:
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        from phoenix.config import get_env_database_connection_str
+
+        connection_str = args.database_url or get_env_database_connection_str()
+        engine = await open_seed_engine(connection_str, migrate=bool(args.migrate))
+        async with AsyncSession(engine) as session:
+            async with session.begin():
+                await replace_or_reject_existing(
+                    session,
+                    [incident.main.name, incident.decoy.name],
+                    replace=bool(args.replace),
+                )
+                await insert_incident(session, incident)
+        await engine.dispose()
+
+    _print_confirmation(incident, wrote=not args.dry_run)
+    if args.answer_key:
+        print()
+        print(render_ground_truth(incident))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/scripts/span_analytics_seeds/seed_support_copilot.py
+++ b/scripts/span_analytics_seeds/seed_support_copilot.py
@@ -1,0 +1,800 @@
+"""Seed a realistic support-copilot workload into a Phoenix database.
+
+One project, ``support-copilot``: ~300 chat sessions from ~120 users over
+the trailing 24 hours. Each session holds one to five turns; each turn is
+its own trace with an AGENT root (``copilot_turn``, carrying ``session.id``,
+``user.id``, and nested ``metadata`` with plan/channel), a RETRIEVER child
+with three scored ``retrieval.documents`` entries, an occasional TOOL call,
+and an LLM span (two models, prompt/completion/total token counts with
+~10% of totals missing, ~6% errors with exception events). LLM spans carry
+OpenInference message lists with the *accumulating* conversation: turn N
+resends system + all prior user/assistant pairs + the current user message
+(2 + 2·(N−1) entries), so conversation depth varies per call and prompt
+tokens — hence cost — grow with the carried history, as instrumented chat
+applications actually behave. LLM spans with a recorded total token count
+carry a deterministic cost record priced from a per-model table; the
+missing-total spans have none, so cost absence mirrors token absence.
+Roughly a third of the AGENT turns carry a ``helpfulness`` span annotation
+from an LLM-judge-style annotator.
+
+**No answer key exists for this project, by design.** It is the organic-use
+dataset: there is no planted regression to find and no expected result to
+check against — it exists to be questioned freely. The annotations follow
+the same rule: scores are plausible organic texture, not an engineered
+pattern.
+
+The generator is a pure function of ``(--now, --seed)``: two runs produce
+identical data.
+
+The workload also carries an instrumentation drop (``metadata.channel``
+stops being recorded ~6 hours before the anchor while usage continues) and
+a sprinkle of GUARDRAIL-kind ``safety_check`` spans (~5% of turns, mostly
+``pass``, some ``trigger``).
+
+Usage:
+    python scripts/span_analytics_seeds/seed_support_copilot.py \
+        [--now 2026-07-23T12:00:00Z] [--seed 20260723] \
+        [--database-url sqlite:///path/to/phoenix.db] \
+        [--migrate] [--replace] [--cardinality N] [--with-policy-props] \
+        [--dry-run]
+
+``--now`` defaults to the current time. Without ``--database-url`` the
+standard Phoenix environment configuration is used. The target database is
+normally a running Phoenix's (no migration attempted); ``--migrate``
+initializes an empty database instead. Re-runs require ``--replace``, which
+deletes and re-seeds this script's project.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+PROJECT_NAME = "support-copilot"
+
+DEFAULT_SEED = 20260723
+SESSION_COUNT = 300
+USER_COUNT = 120
+
+#: (model name, probability weight of picking it).
+MODELS: tuple[tuple[str, float], ...] = (("gpt-4o", 0.7), ("claude-sonnet-4-5", 0.3))
+TOOLS = ("lookup_order", "refund_status", "escalate", "kb_search")
+TOPICS = ("billing", "refunds", "api keys", "rate limits", "sso setup", "data export")
+
+#: Customer organizations. The awkward names are deliberate: values with
+#: embedded quotes and backslashes must survive filter-grammar escaping
+#: and URL encoding end to end.
+ORGS = ("acme-labs", "o'brien-corp", "globex\\emea", "initech")
+
+#: USD per one million tokens, (prompt rate, completion rate). Costs are
+#: computed deterministically from these at build time; LLM spans whose
+#: recorded total token count is missing get no cost record — cost
+#: absence stays a real, queryable fact.
+MODEL_PRICES: dict[str, tuple[float, float]] = {
+    "gpt-4o": (2.50, 10.00),
+    "claude-sonnet-4-5": (3.00, 15.00),
+}
+
+SYSTEM_PROMPT = (
+    "You are the support copilot. Answer the customer's question using the "
+    "retrieved knowledge-base passages; escalate when unsure."
+)
+
+ERROR_RATE = 0.06
+TOOL_CALL_RATE = 0.4
+TOOL_ERROR_RATE = 0.08
+MISSING_TOKEN_TOTAL_RATE = 0.1
+ANNOTATION_RATE = 1 / 3
+GUARDRAIL_RATE = 0.05
+GUARDRAIL_TRIGGER_RATE = 0.15
+
+#: Instrumentation drop: metadata.channel stops being written this many
+#: hours before the anchor — the "did usage fall or did we stop
+#: recording" question needs data where recording, not usage, changed.
+CHANNEL_DROPPED_AFTER_HOURS = 6.0
+
+#: Secret-shaped values planted only under --with-policy-props: they look
+#: like live API keys but are fake.
+POLICY_PROP_KEYS = (
+    "sk-live-4f3a9b1c8d2e7f6a5b4c3d2e1f0a9b8c",
+    "sk-live-7e6d5c4b3a2f1e0d9c8b7a6f5e4d3c2b",
+    "sk-live-0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d",
+)
+
+ANNOTATION_NAME = "helpfulness"
+ANNOTATOR_IDENTIFIER = "llm-judge-helpfulness"
+
+_EXPLANATIONS = (
+    "The answer addresses the question directly and cites the relevant steps.",
+    "Partially helpful: the steps are correct but assume an admin role the user may lack.",
+    "The response is generic and does not engage with the specifics of the request.",
+    "Clear, actionable guidance with the right level of detail.",
+    "The answer is on topic but omits the prerequisite configuration.",
+    "Helpful summary, though the linked procedure has since changed.",
+)
+
+
+@dataclass
+class SpanRecord:
+    span_id: str
+    trace_id: str
+    parent_id: Optional[str]
+    name: str
+    span_kind: str
+    start_time: datetime
+    end_time: datetime
+    attributes: dict[str, Any]
+    events: list[dict[str, Any]]
+    status_code: str
+    status_message: str
+    llm_token_count_prompt: Optional[int] = None
+    llm_token_count_completion: Optional[int] = None
+
+
+@dataclass
+class TraceRecord:
+    trace_id: str
+    session_id: str
+    start_time: datetime
+    end_time: datetime
+
+
+@dataclass
+class SessionRecord:
+    session_id: str
+    start_time: datetime
+    end_time: datetime
+
+
+@dataclass
+class AnnotationRecord:
+    span_id: str
+    name: str
+    score: float
+    explanation: str
+    annotator_kind: str
+    identifier: str
+
+
+@dataclass
+class CostRecord:
+    span_id: str
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    prompt_cost: float
+    completion_cost: float
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+    @property
+    def total_cost(self) -> float:
+        return self.prompt_cost + self.completion_cost
+
+
+@dataclass
+class Workload:
+    now: datetime
+    seed: int
+    project_name: str
+    sessions: list[SessionRecord] = field(default_factory=list)
+    traces: list[TraceRecord] = field(default_factory=list)
+    spans: list[SpanRecord] = field(default_factory=list)
+    annotations: list[AnnotationRecord] = field(default_factory=list)
+    costs: list[CostRecord] = field(default_factory=list)
+
+
+def _exception_event(message: str, at: datetime) -> dict[str, Any]:
+    return {
+        "name": "exception",
+        "timestamp": at.isoformat(),
+        "attributes": {
+            "exception.type": "RuntimeError",
+            "exception.message": message,
+            "exception.stacktrace": (
+                "Traceback (most recent call last):\n"
+                '  File "copilot/llm.py", line 142, in complete\n'
+                "    response = await client.chat(messages)\n"
+                f"RuntimeError: {message}"
+            ),
+        },
+    }
+
+
+def build_workload(
+    now: datetime,
+    seed: int = DEFAULT_SEED,
+    session_count: int = SESSION_COUNT,
+    with_policy_props: bool = False,
+) -> Workload:
+    """Build the full dataset. Pure function of its arguments.
+
+    ``with_policy_props`` plants a few fake API-key-shaped strings in span
+    attributes. It exists for facilitators only, to demonstrate — on
+    purpose, with fake values — that observed-value discovery will surface
+    secret-shaped strings if an application records them; it is never on
+    by default.
+    """
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    now = now.astimezone(timezone.utc)
+    rng = random.Random(seed)
+    workload = Workload(now=now, seed=seed, project_name=PROJECT_NAME)
+
+    docs = {
+        topic: [f"{topic} doc {i}: " + "x" * rng.randint(80, 400) for i in range(8)]
+        for topic in TOPICS
+    }
+    users = [f"user-{i:03d}" for i in range(USER_COUNT)]
+    span_counter = 0
+    trace_counter = 0
+
+    def next_span_id() -> str:
+        nonlocal span_counter
+        span_counter += 1
+        return f"d{span_counter:015x}"
+
+    def next_trace_id() -> str:
+        nonlocal trace_counter
+        trace_counter += 1
+        return f"d{trace_counter:031x}"
+
+    for session_index in range(session_count):
+        session_id = f"sess-{session_index:04d}"
+        user = rng.choice(users)
+        session_start = now - timedelta(hours=rng.uniform(0.2, 24))
+        turns = rng.randint(1, 5)
+        turn_start = session_start
+        session_end = session_start
+        # The running conversation: chat applications resend history, so
+        # turn N carries system + all prior user/assistant pairs + the
+        # current user message (2 + 2·(N−1) entries). Conversation depth
+        # then varies meaningfully per call, and prompt size — hence cost —
+        # grows with the carried history.
+        history: list[dict[str, Any]] = []
+        for turn in range(turns):
+            topic = rng.choice(TOPICS)
+            model = MODELS[0][0] if rng.random() < MODELS[0][1] else MODELS[1][0]
+            failed = rng.random() < ERROR_RATE
+            question = f"How do I handle {topic}? (turn {turn + 1})"
+            duration_s = rng.uniform(1.2, 9.0)
+            trace_id = next_trace_id()
+            root_id = next_span_id()
+            root_end = turn_start + timedelta(seconds=duration_s)
+            # The channel value is always drawn (keeping the stream stable)
+            # but stops being *recorded* after the drop point: usage did not
+            # change, instrumentation did.
+            channel = rng.choice(["web", "slack"])
+            metadata: dict[str, Any] = {
+                "plan": rng.choice(["free", "pro", "enterprise"]),
+                "org": rng.choice(list(ORGS)),
+            }
+            if turn_start < now - timedelta(hours=CHANNEL_DROPPED_AFTER_HOURS):
+                metadata["channel"] = channel
+
+            workload.spans.append(
+                SpanRecord(
+                    span_id=root_id,
+                    trace_id=trace_id,
+                    parent_id=None,
+                    name="copilot_turn",
+                    span_kind="AGENT",
+                    start_time=turn_start,
+                    end_time=root_end,
+                    attributes={
+                        "session": {"id": session_id},
+                        "user": {"id": user},
+                        "input": {"value": question},
+                        "output": {"value": "failed" if failed else "resolved"},
+                        # Over OTLP this arrives as a JSON string that
+                        # ingestion un-flattens; direct insertion writes the
+                        # nested dict the ingested form has.
+                        "metadata": metadata,
+                    },
+                    events=[],
+                    status_code="ERROR" if failed else "OK",
+                    status_message="turn failed" if failed else "",
+                )
+            )
+
+            retriever_start = turn_start + timedelta(seconds=0.05)
+            workload.spans.append(
+                SpanRecord(
+                    span_id=next_span_id(),
+                    trace_id=trace_id,
+                    parent_id=root_id,
+                    name="kb_retrieve",
+                    span_kind="RETRIEVER",
+                    start_time=retriever_start,
+                    end_time=retriever_start + timedelta(seconds=rng.uniform(0.1, 0.6)),
+                    attributes={
+                        # Session context propagates to child spans, as
+                        # OpenInference session propagation does in
+                        # instrumented chat applications.
+                        "session": {"id": session_id},
+                        "user": {"id": user},
+                        "input": {"value": question},
+                        "retrieval": {
+                            "documents": [
+                                {
+                                    "document": {
+                                        "content": rng.choice(docs[topic]),
+                                        "score": round(rng.uniform(0.3, 0.98), 3),
+                                    }
+                                }
+                                for _ in range(3)
+                            ]
+                        },
+                    },
+                    events=[],
+                    status_code="OK",
+                    status_message="",
+                )
+            )
+
+            if rng.random() < TOOL_CALL_RATE:
+                tool_start = retriever_start + timedelta(seconds=0.7)
+                tool_failed = rng.random() < TOOL_ERROR_RATE
+                workload.spans.append(
+                    SpanRecord(
+                        span_id=next_span_id(),
+                        trace_id=trace_id,
+                        parent_id=root_id,
+                        name="tool_call",
+                        span_kind="TOOL",
+                        start_time=tool_start,
+                        end_time=tool_start + timedelta(seconds=rng.uniform(0.2, 2.0)),
+                        attributes={
+                            "session": {"id": session_id},
+                            "user": {"id": user},
+                            "tool": {"name": rng.choice(TOOLS)},
+                        },
+                        events=[],
+                        status_code="ERROR" if tool_failed else "OK",
+                        status_message="tool timeout" if tool_failed else "",
+                    )
+                )
+
+            if rng.random() < GUARDRAIL_RATE:
+                guardrail_start = retriever_start + timedelta(seconds=0.85)
+                workload.spans.append(
+                    SpanRecord(
+                        span_id=next_span_id(),
+                        trace_id=trace_id,
+                        parent_id=root_id,
+                        name="safety_check",
+                        span_kind="GUARDRAIL",
+                        start_time=guardrail_start,
+                        end_time=guardrail_start + timedelta(seconds=rng.uniform(0.02, 0.15)),
+                        attributes={
+                            "session": {"id": session_id},
+                            "user": {"id": user},
+                            "guardrail": {
+                                "outcome": "trigger"
+                                if rng.random() < GUARDRAIL_TRIGGER_RATE
+                                else "pass"
+                            },
+                        },
+                        events=[],
+                        status_code="OK",
+                        status_message="",
+                    )
+                )
+
+            llm_start = retriever_start + timedelta(seconds=1.0)
+            llm_end = llm_start + timedelta(seconds=duration_s * 0.6)
+            llm_id = next_span_id()
+            answer = f"Here is how to handle {topic}..." + "y" * rng.randint(50, 800)
+            input_messages = [
+                {"message": {"role": "system", "content": SYSTEM_PROMPT}},
+                *history,
+                {"message": {"role": "user", "content": question}},
+            ]
+            # Token counts follow the actual payloads (~4 characters per
+            # token, plus jitter) instead of being drawn independently:
+            # prompt size grows with the resent history, so token spend and
+            # cost grow with conversation depth, and completion size tracks
+            # the answer text.
+            prompt_chars = sum(len(m["message"]["content"]) for m in input_messages)
+            prompt_tokens = prompt_chars // 4 + rng.randint(0, 40)
+            completion_tokens = len(answer) // 4 + rng.randint(0, 20)
+            token_count: dict[str, Any] = {
+                "prompt": prompt_tokens,
+                "completion": completion_tokens,
+                "total": prompt_tokens + completion_tokens,
+            }
+            if rng.random() < MISSING_TOKEN_TOTAL_RATE:
+                token_count.pop("total")  # missingness texture
+            workload.spans.append(
+                SpanRecord(
+                    span_id=llm_id,
+                    trace_id=trace_id,
+                    parent_id=root_id,
+                    name=f"{model}.chat",
+                    span_kind="LLM",
+                    start_time=llm_start,
+                    end_time=llm_end,
+                    attributes={
+                        "session": {"id": session_id},
+                        "user": {"id": user},
+                        "llm": {
+                            "model_name": model,
+                            "token_count": token_count,
+                            # The ingested (nested) form of the OpenInference
+                            # message convention: a list of {"message": {...}}.
+                            "input_messages": input_messages,
+                            "output_messages": [
+                                {"message": {"role": "assistant", "content": answer}},
+                            ],
+                        },
+                        "input": {"value": question},
+                        "output": {"value": answer},
+                    },
+                    events=[
+                        _exception_event(
+                            "upstream 429: rate limited",
+                            llm_start + timedelta(seconds=1),
+                        )
+                    ]
+                    if failed
+                    else [],
+                    status_code="ERROR" if failed else "OK",
+                    status_message="upstream 429" if failed else "",
+                    llm_token_count_prompt=prompt_tokens,
+                    llm_token_count_completion=completion_tokens,
+                )
+            )
+            # Cost is recorded only when the total token count was: the
+            # ~10% missing-total spans have no cost record, so cost absence
+            # mirrors token-count absence as a queryable fact.
+            if "total" in token_count:
+                prompt_rate, completion_rate = MODEL_PRICES[model]
+                workload.costs.append(
+                    CostRecord(
+                        span_id=llm_id,
+                        model=model,
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        prompt_cost=prompt_tokens * prompt_rate / 1_000_000,
+                        completion_cost=completion_tokens * completion_rate / 1_000_000,
+                    )
+                )
+
+            # Organic annotation texture: an LLM-judge helpfulness score on
+            # roughly a third of the turns. No engineered pattern and no
+            # answer key — the scores exist to be discovered, not solved.
+            if rng.random() < ANNOTATION_RATE:
+                workload.annotations.append(
+                    AnnotationRecord(
+                        span_id=root_id,
+                        name=ANNOTATION_NAME,
+                        score=round(rng.uniform(0.0, 1.0), 2),
+                        explanation=rng.choice(_EXPLANATIONS),
+                        annotator_kind="LLM",
+                        identifier=ANNOTATOR_IDENTIFIER,
+                    )
+                )
+
+            # The turn's exchange joins the history the next turn resends.
+            history.append({"message": {"role": "user", "content": question}})
+            history.append({"message": {"role": "assistant", "content": answer}})
+
+            trace_end = max(root_end, llm_end)
+            workload.traces.append(
+                TraceRecord(
+                    trace_id=trace_id,
+                    session_id=session_id,
+                    start_time=turn_start,
+                    end_time=trace_end,
+                )
+            )
+            session_end = max(session_end, trace_end)
+            turn_start = turn_start + timedelta(seconds=duration_s + rng.uniform(5, 60))
+        workload.sessions.append(
+            SessionRecord(
+                session_id=session_id,
+                start_time=session_start,
+                end_time=session_end,
+            )
+        )
+    if with_policy_props:
+        # Facilitator-only governance demonstration: value discovery will
+        # faithfully surface these secret-shaped (fake) strings.
+        agent_spans = [s for s in workload.spans if s.span_kind == "AGENT"]
+        for span, fake_key in zip(agent_spans, POLICY_PROP_KEYS):
+            span.attributes["metadata"]["debug_api_key"] = fake_key
+    return workload
+
+
+async def insert_workload(session: Any, workload: Workload) -> None:
+    """Insert the project with plain ORM-table inserts.
+
+    ``session`` is an ``AsyncSession`` bound to a migrated Phoenix
+    database (either backend).
+    """
+    from sqlalchemy import insert, select
+
+    from phoenix.db import models
+
+    project_rowid = await session.scalar(
+        insert(models.Project).values(name=workload.project_name).returning(models.Project.id)
+    )
+    await session.execute(
+        insert(models.ProjectSession),
+        [
+            {
+                "session_id": record.session_id,
+                "project_id": project_rowid,
+                "start_time": record.start_time,
+                "end_time": record.end_time,
+            }
+            for record in workload.sessions
+        ],
+    )
+    session_rowids = dict(
+        (
+            await session.execute(
+                select(models.ProjectSession.session_id, models.ProjectSession.id).where(
+                    models.ProjectSession.project_id == project_rowid
+                )
+            )
+        ).all()
+    )
+    await session.execute(
+        insert(models.Trace),
+        [
+            {
+                "project_rowid": project_rowid,
+                "trace_id": trace.trace_id,
+                "project_session_rowid": session_rowids[trace.session_id],
+                "start_time": trace.start_time,
+                "end_time": trace.end_time,
+            }
+            for trace in workload.traces
+        ],
+    )
+    trace_rowids = dict(
+        (
+            await session.execute(
+                select(models.Trace.trace_id, models.Trace.id).where(
+                    models.Trace.project_rowid == project_rowid
+                )
+            )
+        ).all()
+    )
+    await session.execute(
+        insert(models.Span),
+        [
+            {
+                "span_id": span.span_id,
+                "trace_rowid": trace_rowids[span.trace_id],
+                "parent_id": span.parent_id,
+                "name": span.name,
+                "span_kind": span.span_kind,
+                "start_time": span.start_time,
+                "end_time": span.end_time,
+                "attributes": span.attributes,
+                "events": span.events,
+                "status_code": span.status_code,
+                "status_message": span.status_message,
+                "cumulative_error_count": 1 if span.status_code == "ERROR" else 0,
+                "cumulative_llm_token_count_prompt": 0,
+                "cumulative_llm_token_count_completion": 0,
+                "llm_token_count_prompt": span.llm_token_count_prompt,
+                "llm_token_count_completion": span.llm_token_count_completion,
+            }
+            for span in workload.spans
+        ],
+    )
+    if workload.annotations or workload.costs:
+        span_rowids = dict(
+            (
+                await session.execute(
+                    select(models.Span.span_id, models.Span.id)
+                    .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+                    .where(models.Trace.project_rowid == project_rowid)
+                )
+            ).all()
+        )
+    if workload.annotations:
+        # Uniqueness is (name, span_rowid, identifier); one identifier per
+        # span here, so re-seeding after --replace never collides.
+        await session.execute(
+            insert(models.SpanAnnotation),
+            [
+                {
+                    "span_rowid": span_rowids[annotation.span_id],
+                    "name": annotation.name,
+                    "label": None,
+                    "score": annotation.score,
+                    "explanation": annotation.explanation,
+                    "metadata_": {},
+                    "annotator_kind": annotation.annotator_kind,
+                    "identifier": annotation.identifier,
+                    "source": "API",
+                    "user_id": None,
+                }
+                for annotation in workload.annotations
+            ],
+        )
+    if workload.costs:
+        span_by_id = {span.span_id: span for span in workload.spans}
+        await session.execute(
+            insert(models.SpanCost),
+            [
+                {
+                    "span_rowid": span_rowids[cost.span_id],
+                    "trace_rowid": trace_rowids[span_by_id[cost.span_id].trace_id],
+                    "span_start_time": span_by_id[cost.span_id].start_time,
+                    # The generative-model link is optional; keeping it
+                    # unset keeps seeding self-contained and re-runnable.
+                    "model_id": None,
+                    "total_cost": cost.total_cost,
+                    "total_tokens": float(cost.total_tokens),
+                    "prompt_cost": cost.prompt_cost,
+                    "prompt_tokens": float(cost.prompt_tokens),
+                    "completion_cost": cost.completion_cost,
+                    "completion_tokens": float(cost.completion_tokens),
+                }
+                for cost in workload.costs
+            ],
+        )
+
+
+async def open_seed_engine(connection_str: str, migrate: bool) -> Any:
+    """Open the target database, initializing the schema only on request.
+
+    Running migrations unconditionally fails against a database a running
+    Phoenix owns: SQLite holds a write lock, and the PostgreSQL migration
+    path takes an advisory lock a live server can contend for. Seeding
+    targets are usually live servers, so the default probes for an
+    existing migrated schema (the ``alembic_version`` table) and skips
+    migration entirely; ``--migrate`` opts in for an empty database.
+    """
+    import sqlalchemy
+
+    from phoenix.db.engines import create_engine
+
+    engine = create_engine(connection_str, migrate=False, log_migrations=False)
+    async with engine.connect() as conn:
+        has_schema = await conn.run_sync(
+            lambda sync_conn: bool(sqlalchemy.inspect(sync_conn).has_table("alembic_version"))
+        )
+    if has_schema:
+        return engine
+    await engine.dispose()
+    if not migrate:
+        raise SystemExit(
+            "The target database has no Phoenix schema. Point --database-url at a "
+            "running Phoenix's database, or pass --migrate to initialize an empty one."
+        )
+    return create_engine(connection_str, migrate=True, log_migrations=False)
+
+
+async def replace_or_reject_existing(session: Any, names: list[str], replace: bool) -> None:
+    """Make re-runs safe: the generated ids are deterministic, so inserting
+    over a previous run collides. ``--replace`` deletes this script's own
+    project (by name; the schema cascades to sessions, traces, spans, and
+    annotations) before re-seeding; without it, an existing project is
+    reported up front instead of failing midway on an id collision.
+    """
+    from sqlalchemy import delete, select
+
+    from phoenix.db import models
+
+    existing = list(
+        (
+            await session.execute(select(models.Project.name).where(models.Project.name.in_(names)))
+        ).scalars()
+    )
+    if not existing:
+        return
+    if replace:
+        await session.execute(delete(models.Project).where(models.Project.name.in_(names)))
+        return
+    raise SystemExit(
+        f"Project(s) already seeded: {', '.join(sorted(existing))}. "
+        "Re-run with --replace to delete and re-seed them."
+    )
+
+
+def _print_confirmation(workload: Workload, wrote: bool) -> None:
+    print(
+        f'{"Seeded" if wrote else "Would seed"} project "{workload.project_name}": '
+        f"{len(workload.spans)} spans, {len(workload.traces)} traces, "
+        f"{len(workload.sessions)} sessions, {len(workload.annotations)} annotations, "
+        f"{len(workload.costs)} cost records"
+    )
+    if wrote:
+        print("Open the Phoenix UI and check that the project appears.")
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--now",
+        default=None,
+        help=(
+            "Anchor timestamp, ISO-8601 (e.g. 2026-07-23T12:00:00Z); naive means UTC. "
+            "Defaults to the current time."
+        ),
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="SQLAlchemy database URL; defaults to the Phoenix environment configuration.",
+    )
+    parser.add_argument(
+        "--migrate",
+        action="store_true",
+        help=(
+            "Initialize the Phoenix schema if the database is empty. Off by default: "
+            "seeding a running Phoenix must not attempt migrations against a "
+            "database the server owns."
+        ),
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Delete this script's project (if present) and re-seed it.",
+    )
+    parser.add_argument(
+        "--cardinality",
+        type=int,
+        default=SESSION_COUNT,
+        help=f"Number of sessions to generate (default {SESSION_COUNT}).",
+    )
+    parser.add_argument(
+        "--with-policy-props",
+        action="store_true",
+        help=(
+            "Facilitator-only: plant a few fake API-key-shaped strings in span "
+            "attributes to demonstrate the governance exposure of observed-value "
+            "discovery. Off by default."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the dataset and print the confirmation without writing anywhere.",
+    )
+    args = parser.parse_args()
+    now = (
+        datetime.fromisoformat(str(args.now).replace("Z", "+00:00"))
+        if args.now
+        else datetime.now(timezone.utc)
+    )
+    workload = build_workload(
+        now,
+        int(args.seed),
+        session_count=int(args.cardinality),
+        with_policy_props=bool(args.with_policy_props),
+    )
+
+    if not args.dry_run:
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        from phoenix.config import get_env_database_connection_str
+
+        connection_str = args.database_url or get_env_database_connection_str()
+        engine = await open_seed_engine(connection_str, migrate=bool(args.migrate))
+        async with AsyncSession(engine) as session:
+            async with session.begin():
+                await replace_or_reject_existing(
+                    session, [workload.project_name], replace=bool(args.replace)
+                )
+                await insert_workload(session, workload)
+        await engine.dispose()
+
+    _print_confirmation(workload, wrote=not args.dry_run)
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/src/phoenix/server/mcp_server.py
+++ b/src/phoenix/server/mcp_server.py
@@ -57,6 +57,7 @@ from phoenix.server.bearer_auth import (
     token_audience_permits,
 )
 from phoenix.server.mcp_code_mode import MontyPoolSandboxProvider
+from phoenix.server.mcp_span_analytics import build_span_analytics_tools
 from phoenix.server.oauth2_authorization_server import public_origin
 from phoenix.server.utils import prepend_root_path
 
@@ -478,6 +479,15 @@ def create_phoenix_mcp_app(
         # a mutation.
         mcp_component_fn=_annotate_from_rest_method,
     )
+    # The hand-authored span analytics tools are registered before code mode /
+    # group gating so both surfaces pick them up. They query the database
+    # directly (resolving ``app.state.db`` lazily at call time) and carry the
+    # ``spans`` tag, so they gate and reveal with the same group as the
+    # generated span tools.
+    for analytics_tool in build_span_analytics_tools(app):
+        if isinstance(analytics_tool.parameters, dict):
+            _strip_schema_titles(analytics_tool.parameters)
+        mcp.add_tool(analytics_tool)
     sandbox_provider: Optional[MontyPoolSandboxProvider] = None
     if code_mode_enabled:
         # Code mode replaces the tool surface wholesale: clients see only the

--- a/src/phoenix/server/mcp_span_analytics/__init__.py
+++ b/src/phoenix/server/mcp_span_analytics/__init__.py
@@ -1,0 +1,11 @@
+"""Span analytics MCP tools: a typed, project-scoped query surface.
+
+See :mod:`phoenix.server.mcp_span_analytics.tools` for the tool surface,
+:mod:`phoenix.server.mcp_span_analytics.registry` for the field registry,
+and :mod:`phoenix.server.mcp_span_analytics.compiler` for query
+compilation.
+"""
+
+from phoenix.server.mcp_span_analytics.tools import build_span_analytics_tools
+
+__all__ = ["build_span_analytics_tools"]

--- a/src/phoenix/server/mcp_span_analytics/__init__.py
+++ b/src/phoenix/server/mcp_span_analytics/__init__.py
@@ -2,8 +2,11 @@
 
 See :mod:`phoenix.server.mcp_span_analytics.tools` for the tool surface,
 :mod:`phoenix.server.mcp_span_analytics.registry` for the field registry,
-and :mod:`phoenix.server.mcp_span_analytics.compiler` for query
-compilation.
+:mod:`phoenix.server.mcp_span_analytics.compiler` for query compilation,
+:mod:`phoenix.server.mcp_span_analytics.discovery` for observed-path
+sampling, :mod:`phoenix.server.mcp_span_analytics.envelope` for response
+envelopes and size budgeting, and
+:mod:`phoenix.server.mcp_span_analytics.links` for UI link composition.
 """
 
 from phoenix.server.mcp_span_analytics.tools import build_span_analytics_tools

--- a/src/phoenix/server/mcp_span_analytics/__init__.py
+++ b/src/phoenix/server/mcp_span_analytics/__init__.py
@@ -2,6 +2,7 @@
 
 See :mod:`phoenix.server.mcp_span_analytics.tools` for the tool surface,
 :mod:`phoenix.server.mcp_span_analytics.registry` for the field registry,
+:mod:`phoenix.server.mcp_span_analytics.grains` for the queryable relations,
 :mod:`phoenix.server.mcp_span_analytics.compiler` for query compilation,
 :mod:`phoenix.server.mcp_span_analytics.discovery` for observed-path
 sampling, :mod:`phoenix.server.mcp_span_analytics.envelope` for response

--- a/src/phoenix/server/mcp_span_analytics/compiler.py
+++ b/src/phoenix/server/mcp_span_analytics/compiler.py
@@ -199,7 +199,9 @@ class Calculation(BaseModel):
         default=None,
         description=(
             "Field to aggregate. Required for every function except count; "
-            "count with a field counts rows where the field is non-NULL."
+            "count with a field counts rows where the field is non-NULL. "
+            "count and count_distinct accept any field, authored or observed; "
+            "sum/avg/min/max/percentiles require a value-aggregatable field."
         ),
     )
 
@@ -347,6 +349,22 @@ def project_not_found(identifier: str) -> QueryError:
         path="project",
         message=f"Project {identifier!r} not found.",
     )
+
+
+async def project_not_found_error(session: AsyncSession, identifier: str) -> QueryError:
+    """The not-found error with nearest-name suggestions from existing projects.
+
+    Suggestions are computed over the full project-name list, which is safe
+    today because every project is listable by every caller (getProjects
+    discloses the same names). If per-project authorization is ever
+    introduced, the candidate list here must be filtered to the caller's
+    visible set first — otherwise nearest-name suggestions become a
+    project-enumeration channel that leaks names the caller may not list.
+    """
+    names = list((await session.execute(select(models.Project.name))).scalars())
+    error = project_not_found(identifier)
+    error.suggestions = get_close_matches(identifier, names, n=3)
+    return error
 
 
 def resolve_field(identifier: str) -> registry.ResolvedField:
@@ -802,6 +820,12 @@ class RowPlan:
             chosen.append(sorted_ids[index])
         return sorted(chosen)
 
+    @property
+    def observed_fields(self) -> list[registry.ObservedField]:
+        """The selected observed attribute fields, for admission checks
+        against the discovery sample."""
+        return [f for f in self._selected if isinstance(f, registry.ObservedField)]
+
     def rows_stmt_for_ids(self, ids: Sequence[int]) -> Select[Any]:
         """The one IN-list fetch of the sampled rows."""
         stmt = scoped_base(
@@ -964,6 +988,9 @@ class AggregatePlan:
     #: Whether the filter used annotation existence predicates; the tools
     #: disclose the any-annotator semantics structurally when it did.
     uses_annotation_filter: bool
+    #: Observed attribute fields the query references in breakdowns or
+    #: calculations, for admission checks against the discovery sample.
+    observed_fields: list[registry.ObservedField] = dataclass_field(default_factory=list)
 
 
 def compile_aggregate(
@@ -972,6 +999,7 @@ def compile_aggregate(
     dialect: SupportedSQLDialect,
 ) -> AggregatePlan:
     """Compile an aggregation into its three statements."""
+    observed_fields: dict[str, registry.ObservedField] = {}
     calculations: list[ResolvedCalculation] = []
     for index, calc in enumerate(query.calculations):
         spec = registry.AGGREGATIONS.get(calc.fn)
@@ -989,24 +1017,31 @@ def compile_aggregate(
             except QueryError as error:
                 error.path = error.path or f"calculations[{index}].field"
                 raise
-            if not resolved.aggregatable:
+            if not spec.presence and not resolved.aggregatable:
+                # Presence aggregations (count, count_distinct) never compute
+                # on the value, so they pass for any field; only value
+                # aggregations are gated on declared numeric semantics.
                 aggregatable = sorted(f.id for f in registry.AUTHORED_FIELDS if f.aggregatable)
+                reason = (
+                    " Cast semantics for arbitrary observed JSON paths are "
+                    "undefined, so value aggregation is limited to authored fields."
+                    if isinstance(resolved, registry.ObservedField)
+                    else ""
+                )
                 raise QueryError(
                     code="field_not_aggregatable",
                     path=f"calculations[{index}].field",
                     message=(
-                        f"{calc.field!r} is not aggregatable"
-                        + (
-                            " (observed attribute fields have undefined cast semantics "
-                            "for aggregation; typed aggregation is limited to authored "
-                            "fields)"
-                            if isinstance(resolved, registry.ObservedField)
-                            else ""
-                        )
-                        + f". Aggregatable fields: {', '.join(aggregatable)}."
+                        f"{calc.field!r} supports only presence aggregations (count, "
+                        "count_distinct), which count rows and distinct values without "
+                        "computing on them; value aggregations (sum, avg, min, max, "
+                        f"percentiles) require a value-aggregatable field.{reason} "
+                        f"Value-aggregatable fields: {', '.join(aggregatable)}."
                     ),
                     suggestions=aggregatable,
                 )
+            if isinstance(resolved, registry.ObservedField):
+                observed_fields[resolved.id] = resolved
             field_expr = resolved.expr(dialect)
         elif spec.requires_field:
             raise QueryError(
@@ -1053,6 +1088,8 @@ def compile_aggregate(
                 ),
                 suggestions=alternatives,
             )
+        if isinstance(resolved, registry.ObservedField):
+            observed_fields[resolved.id] = resolved
         breakdowns.append(
             ResolvedBreakdown(
                 id=resolved.id,
@@ -1151,4 +1188,5 @@ def compile_aggregate(
         share_basis=share_basis,
         project_gid=str(GlobalID("Project", str(project_rowid))),
         uses_annotation_filter=filter_.uses_annotations if filter_ else False,
+        observed_fields=list(observed_fields.values()),
     )

--- a/src/phoenix/server/mcp_span_analytics/compiler.py
+++ b/src/phoenix/server/mcp_span_analytics/compiler.py
@@ -1,0 +1,1154 @@
+"""Query compiler for the span analytics MCP tools.
+
+Turns validated request models into SQLAlchemy statements. Three invariants
+live here and nowhere else:
+
+- **Single scoping path.** Every statement is built by ``scoped_base``,
+  which joins spans to their project and binds the project row id and the
+  time window. No statement in this package is constructed outside it, so
+  an unscoped query is inexpressible rather than merely forbidden.
+- **One identifier namespace.** ``fields``, ``filter``, and ``breakdowns``
+  all resolve through ``resolve_field``: registry lookup first, then the
+  canonical-attribute-path parse, and only then a nearest-name error. Any
+  identifier discovery returns therefore works verbatim in every clause.
+- **Structured errors.** Semantic failures raise :class:`QueryError`, which
+  the tools render as a machine-readable error envelope
+  (``{status: "error", code, path, message, suggestions}``) instead of a
+  protocol-level exception that ends the caller's loop.
+"""
+
+from __future__ import annotations
+
+import ast
+import random
+import re
+from bisect import bisect_left
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from datetime import datetime, timedelta, timezone
+from difflib import get_close_matches
+from typing import Any, Literal, Mapping, Optional, Sequence, Union
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from sqlalchemy import Select, SQLColumnExpression, and_, exists, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.expression import ColumnElement
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.server.mcp_span_analytics import registry
+from phoenix.trace.dsl.filter import SpanFilter
+
+#: Row/group limits: the default is small enough to survey cheaply, the cap
+#: bounds what one call can pull. Oversized limits are clamped, not
+#: rejected — the applied value is echoed back.
+ROW_LIMIT_DEFAULT = 50
+ROW_LIMIT_MAX = 200
+AGGREGATE_LIMIT_DEFAULT = 50
+AGGREGATE_LIMIT_MAX = 200
+
+#: When a row query omits ``time_range``, it resolves to this many recent
+#: hours. An unbounded row scan must be a deliberate act, never an accident;
+#: the resolved window is always echoed back.
+ROW_WINDOW_DEFAULT_HOURS = 24
+
+#: Per-statement timeout applied on PostgreSQL via ``SET LOCAL``. SQLite has
+#: no equivalent in-scope backstop, and the tools say so rather than
+#: implying one.
+STATEMENT_TIMEOUT_MS = 30_000
+
+#: Ceiling on the id scan backing sample-ordered row queries.
+SAMPLE_ID_SCAN_CAP = 50_000
+
+#: Fields a row query returns when ``fields`` is omitted.
+DEFAULT_ROW_FIELDS: tuple[str, ...] = (
+    "span_id",
+    "trace_id",
+    "name",
+    "span_kind",
+    "status_code",
+    "start_time",
+    "latency_ms",
+)
+
+#: Names the filter grammar resolves to span columns rather than attribute
+#: paths. Used when scanning a filter's AST so that column references are
+#: not mistaken for attribute paths.
+_FILTER_COLUMN_NAMES: frozenset[str] = frozenset(
+    {
+        "span_id",
+        "trace_id",
+        "context",
+        "parent_id",
+        "span_kind",
+        "name",
+        "status_code",
+        "status_message",
+        "latency_ms",
+        "start_time",
+        "end_time",
+        "cumulative_llm_token_count_prompt",
+        "cumulative_llm_token_count_completion",
+        "cumulative_llm_token_count_total",
+    }
+)
+
+
+class QueryError(Exception):
+    """A semantic query failure, rendered as a structured error envelope."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        path: Optional[str] = None,
+        suggestions: Sequence[str] = (),
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.path = path
+        self.suggestions = list(suggestions)
+
+    def envelope(self) -> dict[str, Any]:
+        return {
+            "status": "error",
+            "code": self.code,
+            "path": self.path,
+            "message": self.message,
+            "suggestions": self.suggestions,
+        }
+
+
+# --------------------------------------------------------------------------
+# Request models
+# --------------------------------------------------------------------------
+
+
+class TimeRange(BaseModel):
+    """Half-open UTC time window over span start_time: start ≤ t < end."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    start: datetime = Field(
+        description=(
+            "Inclusive lower bound on span start_time, ISO-8601 "
+            "(e.g. '2026-07-22T00:00:00Z'). Naive timestamps are treated as UTC."
+        )
+    )
+    end: datetime = Field(
+        description="Exclusive upper bound on span start_time, ISO-8601.",
+    )
+
+
+class RowOrderField(BaseModel):
+    """One ordering entry of a row query."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str = Field(description="Field to order by; must be one of the selected fields.")
+    direction: Literal["asc", "desc"] = Field(
+        default="desc", description="Sort direction (default desc)."
+    )
+
+
+class SampleSpec(BaseModel):
+    """Seeded random sampling parameters."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    seed: int = Field(description="PRNG seed; the same seed returns the same rows.")
+
+
+class SampleOrder(BaseModel):
+    """Sample order mode: representative rows instead of extremes.
+
+    Ordering by an extreme (say latency desc) is biased by construction;
+    a seeded random sample answers "show me representative failures"
+    reproducibly. Deterministic given the seed; not pageable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    sample: SampleSpec = Field(description="Seeded sampling parameters.")
+
+
+class TimeBucket(BaseModel):
+    """A calculated breakdown grouping spans by hour of start_time (UTC)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    bucket: Literal["hour"] = Field(
+        description="Bucket granularity; only 'hour' is supported.",
+    )
+
+
+class Calculation(BaseModel):
+    """One named aggregate calculation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, description="Result column name for this calculation.")
+    fn: str = Field(
+        description=(
+            "Aggregation function: count, count_distinct, sum, avg, min, max, p50, p90, p95, p99."
+        )
+    )
+    field: Optional[str] = Field(
+        default=None,
+        description=(
+            "Field to aggregate. Required for every function except count; "
+            "count with a field counts rows where the field is non-NULL."
+        ),
+    )
+
+
+class AggregateOrderEntry(BaseModel):
+    """One ordering entry of an aggregate query.
+
+    References a declared calculation by name or a breakdown by field id
+    ('time_bucket' for the hour bucket) — exactly one of the two.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    calculation: Optional[str] = Field(
+        default=None, description="Name of a declared calculation to order by."
+    )
+    field: Optional[str] = Field(
+        default=None,
+        description="Breakdown field id to order by ('time_bucket' for the hour bucket).",
+    )
+    direction: Literal["asc", "desc"] = Field(
+        default="desc", description="Sort direction (default desc)."
+    )
+
+    @model_validator(mode="after")
+    def _exactly_one_reference(self) -> "AggregateOrderEntry":
+        if (self.calculation is None) == (self.field is None):
+            raise ValueError("order entries reference exactly one of 'calculation' or 'field'")
+        return self
+
+
+def _normalize_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _validate_time_range(time_range: TimeRange) -> TimeRange:
+    start = _normalize_utc(time_range.start)
+    end = _normalize_utc(time_range.end)
+    if not start < end:
+        raise QueryError(
+            code="invalid_time_range",
+            path="time_range",
+            message="time_range.start must be strictly before time_range.end.",
+        )
+    return TimeRange(start=start, end=end)
+
+
+class RowQuery(BaseModel):
+    """Validated request for a row retrieval."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project: str
+    time_range: Optional[TimeRange] = None
+    fields: Optional[list[str]] = None
+    filter: Optional[str] = None
+    order: Optional[Union[list[RowOrderField], SampleOrder]] = None
+    limit: int = ROW_LIMIT_DEFAULT
+    validate_only: bool = False
+
+    @model_validator(mode="after")
+    def _validate(self) -> "RowQuery":
+        if self.time_range is not None:
+            self.time_range = _validate_time_range(self.time_range)
+        if self.fields is not None and not self.fields:
+            raise QueryError(
+                code="invalid_request",
+                path="fields",
+                message="fields must be omitted or non-empty.",
+            )
+        return self
+
+
+class AggregateQuery(BaseModel):
+    """Validated request for an aggregation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project: str
+    time_range: TimeRange
+    filter: Optional[str] = None
+    calculations: list[Calculation]
+    breakdowns: list[Union[str, TimeBucket]] = Field(default_factory=list)
+    order: Optional[list[AggregateOrderEntry]] = None
+    limit: int = AGGREGATE_LIMIT_DEFAULT
+    validate_only: bool = False
+
+    @model_validator(mode="after")
+    def _validate(self) -> "AggregateQuery":
+        self.time_range = _validate_time_range(self.time_range)
+        if not self.calculations:
+            raise QueryError(
+                code="invalid_request",
+                path="calculations",
+                message="calculations must contain at least one entry.",
+            )
+        names = [c.name for c in self.calculations]
+        duplicates = sorted({n for n in names if names.count(n) > 1})
+        if duplicates:
+            raise QueryError(
+                code="invalid_request",
+                path="calculations",
+                message=f"calculation names must be unique; duplicated: {', '.join(duplicates)}.",
+            )
+        return self
+
+
+# --------------------------------------------------------------------------
+# Resolution
+# --------------------------------------------------------------------------
+
+
+async def resolve_project_rowid(session: AsyncSession, identifier: str) -> Optional[int]:
+    """Resolve a project by id or name to its row id.
+
+    Accepts either form because neighboring tools emit both; a caller
+    should never have to convert an identifier another tool just returned.
+    Both forms produce the same ``None`` for a missing project, so neither
+    is an existence oracle.
+    """
+    try:
+        global_id = GlobalID.from_id(identifier)
+        type_name, node_id = global_id.type_name, int(global_id.node_id)
+    except Exception:
+        pass
+    else:
+        if type_name == "Project":
+            rowid: Optional[int] = await session.scalar(
+                select(models.Project.id).where(models.Project.id == node_id)
+            )
+            return rowid
+        return None
+    by_name: Optional[int] = await session.scalar(
+        select(models.Project.id).where(models.Project.name == identifier)
+    )
+    return by_name
+
+
+def project_not_found(identifier: str) -> QueryError:
+    """The not-found error, identical for id and name forms."""
+    return QueryError(
+        code="project_not_found",
+        path="project",
+        message=f"Project {identifier!r} not found.",
+    )
+
+
+def resolve_field(identifier: str) -> registry.ResolvedField:
+    """Resolve one identifier: registry, then attribute path, then error."""
+    if authored := registry.AUTHORED_BY_ID.get(identifier):
+        return authored
+    if identifier in registry.RESERVED_UNEXPOSED:
+        raise QueryError(
+            code="field_not_exposed",
+            message=(
+                f"{identifier!r} is a span column the filter grammar knows but this surface "
+                "does not expose as a field. Use describeSpans to list available fields."
+            ),
+            suggestions=get_close_matches(identifier, registry.AUTHORED_BY_ID.keys(), n=3),
+        )
+    if re.match(r"^\s*(evals|annotations)\b", identifier):
+        # Annotation *values* stay out of fields/breakdowns/calculations:
+        # several annotators can score one span under one name, so
+        # projecting or aggregating the value needs a declared reduction
+        # this surface does not implement. The refusal carries its route.
+        raise QueryError(
+            code="annotation_values_not_supported",
+            message=(
+                f"{identifier!r} cannot be selected, grouped, or aggregated: a span "
+                "can carry several annotation rows under one name, so value use "
+                "requires declared reduction semantics. Decomposition: fetch rows "
+                "with querySpanRows, then call listSpanAnnotationsBySpanIds with "
+                "the returned span_ids and filter or aggregate client-side. "
+                "Annotation *filters* are supported, e.g. "
+                "\"evals['correctness'].score < 0.5\"."
+            ),
+            suggestions=["listSpanAnnotationsBySpanIds"],
+        )
+    keys = registry.parse_attribute_path(identifier)
+    if keys is not None and keys[0] not in ("evals", "annotations"):
+        # A bare name that closely resembles an authored field id is far
+        # more likely a misspelling than a real top-level attribute; the
+        # subscript spelling remains the unambiguous way to reference a
+        # genuinely so-named attribute.
+        if (
+            len(keys) == 1
+            and identifier.strip() == keys[0]
+            and registry.bare_name_conflicts(keys[0])
+        ):
+            close = get_close_matches(keys[0], registry.AUTHORED_BY_ID.keys(), n=3)
+            raise QueryError(
+                code="unknown_field",
+                message=(
+                    f"Field {identifier!r} does not exist."
+                    + (f" Did you mean: {', '.join(close)}?" if close else "")
+                    + f" To read a literal top-level attribute named {identifier!r}, "
+                    f'spell it attributes["{keys[0]}"].'
+                ),
+                suggestions=[*close, f'attributes["{keys[0]}"]'],
+            )
+        return registry.ObservedField(id=identifier, keys=keys)
+    suggestions = get_close_matches(identifier, registry.AUTHORED_BY_ID.keys(), n=3)
+    hint = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
+    raise QueryError(
+        code="unknown_field",
+        message=f"Field {identifier!r} does not exist.{hint}",
+        suggestions=suggestions,
+    )
+
+
+# --------------------------------------------------------------------------
+# Filter validation
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AnnotationPredicate:
+    """One annotation existence test: name plus a score or label comparison.
+
+    Compiled as an EXISTS subquery against ``span_annotations``, which is
+    what makes annotation *filtering* safe where annotation *aggregation*
+    is not: an existence test never multiplies span rows, no matter how
+    many annotation rows match, so counts and sums over the filtered spans
+    stay correct under annotation multiplicity. The semantics are
+    any-annotator — the predicate is true if any annotation row with the
+    name matches — and are disclosed structurally in the envelope.
+    """
+
+    name: str
+    attribute: Literal["score", "label"]
+    op: str
+    value: Union[float, str]
+
+    def clause(self) -> ColumnElement[bool]:
+        column: SQLColumnExpression[Any] = (
+            models.SpanAnnotation.score
+            if self.attribute == "score"
+            else models.SpanAnnotation.label
+        )
+        comparisons: dict[str, ColumnElement[bool]] = {
+            "<": column < self.value,
+            "<=": column <= self.value,
+            ">": column > self.value,
+            ">=": column >= self.value,
+            "==": column == self.value,
+            "!=": column != self.value,
+        }
+        return exists().where(
+            and_(
+                models.SpanAnnotation.span_rowid == models.Span.id,
+                models.SpanAnnotation.name == self.name,
+                comparisons[self.op],
+            )
+        )
+
+
+@dataclass(frozen=True)
+class CompiledFilter:
+    """A validated filter: the residual grammar expression plus any
+    annotation existence predicates split out for EXISTS compilation."""
+
+    span_filter: Optional[SpanFilter]
+    annotation_predicates: list[AnnotationPredicate]
+
+    @property
+    def uses_annotations(self) -> bool:
+        return bool(self.annotation_predicates)
+
+    def __call__(self, stmt: Select[Any]) -> Select[Any]:
+        if self.span_filter is not None:
+            stmt = self.span_filter(stmt)
+        for predicate in self.annotation_predicates:
+            stmt = stmt.where(predicate.clause())
+        return stmt
+
+
+def validated_filter(condition: Optional[str]) -> Optional[CompiledFilter]:
+    """Validate and compile a filter expression, enforcing surface rules.
+
+    Annotation references get special treatment: a simple comparison of
+    ``evals['name'].score`` / ``.label`` appearing as a top-level AND
+    conjunct compiles to an EXISTS predicate (safe under annotation
+    multiplicity — see :class:`AnnotationPredicate`); any other annotation
+    use is rejected with the supported shape and the two-call
+    decomposition. Beyond that, temporal predicates are rejected (temporal
+    scope has exactly one home, the ``time_range`` parameter), as are
+    computed-field names the grammar would silently misread.
+    """
+    if not condition:
+        return None
+    try:
+        root = ast.parse(condition, mode="eval")
+    except SyntaxError as error:
+        raise QueryError(
+            code="invalid_filter",
+            path="filter",
+            message=f"Invalid filter expression: {error.msg}.",
+        )
+    conjuncts = (
+        list(root.body.values)
+        if isinstance(root.body, ast.BoolOp) and isinstance(root.body.op, ast.And)
+        else [root.body]
+    )
+    residual_parts: list[str] = []
+    predicates: list[AnnotationPredicate] = []
+    for conjunct in conjuncts:
+        predicate = _annotation_predicate(conjunct)
+        if predicate is not None:
+            predicates.append(predicate)
+            continue
+        _reject_unsupported_filter_nodes(conjunct)
+        residual_parts.append(ast.unparse(conjunct))
+    span_filter: Optional[SpanFilter] = None
+    if residual_parts:
+        try:
+            span_filter = SpanFilter(" and ".join(residual_parts))
+        except SyntaxError as error:
+            raise QueryError(
+                code="invalid_filter",
+                path="filter",
+                message=f"Invalid filter expression: {error}.",
+            )
+    return CompiledFilter(span_filter=span_filter, annotation_predicates=predicates)
+
+
+_ANNOTATION_COMPARE_OPS: Mapping[type, str] = {
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+    ast.Eq: "==",
+    ast.NotEq: "!=",
+}
+
+_MIRRORED_OPS: Mapping[str, str] = {
+    "<": ">",
+    "<=": ">=",
+    ">": "<",
+    ">=": "<=",
+    "==": "==",
+    "!=": "!=",
+}
+
+
+def _annotation_reference(node: ast.expr) -> Optional[tuple[str, str]]:
+    """(annotation name, attribute) for ``evals['x'].score``-shaped nodes."""
+    if not (isinstance(node, ast.Attribute) and node.attr in ("score", "label")):
+        return None
+    subscript = node.value
+    if not (
+        isinstance(subscript, ast.Subscript)
+        and isinstance(subscript.value, ast.Name)
+        and subscript.value.id in ("evals", "annotations")
+        and isinstance(subscript.slice, ast.Constant)
+        and isinstance(subscript.slice.value, str)
+    ):
+        return None
+    return subscript.slice.value, node.attr
+
+
+def _annotation_predicate(node: ast.expr) -> Optional["AnnotationPredicate"]:
+    """Recognize one supported annotation comparison, either operand order:
+    ``evals['name'].score <op> <number>`` or ``evals['name'].label ==/!= <string>``.
+    """
+    if not (isinstance(node, ast.Compare) and len(node.ops) == 1):
+        return None
+    op_symbol = _ANNOTATION_COMPARE_OPS.get(type(node.ops[0]))
+    if op_symbol is None:
+        return None
+    left, right = node.left, node.comparators[0]
+    reference = _annotation_reference(left)
+    constant = right
+    if reference is None:
+        reference = _annotation_reference(right)
+        constant = left
+        op_symbol = _MIRRORED_OPS[op_symbol]
+    if reference is None or not isinstance(constant, ast.Constant):
+        return None
+    name, attribute = reference
+    value = constant.value
+    if attribute == "score":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return AnnotationPredicate(name=name, attribute="score", op=op_symbol, value=float(value))
+    if op_symbol in ("==", "!=") and isinstance(value, str):
+        return AnnotationPredicate(name=name, attribute="label", op=op_symbol, value=value)
+    return None
+
+
+def _reject_unsupported_filter_nodes(tree: ast.AST) -> None:
+    """Structured rejections for names the residual filter must not reach."""
+    for node in ast.walk(tree):
+        # Computed dotted fields would otherwise compile as lookups of
+        # nonexistent attributes and silently match nothing.
+        if isinstance(node, ast.Attribute) and ast.unparse(node) in (
+            "input.chars",
+            "input.turns",
+        ):
+            raise QueryError(
+                code="field_not_filterable",
+                path="filter",
+                message=(
+                    f"{ast.unparse(node)} is a computed field, select-and-aggregate "
+                    "only: the filter grammar reads attribute paths, not computed "
+                    "expressions. Filter on recorded attributes (e.g. input.value "
+                    "content) instead."
+                ),
+                suggestions=["input.value"],
+            )
+        if not isinstance(node, ast.Name):
+            continue
+        if node.id in ("start_time", "end_time"):
+            raise QueryError(
+                code="temporal_filter",
+                path="filter",
+                message=(
+                    f"Temporal predicates ({node.id}) are not allowed in filter; "
+                    "temporal scope has exactly one home, the time_range parameter."
+                ),
+                suggestions=["time_range"],
+            )
+        if node.id in ("evals", "annotations"):
+            raise QueryError(
+                code="unsupported_filter_reference",
+                path="filter",
+                message=(
+                    f"{node.id}[...] filters are supported only as simple top-level "
+                    "AND conditions comparing .score to a number or .label to a "
+                    "string (e.g. \"evals['correctness'].score < 0.5\"); nested or "
+                    "composite annotation expressions are not. For anything richer, "
+                    "fetch rows with querySpanRows, then call "
+                    "listSpanAnnotationsBySpanIds with the returned span_ids and "
+                    "filter client-side."
+                ),
+                suggestions=["evals['correctness'].score < 0.5"],
+            )
+        if node.id == "is_error":
+            raise QueryError(
+                code="field_not_filterable",
+                path="filter",
+                message=(
+                    "is_error is aggregate-only. Filter failures with "
+                    "\"status_code == 'ERROR'\" instead."
+                ),
+                suggestions=["status_code == 'ERROR'"],
+            )
+        if node.id == "cost":
+            # Without this guard, "cost.total" in a filter would compile as
+            # a lookup of a (nonexistent) "cost" attribute and silently
+            # match nothing — the silent-wrong failure this surface exists
+            # to prevent.
+            raise QueryError(
+                code="field_not_filterable",
+                path="filter",
+                message=(
+                    "cost.total is select-and-aggregate only: the filter grammar has no "
+                    "cost predicate on this surface. Select cost.total and inspect rows, "
+                    "aggregate it, or filter on llm.token_count.total instead."
+                ),
+                suggestions=["llm.token_count.total"],
+            )
+
+
+def attribute_paths_in_filter(condition: str) -> set[tuple[str, ...]]:
+    """Attribute paths a filter references, for zero-result diagnosis."""
+    try:
+        root = ast.parse(condition, mode="eval")
+    except SyntaxError:
+        return set()
+    paths: set[tuple[str, ...]] = set()
+
+    def visit(node: ast.AST) -> None:
+        if isinstance(node, ast.Name) and node.id in _FILTER_COLUMN_NAMES:
+            return
+        # Annotation references are predicates against their own table, not
+        # attribute paths; they must not feed path_not_observed diagnosis.
+        if isinstance(node, ast.Name) and node.id in ("evals", "annotations"):
+            return
+        if isinstance(node, (ast.Name, ast.Attribute, ast.Subscript)):
+            keys = registry.parse_attribute_path(ast.unparse(node))
+            if keys is not None and keys[0] not in _FILTER_COLUMN_NAMES:
+                paths.add(keys)
+                return
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+
+    visit(root.body)
+    return paths
+
+
+# --------------------------------------------------------------------------
+# Scoped statement base
+# --------------------------------------------------------------------------
+
+
+def scoped_base(
+    columns: Sequence[Any],
+    project_rowid: int,
+    time_range: Optional[TimeRange],
+) -> Select[Any]:
+    """The single statement base: spans joined to traces, bound to one
+    project, restricted to the time window. Deliberately carries no
+    ordering — aggregates must not inherit row ordering, and PostgreSQL
+    rejects ordering by ungrouped columns.
+    """
+    stmt: Select[Any] = (
+        select(*columns)
+        .select_from(models.Span)
+        .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+        .where(models.Trace.project_rowid == project_rowid)
+    )
+    if time_range is not None:
+        stmt = stmt.where(
+            models.Span.start_time >= time_range.start,
+            models.Span.start_time < time_range.end,
+        )
+    return stmt
+
+
+async def apply_statement_timeout(
+    session: AsyncSession, dialect: SupportedSQLDialect
+) -> Optional[int]:
+    """Bound statement runtime on PostgreSQL for the current transaction.
+
+    Returns the applied timeout in milliseconds, or ``None`` on SQLite,
+    which has no equivalent per-statement backstop.
+    """
+    if dialect is SupportedSQLDialect.POSTGRESQL:
+        await session.execute(text(f"SET LOCAL statement_timeout = {STATEMENT_TIMEOUT_MS}"))
+        return STATEMENT_TIMEOUT_MS
+    return None
+
+
+# --------------------------------------------------------------------------
+# Row compilation
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ColumnSpec:
+    """Typed metadata for one result column."""
+
+    id: str
+    type: str
+    unit: Optional[str] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "type": self.type, "unit": self.unit}
+
+
+@dataclass
+class RowPlan:
+    """Compiled row query: statements plus the metadata the envelope needs."""
+
+    columns: list[ColumnSpec]
+    time_range: TimeRange
+    time_range_defaulted: bool
+    applied_limit: int
+    sample: Optional[SampleSpec]
+    stmt: Optional[Select[Any]]
+    #: Sample mode: the bounded id scan feeding the seeded probe.
+    ids_stmt: Optional[Select[Any]]
+    _project_rowid: int = dataclass_field(default=0, repr=False)
+    _selected: list[registry.ResolvedField] = dataclass_field(default_factory=list, repr=False)
+    _filter: Optional[CompiledFilter] = dataclass_field(default=None, repr=False)
+    uses_annotation_filter: bool = False
+    _dialect: SupportedSQLDialect = dataclass_field(default=SupportedSQLDialect.SQLITE, repr=False)
+
+    def choose_sample_ids(self, ids: Sequence[int]) -> list[int]:
+        """Choose up to ``applied_limit`` ids by seeded rowid probing.
+
+        The PRNG draws candidate ids in ``[min(id), max(id)]``; each probe
+        seeks forward to the first not-yet-chosen existing id. Deterministic
+        given the seed and the id set; not pageable.
+        """
+        assert self.sample is not None
+        sorted_ids = sorted(ids)
+        if not sorted_ids:
+            return []
+        rng = random.Random(self.sample.seed)
+        chosen: list[int] = []
+        chosen_set: set[int] = set()
+        max_attempts = self.applied_limit * 20
+        attempts = 0
+        while (
+            len(chosen) < self.applied_limit
+            and len(chosen) < len(sorted_ids)
+            and attempts < max_attempts
+        ):
+            attempts += 1
+            probe = rng.randint(sorted_ids[0], sorted_ids[-1])
+            index = bisect_left(sorted_ids, probe)
+            while index < len(sorted_ids) and sorted_ids[index] in chosen_set:
+                index += 1
+            if index == len(sorted_ids):
+                continue
+            chosen_set.add(sorted_ids[index])
+            chosen.append(sorted_ids[index])
+        return sorted(chosen)
+
+    def rows_stmt_for_ids(self, ids: Sequence[int]) -> Select[Any]:
+        """The one IN-list fetch of the sampled rows."""
+        stmt = scoped_base(
+            [f.expr(self._dialect).label(f.id) for f in self._selected],
+            self._project_rowid,
+            self.time_range,
+        ).where(models.Span.id.in_(list(ids)))
+        if self._filter is not None:
+            stmt = self._filter(stmt)
+        return stmt.order_by(models.Span.id.asc())
+
+
+def _column_spec(resolved: registry.ResolvedField) -> ColumnSpec:
+    if isinstance(resolved, registry.AuthoredField):
+        return ColumnSpec(id=resolved.id, type=resolved.type, unit=resolved.unit)
+    return ColumnSpec(id=resolved.id, type="json", unit=None)
+
+
+def compile_rows(
+    query: RowQuery,
+    project_rowid: int,
+    dialect: SupportedSQLDialect,
+    now: Optional[datetime] = None,
+) -> RowPlan:
+    """Compile a row query into an ordered, bounded statement."""
+    now = now or datetime.now(timezone.utc)
+    if query.time_range is not None:
+        time_range, defaulted = query.time_range, False
+    else:
+        time_range = TimeRange(start=now - timedelta(hours=ROW_WINDOW_DEFAULT_HOURS), end=now)
+        defaulted = True
+
+    field_ids = list(query.fields) if query.fields else list(DEFAULT_ROW_FIELDS)
+    # Row identity is implicit: span_id is always included whether or not it
+    # was selected, so every row can be recovered in full via getSpan.
+    if "span_id" not in field_ids:
+        field_ids.insert(0, "span_id")
+    selected: list[registry.ResolvedField] = []
+    seen: set[str] = set()
+    for index, field_id in enumerate(field_ids):
+        try:
+            resolved = resolve_field(field_id)
+        except QueryError as error:
+            error.path = error.path or f"fields[{index}]"
+            raise
+        if resolved.id not in seen:
+            seen.add(resolved.id)
+            selected.append(resolved)
+
+    filter_ = validated_filter(query.filter)
+    applied_limit = max(1, min(query.limit, ROW_LIMIT_MAX))
+    columns = [_column_spec(f) for f in selected]
+
+    if isinstance(query.order, SampleOrder):
+        ids_stmt = scoped_base([models.Span.id], project_rowid, time_range)
+        if filter_ is not None:
+            ids_stmt = filter_(ids_stmt)
+        ids_stmt = ids_stmt.order_by(models.Span.id.asc()).limit(SAMPLE_ID_SCAN_CAP)
+        return RowPlan(
+            columns=columns,
+            time_range=time_range,
+            time_range_defaulted=defaulted,
+            applied_limit=applied_limit,
+            sample=query.order.sample,
+            stmt=None,
+            ids_stmt=ids_stmt,
+            _project_rowid=project_rowid,
+            _selected=selected,
+            _filter=filter_,
+            _dialect=dialect,
+            uses_annotation_filter=filter_.uses_annotations if filter_ else False,
+        )
+
+    order_exprs: list[ColumnElement[Any]] = []
+    if query.order:
+        by_id = {f.id: f for f in selected}
+        for index, entry in enumerate(query.order):
+            resolved_order = by_id.get(entry.field)
+            if resolved_order is None:
+                raise QueryError(
+                    code="invalid_order",
+                    path=f"order[{index}].field",
+                    message=(
+                        f"order references {entry.field!r}, which is not among the selected "
+                        "fields; add it to fields or order by a selected field."
+                    ),
+                    suggestions=get_close_matches(entry.field, by_id.keys(), n=3),
+                )
+            expr = resolved_order.expr(dialect)
+            # NULL placement is declared, not inherited: the backends
+            # disagree by default (PostgreSQL puts NULLs first on DESC,
+            # SQLite last), and a nullable ordering field (guarded numeric
+            # extraction, cost) would return backend-dependent row order.
+            # NULLs always sort last — values are what an ordering asks for.
+            order_exprs.append(
+                expr.desc().nulls_last() if entry.direction == "desc" else expr.asc().nulls_last()
+            )
+    else:
+        order_exprs.append(models.Span.start_time.desc())
+    # Deterministic tie-break: the primary key ends every ordering.
+    order_exprs.append(models.Span.id.asc())
+
+    stmt = scoped_base([f.expr(dialect).label(f.id) for f in selected], project_rowid, time_range)
+    if filter_ is not None:
+        stmt = filter_(stmt)
+    stmt = stmt.order_by(*order_exprs).limit(applied_limit)
+    return RowPlan(
+        columns=columns,
+        time_range=time_range,
+        time_range_defaulted=defaulted,
+        applied_limit=applied_limit,
+        sample=None,
+        stmt=stmt,
+        ids_stmt=None,
+        _project_rowid=project_rowid,
+        _selected=selected,
+        _filter=filter_,
+        _dialect=dialect,
+        uses_annotation_filter=filter_.uses_annotations if filter_ else False,
+    )
+
+
+# --------------------------------------------------------------------------
+# Aggregate compilation
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResolvedCalculation:
+    name: str
+    fn: str
+    additive: bool
+    expr: ColumnElement[Any]
+
+
+@dataclass(frozen=True)
+class ResolvedBreakdown:
+    id: str
+    expr: SQLColumnExpression[Any]
+    is_time_bucket: bool
+    column: ColumnSpec
+
+
+@dataclass
+class AggregatePlan:
+    """Compiled aggregation: the grouped top-K statement, the explicit
+    group-count statement, and the ungrouped overall-totals statement."""
+
+    calculations: list[ResolvedCalculation]
+    breakdowns: list[ResolvedBreakdown]
+    stmt: Select[Any]
+    groups_total_stmt: Optional[Select[Any]]
+    overall_stmt: Select[Any]
+    applied_limit: int
+    time_range: TimeRange
+    share_basis: Optional[str]
+    #: The project's relay GlobalID — the identifier the UI's routes use —
+    #: resolved once here so every group row can carry a cohort deep link.
+    project_gid: str
+    #: Whether the filter used annotation existence predicates; the tools
+    #: disclose the any-annotator semantics structurally when it did.
+    uses_annotation_filter: bool
+
+
+def compile_aggregate(
+    query: AggregateQuery,
+    project_rowid: int,
+    dialect: SupportedSQLDialect,
+) -> AggregatePlan:
+    """Compile an aggregation into its three statements."""
+    calculations: list[ResolvedCalculation] = []
+    for index, calc in enumerate(query.calculations):
+        spec = registry.AGGREGATIONS.get(calc.fn)
+        if spec is None:
+            raise QueryError(
+                code="unknown_aggregation",
+                path=f"calculations[{index}].fn",
+                message=f"Unknown aggregation {calc.fn!r}.",
+                suggestions=get_close_matches(calc.fn, registry.AGGREGATIONS.keys(), n=3),
+            )
+        field_expr: Optional[SQLColumnExpression[Any]] = None
+        if calc.field is not None:
+            try:
+                resolved = resolve_field(calc.field)
+            except QueryError as error:
+                error.path = error.path or f"calculations[{index}].field"
+                raise
+            if not resolved.aggregatable:
+                aggregatable = sorted(f.id for f in registry.AUTHORED_FIELDS if f.aggregatable)
+                raise QueryError(
+                    code="field_not_aggregatable",
+                    path=f"calculations[{index}].field",
+                    message=(
+                        f"{calc.field!r} is not aggregatable"
+                        + (
+                            " (observed attribute fields have undefined cast semantics "
+                            "for aggregation; typed aggregation is limited to authored "
+                            "fields)"
+                            if isinstance(resolved, registry.ObservedField)
+                            else ""
+                        )
+                        + f". Aggregatable fields: {', '.join(aggregatable)}."
+                    ),
+                    suggestions=aggregatable,
+                )
+            field_expr = resolved.expr(dialect)
+        elif spec.requires_field:
+            raise QueryError(
+                code="invalid_request",
+                path=f"calculations[{index}].field",
+                message=f"Aggregation {calc.fn!r} requires a field.",
+            )
+        calculations.append(
+            ResolvedCalculation(
+                name=calc.name,
+                fn=calc.fn,
+                additive=spec.additive,
+                expr=registry.aggregation_expr(calc.fn, field_expr, dialect),
+            )
+        )
+
+    breakdowns: list[ResolvedBreakdown] = []
+    for index, breakdown in enumerate(query.breakdowns):
+        if isinstance(breakdown, TimeBucket):
+            breakdowns.append(
+                ResolvedBreakdown(
+                    id=registry.TIME_BUCKET_ID,
+                    expr=registry.time_bucket_expr(dialect),
+                    is_time_bucket=True,
+                    column=ColumnSpec(id=registry.TIME_BUCKET_ID, type="datetime"),
+                )
+            )
+            continue
+        try:
+            resolved = resolve_field(breakdown)
+        except QueryError as error:
+            error.path = error.path or f"breakdowns[{index}]"
+            raise
+        if not resolved.groupable:
+            groupable = sorted(f.id for f in registry.AUTHORED_FIELDS if f.groupable)
+            alternatives = [*groupable, '{"bucket": "hour"} (hourly time bucket)']
+            raise QueryError(
+                code="field_not_groupable",
+                path=f"breakdowns[{index}]",
+                message=(
+                    f"{breakdown!r} cannot be used as a breakdown: grouping is limited to "
+                    "declared-groupable fields to keep group cardinality bounded. "
+                    f"Alternatives: {', '.join(alternatives)}."
+                ),
+                suggestions=alternatives,
+            )
+        breakdowns.append(
+            ResolvedBreakdown(
+                id=resolved.id,
+                expr=resolved.expr(dialect),
+                is_time_bucket=False,
+                column=_column_spec(resolved),
+            )
+        )
+    breakdown_ids = [b.id for b in breakdowns]
+    if len(set(breakdown_ids)) != len(breakdown_ids):
+        raise QueryError(
+            code="invalid_request",
+            path="breakdowns",
+            message="breakdowns must not repeat.",
+        )
+
+    order_exprs: list[ColumnElement[Any]] = []
+    ordered_breakdown_ids: set[str] = set()
+    if query.order:
+        calc_by_name = {c.name: c for c in calculations}
+        breakdown_by_id = {b.id: b for b in breakdowns}
+        for index, entry in enumerate(query.order):
+            if entry.calculation is not None:
+                calc_ref = calc_by_name.get(entry.calculation)
+                if calc_ref is None:
+                    raise QueryError(
+                        code="invalid_order",
+                        path=f"order[{index}].calculation",
+                        message=(
+                            f"order[{index}].calculation references no declared calculation: "
+                            f"{entry.calculation!r}."
+                        ),
+                        suggestions=get_close_matches(entry.calculation, calc_by_name.keys(), n=3),
+                    )
+                expr: SQLColumnExpression[Any] = calc_ref.expr
+            else:
+                assert entry.field is not None
+                breakdown_ref = breakdown_by_id.get(entry.field)
+                if breakdown_ref is None:
+                    raise QueryError(
+                        code="invalid_order",
+                        path=f"order[{index}].field",
+                        message=(
+                            f"order[{index}].field references no declared breakdown: "
+                            f"{entry.field!r}."
+                        ),
+                        suggestions=get_close_matches(entry.field, breakdown_by_id.keys(), n=3),
+                    )
+                expr = breakdown_ref.expr
+                ordered_breakdown_ids.add(breakdown_ref.id)
+            # Declared NULL placement, as in row ordering: backends disagree
+            # on the default, so NULL calculation values and null group keys
+            # always sort last.
+            order_exprs.append(
+                expr.desc().nulls_last() if entry.direction == "desc" else expr.asc().nulls_last()
+            )
+    # Breakdown keys always terminate the ordering (default order when no
+    # explicit order was given): group results are deterministic and ties
+    # at the limit boundary break reproducibly.
+    for breakdown_entry in breakdowns:
+        if breakdown_entry.id not in ordered_breakdown_ids:
+            order_exprs.append(breakdown_entry.expr.asc())
+
+    filter_ = validated_filter(query.filter)
+    applied_limit = max(1, min(query.limit, AGGREGATE_LIMIT_MAX))
+
+    select_columns: list[Any] = [b.expr.label(b.id) for b in breakdowns]
+    select_columns.extend(c.expr.label(c.name) for c in calculations)
+    stmt = scoped_base(select_columns, project_rowid, query.time_range)
+    if filter_ is not None:
+        stmt = filter_(stmt)
+    grouped = stmt.group_by(*(b.expr for b in breakdowns)) if breakdowns else stmt
+    final_stmt = grouped.order_by(*order_exprs).limit(applied_limit) if breakdowns else grouped
+
+    groups_total_stmt: Optional[Select[Any]] = None
+    if breakdowns:
+        from sqlalchemy import func as sqla_func
+
+        groups_total_stmt = select(sqla_func.count()).select_from(grouped.subquery())
+
+    overall_stmt = scoped_base(
+        [c.expr.label(c.name) for c in calculations], project_rowid, query.time_range
+    )
+    if filter_ is not None:
+        overall_stmt = filter_(overall_stmt)
+
+    share_basis = next((c.name for c in calculations if c.additive), None)
+    return AggregatePlan(
+        calculations=calculations,
+        breakdowns=breakdowns,
+        stmt=final_stmt,
+        groups_total_stmt=groups_total_stmt,
+        overall_stmt=overall_stmt,
+        applied_limit=applied_limit,
+        time_range=query.time_range,
+        share_basis=share_basis,
+        project_gid=str(GlobalID("Project", str(project_rowid))),
+        uses_annotation_filter=filter_.uses_annotations if filter_ else False,
+    )

--- a/src/phoenix/server/mcp_span_analytics/compiler.py
+++ b/src/phoenix/server/mcp_span_analytics/compiler.py
@@ -4,13 +4,16 @@ Turns validated request models into SQLAlchemy statements. Three invariants
 live here and nowhere else:
 
 - **Single scoping path.** Every statement is built by ``scoped_base``,
-  which joins spans to their project and binds the project row id and the
-  time window. No statement in this package is constructed outside it, so
-  an unscoped query is inexpressible rather than merely forbidden.
-- **One identifier namespace.** ``fields``, ``filter``, and ``breakdowns``
-  all resolve through ``resolve_field``: registry lookup first, then the
-  canonical-attribute-path parse, and only then a nearest-name error. Any
-  identifier discovery returns therefore works verbatim in every clause.
+  which delegates to the grain's own scope: the project row id and the time
+  window are bound there and only there. No statement in this package is
+  constructed outside it, so an unscoped query is inexpressible rather than
+  merely forbidden.
+- **One identifier namespace per grain.** ``fields``, ``filter``, and
+  ``breakdowns`` all resolve through ``resolve_field`` against the grain
+  the request names: grain lookup first, then — on the spans grain only —
+  annotation enrichment and the canonical-attribute-path parse, and only
+  then a nearest-name error. Any identifier discovery returns for a grain
+  therefore works verbatim in every clause of a query on that grain.
 - **Structured errors.** Semantic failures raise :class:`QueryError`, which
   the tools render as a machine-readable error envelope
   (``{status: "error", code, path, message, suggestions}``) instead of a
@@ -27,17 +30,18 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from datetime import datetime, timedelta, timezone
 from difflib import get_close_matches
-from typing import Any, Literal, Mapping, Optional, Sequence, Union
+from typing import Any, Iterable, Literal, Mapping, Optional, Sequence, Union, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-from sqlalchemy import Select, SQLColumnExpression, and_, exists, select, text
+from sqlalchemy import Select, SQLColumnExpression, and_, exists, not_, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.expression import ColumnElement
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
-from phoenix.server.mcp_span_analytics import registry
+from phoenix.server.mcp_span_analytics import grains, registry
+from phoenix.server.mcp_span_analytics.grains import Grain
 from phoenix.trace.dsl.filter import SpanFilter
 
 #: Row/group limits: the default is small enough to survey cheaply, the cap
@@ -251,12 +255,41 @@ def _validate_time_range(time_range: TimeRange) -> TimeRange:
     return TimeRange(start=start, end=end)
 
 
+def resolve_grain(identifier: Optional[str]) -> Grain:
+    """Resolve the grain a request names, defaulting to spans.
+
+    A wrong grain is a wrong question, not a wrong spelling, so the
+    rejection says what each grain's rows *are* rather than only listing
+    names.
+    """
+    if identifier is None:
+        return grains.SPANS_GRAIN
+    grain = grains.GRAINS.get(identifier)
+    if grain is not None:
+        return grain
+    raise QueryError(
+        code="unknown_grain",
+        path="from",
+        message=(
+            f"Unknown grain {identifier!r}. Available: "
+            + "; ".join(
+                f"{g.id} ({g.label.lower()}: {g.description})" for g in grains.GRAINS.values()
+            )
+        ),
+        suggestions=[
+            *get_close_matches(identifier, grains.GRAINS.keys(), n=2),
+            *grains.GRAINS.keys(),
+        ],
+    )
+
+
 class RowQuery(BaseModel):
     """Validated request for a row retrieval."""
 
     model_config = ConfigDict(extra="forbid")
 
     project: str
+    grain: str = grains.SPANS
     time_range: Optional[TimeRange] = None
     fields: Optional[list[str]] = None
     filter: Optional[str] = None
@@ -266,6 +299,7 @@ class RowQuery(BaseModel):
 
     @model_validator(mode="after")
     def _validate(self) -> "RowQuery":
+        resolve_grain(self.grain)
         if self.time_range is not None:
             self.time_range = _validate_time_range(self.time_range)
         if self.fields is not None and not self.fields:
@@ -283,6 +317,7 @@ class AggregateQuery(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     project: str
+    grain: str = grains.SPANS
     time_range: TimeRange
     filter: Optional[str] = None
     calculations: list[Calculation]
@@ -293,6 +328,7 @@ class AggregateQuery(BaseModel):
 
     @model_validator(mode="after")
     def _validate(self) -> "AggregateQuery":
+        resolve_grain(self.grain)
         self.time_range = _validate_time_range(self.time_range)
         if not self.calculations:
             raise QueryError(
@@ -367,10 +403,97 @@ async def project_not_found_error(session: AsyncSession, identifier: str) -> Que
     return error
 
 
-def resolve_field(identifier: str) -> registry.ResolvedField:
-    """Resolve one identifier: registry, then attribute path, then error."""
-    if authored := registry.AUTHORED_BY_ID.get(identifier):
+def _resolve_annotation_enrichment(identifier: str, grain: Grain) -> registry.AuthoredField:
+    """Resolve one annotation enrichment identifier on the spans grain.
+
+    The reference has parsed; what remains is whether its attribute and
+    annotator kind are ones the registry defines. Both rejections are
+    field-anchored and name the legal values, because an agent that guessed
+    ``.value`` or ``"human"`` is one correction away from a working query.
+    """
+    reference = registry.parse_annotation_field(identifier)
+    assert reference is not None
+    if not grain.admits_annotation_enrichment:
+        raise QueryError(
+            code="field_not_on_grain",
+            message=(
+                f"{identifier!r} is a spans-grain enrichment: it reduces a span's "
+                f"annotations to one value. On the {grain.id} grain the annotation "
+                "is already the row, so read its columns directly — 'score', "
+                "'label', 'name', 'annotator_kind'."
+            ),
+            suggestions=["score", "label", "annotator_kind"],
+        )
+    if reference.attribute not in registry.ANNOTATION_ATTRIBUTES:
+        readable = sorted(registry.ANNOTATION_ATTRIBUTES)
+        raise QueryError(
+            code="unknown_annotation_attribute",
+            message=(
+                f"Annotations have no {reference.attribute!r} attribute on this "
+                f"surface. Readable attributes: {', '.join(readable)} — e.g. "
+                f'annotations["{reference.name}"].score.'
+            ),
+            suggestions=[f'annotations["{reference.name}"].{attribute}' for attribute in readable],
+        )
+    if (
+        reference.annotator_kind is not None
+        and reference.annotator_kind not in registry.ANNOTATOR_KINDS
+    ):
+        raise QueryError(
+            code="unknown_annotator_kind",
+            message=(
+                f"{reference.annotator_kind!r} is not an annotator kind. Phoenix "
+                f"records exactly {', '.join(registry.ANNOTATOR_KINDS)} (case "
+                "sensitive); omit the second subscript to reduce over every "
+                "annotator."
+            ),
+            suggestions=[
+                f'annotations["{reference.name}", "{kind}"].{reference.attribute}'
+                for kind in registry.ANNOTATOR_KINDS
+            ],
+        )
+    return registry.annotation_enrichment_field(reference)
+
+
+def resolve_field(identifier: str, grain: Grain = grains.SPANS_GRAIN) -> registry.ResolvedField:
+    """Resolve one identifier against a grain: the grain's own fields, then
+    — on the spans grain only — annotation enrichment and attribute paths,
+    then a nearest-name error."""
+    if authored := grain.fields_by_id.get(identifier):
         return authored
+    if registry.parse_annotation_field(identifier) is not None:
+        return _resolve_annotation_enrichment(identifier, grain)
+    if not grain.admits_observed_paths:
+        # A closed field set: no attribute blob to fall through to, so an
+        # unknown identifier is an error here rather than a discovered path.
+        # Fields of the other grain are the likeliest mistake, so they are
+        # named as such instead of being reported as nonexistent.
+        elsewhere = [
+            other.id
+            for other in grains.GRAINS.values()
+            if other.id != grain.id and identifier in other.fields_by_id
+        ]
+        if elsewhere:
+            raise QueryError(
+                code="field_not_on_grain",
+                message=(
+                    f"{identifier!r} is a field of the {', '.join(elsewhere)} grain, not "
+                    f"of {grain.id}. Query it with from='{elsewhere[0]}', or pick one of "
+                    f"the {grain.id} grain's own fields: "
+                    f"{', '.join(sorted(grain.fields_by_id))}."
+                ),
+                suggestions=sorted(grain.fields_by_id),
+            )
+        close = get_close_matches(identifier, grain.fields_by_id.keys(), n=3)
+        raise QueryError(
+            code="unknown_field",
+            message=(
+                f"Field {identifier!r} does not exist on the {grain.id} grain, whose "
+                f"fields are: {', '.join(sorted(grain.fields_by_id))}."
+                + (f" Did you mean: {', '.join(close)}?" if close else "")
+            ),
+            suggestions=close or sorted(grain.fields_by_id),
+        )
     if identifier in registry.RESERVED_UNEXPOSED:
         raise QueryError(
             code="field_not_exposed",
@@ -381,22 +504,19 @@ def resolve_field(identifier: str) -> registry.ResolvedField:
             suggestions=get_close_matches(identifier, registry.AUTHORED_BY_ID.keys(), n=3),
         )
     if re.match(r"^\s*(evals|annotations)\b", identifier):
-        # Annotation *values* stay out of fields/breakdowns/calculations:
-        # several annotators can score one span under one name, so
-        # projecting or aggregating the value needs a declared reduction
-        # this surface does not implement. The refusal carries its route.
+        # Annotation shaped but not parseable as an enrichment reference:
+        # the supported spellings are worth showing, since the difference is
+        # usually one subscript.
         raise QueryError(
-            code="annotation_values_not_supported",
+            code="invalid_annotation_field",
             message=(
-                f"{identifier!r} cannot be selected, grouped, or aggregated: a span "
-                "can carry several annotation rows under one name, so value use "
-                "requires declared reduction semantics. Decomposition: fetch rows "
-                "with querySpanRows, then call listSpanAnnotationsBySpanIds with "
-                "the returned span_ids and filter or aggregate client-side. "
-                "Annotation *filters* are supported, e.g. "
-                "\"evals['correctness'].score < 0.5\"."
+                f"{identifier!r} is not a readable annotation field. Supported "
+                'spellings: annotations["<name>"].score (mean over every '
+                'annotator), annotations["<name>", "HUMAN"].score (one annotator '
+                "kind), plus .label and .count. Annotation *filters* use the "
+                "predicate form instead, e.g. \"evals['correctness'].score < 0.5\"."
             ),
-            suggestions=["listSpanAnnotationsBySpanIds"],
+            suggestions=['annotations["correctness"].score', 'annotations["correctness"].count'],
         )
     keys = registry.parse_attribute_path(identifier)
     if keys is not None and keys[0] not in ("evals", "annotations"):
@@ -496,6 +616,188 @@ class CompiledFilter:
         return stmt
 
 
+@dataclass(frozen=True)
+class ColumnFilter:
+    """A validated filter compiled to one boolean column expression.
+
+    The annotations grain's columns are typed columns of a relation, so its
+    filter compiles directly instead of routing through the span filter
+    DSL, whose names resolve to span columns and attribute paths that do
+    not exist here.
+    """
+
+    clause: ColumnElement[bool]
+
+    @property
+    def uses_annotations(self) -> bool:
+        # Annotation predicates are a spans-grain construct: on this grain
+        # the annotation is the row, so there is no any-annotator existence
+        # semantics to disclose.
+        return False
+
+    def __call__(self, stmt: Select[Any]) -> Select[Any]:
+        return stmt.where(self.clause)
+
+
+FilterPlan = Union[CompiledFilter, ColumnFilter]
+
+_COMPARE_METHODS: Mapping[type, str] = {
+    ast.Lt: "__lt__",
+    ast.LtE: "__le__",
+    ast.Gt: "__gt__",
+    ast.GtE: "__ge__",
+    ast.Eq: "__eq__",
+    ast.NotEq: "__ne__",
+}
+
+
+def _invalid_filter(message: str, suggestions: Sequence[str] = ()) -> QueryError:
+    return QueryError(
+        code="invalid_filter", path="filter", message=message, suggestions=list(suggestions)
+    )
+
+
+def _grain_filter_field(
+    node: ast.expr, grain: Grain, dialect: SupportedSQLDialect
+) -> Optional[tuple[registry.AuthoredField, SQLColumnExpression[Any]]]:
+    """The field one operand names, or None when the operand is not a field."""
+    if not isinstance(node, ast.Name):
+        return None
+    resolved = resolve_field(node.id, grain)
+    assert isinstance(resolved, registry.AuthoredField)
+    if not resolved.filterable:
+        raise QueryError(
+            code="temporal_filter" if resolved.type == "datetime" else "field_not_filterable",
+            path="filter",
+            message=(
+                f"{resolved.id} is not filterable on the {grain.id} grain. "
+                + (
+                    "Temporal scope has exactly one home, the time_range parameter."
+                    if resolved.type == "datetime"
+                    else "Select or aggregate it instead."
+                )
+            ),
+            suggestions=["time_range"] if resolved.type == "datetime" else [],
+        )
+    return resolved, resolved.expr(dialect)
+
+
+def _grain_literal(node: ast.expr, field: registry.AuthoredField) -> Any:
+    """One comparison operand's literal value, type-checked against the field.
+
+    A type mismatch is caught here rather than at the database, where
+    PostgreSQL aborts the statement and SQLite compares across types by its
+    own storage-class rules — two different wrong answers to one mistake.
+    """
+    if not isinstance(node, ast.Constant) or isinstance(node.value, bool):
+        raise _invalid_filter(
+            f"Comparisons on the {field.id} field take a literal value, not {ast.unparse(node)!r}."
+        )
+    value = node.value
+    numeric = field.type in ("float", "integer")
+    if numeric and not isinstance(value, (int, float)):
+        raise _invalid_filter(f"{field.id} is {field.type}; compare it to a number.")
+    if not numeric and not isinstance(value, str):
+        raise _invalid_filter(f"{field.id} is a string; compare it to a quoted string.")
+    return value
+
+
+def _grain_comparison(
+    node: ast.Compare, grain: Grain, dialect: SupportedSQLDialect
+) -> ColumnElement[bool]:
+    if len(node.ops) != 1:
+        raise _invalid_filter(
+            "Chained comparisons (a < b < c) are not supported; write them as two "
+            "conditions joined by 'and'."
+        )
+    operator_node, left, right = node.ops[0], node.left, node.comparators[0]
+    left_field = _grain_filter_field(left, grain, dialect)
+    right_field = _grain_filter_field(right, grain, dialect)
+
+    if isinstance(operator_node, (ast.Is, ast.IsNot)):
+        if left_field is None or not (isinstance(right, ast.Constant) and right.value is None):
+            raise _invalid_filter("'is' comparisons are supported only as 'field is (not) None'.")
+        column = left_field[1]
+        return column.isnot(None) if isinstance(operator_node, ast.IsNot) else column.is_(None)
+
+    if isinstance(operator_node, (ast.In, ast.NotIn)):
+        # Two readings, both borrowed from the span filter grammar so one
+        # vocabulary carries across grains: a substring test when the left
+        # side is a string literal, membership when the right side is a list.
+        if left_field is None and right_field is not None and isinstance(left, ast.Constant):
+            field, column = right_field
+            if field.type != "string":
+                raise _invalid_filter(f"Substring tests apply to string fields, not {field.id}.")
+            clause = column.contains(_grain_literal(left, field))
+            return ~clause if isinstance(operator_node, ast.NotIn) else clause
+        if left_field is not None and isinstance(right, (ast.List, ast.Tuple)):
+            field, column = left_field
+            values = [_grain_literal(element, field) for element in right.elts]
+            clause = column.in_(values)
+            return ~clause if isinstance(operator_node, ast.NotIn) else clause
+        raise _invalid_filter(
+            "'in' is supported as a substring test (\"'timeout' in explanation\") or "
+            "membership in a literal list (\"annotator_kind in ['HUMAN', 'LLM']\")."
+        )
+
+    method = _COMPARE_METHODS.get(type(operator_node))
+    if method is None:
+        raise _invalid_filter(f"Operator {type(operator_node).__name__} is not supported.")
+    if left_field is not None and right_field is None:
+        field, column = left_field
+        value: Any = _grain_literal(right, field)
+    elif right_field is not None and left_field is None:
+        field, column = right_field
+        value = _grain_literal(left, field)
+        method = {
+            "__lt__": "__gt__",
+            "__le__": "__ge__",
+            "__gt__": "__lt__",
+            "__ge__": "__le__",
+        }.get(method, method)
+    else:
+        raise _invalid_filter(
+            "Each comparison relates one field to one literal value; field-to-field "
+            "and literal-to-literal comparisons are not supported."
+        )
+    return cast("ColumnElement[bool]", getattr(column, method)(value))
+
+
+def _grain_filter_clause(
+    node: ast.expr, grain: Grain, dialect: SupportedSQLDialect
+) -> ColumnElement[bool]:
+    if isinstance(node, ast.BoolOp):
+        clauses = [_grain_filter_clause(value, grain, dialect) for value in node.values]
+        return and_(*clauses) if isinstance(node.op, ast.And) else or_(*clauses)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return not_(_grain_filter_clause(node.operand, grain, dialect))
+    if isinstance(node, ast.Compare):
+        return _grain_comparison(node, grain, dialect)
+    raise _invalid_filter(
+        f"{ast.unparse(node)!r} is not a supported filter expression: write comparisons "
+        "of a field to a literal, combined with and/or/not."
+    )
+
+
+def grain_filter(
+    condition: Optional[str], grain: Grain, dialect: SupportedSQLDialect
+) -> Optional[ColumnFilter]:
+    """Validate and compile a filter over a closed-field-set grain.
+
+    Every name resolves to one of the grain's declared fields, every
+    comparison relates a field to a type-checked literal, and anything else
+    is refused with the supported forms — the same admission discipline the
+    span filter grammar applies, over a different namespace.
+    """
+    if not condition:
+        return None
+    try:
+        root = ast.parse(condition, mode="eval")
+    except SyntaxError as error:
+        raise _invalid_filter(f"Invalid filter expression: {error.msg}.")
+    return ColumnFilter(clause=_grain_filter_clause(root.body, grain, dialect))
+
+
 def validated_filter(condition: Optional[str]) -> Optional[CompiledFilter]:
     """Validate and compile a filter expression, enforcing surface rules.
 
@@ -543,6 +845,20 @@ def validated_filter(condition: Optional[str]) -> Optional[CompiledFilter]:
                 message=f"Invalid filter expression: {error}.",
             )
     return CompiledFilter(span_filter=span_filter, annotation_predicates=predicates)
+
+
+def filter_for_grain(
+    condition: Optional[str], grain: Grain, dialect: SupportedSQLDialect
+) -> Optional[FilterPlan]:
+    """Compile a filter in the grain's own namespace.
+
+    The spans grain routes through the span filter DSL, which resolves span
+    columns, attribute paths, and annotation existence predicates; every
+    other grain compiles against its declared columns.
+    """
+    if grain.admits_observed_paths:
+        return validated_filter(condition)
+    return grain_filter(condition, grain, dialect)
 
 
 _ANNOTATION_COMPARE_OPS: Mapping[type, str] = {
@@ -719,24 +1035,19 @@ def scoped_base(
     columns: Sequence[Any],
     project_rowid: int,
     time_range: Optional[TimeRange],
+    grain: Grain = grains.SPANS_GRAIN,
 ) -> Select[Any]:
-    """The single statement base: spans joined to traces, bound to one
-    project, restricted to the time window. Deliberately carries no
-    ordering — aggregates must not inherit row ordering, and PostgreSQL
-    rejects ordering by ungrouped columns.
+    """The single statement base, delegated to the grain's own scope: its
+    rows bound to one project and restricted to the time window.
+    Deliberately carries no ordering — aggregates must not inherit row
+    ordering, and PostgreSQL rejects ordering by ungrouped columns.
     """
-    stmt: Select[Any] = (
-        select(*columns)
-        .select_from(models.Span)
-        .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
-        .where(models.Trace.project_rowid == project_rowid)
+    return grain.scoped(
+        columns,
+        project_rowid,
+        time_range.start if time_range is not None else None,
+        time_range.end if time_range is not None else None,
     )
-    if time_range is not None:
-        stmt = stmt.where(
-            models.Span.start_time >= time_range.start,
-            models.Span.start_time < time_range.end,
-        )
-    return stmt
 
 
 async def apply_statement_timeout(
@@ -782,11 +1093,22 @@ class RowPlan:
     stmt: Optional[Select[Any]]
     #: Sample mode: the bounded id scan feeding the seeded probe.
     ids_stmt: Optional[Select[Any]]
+    grain: Grain = grains.SPANS_GRAIN
     _project_rowid: int = dataclass_field(default=0, repr=False)
     _selected: list[registry.ResolvedField] = dataclass_field(default_factory=list, repr=False)
-    _filter: Optional[CompiledFilter] = dataclass_field(default=None, repr=False)
+    _filter: Optional[FilterPlan] = dataclass_field(default=None, repr=False)
     uses_annotation_filter: bool = False
     _dialect: SupportedSQLDialect = dataclass_field(default=SupportedSQLDialect.SQLITE, repr=False)
+
+    @property
+    def reductions(self) -> list[registry.AuthoredField]:
+        """Selected fields that collapsed a to-many relationship, for
+        disclosure: a reduced value means nothing without its rule."""
+        return [
+            f
+            for f in self._selected
+            if isinstance(f, registry.AuthoredField) and f.reduction is not None
+        ]
 
     def choose_sample_ids(self, ids: Sequence[int]) -> list[int]:
         """Choose up to ``applied_limit`` ids by seeded rowid probing.
@@ -832,6 +1154,7 @@ class RowPlan:
             [f.expr(self._dialect).label(f.id) for f in self._selected],
             self._project_rowid,
             self.time_range,
+            self.grain,
         ).where(models.Span.id.in_(list(ids)))
         if self._filter is not None:
             stmt = self._filter(stmt)
@@ -852,22 +1175,24 @@ def compile_rows(
 ) -> RowPlan:
     """Compile a row query into an ordered, bounded statement."""
     now = now or datetime.now(timezone.utc)
+    grain = resolve_grain(query.grain)
     if query.time_range is not None:
         time_range, defaulted = query.time_range, False
     else:
         time_range = TimeRange(start=now - timedelta(hours=ROW_WINDOW_DEFAULT_HOURS), end=now)
         defaulted = True
 
-    field_ids = list(query.fields) if query.fields else list(DEFAULT_ROW_FIELDS)
-    # Row identity is implicit: span_id is always included whether or not it
-    # was selected, so every row can be recovered in full via getSpan.
-    if "span_id" not in field_ids:
-        field_ids.insert(0, "span_id")
+    field_ids = list(query.fields) if query.fields else list(grain.default_row_fields)
+    # Row identity is implicit: the grain's identity field is always
+    # included whether or not it was selected, so no returned row is
+    # unrecoverable.
+    if grain.identity_field not in field_ids:
+        field_ids.insert(0, grain.identity_field)
     selected: list[registry.ResolvedField] = []
     seen: set[str] = set()
     for index, field_id in enumerate(field_ids):
         try:
-            resolved = resolve_field(field_id)
+            resolved = resolve_field(field_id, grain)
         except QueryError as error:
             error.path = error.path or f"fields[{index}]"
             raise
@@ -875,12 +1200,24 @@ def compile_rows(
             seen.add(resolved.id)
             selected.append(resolved)
 
-    filter_ = validated_filter(query.filter)
+    filter_ = filter_for_grain(query.filter, grain, dialect)
     applied_limit = max(1, min(query.limit, ROW_LIMIT_MAX))
     columns = [_column_spec(f) for f in selected]
 
     if isinstance(query.order, SampleOrder):
-        ids_stmt = scoped_base([models.Span.id], project_rowid, time_range)
+        if not grain.supports_sampling:
+            raise QueryError(
+                code="sample_not_supported",
+                path="order.sample",
+                message=(
+                    f"Seeded sampling is not available on the {grain.id} grain: it "
+                    "probes a dense integer row id, and this grain's rows are unioned "
+                    "across tables that number themselves independently. Order "
+                    "explicitly instead — results stay deterministic."
+                ),
+                suggestions=[f'[{{"field": "{grain.time_field}", "direction": "desc"}}]'],
+            )
+        ids_stmt = scoped_base([models.Span.id], project_rowid, time_range, grain)
         if filter_ is not None:
             ids_stmt = filter_(ids_stmt)
         ids_stmt = ids_stmt.order_by(models.Span.id.asc()).limit(SAMPLE_ID_SCAN_CAP)
@@ -892,6 +1229,7 @@ def compile_rows(
             sample=query.order.sample,
             stmt=None,
             ids_stmt=ids_stmt,
+            grain=grain,
             _project_rowid=project_rowid,
             _selected=selected,
             _filter=filter_,
@@ -924,11 +1262,13 @@ def compile_rows(
                 expr.desc().nulls_last() if entry.direction == "desc" else expr.asc().nulls_last()
             )
     else:
-        order_exprs.append(models.Span.start_time.desc())
-    # Deterministic tie-break: the primary key ends every ordering.
-    order_exprs.append(models.Span.id.asc())
+        order_exprs.append(grain.time_column.desc())
+    # Deterministic tie-break: the grain's unique key ends every ordering.
+    order_exprs.append(grain.tiebreak_column.asc())
 
-    stmt = scoped_base([f.expr(dialect).label(f.id) for f in selected], project_rowid, time_range)
+    stmt = scoped_base(
+        [f.expr(dialect).label(f.id) for f in selected], project_rowid, time_range, grain
+    )
     if filter_ is not None:
         stmt = filter_(stmt)
     stmt = stmt.order_by(*order_exprs).limit(applied_limit)
@@ -940,6 +1280,7 @@ def compile_rows(
         sample=None,
         stmt=stmt,
         ids_stmt=None,
+        grain=grain,
         _project_rowid=project_rowid,
         _selected=selected,
         _filter=filter_,
@@ -969,6 +1310,22 @@ class ResolvedBreakdown:
     column: ColumnSpec
 
 
+@dataclass(frozen=True)
+class CompositionProbe:
+    """One hidden per-group count of the annotations behind a reduced value.
+
+    A blended average moves when the annotator mix moves, with no annotator
+    having changed its scoring. The probe makes the mix a returned number
+    rather than an inference the caller has to think to make: for every
+    kind-unrestricted reduction the query asked for, the response reports
+    how many annotations of each kind each group actually contained.
+    """
+
+    annotation_name: str
+    annotator_kind: str
+    expr: ColumnElement[Any]
+
+
 @dataclass
 class AggregatePlan:
     """Compiled aggregation: the grouped top-K statement, the explicit
@@ -991,6 +1348,47 @@ class AggregatePlan:
     #: Observed attribute fields the query references in breakdowns or
     #: calculations, for admission checks against the discovery sample.
     observed_fields: list[registry.ObservedField] = dataclass_field(default_factory=list)
+    grain: Grain = grains.SPANS_GRAIN
+    #: Fields whose values were reduced from a to-many relationship, for
+    #: disclosure of the rule that produced them.
+    reductions: list[registry.AuthoredField] = dataclass_field(default_factory=list)
+    #: Hidden per-group annotator counts appended after the visible
+    #: calculations; stripped from the result rows into their own block.
+    composition: list[CompositionProbe] = dataclass_field(default_factory=list)
+
+
+def _composition_probes(
+    reductions: Iterable[registry.AuthoredField],
+    dialect: SupportedSQLDialect,
+) -> list[CompositionProbe]:
+    """Per-annotator-kind counts behind every kind-unrestricted reduction.
+
+    Only unrestricted reductions get probes. A caller who already asked for
+    one annotator kind has excluded the mix from the number, so there is no
+    composition artifact left to disclose — and no reason to pay for three
+    extra correlated subqueries.
+    """
+    probes: list[CompositionProbe] = []
+    seen: set[str] = set()
+    for field in reductions:
+        reference = field.annotation
+        if reference is None or reference.annotator_kind is not None:
+            continue
+        if reference.name in seen:
+            continue
+        seen.add(reference.name)
+        for kind in registry.ANNOTATOR_KINDS:
+            counter = registry.annotation_enrichment_field(
+                registry.AnnotationRef(name=reference.name, annotator_kind=kind, attribute="count")
+            )
+            probes.append(
+                CompositionProbe(
+                    annotation_name=reference.name,
+                    annotator_kind=kind,
+                    expr=registry.aggregation_expr("sum", counter.expr(dialect), dialect),
+                )
+            )
+    return probes
 
 
 def compile_aggregate(
@@ -999,7 +1397,9 @@ def compile_aggregate(
     dialect: SupportedSQLDialect,
 ) -> AggregatePlan:
     """Compile an aggregation into its three statements."""
+    grain = resolve_grain(query.grain)
     observed_fields: dict[str, registry.ObservedField] = {}
+    reductions: dict[str, registry.AuthoredField] = {}
     calculations: list[ResolvedCalculation] = []
     for index, calc in enumerate(query.calculations):
         spec = registry.AGGREGATIONS.get(calc.fn)
@@ -1013,7 +1413,7 @@ def compile_aggregate(
         field_expr: Optional[SQLColumnExpression[Any]] = None
         if calc.field is not None:
             try:
-                resolved = resolve_field(calc.field)
+                resolved = resolve_field(calc.field, grain)
             except QueryError as error:
                 error.path = error.path or f"calculations[{index}].field"
                 raise
@@ -1042,6 +1442,8 @@ def compile_aggregate(
                 )
             if isinstance(resolved, registry.ObservedField):
                 observed_fields[resolved.id] = resolved
+            elif resolved.reduction is not None:
+                reductions[resolved.id] = resolved
             field_expr = resolved.expr(dialect)
         elif spec.requires_field:
             raise QueryError(
@@ -1064,19 +1466,19 @@ def compile_aggregate(
             breakdowns.append(
                 ResolvedBreakdown(
                     id=registry.TIME_BUCKET_ID,
-                    expr=registry.time_bucket_expr(dialect),
+                    expr=registry.time_bucket_expr(dialect, grain.time_column),
                     is_time_bucket=True,
                     column=ColumnSpec(id=registry.TIME_BUCKET_ID, type="datetime"),
                 )
             )
             continue
         try:
-            resolved = resolve_field(breakdown)
+            resolved = resolve_field(breakdown, grain)
         except QueryError as error:
             error.path = error.path or f"breakdowns[{index}]"
             raise
         if not resolved.groupable:
-            groupable = sorted(f.id for f in registry.AUTHORED_FIELDS if f.groupable)
+            groupable = sorted(f.id for f in grain.fields if f.groupable)
             alternatives = [*groupable, '{"bucket": "hour"} (hourly time bucket)']
             raise QueryError(
                 code="field_not_groupable",
@@ -1090,6 +1492,8 @@ def compile_aggregate(
             )
         if isinstance(resolved, registry.ObservedField):
             observed_fields[resolved.id] = resolved
+        elif resolved.reduction is not None:
+            reductions[resolved.id] = resolved
         breakdowns.append(
             ResolvedBreakdown(
                 id=resolved.id,
@@ -1153,12 +1557,16 @@ def compile_aggregate(
         if breakdown_entry.id not in ordered_breakdown_ids:
             order_exprs.append(breakdown_entry.expr.asc())
 
-    filter_ = validated_filter(query.filter)
+    filter_ = filter_for_grain(query.filter, grain, dialect)
     applied_limit = max(1, min(query.limit, AGGREGATE_LIMIT_MAX))
+    composition = _composition_probes(reductions.values(), dialect)
 
     select_columns: list[Any] = [b.expr.label(b.id) for b in breakdowns]
     select_columns.extend(c.expr.label(c.name) for c in calculations)
-    stmt = scoped_base(select_columns, project_rowid, query.time_range)
+    select_columns.extend(
+        probe.expr.label(f"_composition_{index}") for index, probe in enumerate(composition)
+    )
+    stmt = scoped_base(select_columns, project_rowid, query.time_range, grain)
     if filter_ is not None:
         stmt = filter_(stmt)
     grouped = stmt.group_by(*(b.expr for b in breakdowns)) if breakdowns else stmt
@@ -1171,7 +1579,11 @@ def compile_aggregate(
         groups_total_stmt = select(sqla_func.count()).select_from(grouped.subquery())
 
     overall_stmt = scoped_base(
-        [c.expr.label(c.name) for c in calculations], project_rowid, query.time_range
+        [c.expr.label(c.name) for c in calculations]
+        + [probe.expr.label(f"_composition_{index}") for index, probe in enumerate(composition)],
+        project_rowid,
+        query.time_range,
+        grain,
     )
     if filter_ is not None:
         overall_stmt = filter_(overall_stmt)
@@ -1189,4 +1601,7 @@ def compile_aggregate(
         project_gid=str(GlobalID("Project", str(project_rowid))),
         uses_annotation_filter=filter_.uses_annotations if filter_ else False,
         observed_fields=list(observed_fields.values()),
+        grain=grain,
+        reductions=list(reductions.values()),
+        composition=composition,
     )

--- a/src/phoenix/server/mcp_span_analytics/discovery.py
+++ b/src/phoenix/server/mcp_span_analytics/discovery.py
@@ -1,0 +1,211 @@
+"""Observed-path discovery sampling for the span analytics MCP tools.
+
+Project-specific context lives in the free-form attribute blob, so the
+queryable paths of a project are discovered from its data: a bounded,
+seeded sample of spans drawn evenly across the project's span id range is
+scanned and its scalar attribute paths collected with per-path statistics.
+The same sample backs discovery output (``describeSpans``), zero-result
+diagnosis, and per-request observed-path checks — one sampling strategy,
+one epistemic contract: an unobserved path means not-seen-in-sample, never
+nonexistent.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import Counter
+from typing import Any, Mapping, Optional
+
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+from phoenix.server.mcp_span_analytics import compiler, registry
+from phoenix.server.mcp_span_analytics.compiler import TimeRange
+from phoenix.server.mcp_span_analytics.envelope import iso
+
+#: Upper bound on spans scanned for observed-field discovery and
+#: zero-result diagnosis. A bounded sample drawn evenly across the
+#: project's span id range, never a full scan.
+SAMPLE_SIZE = 500
+
+#: Declared sampling strategy of the discovery scan: up to N span ids
+#: drawn uniformly across the project's id range (approximately
+#: time-ordered, since ids are allocated in ingestion order).
+STRATEGY = f"id_spread_{SAMPLE_SIZE}"
+
+#: Fixed seed of the discovery draw: the same project state always yields
+#: the same sample, so repeated discovery calls agree with each other.
+SAMPLE_SEED = 0
+
+#: Cap on observed-field entries in one describeSpans response.
+MAX_OBSERVED_FIELDS = 100
+
+#: Observed values are tracked for top-value reporting only up to this many
+#: distinct values per path and this many characters per value.
+TOP_VALUES_LIMIT = 20
+TOP_VALUE_MAX_CHARS = 100
+
+
+class PathStats:
+    """Streaming statistics for one attribute path in the discovery sample."""
+
+    __slots__ = ("count", "types", "values", "values_complete")
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.types: Counter[str] = Counter()
+        self.values: Counter[Any] = Counter()
+        #: True while every observed value has been tracked; long values and
+        #: high cardinality forfeit top-value reporting rather than
+        #: misreport it as complete.
+        self.values_complete = True
+
+    def record(self, value: Any) -> None:
+        self.count += 1
+        if isinstance(value, bool):
+            self.types["boolean"] += 1
+        elif isinstance(value, int):
+            self.types["integer"] += 1
+        elif isinstance(value, float):
+            self.types["float"] += 1
+        else:
+            self.types["string"] += 1
+        trackable = not isinstance(value, str) or len(value) <= TOP_VALUE_MAX_CHARS
+        if not trackable:
+            self.values_complete = False
+            return
+        if value in self.values or len(self.values) < TOP_VALUES_LIMIT + 1:
+            self.values[value] += 1
+        else:
+            self.values_complete = False
+
+    def top_values(self) -> Optional[list[dict[str, Any]]]:
+        if not self.values_complete or not self.values or len(self.values) > TOP_VALUES_LIMIT:
+            return None
+        return [
+            {"value": value, "count": count}
+            for value, count in sorted(self.values.items(), key=lambda kv: (-kv[1], str(kv[0])))
+        ]
+
+
+def _flatten_scalars(
+    blob: Mapping[str, Any],
+    prefix: tuple[str, ...],
+    out: dict[tuple[str, ...], PathStats],
+    depth: int = 0,
+) -> None:
+    if depth > 6:
+        return
+    for key, value in blob.items():
+        if not isinstance(key, str):
+            continue
+        path = (*prefix, key)
+        if isinstance(value, dict):
+            _flatten_scalars(value, path, out, depth + 1)
+        elif isinstance(value, (str, int, float, bool)):
+            out.setdefault(path, PathStats()).record(value)
+        # None and list values are skipped: only scalar paths are fields.
+        # List-valued paths (message lists, retrieval documents) are
+        # deliberately omitted from observed discovery rather than emitted
+        # with empty capabilities — list-entry access is defined by authored
+        # convention fields, not by arbitrary observed indexing.
+
+
+async def sample_observed_paths(
+    session: AsyncSession,
+    project_rowid: int,
+) -> tuple[int, dict[tuple[str, ...], PathStats]]:
+    """Scan a bounded, time-spread sample of the project's spans.
+
+    Value discovery biased toward recent rows hides dimension values that
+    stopped occurring — exactly the values an investigation of a change
+    needs (the pre-cut release tag, the retired model name). So instead of
+    the most recent N spans, the sample draws span ids uniformly across
+    the project's whole id range: ids are allocated in ingestion order, so
+    the draw reaches old and new rows alike, in one bounded IN-list query.
+    The draw is seeded and therefore deterministic across calls, and it is
+    random rather than fixed-stride because trace structure is periodic
+    (root/child spans alternate ids) and a stride aliases with that period
+    — an even stride can sample only root spans and miss every LLM
+    attribute. Drawn ids that do not exist (gaps, other projects'
+    interleaved rows) simply reduce the scanned row count, which is
+    reported as ``sample_count``.
+    """
+    min_id, max_id = (
+        await session.execute(
+            compiler.scoped_base(
+                [func.min(models.Span.id), func.max(models.Span.id)], project_rowid, None
+            )
+        )
+    ).one()
+    if min_id is None or max_id is None:
+        return 0, {}
+    id_range = range(min_id, max_id + 1)
+    if len(id_range) <= SAMPLE_SIZE:
+        candidate_ids = list(id_range)
+    else:
+        rng = random.Random(SAMPLE_SEED)
+        candidate_ids = sorted(rng.sample(id_range, SAMPLE_SIZE))
+    stmt = (
+        compiler.scoped_base([models.Span.attributes], project_rowid, None)
+        .where(models.Span.id.in_(candidate_ids))
+        .order_by(models.Span.id.asc())
+        .limit(SAMPLE_SIZE)
+    )
+    stats: dict[tuple[str, ...], PathStats] = {}
+    sample_count = 0
+    for attributes in (await session.execute(stmt)).scalars():
+        sample_count += 1
+        if isinstance(attributes, dict):
+            _flatten_scalars(attributes, (), stats)
+    return sample_count, stats
+
+
+async def zero_result_guidance(
+    session: AsyncSession,
+    project_rowid: int,
+    time_range: Optional[TimeRange],
+    filter_condition: Optional[str],
+) -> dict[str, str]:
+    """Diagnose an empty result with bounded checks only.
+
+    The window check counts spans within the queried window — never an
+    unrestricted historical scan — and the path check reads the same
+    bounded time-spread sample discovery uses.
+    """
+    window_count = await session.scalar(
+        compiler.scoped_base([func.count()], project_rowid, time_range)
+    )
+    if not window_count:
+        detail = "The project has no spans"
+        if time_range is not None:
+            detail += (
+                f" between {iso(time_range.start)} and {iso(time_range.end)}"
+                " (the check counted only within this window)"
+            )
+        return {"cause": "window_empty", "detail": detail + "."}
+    if filter_condition:
+        referenced = compiler.attribute_paths_in_filter(filter_condition)
+        if referenced:
+            sample_count, stats = await sample_observed_paths(session, project_rowid)
+            missing = sorted(
+                registry.canonical_attribute_spelling(keys)
+                for keys in referenced
+                if keys not in stats
+            )
+            if missing:
+                return {
+                    "cause": "path_not_observed",
+                    "detail": (
+                        f"Attribute path(s) {', '.join(missing)} did not appear in a "
+                        f"sample of {sample_count} spans drawn across the project's "
+                        "history — sampled evidence, not proof of absence."
+                    ),
+                }
+    return {
+        "cause": "no_matches",
+        "detail": (
+            "The window contains spans and the query is well-formed; nothing matched the filter."
+        ),
+    }

--- a/src/phoenix/server/mcp_span_analytics/discovery.py
+++ b/src/phoenix/server/mcp_span_analytics/discovery.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import random
 from collections import Counter
+from difflib import get_close_matches
 from typing import Any, Mapping, Optional
 
 from sqlalchemy import func
@@ -160,6 +161,78 @@ async def sample_observed_paths(
         if isinstance(attributes, dict):
             _flatten_scalars(attributes, (), stats)
     return sample_count, stats
+
+
+#: How many observed dimensions augment a field_not_groupable rejection.
+TOP_GROUPABLES_LIMIT = 5
+
+#: How many nearest observed spellings a not_observed note suggests.
+NEAREST_PATHS_LIMIT = 3
+
+
+async def not_observed_field_notes(
+    session: AsyncSession,
+    project_rowid: int,
+    paths: Mapping[tuple[str, ...], str],
+) -> list[dict[str, Any]]:
+    """Check observed attribute paths a query uses against the discovery
+    sample, returning one structured note per path the sample never saw.
+
+    ``paths`` maps each path's key sequence to the identifier the caller
+    wrote, so a note anchors to the request's own spelling. Open admission
+    stands: a path can be real but unsampled, so an unobserved path is
+    never an error. The note teaches instead — it names the sample size,
+    points at describeSpans, and suggests the nearest spellings among the
+    paths that *were* observed (full multi-segment similarity, so
+    ``metadata.releas`` finds ``metadata.release``).
+    """
+    sample_count, stats = await sample_observed_paths(session, project_rowid)
+    observed_spellings = [registry.canonical_attribute_spelling(keys) for keys in stats]
+    notes: list[dict[str, Any]] = []
+    for keys, anchor in sorted(paths.items(), key=lambda item: item[1]):
+        if keys in stats:
+            continue
+        notes.append(
+            {
+                "field": anchor,
+                "code": "not_observed",
+                "note": (
+                    f"{anchor!r} was not seen in a sample of {sample_count} spans "
+                    "drawn across the project's history — sampled evidence, not "
+                    "proof of absence; verify the spelling via describeSpans."
+                ),
+                "suggestions": get_close_matches(
+                    registry.canonical_attribute_spelling(keys),
+                    observed_spellings,
+                    n=NEAREST_PATHS_LIMIT,
+                ),
+            }
+        )
+    return notes
+
+
+async def top_observed_groupables(
+    session: AsyncSession,
+    project_rowid: int,
+    limit: int = TOP_GROUPABLES_LIMIT,
+) -> list[str]:
+    """The project's most-observed attribute dimensions, in canonical
+    spelling, for augmenting groupability rejections.
+
+    Authored ids are excluded — the rejection already lists them — so what
+    comes back is the discovered, project-specific dimensions a caller
+    actually groups by, bounded and ordered by observation count.
+    """
+    _, stats = await sample_observed_paths(session, project_rowid)
+    spellings = {
+        registry.canonical_attribute_spelling(keys): path_stats.count
+        for keys, path_stats in stats.items()
+    }
+    ranked = sorted(
+        (s for s in spellings if s not in registry.AUTHORED_BY_ID),
+        key=lambda s: (-spellings[s], s),
+    )
+    return ranked[:limit]
 
 
 async def zero_result_guidance(

--- a/src/phoenix/server/mcp_span_analytics/discovery.py
+++ b/src/phoenix/server/mcp_span_analytics/discovery.py
@@ -21,7 +21,7 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from phoenix.db import models
-from phoenix.server.mcp_span_analytics import compiler, registry
+from phoenix.server.mcp_span_analytics import compiler, grains, registry
 from phoenix.server.mcp_span_analytics.compiler import TimeRange
 from phoenix.server.mcp_span_analytics.envelope import iso
 
@@ -163,6 +163,66 @@ async def sample_observed_paths(
     return sample_count, stats
 
 
+#: Cap on the (name, kind, target) combinations one annotation scan
+#: reports. Annotation vocabularies are small by nature — a project runs a
+#: handful of evaluators — so this bounds a pathological case rather than a
+#: normal one, and the cap is reported when it binds.
+MAX_ANNOTATION_GROUPS = 200
+
+
+async def observed_annotation_names(
+    session: AsyncSession,
+    project_rowid: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    """The annotation names recorded in a project, with their composition.
+
+    Annotation names are project data, not a fixed vocabulary, so an agent
+    that has to invent one will: this is the enumerate-don't-fabricate
+    contract applied to the annotation namespace. Unlike attribute-path
+    discovery, the scan is exact rather than sampled — it is a grouped
+    count over the annotation tables, which are small relative to spans —
+    so the counts it reports are the project's real counts.
+
+    Each entry carries the per-annotator-kind and per-target breakdown,
+    because those are what decide whether a blended average over the name
+    is trustworthy. Returns the entries and whether the group cap bound.
+    """
+    union = grains.ANNOTATIONS_UNION
+    stmt = (
+        compiler.scoped_base(
+            [
+                union.c.name,
+                union.c.annotator_kind,
+                union.c.target,
+                func.count().label("rows"),
+                func.count(union.c.score).label("scored"),
+            ],
+            project_rowid,
+            None,
+            grains.ANNOTATIONS_GRAIN,
+        )
+        .group_by(union.c.name, union.c.annotator_kind, union.c.target)
+        .order_by(func.count().desc(), union.c.name.asc())
+        .limit(MAX_ANNOTATION_GROUPS + 1)
+    )
+    rows = (await session.execute(stmt)).all()
+    capped = len(rows) > MAX_ANNOTATION_GROUPS
+    entries: dict[str, dict[str, Any]] = {}
+    for name, annotator_kind, target, count, scored in rows[:MAX_ANNOTATION_GROUPS]:
+        entry = entries.setdefault(
+            name,
+            {"name": name, "count": 0, "scored": 0, "annotator_kinds": {}, "targets": {}},
+        )
+        entry["count"] += count
+        entry["scored"] += scored
+        entry["annotator_kinds"][annotator_kind] = (
+            entry["annotator_kinds"].get(annotator_kind, 0) + count
+        )
+        entry["targets"][target] = entry["targets"].get(target, 0) + count
+    ordered = sorted(entries.values(), key=lambda entry: (-entry["count"], entry["name"]))
+    return ordered, capped
+
+
 #: How many observed dimensions augment a field_not_groupable rejection.
 TOP_GROUPABLES_LIMIT = 5
 
@@ -240,25 +300,27 @@ async def zero_result_guidance(
     project_rowid: int,
     time_range: Optional[TimeRange],
     filter_condition: Optional[str],
+    grain: Optional[grains.Grain] = None,
 ) -> dict[str, str]:
     """Diagnose an empty result with bounded checks only.
 
-    The window check counts spans within the queried window — never an
-    unrestricted historical scan — and the path check reads the same
-    bounded time-spread sample discovery uses.
+    The window check counts the grain's own rows within the queried
+    window — never an unrestricted historical scan — and the path check
+    reads the same bounded time-spread sample discovery uses.
     """
+    grain = grain or grains.SPANS_GRAIN
     window_count = await session.scalar(
-        compiler.scoped_base([func.count()], project_rowid, time_range)
+        compiler.scoped_base([func.count()], project_rowid, time_range, grain)
     )
     if not window_count:
-        detail = "The project has no spans"
+        detail = f"The project has no {grain.id}"
         if time_range is not None:
             detail += (
                 f" between {iso(time_range.start)} and {iso(time_range.end)}"
                 " (the check counted only within this window)"
             )
         return {"cause": "window_empty", "detail": detail + "."}
-    if filter_condition:
+    if filter_condition and grain.admits_observed_paths:
         referenced = compiler.attribute_paths_in_filter(filter_condition)
         if referenced:
             sample_count, stats = await sample_observed_paths(session, project_rowid)

--- a/src/phoenix/server/mcp_span_analytics/envelope.py
+++ b/src/phoenix/server/mcp_span_analytics/envelope.py
@@ -1,0 +1,227 @@
+"""Response-envelope assembly for the span analytics MCP tools.
+
+Everything a tool needs to turn raw query results into the response
+contract lives here: the discriminated-union output schemas (``ok`` /
+``validate`` / ``error`` arms), value serialization, and the two size
+disciplines — per-string clipping for drill-down payloads and whole-row
+budgeting for surveys. Whole values are never dropped silently: clipping
+marks what it removed and points at the recovery path, and budgeting
+reports how many rows fit.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Sequence
+
+from phoenix.server.mcp_span_analytics.compiler import TimeRange
+
+#: Structural disclosure attached whenever a filter used an annotation
+#: predicate: existence tests are any-annotator by construction.
+ANNOTATION_SEMANTICS_NOTE = (
+    "The filter's annotation predicate uses any-annotator semantics: any "
+    "matching annotation row satisfies it; consensus or reduced semantics "
+    "are not implemented."
+)
+
+ANNOTATION_SEMANTICS_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "enum": ["any"],
+    "description": (
+        "Present when the filter used an annotation predicate: the predicate "
+        "is satisfied by any matching annotation row (any-annotator "
+        "semantics); consensus/reduced semantics are not implemented."
+    ),
+}
+
+
+# --------------------------------------------------------------------------
+# Output schemas
+# --------------------------------------------------------------------------
+
+ERROR_ARM: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"const": "error"},
+        "code": {
+            "type": "string",
+            "description": (
+                "Machine-readable failure class, e.g. unknown_field, invalid_filter, "
+                "invalid_shape, field_not_groupable, project_not_found."
+            ),
+        },
+        "path": {
+            "type": ["string", "null"],
+            "description": "Request location the error anchors to, e.g. 'order[0].field'.",
+        },
+        "message": {"type": "string"},
+        "suggestions": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Nearest-name or alternative-usage candidates, directly usable.",
+        },
+    },
+    "required": ["status", "code", "message"],
+}
+
+VALIDATE_ARM: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"const": "ok"},
+        "valid": {"const": True},
+        "applied": {"type": "object"},
+    },
+    "required": ["status", "valid"],
+}
+
+
+def union_schema(
+    ok_properties: dict[str, Any],
+    ok_required: Sequence[str],
+    validate_arm: bool = False,
+) -> dict[str, Any]:
+    """The discriminated-union output schema: an ``ok`` arm with the given
+    properties, optionally the ``validate_only`` arm, and the error arm."""
+    ok_arm: dict[str, Any] = {
+        "type": "object",
+        "properties": {"status": {"const": "ok"}, **ok_properties},
+        "required": ["status", *ok_required],
+    }
+    arms = [ok_arm, *([VALIDATE_ARM] if validate_arm else []), ERROR_ARM]
+    return {"type": "object", "oneOf": arms}
+
+
+COLUMNS_SCHEMA: dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "type": {"type": "string"},
+            "unit": {"type": ["string", "null"]},
+        },
+    },
+    "description": "Typed metadata of the result columns, in order.",
+}
+
+GUIDANCE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cause": {
+            "type": "string",
+            "enum": ["window_empty", "path_not_observed", "no_matches"],
+        },
+        "detail": {"type": "string"},
+    },
+    "description": (
+        "Present when the result is empty: which of the enumerated causes applies. "
+        "path_not_observed is sampled evidence, not proof of absence."
+    ),
+}
+
+
+# --------------------------------------------------------------------------
+# Serialization
+# --------------------------------------------------------------------------
+
+
+def cell(value: Any) -> Any:
+    """Serialize one result cell: datetimes as UTC ISO-8601, Decimals as
+    floats, everything else unchanged."""
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def serialized_size(obj: Any) -> int:
+    return len(json.dumps(obj, ensure_ascii=False, default=str))
+
+
+def iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def time_range_resolved(time_range: TimeRange) -> dict[str, str]:
+    return {"start": iso(time_range.start), "end": iso(time_range.end)}
+
+
+# --------------------------------------------------------------------------
+# Size budgets
+# --------------------------------------------------------------------------
+
+
+def rows_within_budget(rows: Sequence[dict[str, Any]], budget: int) -> list[dict[str, Any]]:
+    """Keep the leading rows that fit the character budget.
+
+    Rows are kept whole, never truncated mid-record; at least one row is
+    always kept so a too-small budget degrades to a single record instead
+    of an empty result.
+    """
+    kept: list[dict[str, Any]] = []
+    used = 0
+    for row in rows:
+        cost = serialized_size(row)
+        if kept and used + cost > budget:
+            break
+        kept.append(row)
+        used += cost
+    return kept
+
+
+def clip_strings_to_budget(
+    obj: Any,
+    budget: int,
+    marker: str,
+    min_keep: int = 500,
+) -> tuple[Any, list[str]]:
+    """Clip the largest string leaves of a JSON-like object until it fits.
+
+    Returns the (possibly copied and clipped) object and the dotted paths of
+    clipped leaves. Whole values are never dropped — clipping a cell and
+    pointing at the recovery path degrades better than losing the row.
+    """
+    size = serialized_size(obj)
+    if size <= budget:
+        return obj, []
+    obj = deepcopy(obj)
+    leaves: list[tuple[int, Any, Any, str]] = []
+
+    def collect(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                child_path = f"{path}.{key}" if path else str(key)
+                if isinstance(value, str) and len(value) > min_keep:
+                    leaves.append((len(value), node, key, child_path))
+                else:
+                    collect(value, child_path)
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                child_path = f"{path}[{index}]"
+                if isinstance(value, str) and len(value) > min_keep:
+                    leaves.append((len(value), node, index, child_path))
+                else:
+                    collect(value, child_path)
+
+    collect(obj, "")
+    leaves.sort(key=lambda item: item[0], reverse=True)
+    clipped: list[str] = []
+    for length, container, key, path in leaves:
+        if size <= budget:
+            break
+        text_value = container[key]
+        excess = size - budget
+        keep = max(min_keep, len(text_value) - excess - len(marker))
+        if keep >= len(text_value):
+            continue
+        suffix = f"…[clipped {len(text_value) - keep} chars; {marker}]"
+        container[key] = text_value[:keep] + suffix
+        size += len(suffix) + keep - len(text_value)
+        clipped.append(path)
+    return obj, clipped

--- a/src/phoenix/server/mcp_span_analytics/envelope.py
+++ b/src/phoenix/server/mcp_span_analytics/envelope.py
@@ -67,12 +67,44 @@ ERROR_ARM: dict[str, Any] = {
     "required": ["status", "code", "message"],
 }
 
+#: One coherent per-field notes mechanism, shared by live responses
+#: (``field_notes``) and validation (``warnings``): ``not_observed`` — the
+#: path was not seen in the discovery sample (open admission stands, so
+#: this is a disclosure with nearest-spelling suggestions, not an error);
+#: ``all_null`` — the path was observed in the project but carries no
+#: value anywhere in this result.
+FIELD_NOTES_SCHEMA: dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "field": {"type": "string", "description": "The path, in canonical query spelling."},
+            "code": {"type": "string", "enum": ["not_observed", "all_null"]},
+            "note": {"type": "string"},
+            "suggestions": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Nearest observed spellings, directly usable.",
+            },
+        },
+        "required": ["field", "code", "note"],
+    },
+    "description": (
+        "Per-field admission and completeness notes: not_observed — the path was "
+        "not seen in the discovery sample (sampled evidence, not proof of "
+        "absence; suggestions name the nearest observed spellings); all_null — "
+        "the path was observed in the project's sample but was NULL on every "
+        "returned row or produced only a null group."
+    ),
+}
+
 VALIDATE_ARM: dict[str, Any] = {
     "type": "object",
     "properties": {
         "status": {"const": "ok"},
         "valid": {"const": True},
         "applied": {"type": "object"},
+        "warnings": FIELD_NOTES_SCHEMA,
     },
     "required": ["status", "valid"],
 }

--- a/src/phoenix/server/mcp_span_analytics/envelope.py
+++ b/src/phoenix/server/mcp_span_analytics/envelope.py
@@ -37,6 +37,48 @@ ANNOTATION_SEMANTICS_SCHEMA: dict[str, Any] = {
     ),
 }
 
+ANNOTATION_REDUCTIONS_SCHEMA: dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "field": {"type": "string", "description": "The field id, as requested."},
+            "annotation": {"type": "string", "description": "Annotation name reduced."},
+            "annotator_kind": {
+                "type": ["string", "null"],
+                "description": "Annotator kind the reduction was restricted to, or null for all.",
+            },
+            "reduction": {
+                "type": "string",
+                "enum": ["mean_over_annotators", "latest_by_updated_at", "cardinality"],
+            },
+            "note": {"type": "string"},
+        },
+        "required": ["field", "annotation", "reduction"],
+    },
+    "description": (
+        "Present when the query read annotation values through the spans grain: one "
+        "entry per reduced field, naming the rule that collapsed a span's several "
+        "annotations into one value. A reduced number means nothing without it."
+    ),
+}
+
+ANNOTATION_COMPOSITION_NOTE = (
+    "Rows carry annotation_composition: how many annotations of each annotator kind "
+    "each group actually contained. A blended average moves when that mix moves, with "
+    "no annotator having changed its scoring, so compare the composition across groups "
+    "before reading a difference as a quality change."
+)
+
+ANNOTATION_COMPOSITION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Per annotation name, the count of contributing annotations by annotator kind "
+        "('LLM', 'CODE', 'HUMAN'), for every reduction that was not already restricted "
+        "to one kind. Kinds with no annotations are omitted."
+    ),
+}
+
 
 # --------------------------------------------------------------------------
 # Output schemas
@@ -158,6 +200,41 @@ GUIDANCE_SCHEMA: dict[str, Any] = {
 # --------------------------------------------------------------------------
 # Serialization
 # --------------------------------------------------------------------------
+
+
+def annotation_reductions(fields: Sequence[Any]) -> list[dict[str, Any]]:
+    """Disclosure entries for the reduced fields a query used."""
+    entries: list[dict[str, Any]] = []
+    for field in fields:
+        reference = getattr(field, "annotation", None)
+        entries.append(
+            {
+                "field": field.id,
+                "annotation": reference.name if reference is not None else None,
+                "annotator_kind": reference.annotator_kind if reference is not None else None,
+                "reduction": field.reduction,
+                "note": field.description,
+            }
+        )
+    return entries
+
+
+def composition_map(
+    probes: Sequence[Any],
+    values: Sequence[Any],
+) -> dict[str, dict[str, int]]:
+    """Fold the hidden per-kind probe values into one nested count map.
+
+    Zero counts are dropped: an annotator kind that wrote nothing is noise
+    in every row, and its absence is what the caller needs to see.
+    """
+    composition: dict[str, dict[str, int]] = {}
+    for probe, value in zip(probes, values):
+        count = int(value or 0)
+        if not count:
+            continue
+        composition.setdefault(probe.annotation_name, {})[probe.annotator_kind] = count
+    return composition
 
 
 def cell(value: Any) -> Any:

--- a/src/phoenix/server/mcp_span_analytics/grains.py
+++ b/src/phoenix/server/mcp_span_analytics/grains.py
@@ -1,0 +1,500 @@
+"""Queryable grains of the span analytics surface.
+
+A grain is the relation a query reads: which rows exist, what one row
+means, and which columns are addressable on it. Two grains ship:
+
+- **``spans``** — one row per span, the surface's original and default
+  grain. Its fields are the registry's authored catalog plus attribute
+  paths observed in the project's data plus annotation enrichment.
+- **``annotations``** — one row per annotation, unioned across every
+  annotation target Phoenix records (span, trace, document, and session)
+  with ``target`` as an ordinary groupable dimension. Its field set is
+  closed: annotations carry typed columns, not a free-form attribute blob,
+  so nothing here is discovered.
+
+The two grains answer different questions, and which one is right follows
+from the subject of the question rather than from the data it touches.
+"Correctness by prompt version" is a question about spans, so it belongs to
+the ``spans`` grain, where each span contributes one reduced value. "Which
+annotators scored this release, and how many times" is a question about
+annotations, so it belongs to the ``annotations`` grain, where each
+annotation contributes one row. Asking the second question on the first
+grain is what makes annotator-mix artifacts invisible.
+
+Both grains bind their project scope and time window through
+:meth:`Grain.scoped`, which is the only statement base in this package —
+an unscoped query stays inexpressible rather than merely discouraged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from types import MappingProxyType
+from typing import Any, Mapping, Optional, Sequence
+
+from sqlalchemy import (
+    Integer,
+    Select,
+    SQLColumnExpression,
+    String,
+    cast,
+    literal,
+    null,
+    select,
+    union_all,
+)
+from sqlalchemy.sql.expression import ColumnElement
+
+from phoenix.db import models
+from phoenix.server.mcp_span_analytics import registry
+from phoenix.server.mcp_span_analytics.registry import AuthoredField
+
+#: Grain ids, as written in a request's ``from``.
+SPANS = "spans"
+ANNOTATIONS = "annotations"
+
+#: The annotation targets Phoenix records. Every one of them is an arm of
+#: the annotations union, so ``target`` discriminates rows that are
+#: otherwise identically shaped.
+ANNOTATION_TARGETS: tuple[str, ...] = ("span", "trace", "document", "session")
+
+
+# --------------------------------------------------------------------------
+# The annotations union
+# --------------------------------------------------------------------------
+
+
+def _annotation_id(target: str, column: Any) -> ColumnElement[Any]:
+    """A row identity unique across the union's arms.
+
+    Each annotation table numbers its rows independently, so the row id
+    alone collides across targets; prefixing with the target makes one
+    opaque string that identifies an annotation globally.
+    """
+    return literal(f"{target}:", String) + cast(column, String)
+
+
+def _span_annotation_arm() -> Select[Any]:
+    return (
+        select(
+            models.Trace.project_rowid.label("project_rowid"),
+            models.Span.start_time.label("start_time"),
+            literal("span", String).label("target"),
+            models.Span.span_id.label("target_id"),
+            _annotation_id("span", models.SpanAnnotation.id).label("annotation_id"),
+            models.SpanAnnotation.name.label("name"),
+            models.SpanAnnotation.label.label("label"),
+            models.SpanAnnotation.score.label("score"),
+            models.SpanAnnotation.explanation.label("explanation"),
+            models.SpanAnnotation.annotator_kind.label("annotator_kind"),
+            models.SpanAnnotation.identifier.label("identifier"),
+            models.SpanAnnotation.source.label("source"),
+            models.SpanAnnotation.created_at.label("created_at"),
+            models.Trace.trace_id.label("trace_id"),
+            cast(null(), Integer).label("document_position"),
+        )
+        .select_from(models.SpanAnnotation)
+        .join(models.Span, models.SpanAnnotation.span_rowid == models.Span.id)
+        .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+    )
+
+
+def _trace_annotation_arm() -> Select[Any]:
+    return (
+        select(
+            models.Trace.project_rowid.label("project_rowid"),
+            models.Trace.start_time.label("start_time"),
+            literal("trace", String).label("target"),
+            models.Trace.trace_id.label("target_id"),
+            _annotation_id("trace", models.TraceAnnotation.id).label("annotation_id"),
+            models.TraceAnnotation.name.label("name"),
+            models.TraceAnnotation.label.label("label"),
+            models.TraceAnnotation.score.label("score"),
+            models.TraceAnnotation.explanation.label("explanation"),
+            models.TraceAnnotation.annotator_kind.label("annotator_kind"),
+            models.TraceAnnotation.identifier.label("identifier"),
+            models.TraceAnnotation.source.label("source"),
+            models.TraceAnnotation.created_at.label("created_at"),
+            models.Trace.trace_id.label("trace_id"),
+            cast(null(), Integer).label("document_position"),
+        )
+        .select_from(models.TraceAnnotation)
+        .join(models.Trace, models.TraceAnnotation.trace_rowid == models.Trace.id)
+    )
+
+
+def _document_annotation_arm() -> Select[Any]:
+    return (
+        select(
+            models.Trace.project_rowid.label("project_rowid"),
+            models.Span.start_time.label("start_time"),
+            literal("document", String).label("target"),
+            models.Span.span_id.label("target_id"),
+            _annotation_id("document", models.DocumentAnnotation.id).label("annotation_id"),
+            models.DocumentAnnotation.name.label("name"),
+            models.DocumentAnnotation.label.label("label"),
+            models.DocumentAnnotation.score.label("score"),
+            models.DocumentAnnotation.explanation.label("explanation"),
+            models.DocumentAnnotation.annotator_kind.label("annotator_kind"),
+            models.DocumentAnnotation.identifier.label("identifier"),
+            models.DocumentAnnotation.source.label("source"),
+            models.DocumentAnnotation.created_at.label("created_at"),
+            models.Trace.trace_id.label("trace_id"),
+            models.DocumentAnnotation.document_position.label("document_position"),
+        )
+        .select_from(models.DocumentAnnotation)
+        .join(models.Span, models.DocumentAnnotation.span_rowid == models.Span.id)
+        .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+    )
+
+
+def _session_annotation_arm() -> Select[Any]:
+    return (
+        select(
+            models.ProjectSession.project_id.label("project_rowid"),
+            models.ProjectSession.start_time.label("start_time"),
+            literal("session", String).label("target"),
+            models.ProjectSession.session_id.label("target_id"),
+            _annotation_id("session", models.ProjectSessionAnnotation.id).label("annotation_id"),
+            models.ProjectSessionAnnotation.name.label("name"),
+            models.ProjectSessionAnnotation.label.label("label"),
+            models.ProjectSessionAnnotation.score.label("score"),
+            models.ProjectSessionAnnotation.explanation.label("explanation"),
+            models.ProjectSessionAnnotation.annotator_kind.label("annotator_kind"),
+            models.ProjectSessionAnnotation.identifier.label("identifier"),
+            models.ProjectSessionAnnotation.source.label("source"),
+            models.ProjectSessionAnnotation.created_at.label("created_at"),
+            cast(null(), String).label("trace_id"),
+            cast(null(), Integer).label("document_position"),
+        )
+        .select_from(models.ProjectSessionAnnotation)
+        .join(
+            models.ProjectSession,
+            models.ProjectSessionAnnotation.project_session_id == models.ProjectSession.id,
+        )
+    )
+
+
+#: The four-arm union, built once. Project and time predicates are applied
+#: by the outer statement rather than inside the arms: both backends push a
+#: predicate on a union column down into every arm, and keeping the arms
+#: free of request state means the union is a constant, not a builder.
+ANNOTATIONS_UNION = union_all(
+    _span_annotation_arm(),
+    _trace_annotation_arm(),
+    _document_annotation_arm(),
+    _session_annotation_arm(),
+).subquery("annotations")
+
+
+# --------------------------------------------------------------------------
+# Annotation grain fields
+# --------------------------------------------------------------------------
+
+
+def _union_column(name: str) -> Any:
+    column = ANNOTATIONS_UNION.c[name]
+
+    def factory(dialect: Any) -> Any:
+        return column
+
+    return factory
+
+
+ANNOTATION_FIELDS: tuple[AuthoredField, ...] = (
+    AuthoredField(
+        id="annotation_id",
+        label="Annotation ID",
+        type="string",
+        description=(
+            "Stable row identity of an annotation, unique across targets "
+            "(e.g. 'span:412'). Always returned by row queries."
+        ),
+        factory=_union_column("annotation_id"),
+    ),
+    AuthoredField(
+        id="target",
+        label="Annotation target",
+        type="string",
+        description=(
+            "What the annotation is attached to: 'span', 'trace', 'document', or "
+            "'session'. Annotations of different targets are different populations — "
+            "group or filter by target rather than mixing them silently."
+        ),
+        factory=_union_column("target"),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="target_id",
+        label="Target ID",
+        type="string",
+        description=(
+            "Public id of the annotated entity, in its target's own namespace: the "
+            "span id for 'span' and 'document' targets (recover the record with "
+            "getSpan), the trace id for 'trace' (getTrace), the session id for "
+            "'session'."
+        ),
+        factory=_union_column("target_id"),
+    ),
+    AuthoredField(
+        id="name",
+        label="Annotation name",
+        type="string",
+        description=(
+            "Annotation name, e.g. 'correctness'. Project data, not a fixed "
+            "vocabulary — describeSpans lists the names observed in this project."
+        ),
+        factory=_union_column("name"),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="score",
+        label="Score",
+        type="float",
+        description=(
+            "Numeric score, NULL on label-only annotations. Averaging over this grain "
+            "weights every annotation equally, so a shift in the annotator mix moves "
+            "the average even when no annotator changed its scoring — break down by "
+            "annotator_kind to see the composition."
+        ),
+        factory=_union_column("score"),
+        aggregatable=True,
+    ),
+    AuthoredField(
+        id="label",
+        label="Label",
+        type="string",
+        description="Categorical label, NULL on score-only annotations.",
+        factory=_union_column("label"),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="explanation",
+        label="Explanation",
+        type="string",
+        description=(
+            "The annotator's written rationale; NULL when none was recorded. Often "
+            "large, so row results clip it to a preview — recover the full text with "
+            "getSpan on the row's target_id."
+        ),
+        factory=_union_column("explanation"),
+    ),
+    AuthoredField(
+        id="annotator_kind",
+        label="Annotator kind",
+        type="string",
+        description=(
+            "Who produced the annotation: 'LLM', 'CODE', or 'HUMAN'. The dimension "
+            "that separates a real quality change from a change in who was measuring."
+        ),
+        factory=_union_column("annotator_kind"),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="identifier",
+        label="Annotator identifier",
+        type="string",
+        description=(
+            "Distinguishes annotators writing under one name; empty string when the "
+            "annotation carries no identifier. Uniqueness is (name, target, "
+            "identifier), so this is what makes several annotations of one name on "
+            "one span legal."
+        ),
+        factory=_union_column("identifier"),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="source",
+        label="Source",
+        type="string",
+        description="How the annotation was written: 'API' or 'APP'.",
+        factory=_union_column("source"),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="created_at",
+        label="Annotation created",
+        type="datetime",
+        description=(
+            "When the annotation was written, UTC. Distinct from start_time, which is "
+            "when the annotated work ran — an annotation written today can score a "
+            "span from last week. Not filterable: temporal scope has one home, "
+            "time_range, and it binds start_time."
+        ),
+        factory=_union_column("created_at"),
+        filterable=False,
+    ),
+    AuthoredField(
+        id="start_time",
+        label="Target start time",
+        type="datetime",
+        description=(
+            "Start of the annotated span, trace, or session, UTC — the time this "
+            "grain's time_range binds, so the same window selects the same underlying "
+            "work on both grains. Not filterable: time_range is its only home."
+        ),
+        factory=_union_column("start_time"),
+        filterable=False,
+    ),
+    AuthoredField(
+        id="trace_id",
+        label="Trace ID",
+        type="string",
+        description=(
+            "Trace of the annotated entity; NULL for session annotations, which do not "
+            "belong to a single trace. Pass it to getTrace for the span tree."
+        ),
+        factory=_union_column("trace_id"),
+    ),
+    AuthoredField(
+        id="document_position",
+        label="Document position",
+        type="integer",
+        description=(
+            "Zero-based position of the annotated retrieval document within its span; "
+            "NULL unless target is 'document'."
+        ),
+        factory=_union_column("document_position"),
+        groupable=True,
+    ),
+)
+
+
+# --------------------------------------------------------------------------
+# Grains
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Grain:
+    """One queryable relation: its fields, its scope, and its row identity."""
+
+    id: str
+    label: str
+    description: str
+    fields: tuple[AuthoredField, ...]
+    fields_by_id: Mapping[str, AuthoredField]
+    #: Field every row query returns whether or not it was selected, so no
+    #: result row is unrecoverable.
+    identity_field: str
+    default_row_fields: tuple[str, ...]
+    #: Field ``time_range`` binds, and the default row ordering key.
+    time_field: str
+    #: That field's column, held directly so scoping never depends on a
+    #: dialect the scope call does not have.
+    time_column: SQLColumnExpression[Any]
+    #: Unique column ending every ordering, so ties break reproducibly.
+    tiebreak_column: SQLColumnExpression[Any]
+    #: Whether seeded random sampling is offered. It probes a dense integer
+    #: row id; the annotations union has no such key (its arms number their
+    #: rows independently), so the capability is published as absent rather
+    #: than approximated.
+    supports_sampling: bool
+    #: Whether identifiers may resolve to attribute paths discovered in the
+    #: project's data. Only the spans grain carries a free-form blob.
+    admits_observed_paths: bool
+    #: Whether ``annotations["name"].score``-style enrichment resolves here.
+    #: On the annotations grain the annotation is the row, so a reduction
+    #: over it would be answering the question twice.
+    admits_annotation_enrichment: bool
+    #: Whether the filter grammar's annotation existence predicates apply.
+    admits_annotation_predicates: bool
+
+    def scoped(
+        self,
+        columns: Sequence[Any],
+        project_rowid: int,
+        start: Optional[datetime],
+        end: Optional[datetime],
+    ) -> Select[Any]:
+        """The grain's only statement base: bound to one project, and to the
+        time window when one is given. Deliberately unordered — aggregates
+        must not inherit row ordering, and PostgreSQL rejects ordering by
+        ungrouped columns.
+        """
+        stmt: Select[Any] = select(*columns)
+        if self.id == SPANS:
+            stmt = stmt.select_from(models.Span).join(
+                models.Trace, models.Span.trace_rowid == models.Trace.id
+            )
+            project_column: SQLColumnExpression[Any] = models.Trace.project_rowid
+        else:
+            stmt = stmt.select_from(ANNOTATIONS_UNION)
+            project_column = ANNOTATIONS_UNION.c.project_rowid
+        stmt = stmt.where(project_column == project_rowid)
+        if start is not None and end is not None:
+            stmt = stmt.where(self.time_column >= start, self.time_column < end)
+        return stmt
+
+
+def _by_id(fields: Sequence[AuthoredField]) -> Mapping[str, AuthoredField]:
+    return MappingProxyType({f.id: f for f in fields})
+
+
+SPANS_GRAIN = Grain(
+    id=SPANS,
+    label="Spans",
+    description=(
+        "One row per span: the traced unit of work. The default grain, and the one "
+        "whose subject is the application's behavior — latency, errors, tokens, cost, "
+        "model, and any attribute the application recorded."
+    ),
+    fields=registry.AUTHORED_FIELDS,
+    fields_by_id=registry.AUTHORED_BY_ID,
+    identity_field="span_id",
+    default_row_fields=(
+        "span_id",
+        "trace_id",
+        "name",
+        "span_kind",
+        "status_code",
+        "start_time",
+        "latency_ms",
+    ),
+    time_field="start_time",
+    time_column=models.Span.start_time,
+    tiebreak_column=models.Span.id,
+    supports_sampling=True,
+    admits_observed_paths=True,
+    admits_annotation_enrichment=True,
+    admits_annotation_predicates=True,
+)
+
+ANNOTATIONS_GRAIN = Grain(
+    id=ANNOTATIONS,
+    label="Annotations",
+    description=(
+        "One row per annotation — an eval score, label, or human review — across every "
+        "target Phoenix annotates (span, trace, document, session), discriminated by "
+        "the target dimension. The grain to use when the annotation itself is the "
+        "subject: score distributions, annotator composition, label breakdowns. "
+        "time_range binds the annotated work's start_time, not the annotation's "
+        "created_at, so a window here selects the same population it selects on spans."
+    ),
+    fields=ANNOTATION_FIELDS,
+    fields_by_id=_by_id(ANNOTATION_FIELDS),
+    identity_field="annotation_id",
+    default_row_fields=(
+        "annotation_id",
+        "target",
+        "target_id",
+        "name",
+        "label",
+        "score",
+        "annotator_kind",
+        "identifier",
+        "start_time",
+    ),
+    time_field="start_time",
+    time_column=ANNOTATIONS_UNION.c.start_time,
+    tiebreak_column=ANNOTATIONS_UNION.c.annotation_id,
+    supports_sampling=False,
+    admits_observed_paths=False,
+    admits_annotation_enrichment=False,
+    admits_annotation_predicates=False,
+)
+
+GRAINS: Mapping[str, Grain] = MappingProxyType(
+    {grain.id: grain for grain in (SPANS_GRAIN, ANNOTATIONS_GRAIN)}
+)

--- a/src/phoenix/server/mcp_span_analytics/links.py
+++ b/src/phoenix/server/mcp_span_analytics/links.py
@@ -1,0 +1,106 @@
+"""Phoenix UI link composition for the span analytics MCP tools.
+
+Every result that names a span, a trace, or a cohort carries a deep link
+into the Phoenix UI, so a finding made through the tools is one click away
+from the human view of the same data. This module owns two concerns: how
+the public origin of the deployment is determined, and how a group row's
+identity becomes a filter-grammar condition the UI's span view accepts.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Optional, Sequence
+from urllib.parse import urlencode
+
+from phoenix.config import ENV_PHOENIX_ROOT_URL, get_env_root_url
+from phoenix.server.mcp_span_analytics.compiler import TimeRange
+from phoenix.server.mcp_span_analytics.envelope import iso
+from phoenix.server.utils import prepend_root_path
+
+
+def public_url(path: str, get_request: Callable[[], Any]) -> str:
+    """Compose an absolute Phoenix UI link for ``path``.
+
+    Behind a reverse proxy, only two parties can know the public origin:
+    explicit configuration, or the incoming request itself — the server's
+    own host/port settings describe where it listens, not where clients
+    reach it. Precedence follows the OAuth machinery's ``public_origin``:
+    ``PHOENIX_ROOT_URL`` when set; otherwise the current MCP request's
+    origin with its ASGI ``root_path`` prepended; and the
+    environment-composed URL only as the last resort when no request
+    context exists. ``get_request`` is the transport's request accessor,
+    injected so link composition stays independent of the serving stack.
+    """
+    if os.getenv(ENV_PHOENIX_ROOT_URL):
+        return f"{str(get_env_root_url()).rstrip('/')}{path}"
+    try:
+        request = get_request()
+    except RuntimeError:
+        return f"{str(get_env_root_url()).rstrip('/')}{path}"
+    origin = f"{request.base_url.scheme}://{request.base_url.netloc}"
+    # The request is seen inside the mounted MCP app, so its ASGI root_path
+    # is "<deployment prefix><MCP mount>". The deployment prefix (a reverse
+    # proxy's) belongs in UI links; the app's own MCP mount does not — a UI
+    # route lives at /projects/..., never /mcp/projects/....
+    from phoenix.server.mcp_server import MCP_MOUNT_PATH
+
+    root_path = str(request.scope.get("root_path", "")).rstrip("/")
+    if root_path.endswith(MCP_MOUNT_PATH):
+        root_path = root_path[: -len(MCP_MOUNT_PATH)]
+    return f"{origin}{prepend_root_path({'root_path': root_path}, path)}"
+
+
+def filter_literal(value: Any) -> str:
+    """Render one group-key value as a filter-grammar literal.
+
+    Strings are escaped for the grammar (which parses Python string
+    literals): backslashes first, then single quotes — a value like
+    ``o'brien-corp`` must survive both the grammar and URL encoding.
+    """
+    if isinstance(value, str):
+        escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+        return f"'{escaped}'"
+    return repr(value)
+
+
+def bucket_start(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str) and value:
+        return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+    return None
+
+
+def cohort_url(
+    base: str,
+    breakdowns: Sequence[Any],
+    raw_values: Sequence[Any],
+    time_range: TimeRange,
+) -> str:
+    """Deep link to the group's cohort in the Phoenix UI span view.
+
+    The link carries the group's condition as a ``filter`` in the filter
+    grammar (breakdown-key equalities ANDed) plus ``start``/``end``. A
+    time bucket contributes nothing to ``filter``; it narrows the time
+    params to its hour instead. A **null group key is skipped**: the UI
+    filter grammar cannot express "attribute is absent" today, so the
+    null bucket links to the window without that conjunct — a wider
+    cohort than the row, by declared necessity.
+    """
+    conjuncts: list[str] = []
+    window_start, window_end = time_range.start, time_range.end
+    for breakdown, value in zip(breakdowns, raw_values):
+        if breakdown.is_time_bucket:
+            bucket = bucket_start(value)
+            if bucket is not None:
+                window_start, window_end = bucket, bucket + timedelta(hours=1)
+        elif value is not None:
+            conjuncts.append(f"{breakdown.id} == {filter_literal(value)}")
+    params: dict[str, str] = {}
+    if conjuncts:
+        params["filter"] = " and ".join(conjuncts)
+    params["start"] = iso(window_start)
+    params["end"] = iso(window_end)
+    return f"{base}?{urlencode(params)}"

--- a/src/phoenix/server/mcp_span_analytics/links.py
+++ b/src/phoenix/server/mcp_span_analytics/links.py
@@ -78,16 +78,20 @@ def cohort_url(
     breakdowns: Sequence[Any],
     raw_values: Sequence[Any],
     time_range: TimeRange,
+    filter_condition: Optional[str] = None,
 ) -> str:
     """Deep link to the group's cohort in the Phoenix UI span view.
 
-    The link carries the group's condition as a ``filter`` in the filter
-    grammar (breakdown-key equalities ANDed) plus ``start``/``end``. A
-    time bucket contributes nothing to ``filter``; it narrows the time
-    params to its hour instead. A **null group key is skipped**: the UI
-    filter grammar cannot express "attribute is absent" today, so the
-    null bucket links to the window without that conjunct — a wider
-    cohort than the row, by declared necessity.
+    The link carries the group's *whole* condition as a ``filter`` in the
+    filter grammar — the query's own filter (parenthesized) conjoined with
+    the breakdown-key equalities — plus ``start``/``end``: the linked
+    cohort is the same population the row's numbers were computed over,
+    not just the breakdown slice. A time bucket contributes nothing to
+    ``filter``; it narrows the time params to its hour instead. A **null
+    group key is skipped**: the UI filter grammar cannot express
+    "attribute is absent" today, so the null bucket links to the window
+    without that conjunct — a wider cohort than the row, by declared
+    necessity.
     """
     conjuncts: list[str] = []
     window_start, window_end = time_range.start, time_range.end
@@ -98,6 +102,8 @@ def cohort_url(
                 window_start, window_end = bucket, bucket + timedelta(hours=1)
         elif value is not None:
             conjuncts.append(f"{breakdown.id} == {filter_literal(value)}")
+    if filter_condition:
+        conjuncts.insert(0, f"({filter_condition})" if conjuncts else filter_condition)
     params: dict[str, str] = {}
     if conjuncts:
         params["filter"] = " and ".join(conjuncts)

--- a/src/phoenix/server/mcp_span_analytics/registry.py
+++ b/src/phoenix/server/mcp_span_analytics/registry.py
@@ -19,9 +19,12 @@ namespace:
   ``custom_flag``). Project-specific context lives in the free-form
   attribute blob and varies per deployment, so it is discovered from the
   data rather than assumed. Observed fields are selectable, filterable, and
-  groupable, but never aggregatable: cast and mixed-type semantics for
-  arbitrary JSON paths are undefined, so typed aggregation stays on
-  authored fields.
+  groupable, and they admit **presence aggregations** (``count``,
+  ``count_distinct``), which count rows and distinct values without ever
+  computing on them. **Value aggregations** (``sum``, ``avg``, ``min``,
+  ``max``, percentiles) stay on authored fields: cast and mixed-type
+  semantics for arbitrary JSON paths are undefined, so typed arithmetic
+  needs declared semantics.
 
 Expressions are built per SQL dialect because JSON access and percentile
 aggregation genuinely differ between PostgreSQL and SQLite; every factory in
@@ -61,6 +64,10 @@ _ExprFactory = Callable[[SupportedSQLDialect], SQLColumnExpression[Any]]
 class AuthoredField:
     """A hand-defined field with declared type, unit, and capabilities.
 
+    ``aggregatable`` grants *value* aggregations (sum, avg, min, max,
+    percentiles); presence aggregations (count, count_distinct) never
+    compute on values and are valid on every field, so no flag gates them.
+
     ``source`` records the field's provenance so a caller can tell which
     identifiers are portable across projects and which are not:
     ``"column"`` for physical span columns, ``"computed"`` for derived
@@ -92,13 +99,14 @@ class ObservedField:
     The value is extracted as the raw JSON value (deserialized by the JSON
     result processor on both dialects), so strings and numbers come back
     natively typed. Observed fields carry no declared type and are never
-    aggregatable.
+    *value*-aggregatable; presence aggregations (count, count_distinct)
+    remain valid because they never compute on the value.
     """
 
     id: str
     keys: tuple[str, ...]
 
-    #: Observed fields support everything except aggregation.
+    #: Observed fields support everything except value aggregation.
     filterable: bool = True
     groupable: bool = True
     aggregatable: bool = False
@@ -619,12 +627,19 @@ class Aggregation:
     value (``count``, ``sum``); share-of-total is meaningful only for those.
     An average or percentile of a subgroup carries no share of the overall
     average, so shares are omitted for non-additive calculations.
+
+    ``presence`` marks functions that count rows and distinct values
+    without ever computing on the value (``count``, ``count_distinct``):
+    they are type-safe on any field, authored or observed. Every other
+    function is a value aggregation, gated on a field's declared
+    ``aggregatable`` capability.
     """
 
     fn: str
     additive: bool
     requires_field: bool
     accepts_field: bool = True
+    presence: bool = False
     description: str = ""
 
 
@@ -634,6 +649,7 @@ AGGREGATIONS: Mapping[str, Aggregation] = MappingProxyType(
             fn="count",
             additive=True,
             requires_field=False,
+            presence=True,
             description=(
                 "Row count. With a field, counts rows where the field is non-NULL — "
                 "the missingness probe for guarded numeric fields."
@@ -643,6 +659,7 @@ AGGREGATIONS: Mapping[str, Aggregation] = MappingProxyType(
             fn="count_distinct",
             additive=False,
             requires_field=True,
+            presence=True,
             description="Number of distinct non-NULL values of the field.",
         ),
         "sum": Aggregation(fn="sum", additive=True, requires_field=True),

--- a/src/phoenix/server/mcp_span_analytics/registry.py
+++ b/src/phoenix/server/mcp_span_analytics/registry.py
@@ -1,0 +1,732 @@
+"""Field registry for the span analytics MCP tools.
+
+The registry is the semantic layer of the analytics surface: the single
+authority on which fields exist, what they mean, and what each one may be
+used for (select, filter, group, aggregate). Two field classes share one
+namespace:
+
+- **Authored fields** are hand-defined with full type, unit, and capability
+  metadata. The registry authors only semantics that hold across all
+  Phoenix projects: physical span columns (``span_id``, ``latency_ms``, ...),
+  documented OpenInference conventions (``llm.model_name``,
+  ``llm.token_count.total``, ``input.value``, ``output.value``), and the
+  computed ``is_error`` indicator. Field ids are the same raw paths the span
+  filter grammar already understands, so a field id read from discovery
+  output works verbatim in ``fields``, ``filter``, and ``breakdowns`` — the
+  caller copies identifiers instead of constructing them.
+- **Observed attribute fields** are constructed on demand from any canonical
+  attribute path (``metadata.release``, ``metadata["build.version"]``,
+  ``custom_flag``). Project-specific context lives in the free-form
+  attribute blob and varies per deployment, so it is discovered from the
+  data rather than assumed. Observed fields are selectable, filterable, and
+  groupable, but never aggregatable: cast and mixed-type semantics for
+  arbitrary JSON paths are undefined, so typed aggregation stays on
+  authored fields.
+
+Expressions are built per SQL dialect because JSON access and percentile
+aggregation genuinely differ between PostgreSQL and SQLite; every factory in
+this module must compile — and agree in behavior — on both.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from difflib import get_close_matches
+from types import MappingProxyType
+from typing import Any, Optional, Union, cast
+
+# Attribute names defined by the OpenInference semantic conventions come
+# from the convention package itself: the registry's ids stay in lockstep
+# with the conventions, and a renamed constant fails at import time instead
+# of silently drifting.
+from openinference.semconv.trace import MessageAttributes, SpanAttributes
+from sqlalchemy import SQLColumnExpression, case, distinct, func, null
+from sqlalchemy import select as sqlalchemy_select
+from sqlalchemy.sql.expression import ColumnElement
+from sqlalchemy.sql.functions import percentile_cont
+
+from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
+
+FieldTypeName = str  # "string" | "integer" | "float" | "datetime"
+
+_ExprFactory = Callable[[SupportedSQLDialect], SQLColumnExpression[Any]]
+
+
+@dataclass(frozen=True)
+class AuthoredField:
+    """A hand-defined field with declared type, unit, and capabilities.
+
+    ``source`` records the field's provenance so a caller can tell which
+    identifiers are portable across projects and which are not:
+    ``"column"`` for physical span columns, ``"computed"`` for derived
+    indicators, and ``"openinference_convention"`` for attributes whose
+    names and meanings are defined by the OpenInference semantic
+    conventions. (Discovered paths report ``"observed_attribute"`` and are
+    project-specific by nature.)
+    """
+
+    id: str
+    label: str
+    type: FieldTypeName
+    description: str
+    factory: _ExprFactory
+    unit: Optional[str] = None
+    filterable: bool = True
+    groupable: bool = False
+    aggregatable: bool = False
+    source: str = "column"
+
+    def expr(self, dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
+        return self.factory(dialect)
+
+
+@dataclass(frozen=True)
+class ObservedField:
+    """A field resolved dynamically from a canonical attribute path.
+
+    The value is extracted as the raw JSON value (deserialized by the JSON
+    result processor on both dialects), so strings and numbers come back
+    natively typed. Observed fields carry no declared type and are never
+    aggregatable.
+    """
+
+    id: str
+    keys: tuple[str, ...]
+
+    #: Observed fields support everything except aggregation.
+    filterable: bool = True
+    groupable: bool = True
+    aggregatable: bool = False
+
+    def expr(self, dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
+        return cast(
+            SQLColumnExpression[Any],
+            models.Span.attributes[list(self.keys)],
+        )
+
+
+ResolvedField = Union[AuthoredField, ObservedField]
+
+
+def _plain(column: SQLColumnExpression[Any]) -> _ExprFactory:
+    def factory(dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
+        return column
+
+    return factory
+
+
+def _string_attribute(keys: Sequence[Union[str, int]]) -> _ExprFactory:
+    """Text extraction of one attribute path.
+
+    Integer segments index into JSON lists and compile on both dialects
+    (``#>> '{llm,input_messages,0,...}'`` on PostgreSQL, ``$[0]`` path
+    syntax on SQLite). ``as_string`` extracts text on both dialects, so
+    string values come back unquoted and identical.
+    """
+
+    def factory(dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
+        return cast(
+            SQLColumnExpression[Any],
+            models.Span.attributes[list(keys)].as_string(),
+        )
+
+    return factory
+
+
+def _input_chars(dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
+    """Character length of the span's input payload.
+
+    A derived scalar declared in the registry because callers cannot
+    supply expressions; ``LENGTH`` over the text extraction is NULL when
+    no input was recorded, so absence stays countable rather than reading
+    as zero.
+    """
+    input_value = models.Span.attributes[list(SpanAttributes.INPUT_VALUE.split("."))].as_string()
+    return cast(SQLColumnExpression[Any], func.length(input_value))
+
+
+def _guarded_array_length(keys: Sequence[str]) -> _ExprFactory:
+    """Array length of one attribute path, NULL unless it is an array.
+
+    The guarded-cast doctrine extended to arrays: an unguarded array
+    length diverges between backends when the value is absent or not an
+    array, so the length is taken only when the backend's JSON type
+    introspection says ``array`` — anything else reads NULL on both
+    engines, excluded from aggregates and countable as missing.
+    """
+
+    def factory(dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
+        json_value = models.Span.attributes[list(keys)]
+        if dialect is SupportedSQLDialect.POSTGRESQL:
+            guard = func.jsonb_typeof(json_value) == "array"
+            length = func.jsonb_array_length(json_value)
+        else:
+            guard = func.json_type(json_value) == "array"
+            length = func.json_array_length(json_value)
+        return case((guard, length), else_=null())
+
+    return factory
+
+
+def _cost_total(dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
+    """The span's total cost, as a declared sum reduction.
+
+    Cost rows live in their own table whose span linkage is not
+    unique-constrained: a span may carry zero or several cost rows, so a
+    join would multiply span rows and silently corrupt every aggregate
+    around it. The field is therefore defined as a correlated scalar
+    subquery with an explicit reduction — ``sum`` over the span's cost
+    rows — which is structurally incapable of row multiplication and
+    stays correct under multiplicity (the sum of a span's cost rows *is*
+    the span's cost). A span with no cost rows reads as NULL, excluded
+    from aggregates by standard SQL semantics and countable as missing
+    via ``count(cost.total)`` versus ``count()``.
+    """
+    return (
+        sqlalchemy_select(func.sum(models.SpanCost.total_cost))
+        .where(models.SpanCost.span_rowid == models.Span.id)
+        .correlate(models.Span)
+        .scalar_subquery()
+    )
+
+
+def _message_field(index: int, message_attribute: str) -> tuple[str, _ExprFactory]:
+    """Id and expression of one input-message subfield, from the convention
+    constants: ``llm.input_messages[<index>].message.<role|content>``.
+
+    The id uses list-index subscript spelling; these fields are authored
+    (resolved by registry lookup), so the spelling is presentation, not
+    something the attribute-path parser needs to accept.
+    """
+    field_id = f"{SpanAttributes.LLM_INPUT_MESSAGES}[{index}].{message_attribute}"
+    keys: tuple[Union[str, int], ...] = (
+        *SpanAttributes.LLM_INPUT_MESSAGES.split("."),
+        index,
+        *message_attribute.split("."),
+    )
+    return field_id, _string_attribute(keys)
+
+
+def _guarded_numeric(keys: Sequence[str]) -> _ExprFactory:
+    """A numeric JSON extraction that maps wrongly-typed values to NULL.
+
+    A plain CAST on a JSON value makes the two backends disagree about
+    failure: PostgreSQL aborts the entire query on one non-numeric value
+    (``invalid input syntax``), while SQLite silently coerces garbage to
+    ``0.0`` and returns a confident wrong number. Guarding the cast with the
+    backend's JSON type introspection turns a wrongly-typed value into NULL
+    on both engines: excluded from ``sum``/``avg`` by standard SQL
+    semantics, countable as missing, and identical across backends.
+
+    The cast itself is float-typed even for integer fields because
+    ``jsonb_typeof`` cannot distinguish integers from reals — an
+    integer-only guard is not expressible symmetrically. Float arithmetic is
+    exact for values of token-count magnitude, and integral inputs produce
+    integral results.
+    """
+
+    def factory(dialect: SupportedSQLDialect) -> ColumnElement[Any]:
+        json_value = models.Span.attributes[list(keys)]
+        cast_value = json_value.as_float()
+        guard: ColumnElement[bool]
+        if dialect is SupportedSQLDialect.POSTGRESQL:
+            guard = func.jsonb_typeof(json_value) == "number"
+        else:
+            guard = func.json_type(json_value).in_(("integer", "real"))
+        return case((guard, cast_value), else_=null())
+
+    return factory
+
+
+def _is_error(dialect: SupportedSQLDialect) -> ColumnElement[Any]:
+    return case((models.Span.status_code == "ERROR", 1), else_=0)
+
+
+AUTHORED_FIELDS: tuple[AuthoredField, ...] = (
+    AuthoredField(
+        id="span_id",
+        label="Span ID",
+        type="string",
+        description=(
+            "OpenTelemetry span id (hex). The stable row identity of every result row; "
+            "pass it to getSpan for the full record."
+        ),
+        factory=_plain(models.Span.span_id),
+    ),
+    AuthoredField(
+        id="trace_id",
+        label="Trace ID",
+        type="string",
+        description="OpenTelemetry trace id (hex); pass it to getTrace for the span tree.",
+        factory=_plain(models.Trace.trace_id),
+    ),
+    AuthoredField(
+        id="name",
+        label="Span name",
+        type="string",
+        description="Operation name of the span.",
+        factory=_plain(models.Span.name),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="span_kind",
+        label="Span kind",
+        type="string",
+        description="OpenInference span kind: 'LLM', 'CHAIN', 'RETRIEVER', 'TOOL', 'AGENT', ...",
+        factory=_plain(models.Span.span_kind),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="status_code",
+        label="Status",
+        type="string",
+        description=("'OK', 'ERROR', or 'UNSET'. Filter failures with \"status_code == 'ERROR'\"."),
+        factory=_plain(models.Span.status_code),
+        groupable=True,
+    ),
+    AuthoredField(
+        id="start_time",
+        label="Start time",
+        type="datetime",
+        description=(
+            "Span start, UTC. Not filterable: temporal scope has exactly one home, the "
+            "time_range parameter."
+        ),
+        factory=_plain(models.Span.start_time),
+        filterable=False,
+    ),
+    AuthoredField(
+        id="latency_ms",
+        label="Latency",
+        type="float",
+        unit="ms",
+        description="Span duration in milliseconds.",
+        factory=_plain(models.Span.latency_ms),
+        aggregatable=True,
+    ),
+    AuthoredField(
+        id="is_error",
+        label="Error indicator",
+        type="integer",
+        description=(
+            "1 when status_code is 'ERROR', else 0. Aggregate-only: avg(is_error) is the "
+            "error rate, sum(is_error) the error count. To filter failures use "
+            "\"status_code == 'ERROR'\" instead."
+        ),
+        factory=_is_error,
+        filterable=False,
+        aggregatable=True,
+        source="computed",
+    ),
+    AuthoredField(
+        id=SpanAttributes.LLM_MODEL_NAME,
+        label="Model",
+        type="string",
+        description="Model name recorded on LLM spans, e.g. 'gpt-4'.",
+        factory=_string_attribute(tuple(SpanAttributes.LLM_MODEL_NAME.split("."))),
+        groupable=True,
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id=SpanAttributes.LLM_TOKEN_COUNT_TOTAL,
+        label="Total tokens",
+        type="integer",
+        unit="tokens",
+        description=(
+            "Total token count of the span. Wrongly-typed recorded values (e.g. a string) "
+            "read as NULL and are excluded from aggregates; count them via "
+            "count(llm.token_count.total) versus count()."
+        ),
+        factory=_guarded_numeric(tuple(SpanAttributes.LLM_TOKEN_COUNT_TOTAL.split("."))),
+        aggregatable=True,
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id=SpanAttributes.INPUT_VALUE,
+        label="Input",
+        type="string",
+        description="Span input payload. Often large; row results clip it to a preview.",
+        factory=_string_attribute(tuple(SpanAttributes.INPUT_VALUE.split("."))),
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id=SpanAttributes.OUTPUT_VALUE,
+        label="Output",
+        type="string",
+        description="Span output payload. Often large; row results clip it to a preview.",
+        factory=_string_attribute(tuple(SpanAttributes.OUTPUT_VALUE.split("."))),
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id="cost.total",
+        label="Cost",
+        type="float",
+        unit="USD",
+        description=(
+            "Total recorded cost of the span in USD, summed over its cost records. "
+            "NULL when no cost was recorded — count spans with cost via "
+            "count(cost.total) versus count(). Select-and-aggregate only: cost is "
+            "not a filter predicate on this surface."
+        ),
+        factory=_cost_total,
+        filterable=False,
+        aggregatable=True,
+        source="computed",
+    ),
+    AuthoredField(
+        id=SpanAttributes.LLM_TOKEN_COUNT_PROMPT,
+        label="Prompt tokens",
+        type="integer",
+        unit="tokens",
+        description=(
+            "Prompt token count of the span. Wrongly-typed recorded values read as "
+            "NULL and are excluded from aggregates."
+        ),
+        factory=_guarded_numeric(tuple(SpanAttributes.LLM_TOKEN_COUNT_PROMPT.split("."))),
+        aggregatable=True,
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id=SpanAttributes.LLM_TOKEN_COUNT_COMPLETION,
+        label="Completion tokens",
+        type="integer",
+        unit="tokens",
+        description=(
+            "Completion token count of the span. Wrongly-typed recorded values read "
+            "as NULL and are excluded from aggregates."
+        ),
+        factory=_guarded_numeric(tuple(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION.split("."))),
+        aggregatable=True,
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id="input.chars",
+        label="Input length",
+        type="integer",
+        unit="chars",
+        description=(
+            "Character length of the span's input payload; NULL when no input was "
+            "recorded. Distinct from input.turns: this measures text volume, not "
+            "conversation depth. Select-and-aggregate only."
+        ),
+        factory=_input_chars,
+        filterable=False,
+        aggregatable=True,
+        source="computed",
+    ),
+    AuthoredField(
+        id="input.turns",
+        label="Input messages",
+        type="integer",
+        unit="messages",
+        description=(
+            "Number of LLM input messages (the conversation depth carried into the "
+            "call); NULL when the span records no message list. Distinct from "
+            "input.chars: depth in messages, not character volume. Groupable — "
+            "conversation depth is a bounded small-integer dimension, so grouping "
+            "by it (e.g. avg cost by depth) is safe — but not filterable."
+        ),
+        factory=_guarded_array_length(tuple(SpanAttributes.LLM_INPUT_MESSAGES.split("."))),
+        filterable=False,
+        groupable=True,
+        aggregatable=True,
+        source="computed",
+    ),
+    # The first two input messages, per the OpenInference message
+    # convention. Select-only: the filter grammar does not accept
+    # list-index paths, so these carry no filter capability, and list
+    # entries are neither groupable nor aggregatable.
+    AuthoredField(
+        id=_message_field(0, MessageAttributes.MESSAGE_ROLE)[0],
+        label="First input message role",
+        type="string",
+        description="Role of the first LLM input message (e.g. 'system'); NULL when absent.",
+        factory=_message_field(0, MessageAttributes.MESSAGE_ROLE)[1],
+        filterable=False,
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id=_message_field(0, MessageAttributes.MESSAGE_CONTENT)[0],
+        label="First input message content",
+        type="string",
+        description=(
+            "Content of the first LLM input message; NULL when absent. Often large; "
+            "row results clip it to a preview."
+        ),
+        factory=_message_field(0, MessageAttributes.MESSAGE_CONTENT)[1],
+        filterable=False,
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id=_message_field(1, MessageAttributes.MESSAGE_ROLE)[0],
+        label="Second input message role",
+        type="string",
+        description=(
+            "Role of the second LLM input message (e.g. 'user'); NULL when the span "
+            "has fewer than two input messages."
+        ),
+        factory=_message_field(1, MessageAttributes.MESSAGE_ROLE)[1],
+        filterable=False,
+        source="openinference_convention",
+    ),
+    AuthoredField(
+        id=_message_field(1, MessageAttributes.MESSAGE_CONTENT)[0],
+        label="Second input message content",
+        type="string",
+        description=(
+            "Content of the second LLM input message; NULL when the span has fewer "
+            "than two input messages. Often large; row results clip it to a preview."
+        ),
+        factory=_message_field(1, MessageAttributes.MESSAGE_CONTENT)[1],
+        filterable=False,
+        source="openinference_convention",
+    ),
+)
+
+AUTHORED_BY_ID: Mapping[str, AuthoredField] = MappingProxyType({f.id: f for f in AUTHORED_FIELDS})
+
+#: Names the span filter grammar reserves for real span columns that this
+#: surface does not expose as fields. They must not fall through to the
+#: attribute-path parser: ``cumulative_llm_token_count_total`` as a field
+#: would silently read ``attributes["cumulative_llm_token_count_total"]``
+#: (always NULL) instead of the column the filter grammar means.
+RESERVED_UNEXPOSED: frozenset[str] = frozenset(
+    {
+        "context.span_id",
+        "context.trace_id",
+        "parent_id",
+        "status_message",
+        "end_time",
+        "cumulative_llm_token_count_prompt",
+        "cumulative_llm_token_count_completion",
+        "cumulative_llm_token_count_total",
+        "attributes",
+        "events",
+    }
+)
+
+
+# --------------------------------------------------------------------------
+# Canonical attribute paths
+# --------------------------------------------------------------------------
+
+_IDENTIFIER_SEGMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+#: Similarity threshold above which a bare name is treated as a probable
+#: misspelling of an authored field id rather than a real attribute name.
+_BARE_NAME_CONFLICT_CUTOFF = 0.75
+
+
+def bare_name_conflicts(name: str) -> bool:
+    """Whether a bare top-level attribute name collides with the field
+    namespace: it is (or closely resembles) an authored field id, or it is a
+    reserved span-column name. Conflicting bare names are far more likely
+    typos than real attributes, so they do not silently fall through to an
+    attribute read; the subscript spelling (``attributes["name"]``) remains
+    the unambiguous way to reference a genuinely so-named attribute.
+    """
+    if name in AUTHORED_BY_ID or name in RESERVED_UNEXPOSED:
+        return True
+    return bool(
+        get_close_matches(name, AUTHORED_BY_ID.keys(), n=1, cutoff=_BARE_NAME_CONFLICT_CUTOFF)
+    )
+
+
+def canonical_attribute_spelling(keys: Sequence[str]) -> str:
+    """The canonical query spelling of an attribute path.
+
+    Plain identifier segments join with dots (``llm.model_name``); paths
+    with awkward segments (a key containing a literal dot, say) use the
+    subscript form the filter grammar accepts (``metadata["build.version"]``,
+    ``attributes["a"]["b.c"]``); a single-segment name that collides with
+    the field namespace is spelled in subscript form so it stays
+    resolvable. Discovery output uses this spelling so that every returned
+    identifier works verbatim in every clause.
+    """
+    if len(keys) == 1 and bare_name_conflicts(keys[0]):
+        return f'attributes["{keys[0]}"]'
+    if all(_IDENTIFIER_SEGMENT.match(key) for key in keys):
+        return ".".join(keys)
+    if keys[0] == "metadata":
+        return "metadata" + "".join(f'["{key}"]' for key in keys[1:])
+    return "attributes" + "".join(f'["{key}"]' for key in keys)
+
+
+def parse_attribute_path(identifier: str) -> Optional[tuple[str, ...]]:
+    """Parse a canonical attribute path into its key sequence.
+
+    Accepts the same spellings the filter grammar does — bare names, dotted
+    paths, and ``attributes[...]``/``metadata[...]`` subscripts — and
+    returns ``None`` for anything else (calls, operators, subscripts of
+    other names such as ``evals[...]``).
+    """
+    try:
+        body = ast.parse(identifier.strip(), mode="eval").body
+    except SyntaxError:
+        return None
+    if isinstance(body, ast.Name):
+        return (body.id,)
+    if isinstance(body, ast.Attribute):
+        keys: list[str] = []
+        node: ast.expr = body
+        while isinstance(node, ast.Attribute):
+            keys.append(node.attr)
+            node = node.value
+        if isinstance(node, ast.Name):
+            keys.append(node.id)
+            return tuple(reversed(keys))
+        return None
+    if isinstance(body, ast.Subscript):
+        keys = []
+        node = body
+        while isinstance(node, ast.Subscript):
+            slice_node = node.slice
+            if isinstance(slice_node, ast.Constant) and isinstance(slice_node.value, str):
+                keys.append(slice_node.value)
+            elif isinstance(slice_node, ast.List):
+                slice_keys: list[str] = []
+                for elt in slice_node.elts:
+                    if not (isinstance(elt, ast.Constant) and isinstance(elt.value, str)):
+                        return None
+                    slice_keys.append(elt.value)
+                keys.extend(reversed(slice_keys))
+            else:
+                return None
+            node = node.value
+        if isinstance(node, ast.Name) and node.id == "attributes":
+            return tuple(reversed(keys))
+        if isinstance(node, ast.Name) and node.id == "metadata":
+            return ("metadata", *reversed(keys))
+        return None
+    return None
+
+
+# --------------------------------------------------------------------------
+# Aggregations
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Aggregation:
+    """One aggregation function and its calculation-level semantics.
+
+    ``additive`` marks functions whose per-group values sum to the overall
+    value (``count``, ``sum``); share-of-total is meaningful only for those.
+    An average or percentile of a subgroup carries no share of the overall
+    average, so shares are omitted for non-additive calculations.
+    """
+
+    fn: str
+    additive: bool
+    requires_field: bool
+    accepts_field: bool = True
+    description: str = ""
+
+
+AGGREGATIONS: Mapping[str, Aggregation] = MappingProxyType(
+    {
+        "count": Aggregation(
+            fn="count",
+            additive=True,
+            requires_field=False,
+            description=(
+                "Row count. With a field, counts rows where the field is non-NULL — "
+                "the missingness probe for guarded numeric fields."
+            ),
+        ),
+        "count_distinct": Aggregation(
+            fn="count_distinct",
+            additive=False,
+            requires_field=True,
+            description="Number of distinct non-NULL values of the field.",
+        ),
+        "sum": Aggregation(fn="sum", additive=True, requires_field=True),
+        "avg": Aggregation(fn="avg", additive=False, requires_field=True),
+        "min": Aggregation(fn="min", additive=False, requires_field=True),
+        "max": Aggregation(fn="max", additive=False, requires_field=True),
+        "p50": Aggregation(fn="p50", additive=False, requires_field=True),
+        "p90": Aggregation(fn="p90", additive=False, requires_field=True),
+        "p95": Aggregation(fn="p95", additive=False, requires_field=True),
+        "p99": Aggregation(fn="p99", additive=False, requires_field=True),
+    }
+)
+
+_PERCENTILE_FRACTIONS: Mapping[str, float] = MappingProxyType(
+    {"p50": 0.5, "p90": 0.9, "p95": 0.95, "p99": 0.99}
+)
+
+
+def aggregation_expr(
+    fn: str,
+    field_expr: Optional[SQLColumnExpression[Any]],
+    dialect: SupportedSQLDialect,
+) -> ColumnElement[Any]:
+    """Build the SQL expression for one calculation.
+
+    Percentiles are dialect-branched: PostgreSQL has ``percentile_cont``
+    (ordered-set aggregate, linear interpolation); SQLite gets the sqlean
+    ``stats`` extension's ``median``/``percentile`` functions, which use the
+    same linear interpolation — their agreement is covered by executing
+    tests, not assumed.
+    """
+    if fn == "count":
+        return func.count() if field_expr is None else func.count(field_expr)
+    assert field_expr is not None
+    if fn == "count_distinct":
+        return func.count(distinct(field_expr))
+    if fn == "sum":
+        return func.sum(field_expr)
+    if fn == "avg":
+        return func.avg(field_expr)
+    if fn == "min":
+        return func.min(field_expr)
+    if fn == "max":
+        return func.max(field_expr)
+    fraction = _PERCENTILE_FRACTIONS[fn]
+    if dialect is SupportedSQLDialect.POSTGRESQL:
+        return percentile_cont(fraction).within_group(field_expr.asc())
+    # sqlean names its percentile functions by percent: median(x) is the
+    # 50th percentile; percentile(x, K) takes K in [0, 100].
+    if fn == "p50":
+        return func.median(field_expr)
+    return func.percentile(field_expr, int(fraction * 100))
+
+
+# --------------------------------------------------------------------------
+# Time buckets
+# --------------------------------------------------------------------------
+
+#: Column id of the calculated hour-bucket breakdown.
+TIME_BUCKET_ID = "time_bucket"
+
+
+def time_bucket_expr(dialect: SupportedSQLDialect) -> ColumnElement[Any]:
+    """Truncate ``start_time`` to the hour, per dialect.
+
+    Timestamps are stored in UTC on both backends, so both renderings
+    produce the same UTC hour boundary.
+    """
+    if dialect is SupportedSQLDialect.POSTGRESQL:
+        return func.date_trunc("hour", models.Span.start_time)
+    return func.strftime("%Y-%m-%dT%H:00:00", models.Span.start_time)
+
+
+def normalize_time_bucket_value(value: Any) -> Any:
+    """Render a bucket key identically on both dialects.
+
+    PostgreSQL's ``date_trunc`` returns a datetime; SQLite's ``strftime``
+    returns the ISO string without an offset. Both become
+    ``YYYY-MM-DDTHH:00:00+00:00``.
+    """
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat()
+    if isinstance(value, str) and value:
+        return f"{value}+00:00"
+    return value

--- a/src/phoenix/server/mcp_span_analytics/registry.py
+++ b/src/phoenix/server/mcp_span_analytics/registry.py
@@ -25,6 +25,13 @@ namespace:
   ``max``, percentiles) stay on authored fields: cast and mixed-type
   semantics for arbitrary JSON paths are undefined, so typed arithmetic
   needs declared semantics.
+- **Annotation enrichment fields** (``annotations["correctness"].score``)
+  are authored fields constructed on demand for one annotation name, and
+  they are the to-many case: a span can carry several annotation rows
+  under one name, so every one of them declares the **reduction** that
+  collapses those rows to a scalar. The reduction is part of the field's
+  identity, not an implementation detail, and it is echoed in every
+  response that uses one.
 
 Expressions are built per SQL dialect because JSON access and percentile
 aggregation genuinely differ between PostgreSQL and SQLite; every factory in
@@ -60,6 +67,36 @@ FieldTypeName = str  # "string" | "integer" | "float" | "datetime"
 _ExprFactory = Callable[[SupportedSQLDialect], SQLColumnExpression[Any]]
 
 
+#: The annotator kinds Phoenix records, as constrained by the annotation
+#: tables' own check constraint. A closed set, so composition disclosure can
+#: enumerate it instead of discovering it.
+ANNOTATOR_KINDS: tuple[str, ...] = ("LLM", "CODE", "HUMAN")
+
+
+@dataclass(frozen=True)
+class AnnotationRef:
+    """One annotation enrichment reference: which annotation, whose, and
+    which of its attributes.
+
+    ``annotator_kind`` is ``None`` for the unrestricted form, which reduces
+    over every annotator that scored the span — the form whose blended
+    values shift when the annotator mix shifts, and therefore the form that
+    triggers composition disclosure.
+    """
+
+    name: str
+    annotator_kind: Optional[str]
+    attribute: str
+
+    @property
+    def id(self) -> str:
+        """The field's canonical query spelling."""
+        subscript = f'"{self.name}"'
+        if self.annotator_kind is not None:
+            subscript += f', "{self.annotator_kind}"'
+        return f"annotations[{subscript}].{self.attribute}"
+
+
 @dataclass(frozen=True)
 class AuthoredField:
     """A hand-defined field with declared type, unit, and capabilities.
@@ -74,7 +111,14 @@ class AuthoredField:
     indicators, and ``"openinference_convention"`` for attributes whose
     names and meanings are defined by the OpenInference semantic
     conventions. (Discovered paths report ``"observed_attribute"`` and are
-    project-specific by nature.)
+    project-specific by nature; annotation enrichment reports
+    ``"annotation_enrichment"``.)
+
+    ``reduction`` is set only on fields that collapse a to-many
+    relationship to a scalar. It names the collapsing rule so responses can
+    disclose it: a reduced value is an answer to a question the caller did
+    not fully ask, and the difference between ``mean_over_annotators`` and
+    ``latest_by_updated_at`` changes what the number means.
     """
 
     id: str
@@ -87,6 +131,8 @@ class AuthoredField:
     groupable: bool = False
     aggregatable: bool = False
     source: str = "column"
+    reduction: Optional[str] = None
+    annotation: Optional["AnnotationRef"] = None
 
     def expr(self, dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
         return self.factory(dialect)
@@ -615,6 +661,178 @@ def parse_attribute_path(identifier: str) -> Optional[tuple[str, ...]]:
 
 
 # --------------------------------------------------------------------------
+# Annotation enrichment
+# --------------------------------------------------------------------------
+#
+# Annotations are the openly to-many relationship: uniqueness is
+# ``(name, span_rowid, identifier)``, so one span can carry a row per
+# annotator under one name. A join would multiply span rows and corrupt
+# every aggregate around it, so each enrichment field is a correlated
+# scalar subquery with a declared reduction — structurally incapable of
+# row multiplication, exactly as ``cost.total`` is.
+
+
+@dataclass(frozen=True)
+class AnnotationAttribute:
+    """One readable attribute of an annotation, with its declared reduction."""
+
+    type: FieldTypeName
+    reduction: str
+    reduction_note: str
+    label: str
+    groupable: bool = False
+    aggregatable: bool = False
+
+
+ANNOTATION_ATTRIBUTES: Mapping[str, AnnotationAttribute] = MappingProxyType(
+    {
+        "score": AnnotationAttribute(
+            type="float",
+            reduction="mean_over_annotators",
+            reduction_note=(
+                "the mean of the matching annotations' scores, one span at a time "
+                "(annotations without a score are excluded from the mean)"
+            ),
+            label="Annotation score",
+            aggregatable=True,
+        ),
+        "label": AnnotationAttribute(
+            type="string",
+            reduction="latest_by_updated_at",
+            reduction_note=(
+                "the most recently updated matching annotation's label, ties broken by "
+                "annotation id — a mean of labels is meaningless, so recency is the "
+                "declared rule"
+            ),
+            label="Annotation label",
+            groupable=True,
+        ),
+        "count": AnnotationAttribute(
+            type="integer",
+            reduction="cardinality",
+            reduction_note="how many matching annotation rows the span carries",
+            label="Annotation count",
+            groupable=True,
+            aggregatable=True,
+        ),
+    }
+)
+
+#: Names the filter grammar and this registry both accept as the head of an
+#: annotation reference. ``evals`` is the span filter DSL's shipped
+#: spelling; ``annotations`` is what discovery advertises.
+ANNOTATION_HEADS: frozenset[str] = frozenset({"annotations", "evals"})
+
+
+def parse_annotation_field(identifier: str) -> Optional[AnnotationRef]:
+    """Parse an annotation enrichment identifier into its reference.
+
+    Accepts ``annotations["name"].attr`` and the kind-restricted
+    ``annotations["name", "HUMAN"].attr``, with ``evals`` as an accepted
+    alias head. Returns ``None`` when the identifier is not annotation
+    shaped at all; the reference's ``annotator_kind`` and ``attribute`` are
+    returned as written, so the caller can reject unknown ones with a
+    field-anchored error rather than a parse failure.
+    """
+    try:
+        body = ast.parse(identifier.strip(), mode="eval").body
+    except SyntaxError:
+        return None
+    if not isinstance(body, ast.Attribute) or not isinstance(body.value, ast.Subscript):
+        return None
+    subscript = body.value
+    if not isinstance(subscript.value, ast.Name) or subscript.value.id not in ANNOTATION_HEADS:
+        return None
+    slice_node = subscript.slice
+    keys: list[str] = []
+    elements = slice_node.elts if isinstance(slice_node, ast.Tuple) else [slice_node]
+    for element in elements:
+        if not (isinstance(element, ast.Constant) and isinstance(element.value, str)):
+            return None
+        keys.append(element.value)
+    if not 1 <= len(keys) <= 2:
+        return None
+    return AnnotationRef(
+        name=keys[0],
+        annotator_kind=keys[1] if len(keys) == 2 else None,
+        attribute=body.attr,
+    )
+
+
+def _annotation_rows(ref: AnnotationRef) -> Any:
+    """The span's matching annotation rows, as a correlated WHERE clause set."""
+    conditions = [
+        models.SpanAnnotation.span_rowid == models.Span.id,
+        models.SpanAnnotation.name == ref.name,
+    ]
+    if ref.annotator_kind is not None:
+        conditions.append(models.SpanAnnotation.annotator_kind == ref.annotator_kind)
+    return conditions
+
+
+def _annotation_expr(ref: AnnotationRef) -> _ExprFactory:
+    """The reduced scalar for one annotation reference, per its attribute."""
+
+    def factory(dialect: SupportedSQLDialect) -> SQLColumnExpression[Any]:
+        conditions = _annotation_rows(ref)
+        if ref.attribute == "count":
+            selected: Any = func.count()
+        elif ref.attribute == "score":
+            selected = func.avg(models.SpanAnnotation.score)
+        else:
+            selected = models.SpanAnnotation.label
+        statement = sqlalchemy_select(selected).where(*conditions).correlate(models.Span)
+        if ref.attribute == "label":
+            # Recency is the declared reduction for labels; the id breaks
+            # ties so two annotations written in the same instant still
+            # resolve to one deterministic value on both backends.
+            statement = statement.order_by(
+                models.SpanAnnotation.updated_at.desc(), models.SpanAnnotation.id.desc()
+            ).limit(1)
+        return cast(SQLColumnExpression[Any], statement.scalar_subquery())
+
+    return factory
+
+
+def annotation_enrichment_field(ref: AnnotationRef) -> AuthoredField:
+    """Build the authored field for one validated annotation reference.
+
+    The caller validates ``attribute`` and ``annotator_kind`` first; this
+    function assumes both are known.
+    """
+    attribute = ANNOTATION_ATTRIBUTES[ref.attribute]
+    scope = (
+        f"annotations of kind {ref.annotator_kind}"
+        if ref.annotator_kind is not None
+        else "annotations from every annotator"
+    )
+    zero_note = (
+        " Spans with no matching annotation count 0."
+        if ref.attribute == "count"
+        else " Spans with no matching annotation read as NULL."
+    )
+    return AuthoredField(
+        id=ref.id,
+        label=f"{attribute.label} ({ref.name})",
+        type=attribute.type,
+        description=(
+            f"Reduced over the span's {ref.name!r} {scope}: {attribute.reduction_note}. "
+            f"Reduction {attribute.reduction!r} is disclosed in every response that "
+            f"uses this field.{zero_note} Not filterable — annotation predicates have "
+            f"one home, the filter grammar's evals[{ref.name!r}] form, whose "
+            "any-annotator semantics differ from this reduction."
+        ),
+        factory=_annotation_expr(ref),
+        filterable=False,
+        groupable=attribute.groupable,
+        aggregatable=attribute.aggregatable,
+        source="annotation_enrichment",
+        reduction=attribute.reduction,
+        annotation=ref,
+    )
+
+
+# --------------------------------------------------------------------------
 # Aggregations
 # --------------------------------------------------------------------------
 
@@ -722,15 +940,20 @@ def aggregation_expr(
 TIME_BUCKET_ID = "time_bucket"
 
 
-def time_bucket_expr(dialect: SupportedSQLDialect) -> ColumnElement[Any]:
-    """Truncate ``start_time`` to the hour, per dialect.
+def time_bucket_expr(
+    dialect: SupportedSQLDialect, column: Optional[SQLColumnExpression[Any]] = None
+) -> ColumnElement[Any]:
+    """Truncate a timestamp column to the hour, per dialect.
 
-    Timestamps are stored in UTC on both backends, so both renderings
-    produce the same UTC hour boundary.
+    The column defaults to span start time; a grain whose time column is
+    something else passes its own. Timestamps are stored in UTC on both
+    backends, so both renderings produce the same UTC hour boundary.
     """
+    if column is None:
+        column = models.Span.start_time
     if dialect is SupportedSQLDialect.POSTGRESQL:
-        return func.date_trunc("hour", models.Span.start_time)
-    return func.strftime("%Y-%m-%dT%H:00:00", models.Span.start_time)
+        return func.date_trunc("hour", column)
+    return func.strftime("%Y-%m-%dT%H:00:00", column)
 
 
 def normalize_time_bucket_value(value: Any) -> Any:

--- a/src/phoenix/server/mcp_span_analytics/tools.py
+++ b/src/phoenix/server/mcp_span_analytics/tools.py
@@ -1,0 +1,1794 @@
+"""Hand-authored MCP tools for span analytics.
+
+Five tools over one project-scoped span surface:
+
+- ``describeSpans`` — the field catalog as data: authored fields merged with
+  attribute paths observed in a recent sample, every entry in canonical
+  query spelling so discovery output is copy-paste usable in every clause.
+- ``aggregateSpans`` — grouped calculations (counts, sums, averages,
+  percentiles, hourly buckets) with explicit completeness metadata.
+- ``querySpanRows`` — ordered, bounded row retrieval with per-cell preview
+  clipping and an always-present ``span_id`` row identity.
+- ``getSpan`` — full-fidelity drill-down for one span, the recovery path
+  every clipped preview points at.
+- ``getTrace`` — the parent/child span tree of one trace.
+
+Every tool returns a discriminated union: ``{status: "ok", ...}`` on
+success or ``{status: "error", code, path, message, suggestions}`` on
+semantic failure, so callers branch on data instead of parsing prose.
+``ToolError`` is reserved for transport-level failures.
+
+Field declarations use the ``param: T = Field(default=..., description=...)``
+style; ``Annotated`` wrapping nests descriptions inside an extra ``anyOf``
+level where JSON-schema consumers do not look.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+from collections import Counter
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Union
+from urllib.parse import urlencode
+
+from fastmcp.server.dependencies import get_http_request
+from fastmcp.tools.base import Tool
+from mcp.types import ToolAnnotations
+from pydantic import Field, TypeAdapter, ValidationError
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.config import ENV_PHOENIX_ROOT_URL, get_env_root_url
+from phoenix.db import models
+from phoenix.server.mcp_span_analytics import compiler, registry
+from phoenix.server.mcp_span_analytics.compiler import (
+    AggregateOrderEntry,
+    AggregateQuery,
+    Calculation,
+    QueryError,
+    RowOrderField,
+    RowQuery,
+    SampleOrder,
+    TimeBucket,
+    TimeRange,
+)
+from phoenix.server.utils import prepend_root_path
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from phoenix.server.types import DbSessionFactory
+
+#: REST router tag of the generated span tools. Carrying it makes these
+#: tools gate and reveal together with the ``spans`` group, and share that
+#: vocabulary in code mode's ``tags`` browser.
+SPANS_GROUP_TAG = "spans"
+
+#: A second tag marking the analytical query surface. Catalog search ranks
+#: by vocabulary overlap, and "spans" alone ranks CRUD tools above these
+#: for analytics-shaped queries (aggregate, group by, error rate); the tag
+#: gives that vocabulary a first-class home.
+ANALYTICS_TAG = "analytics"
+
+#: Every tool here only reads span data — the same annotation profile the
+#: generated GET tools receive: safe to retry, no side effects, and scoped
+#: to the server's own database rather than the open world.
+_READ_ONLY_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+)
+
+#: Size budget defaults, in characters (~4 characters per token of the
+#: caller's context). Row surveys stay small because ``getSpan`` exists for
+#: full recovery; ``getSpan`` itself gets a larger default because it *is*
+#: the recovery path.
+_DEFAULT_MAX_RESULT_CHARS = 50_000
+_GET_SPAN_MAX_RESULT_CHARS = 100_000
+_DEFAULT_MAX_CELL_CHARS = 400
+
+#: Upper bound on spans scanned for observed-field discovery and
+#: zero-result diagnosis. A bounded sample drawn evenly across the
+#: project's span id range, never a full scan.
+_DISCOVERY_SAMPLE_SIZE = 500
+
+#: Declared sampling strategy of the discovery scan: up to N span ids
+#: drawn uniformly across the project's id range (approximately
+#: time-ordered, since ids are allocated in ingestion order).
+_DISCOVERY_STRATEGY = f"id_spread_{_DISCOVERY_SAMPLE_SIZE}"
+
+#: Fixed seed of the discovery draw: the same project state always yields
+#: the same sample, so repeated discovery calls agree with each other.
+_DISCOVERY_SAMPLE_SEED = 0
+
+#: Cap on observed-field entries in one describeSpans response.
+_DISCOVERY_MAX_OBSERVED_FIELDS = 100
+
+#: Observed values are tracked for top-value reporting only up to this many
+#: distinct values per path and this many characters per value.
+_TOP_VALUES_LIMIT = 20
+_TOP_VALUE_MAX_CHARS = 100
+
+_FILTER_DESCRIPTION = (
+    "Boolean expression selecting spans, written in Python syntax and compiled to SQL. "
+    "Names you can reference: span fields `name`, `span_kind` ('LLM', 'CHAIN', "
+    "'RETRIEVER', 'TOOL', 'AGENT', 'EMBEDDING', ...), `status_code` ('OK', 'ERROR', "
+    "'UNSET'), `status_message`, `parent_id`, `span_id`, `trace_id`, `latency_ms`; and "
+    "attribute paths such as `input.value`, `output.value`, `llm.model_name`, "
+    "`llm.token_count.total`, `metadata['key']` — any field id or observed path from "
+    "describeSpans works verbatim. Operators: comparisons (==, !=, <, <=, >, >=), "
+    "`and`/`or`/`not`, `in`/`not in` (substring test on strings, membership on a list), "
+    "`is None`/`is not None`; casts `str(...)`, `float(...)`, `int(...)`. Function "
+    "calls other than casts are rejected. Temporal predicates are rejected here — "
+    "scope time with time_range, its only home. Examples: "
+    "\"span_kind == 'LLM' and latency_ms > 1000\"; \"status_code == 'ERROR'\"; "
+    "\"'rate limit' in output.value\"; \"metadata['release'] == 'v42'\"."
+)
+
+_PROJECT_DESCRIPTION = "Project id or name (either form works; list projects with getProjects)."
+
+_VALIDATE_ONLY_DESCRIPTION = (
+    "If true, resolve and validate the query without executing anything: returns "
+    "{status: 'ok', valid: true} or the structured error the real call would return."
+)
+
+
+# --------------------------------------------------------------------------
+# Structured-parameter shape validation
+# --------------------------------------------------------------------------
+#
+# Structured parameters are declared loosely (``Any`` plus a hand-authored
+# JSON schema) and validated inside the tool body: validation in the MCP
+# argument-parsing layer would surface malformed shapes as raw pydantic
+# text — stacked errors, internal model names, vendor URLs — instead of
+# the structured error union every other failure uses. In-body validation
+# turns a wrong shape into ``{status: "error", code: "invalid_shape", ...}``
+# with a plain-language expected form.
+
+_TIME_RANGE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "start": {
+            "type": "string",
+            "format": "date-time",
+            "description": (
+                "Inclusive lower bound on span start_time, ISO-8601 (e.g. "
+                "'2026-07-22T00:00:00Z'). Naive timestamps are treated as UTC."
+            ),
+        },
+        "end": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Exclusive upper bound on span start_time, ISO-8601.",
+        },
+    },
+    "required": ["start", "end"],
+}
+
+_OPTIONAL_TIME_RANGE_SCHEMA: dict[str, Any] = {
+    "anyOf": [_TIME_RANGE_SCHEMA, {"type": "null"}],
+}
+
+_CALCULATIONS_SCHEMA: dict[str, Any] = {
+    "type": "array",
+    "minItems": 1,
+    "items": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Result column name for this calculation.",
+            },
+            "fn": {
+                "type": "string",
+                "description": (
+                    "Aggregation function: count, count_distinct, sum, avg, min, max, "
+                    "p50, p90, p95, p99."
+                ),
+            },
+            "field": {
+                "type": ["string", "null"],
+                "description": (
+                    "Field to aggregate. Required for every function except count; "
+                    "count with a field counts rows where the field is non-NULL."
+                ),
+            },
+        },
+        "required": ["name", "fn"],
+    },
+}
+
+_BREAKDOWNS_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {"type": "string", "description": "A groupable field id."},
+                    {
+                        "type": "object",
+                        "properties": {"bucket": {"type": "string", "enum": ["hour"]}},
+                        "required": ["bucket"],
+                        "description": "Hourly time bucket of start_time.",
+                    },
+                ]
+            },
+        },
+        {"type": "null"},
+    ],
+}
+
+_ROW_ORDER_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "field": {
+                        "type": "string",
+                        "description": "Field to order by; must be a selected field.",
+                    },
+                    "direction": {"type": "string", "enum": ["asc", "desc"], "default": "desc"},
+                },
+                "required": ["field"],
+            },
+        },
+        {
+            "type": "object",
+            "properties": {
+                "sample": {
+                    "type": "object",
+                    "properties": {"seed": {"type": "integer"}},
+                    "required": ["seed"],
+                }
+            },
+            "required": ["sample"],
+        },
+        {"type": "null"},
+    ],
+}
+
+_AGGREGATE_ORDER_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "calculation": {
+                        "type": ["string", "null"],
+                        "description": "Name of a declared calculation to order by.",
+                    },
+                    "field": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "Breakdown field id to order by ('time_bucket' for the hour bucket)."
+                        ),
+                    },
+                    "direction": {"type": "string", "enum": ["asc", "desc"], "default": "desc"},
+                },
+            },
+        },
+        {"type": "null"},
+    ],
+}
+
+_ROW_FIELDS_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        {"type": "null"},
+    ],
+}
+
+_TIME_RANGE_ADAPTER: TypeAdapter[TimeRange] = TypeAdapter(TimeRange)
+_OPTIONAL_TIME_RANGE_ADAPTER: TypeAdapter[Optional[TimeRange]] = TypeAdapter(Optional[TimeRange])
+_CALCULATIONS_ADAPTER: TypeAdapter[list[Calculation]] = TypeAdapter(list[Calculation])
+_BREAKDOWNS_ADAPTER: TypeAdapter[Optional[list[Union[str, TimeBucket]]]] = TypeAdapter(
+    Optional[list[Union[str, TimeBucket]]]
+)
+_ROW_ORDER_ADAPTER: TypeAdapter[Optional[Union[list[RowOrderField], SampleOrder]]] = TypeAdapter(
+    Optional[Union[list[RowOrderField], SampleOrder]]
+)
+_AGGREGATE_ORDER_ADAPTER: TypeAdapter[Optional[list[AggregateOrderEntry]]] = TypeAdapter(
+    Optional[list[AggregateOrderEntry]]
+)
+_ROW_FIELDS_ADAPTER: TypeAdapter[Optional[list[str]]] = TypeAdapter(Optional[list[str]])
+
+#: Location parts worth showing in an invalid_shape path: list indices and
+#: plain lowercase field names. Union-arm labels (class names, generic
+#: forms) and scalar type names are internal vocabulary and are dropped.
+_PLAIN_LOC_PART = re.compile(r"^[a-z][a-z0-9_]*$")
+_TYPE_NAME_LOC_PARTS = frozenset({"null", "str", "int", "float", "bool", "list", "dict"})
+
+
+def _shape_error_path(param: str, error: ValidationError) -> str:
+    parts = [param]
+    errors = error.errors(include_url=False)
+    if errors:
+        for part in errors[0]["loc"]:
+            if isinstance(part, int):
+                parts[-1] = f"{parts[-1]}[{part}]"
+            elif (
+                isinstance(part, str)
+                and _PLAIN_LOC_PART.match(part)
+                and part not in _TYPE_NAME_LOC_PARTS
+            ):
+                parts.append(part)
+    return ".".join(parts)
+
+
+def _parse_shape(adapter: TypeAdapter[Any], value: Any, param: str, expected: str) -> Any:
+    """Validate one structured parameter, mapping failure to the error union."""
+    try:
+        return adapter.validate_python(value)
+    except ValidationError as error:
+        raise QueryError(
+            code="invalid_shape",
+            path=_shape_error_path(param, error),
+            message=f"{param} has an invalid shape; expected {expected}.",
+        )
+
+
+#: Structural disclosure attached whenever a filter used an annotation
+#: predicate: existence tests are any-annotator by construction.
+_ANNOTATION_SEMANTICS_NOTE = (
+    "The filter's annotation predicate uses any-annotator semantics: any "
+    "matching annotation row satisfies it; consensus or reduced semantics "
+    "are not implemented."
+)
+
+_ANNOTATION_SEMANTICS_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "enum": ["any"],
+    "description": (
+        "Present when the filter used an annotation predicate: the predicate "
+        "is satisfied by any matching annotation row (any-annotator "
+        "semantics); consensus/reduced semantics are not implemented."
+    ),
+}
+
+
+# --------------------------------------------------------------------------
+# Output schemas
+# --------------------------------------------------------------------------
+
+_ERROR_ARM: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"const": "error"},
+        "code": {
+            "type": "string",
+            "description": (
+                "Machine-readable failure class, e.g. unknown_field, invalid_filter, "
+                "invalid_shape, field_not_groupable, project_not_found."
+            ),
+        },
+        "path": {
+            "type": ["string", "null"],
+            "description": "Request location the error anchors to, e.g. 'order[0].field'.",
+        },
+        "message": {"type": "string"},
+        "suggestions": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Nearest-name or alternative-usage candidates, directly usable.",
+        },
+    },
+    "required": ["status", "code", "message"],
+}
+
+_VALIDATE_ARM: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"const": "ok"},
+        "valid": {"const": True},
+        "applied": {"type": "object"},
+    },
+    "required": ["status", "valid"],
+}
+
+
+def _union_schema(
+    ok_properties: dict[str, Any],
+    ok_required: Sequence[str],
+    validate_arm: bool = False,
+) -> dict[str, Any]:
+    ok_arm: dict[str, Any] = {
+        "type": "object",
+        "properties": {"status": {"const": "ok"}, **ok_properties},
+        "required": ["status", *ok_required],
+    }
+    arms = [ok_arm, *([_VALIDATE_ARM] if validate_arm else []), _ERROR_ARM]
+    return {"type": "object", "oneOf": arms}
+
+
+_COLUMNS_SCHEMA: dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "type": {"type": "string"},
+            "unit": {"type": ["string", "null"]},
+        },
+    },
+    "description": "Typed metadata of the result columns, in order.",
+}
+
+_GUIDANCE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cause": {
+            "type": "string",
+            "enum": ["window_empty", "path_not_observed", "no_matches"],
+        },
+        "detail": {"type": "string"},
+    },
+    "description": (
+        "Present when the result is empty: which of the enumerated causes applies. "
+        "path_not_observed is sampled evidence, not proof of absence."
+    ),
+}
+
+
+# --------------------------------------------------------------------------
+# Serialization helpers
+# --------------------------------------------------------------------------
+
+
+def _cell(value: Any) -> Any:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def _serialized_size(obj: Any) -> int:
+    return len(json.dumps(obj, ensure_ascii=False, default=str))
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _time_range_resolved(time_range: TimeRange) -> dict[str, str]:
+    return {"start": _iso(time_range.start), "end": _iso(time_range.end)}
+
+
+def _public_url(path: str) -> str:
+    """Compose an absolute Phoenix UI link for ``path``.
+
+    Behind a reverse proxy, only two parties can know the public origin:
+    explicit configuration, or the incoming request itself — the server's
+    own host/port settings describe where it listens, not where clients
+    reach it. Precedence follows the OAuth machinery's ``public_origin``:
+    ``PHOENIX_ROOT_URL`` when set; otherwise the current MCP request's
+    origin with its ASGI ``root_path`` prepended; and the
+    environment-composed URL only as the last resort when no request
+    context exists.
+    """
+    if os.getenv(ENV_PHOENIX_ROOT_URL):
+        return f"{str(get_env_root_url()).rstrip('/')}{path}"
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return f"{str(get_env_root_url()).rstrip('/')}{path}"
+    origin = f"{request.base_url.scheme}://{request.base_url.netloc}"
+    # The request is seen inside the mounted MCP app, so its ASGI root_path
+    # is "<deployment prefix><MCP mount>". The deployment prefix (a reverse
+    # proxy's) belongs in UI links; the app's own MCP mount does not — a UI
+    # route lives at /projects/..., never /mcp/projects/....
+    from phoenix.server.mcp_server import MCP_MOUNT_PATH
+
+    root_path = str(request.scope.get("root_path", "")).rstrip("/")
+    if root_path.endswith(MCP_MOUNT_PATH):
+        root_path = root_path[: -len(MCP_MOUNT_PATH)]
+    return f"{origin}{prepend_root_path({'root_path': root_path}, path)}"
+
+
+def _ui_span_url(span_id: str) -> str:
+    return _public_url(f"/redirects/spans/{span_id}")
+
+
+def _ui_trace_url(trace_id: str) -> str:
+    return _public_url(f"/redirects/traces/{trace_id}")
+
+
+def _filter_literal(value: Any) -> str:
+    """Render one group-key value as a filter-grammar literal.
+
+    Strings are escaped for the grammar (which parses Python string
+    literals): backslashes first, then single quotes — a value like
+    ``o'brien-corp`` must survive both the grammar and URL encoding.
+    """
+    if isinstance(value, str):
+        escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+        return f"'{escaped}'"
+    return repr(value)
+
+
+def _bucket_start(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str) and value:
+        return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+    return None
+
+
+def _cohort_ui_url(
+    base: str,
+    breakdowns: Sequence[Any],
+    raw_values: Sequence[Any],
+    time_range: "TimeRange",
+) -> str:
+    """Deep link to the group's cohort in the Phoenix UI span view.
+
+    The link carries the group's condition as a ``filter`` in the filter
+    grammar (breakdown-key equalities ANDed) plus ``start``/``end``. A
+    time bucket contributes nothing to ``filter``; it narrows the time
+    params to its hour instead. A **null group key is skipped**: the UI
+    filter grammar cannot express "attribute is absent" today, so the
+    null bucket links to the window without that conjunct — a wider
+    cohort than the row, by declared necessity.
+    """
+    conjuncts: list[str] = []
+    window_start, window_end = time_range.start, time_range.end
+    for breakdown, value in zip(breakdowns, raw_values):
+        if breakdown.is_time_bucket:
+            bucket = _bucket_start(value)
+            if bucket is not None:
+                window_start, window_end = bucket, bucket + timedelta(hours=1)
+        elif value is not None:
+            conjuncts.append(f"{breakdown.id} == {_filter_literal(value)}")
+    params: dict[str, str] = {}
+    if conjuncts:
+        params["filter"] = " and ".join(conjuncts)
+    params["start"] = _iso(window_start)
+    params["end"] = _iso(window_end)
+    return f"{base}?{urlencode(params)}"
+
+
+def _clip_strings_to_budget(
+    obj: Any,
+    budget: int,
+    marker: str,
+    min_keep: int = 500,
+) -> tuple[Any, list[str]]:
+    """Clip the largest string leaves of a JSON-like object until it fits.
+
+    Returns the (possibly copied and clipped) object and the dotted paths of
+    clipped leaves. Whole values are never dropped — clipping a cell and
+    pointing at the recovery path degrades better than losing the row.
+    """
+    size = _serialized_size(obj)
+    if size <= budget:
+        return obj, []
+    obj = deepcopy(obj)
+    leaves: list[tuple[int, Any, Any, str]] = []
+
+    def collect(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                child_path = f"{path}.{key}" if path else str(key)
+                if isinstance(value, str) and len(value) > min_keep:
+                    leaves.append((len(value), node, key, child_path))
+                else:
+                    collect(value, child_path)
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                child_path = f"{path}[{index}]"
+                if isinstance(value, str) and len(value) > min_keep:
+                    leaves.append((len(value), node, index, child_path))
+                else:
+                    collect(value, child_path)
+
+    collect(obj, "")
+    leaves.sort(key=lambda item: item[0], reverse=True)
+    clipped: list[str] = []
+    for length, container, key, path in leaves:
+        if size <= budget:
+            break
+        text_value = container[key]
+        excess = size - budget
+        keep = max(min_keep, len(text_value) - excess - len(marker))
+        if keep >= len(text_value):
+            continue
+        suffix = f"…[clipped {len(text_value) - keep} chars; {marker}]"
+        container[key] = text_value[:keep] + suffix
+        size += len(suffix) + keep - len(text_value)
+        clipped.append(path)
+    return obj, clipped
+
+
+# --------------------------------------------------------------------------
+# Observed-path sampling
+# --------------------------------------------------------------------------
+
+
+class _PathStats:
+    """Streaming statistics for one attribute path in the discovery sample."""
+
+    __slots__ = ("count", "types", "values", "values_complete")
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.types: Counter[str] = Counter()
+        self.values: Counter[Any] = Counter()
+        #: True while every observed value has been tracked; long values and
+        #: high cardinality forfeit top-value reporting rather than
+        #: misreport it as complete.
+        self.values_complete = True
+
+    def record(self, value: Any) -> None:
+        self.count += 1
+        if isinstance(value, bool):
+            self.types["boolean"] += 1
+        elif isinstance(value, int):
+            self.types["integer"] += 1
+        elif isinstance(value, float):
+            self.types["float"] += 1
+        else:
+            self.types["string"] += 1
+        trackable = not isinstance(value, str) or len(value) <= _TOP_VALUE_MAX_CHARS
+        if not trackable:
+            self.values_complete = False
+            return
+        if value in self.values or len(self.values) < _TOP_VALUES_LIMIT + 1:
+            self.values[value] += 1
+        else:
+            self.values_complete = False
+
+    def top_values(self) -> Optional[list[dict[str, Any]]]:
+        if not self.values_complete or not self.values or len(self.values) > _TOP_VALUES_LIMIT:
+            return None
+        return [
+            {"value": value, "count": count}
+            for value, count in sorted(self.values.items(), key=lambda kv: (-kv[1], str(kv[0])))
+        ]
+
+
+def _flatten_scalars(
+    blob: Mapping[str, Any],
+    prefix: tuple[str, ...],
+    out: dict[tuple[str, ...], _PathStats],
+    depth: int = 0,
+) -> None:
+    if depth > 6:
+        return
+    for key, value in blob.items():
+        if not isinstance(key, str):
+            continue
+        path = (*prefix, key)
+        if isinstance(value, dict):
+            _flatten_scalars(value, path, out, depth + 1)
+        elif isinstance(value, (str, int, float, bool)):
+            out.setdefault(path, _PathStats()).record(value)
+        # None and list values are skipped: only scalar paths are fields.
+        # List-valued paths (message lists, retrieval documents) are
+        # deliberately omitted from observed discovery rather than emitted
+        # with empty capabilities — list-entry access is defined by authored
+        # convention fields, not by arbitrary observed indexing.
+
+
+async def _sample_observed_paths(
+    session: AsyncSession,
+    project_rowid: int,
+) -> tuple[int, dict[tuple[str, ...], _PathStats]]:
+    """Scan a bounded, time-spread sample of the project's spans.
+
+    Value discovery biased toward recent rows hides dimension values that
+    stopped occurring — exactly the values an investigation of a change
+    needs (the pre-cut release tag, the retired model name). So instead of
+    the most recent N spans, the sample draws span ids uniformly across
+    the project's whole id range: ids are allocated in ingestion order, so
+    the draw reaches old and new rows alike, in one bounded IN-list query.
+    The draw is seeded and therefore deterministic across calls, and it is
+    random rather than fixed-stride because trace structure is periodic
+    (root/child spans alternate ids) and a stride aliases with that period
+    — an even stride can sample only root spans and miss every LLM
+    attribute. Drawn ids that do not exist (gaps, other projects'
+    interleaved rows) simply reduce the scanned row count, which is
+    reported as ``sample_count``.
+    """
+    min_id, max_id = (
+        await session.execute(
+            compiler.scoped_base(
+                [func.min(models.Span.id), func.max(models.Span.id)], project_rowid, None
+            )
+        )
+    ).one()
+    if min_id is None or max_id is None:
+        return 0, {}
+    id_range = range(min_id, max_id + 1)
+    if len(id_range) <= _DISCOVERY_SAMPLE_SIZE:
+        candidate_ids = list(id_range)
+    else:
+        rng = random.Random(_DISCOVERY_SAMPLE_SEED)
+        candidate_ids = sorted(rng.sample(id_range, _DISCOVERY_SAMPLE_SIZE))
+    stmt = (
+        compiler.scoped_base([models.Span.attributes], project_rowid, None)
+        .where(models.Span.id.in_(candidate_ids))
+        .order_by(models.Span.id.asc())
+        .limit(_DISCOVERY_SAMPLE_SIZE)
+    )
+    stats: dict[tuple[str, ...], _PathStats] = {}
+    sample_count = 0
+    for attributes in (await session.execute(stmt)).scalars():
+        sample_count += 1
+        if isinstance(attributes, dict):
+            _flatten_scalars(attributes, (), stats)
+    return sample_count, stats
+
+
+async def _zero_result_guidance(
+    session: AsyncSession,
+    project_rowid: int,
+    time_range: Optional[TimeRange],
+    filter_condition: Optional[str],
+) -> dict[str, str]:
+    """Diagnose an empty result with bounded checks only.
+
+    The window check counts spans within the queried window — never an
+    unrestricted historical scan — and the path check reads the same
+    bounded time-spread sample discovery uses.
+    """
+    window_count = await session.scalar(
+        compiler.scoped_base([func.count()], project_rowid, time_range)
+    )
+    if not window_count:
+        detail = "The project has no spans"
+        if time_range is not None:
+            detail += (
+                f" between {_iso(time_range.start)} and {_iso(time_range.end)}"
+                " (the check counted only within this window)"
+            )
+        return {"cause": "window_empty", "detail": detail + "."}
+    if filter_condition:
+        referenced = compiler.attribute_paths_in_filter(filter_condition)
+        if referenced:
+            sample_count, stats = await _sample_observed_paths(session, project_rowid)
+            missing = sorted(
+                registry.canonical_attribute_spelling(keys)
+                for keys in referenced
+                if keys not in stats
+            )
+            if missing:
+                return {
+                    "cause": "path_not_observed",
+                    "detail": (
+                        f"Attribute path(s) {', '.join(missing)} did not appear in a "
+                        f"sample of {sample_count} spans drawn across the project's "
+                        "history — sampled evidence, not proof of absence."
+                    ),
+                }
+    return {
+        "cause": "no_matches",
+        "detail": (
+            "The window contains spans and the query is well-formed; nothing matched the filter."
+        ),
+    }
+
+
+# --------------------------------------------------------------------------
+# Tool construction
+# --------------------------------------------------------------------------
+
+
+def _db(app: "FastAPI") -> "DbSessionFactory":
+    # ``app.state.db`` is assigned after the MCP app is built, so it must be
+    # resolved lazily at call time, never captured at build time.
+    db: "DbSessionFactory" = app.state.db
+    return db
+
+
+def _capabilities(field: registry.AuthoredField) -> list[str]:
+    capabilities = ["select"]
+    if field.filterable:
+        capabilities.append("filter")
+    if field.groupable:
+        capabilities.append("breakdown")
+    if field.aggregatable:
+        capabilities.append("aggregate")
+    return capabilities
+
+
+def _build_describe_spans(app: "FastAPI") -> Tool:
+    async def describe_spans(
+        project: str = Field(description=_PROJECT_DESCRIPTION),
+    ) -> dict[str, Any]:
+        try:
+            db = _db(app)
+            async with db.read() as session:
+                project_rowid = await compiler.resolve_project_rowid(session, project)
+                if project_rowid is None:
+                    raise compiler.project_not_found(project)
+                sample_count, stats = await _sample_observed_paths(session, project_rowid)
+        except QueryError as error:
+            return error.envelope()
+
+        stats_by_spelling = {
+            registry.canonical_attribute_spelling(keys): path_stats
+            for keys, path_stats in stats.items()
+        }
+        fields: list[dict[str, Any]] = []
+        for authored in registry.AUTHORED_FIELDS:
+            entry: dict[str, Any] = {
+                "field": authored.id,
+                "label": authored.label,
+                # Provenance tells the caller which identifiers are portable
+                # across projects (columns, computed indicators, OpenInference
+                # convention attributes) versus discovered in this project's
+                # data (observed_attribute).
+                "source": authored.source,
+                "type": authored.type,
+                "unit": authored.unit,
+                "description": authored.description,
+                "capabilities": _capabilities(authored),
+            }
+            observed = stats_by_spelling.pop(authored.id, None)
+            if observed is not None:
+                entry["observed_count"] = observed.count
+                entry["sample_count"] = sample_count
+                entry["sampled"] = True
+            fields.append(entry)
+
+        observed_spellings = sorted(
+            stats_by_spelling, key=lambda spelling: -stats_by_spelling[spelling].count
+        )
+        capped = len(observed_spellings) > _DISCOVERY_MAX_OBSERVED_FIELDS
+        for spelling in observed_spellings[:_DISCOVERY_MAX_OBSERVED_FIELDS]:
+            path_stats = stats_by_spelling[spelling]
+            observed_types = sorted(path_stats.types)
+            entry = {
+                "field": spelling,
+                "source": "observed_attribute",
+                "observed_types": observed_types,
+                "observed_count": path_stats.count,
+                "sample_count": sample_count,
+                "missing_frequency": round(1 - path_stats.count / sample_count, 4)
+                if sample_count
+                else None,
+                "capabilities": ["select", "filter", "breakdown"],
+                "sampled": True,
+            }
+            if len(observed_types) > 1:
+                entry["type_conflicts"] = observed_types
+            top_values = path_stats.top_values()
+            if top_values is not None:
+                entry["top_values"] = top_values
+            fields.append(entry)
+
+        result: dict[str, Any] = {
+            "status": "ok",
+            "project": project,
+            "fields": fields,
+            "sampling": {
+                "strategy": _DISCOVERY_STRATEGY,
+                "sample_count": sample_count,
+                "note": (
+                    f"Observed fields come from a bounded sample of {sample_count} "
+                    "spans drawn evenly across the project's span id range "
+                    "(approximately time-ordered): observed, not exhaustive. An "
+                    "unobserved path or value means not-seen-in-sample, never "
+                    "nonexistent."
+                ),
+            },
+        }
+        if capped:
+            result["note"] = (
+                f"Observed fields were capped at {_DISCOVERY_MAX_OBSERVED_FIELDS} "
+                "entries (ordered by observation count)."
+            )
+        return result
+
+    return Tool.from_function(
+        describe_spans,
+        name="describeSpans",
+        description=(
+            "Discover the queryable span fields of a project — the dimensions and "
+            "metrics for analytics: authored fields (typed, with units and "
+            "capabilities) merged with attribute paths observed in a bounded sample "
+            "drawn across the project's history (with types, frequencies, and top "
+            "values for low-cardinality paths). Every returned `field` string is in "
+            "canonical query spelling and works verbatim in querySpanRows "
+            "fields/filter and aggregateSpans filter/breakdowns — copy identifiers "
+            "from here instead of constructing them. Capabilities per entry: select, "
+            "filter, breakdown, aggregate. Start here before aggregating or "
+            "filtering. Full field-level documentation is in the JSON schema's "
+            "descriptions (get_schema detail='full')."
+        ),
+        tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
+        annotations=_READ_ONLY_ANNOTATIONS,
+        output_schema=_union_schema(
+            {
+                "project": {"type": "string"},
+                "fields": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "The merged field catalog: authored entries carry type/unit/"
+                        "capabilities; observed entries carry observed_types, counts, "
+                        "and top_values where cardinality is low."
+                    ),
+                },
+                "sampling": {"type": "object"},
+                "note": {"type": "string"},
+            },
+            ["project", "fields", "sampling"],
+        ),
+    )
+
+
+def _build_aggregate_spans(app: "FastAPI") -> Tool:
+    async def aggregate_spans(
+        project: str = Field(description=_PROJECT_DESCRIPTION),
+        time_range: Any = Field(
+            description="Required time window (UTC, start-inclusive, end-exclusive).",
+            json_schema_extra=_TIME_RANGE_SCHEMA,
+        ),
+        calculations: Any = Field(
+            description=(
+                "Named aggregate calculations, e.g. "
+                '[{"name": "calls", "fn": "count"}, '
+                '{"name": "error_rate", "fn": "avg", "field": "is_error"}].'
+            ),
+            json_schema_extra=_CALCULATIONS_SCHEMA,
+        ),
+        filter: Optional[str] = Field(default=None, description=_FILTER_DESCRIPTION),
+        breakdowns: Any = Field(
+            default=None,
+            description=(
+                "Group-by dimensions: groupable field ids (see describeSpans "
+                'capabilities) and/or {"bucket": "hour"} for hourly buckets of '
+                'start_time, e.g. ["llm.model_name", {"bucket": "hour"}].'
+            ),
+            json_schema_extra=_BREAKDOWNS_SCHEMA,
+        ),
+        order: Any = Field(
+            default=None,
+            description=(
+                "Ordering over declared calculations or breakdowns, e.g. "
+                '[{"calculation": "error_rate", "direction": "desc"}] or '
+                '[{"field": "time_bucket", "direction": "asc"}]. Breakdown keys '
+                "are always appended as deterministic tie-breakers."
+            ),
+            json_schema_extra=_AGGREGATE_ORDER_SCHEMA,
+        ),
+        limit: int = Field(
+            default=compiler.AGGREGATE_LIMIT_DEFAULT,
+            gt=0,
+            description=(
+                f"Maximum groups returned (top-K; default "
+                f"{compiler.AGGREGATE_LIMIT_DEFAULT}, capped at "
+                f"{compiler.AGGREGATE_LIMIT_MAX} — larger values are clamped and the "
+                "applied value reported). Calculations always run over the full "
+                "matching set; the limit bounds only how many groups come back."
+            ),
+        ),
+        validate_only: bool = Field(default=False, description=_VALIDATE_ONLY_DESCRIPTION),
+        max_result_chars: int = Field(
+            default=_DEFAULT_MAX_RESULT_CHARS,
+            ge=1_000,
+            le=500_000,
+            description="Size budget for the returned rows, in characters.",
+        ),
+    ) -> dict[str, Any]:
+        try:
+            query = AggregateQuery(
+                project=project,
+                time_range=_parse_shape(
+                    _TIME_RANGE_ADAPTER,
+                    time_range,
+                    "time_range",
+                    '{"start": "<ISO-8601>", "end": "<ISO-8601>"}',
+                ),
+                filter=filter,
+                calculations=_parse_shape(
+                    _CALCULATIONS_ADAPTER,
+                    calculations,
+                    "calculations",
+                    'a non-empty list like [{"name": "calls", "fn": "count"}, '
+                    '{"name": "error_rate", "fn": "avg", "field": "is_error"}]',
+                ),
+                breakdowns=_parse_shape(
+                    _BREAKDOWNS_ADAPTER,
+                    breakdowns,
+                    "breakdowns",
+                    'a list of field ids and/or {"bucket": "hour"}, e.g. '
+                    '["llm.model_name", {"bucket": "hour"}]',
+                )
+                or [],
+                order=_parse_shape(
+                    _AGGREGATE_ORDER_ADAPTER,
+                    order,
+                    "order",
+                    'a list of entries like [{"calculation": "error_rate", '
+                    '"direction": "desc"}] or [{"field": "time_bucket", '
+                    '"direction": "asc"}]',
+                ),
+                limit=limit,
+                validate_only=validate_only,
+            )
+            db = _db(app)
+            async with db.read() as session:
+                project_rowid = await compiler.resolve_project_rowid(session, project)
+                if project_rowid is None:
+                    raise compiler.project_not_found(project)
+                plan = compiler.compile_aggregate(query, project_rowid, db.dialect)
+                applied: dict[str, Any] = {
+                    "limit": plan.applied_limit,
+                    "time_range_resolved": _time_range_resolved(plan.time_range),
+                    "timeout": {
+                        "statement_timeout_ms": compiler.STATEMENT_TIMEOUT_MS
+                        if db.dialect.value == "postgresql"
+                        else None
+                    },
+                }
+                if validate_only:
+                    return {"status": "ok", "valid": True, "applied": applied}
+                await compiler.apply_statement_timeout(session, db.dialect)
+                raw_rows = (await session.execute(plan.stmt)).all()
+                groups_total = (
+                    await session.scalar(plan.groups_total_stmt)
+                    if plan.groups_total_stmt is not None
+                    else 1
+                )
+                overall_row = (await session.execute(plan.overall_stmt)).one()
+                guidance = (
+                    await _zero_result_guidance(
+                        session, project_rowid, plan.time_range, query.filter
+                    )
+                    if not raw_rows
+                    else None
+                )
+        except QueryError as error:
+            return error.envelope()
+        except ValidationError as error:
+            # Safety net: any shape failure not caught by per-parameter
+            # parsing still surfaces on the error union, never as raw
+            # validation text.
+            return QueryError(
+                code="invalid_shape",
+                path=_shape_error_path("request", error),
+                message="The request has an invalid shape; check the parameter descriptions.",
+            ).envelope()
+
+        overall = {calc.name: _cell(value) for calc, value in zip(plan.calculations, overall_row)}
+        columns = [b.column.as_dict() for b in plan.breakdowns] + [
+            {"id": c.name, "type": "float", "unit": None} for c in plan.calculations
+        ]
+        share_basis = plan.share_basis
+        overall_basis = overall.get(share_basis) if share_basis else None
+        if share_basis is not None and overall_basis:
+            columns.append(
+                {
+                    "id": "share",
+                    "type": "float",
+                    "unit": None,
+                }
+            )
+        cohort_base = _public_url(f"/projects/{plan.project_gid}/spans")
+        rows: list[dict[str, Any]] = []
+        for raw in raw_rows:
+            row: dict[str, Any] = {}
+            for breakdown, value in zip(plan.breakdowns, raw):
+                row[breakdown.id] = (
+                    registry.normalize_time_bucket_value(value)
+                    if breakdown.is_time_bucket
+                    else _cell(value)
+                )
+            offset = len(plan.breakdowns)
+            for calc, value in zip(plan.calculations, raw[offset:]):
+                row[calc.name] = _cell(value)
+            if share_basis is not None and overall_basis:
+                basis_value = row.get(share_basis)
+                if isinstance(basis_value, (int, float)):
+                    row["share"] = basis_value / overall_basis
+            row["ui_url"] = _cohort_ui_url(
+                cohort_base,
+                plan.breakdowns,
+                raw[: len(plan.breakdowns)],
+                plan.time_range,
+            )
+            rows.append(row)
+
+        result: dict[str, Any] = {
+            "status": "ok",
+            "columns": columns,
+            "rows": rows,
+            "groups_total": groups_total,
+            "groups_returned": len(rows),
+            "overall": overall,
+            "share_basis": share_basis,
+            "applied": applied,
+        }
+        if guidance is not None:
+            result["guidance"] = guidance
+        notes: list[str] = []
+        if plan.uses_annotation_filter:
+            result["annotation_semantics"] = "any"
+            notes.append(_ANNOTATION_SEMANTICS_NOTE)
+        if groups_total is not None and groups_total > len(rows):
+            notes.append(
+                f"Top {len(rows)} of {groups_total} groups returned; ordering ties at "
+                "the boundary break deterministically on the breakdown keys."
+            )
+        if share_basis is None and any(not c.additive for c in plan.calculations):
+            notes.append(
+                "share is omitted: none of the calculations is additive (only count "
+                "and sum have meaningful shares of the overall total)."
+            )
+        if _serialized_size(rows) > max_result_chars:
+            kept: list[dict[str, Any]] = []
+            used = 0
+            for row in rows:
+                cost = _serialized_size(row)
+                if kept and used + cost > max_result_chars:
+                    break
+                kept.append(row)
+                used += cost
+            notes.append(
+                f"Only {len(kept)} of {len(rows)} groups fit max_result_chars; narrow "
+                "breakdowns or raise the budget."
+            )
+            result["rows"] = kept
+            result["groups_returned"] = len(kept)
+        if notes:
+            result["note"] = " ".join(notes)
+        return result
+
+    return Tool.from_function(
+        aggregate_spans,
+        name="aggregateSpans",
+        description=(
+            "Aggregate (group by) a project's spans into metrics: named calculations "
+            "(count, count_distinct, sum, avg, min, max, p50/p90/p95/p99 percentiles) "
+            "over aggregatable fields, grouped by breakdowns (groupable fields and/or "
+            "hourly time buckets), filtered, ordered, and bounded to the top-N "
+            "groups. Answers analytics questions like error rate by model, token "
+            "totals by release, or latency percentiles per hour: error rate is "
+            "avg(is_error), error count is sum(is_error). Returns typed columns, "
+            "rows, groups_total vs groups_returned, the overall (ungrouped) totals, "
+            "and per-group share of total for the first additive calculation; each "
+            "group row carries a ui_url deep-linking the Phoenix UI to that cohort. "
+            "Use describeSpans first to discover fields. The nested parameter shapes "
+            "(time_range, calculations, breakdowns, order) and the filter grammar "
+            "are documented in the JSON schema's field descriptions (get_schema "
+            "detail='full')."
+        ),
+        tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
+        annotations=_READ_ONLY_ANNOTATIONS,
+        output_schema=_union_schema(
+            {
+                "columns": _COLUMNS_SCHEMA,
+                "rows": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "One record per group, keyed by breakdown ids and calculation names."
+                    ),
+                },
+                "groups_total": {
+                    "type": ["integer", "null"],
+                    "description": "Total number of groups the query produced (before top-K).",
+                },
+                "groups_returned": {"type": "integer"},
+                "overall": {
+                    "type": "object",
+                    "description": "The same calculations over the full matching set, ungrouped.",
+                },
+                "share_basis": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Calculation whose per-group share of the overall total is "
+                        "reported (first additive calculation), or null."
+                    ),
+                },
+                "applied": {"type": "object"},
+                "annotation_semantics": _ANNOTATION_SEMANTICS_SCHEMA,
+                "guidance": _GUIDANCE_SCHEMA,
+                "note": {"type": "string"},
+            },
+            ["columns", "rows", "groups_total", "groups_returned", "overall", "applied"],
+            validate_arm=True,
+        ),
+    )
+
+
+def _build_query_span_rows(app: "FastAPI") -> Tool:
+    async def query_span_rows(
+        project: str = Field(description=_PROJECT_DESCRIPTION),
+        time_range: Any = Field(
+            default=None,
+            description=(
+                "Time window (UTC, start-inclusive, end-exclusive). Defaults to the "
+                f"last {compiler.ROW_WINDOW_DEFAULT_HOURS} hours; the resolved window "
+                "is always echoed in applied.time_range_resolved."
+            ),
+            json_schema_extra=_OPTIONAL_TIME_RANGE_SCHEMA,
+        ),
+        fields: Any = Field(
+            default=None,
+            description=(
+                "Field ids to return (authored ids or observed attribute paths from "
+                "describeSpans). span_id is always included as the row identity. "
+                "Defaults to: " + ", ".join(compiler.DEFAULT_ROW_FIELDS) + "."
+            ),
+            json_schema_extra=_ROW_FIELDS_SCHEMA,
+        ),
+        filter: Optional[str] = Field(default=None, description=_FILTER_DESCRIPTION),
+        order: Any = Field(
+            default=None,
+            description=(
+                "Two spellings. Ordered rows: a list of entries over selected "
+                'fields, e.g. [{"field": "latency_ms", "direction": "desc"}] '
+                "(default: start_time desc). Seeded random sample: an object, e.g. "
+                '{"sample": {"seed": 42}} — representative rows instead of '
+                "extremes, deterministic given the seed. The primary key always "
+                "terminates the ordering, so results are deterministic."
+            ),
+            json_schema_extra=_ROW_ORDER_SCHEMA,
+        ),
+        limit: int = Field(
+            default=compiler.ROW_LIMIT_DEFAULT,
+            gt=0,
+            description=(
+                f"Maximum rows (default {compiler.ROW_LIMIT_DEFAULT}, capped at "
+                f"{compiler.ROW_LIMIT_MAX} — larger values are clamped and the applied "
+                "value reported)."
+            ),
+        ),
+        validate_only: bool = Field(default=False, description=_VALIDATE_ONLY_DESCRIPTION),
+        max_cell_chars: int = Field(
+            default=_DEFAULT_MAX_CELL_CHARS,
+            ge=50,
+            le=10_000,
+            description=(
+                "Per-cell preview budget: longer string values are clipped and listed "
+                "in `clipped`; recover any full value via getSpan."
+            ),
+        ),
+        max_result_chars: int = Field(
+            default=_DEFAULT_MAX_RESULT_CHARS,
+            ge=1_000,
+            le=500_000,
+            description="Size budget for the returned rows, in characters.",
+        ),
+    ) -> dict[str, Any]:
+        try:
+            query = RowQuery(
+                project=project,
+                time_range=_parse_shape(
+                    _OPTIONAL_TIME_RANGE_ADAPTER,
+                    time_range,
+                    "time_range",
+                    '{"start": "<ISO-8601>", "end": "<ISO-8601>"}',
+                ),
+                fields=_parse_shape(
+                    _ROW_FIELDS_ADAPTER,
+                    fields,
+                    "fields",
+                    'a non-empty list of field ids, e.g. ["span_id", "latency_ms"]',
+                ),
+                filter=filter,
+                order=_parse_shape(
+                    _ROW_ORDER_ADAPTER,
+                    order,
+                    "order",
+                    'either a list like [{"field": "latency_ms", "direction": '
+                    '"desc"}] or a sample object like {"sample": {"seed": 42}}',
+                ),
+                limit=limit,
+                validate_only=validate_only,
+            )
+            db = _db(app)
+            async with db.read() as session:
+                project_rowid = await compiler.resolve_project_rowid(session, project)
+                if project_rowid is None:
+                    raise compiler.project_not_found(project)
+                plan = compiler.compile_rows(query, project_rowid, db.dialect)
+                applied: dict[str, Any] = {
+                    "limit": plan.applied_limit,
+                    "time_range_resolved": _time_range_resolved(plan.time_range),
+                    "time_range_defaulted": plan.time_range_defaulted,
+                    "max_cell_chars": max_cell_chars,
+                    "max_result_chars": max_result_chars,
+                    "timeout": {
+                        "statement_timeout_ms": compiler.STATEMENT_TIMEOUT_MS
+                        if db.dialect.value == "postgresql"
+                        else None
+                    },
+                }
+                if validate_only:
+                    return {"status": "ok", "valid": True, "applied": applied}
+                await compiler.apply_statement_timeout(session, db.dialect)
+                sample_note: Optional[str] = None
+                if plan.sample is not None:
+                    assert plan.ids_stmt is not None
+                    ids = list((await session.execute(plan.ids_stmt)).scalars())
+                    chosen = plan.choose_sample_ids(ids)
+                    raw_rows = (
+                        (await session.execute(plan.rows_stmt_for_ids(chosen))).all()
+                        if chosen
+                        else []
+                    )
+                    applied["sample"] = {"seed": plan.sample.seed}
+                    if len(ids) >= compiler.SAMPLE_ID_SCAN_CAP:
+                        sample_note = (
+                            f"The sample was drawn from the first "
+                            f"{compiler.SAMPLE_ID_SCAN_CAP} matching row ids; narrow "
+                            "the window for full coverage."
+                        )
+                else:
+                    assert plan.stmt is not None
+                    raw_rows = (await session.execute(plan.stmt)).all()
+                guidance = (
+                    await _zero_result_guidance(
+                        session, project_rowid, plan.time_range, query.filter
+                    )
+                    if not raw_rows
+                    else None
+                )
+        except QueryError as error:
+            return error.envelope()
+        except ValidationError as error:
+            # Safety net: any shape failure not caught by per-parameter
+            # parsing still surfaces on the error union, never as raw
+            # validation text.
+            return QueryError(
+                code="invalid_shape",
+                path=_shape_error_path("request", error),
+                message="The request has an invalid shape; check the parameter descriptions.",
+            ).envelope()
+
+        column_ids = [c.id for c in plan.columns]
+        clipped: list[dict[str, Any]] = []
+        rows: list[dict[str, Any]] = []
+        for raw in raw_rows:
+            row = {column_id: _cell(value) for column_id, value in zip(column_ids, raw)}
+            span_id = row.get("span_id")
+            for column_id, value in row.items():
+                if isinstance(value, str) and len(value) > max_cell_chars:
+                    row[column_id] = value[:max_cell_chars] + (
+                        f"…[clipped {len(value) - max_cell_chars} chars]"
+                    )
+                    clipped.append({"row": span_id, "field": column_id})
+            rows.append(row)
+
+        kept_rows: list[dict[str, Any]] = []
+        used = 0
+        for row in rows:
+            cost = _serialized_size(row)
+            if kept_rows and used + cost > max_result_chars:
+                break
+            kept_rows.append(row)
+            used += cost
+
+        result: dict[str, Any] = {
+            "status": "ok",
+            "columns": [c.as_dict() for c in plan.columns],
+            "rows": kept_rows,
+            "row_count": len(rows),
+            "applied": applied,
+            "clipped": [
+                marker
+                for marker in clipped
+                if any(r.get("span_id") == marker["row"] for r in kept_rows)
+            ],
+        }
+        if guidance is not None:
+            result["guidance"] = guidance
+        # An observed-path column that is NULL on every returned row is
+        # indistinguishable from a misspelled path: the projection compiles,
+        # returns, and quietly says nothing. Say so per column instead of
+        # letting the silence read as data. Authored fields are exempt —
+        # their NULLs carry documented meaning (no cost recorded, fewer
+        # than two messages).
+        if kept_rows:
+            column_notes = [
+                {
+                    "column": spec.id,
+                    "note": (
+                        "path not observed in these results — verify the spelling "
+                        "via describeSpans."
+                    ),
+                }
+                for spec in plan.columns
+                if spec.type == "json" and all(row.get(spec.id) is None for row in kept_rows)
+            ]
+            if column_notes:
+                result["column_notes"] = column_notes
+        notes: list[str] = []
+        if plan.uses_annotation_filter:
+            result["annotation_semantics"] = "any"
+            notes.append(_ANNOTATION_SEMANTICS_NOTE)
+        if sample_note:
+            notes.append(sample_note)
+        if clipped:
+            notes.append(
+                "Some cells were clipped to max_cell_chars previews; recover any full "
+                "value with getSpan(project, span_id)."
+            )
+        if len(kept_rows) < len(rows):
+            notes.append(
+                f"Only {len(kept_rows)} of {len(rows)} rows fit max_result_chars; "
+                "select fewer or smaller fields, narrow the filter, or raise the "
+                "budget."
+            )
+        if plan.sample is None and len(rows) >= plan.applied_limit:
+            notes.append(
+                f"Row count is at the limit ({plan.applied_limit}); results may be "
+                "incomplete — raise limit or narrow filter/time_range."
+            )
+        if notes:
+            result["note"] = " ".join(notes)
+        return result
+
+    return Tool.from_function(
+        query_span_rows,
+        name="querySpanRows",
+        description=(
+            "Retrieve individual spans as ordered, bounded rows — top-N listings "
+            "(order + limit, e.g. the slowest failures), filtered slices, or a "
+            "seeded random sample: select fields (authored ids or observed attribute "
+            "paths from describeSpans), filter, order, and limit. Results are "
+            "deterministic; span_id is always included as the row identity; long "
+            "values are clipped to previews with getSpan as the recovery path. "
+            "Defaults to the last 24 hours when time_range is omitted. The nested "
+            "parameter shapes (time_range, fields, order) and the filter grammar are "
+            "documented in the JSON schema's field descriptions (get_schema "
+            "detail='full')."
+        ),
+        tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
+        annotations=_READ_ONLY_ANNOTATIONS,
+        output_schema=_union_schema(
+            {
+                "columns": _COLUMNS_SCHEMA,
+                "rows": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "One record per span, keyed by field id.",
+                },
+                "row_count": {"type": "integer"},
+                "applied": {"type": "object"},
+                "clipped": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "row": {"type": ["string", "null"]},
+                            "field": {"type": "string"},
+                        },
+                    },
+                    "description": (
+                        "Cells clipped to the preview budget, identified by row "
+                        "span_id and field id; getSpan returns full values."
+                    ),
+                },
+                "column_notes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "column": {"type": "string"},
+                            "note": {"type": "string"},
+                        },
+                    },
+                    "description": (
+                        "Present when a selected observed attribute path was NULL on "
+                        "every returned row — usually a misspelled path; verify via "
+                        "describeSpans."
+                    ),
+                },
+                "annotation_semantics": _ANNOTATION_SEMANTICS_SCHEMA,
+                "guidance": _GUIDANCE_SCHEMA,
+                "note": {"type": "string"},
+            },
+            ["columns", "rows", "row_count", "applied", "clipped"],
+            validate_arm=True,
+        ),
+    )
+
+
+def _build_get_span(app: "FastAPI") -> Tool:
+    async def get_span(
+        project: str = Field(description=_PROJECT_DESCRIPTION),
+        span_id: str = Field(description="OpenTelemetry span id (hex), e.g. from querySpanRows."),
+        max_result_chars: int = Field(
+            default=_GET_SPAN_MAX_RESULT_CHARS,
+            ge=1_000,
+            le=500_000,
+            description=(
+                "Size budget in characters; oversized string values are clipped "
+                "largest-first and listed in `clipped`."
+            ),
+        ),
+    ) -> dict[str, Any]:
+        try:
+            db = _db(app)
+            async with db.read() as session:
+                project_rowid = await compiler.resolve_project_rowid(session, project)
+                if project_rowid is None:
+                    raise compiler.project_not_found(project)
+                stmt = compiler.scoped_base(
+                    [models.Span, models.Trace.trace_id], project_rowid, None
+                ).where(models.Span.span_id == span_id)
+                row = (await session.execute(stmt)).first()
+                if row is None:
+                    # Identical for a span in another project and a span that
+                    # does not exist: not-found must not be an existence oracle.
+                    raise QueryError(
+                        code="span_not_found",
+                        path="span_id",
+                        message=f"Span {span_id!r} not found in project {project!r}.",
+                    )
+                span, trace_id = row
+                # The flat registry-field echo, computed through the same
+                # registry expressions row queries use (so guarded numeric
+                # semantics are identical): the survey and the drill-down
+                # keep one naming scheme, instead of remapping flat ids like
+                # status_code onto the nested record at the handoff.
+                fields_stmt = compiler.scoped_base(
+                    [f.expr(db.dialect).label(f.id) for f in registry.AUTHORED_FIELDS],
+                    project_rowid,
+                    None,
+                ).where(models.Span.span_id == span_id)
+                fields_row = (await session.execute(fields_stmt)).first()
+        except QueryError as error:
+            return error.envelope()
+
+        registry_fields = (
+            {field.id: _cell(value) for field, value in zip(registry.AUTHORED_FIELDS, fields_row)}
+            if fields_row is not None
+            else {}
+        )
+        payload: dict[str, Any] = {
+            "span_id": span.span_id,
+            "trace_id": trace_id,
+            "parent_id": span.parent_id,
+            "name": span.name,
+            "span_kind": span.span_kind,
+            "status": {"code": span.status_code, "message": span.status_message},
+            "start_time": _cell(span.start_time),
+            "end_time": _cell(span.end_time),
+            "latency_ms": span.latency_ms,
+            "attributes": span.attributes,
+            "events": span.events,
+        }
+        payload, clipped_paths = _clip_strings_to_budget(
+            payload,
+            max_result_chars,
+            marker="raise max_result_chars for more",
+        )
+        result: dict[str, Any] = {
+            "status": "ok",
+            "span": payload,
+            "fields": registry_fields,
+            "ui_url": _ui_span_url(span.span_id),
+            "applied": {"max_result_chars": max_result_chars},
+            "clipped": clipped_paths,
+        }
+        if clipped_paths:
+            result["note"] = (
+                "Some values exceeded max_result_chars and were clipped largest-first; "
+                "raise max_result_chars to recover them."
+            )
+        return result
+
+    return Tool.from_function(
+        get_span,
+        name="getSpan",
+        description=(
+            "Fetch one span in full: attributes, events (including exception details), "
+            "status, timing, trace_id, and a Phoenix UI link (ui_url). Also echoes "
+            "`fields` — the flat registry field values (status_code, latency_ms, "
+            "llm.model_name, ...) exactly as querySpanRows returns them, so the "
+            "survey and the drill-down share one naming scheme. The recovery path "
+            "for every clipped preview in querySpanRows. Parameter documentation is "
+            "in the JSON schema's field descriptions (get_schema detail='full')."
+        ),
+        tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
+        annotations=_READ_ONLY_ANNOTATIONS,
+        output_schema=_union_schema(
+            {
+                "span": {
+                    "type": "object",
+                    "description": (
+                        "The full span record: identity, name, kind, status, timing, "
+                        "attributes, and events."
+                    ),
+                },
+                "fields": {
+                    "type": "object",
+                    "description": (
+                        "Flat registry field values for this span, keyed by the same "
+                        "field ids querySpanRows uses (status_code, latency_ms, "
+                        "llm.model_name, ...) and computed through the same "
+                        "expressions, guarded numeric semantics included."
+                    ),
+                },
+                "ui_url": {
+                    "type": "string",
+                    "description": "Phoenix UI link opening this span.",
+                },
+                "applied": {"type": "object"},
+                "clipped": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Dotted paths of values clipped to fit max_result_chars.",
+                },
+                "note": {"type": "string"},
+            },
+            ["span", "fields", "ui_url"],
+        ),
+    )
+
+
+def _build_get_trace(app: "FastAPI") -> Tool:
+    async def get_trace(
+        project: str = Field(description=_PROJECT_DESCRIPTION),
+        trace_id: str = Field(description="OpenTelemetry trace id (hex), e.g. from querySpanRows."),
+        max_result_chars: int = Field(
+            default=_DEFAULT_MAX_RESULT_CHARS,
+            ge=1_000,
+            le=500_000,
+            description=(
+                "Size budget in characters; if the tree exceeds it, latest-started "
+                "spans are omitted and counted in `note`."
+            ),
+        ),
+    ) -> dict[str, Any]:
+        try:
+            db = _db(app)
+            async with db.read() as session:
+                project_rowid = await compiler.resolve_project_rowid(session, project)
+                if project_rowid is None:
+                    raise compiler.project_not_found(project)
+                stmt = (
+                    compiler.scoped_base(
+                        [
+                            models.Span.span_id,
+                            models.Span.parent_id,
+                            models.Span.name,
+                            models.Span.span_kind,
+                            models.Span.status_code,
+                            models.Span.start_time,
+                            models.Span.latency_ms,
+                        ],
+                        project_rowid,
+                        None,
+                    )
+                    .where(models.Trace.trace_id == trace_id)
+                    .order_by(models.Span.start_time.asc(), models.Span.id.asc())
+                )
+                raw_rows = (await session.execute(stmt)).all()
+                if not raw_rows:
+                    # Identical for a trace in another project and a trace that
+                    # does not exist: not-found must not be an existence oracle.
+                    raise QueryError(
+                        code="trace_not_found",
+                        path="trace_id",
+                        message=f"Trace {trace_id!r} not found in project {project!r}.",
+                    )
+        except QueryError as error:
+            return error.envelope()
+
+        summaries = [
+            {
+                "span_id": span_id,
+                "parent_id": parent_id,
+                "name": name,
+                "span_kind": span_kind,
+                "status_code": status_code,
+                "start_time": _cell(start_time),
+                "latency_ms": latency_ms,
+                "ui_url": _ui_span_url(span_id),
+            }
+            for span_id, parent_id, name, span_kind, status_code, start_time, latency_ms in (
+                raw_rows
+            )
+        ]
+        total = len(summaries)
+        omitted = 0
+        while True:
+            roots = _assemble_tree(summaries)
+            result: dict[str, Any] = {
+                "status": "ok",
+                "trace_id": trace_id,
+                "span_count": total,
+                "roots": roots,
+                "ui_url": _ui_trace_url(trace_id),
+                "applied": {"max_result_chars": max_result_chars},
+            }
+            if omitted:
+                result["note"] = (
+                    f"{omitted} of {total} spans were omitted (latest-started first) "
+                    "to fit max_result_chars; raise it or drill into spans with "
+                    "getSpan."
+                )
+            if _serialized_size(result) <= max_result_chars or len(summaries) <= 1:
+                return result
+            drop = max(1, len(summaries) // 10)
+            summaries = summaries[:-drop]
+            omitted += drop
+
+    return Tool.from_function(
+        get_trace,
+        name="getTrace",
+        description=(
+            "Fetch one trace's spans with parent/child structure assembled as a tree "
+            "of summaries (identity, name, kind, status, timing, ui_url per span; "
+            "orphaned spans surface as roots and are flagged). Full span values come "
+            "from getSpan."
+        ),
+        tags={SPANS_GROUP_TAG},
+        annotations=_READ_ONLY_ANNOTATIONS,
+        output_schema=_union_schema(
+            {
+                "trace_id": {"type": "string"},
+                "span_count": {"type": "integer"},
+                "roots": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Root span summaries, each with a nested `children` list; "
+                        "orphaned spans (parent never received) appear as roots with "
+                        "orphan: true."
+                    ),
+                },
+                "ui_url": {
+                    "type": "string",
+                    "description": "Phoenix UI link opening this trace.",
+                },
+                "applied": {"type": "object"},
+                "note": {"type": "string"},
+            },
+            ["trace_id", "span_count", "roots", "ui_url"],
+        ),
+    )
+
+
+def _assemble_tree(summaries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Nest span summaries into parent/child structure.
+
+    Spans whose parent is absent from the set (orphans) become roots with an
+    ``orphan: true`` flag — absence of the parent is data, not an error.
+    """
+    nodes: dict[str, dict[str, Any]] = {}
+    for summary in summaries:
+        node = dict(summary)
+        node["children"] = []
+        nodes[node["span_id"]] = node
+    roots: list[dict[str, Any]] = []
+    for node in nodes.values():
+        parent_id = node["parent_id"]
+        if parent_id is None:
+            roots.append(node)
+        elif parent_id in nodes:
+            nodes[parent_id]["children"].append(node)
+        else:
+            node["orphan"] = True
+            roots.append(node)
+    return roots
+
+
+def build_span_analytics_tools(app: "FastAPI") -> list[Tool]:
+    """Build the five span analytics tools bound to ``app``.
+
+    The tools resolve ``app.state.db`` lazily at call time because it is
+    assigned after the MCP app is constructed.
+    """
+    return [
+        _build_describe_spans(app),
+        _build_aggregate_spans(app),
+        _build_query_span_rows(app),
+        _build_get_span(app),
+        _build_get_trace(app),
+    ]

--- a/src/phoenix/server/mcp_span_analytics/tools.py
+++ b/src/phoenix/server/mcp_span_analytics/tools.py
@@ -18,6 +18,13 @@ success or ``{status: "error", code, path, message, suggestions}`` on
 semantic failure, so callers branch on data instead of parsing prose.
 ``ToolError`` is reserved for transport-level failures.
 
+The supporting mechanics live in sibling modules — query compilation in
+:mod:`.compiler`, the field registry in :mod:`.registry`, observed-path
+sampling in :mod:`.discovery`, response envelopes and size budgeting in
+:mod:`.envelope`, and UI link composition in :mod:`.links`. This module
+owns the tool definitions themselves: parameter schemas, handlers, and
+descriptions.
+
 Field declarations use the ``param: T = Field(default=..., description=...)``
 style; ``Annotated`` wrapping nests descriptions inside an extra ``anyOf``
 level where JSON-schema consumers do not look.
@@ -25,27 +32,16 @@ level where JSON-schema consumers do not look.
 
 from __future__ import annotations
 
-import json
-import os
-import random
 import re
-from collections import Counter
-from copy import deepcopy
-from datetime import datetime, timedelta, timezone
-from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Union
-from urllib.parse import urlencode
 
 from fastmcp.server.dependencies import get_http_request
 from fastmcp.tools.base import Tool
 from mcp.types import ToolAnnotations
 from pydantic import Field, TypeAdapter, ValidationError
-from sqlalchemy import func
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from phoenix.config import ENV_PHOENIX_ROOT_URL, get_env_root_url
 from phoenix.db import models
-from phoenix.server.mcp_span_analytics import compiler, registry
+from phoenix.server.mcp_span_analytics import compiler, discovery, envelope, links, registry
 from phoenix.server.mcp_span_analytics.compiler import (
     AggregateOrderEntry,
     AggregateQuery,
@@ -57,7 +53,6 @@ from phoenix.server.mcp_span_analytics.compiler import (
     TimeBucket,
     TimeRange,
 )
-from phoenix.server.utils import prepend_root_path
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -89,28 +84,6 @@ _READ_ONLY_ANNOTATIONS = ToolAnnotations(
 _DEFAULT_MAX_RESULT_CHARS = 50_000
 _GET_SPAN_MAX_RESULT_CHARS = 100_000
 _DEFAULT_MAX_CELL_CHARS = 400
-
-#: Upper bound on spans scanned for observed-field discovery and
-#: zero-result diagnosis. A bounded sample drawn evenly across the
-#: project's span id range, never a full scan.
-_DISCOVERY_SAMPLE_SIZE = 500
-
-#: Declared sampling strategy of the discovery scan: up to N span ids
-#: drawn uniformly across the project's id range (approximately
-#: time-ordered, since ids are allocated in ingestion order).
-_DISCOVERY_STRATEGY = f"id_spread_{_DISCOVERY_SAMPLE_SIZE}"
-
-#: Fixed seed of the discovery draw: the same project state always yields
-#: the same sample, so repeated discovery calls agree with each other.
-_DISCOVERY_SAMPLE_SEED = 0
-
-#: Cap on observed-field entries in one describeSpans response.
-_DISCOVERY_MAX_OBSERVED_FIELDS = 100
-
-#: Observed values are tracked for top-value reporting only up to this many
-#: distinct values per path and this many characters per value.
-_TOP_VALUES_LIMIT = 20
-_TOP_VALUE_MAX_CHARS = 100
 
 _FILTER_DESCRIPTION = (
     "Boolean expression selecting spans, written in Python syntax and compiled to SQL. "
@@ -333,164 +306,18 @@ def _parse_shape(adapter: TypeAdapter[Any], value: Any, param: str, expected: st
         )
 
 
-#: Structural disclosure attached whenever a filter used an annotation
-#: predicate: existence tests are any-annotator by construction.
-_ANNOTATION_SEMANTICS_NOTE = (
-    "The filter's annotation predicate uses any-annotator semantics: any "
-    "matching annotation row satisfies it; consensus or reduced semantics "
-    "are not implemented."
-)
-
-_ANNOTATION_SEMANTICS_SCHEMA: dict[str, Any] = {
-    "type": "string",
-    "enum": ["any"],
-    "description": (
-        "Present when the filter used an annotation predicate: the predicate "
-        "is satisfied by any matching annotation row (any-annotator "
-        "semantics); consensus/reduced semantics are not implemented."
-    ),
-}
-
-
 # --------------------------------------------------------------------------
-# Output schemas
+# UI links
 # --------------------------------------------------------------------------
-
-_ERROR_ARM: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "status": {"const": "error"},
-        "code": {
-            "type": "string",
-            "description": (
-                "Machine-readable failure class, e.g. unknown_field, invalid_filter, "
-                "invalid_shape, field_not_groupable, project_not_found."
-            ),
-        },
-        "path": {
-            "type": ["string", "null"],
-            "description": "Request location the error anchors to, e.g. 'order[0].field'.",
-        },
-        "message": {"type": "string"},
-        "suggestions": {
-            "type": "array",
-            "items": {"type": "string"},
-            "description": "Nearest-name or alternative-usage candidates, directly usable.",
-        },
-    },
-    "required": ["status", "code", "message"],
-}
-
-_VALIDATE_ARM: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "status": {"const": "ok"},
-        "valid": {"const": True},
-        "applied": {"type": "object"},
-    },
-    "required": ["status", "valid"],
-}
-
-
-def _union_schema(
-    ok_properties: dict[str, Any],
-    ok_required: Sequence[str],
-    validate_arm: bool = False,
-) -> dict[str, Any]:
-    ok_arm: dict[str, Any] = {
-        "type": "object",
-        "properties": {"status": {"const": "ok"}, **ok_properties},
-        "required": ["status", *ok_required],
-    }
-    arms = [ok_arm, *([_VALIDATE_ARM] if validate_arm else []), _ERROR_ARM]
-    return {"type": "object", "oneOf": arms}
-
-
-_COLUMNS_SCHEMA: dict[str, Any] = {
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "id": {"type": "string"},
-            "type": {"type": "string"},
-            "unit": {"type": ["string", "null"]},
-        },
-    },
-    "description": "Typed metadata of the result columns, in order.",
-}
-
-_GUIDANCE_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "cause": {
-            "type": "string",
-            "enum": ["window_empty", "path_not_observed", "no_matches"],
-        },
-        "detail": {"type": "string"},
-    },
-    "description": (
-        "Present when the result is empty: which of the enumerated causes applies. "
-        "path_not_observed is sampled evidence, not proof of absence."
-    ),
-}
-
-
-# --------------------------------------------------------------------------
-# Serialization helpers
-# --------------------------------------------------------------------------
-
-
-def _cell(value: Any) -> Any:
-    if isinstance(value, datetime):
-        if value.tzinfo is None:
-            value = value.replace(tzinfo=timezone.utc)
-        return value.astimezone(timezone.utc).isoformat()
-    if isinstance(value, Decimal):
-        return float(value)
-    return value
-
-
-def _serialized_size(obj: Any) -> int:
-    return len(json.dumps(obj, ensure_ascii=False, default=str))
-
-
-def _iso(value: datetime) -> str:
-    return value.astimezone(timezone.utc).isoformat()
-
-
-def _time_range_resolved(time_range: TimeRange) -> dict[str, str]:
-    return {"start": _iso(time_range.start), "end": _iso(time_range.end)}
 
 
 def _public_url(path: str) -> str:
-    """Compose an absolute Phoenix UI link for ``path``.
+    """Absolute Phoenix UI link for ``path``; see :func:`links.public_url`.
 
-    Behind a reverse proxy, only two parties can know the public origin:
-    explicit configuration, or the incoming request itself — the server's
-    own host/port settings describe where it listens, not where clients
-    reach it. Precedence follows the OAuth machinery's ``public_origin``:
-    ``PHOENIX_ROOT_URL`` when set; otherwise the current MCP request's
-    origin with its ASGI ``root_path`` prepended; and the
-    environment-composed URL only as the last resort when no request
-    context exists.
+    The transport's request accessor is resolved here, at the tool layer,
+    and injected into the composition logic.
     """
-    if os.getenv(ENV_PHOENIX_ROOT_URL):
-        return f"{str(get_env_root_url()).rstrip('/')}{path}"
-    try:
-        request = get_http_request()
-    except RuntimeError:
-        return f"{str(get_env_root_url()).rstrip('/')}{path}"
-    origin = f"{request.base_url.scheme}://{request.base_url.netloc}"
-    # The request is seen inside the mounted MCP app, so its ASGI root_path
-    # is "<deployment prefix><MCP mount>". The deployment prefix (a reverse
-    # proxy's) belongs in UI links; the app's own MCP mount does not — a UI
-    # route lives at /projects/..., never /mcp/projects/....
-    from phoenix.server.mcp_server import MCP_MOUNT_PATH
-
-    root_path = str(request.scope.get("root_path", "")).rstrip("/")
-    if root_path.endswith(MCP_MOUNT_PATH):
-        root_path = root_path[: -len(MCP_MOUNT_PATH)]
-    return f"{origin}{prepend_root_path({'root_path': root_path}, path)}"
+    return links.public_url(path, get_http_request)
 
 
 def _ui_span_url(span_id: str) -> str:
@@ -499,281 +326,6 @@ def _ui_span_url(span_id: str) -> str:
 
 def _ui_trace_url(trace_id: str) -> str:
     return _public_url(f"/redirects/traces/{trace_id}")
-
-
-def _filter_literal(value: Any) -> str:
-    """Render one group-key value as a filter-grammar literal.
-
-    Strings are escaped for the grammar (which parses Python string
-    literals): backslashes first, then single quotes — a value like
-    ``o'brien-corp`` must survive both the grammar and URL encoding.
-    """
-    if isinstance(value, str):
-        escaped = value.replace("\\", "\\\\").replace("'", "\\'")
-        return f"'{escaped}'"
-    return repr(value)
-
-
-def _bucket_start(value: Any) -> Optional[datetime]:
-    if isinstance(value, datetime):
-        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
-    if isinstance(value, str) and value:
-        return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
-    return None
-
-
-def _cohort_ui_url(
-    base: str,
-    breakdowns: Sequence[Any],
-    raw_values: Sequence[Any],
-    time_range: "TimeRange",
-) -> str:
-    """Deep link to the group's cohort in the Phoenix UI span view.
-
-    The link carries the group's condition as a ``filter`` in the filter
-    grammar (breakdown-key equalities ANDed) plus ``start``/``end``. A
-    time bucket contributes nothing to ``filter``; it narrows the time
-    params to its hour instead. A **null group key is skipped**: the UI
-    filter grammar cannot express "attribute is absent" today, so the
-    null bucket links to the window without that conjunct — a wider
-    cohort than the row, by declared necessity.
-    """
-    conjuncts: list[str] = []
-    window_start, window_end = time_range.start, time_range.end
-    for breakdown, value in zip(breakdowns, raw_values):
-        if breakdown.is_time_bucket:
-            bucket = _bucket_start(value)
-            if bucket is not None:
-                window_start, window_end = bucket, bucket + timedelta(hours=1)
-        elif value is not None:
-            conjuncts.append(f"{breakdown.id} == {_filter_literal(value)}")
-    params: dict[str, str] = {}
-    if conjuncts:
-        params["filter"] = " and ".join(conjuncts)
-    params["start"] = _iso(window_start)
-    params["end"] = _iso(window_end)
-    return f"{base}?{urlencode(params)}"
-
-
-def _clip_strings_to_budget(
-    obj: Any,
-    budget: int,
-    marker: str,
-    min_keep: int = 500,
-) -> tuple[Any, list[str]]:
-    """Clip the largest string leaves of a JSON-like object until it fits.
-
-    Returns the (possibly copied and clipped) object and the dotted paths of
-    clipped leaves. Whole values are never dropped — clipping a cell and
-    pointing at the recovery path degrades better than losing the row.
-    """
-    size = _serialized_size(obj)
-    if size <= budget:
-        return obj, []
-    obj = deepcopy(obj)
-    leaves: list[tuple[int, Any, Any, str]] = []
-
-    def collect(node: Any, path: str) -> None:
-        if isinstance(node, dict):
-            for key, value in node.items():
-                child_path = f"{path}.{key}" if path else str(key)
-                if isinstance(value, str) and len(value) > min_keep:
-                    leaves.append((len(value), node, key, child_path))
-                else:
-                    collect(value, child_path)
-        elif isinstance(node, list):
-            for index, value in enumerate(node):
-                child_path = f"{path}[{index}]"
-                if isinstance(value, str) and len(value) > min_keep:
-                    leaves.append((len(value), node, index, child_path))
-                else:
-                    collect(value, child_path)
-
-    collect(obj, "")
-    leaves.sort(key=lambda item: item[0], reverse=True)
-    clipped: list[str] = []
-    for length, container, key, path in leaves:
-        if size <= budget:
-            break
-        text_value = container[key]
-        excess = size - budget
-        keep = max(min_keep, len(text_value) - excess - len(marker))
-        if keep >= len(text_value):
-            continue
-        suffix = f"…[clipped {len(text_value) - keep} chars; {marker}]"
-        container[key] = text_value[:keep] + suffix
-        size += len(suffix) + keep - len(text_value)
-        clipped.append(path)
-    return obj, clipped
-
-
-# --------------------------------------------------------------------------
-# Observed-path sampling
-# --------------------------------------------------------------------------
-
-
-class _PathStats:
-    """Streaming statistics for one attribute path in the discovery sample."""
-
-    __slots__ = ("count", "types", "values", "values_complete")
-
-    def __init__(self) -> None:
-        self.count = 0
-        self.types: Counter[str] = Counter()
-        self.values: Counter[Any] = Counter()
-        #: True while every observed value has been tracked; long values and
-        #: high cardinality forfeit top-value reporting rather than
-        #: misreport it as complete.
-        self.values_complete = True
-
-    def record(self, value: Any) -> None:
-        self.count += 1
-        if isinstance(value, bool):
-            self.types["boolean"] += 1
-        elif isinstance(value, int):
-            self.types["integer"] += 1
-        elif isinstance(value, float):
-            self.types["float"] += 1
-        else:
-            self.types["string"] += 1
-        trackable = not isinstance(value, str) or len(value) <= _TOP_VALUE_MAX_CHARS
-        if not trackable:
-            self.values_complete = False
-            return
-        if value in self.values or len(self.values) < _TOP_VALUES_LIMIT + 1:
-            self.values[value] += 1
-        else:
-            self.values_complete = False
-
-    def top_values(self) -> Optional[list[dict[str, Any]]]:
-        if not self.values_complete or not self.values or len(self.values) > _TOP_VALUES_LIMIT:
-            return None
-        return [
-            {"value": value, "count": count}
-            for value, count in sorted(self.values.items(), key=lambda kv: (-kv[1], str(kv[0])))
-        ]
-
-
-def _flatten_scalars(
-    blob: Mapping[str, Any],
-    prefix: tuple[str, ...],
-    out: dict[tuple[str, ...], _PathStats],
-    depth: int = 0,
-) -> None:
-    if depth > 6:
-        return
-    for key, value in blob.items():
-        if not isinstance(key, str):
-            continue
-        path = (*prefix, key)
-        if isinstance(value, dict):
-            _flatten_scalars(value, path, out, depth + 1)
-        elif isinstance(value, (str, int, float, bool)):
-            out.setdefault(path, _PathStats()).record(value)
-        # None and list values are skipped: only scalar paths are fields.
-        # List-valued paths (message lists, retrieval documents) are
-        # deliberately omitted from observed discovery rather than emitted
-        # with empty capabilities — list-entry access is defined by authored
-        # convention fields, not by arbitrary observed indexing.
-
-
-async def _sample_observed_paths(
-    session: AsyncSession,
-    project_rowid: int,
-) -> tuple[int, dict[tuple[str, ...], _PathStats]]:
-    """Scan a bounded, time-spread sample of the project's spans.
-
-    Value discovery biased toward recent rows hides dimension values that
-    stopped occurring — exactly the values an investigation of a change
-    needs (the pre-cut release tag, the retired model name). So instead of
-    the most recent N spans, the sample draws span ids uniformly across
-    the project's whole id range: ids are allocated in ingestion order, so
-    the draw reaches old and new rows alike, in one bounded IN-list query.
-    The draw is seeded and therefore deterministic across calls, and it is
-    random rather than fixed-stride because trace structure is periodic
-    (root/child spans alternate ids) and a stride aliases with that period
-    — an even stride can sample only root spans and miss every LLM
-    attribute. Drawn ids that do not exist (gaps, other projects'
-    interleaved rows) simply reduce the scanned row count, which is
-    reported as ``sample_count``.
-    """
-    min_id, max_id = (
-        await session.execute(
-            compiler.scoped_base(
-                [func.min(models.Span.id), func.max(models.Span.id)], project_rowid, None
-            )
-        )
-    ).one()
-    if min_id is None or max_id is None:
-        return 0, {}
-    id_range = range(min_id, max_id + 1)
-    if len(id_range) <= _DISCOVERY_SAMPLE_SIZE:
-        candidate_ids = list(id_range)
-    else:
-        rng = random.Random(_DISCOVERY_SAMPLE_SEED)
-        candidate_ids = sorted(rng.sample(id_range, _DISCOVERY_SAMPLE_SIZE))
-    stmt = (
-        compiler.scoped_base([models.Span.attributes], project_rowid, None)
-        .where(models.Span.id.in_(candidate_ids))
-        .order_by(models.Span.id.asc())
-        .limit(_DISCOVERY_SAMPLE_SIZE)
-    )
-    stats: dict[tuple[str, ...], _PathStats] = {}
-    sample_count = 0
-    for attributes in (await session.execute(stmt)).scalars():
-        sample_count += 1
-        if isinstance(attributes, dict):
-            _flatten_scalars(attributes, (), stats)
-    return sample_count, stats
-
-
-async def _zero_result_guidance(
-    session: AsyncSession,
-    project_rowid: int,
-    time_range: Optional[TimeRange],
-    filter_condition: Optional[str],
-) -> dict[str, str]:
-    """Diagnose an empty result with bounded checks only.
-
-    The window check counts spans within the queried window — never an
-    unrestricted historical scan — and the path check reads the same
-    bounded time-spread sample discovery uses.
-    """
-    window_count = await session.scalar(
-        compiler.scoped_base([func.count()], project_rowid, time_range)
-    )
-    if not window_count:
-        detail = "The project has no spans"
-        if time_range is not None:
-            detail += (
-                f" between {_iso(time_range.start)} and {_iso(time_range.end)}"
-                " (the check counted only within this window)"
-            )
-        return {"cause": "window_empty", "detail": detail + "."}
-    if filter_condition:
-        referenced = compiler.attribute_paths_in_filter(filter_condition)
-        if referenced:
-            sample_count, stats = await _sample_observed_paths(session, project_rowid)
-            missing = sorted(
-                registry.canonical_attribute_spelling(keys)
-                for keys in referenced
-                if keys not in stats
-            )
-            if missing:
-                return {
-                    "cause": "path_not_observed",
-                    "detail": (
-                        f"Attribute path(s) {', '.join(missing)} did not appear in a "
-                        f"sample of {sample_count} spans drawn across the project's "
-                        "history — sampled evidence, not proof of absence."
-                    ),
-                }
-    return {
-        "cause": "no_matches",
-        "detail": (
-            "The window contains spans and the query is well-formed; nothing matched the filter."
-        ),
-    }
 
 
 # --------------------------------------------------------------------------
@@ -809,7 +361,7 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
                 project_rowid = await compiler.resolve_project_rowid(session, project)
                 if project_rowid is None:
                     raise compiler.project_not_found(project)
-                sample_count, stats = await _sample_observed_paths(session, project_rowid)
+                sample_count, stats = await discovery.sample_observed_paths(session, project_rowid)
         except QueryError as error:
             return error.envelope()
 
@@ -842,8 +394,8 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
         observed_spellings = sorted(
             stats_by_spelling, key=lambda spelling: -stats_by_spelling[spelling].count
         )
-        capped = len(observed_spellings) > _DISCOVERY_MAX_OBSERVED_FIELDS
-        for spelling in observed_spellings[:_DISCOVERY_MAX_OBSERVED_FIELDS]:
+        capped = len(observed_spellings) > discovery.MAX_OBSERVED_FIELDS
+        for spelling in observed_spellings[: discovery.MAX_OBSERVED_FIELDS]:
             path_stats = stats_by_spelling[spelling]
             observed_types = sorted(path_stats.types)
             entry = {
@@ -870,7 +422,7 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
             "project": project,
             "fields": fields,
             "sampling": {
-                "strategy": _DISCOVERY_STRATEGY,
+                "strategy": discovery.STRATEGY,
                 "sample_count": sample_count,
                 "note": (
                     f"Observed fields come from a bounded sample of {sample_count} "
@@ -883,7 +435,7 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
         }
         if capped:
             result["note"] = (
-                f"Observed fields were capped at {_DISCOVERY_MAX_OBSERVED_FIELDS} "
+                f"Observed fields were capped at {discovery.MAX_OBSERVED_FIELDS} "
                 "entries (ordered by observation count)."
             )
         return result
@@ -906,7 +458,7 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
         ),
         tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
         annotations=_READ_ONLY_ANNOTATIONS,
-        output_schema=_union_schema(
+        output_schema=envelope.union_schema(
             {
                 "project": {"type": "string"},
                 "fields": {
@@ -1024,7 +576,7 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 plan = compiler.compile_aggregate(query, project_rowid, db.dialect)
                 applied: dict[str, Any] = {
                     "limit": plan.applied_limit,
-                    "time_range_resolved": _time_range_resolved(plan.time_range),
+                    "time_range_resolved": envelope.time_range_resolved(plan.time_range),
                     "timeout": {
                         "statement_timeout_ms": compiler.STATEMENT_TIMEOUT_MS
                         if db.dialect.value == "postgresql"
@@ -1042,7 +594,7 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 )
                 overall_row = (await session.execute(plan.overall_stmt)).one()
                 guidance = (
-                    await _zero_result_guidance(
+                    await discovery.zero_result_guidance(
                         session, project_rowid, plan.time_range, query.filter
                     )
                     if not raw_rows
@@ -1060,7 +612,9 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 message="The request has an invalid shape; check the parameter descriptions.",
             ).envelope()
 
-        overall = {calc.name: _cell(value) for calc, value in zip(plan.calculations, overall_row)}
+        overall = {
+            calc.name: envelope.cell(value) for calc, value in zip(plan.calculations, overall_row)
+        }
         columns = [b.column.as_dict() for b in plan.breakdowns] + [
             {"id": c.name, "type": "float", "unit": None} for c in plan.calculations
         ]
@@ -1082,16 +636,16 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 row[breakdown.id] = (
                     registry.normalize_time_bucket_value(value)
                     if breakdown.is_time_bucket
-                    else _cell(value)
+                    else envelope.cell(value)
                 )
             offset = len(plan.breakdowns)
             for calc, value in zip(plan.calculations, raw[offset:]):
-                row[calc.name] = _cell(value)
+                row[calc.name] = envelope.cell(value)
             if share_basis is not None and overall_basis:
                 basis_value = row.get(share_basis)
                 if isinstance(basis_value, (int, float)):
                     row["share"] = basis_value / overall_basis
-            row["ui_url"] = _cohort_ui_url(
+            row["ui_url"] = links.cohort_url(
                 cohort_base,
                 plan.breakdowns,
                 raw[: len(plan.breakdowns)],
@@ -1114,7 +668,7 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
         notes: list[str] = []
         if plan.uses_annotation_filter:
             result["annotation_semantics"] = "any"
-            notes.append(_ANNOTATION_SEMANTICS_NOTE)
+            notes.append(envelope.ANNOTATION_SEMANTICS_NOTE)
         if groups_total is not None and groups_total > len(rows):
             notes.append(
                 f"Top {len(rows)} of {groups_total} groups returned; ordering ties at "
@@ -1125,15 +679,8 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 "share is omitted: none of the calculations is additive (only count "
                 "and sum have meaningful shares of the overall total)."
             )
-        if _serialized_size(rows) > max_result_chars:
-            kept: list[dict[str, Any]] = []
-            used = 0
-            for row in rows:
-                cost = _serialized_size(row)
-                if kept and used + cost > max_result_chars:
-                    break
-                kept.append(row)
-                used += cost
+        if envelope.serialized_size(rows) > max_result_chars:
+            kept = envelope.rows_within_budget(rows, max_result_chars)
             notes.append(
                 f"Only {len(kept)} of {len(rows)} groups fit max_result_chars; narrow "
                 "breakdowns or raise the budget."
@@ -1165,9 +712,9 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
         ),
         tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
         annotations=_READ_ONLY_ANNOTATIONS,
-        output_schema=_union_schema(
+        output_schema=envelope.union_schema(
             {
-                "columns": _COLUMNS_SCHEMA,
+                "columns": envelope.COLUMNS_SCHEMA,
                 "rows": {
                     "type": "array",
                     "items": {"type": "object"},
@@ -1192,8 +739,8 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                     ),
                 },
                 "applied": {"type": "object"},
-                "annotation_semantics": _ANNOTATION_SEMANTICS_SCHEMA,
-                "guidance": _GUIDANCE_SCHEMA,
+                "annotation_semantics": envelope.ANNOTATION_SEMANTICS_SCHEMA,
+                "guidance": envelope.GUIDANCE_SCHEMA,
                 "note": {"type": "string"},
             },
             ["columns", "rows", "groups_total", "groups_returned", "overall", "applied"],
@@ -1296,7 +843,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                 plan = compiler.compile_rows(query, project_rowid, db.dialect)
                 applied: dict[str, Any] = {
                     "limit": plan.applied_limit,
-                    "time_range_resolved": _time_range_resolved(plan.time_range),
+                    "time_range_resolved": envelope.time_range_resolved(plan.time_range),
                     "time_range_defaulted": plan.time_range_defaulted,
                     "max_cell_chars": max_cell_chars,
                     "max_result_chars": max_result_chars,
@@ -1330,7 +877,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                     assert plan.stmt is not None
                     raw_rows = (await session.execute(plan.stmt)).all()
                 guidance = (
-                    await _zero_result_guidance(
+                    await discovery.zero_result_guidance(
                         session, project_rowid, plan.time_range, query.filter
                     )
                     if not raw_rows
@@ -1352,7 +899,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
         clipped: list[dict[str, Any]] = []
         rows: list[dict[str, Any]] = []
         for raw in raw_rows:
-            row = {column_id: _cell(value) for column_id, value in zip(column_ids, raw)}
+            row = {column_id: envelope.cell(value) for column_id, value in zip(column_ids, raw)}
             span_id = row.get("span_id")
             for column_id, value in row.items():
                 if isinstance(value, str) and len(value) > max_cell_chars:
@@ -1362,14 +909,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                     clipped.append({"row": span_id, "field": column_id})
             rows.append(row)
 
-        kept_rows: list[dict[str, Any]] = []
-        used = 0
-        for row in rows:
-            cost = _serialized_size(row)
-            if kept_rows and used + cost > max_result_chars:
-                break
-            kept_rows.append(row)
-            used += cost
+        kept_rows = envelope.rows_within_budget(rows, max_result_chars)
 
         result: dict[str, Any] = {
             "status": "ok",
@@ -1408,7 +948,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
         notes: list[str] = []
         if plan.uses_annotation_filter:
             result["annotation_semantics"] = "any"
-            notes.append(_ANNOTATION_SEMANTICS_NOTE)
+            notes.append(envelope.ANNOTATION_SEMANTICS_NOTE)
         if sample_note:
             notes.append(sample_note)
         if clipped:
@@ -1448,9 +988,9 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
         ),
         tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
         annotations=_READ_ONLY_ANNOTATIONS,
-        output_schema=_union_schema(
+        output_schema=envelope.union_schema(
             {
-                "columns": _COLUMNS_SCHEMA,
+                "columns": envelope.COLUMNS_SCHEMA,
                 "rows": {
                     "type": "array",
                     "items": {"type": "object"},
@@ -1487,8 +1027,8 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                         "describeSpans."
                     ),
                 },
-                "annotation_semantics": _ANNOTATION_SEMANTICS_SCHEMA,
-                "guidance": _GUIDANCE_SCHEMA,
+                "annotation_semantics": envelope.ANNOTATION_SEMANTICS_SCHEMA,
+                "guidance": envelope.GUIDANCE_SCHEMA,
                 "note": {"type": "string"},
             },
             ["columns", "rows", "row_count", "applied", "clipped"],
@@ -1545,7 +1085,10 @@ def _build_get_span(app: "FastAPI") -> Tool:
             return error.envelope()
 
         registry_fields = (
-            {field.id: _cell(value) for field, value in zip(registry.AUTHORED_FIELDS, fields_row)}
+            {
+                field.id: envelope.cell(value)
+                for field, value in zip(registry.AUTHORED_FIELDS, fields_row)
+            }
             if fields_row is not None
             else {}
         )
@@ -1556,13 +1099,13 @@ def _build_get_span(app: "FastAPI") -> Tool:
             "name": span.name,
             "span_kind": span.span_kind,
             "status": {"code": span.status_code, "message": span.status_message},
-            "start_time": _cell(span.start_time),
-            "end_time": _cell(span.end_time),
+            "start_time": envelope.cell(span.start_time),
+            "end_time": envelope.cell(span.end_time),
             "latency_ms": span.latency_ms,
             "attributes": span.attributes,
             "events": span.events,
         }
-        payload, clipped_paths = _clip_strings_to_budget(
+        payload, clipped_paths = envelope.clip_strings_to_budget(
             payload,
             max_result_chars,
             marker="raise max_result_chars for more",
@@ -1596,7 +1139,7 @@ def _build_get_span(app: "FastAPI") -> Tool:
         ),
         tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
         annotations=_READ_ONLY_ANNOTATIONS,
-        output_schema=_union_schema(
+        output_schema=envelope.union_schema(
             {
                 "span": {
                     "type": "object",
@@ -1687,7 +1230,7 @@ def _build_get_trace(app: "FastAPI") -> Tool:
                 "name": name,
                 "span_kind": span_kind,
                 "status_code": status_code,
-                "start_time": _cell(start_time),
+                "start_time": envelope.cell(start_time),
                 "latency_ms": latency_ms,
                 "ui_url": _ui_span_url(span_id),
             }
@@ -1713,7 +1256,7 @@ def _build_get_trace(app: "FastAPI") -> Tool:
                     "to fit max_result_chars; raise it or drill into spans with "
                     "getSpan."
                 )
-            if _serialized_size(result) <= max_result_chars or len(summaries) <= 1:
+            if envelope.serialized_size(result) <= max_result_chars or len(summaries) <= 1:
                 return result
             drop = max(1, len(summaries) // 10)
             summaries = summaries[:-drop]
@@ -1730,7 +1273,7 @@ def _build_get_trace(app: "FastAPI") -> Tool:
         ),
         tags={SPANS_GROUP_TAG},
         annotations=_READ_ONLY_ANNOTATIONS,
-        output_schema=_union_schema(
+        output_schema=envelope.union_schema(
             {
                 "trace_id": {"type": "string"},
                 "span_count": {"type": "integer"},

--- a/src/phoenix/server/mcp_span_analytics/tools.py
+++ b/src/phoenix/server/mcp_span_analytics/tools.py
@@ -95,17 +95,27 @@ _FILTER_DESCRIPTION = (
     "describeSpans works verbatim. Operators: comparisons (==, !=, <, <=, >, >=), "
     "`and`/`or`/`not`, `in`/`not in` (substring test on strings, membership on a list), "
     "`is None`/`is not None`; casts `str(...)`, `float(...)`, `int(...)`. Function "
-    "calls other than casts are rejected. Temporal predicates are rejected here — "
+    "calls other than casts are rejected. Annotation predicates are supported in "
+    "exactly two forms — `evals['<name>'].score <op> <number>` and "
+    "`evals['<name>'].label ==/!= '<string>'` — and only as top-level AND conjuncts "
+    "(combinable with other conditions via `and`); placement under `or`/`not` or any "
+    "richer annotation expression is rejected. Their semantics are any-annotator "
+    "(any matching annotation row satisfies the predicate), disclosed in the "
+    "response's `annotation_semantics` field. Temporal predicates are rejected here — "
     "scope time with time_range, its only home. Examples: "
     "\"span_kind == 'LLM' and latency_ms > 1000\"; \"status_code == 'ERROR'\"; "
-    "\"'rate limit' in output.value\"; \"metadata['release'] == 'v42'\"."
+    "\"'rate limit' in output.value\"; \"metadata['release'] == 'v42'\"; "
+    "\"evals['correctness'].score < 0.5\"."
 )
 
 _PROJECT_DESCRIPTION = "Project id or name (either form works; list projects with getProjects)."
 
 _VALIDATE_ONLY_DESCRIPTION = (
-    "If true, resolve and validate the query without executing anything: returns "
-    "{status: 'ok', valid: true} or the structured error the real call would return."
+    "If true, resolve and validate the query without executing it: returns "
+    "{status: 'ok', valid: true} or the structured error the real call would return. "
+    "Observed attribute paths are additionally checked against the discovery sample; "
+    "paths the sample never saw come back as structured `warnings` (open admission — "
+    "a warning, never an error)."
 )
 
 
@@ -166,7 +176,10 @@ _CALCULATIONS_SCHEMA: dict[str, Any] = {
                 "type": ["string", "null"],
                 "description": (
                     "Field to aggregate. Required for every function except count; "
-                    "count with a field counts rows where the field is non-NULL."
+                    "count with a field counts rows where the field is non-NULL. "
+                    "count and count_distinct accept any field, authored or "
+                    "observed; sum/avg/min/max/percentiles require a "
+                    "value-aggregatable field."
                 ),
             },
         },
@@ -348,7 +361,22 @@ def _capabilities(field: registry.AuthoredField) -> list[str]:
         capabilities.append("breakdown")
     if field.aggregatable:
         capabilities.append("aggregate")
+    # Presence aggregations (count, count_distinct) never compute on the
+    # value, so every field carries the count capability.
+    capabilities.append("count")
     return capabilities
+
+
+def _observed_filter_paths(filter_condition: Optional[str]) -> set[tuple[str, ...]]:
+    """Attribute paths a filter reads that are not authored fields —
+    the observed-path portion of the filter, for admission checks."""
+    if not filter_condition:
+        return set()
+    return {
+        keys
+        for keys in compiler.attribute_paths_in_filter(filter_condition)
+        if registry.canonical_attribute_spelling(keys) not in registry.AUTHORED_BY_ID
+    }
 
 
 def _build_describe_spans(app: "FastAPI") -> Tool:
@@ -360,7 +388,7 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
             async with db.read() as session:
                 project_rowid = await compiler.resolve_project_rowid(session, project)
                 if project_rowid is None:
-                    raise compiler.project_not_found(project)
+                    raise await compiler.project_not_found_error(session, project)
                 sample_count, stats = await discovery.sample_observed_paths(session, project_rowid)
         except QueryError as error:
             return error.envelope()
@@ -407,7 +435,11 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
                 "missing_frequency": round(1 - path_stats.count / sample_count, 4)
                 if sample_count
                 else None,
-                "capabilities": ["select", "filter", "breakdown"],
+                # Observed fields admit presence aggregations (count,
+                # count_distinct) — they never compute on the value — but
+                # not value aggregations, whose cast semantics for arbitrary
+                # JSON paths are undefined.
+                "capabilities": ["select", "filter", "breakdown", "count"],
                 "sampled": True,
             }
             if len(observed_types) > 1:
@@ -452,9 +484,11 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
             "canonical query spelling and works verbatim in querySpanRows "
             "fields/filter and aggregateSpans filter/breakdowns — copy identifiers "
             "from here instead of constructing them. Capabilities per entry: select, "
-            "filter, breakdown, aggregate. Start here before aggregating or "
-            "filtering. Full field-level documentation is in the JSON schema's "
-            "descriptions (get_schema detail='full')."
+            "filter, breakdown, aggregate (value aggregations: sum/avg/min/max/"
+            "percentiles), count (presence aggregations: count, count_distinct — "
+            "valid on any field because they never compute on the value). Start "
+            "here before aggregating or filtering. Full field-level documentation "
+            "is in the JSON schema's descriptions (get_schema detail='full')."
         ),
         tags={SPANS_GROUP_TAG, ANALYTICS_TAG},
         annotations=_READ_ONLY_ANNOTATIONS,
@@ -572,8 +606,25 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
             async with db.read() as session:
                 project_rowid = await compiler.resolve_project_rowid(session, project)
                 if project_rowid is None:
-                    raise compiler.project_not_found(project)
-                plan = compiler.compile_aggregate(query, project_rowid, db.dialect)
+                    raise await compiler.project_not_found_error(session, project)
+                try:
+                    plan = compiler.compile_aggregate(query, project_rowid, db.dialect)
+                except QueryError as error:
+                    if error.code == "field_not_groupable":
+                        # The static alternatives list only authored ids; the
+                        # dimensions a caller actually groups by are usually the
+                        # project's own discovered attributes, so the rejection
+                        # is augmented with the top observed ones.
+                        observed_dims = await discovery.top_observed_groupables(
+                            session, project_rowid
+                        )
+                        if observed_dims:
+                            error.suggestions.extend(observed_dims)
+                            error.message += (
+                                " Observed dimensions in this project (top by "
+                                f"observed count): {', '.join(observed_dims)}."
+                            )
+                    raise
                 applied: dict[str, Any] = {
                     "limit": plan.applied_limit,
                     "time_range_resolved": envelope.time_range_resolved(plan.time_range),
@@ -583,8 +634,28 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                         else None
                     },
                 }
+                # Admission teaching for observed paths: every observed path
+                # the query references (breakdowns, calculations, filter) is
+                # checked against the discovery sample; unsampled ones get a
+                # structured not_observed note rather than an error, because a
+                # path can be real but unsampled (open admission).
+                observed_targets: dict[tuple[str, ...], str] = {
+                    f.keys: f.id for f in plan.observed_fields
+                }
+                for keys in _observed_filter_paths(query.filter):
+                    observed_targets.setdefault(keys, registry.canonical_attribute_spelling(keys))
+                field_notes: list[dict[str, Any]] = (
+                    await discovery.not_observed_field_notes(
+                        session, project_rowid, observed_targets
+                    )
+                    if observed_targets
+                    else []
+                )
                 if validate_only:
-                    return {"status": "ok", "valid": True, "applied": applied}
+                    validated: dict[str, Any] = {"status": "ok", "valid": True, "applied": applied}
+                    if field_notes:
+                        validated["warnings"] = field_notes
+                    return validated
                 await compiler.apply_statement_timeout(session, db.dialect)
                 raw_rows = (await session.execute(plan.stmt)).all()
                 groups_total = (
@@ -645,11 +716,15 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 basis_value = row.get(share_basis)
                 if isinstance(basis_value, (int, float)):
                     row["share"] = basis_value / overall_basis
+            # The row's link must select the same cohort the row's numbers
+            # were computed over: the query's own filter conjoined with the
+            # breakdown-key equalities, not the equalities alone.
             row["ui_url"] = links.cohort_url(
                 cohort_base,
                 plan.breakdowns,
                 raw[: len(plan.breakdowns)],
                 plan.time_range,
+                filter_condition=query.filter,
             )
             rows.append(row)
 
@@ -665,6 +740,33 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
         }
         if guidance is not None:
             result["guidance"] = guidance
+        # A breakdown that produced only a null group key is the aggregate
+        # face of the all-NULL projection: the query succeeded and quietly
+        # said nothing. When the path itself was sampled (so not_observed
+        # did not fire), say so per field.
+        noted_fields = {note["field"] for note in field_notes}
+        if rows:
+            for breakdown in plan.breakdowns:
+                if (
+                    breakdown.is_time_bucket
+                    or breakdown.column.type != "json"
+                    or breakdown.id in noted_fields
+                    or any(row.get(breakdown.id) is not None for row in rows)
+                ):
+                    continue
+                field_notes.append(
+                    {
+                        "field": breakdown.id,
+                        "code": "all_null",
+                        "note": (
+                            f"{breakdown.id!r} produced only a null group: no span in "
+                            "the current window/filter carries this path, though it "
+                            "was observed in the project's sample."
+                        ),
+                    }
+                )
+        if field_notes:
+            result["field_notes"] = field_notes
         notes: list[str] = []
         if plan.uses_annotation_filter:
             result["annotation_semantics"] = "any"
@@ -696,9 +798,10 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
         name="aggregateSpans",
         description=(
             "Aggregate (group by) a project's spans into metrics: named calculations "
-            "(count, count_distinct, sum, avg, min, max, p50/p90/p95/p99 percentiles) "
-            "over aggregatable fields, grouped by breakdowns (groupable fields and/or "
-            "hourly time buckets), filtered, ordered, and bounded to the top-N "
+            "(count and count_distinct on any field; sum, avg, min, max, "
+            "p50/p90/p95/p99 percentiles on value-aggregatable fields), grouped by "
+            "breakdowns (groupable fields and/or hourly time buckets), filtered, "
+            "ordered, and bounded to the top-N "
             "groups. Answers analytics questions like error rate by model, token "
             "totals by release, or latency percentiles per hour: error rate is "
             "avg(is_error), error count is sum(is_error). Returns typed columns, "
@@ -739,6 +842,7 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                     ),
                 },
                 "applied": {"type": "object"},
+                "field_notes": envelope.FIELD_NOTES_SCHEMA,
                 "annotation_semantics": envelope.ANNOTATION_SEMANTICS_SCHEMA,
                 "guidance": envelope.GUIDANCE_SCHEMA,
                 "note": {"type": "string"},
@@ -839,7 +943,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
             async with db.read() as session:
                 project_rowid = await compiler.resolve_project_rowid(session, project)
                 if project_rowid is None:
-                    raise compiler.project_not_found(project)
+                    raise await compiler.project_not_found_error(session, project)
                 plan = compiler.compile_rows(query, project_rowid, db.dialect)
                 applied: dict[str, Any] = {
                     "limit": plan.applied_limit,
@@ -853,8 +957,28 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                         else None
                     },
                 }
+                # Admission teaching for observed paths: every observed path
+                # the query references (selected fields, filter) is checked
+                # against the discovery sample; unsampled ones get a
+                # structured not_observed note rather than an error, because
+                # a path can be real but unsampled (open admission).
+                observed_targets: dict[tuple[str, ...], str] = {
+                    f.keys: f.id for f in plan.observed_fields
+                }
+                for keys in _observed_filter_paths(query.filter):
+                    observed_targets.setdefault(keys, registry.canonical_attribute_spelling(keys))
+                field_notes: list[dict[str, Any]] = (
+                    await discovery.not_observed_field_notes(
+                        session, project_rowid, observed_targets
+                    )
+                    if observed_targets
+                    else []
+                )
                 if validate_only:
-                    return {"status": "ok", "valid": True, "applied": applied}
+                    validated: dict[str, Any] = {"status": "ok", "valid": True, "applied": applied}
+                    if field_notes:
+                        validated["warnings"] = field_notes
+                    return validated
                 await compiler.apply_statement_timeout(session, db.dialect)
                 sample_note: Optional[str] = None
                 if plan.sample is not None:
@@ -925,26 +1049,35 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
         }
         if guidance is not None:
             result["guidance"] = guidance
-        # An observed-path column that is NULL on every returned row is
-        # indistinguishable from a misspelled path: the projection compiles,
-        # returns, and quietly says nothing. Say so per column instead of
-        # letting the silence read as data. Authored fields are exempt —
-        # their NULLs carry documented meaning (no cost recorded, fewer
-        # than two messages).
+        # An observed-path column that is NULL on every returned row still
+        # deserves a note when the path itself was sampled (so not_observed
+        # did not fire): the projection compiled, returned, and quietly said
+        # nothing about this slice. Authored fields are exempt — their NULLs
+        # carry documented meaning (no cost recorded, fewer than two
+        # messages).
+        noted_fields = {note["field"] for note in field_notes}
         if kept_rows:
-            column_notes = [
-                {
-                    "column": spec.id,
-                    "note": (
-                        "path not observed in these results — verify the spelling "
-                        "via describeSpans."
-                    ),
-                }
-                for spec in plan.columns
-                if spec.type == "json" and all(row.get(spec.id) is None for row in kept_rows)
-            ]
-            if column_notes:
-                result["column_notes"] = column_notes
+            for spec in plan.columns:
+                if (
+                    spec.type != "json"
+                    or spec.id in noted_fields
+                    or any(row.get(spec.id) is not None for row in kept_rows)
+                ):
+                    continue
+                field_notes.append(
+                    {
+                        "field": spec.id,
+                        "code": "all_null",
+                        "note": (
+                            f"{spec.id!r} was NULL on every returned row, though it "
+                            "was observed in the project's sample; the current "
+                            "filter/window slice may simply not carry it. Verify via "
+                            "describeSpans if a value was expected."
+                        ),
+                    }
+                )
+        if field_notes:
+            result["field_notes"] = field_notes
         notes: list[str] = []
         if plan.uses_annotation_filter:
             result["annotation_semantics"] = "any"
@@ -1012,21 +1145,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                         "span_id and field id; getSpan returns full values."
                     ),
                 },
-                "column_notes": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "column": {"type": "string"},
-                            "note": {"type": "string"},
-                        },
-                    },
-                    "description": (
-                        "Present when a selected observed attribute path was NULL on "
-                        "every returned row — usually a misspelled path; verify via "
-                        "describeSpans."
-                    ),
-                },
+                "field_notes": envelope.FIELD_NOTES_SCHEMA,
                 "annotation_semantics": envelope.ANNOTATION_SEMANTICS_SCHEMA,
                 "guidance": envelope.GUIDANCE_SCHEMA,
                 "note": {"type": "string"},
@@ -1056,7 +1175,7 @@ def _build_get_span(app: "FastAPI") -> Tool:
             async with db.read() as session:
                 project_rowid = await compiler.resolve_project_rowid(session, project)
                 if project_rowid is None:
-                    raise compiler.project_not_found(project)
+                    raise await compiler.project_not_found_error(session, project)
                 stmt = compiler.scoped_base(
                     [models.Span, models.Trace.trace_id], project_rowid, None
                 ).where(models.Span.span_id == span_id)
@@ -1193,7 +1312,7 @@ def _build_get_trace(app: "FastAPI") -> Tool:
             async with db.read() as session:
                 project_rowid = await compiler.resolve_project_rowid(session, project)
                 if project_rowid is None:
-                    raise compiler.project_not_found(project)
+                    raise await compiler.project_not_found_error(session, project)
                 stmt = (
                     compiler.scoped_base(
                         [

--- a/src/phoenix/server/mcp_span_analytics/tools.py
+++ b/src/phoenix/server/mcp_span_analytics/tools.py
@@ -1,16 +1,23 @@
 """Hand-authored MCP tools for span analytics.
 
-Five tools over one project-scoped span surface:
+Five tools over one project-scoped surface, whose two query tools read
+either of two grains (:mod:`.grains`) — spans by default, annotations when
+the request says so:
 
-- ``describeSpans`` — the field catalog as data: authored fields merged with
-  attribute paths observed in a recent sample, every entry in canonical
-  query spelling so discovery output is copy-paste usable in every clause.
+- ``describeSpans`` — the field catalog as data: authored fields merged
+  with attribute paths observed in a recent sample and with the annotation
+  enrichment the project's own annotation names generate, plus the grains
+  themselves. Every entry is in canonical query spelling, so discovery
+  output is copy-paste usable in every clause.
 - ``aggregateSpans`` — grouped calculations (counts, sums, averages,
-  percentiles, hourly buckets) with explicit completeness metadata.
+  percentiles, hourly buckets) with explicit completeness metadata, and —
+  where a value was reduced from a span's several annotations — the
+  reduction applied and the annotator mix behind it.
 - ``querySpanRows`` — ordered, bounded row retrieval with per-cell preview
-  clipping and an always-present ``span_id`` row identity.
-- ``getSpan`` — full-fidelity drill-down for one span, the recovery path
-  every clipped preview points at.
+  clipping and an always-present row identity (``span_id`` on spans,
+  ``annotation_id`` on annotations).
+- ``getSpan`` — full-fidelity drill-down for one span, its annotations
+  included: the recovery path every clipped preview points at.
 - ``getTrace`` — the parent/child span tree of one trace.
 
 Every tool returns a discriminated union: ``{status: "ok", ...}`` on
@@ -41,7 +48,14 @@ from mcp.types import ToolAnnotations
 from pydantic import Field, TypeAdapter, ValidationError
 
 from phoenix.db import models
-from phoenix.server.mcp_span_analytics import compiler, discovery, envelope, links, registry
+from phoenix.server.mcp_span_analytics import (
+    compiler,
+    discovery,
+    envelope,
+    grains,
+    links,
+    registry,
+)
 from phoenix.server.mcp_span_analytics.compiler import (
     AggregateOrderEntry,
     AggregateQuery,
@@ -108,7 +122,50 @@ _FILTER_DESCRIPTION = (
     "\"evals['correctness'].score < 0.5\"."
 )
 
+_ANNOTATION_GRAIN_FILTER_DESCRIPTION = (
+    "Boolean expression selecting annotations, written in Python syntax and compiled "
+    "to SQL. Names you can reference are this grain's fields: `name`, `score`, "
+    "`label`, `explanation`, `annotator_kind` ('LLM', 'CODE', 'HUMAN'), `identifier`, "
+    "`source`, `target` ('span', 'trace', 'document', 'session'), `target_id`, "
+    "`trace_id`, `document_position`. Operators: comparisons (==, !=, <, <=, >, >=), "
+    "`and`/`or`/`not`, `is None`/`is not None`, and `in` in two forms — substring test "
+    "(\"'timeout' in explanation\") and membership in a literal list "
+    "(\"annotator_kind in ['HUMAN', 'LLM']\"). Each comparison relates one field to "
+    "one literal of matching type. Temporal predicates are rejected — scope time with "
+    "time_range, its only home, which binds the annotated work's start_time. Examples: "
+    "\"name == 'correctness' and annotator_kind == 'HUMAN'\"; \"score < 0.5\"; "
+    "\"label != 'correct' and target == 'span'\"."
+)
+
+#: The filter parameter serves both grains, so its description carries both
+#: namespaces: the grammar is one grammar, but the names it resolves are the
+#: names of whichever grain the request asked for.
+_FILTER_DESCRIPTION = (
+    _FILTER_DESCRIPTION
+    + " ——— With from='annotations' the namespace changes to that grain's fields: "
+    + _ANNOTATION_GRAIN_FILTER_DESCRIPTION
+)
+
 _PROJECT_DESCRIPTION = "Project id or name (either form works; list projects with getProjects)."
+
+_GRAIN_DESCRIPTION = (
+    "Which relation to query — what one result row is. 'spans' (default): one row per "
+    "span, with span fields, observed attributes, and annotation enrichment such as "
+    "annotations[\"correctness\"].score. 'annotations': one row per annotation (eval "
+    "score, label, or human review) across every target Phoenix annotates, with fields "
+    "name, score, label, explanation, annotator_kind, identifier, target, target_id. "
+    "Pick by the subject of the question: 'correctness by model' is about spans, "
+    "'which annotators scored this, and how often' is about annotations. Each grain "
+    "has its own field namespace — describeSpans lists both — and they do not mix in "
+    "one call."
+)
+
+_GRAIN_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"type": "string", "enum": list(grains.GRAINS)},
+        {"type": "null"},
+    ],
+}
 
 _VALIDATE_ONLY_DESCRIPTION = (
     "If true, resolve and validate the query without executing it: returns "
@@ -367,10 +424,17 @@ def _capabilities(field: registry.AuthoredField) -> list[str]:
     return capabilities
 
 
-def _observed_filter_paths(filter_condition: Optional[str]) -> set[tuple[str, ...]]:
+def _observed_filter_paths(
+    filter_condition: Optional[str], grain: grains.Grain
+) -> set[tuple[str, ...]]:
     """Attribute paths a filter reads that are not authored fields —
-    the observed-path portion of the filter, for admission checks."""
-    if not filter_condition:
+    the observed-path portion of the filter, for admission checks.
+
+    Grains with a closed field set have none: every name in such a filter
+    resolved to a declared column, and reading them as attribute paths
+    would invent observations that do not exist.
+    """
+    if not filter_condition or not grain.admits_observed_paths:
         return set()
     return {
         keys
@@ -390,6 +454,9 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
                 if project_rowid is None:
                     raise await compiler.project_not_found_error(session, project)
                 sample_count, stats = await discovery.sample_observed_paths(session, project_rowid)
+                annotation_names, annotations_capped = await discovery.observed_annotation_names(
+                    session, project_rowid
+                )
         except QueryError as error:
             return error.envelope()
 
@@ -449,10 +516,84 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
                 entry["top_values"] = top_values
             fields.append(entry)
 
+        # Annotation names are project data, so the enrichment fields they
+        # generate are enumerated here rather than left to be guessed. Each
+        # name yields its readable attributes on the spans grain; the
+        # composition that decides whether a blended value is trustworthy
+        # travels with them.
+        for entry in annotation_names:
+            for attribute in registry.ANNOTATION_ATTRIBUTES:
+                enrichment = registry.annotation_enrichment_field(
+                    registry.AnnotationRef(
+                        name=entry["name"], annotator_kind=None, attribute=attribute
+                    )
+                )
+                fields.append(
+                    {
+                        "field": enrichment.id,
+                        "label": enrichment.label,
+                        "source": enrichment.source,
+                        "type": enrichment.type,
+                        "unit": None,
+                        "description": enrichment.description,
+                        "capabilities": _capabilities(enrichment),
+                        "reduction": enrichment.reduction,
+                        "annotation": {
+                            "name": entry["name"],
+                            "annotations": entry["count"],
+                            "with_score": entry["scored"],
+                            "annotator_kinds": entry["annotator_kinds"],
+                            "targets": entry["targets"],
+                            "kind_restricted_form": registry.AnnotationRef(
+                                name=entry["name"],
+                                annotator_kind=next(iter(entry["annotator_kinds"]), "HUMAN"),
+                                attribute=attribute,
+                            ).id,
+                        },
+                    }
+                )
+
         result: dict[str, Any] = {
             "status": "ok",
             "project": project,
             "fields": fields,
+            "grains": [
+                {
+                    "grain": grain.id,
+                    "description": grain.description,
+                    "identity_field": grain.identity_field,
+                    "time_field": grain.time_field,
+                    "supports_sampling": grain.supports_sampling,
+                    "fields": [
+                        {
+                            "field": field.id,
+                            "label": field.label,
+                            "type": field.type,
+                            "unit": field.unit,
+                            "description": field.description,
+                            "capabilities": _capabilities(field),
+                        }
+                        for field in grain.fields
+                    ]
+                    if grain.id != grains.SPANS
+                    # The spans grain's catalog is the top-level `fields`
+                    # block, which additionally carries observed paths and
+                    # annotation enrichment; repeating it here would be a
+                    # second home for one thing.
+                    else None,
+                }
+                for grain in grains.GRAINS.values()
+            ],
+            "annotations": {
+                "names": annotation_names,
+                "note": (
+                    "Annotation names recorded in this project, counted exactly (not "
+                    "sampled). Read them per annotation with from='annotations', or "
+                    'per span through the enrichment fields annotations["<name>"].'
+                    "score/.label/.count listed in fields."
+                ),
+                "capped": annotations_capped,
+            },
             "sampling": {
                 "strategy": discovery.STRATEGY,
                 "sample_count": sample_count,
@@ -486,7 +627,11 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
             "from here instead of constructing them. Capabilities per entry: select, "
             "filter, breakdown, aggregate (value aggregations: sum/avg/min/max/"
             "percentiles), count (presence aggregations: count, count_distinct — "
-            "valid on any field because they never compute on the value). Start "
+            "valid on any field because they never compute on the value). Also "
+            "returns the project's annotation names with exact counts by annotator "
+            'kind, the enrichment fields they generate (annotations["<name>"].'
+            "score/.label/.count), and the queryable grains for the `from` parameter "
+            "— spans and annotations, each with its own field namespace. Start "
             "here before aggregating or filtering. Full field-level documentation "
             "is in the JSON schema's descriptions (get_schema detail='full')."
         ),
@@ -504,10 +649,27 @@ def _build_describe_spans(app: "FastAPI") -> Tool:
                         "and top_values where cardinality is low."
                     ),
                 },
+                "grains": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "The queryable relations and what one of their rows is, for the "
+                        "`from` parameter of querySpanRows and aggregateSpans. The spans "
+                        "grain's own field list is the top-level `fields` block."
+                    ),
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": (
+                        "Annotation names recorded in this project with exact counts by "
+                        "annotator kind and target — the vocabulary of the annotations "
+                        "grain and of the annotation enrichment fields."
+                    ),
+                },
                 "sampling": {"type": "object"},
                 "note": {"type": "string"},
             },
-            ["project", "fields", "sampling"],
+            ["project", "fields", "grains", "annotations", "sampling"],
         ),
     )
 
@@ -526,6 +688,12 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 '{"name": "error_rate", "fn": "avg", "field": "is_error"}].'
             ),
             json_schema_extra=_CALCULATIONS_SCHEMA,
+        ),
+        grain_: Optional[str] = Field(
+            default=None,
+            alias="from",
+            description=_GRAIN_DESCRIPTION,
+            json_schema_extra=_GRAIN_SCHEMA,
         ),
         filter: Optional[str] = Field(default=None, description=_FILTER_DESCRIPTION),
         breakdowns: Any = Field(
@@ -569,6 +737,7 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
         try:
             query = AggregateQuery(
                 project=project,
+                grain=grain_ or grains.SPANS,
                 time_range=_parse_shape(
                     _TIME_RANGE_ADAPTER,
                     time_range,
@@ -642,7 +811,7 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 observed_targets: dict[tuple[str, ...], str] = {
                     f.keys: f.id for f in plan.observed_fields
                 }
-                for keys in _observed_filter_paths(query.filter):
+                for keys in _observed_filter_paths(query.filter, plan.grain):
                     observed_targets.setdefault(keys, registry.canonical_attribute_spelling(keys))
                 field_notes: list[dict[str, Any]] = (
                     await discovery.not_observed_field_notes(
@@ -666,7 +835,7 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 overall_row = (await session.execute(plan.overall_stmt)).one()
                 guidance = (
                     await discovery.zero_result_guidance(
-                        session, project_rowid, plan.time_range, query.filter
+                        session, project_rowid, plan.time_range, query.filter, plan.grain
                     )
                     if not raw_rows
                     else None
@@ -683,9 +852,16 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 message="The request has an invalid shape; check the parameter descriptions.",
             ).envelope()
 
+        # Composition probes ride after the visible calculations in every
+        # statement; they are folded into their own block rather than shown
+        # as columns, so the result's shape does not change with disclosure.
+        calculation_count = len(plan.calculations)
         overall = {
             calc.name: envelope.cell(value) for calc, value in zip(plan.calculations, overall_row)
         }
+        overall_composition = envelope.composition_map(
+            plan.composition, tuple(overall_row)[calculation_count:]
+        )
         columns = [b.column.as_dict() for b in plan.breakdowns] + [
             {"id": c.name, "type": "float", "unit": None} for c in plan.calculations
         ]
@@ -712,6 +888,10 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
             offset = len(plan.breakdowns)
             for calc, value in zip(plan.calculations, raw[offset:]):
                 row[calc.name] = envelope.cell(value)
+            if plan.composition:
+                row["annotation_composition"] = envelope.composition_map(
+                    plan.composition, tuple(raw)[offset + calculation_count :]
+                )
             if share_basis is not None and overall_basis:
                 basis_value = row.get(share_basis)
                 if isinstance(basis_value, (int, float)):
@@ -738,6 +918,10 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
             "share_basis": share_basis,
             "applied": applied,
         }
+        if plan.reductions:
+            result["annotation_reductions"] = envelope.annotation_reductions(plan.reductions)
+        if plan.composition:
+            result["overall"] = {**overall, "annotation_composition": overall_composition}
         if guidance is not None:
             result["guidance"] = guidance
         # A breakdown that produced only a null group key is the aggregate
@@ -771,6 +955,8 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
         if plan.uses_annotation_filter:
             result["annotation_semantics"] = "any"
             notes.append(envelope.ANNOTATION_SEMANTICS_NOTE)
+        if plan.composition:
+            notes.append(envelope.ANNOTATION_COMPOSITION_NOTE)
         if groups_total is not None and groups_total > len(rows):
             notes.append(
                 f"Top {len(rows)} of {groups_total} groups returned; ordering ties at "
@@ -797,7 +983,8 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
         aggregate_spans,
         name="aggregateSpans",
         description=(
-            "Aggregate (group by) a project's spans into metrics: named calculations "
+            "Aggregate (group by) a project's spans — or, with from='annotations', its "
+            "eval scores and human reviews — into metrics: named calculations "
             "(count and count_distinct on any field; sum, avg, min, max, "
             "p50/p90/p95/p99 percentiles on value-aggregatable fields), grouped by "
             "breakdowns (groupable fields and/or hourly time buckets), filtered, "
@@ -808,6 +995,10 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
             "rows, groups_total vs groups_returned, the overall (ungrouped) totals, "
             "and per-group share of total for the first additive calculation; each "
             "group row carries a ui_url deep-linking the Phoenix UI to that cohort. "
+            "Averaging an annotation score through the spans grain (e.g. "
+            'avg of annotations["correctness"].score) additionally returns the '
+            "reduction applied and, per group, how many annotations of each annotator "
+            "kind produced it — the mix that makes a blended average move on its own. "
             "Use describeSpans first to discover fields. The nested parameter shapes "
             "(time_range, calculations, breakdowns, order) and the filter grammar "
             "are documented in the JSON schema's field descriptions (get_schema "
@@ -844,6 +1035,7 @@ def _build_aggregate_spans(app: "FastAPI") -> Tool:
                 "applied": {"type": "object"},
                 "field_notes": envelope.FIELD_NOTES_SCHEMA,
                 "annotation_semantics": envelope.ANNOTATION_SEMANTICS_SCHEMA,
+                "annotation_reductions": envelope.ANNOTATION_REDUCTIONS_SCHEMA,
                 "guidance": envelope.GUIDANCE_SCHEMA,
                 "note": {"type": "string"},
             },
@@ -865,12 +1057,20 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
             ),
             json_schema_extra=_OPTIONAL_TIME_RANGE_SCHEMA,
         ),
+        grain_: Optional[str] = Field(
+            default=None,
+            alias="from",
+            description=_GRAIN_DESCRIPTION,
+            json_schema_extra=_GRAIN_SCHEMA,
+        ),
         fields: Any = Field(
             default=None,
             description=(
                 "Field ids to return (authored ids or observed attribute paths from "
-                "describeSpans). span_id is always included as the row identity. "
-                "Defaults to: " + ", ".join(compiler.DEFAULT_ROW_FIELDS) + "."
+                "describeSpans). The grain's identity field is always included: "
+                "span_id on spans, annotation_id on annotations. Defaults on spans "
+                "to: " + ", ".join(grains.SPANS_GRAIN.default_row_fields) + "; on "
+                "annotations to: " + ", ".join(grains.ANNOTATIONS_GRAIN.default_row_fields) + "."
             ),
             json_schema_extra=_ROW_FIELDS_SCHEMA,
         ),
@@ -916,6 +1116,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
         try:
             query = RowQuery(
                 project=project,
+                grain=grain_ or grains.SPANS,
                 time_range=_parse_shape(
                     _OPTIONAL_TIME_RANGE_ADAPTER,
                     time_range,
@@ -965,7 +1166,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                 observed_targets: dict[tuple[str, ...], str] = {
                     f.keys: f.id for f in plan.observed_fields
                 }
-                for keys in _observed_filter_paths(query.filter):
+                for keys in _observed_filter_paths(query.filter, plan.grain):
                     observed_targets.setdefault(keys, registry.canonical_attribute_spelling(keys))
                 field_notes: list[dict[str, Any]] = (
                     await discovery.not_observed_field_notes(
@@ -1002,7 +1203,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                     raw_rows = (await session.execute(plan.stmt)).all()
                 guidance = (
                     await discovery.zero_result_guidance(
-                        session, project_rowid, plan.time_range, query.filter
+                        session, project_rowid, plan.time_range, query.filter, plan.grain
                     )
                     if not raw_rows
                     else None
@@ -1020,17 +1221,18 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
             ).envelope()
 
         column_ids = [c.id for c in plan.columns]
+        identity_field = plan.grain.identity_field
         clipped: list[dict[str, Any]] = []
         rows: list[dict[str, Any]] = []
         for raw in raw_rows:
             row = {column_id: envelope.cell(value) for column_id, value in zip(column_ids, raw)}
-            span_id = row.get("span_id")
+            row_identity = row.get(identity_field)
             for column_id, value in row.items():
                 if isinstance(value, str) and len(value) > max_cell_chars:
                     row[column_id] = value[:max_cell_chars] + (
                         f"…[clipped {len(value) - max_cell_chars} chars]"
                     )
-                    clipped.append({"row": span_id, "field": column_id})
+                    clipped.append({"row": row_identity, "field": column_id})
             rows.append(row)
 
         kept_rows = envelope.rows_within_budget(rows, max_result_chars)
@@ -1044,9 +1246,11 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
             "clipped": [
                 marker
                 for marker in clipped
-                if any(r.get("span_id") == marker["row"] for r in kept_rows)
+                if any(r.get(identity_field) == marker["row"] for r in kept_rows)
             ],
         }
+        if plan.reductions:
+            result["annotation_reductions"] = envelope.annotation_reductions(plan.reductions)
         if guidance is not None:
             result["guidance"] = guidance
         # An observed-path column that is NULL on every returned row still
@@ -1087,7 +1291,14 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
         if clipped:
             notes.append(
                 "Some cells were clipped to max_cell_chars previews; recover any full "
-                "value with getSpan(project, span_id)."
+                + (
+                    "value with getSpan(project, span_id)."
+                    if plan.grain.id == grains.SPANS
+                    else "value with getSpan(project, target_id) for span and document "
+                    "targets, or getTrace(project, target_id) for trace targets — "
+                    "getSpan returns the span's annotations with their full "
+                    "explanations."
+                )
             )
         if len(kept_rows) < len(rows):
             notes.append(
@@ -1111,8 +1322,11 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
             "Retrieve individual spans as ordered, bounded rows — top-N listings "
             "(order + limit, e.g. the slowest failures), filtered slices, or a "
             "seeded random sample: select fields (authored ids or observed attribute "
-            "paths from describeSpans), filter, order, and limit. Results are "
-            "deterministic; span_id is always included as the row identity; long "
+            "paths from describeSpans), filter, order, and limit. With "
+            "from='annotations' the rows are individual eval scores and human reviews "
+            "instead, carrying annotator_kind, identifier, explanation, and the "
+            "annotated target's id. Results are "
+            "deterministic; the grain's identity field is always included; long "
             "values are clipped to previews with getSpan as the recovery path. "
             "Defaults to the last 24 hours when time_range is omitted. The nested "
             "parameter shapes (time_range, fields, order) and the filter grammar are "
@@ -1147,6 +1361,7 @@ def _build_query_span_rows(app: "FastAPI") -> Tool:
                 },
                 "field_notes": envelope.FIELD_NOTES_SCHEMA,
                 "annotation_semantics": envelope.ANNOTATION_SEMANTICS_SCHEMA,
+                "annotation_reductions": envelope.ANNOTATION_REDUCTIONS_SCHEMA,
                 "guidance": envelope.GUIDANCE_SCHEMA,
                 "note": {"type": "string"},
             },
@@ -1200,6 +1415,24 @@ def _build_get_span(app: "FastAPI") -> Tool:
                     None,
                 ).where(models.Span.span_id == span_id)
                 fields_row = (await session.execute(fields_stmt)).first()
+                # The span's annotations travel with it: they are the
+                # recovery path for every explanation clipped on the
+                # annotations grain, and the evidence beside the span that a
+                # quality investigation ends at.
+                annotations_stmt = (
+                    compiler.scoped_base(
+                        [grains.ANNOTATIONS_UNION], project_rowid, None, grains.ANNOTATIONS_GRAIN
+                    )
+                    .where(
+                        grains.ANNOTATIONS_UNION.c.target_id == span_id,
+                        grains.ANNOTATIONS_UNION.c.target.in_(("span", "document")),
+                    )
+                    .order_by(
+                        grains.ANNOTATIONS_UNION.c.name.asc(),
+                        grains.ANNOTATIONS_UNION.c.identifier.asc(),
+                    )
+                )
+                annotation_rows = (await session.execute(annotations_stmt)).mappings().all()
         except QueryError as error:
             return error.envelope()
 
@@ -1211,6 +1444,25 @@ def _build_get_span(app: "FastAPI") -> Tool:
             if fields_row is not None
             else {}
         )
+        annotations = [
+            {
+                field: envelope.cell(row[field])
+                for field in (
+                    "annotation_id",
+                    "target",
+                    "name",
+                    "label",
+                    "score",
+                    "explanation",
+                    "annotator_kind",
+                    "identifier",
+                    "source",
+                    "created_at",
+                    "document_position",
+                )
+            }
+            for row in annotation_rows
+        ]
         payload: dict[str, Any] = {
             "span_id": span.span_id,
             "trace_id": trace_id,
@@ -1223,6 +1475,7 @@ def _build_get_span(app: "FastAPI") -> Tool:
             "latency_ms": span.latency_ms,
             "attributes": span.attributes,
             "events": span.events,
+            "annotations": annotations,
         }
         payload, clipped_paths = envelope.clip_strings_to_budget(
             payload,
@@ -1249,7 +1502,8 @@ def _build_get_span(app: "FastAPI") -> Tool:
         name="getSpan",
         description=(
             "Fetch one span in full: attributes, events (including exception details), "
-            "status, timing, trace_id, and a Phoenix UI link (ui_url). Also echoes "
+            "status, timing, trace_id, its annotations with full explanations, and a "
+            "Phoenix UI link (ui_url). Also echoes "
             "`fields` — the flat registry field values (status_code, latency_ms, "
             "llm.model_name, ...) exactly as querySpanRows returns them, so the "
             "survey and the drill-down share one naming scheme. The recovery path "
@@ -1264,7 +1518,9 @@ def _build_get_span(app: "FastAPI") -> Tool:
                     "type": "object",
                     "description": (
                         "The full span record: identity, name, kind, status, timing, "
-                        "attributes, and events."
+                        "attributes, events, and annotations — one entry per annotation "
+                        "on this span (and on its documents), with the full explanation "
+                        "text that the annotations grain clips to a preview."
                     ),
                 },
                 "fields": {

--- a/tests/unit/server/test_mcp_span_analytics.py
+++ b/tests/unit/server/test_mcp_span_analytics.py
@@ -1,0 +1,1892 @@
+"""Tests for the span analytics MCP tools.
+
+Covers the field registry (dialect-branched expressions, guarded numeric
+casts, percentiles), the query compiler (single scoping path, structured
+errors, admission control), the five tools end-to-end over the real MCP
+protocol, and a differential check of query results against the seed
+script's independently computed ground truth. The suite runs under both
+database backends via the ``--db`` option.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+from collections import Counter
+from contextlib import AsyncExitStack
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Sequence, cast
+
+import httpx
+import pytest
+import sqlalchemy
+from asgi_lifespan import LifespanManager
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql, sqlite
+
+from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.server.app import create_app
+from phoenix.server.mcp_server import MCP_MOUNT_PATH
+from phoenix.server.mcp_span_analytics import build_span_analytics_tools, compiler, registry
+from phoenix.server.mcp_span_analytics.compiler import (
+    AggregateQuery,
+    Calculation,
+    QueryError,
+    RowQuery,
+    TimeRange,
+)
+from phoenix.server.types import DbSessionFactory
+from tests.unit.conftest import (
+    TestBulkInserter,
+    patch_batched_caller,
+    patch_grpc_server,
+)
+
+# ---------------------------------------------------------------------------
+# Seed-script import (the script is not a package module)
+# ---------------------------------------------------------------------------
+
+_SEED_PATH = Path(__file__).parents[3] / "scripts" / "span_analytics_seeds" / "seed_incident.py"
+_spec = importlib.util.spec_from_file_location("seed_incident", _SEED_PATH)
+assert _spec is not None and _spec.loader is not None
+seed_incident: Any = importlib.util.module_from_spec(_spec)
+# Dataclass field resolution looks the module up by name at class-creation
+# time, so it must be registered before execution.
+sys.modules["seed_incident"] = seed_incident
+_spec.loader.exec_module(seed_incident)
+
+_COPILOT_PATH = (
+    Path(__file__).parents[3] / "scripts" / "span_analytics_seeds" / "seed_support_copilot.py"
+)
+_copilot_spec = importlib.util.spec_from_file_location("seed_support_copilot", _COPILOT_PATH)
+assert _copilot_spec is not None and _copilot_spec.loader is not None
+seed_support_copilot: Any = importlib.util.module_from_spec(_copilot_spec)
+sys.modules["seed_support_copilot"] = seed_support_copilot
+_copilot_spec.loader.exec_module(seed_support_copilot)
+
+FIXED_NOW = datetime(2026, 7, 23, 12, 0, 0, tzinfo=timezone.utc)
+CUT = FIXED_NOW - timedelta(hours=seed_incident.RELEASE_CUT_HOURS_AGO)
+FULL_WINDOW = {
+    "start": (FIXED_NOW - timedelta(hours=49)).isoformat(),
+    "end": (FIXED_NOW + timedelta(hours=1)).isoformat(),
+}
+POST_CUT_WINDOW = {"start": CUT.isoformat(), "end": (FIXED_NOW + timedelta(hours=1)).isoformat()}
+#: The copilot workload backdates over the trailing 24 hours; turn chains
+#: can run slightly past the anchor.
+COPILOT_WINDOW = {
+    "start": (FIXED_NOW - timedelta(hours=26)).isoformat(),
+    "end": (FIXED_NOW + timedelta(hours=2)).isoformat(),
+}
+
+ANALYTICS_TOOLS = ("describeSpans", "aggregateSpans", "querySpanRows", "getSpan", "getTrace")
+
+
+@pytest.fixture(scope="module")
+def incident() -> Any:
+    return seed_incident.build_incident(FIXED_NOW, seed_incident.DEFAULT_SEED)
+
+
+@pytest.fixture
+async def seeded(db: DbSessionFactory, incident: Any) -> Any:
+    async with db() as session:
+        await seed_incident.insert_incident(session, incident)
+    return incident
+
+
+@pytest.fixture(scope="module")
+def copilot_workload() -> Any:
+    return seed_support_copilot.build_workload(FIXED_NOW, seed_support_copilot.DEFAULT_SEED)
+
+
+@pytest.fixture
+async def seeded_copilot(db: DbSessionFactory, copilot_workload: Any) -> Any:
+    async with db() as session:
+        await seed_support_copilot.insert_workload(session, copilot_workload)
+    return copilot_workload
+
+
+@pytest.fixture
+async def mcp_app(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[Any]:
+    monkeypatch.setattr("phoenix.server.app.get_env_enable_mcp_server", lambda: True)
+    monkeypatch.setattr("phoenix.server.mcp_server.get_env_mcp_code_mode", lambda: False)
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        app = create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+        await stack.enter_async_context(LifespanManager(app))
+        yield app
+
+
+def _mcp_client(app: Any) -> Any:
+    from fastmcp import Client
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    def _factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+        follow_redirects: bool = True,
+    ) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+            headers=headers,
+            follow_redirects=follow_redirects,
+        )
+
+    return Client(
+        StreamableHttpTransport(
+            url=f"http://testserver{MCP_MOUNT_PATH}",
+            httpx_client_factory=_factory,
+        )
+    )
+
+
+def _payload(result: Any) -> dict[str, Any]:
+    payload = json.loads(result.content[0].text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+async def _enable_spans(client: Any) -> None:
+    await client.call_tool("enable_tool_group", {"group": "spans"})
+
+
+def _percentile_cont(values: Sequence[float], q: float) -> float:
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * q
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    @pytest.mark.parametrize("sql_dialect", [sqlite.dialect(), postgresql.dialect()])  # type: ignore[no-untyped-call]
+    def test_every_authored_field_compiles(self, sql_dialect: Any) -> None:
+        supported = SupportedSQLDialect(sql_dialect.name)
+        for field in registry.AUTHORED_FIELDS:
+            compiled = str(sqlalchemy.select(field.expr(supported)).compile(dialect=sql_dialect))
+            assert compiled  # compilation succeeded
+
+    @pytest.mark.parametrize("sql_dialect", [sqlite.dialect(), postgresql.dialect()])  # type: ignore[no-untyped-call]
+    def test_observed_field_and_time_bucket_compile(self, sql_dialect: Any) -> None:
+        supported = SupportedSQLDialect(sql_dialect.name)
+        observed = registry.ObservedField(
+            id='metadata["build.version"]', keys=("metadata", "build.version")
+        )
+        assert str(sqlalchemy.select(observed.expr(supported)).compile(dialect=sql_dialect))
+        assert str(
+            sqlalchemy.select(registry.time_bucket_expr(supported)).compile(dialect=sql_dialect)
+        )
+
+    def test_canonical_spelling_round_trips_through_parse(self) -> None:
+        for keys in [
+            ("llm", "model_name"),
+            ("metadata", "release"),
+            ("metadata", "build.version"),
+            ("custom_flag",),
+            ("a", "b.c", "d"),
+        ]:
+            spelling = registry.canonical_attribute_spelling(keys)
+            assert registry.parse_attribute_path(spelling) == keys, spelling
+
+    def test_parse_rejects_non_paths(self) -> None:
+        for bad in ["evals['x'].score", "f(x)", "a + b", "attributes[0]", "not a path"]:
+            keys = registry.parse_attribute_path(bad)
+            assert keys is None or keys[0] in ("evals", "annotations"), bad
+
+    def test_guarded_cast_diverges_from_plain_cast_in_sql(self) -> None:
+        for sql_dialect, guard in [
+            (postgresql.dialect(), "jsonb_typeof"),  # type: ignore[no-untyped-call]
+            (sqlite.dialect(), "json_type"),
+        ]:
+            supported = SupportedSQLDialect(sql_dialect.name)
+            field = registry.AUTHORED_BY_ID["llm.token_count.total"]
+            compiled = str(sqlalchemy.select(field.expr(supported)).compile(dialect=sql_dialect))
+            assert guard in compiled
+            assert "CASE" in compiled
+
+
+async def test_percentiles_execute_with_known_values(db: DbSessionFactory, seeded: Any) -> None:
+    """Percentiles run for real on both engines and agree with linear
+    (``percentile_cont``) interpolation computed independently in Python."""
+    query = AggregateQuery(
+        project=seed_incident.MAIN_PROJECT_NAME,
+        time_range=TimeRange(**FULL_WINDOW),
+        filter="span_kind == 'LLM'",
+        calculations=[
+            Calculation(name="p50", fn="p50", field="latency_ms"),
+            Calculation(name="p90", fn="p90", field="latency_ms"),
+            Calculation(name="p95", fn="p95", field="latency_ms"),
+            Calculation(name="p99", fn="p99", field="latency_ms"),
+        ],
+    )
+    async with db.read() as session:
+        rowid = await compiler.resolve_project_rowid(session, seed_incident.MAIN_PROJECT_NAME)
+        assert rowid is not None
+        plan = compiler.compile_aggregate(query, rowid, db.dialect)
+        row = (await session.execute(plan.overall_stmt)).one()
+    latencies = [span.latency_ms for span in seeded.main.spans if span.span_kind == "LLM"]
+    for value, q in zip(row, (0.5, 0.9, 0.95, 0.99)):
+        expected = _percentile_cont(latencies, q)
+        assert float(value) == pytest.approx(expected, abs=0.05), q
+
+
+async def test_guarded_cast_mixed_type_row(db: DbSessionFactory, seeded: Any) -> None:
+    """A string-valued token count must read as NULL on both engines: the
+    aggregate succeeds, excludes the malformed value, and the non-null count
+    exposes it as missing."""
+    numeric_tokens = [
+        span.attributes["llm"]["token_count"]["total"]
+        for span in seeded.main.spans
+        if span.span_kind == "LLM"
+        and isinstance(span.attributes["llm"]["token_count"]["total"], int)
+    ]
+    llm_span_count = sum(1 for s in seeded.main.spans if s.span_kind == "LLM")
+    assert llm_span_count == len(numeric_tokens) + 1  # exactly one string-valued row
+
+    query = AggregateQuery(
+        project=seed_incident.MAIN_PROJECT_NAME,
+        time_range=TimeRange(**FULL_WINDOW),
+        filter="span_kind == 'LLM'",
+        calculations=[
+            Calculation(name="total", fn="sum", field="llm.token_count.total"),
+            Calculation(name="with_tokens", fn="count", field="llm.token_count.total"),
+            Calculation(name="all_rows", fn="count"),
+            Calculation(name="avg_tokens", fn="avg", field="llm.token_count.total"),
+        ],
+    )
+    async with db.read() as session:
+        rowid = await compiler.resolve_project_rowid(session, seed_incident.MAIN_PROJECT_NAME)
+        assert rowid is not None
+        plan = compiler.compile_aggregate(query, rowid, db.dialect)
+        total, with_tokens, all_rows, avg_tokens = (await session.execute(plan.overall_stmt)).one()
+    assert float(total) == sum(numeric_tokens)
+    assert with_tokens == len(numeric_tokens)
+    assert all_rows == llm_span_count
+    assert float(avg_tokens) == pytest.approx(sum(numeric_tokens) / len(numeric_tokens))
+
+
+# ---------------------------------------------------------------------------
+# Compiler validation (no database required)
+# ---------------------------------------------------------------------------
+
+
+class TestCompilerValidation:
+    def test_temporal_filter_rejected_pointing_at_time_range(self) -> None:
+        with pytest.raises(QueryError) as info:
+            compiler.validated_filter("start_time > '2026-01-01'")
+        assert info.value.code == "temporal_filter"
+        assert "time_range" in info.value.message
+
+    def test_annotation_predicate_compiles_to_exists(self) -> None:
+        """A top-level annotation comparison becomes an EXISTS predicate —
+        never a join, so it cannot multiply span rows under aggregation."""
+        compiled = compiler.validated_filter("evals['correctness'].score < 0.5")
+        assert compiled is not None and compiled.uses_annotations
+        (predicate,) = compiled.annotation_predicates
+        assert (predicate.name, predicate.attribute, predicate.op, predicate.value) == (
+            "correctness",
+            "score",
+            "<",
+            0.5,
+        )
+        combined = compiler.validated_filter(
+            "status_code == 'ERROR' and evals['correctness'].score < 0.5"
+        )
+        assert combined is not None
+        assert combined.uses_annotations and combined.span_filter is not None
+        stmt = combined(compiler.scoped_base([sqlalchemy.func.count()], 1, None))
+        compiled_sql = str(stmt)
+        assert "EXISTS" in compiled_sql
+        assert "JOIN span_annotations" not in compiled_sql
+
+    def test_label_and_reversed_annotation_forms(self) -> None:
+        label_form = compiler.validated_filter("evals['correctness'].label == 'incorrect'")
+        assert label_form is not None
+        (predicate,) = label_form.annotation_predicates
+        assert (predicate.attribute, predicate.op, predicate.value) == (
+            "label",
+            "==",
+            "incorrect",
+        )
+        reversed_form = compiler.validated_filter("0.5 > evals['correctness'].score")
+        assert reversed_form is not None
+        (mirrored,) = reversed_form.annotation_predicates
+        assert (mirrored.op, mirrored.value) == ("<", 0.5)
+
+    def test_nested_annotation_reference_rejected_with_route(self) -> None:
+        with pytest.raises(QueryError) as info:
+            compiler.validated_filter("status_code == 'ERROR' or evals['correctness'].score < 0.5")
+        assert info.value.code == "unsupported_filter_reference"
+        assert "top-level" in info.value.message
+        assert "listSpanAnnotationsBySpanIds" in info.value.message
+
+    def test_is_error_filter_rejected_with_route(self) -> None:
+        with pytest.raises(QueryError) as info:
+            compiler.validated_filter("is_error == 1")
+        assert info.value.code == "field_not_filterable"
+        assert "status_code == 'ERROR'" in info.value.suggestions
+
+    def test_unknown_field_gets_nearest_name_suggestion(self) -> None:
+        with pytest.raises(QueryError) as info:
+            compiler.resolve_field("latencyms")
+        assert info.value.code == "unknown_field"
+        assert "latency_ms" in info.value.suggestions
+        assert "Did you mean" in info.value.message
+
+    def test_reserved_column_names_do_not_fall_through_to_attributes(self) -> None:
+        with pytest.raises(QueryError) as info:
+            compiler.resolve_field("cumulative_llm_token_count_total")
+        assert info.value.code == "field_not_exposed"
+
+    def test_scoped_base_carries_no_ordering(self) -> None:
+        stmt = compiler.scoped_base([sqlalchemy.func.count()], project_rowid=1, time_range=None)
+        assert "ORDER BY" not in str(stmt)
+
+    def test_aggregate_statement_has_no_ungrouped_order_by(self) -> None:
+        query = AggregateQuery(
+            project="p",
+            time_range=TimeRange(**FULL_WINDOW),
+            calculations=[Calculation(name="n", fn="count")],
+        )
+        plan = compiler.compile_aggregate(query, 1, SupportedSQLDialect.SQLITE)
+        assert "ORDER BY" not in str(plan.stmt)
+        assert "ORDER BY" not in str(plan.overall_stmt)
+
+    def test_project_predicate_present_in_every_statement(self) -> None:
+        query = RowQuery(project="p", time_range=TimeRange(**FULL_WINDOW))
+        plan = compiler.compile_rows(query, 123, SupportedSQLDialect.SQLITE)
+        assert plan.stmt is not None
+        assert "project_rowid" in str(plan.stmt)
+
+    def test_order_referencing_undeclared_calculation(self) -> None:
+        query = AggregateQuery(
+            project="p",
+            time_range=TimeRange(**FULL_WINDOW),
+            calculations=[Calculation(name="calls", fn="count")],
+            breakdowns=["name"],
+            order=[compiler.AggregateOrderEntry(calculation="total_tokens")],
+        )
+        with pytest.raises(QueryError) as info:
+            compiler.compile_aggregate(query, 1, SupportedSQLDialect.SQLITE)
+        assert info.value.code == "invalid_order"
+        assert "order[0].calculation" == info.value.path
+
+    def test_non_groupable_breakdown_rejected_with_alternatives(self) -> None:
+        query = AggregateQuery(
+            project="p",
+            time_range=TimeRange(**FULL_WINDOW),
+            calculations=[Calculation(name="calls", fn="count")],
+            breakdowns=["latency_ms"],
+        )
+        with pytest.raises(QueryError) as info:
+            compiler.compile_aggregate(query, 1, SupportedSQLDialect.SQLITE)
+        assert info.value.code == "field_not_groupable"
+        assert info.value.suggestions  # alternatives offered
+
+    def test_non_aggregatable_field_rejected(self) -> None:
+        query = AggregateQuery(
+            project="p",
+            time_range=TimeRange(**FULL_WINDOW),
+            calculations=[Calculation(name="s", fn="sum", field="name")],
+        )
+        with pytest.raises(QueryError) as info:
+            compiler.compile_aggregate(query, 1, SupportedSQLDialect.SQLITE)
+        assert info.value.code == "field_not_aggregatable"
+
+    def test_observed_field_not_aggregatable(self) -> None:
+        query = AggregateQuery(
+            project="p",
+            time_range=TimeRange(**FULL_WINDOW),
+            calculations=[Calculation(name="s", fn="sum", field="metadata.release")],
+        )
+        with pytest.raises(QueryError) as info:
+            compiler.compile_aggregate(query, 1, SupportedSQLDialect.SQLITE)
+        assert info.value.code == "field_not_aggregatable"
+
+    def test_limit_clamped_not_rejected(self) -> None:
+        query = RowQuery(project="p", time_range=TimeRange(**FULL_WINDOW), limit=100_000)
+        plan = compiler.compile_rows(query, 1, SupportedSQLDialect.SQLITE)
+        assert plan.applied_limit == compiler.ROW_LIMIT_MAX
+
+    def test_invalid_time_range_is_structured(self) -> None:
+        with pytest.raises(QueryError) as info:
+            RowQuery(
+                project="p",
+                time_range=TimeRange(start=FIXED_NOW, end=FIXED_NOW - timedelta(hours=1)),
+            )
+        assert info.value.code == "invalid_time_range"
+
+    def test_naive_timestamps_normalized_to_utc(self) -> None:
+        query = RowQuery(
+            project="p",
+            time_range=TimeRange(
+                start=datetime(2026, 7, 22, 0, 0), end=datetime(2026, 7, 23, 0, 0)
+            ),
+        )
+        assert query.time_range is not None
+        assert query.time_range.start.tzinfo == timezone.utc
+        assert query.time_range.end.tzinfo == timezone.utc
+
+    def test_row_window_defaults_to_last_24_hours(self) -> None:
+        query = RowQuery(project="p")
+        plan = compiler.compile_rows(query, 1, SupportedSQLDialect.SQLITE, now=FIXED_NOW)
+        assert plan.time_range_defaulted is True
+        assert plan.time_range.end == FIXED_NOW
+        assert plan.time_range.start == FIXED_NOW - timedelta(
+            hours=compiler.ROW_WINDOW_DEFAULT_HOURS
+        )
+
+    def test_row_order_must_reference_selected_field(self) -> None:
+        query = RowQuery(
+            project="p",
+            time_range=TimeRange(**FULL_WINDOW),
+            fields=["span_id", "name"],
+            order=[compiler.RowOrderField(field="latency_ms")],
+        )
+        with pytest.raises(QueryError) as info:
+            compiler.compile_rows(query, 1, SupportedSQLDialect.SQLITE)
+        assert info.value.code == "invalid_order"
+
+    def test_span_id_identity_is_implicit(self) -> None:
+        query = RowQuery(
+            project="p", time_range=TimeRange(**FULL_WINDOW), fields=["name", "latency_ms"]
+        )
+        plan = compiler.compile_rows(query, 1, SupportedSQLDialect.SQLITE)
+        assert plan.columns[0].id == "span_id"
+
+    def test_duplicate_calculation_names_rejected(self) -> None:
+        with pytest.raises(QueryError) as info:
+            AggregateQuery(
+                project="p",
+                time_range=TimeRange(**FULL_WINDOW),
+                calculations=[
+                    Calculation(name="x", fn="count"),
+                    Calculation(name="x", fn="count"),
+                ],
+            )
+        assert info.value.code == "invalid_request"
+
+
+@pytest.mark.postgres_only
+async def test_statement_timeout_applied_on_postgres(db: DbSessionFactory, seeded: Any) -> None:
+    async with db.read() as session:
+        applied = await compiler.apply_statement_timeout(session, db.dialect)
+        assert applied == compiler.STATEMENT_TIMEOUT_MS
+        shown = (await session.execute(text("SHOW statement_timeout"))).scalar()
+        assert shown == "30s"
+
+
+# ---------------------------------------------------------------------------
+# Seed script determinism
+# ---------------------------------------------------------------------------
+
+
+class TestSeedScript:
+    def test_two_builds_render_identical_ground_truth(self) -> None:
+        first = seed_incident.build_incident(FIXED_NOW, seed_incident.DEFAULT_SEED)
+        second = seed_incident.build_incident(FIXED_NOW, seed_incident.DEFAULT_SEED)
+        assert seed_incident.render_ground_truth(first) == seed_incident.render_ground_truth(second)
+
+    def test_fixture_contains_the_special_rows(self, incident: Any) -> None:
+        llm_spans = [s for s in incident.main.spans if s.span_kind == "LLM"]
+        string_tokens = [
+            s for s in llm_spans if isinstance(s.attributes["llm"]["token_count"]["total"], str)
+        ]
+        assert len(string_tokens) == 1
+        large_inputs = [s for s in llm_spans if len(s.attributes["input"]["value"]) >= 19_000]
+        assert len(large_inputs) == 1
+        assert large_inputs[0].status_code == "ERROR"
+        orphans = [s for s in incident.main.spans if s.name == seed_incident.ORPHAN_SPAN_NAME]
+        assert len(orphans) == 5
+        dotted = incident.main.spans[0].attributes["metadata"]
+        assert "build.version" in dotted
+
+    def test_fixture_contains_eval_annotations(self, incident: Any) -> None:
+        annotations = incident.main.annotations
+        assert len(annotations) >= 24
+        assert {a.annotator_kind for a in annotations} == {"LLM", "HUMAN"}
+        assert {a.name for a in annotations} == {"correctness"}
+        # The same span can carry rows from both annotators under one name.
+        by_span = Counter(a.span_id for a in annotations)
+        assert max(by_span.values()) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tools end-to-end over MCP
+# ---------------------------------------------------------------------------
+
+
+async def test_tools_gate_with_spans_group_and_advertise_contracts(mcp_app: Any) -> None:
+    async with _mcp_client(mcp_app) as client:
+        visible = {t.name for t in await client.list_tools()}
+        for name in ANALYTICS_TOOLS:
+            assert name not in visible, f"{name} must gate with the spans group"
+
+        await _enable_spans(client)
+        tools = {t.name: t for t in await client.list_tools()}
+        for name in ANALYTICS_TOOLS:
+            assert name in tools, name
+            tool = tools[name]
+            assert tool.annotations is not None
+            assert tool.annotations.readOnlyHint is True
+            assert tool.annotations.destructiveHint is False
+            assert tool.outputSchema is not None
+            arms = tool.outputSchema["oneOf"]
+            statuses = [arm["properties"]["status"].get("const") for arm in arms]
+            assert "ok" in statuses and "error" in statuses
+
+        # The filter documentation teaches only what the surface accepts:
+        # annotation lookups are rejected, so they are not advertised.
+        for name in ("aggregateSpans", "querySpanRows"):
+            filter_description = tools[name].inputSchema["properties"]["filter"]["description"]
+            assert "evals[" not in filter_description
+            assert "annotations[" not in filter_description
+            assert "llm.model_name" in filter_description
+            assert "time_range" in filter_description
+
+
+async def test_describe_spans_effective_catalog(mcp_app: Any, seeded: Any) -> None:
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool("describeSpans", {"project": seed_incident.MAIN_PROJECT_NAME})
+        )
+    assert result["status"] == "ok"
+    entries = {e["field"]: e for e in result["fields"]}
+
+    authored = entries["llm.model_name"]
+    assert authored["source"] == "openinference_convention"
+    assert authored["type"] == "string"
+    assert "breakdown" in authored["capabilities"]
+    assert authored.get("observed_count", 0) > 0  # enriched with sampled stats
+
+    assert entries["span_id"]["source"] == "column"
+    assert entries["status_code"]["source"] == "column"
+
+    aggregate_only = entries["is_error"]
+    assert aggregate_only["source"] == "computed"
+    assert "aggregate" in aggregate_only["capabilities"]
+    assert "filter" not in aggregate_only["capabilities"]
+
+    release = entries["metadata.release"]
+    assert release["source"] == "observed_attribute"
+    assert release["observed_types"] == ["string"]
+    assert "aggregate" not in release["capabilities"]
+    # The discovery sample is drawn across the project's whole id range, so
+    # dimension values that stopped occurring (the pre-cut release) are
+    # visible alongside current ones — a recency-only sample would hide
+    # exactly the values an investigation of a change needs.
+    top_values = {v["value"] for v in release["top_values"]}
+    assert top_values == {"v41", "v42"}
+
+    tenant = entries["metadata.tenant"]
+    assert tenant["source"] == "observed_attribute"
+    assert {v["value"] for v in tenant["top_values"]} <= set(seed_incident.TENANTS)
+
+    # cost.total: a declared reduction, select-and-aggregate only.
+    cost_entry = entries["cost.total"]
+    assert cost_entry["unit"] == "USD"
+    assert set(cost_entry["capabilities"]) == {"select", "aggregate"}
+
+    # The message fields appear as authored convention entries in
+    # list-index subscript spelling, select-only, and the message lists
+    # themselves produce no observed entries (list-valued paths are
+    # omitted from observed discovery).
+    first_content = entries["llm.input_messages[0].message.content"]
+    assert first_content["source"] == "openinference_convention"
+    assert first_content["capabilities"] == ["select"]
+    assert not any(
+        e["source"] == "observed_attribute" and "input_messages" in e["field"]
+        for e in result["fields"]
+    )
+
+    # A key containing a literal dot comes back in subscript spelling.
+    dotted = entries['metadata["build.version"]']
+    assert dotted["source"] == "observed_attribute"
+
+    sampling = result["sampling"]
+    assert sampling["strategy"] == "id_spread_500"
+    assert 0 < sampling["sample_count"] <= 500
+    assert "not exhaustive" in sampling["note"]
+
+
+async def test_discovery_round_trip(mcp_app: Any, seeded: Any) -> None:
+    """Every identifier discovery returns works verbatim in fields, filter,
+    and breakdowns — authored, observed, and the literal-dotted key."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        described = _payload(
+            await client.call_tool("describeSpans", {"project": seed_incident.MAIN_PROJECT_NAME})
+        )
+        assert described["status"] == "ok"
+        # The response-level sampling epistemics must always be present:
+        # strategy, sample size, and the note (an unobserved path or value
+        # means not-seen-in-sample, never nonexistent).
+        sampling = described["sampling"]
+        assert sampling["strategy"] == "id_spread_500"
+        assert sampling["sample_count"] > 0
+        assert "never nonexistent" in sampling["note"]
+        spellings = [e["field"] for e in described["fields"]]
+        assert 'metadata["build.version"]' in spellings
+
+        for entry in described["fields"]:
+            field_id = entry["field"]
+            capabilities = entry["capabilities"]
+            if "select" in capabilities:
+                rows = _payload(
+                    await client.call_tool(
+                        "querySpanRows",
+                        {
+                            "project": seed_incident.MAIN_PROJECT_NAME,
+                            "time_range": FULL_WINDOW,
+                            "fields": [field_id],
+                            "limit": 1,
+                        },
+                    )
+                )
+                assert rows["status"] == "ok", (field_id, rows)
+            if "filter" in capabilities:
+                filtered = _payload(
+                    await client.call_tool(
+                        "querySpanRows",
+                        {
+                            "project": seed_incident.MAIN_PROJECT_NAME,
+                            "time_range": FULL_WINDOW,
+                            "filter": f"{field_id} is not None",
+                            "limit": 1,
+                        },
+                    )
+                )
+                assert filtered["status"] == "ok", (field_id, filtered)
+            if "breakdown" in capabilities:
+                grouped = _payload(
+                    await client.call_tool(
+                        "aggregateSpans",
+                        {
+                            "project": seed_incident.MAIN_PROJECT_NAME,
+                            "time_range": FULL_WINDOW,
+                            "calculations": [{"name": "calls", "fn": "count"}],
+                            "breakdowns": [field_id],
+                        },
+                    )
+                )
+                assert grouped["status"] == "ok", (field_id, grouped)
+
+
+async def test_aggregate_error_rate_by_release_matches_ground_truth(
+    mcp_app: Any, seeded: Any
+) -> None:
+    expected_counts: Counter[Any] = Counter()
+    expected_errors: Counter[Any] = Counter()
+    for span in seeded.main.spans:
+        release = span.attributes.get("metadata", {}).get("release")
+        expected_counts[release] += 1
+        if span.status_code == "ERROR":
+            expected_errors[release] += 1
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [
+                        {"name": "error_count", "fn": "sum", "field": "is_error"},
+                        {"name": "error_rate", "fn": "avg", "field": "is_error"},
+                        {"name": "calls", "fn": "count"},
+                    ],
+                    "breakdowns": ["metadata.release"],
+                    "order": [{"calculation": "error_count", "direction": "desc"}],
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    assert result["share_basis"] == "error_count"
+    assert result["groups_total"] == len(expected_counts)  # v41, v42, and the null bucket
+    by_release = {row["metadata.release"]: row for row in result["rows"]}
+    assert set(by_release) == set(expected_counts)
+    total_errors = sum(expected_errors.values())
+    for release, count in expected_counts.items():
+        row = by_release[release]
+        assert row["calls"] == count
+        assert row["error_count"] == expected_errors[release]
+        assert row["error_rate"] == pytest.approx(expected_errors[release] / count)
+        if total_errors:
+            assert row["share"] == pytest.approx(expected_errors[release] / total_errors)
+    overall = result["overall"]
+    assert overall["calls"] == sum(expected_counts.values())
+    assert overall["error_count"] == total_errors
+
+
+async def test_aggregate_hourly_series_shows_the_jump(mcp_app: Any, seeded: Any) -> None:
+    expected_counts: Counter[str] = Counter()
+    expected_errors: Counter[str] = Counter()
+    for span in seeded.main.spans:
+        bucket = span.start_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:00:00+00:00")
+        expected_counts[bucket] += 1
+        if span.status_code == "ERROR":
+            expected_errors[bucket] += 1
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [
+                        {"name": "errors", "fn": "sum", "field": "is_error"},
+                        {"name": "error_rate", "fn": "avg", "field": "is_error"},
+                    ],
+                    "breakdowns": [{"bucket": "hour"}],
+                    "limit": 200,
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    series = {row["time_bucket"]: row for row in result["rows"]}
+    assert set(series) == set(expected_counts)
+    for bucket, row in series.items():
+        assert row["errors"] == expected_errors[bucket], bucket
+    # The regression is visible in the series: the post-cut hours run far
+    # hotter than the pre-cut hours.
+    pre = [r["error_rate"] for b, r in series.items() if b < CUT.strftime("%Y-%m-%dT%H")]
+    post = [r["error_rate"] for b, r in series.items() if b > CUT.strftime("%Y-%m-%dT%H:59")]
+    assert sum(post) / len(post) > 3 * (sum(pre) / len(pre))
+
+
+async def test_query_rows_slowest_failures_with_clipping(mcp_app: Any, seeded: Any) -> None:
+    failed_llm = [s for s in seeded.main.spans if s.span_kind == "LLM" and s.status_code == "ERROR"]
+    expected = [s.span_id for s in sorted(failed_llm, key=lambda s: (-s.latency_ms, s.span_id))[:5]]
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["name", "latency_ms", "input.value", "metadata.tenant"],
+                    "filter": "span_kind == 'LLM' and status_code == 'ERROR'",
+                    "order": [{"field": "latency_ms", "direction": "desc"}],
+                    "limit": 5,
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    assert [row["span_id"] for row in result["rows"]] == expected
+    # span_id is present although it was not selected: row identity is
+    # implicit, so the clipping recovery path always has an anchor.
+    worst = result["rows"][0]
+    assert len(worst["input.value"]) < 20_000  # clipped to a preview
+    assert any(
+        marker["row"] == expected[0] and marker["field"] == "input.value"
+        for marker in result["clipped"]
+    )
+    assert "getSpan" in result["note"]
+
+
+async def test_get_span_recovers_the_clipped_value_in_full(mcp_app: Any, seeded: Any) -> None:
+    large = next(
+        s
+        for s in seeded.main.spans
+        if s.span_kind == "LLM" and len(s.attributes["input"]["value"]) >= 19_000
+    )
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "getSpan",
+                {"project": seed_incident.MAIN_PROJECT_NAME, "span_id": large.span_id},
+            )
+        )
+    assert result["status"] == "ok"
+    span = result["span"]
+    assert span["attributes"]["input"]["value"] == large.attributes["input"]["value"]
+    assert span["status"]["code"] == "ERROR"
+    (event,) = span["events"]
+    assert event["attributes"]["exception.type"]
+    assert result["ui_url"].endswith(f"/redirects/spans/{large.span_id}")
+    # The link is a UI route: the MCP mount the request arrived through
+    # must never leak into it.
+    assert "/mcp" not in result["ui_url"]
+    assert result["clipped"] == []  # within the default budget
+
+
+async def test_cost_field_top10_matches_answer_key_and_nulls(mcp_app: Any, seeded: Any) -> None:
+    """cost.total is a declared sum reduction over the cost table: the ten
+    priciest spans match the seed's answer key on both backends (NULL cost
+    rows sort last by declared placement), and a span without cost records
+    reads NULL — with no observed-path note, because the NULL is authored
+    meaning, not a misspelling."""
+    expected_top10 = [
+        c.span_id for c in sorted(seeded.main.costs, key=lambda c: (-c.total_cost, c.span_id))[:10]
+    ]
+    expected_costs = {c.span_id: c.total_cost for c in seeded.main.costs}
+    mixed = next(
+        s
+        for s in seeded.main.spans
+        if s.span_kind == "LLM" and isinstance(s.attributes["llm"]["token_count"]["total"], str)
+    )
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["cost.total", "llm.model_name"],
+                    "filter": "span_kind == 'LLM'",
+                    "order": [{"field": "cost.total", "direction": "desc"}],
+                    "limit": 10,
+                },
+            )
+        )
+        assert result["status"] == "ok"
+        assert [row["span_id"] for row in result["rows"]] == expected_top10
+        for row in result["rows"]:
+            assert row["cost.total"] == pytest.approx(expected_costs[row["span_id"]])
+
+        costless = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["cost.total"],
+                    "filter": f"span_id == '{mixed.span_id}'",
+                },
+            )
+        )
+        (costless_row,) = costless["rows"]
+        assert costless_row["cost.total"] is None
+        assert "column_notes" not in costless
+
+        # cost.total is select-and-aggregate only: a filter reference is
+        # rejected instead of silently reading a nonexistent attribute.
+        filtered = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "filter": "cost.total > 0.01",
+                },
+            )
+        )
+        assert filtered["status"] == "error"
+        assert filtered["code"] == "field_not_filterable"
+
+
+async def test_cost_aggregation_matches_answer_key(mcp_app: Any, seeded: Any) -> None:
+    costs = seeded.main.costs
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [
+                        {"name": "total_cost", "fn": "sum", "field": "cost.total"},
+                        {"name": "with_cost", "fn": "count", "field": "cost.total"},
+                        {"name": "spans", "fn": "count"},
+                    ],
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    overall = result["overall"]
+    assert overall["with_cost"] == len(costs)
+    assert overall["spans"] == len(seeded.main.spans)
+    assert overall["total_cost"] == pytest.approx(sum(c.total_cost for c in costs), rel=1e-9)
+    # sum is additive, so cost carries share-of-total semantics.
+    assert result["share_basis"] == "total_cost"
+    (row,) = result["rows"]
+    assert row["share"] == pytest.approx(1.0)
+
+
+async def test_input_turns_by_user_matches_ground_truth(mcp_app: Any, seeded_copilot: Any) -> None:
+    """avg/max conversation depth (input.turns) grouped by user matches the
+    seed's independently computed ground truth on both backends; prompt
+    token sums agree as well."""
+    expected_depths: dict[str, list[int]] = {}
+    expected_prompt_tokens = 0
+    for span in seeded_copilot.spans:
+        if span.span_kind != "LLM":
+            continue
+        user = span.attributes["user"]["id"]
+        expected_depths.setdefault(user, []).append(len(span.attributes["llm"]["input_messages"]))
+        expected_prompt_tokens += span.attributes["llm"]["token_count"]["prompt"]
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_support_copilot.PROJECT_NAME,
+                    "time_range": COPILOT_WINDOW,
+                    "calculations": [
+                        {"name": "avg_depth", "fn": "avg", "field": "input.turns"},
+                        {"name": "max_depth", "fn": "max", "field": "input.turns"},
+                        {"name": "llm_calls", "fn": "count", "field": "input.turns"},
+                        {
+                            "name": "prompt_tokens",
+                            "fn": "sum",
+                            "field": "llm.token_count.prompt",
+                        },
+                    ],
+                    "breakdowns": ["user.id"],
+                    "limit": 200,
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    by_user = {row["user.id"]: row for row in result["rows"]}
+    assert set(by_user) == set(expected_depths)
+    for user, depths in expected_depths.items():
+        row = by_user[user]
+        assert row["max_depth"] == max(depths), user
+        assert row["llm_calls"] == len(depths), user
+        assert row["avg_depth"] == pytest.approx(sum(depths) / len(depths)), user
+    assert result["overall"]["prompt_tokens"] == expected_prompt_tokens
+
+
+async def test_avg_cost_by_conversation_depth(mcp_app: Any, seeded_copilot: Any) -> None:
+    """The context-depth economics query: input.turns is a groupable
+    bounded small-integer dimension, so avg cost by conversation depth is
+    one aggregate — and it matches the workload-derived oracle."""
+    cost_by_span = {c.span_id: c.total_cost for c in seeded_copilot.costs}
+    expected: dict[int, list[float]] = {}
+    for span in seeded_copilot.spans:
+        if span.span_kind == "LLM" and span.span_id in cost_by_span:
+            depth = len(span.attributes["llm"]["input_messages"])
+            expected.setdefault(depth, []).append(cost_by_span[span.span_id])
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_support_copilot.PROJECT_NAME,
+                    "time_range": COPILOT_WINDOW,
+                    "calculations": [
+                        {"name": "avg_cost", "fn": "avg", "field": "cost.total"},
+                        {"name": "calls_with_cost", "fn": "count", "field": "cost.total"},
+                    ],
+                    "breakdowns": ["input.turns"],
+                    "order": [{"field": "input.turns", "direction": "asc"}],
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    with_depth = [row for row in result["rows"] if row["input.turns"] is not None]
+    assert [row["input.turns"] for row in with_depth] == sorted(expected)
+    for row in with_depth:
+        costs = expected[row["input.turns"]]
+        assert row["calls_with_cost"] == len(costs)
+        assert row["avg_cost"] == pytest.approx(sum(costs) / len(costs))
+    # The economics are visible: deeper conversations cost more per call.
+    averages = [row["avg_cost"] for row in with_depth]
+    assert averages[-1] > averages[0]
+
+
+async def test_input_turns_array_guard_and_input_chars(mcp_app: Any, seeded: Any) -> None:
+    """The array-guarded depth field reads NULL — not an error, not zero —
+    for spans without a message list, and input.chars matches the known
+    string length."""
+    normal = seeded.main.spans[1]  # LLM span with two input messages
+    chain = seeded.main.spans[0]  # CHAIN root: no llm.input_messages at all
+    single = next(
+        s
+        for s in seeded.main.spans
+        if s.span_kind == "LLM" and isinstance(s.attributes["llm"]["token_count"]["total"], str)
+    )
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+
+        async def fetch(span_id: str) -> dict[str, Any]:
+            result = _payload(
+                await client.call_tool(
+                    "querySpanRows",
+                    {
+                        "project": seed_incident.MAIN_PROJECT_NAME,
+                        "time_range": FULL_WINDOW,
+                        "fields": ["input.turns", "input.chars"],
+                        "filter": f"span_id == '{span_id}'",
+                    },
+                )
+            )
+            assert result["status"] == "ok", result
+            (row,) = result["rows"]
+            return dict(row)
+
+        assert (await fetch(normal.span_id))["input.turns"] == 2
+        assert (await fetch(single.span_id))["input.turns"] == 1
+        chain_row = await fetch(chain.span_id)
+        assert chain_row["input.turns"] is None
+
+        normal_row = await fetch(normal.span_id)
+        assert normal_row["input.chars"] == len(normal.attributes["input"]["value"])
+
+        # Computed dotted fields are rejected in filters instead of silently
+        # reading nonexistent attributes.
+        filtered = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "filter": "input.turns > 2",
+                },
+            )
+        )
+        assert filtered["status"] == "error"
+        assert filtered["code"] == "field_not_filterable"
+
+
+def test_public_url_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only configuration or the request itself can know the public origin:
+    PHOENIX_ROOT_URL wins when set; otherwise the current request's origin
+    plus its ASGI root_path; the env-composed URL only without a request."""
+    from starlette.requests import Request as StarletteRequest
+
+    from phoenix.server.mcp_span_analytics import tools as tools_module
+
+    def scope(root_path: str) -> dict[str, Any]:
+        return {
+            "type": "http",
+            "scheme": "https",
+            "server": ("proxy-internal", 8080),
+            "headers": [(b"host", b"phoenix.example.com")],
+            "root_path": root_path,
+            "path": f"{root_path}/mcp",
+            "query_string": b"",
+            "method": "GET",
+            "http_version": "1.1",
+        }
+
+    plain_request = StarletteRequest(scope(""))
+    prefixed_request = StarletteRequest(scope("/apps/phoenix"))
+
+    # (a) Explicit configuration wins over everything.
+    monkeypatch.setenv("PHOENIX_ROOT_URL", "https://obs.example.com/px")
+    monkeypatch.setattr(tools_module, "get_http_request", lambda: plain_request)
+    assert (
+        tools_module._public_url("/redirects/spans/abc")
+        == "https://obs.example.com/px/redirects/spans/abc"
+    )
+
+    # (b) Without configuration, the request's own origin is the truth.
+    monkeypatch.delenv("PHOENIX_ROOT_URL")
+    assert (
+        tools_module._public_url("/redirects/spans/abc")
+        == "https://phoenix.example.com/redirects/spans/abc"
+    )
+
+    # (c) A non-empty ASGI root_path prefixes every link.
+    monkeypatch.setattr(tools_module, "get_http_request", lambda: prefixed_request)
+    assert (
+        tools_module._public_url("/redirects/spans/abc")
+        == "https://phoenix.example.com/apps/phoenix/redirects/spans/abc"
+    )
+
+    # (d) The MCP mount segment is the app's own, not the deployment's:
+    # requests seen inside the mount carry it in root_path, and it must be
+    # stripped from UI links while the deployment prefix is preserved.
+    mounted_request = StarletteRequest(scope("/prefix/mcp"))
+    monkeypatch.setattr(tools_module, "get_http_request", lambda: mounted_request)
+    mounted_url = tools_module._public_url("/projects/UHJvamVjdDox/spans")
+    assert mounted_url == "https://phoenix.example.com/prefix/projects/UHJvamVjdDox/spans"
+    assert "/mcp" not in mounted_url
+
+    bare_mount_request = StarletteRequest(scope("/mcp"))
+    monkeypatch.setattr(tools_module, "get_http_request", lambda: bare_mount_request)
+    bare_url = tools_module._public_url("/redirects/spans/abc")
+    assert bare_url == "https://phoenix.example.com/redirects/spans/abc"
+
+    # No request context at all: fall back to the env-composed URL.
+    def no_context() -> Any:
+        raise RuntimeError("no active request")
+
+    monkeypatch.setattr(tools_module, "get_http_request", no_context)
+    fallback = tools_module._public_url("/redirects/spans/abc")
+    assert fallback.startswith("http") and fallback.endswith("/redirects/spans/abc")
+
+
+async def test_cohort_links_escape_and_round_trip(mcp_app: Any, seeded_copilot: Any) -> None:
+    """Every aggregate row deep-links its cohort; values with embedded
+    quotes and backslashes survive both the filter grammar and URL encoding,
+    and the decoded link re-selects exactly the group's rows."""
+    from urllib.parse import parse_qs, urlparse
+
+    from phoenix.trace.dsl.filter import SpanFilter
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_support_copilot.PROJECT_NAME,
+                    "time_range": COPILOT_WINDOW,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "breakdowns": ["metadata.org"],
+                    "limit": 200,
+                },
+            )
+        )
+        assert result["status"] == "ok"
+        by_org = {row["metadata.org"]: row for row in result["rows"]}
+        for adversarial in ("o'brien-corp", "globex\\emea"):
+            row = by_org[adversarial]
+            parsed = urlparse(row["ui_url"])
+            assert "/projects/" in parsed.path and parsed.path.endswith("/spans")
+            assert "/mcp" not in parsed.path  # UI route, not the MCP mount
+            params = parse_qs(parsed.query)
+            condition = params["filter"][0]
+            SpanFilter(condition)  # decodes to a valid filter-grammar string
+            requery = _payload(
+                await client.call_tool(
+                    "aggregateSpans",
+                    {
+                        "project": seed_support_copilot.PROJECT_NAME,
+                        "time_range": {
+                            "start": params["start"][0],
+                            "end": params["end"][0],
+                        },
+                        "calculations": [{"name": "spans_n", "fn": "count"}],
+                        "filter": condition,
+                    },
+                )
+            )
+            assert requery["status"] == "ok", (adversarial, requery)
+            assert requery["overall"]["spans_n"] == row["spans_n"], adversarial
+
+
+async def test_cohort_links_time_buckets_and_null_keys(mcp_app: Any, seeded: Any) -> None:
+    """A time bucket narrows the link's time params to its hour and adds no
+    filter conjunct; a null group key is skipped (the UI filter cannot say
+    'absent'), so the null bucket links to the window without it."""
+    from urllib.parse import parse_qs, urlparse
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "breakdowns": ["metadata.release", {"bucket": "hour"}],
+                    "limit": 200,
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    bucketed = next(r for r in result["rows"] if r["metadata.release"] == "v42")
+    params = parse_qs(urlparse(bucketed["ui_url"]).query)
+    assert params["filter"][0] == "metadata.release == 'v42'"  # no bucket conjunct
+    start = datetime.fromisoformat(params["start"][0])
+    end = datetime.fromisoformat(params["end"][0])
+    assert end - start == timedelta(hours=1)
+
+    null_key = next(r for r in result["rows"] if r["metadata.release"] is None)
+    null_params = parse_qs(urlparse(null_key["ui_url"]).query)
+    assert "filter" not in null_params
+
+
+async def test_message_fields_select_and_clip(mcp_app: Any, seeded: Any) -> None:
+    """The first-two-input-message fields read the OpenInference message
+    lists: correct role/content for messages 0 and 1, NULL second message on
+    a single-message span, and preview clipping on oversized content."""
+    message_fields = [
+        "llm.input_messages[0].message.role",
+        "llm.input_messages[0].message.content",
+        "llm.input_messages[1].message.role",
+        "llm.input_messages[1].message.content",
+    ]
+    normal = seeded.main.spans[1]
+    mixed = next(
+        s
+        for s in seeded.main.spans
+        if s.span_kind == "LLM" and isinstance(s.attributes["llm"]["token_count"]["total"], str)
+    )
+    large = next(
+        s
+        for s in seeded.main.spans
+        if s.span_kind == "LLM" and len(s.attributes["input"]["value"]) >= 19_000
+    )
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+
+        async def fetch(span_id: str, max_cell_chars: int = 10_000) -> dict[str, Any]:
+            result = _payload(
+                await client.call_tool(
+                    "querySpanRows",
+                    {
+                        "project": seed_incident.MAIN_PROJECT_NAME,
+                        "time_range": FULL_WINDOW,
+                        "fields": message_fields,
+                        "filter": f"span_id == '{span_id}'",
+                        "max_cell_chars": max_cell_chars,
+                    },
+                )
+            )
+            assert result["status"] == "ok", result
+            return result
+
+        both = await fetch(normal.span_id)
+        (row,) = both["rows"]
+        assert row["llm.input_messages[0].message.role"] == "system"
+        assert row["llm.input_messages[0].message.content"] == seed_incident.SYSTEM_PROMPT
+        assert row["llm.input_messages[1].message.role"] == "user"
+        assert row["llm.input_messages[1].message.content"] == normal.attributes["input"]["value"]
+
+        single = await fetch(mixed.span_id)
+        (single_row,) = single["rows"]
+        assert single_row["llm.input_messages[0].message.role"] == "user"
+        assert single_row["llm.input_messages[1].message.role"] is None
+        assert single_row["llm.input_messages[1].message.content"] is None
+
+        clipped = await fetch(large.span_id, max_cell_chars=400)
+        (clipped_row,) = clipped["rows"]
+        content = clipped_row["llm.input_messages[1].message.content"]
+        assert len(content) < 1_000 and "clipped" in content
+        assert any(
+            marker["field"] == "llm.input_messages[1].message.content"
+            for marker in clipped["clipped"]
+        )
+        assert "getSpan" in clipped["note"]
+
+
+async def test_silent_null_projection_note(mcp_app: Any, seeded: Any) -> None:
+    """A selected observed path that is NULL on every returned row gets a
+    per-column note (it is indistinguishable from a misspelling); a sparse
+    path with some values present does not."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        missing = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["metadata.nonexistent_key", "name"],
+                    "limit": 20,
+                },
+            )
+        )
+        assert missing["status"] == "ok"
+        assert any(
+            note["column"] == "metadata.nonexistent_key" and "describeSpans" in note["note"]
+            for note in missing["column_notes"]
+        )
+
+        # A genuinely sparse path: orphan spans carry no metadata, ordinary
+        # spans do; mixed NULL and non-NULL draws no note.
+        sparse = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["start_time", "metadata.tenant", "name"],
+                    "filter": (
+                        f"name == '{seed_incident.ORPHAN_SPAN_NAME}' or "
+                        f"name == '{seed_incident.ROOT_SPAN_NAME}'"
+                    ),
+                    "order": [{"field": "start_time", "direction": "asc"}],
+                    "limit": 200,
+                },
+            )
+        )
+        assert sparse["status"] == "ok"
+        values = [row["metadata.tenant"] for row in sparse["rows"]]
+        assert any(v is None for v in values) and any(v is not None for v in values)
+        assert "column_notes" not in sparse
+
+
+async def test_get_span_fields_match_row_values(mcp_app: Any, seeded: Any) -> None:
+    """getSpan's flat `fields` echo must equal the querySpanRows row for the
+    same span, id for id — the survey-to-drill-down handoff keeps one naming
+    scheme (flat status_code, not a nested remap)."""
+    span = seeded.main.spans[1]  # an ordinary LLM span with small payloads
+    authored_ids = [f.id for f in registry.AUTHORED_FIELDS]
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        rows = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": authored_ids,
+                    "filter": f"span_id == '{span.span_id}'",
+                    "max_cell_chars": 10_000,
+                },
+            )
+        )
+        assert rows["status"] == "ok"
+        (row,) = rows["rows"]
+        drilled = _payload(
+            await client.call_tool(
+                "getSpan",
+                {"project": seed_incident.MAIN_PROJECT_NAME, "span_id": span.span_id},
+            )
+        )
+    assert drilled["status"] == "ok"
+    fields = drilled["fields"]
+    assert set(fields) == set(authored_ids)
+    for field_id in authored_ids:
+        assert fields[field_id] == row[field_id], field_id
+
+
+def test_analytics_tools_carry_tags_and_search_vocabulary() -> None:
+    """The analytics tools carry the analytics tag beside the spans group
+    tag, speak the vocabulary catalog search ranks on, and point at
+    get_schema detail='full' for their nested parameter shapes."""
+    tools = {t.name: t for t in build_span_analytics_tools(cast(Any, object()))}
+    for name in ("describeSpans", "aggregateSpans", "querySpanRows", "getSpan"):
+        assert "analytics" in tools[name].tags, name
+        assert "spans" in tools[name].tags, name
+        assert "detail='full'" in (tools[name].description or ""), name
+    assert "spans" in tools["getTrace"].tags
+    aggregate_description = tools["aggregateSpans"].description or ""
+    for keyword in ("group by", "metrics", "error rate", "percentiles", "top-N"):
+        assert keyword in aggregate_description, keyword
+    assert "top-N" in (tools["querySpanRows"].description or "")
+
+
+async def test_get_trace_assembles_the_tree(mcp_app: Any, seeded: Any) -> None:
+    large = next(
+        s
+        for s in seeded.main.spans
+        if s.span_kind == "LLM" and len(s.attributes["input"]["value"]) >= 19_000
+    )
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "getTrace",
+                {"project": seed_incident.MAIN_PROJECT_NAME, "trace_id": large.trace_id},
+            )
+        )
+    assert result["status"] == "ok"
+    (root,) = [r for r in result["roots"] if r["parent_id"] is None]
+    assert root["name"] == seed_incident.ROOT_SPAN_NAME
+    child_ids = {c["span_id"] for c in root["children"]}
+    assert large.span_id in child_ids
+    assert root["ui_url"].endswith(f"/redirects/spans/{root['span_id']}")
+
+
+async def test_get_trace_flags_orphans_as_roots(mcp_app: Any, seeded: Any) -> None:
+    orphan = next(s for s in seeded.main.spans if s.name == seed_incident.ORPHAN_SPAN_NAME)
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "getTrace",
+                {"project": seed_incident.MAIN_PROJECT_NAME, "trace_id": orphan.trace_id},
+            )
+        )
+    assert result["status"] == "ok"
+    orphan_roots = [r for r in result["roots"] if r.get("orphan")]
+    assert [r["span_id"] for r in orphan_roots] == [orphan.span_id]
+
+
+async def test_zero_result_guidance_causes(mcp_app: Any, seeded: Any) -> None:
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+
+        absent_path = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "filter": "metadata['never_recorded_key'] == 'x'",
+                },
+            )
+        )
+        assert absent_path["status"] == "ok"
+        assert absent_path["rows"] == []
+        assert absent_path["guidance"]["cause"] == "path_not_observed"
+        assert "sampled evidence" in absent_path["guidance"]["detail"]
+
+        empty_window = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": {
+                        "start": "2020-01-01T00:00:00Z",
+                        "end": "2020-01-02T00:00:00Z",
+                    },
+                },
+            )
+        )
+        assert empty_window["guidance"]["cause"] == "window_empty"
+
+        no_match = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "filter": "'zzz-not-in-any-payload' in input.value",
+                },
+            )
+        )
+        assert no_match["guidance"]["cause"] == "no_matches"
+
+
+async def test_project_isolation_is_behavioral(mcp_app: Any, seeded: Any) -> None:
+    """A decoy project with identical span names and attribute keys but
+    different values must never leak through any tool path."""
+    decoy_span = seeded.decoy.spans[0]
+    decoy_tenants = set(seed_incident.DECOY_TENANTS)
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+
+        described = _payload(
+            await client.call_tool("describeSpans", {"project": seed_incident.MAIN_PROJECT_NAME})
+        )
+        tenant_entry = next(e for e in described["fields"] if e["field"] == "metadata.tenant")
+        assert not ({v["value"] for v in tenant_entry["top_values"]} & decoy_tenants)
+
+        counted = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "calls", "fn": "count"}],
+                },
+            )
+        )
+        assert counted["overall"]["calls"] == len(seeded.main.spans)
+
+        rows = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "limit": 200,
+                },
+            )
+        )
+        decoy_ids = {s.span_id for s in seeded.decoy.spans}
+        assert not ({r["span_id"] for r in rows["rows"]} & decoy_ids)
+
+        # A span id from the decoy project answers exactly like a span id
+        # that exists nowhere.
+        foreign = _payload(
+            await client.call_tool(
+                "getSpan",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "span_id": decoy_span.span_id,
+                },
+            )
+        )
+        nonexistent = _payload(
+            await client.call_tool(
+                "getSpan",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "span_id": "0000000000000000",
+                },
+            )
+        )
+        assert foreign["status"] == "error" and foreign["code"] == "span_not_found"
+        assert nonexistent["code"] == "span_not_found"
+        assert foreign["message"].replace(decoy_span.span_id, "X") == nonexistent[
+            "message"
+        ].replace("0000000000000000", "X")
+
+        foreign_trace = _payload(
+            await client.call_tool(
+                "getTrace",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "trace_id": seeded.decoy.traces[0].trace_id,
+                },
+            )
+        )
+        assert foreign_trace["status"] == "error"
+        assert foreign_trace["code"] == "trace_not_found"
+
+
+async def test_nearest_name_error_surfaces_through_the_client(mcp_app: Any, seeded: Any) -> None:
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["latencyms"],
+                },
+            )
+        )
+    assert result["status"] == "error"
+    assert result["code"] == "unknown_field"
+    assert "latency_ms" in result["suggestions"]
+
+
+async def test_malformed_order_shape_is_structured(mcp_app: Any, seeded: Any) -> None:
+    """A wrong parameter shape must surface on the error union with a plain
+    message and a usable path — never as raw validation text with internal
+    model names or vendor URLs."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        # The sample spelling wrapped in a list: matches neither order form.
+        result = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "order": [{"sample": {"seed": 42}}],
+                },
+            )
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "invalid_shape"
+        assert result["path"].startswith("order")
+        assert '{"sample": {"seed": 42}}' in result["message"]
+        serialized = json.dumps(result)
+        assert "pydantic" not in serialized.lower()
+        assert "RowOrderField" not in serialized
+        assert "SampleOrder" not in serialized
+
+        # Same contract on the aggregate shape.
+        aggregate = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": {"name": "calls", "fn": "count"},
+                },
+            )
+        )
+        assert aggregate["status"] == "error"
+        assert aggregate["code"] == "invalid_shape"
+        assert aggregate["path"].startswith("calculations")
+        assert "Calculation" not in json.dumps(aggregate)
+
+
+async def test_validate_only_executes_nothing(mcp_app: Any, seeded: Any) -> None:
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        valid = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "calls", "fn": "count"}],
+                    "breakdowns": ["metadata.release"],
+                    "validate_only": True,
+                },
+            )
+        )
+        assert valid == {
+            "status": "ok",
+            "valid": True,
+            "applied": valid["applied"],
+        }
+        assert "rows" not in valid
+
+        invalid = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "s", "fn": "sum", "field": "name"}],
+                    "validate_only": True,
+                },
+            )
+        )
+        assert invalid["status"] == "error"
+        assert invalid["code"] == "field_not_aggregatable"
+
+
+async def test_two_control_beat_clamping_and_admission(
+    mcp_app: Any, seeded: Any, db: DbSessionFactory
+) -> None:
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        clamped = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "limit": 100_000,
+                },
+            )
+        )
+        assert clamped["status"] == "ok"
+        assert clamped["applied"]["limit"] == compiler.ROW_LIMIT_MAX
+        expected_timeout = (
+            compiler.STATEMENT_TIMEOUT_MS if db.dialect.value == "postgresql" else None
+        )
+        assert clamped["applied"]["timeout"]["statement_timeout_ms"] == expected_timeout
+
+        rejected = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "calls", "fn": "count"}],
+                    "breakdowns": ["input.value"],
+                },
+            )
+        )
+        assert rejected["status"] == "error"
+        assert rejected["code"] == "field_not_groupable"
+        assert rejected["suggestions"]
+
+
+async def test_filter_grammar_rejections_are_structured(mcp_app: Any, seeded: Any) -> None:
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        call_expression = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "filter": "__import__('os').system('true')",
+                },
+            )
+        )
+        assert call_expression["status"] == "error"
+        assert call_expression["code"] == "invalid_filter"
+
+        # Composite annotation expressions stay rejected — with the
+        # supported shape and the two-call decomposition as the route.
+        nested_evals = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "filter": "status_code == 'ERROR' or evals['correctness'].score < 0.5",
+                },
+            )
+        )
+        assert nested_evals["status"] == "error"
+        assert nested_evals["code"] == "unsupported_filter_reference"
+        assert "top-level" in nested_evals["message"]
+        assert "listSpanAnnotationsBySpanIds" in nested_evals["message"]
+
+
+async def test_annotation_filter_end_to_end(mcp_app: Any, seeded: Any) -> None:
+    """Annotation existence filters work without multiplying rows: the
+    top-10-by-cost among low-scored spans matches the answer key, a span
+    scored by two annotators counts once, the label form works, the
+    any-annotator semantics are disclosed structurally, and annotation
+    *value* uses are refused with their decomposition."""
+    annotations = [a for a in seeded.main.annotations if a.name == "correctness"]
+    low_spans = {a.span_id for a in annotations if a.score < 0.5}
+    all_annotated = {a.span_id for a in annotations}
+    incorrect_spans = {a.span_id for a in annotations if a.label == "incorrect"}
+    per_span = Counter(a.span_id for a in annotations)
+    assert max(per_span.values()) == 2  # at least one span carries both annotators
+    cost_by_span = {c.span_id: c for c in seeded.main.costs}
+    expected_top = [
+        c.span_id
+        for c in sorted(
+            (cost_by_span[sid] for sid in low_spans if sid in cost_by_span),
+            key=lambda c: (-c.total_cost, c.span_id),
+        )[:10]
+    ]
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        rows = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["cost.total"],
+                    "filter": "evals['correctness'].score < 0.5",
+                    "order": [{"field": "cost.total", "direction": "desc"}],
+                    "limit": 10,
+                },
+            )
+        )
+        assert rows["status"] == "ok"
+        assert [row["span_id"] for row in rows["rows"]] == expected_top
+        assert rows["annotation_semantics"] == "any"
+        assert "any-annotator" in rows["note"]
+
+        # Unmultiplied counts: a span with two annotator rows counts once.
+        counted = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "n", "fn": "count"}],
+                    "filter": "evals['correctness'].score <= 1.0",
+                },
+            )
+        )
+        assert counted["status"] == "ok"
+        assert counted["overall"]["n"] == len(all_annotated)
+        assert counted["annotation_semantics"] == "any"
+
+        labeled = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "n", "fn": "count"}],
+                    "filter": "evals['correctness'].label == 'incorrect'",
+                },
+            )
+        )
+        assert labeled["overall"]["n"] == len(incorrect_spans)
+
+        # Annotation values stay refused — with the decomposition route.
+        value_select = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["evals['correctness'].score"],
+                },
+            )
+        )
+        assert value_select["status"] == "error"
+        assert value_select["code"] == "annotation_values_not_supported"
+        assert "listSpanAnnotationsBySpanIds" in value_select["message"]
+
+        value_calc = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [
+                        {
+                            "name": "avg_score",
+                            "fn": "avg",
+                            "field": "evals['correctness'].score",
+                        }
+                    ],
+                },
+            )
+        )
+        assert value_calc["status"] == "error"
+        assert value_calc["code"] == "annotation_values_not_supported"
+
+
+async def test_sample_order_is_deterministic_per_seed(mcp_app: Any, seeded: Any) -> None:
+    async def draw(client: Any, seed: int) -> list[str]:
+        result = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "filter": "status_code == 'ERROR'",
+                    "order": {"sample": {"seed": seed}},
+                    "limit": 10,
+                },
+            )
+        )
+        assert result["status"] == "ok"
+        assert result["applied"]["sample"] == {"seed": seed}
+        return [row["span_id"] for row in result["rows"]]
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        first = await draw(client, seed=11)
+        second = await draw(client, seed=11)
+        different = await draw(client, seed=12)
+    assert first == second
+    assert len(first) == 10
+    assert first != different
+
+
+async def test_response_budget_bounds_rows(mcp_app: Any, seeded: Any) -> None:
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["input.value", "output.value"],
+                    "limit": 200,
+                    "max_result_chars": 2_000,
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    assert 0 < len(result["rows"]) < result["row_count"]
+    assert "max_result_chars" in result["note"]
+    assert len(json.dumps(result["rows"])) < 4_000
+
+
+async def test_code_mode_catalog_includes_the_tools(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("phoenix.server.app.get_env_enable_mcp_server", lambda: True)
+    monkeypatch.setattr("phoenix.server.mcp_server.get_env_mcp_code_mode", lambda: True)
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        app = create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+        await stack.enter_async_context(LifespanManager(app))
+        async with _mcp_client(app) as client:
+            listing = (await client.call_tool("list_tools", {})).content[0].text
+            for name in ANALYTICS_TOOLS:
+                assert name in listing

--- a/tests/unit/server/test_mcp_span_analytics.py
+++ b/tests/unit/server/test_mcp_span_analytics.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import math
+import random
 import sys
 from collections import Counter
 from contextlib import AsyncExitStack
@@ -27,10 +28,16 @@ from asgi_lifespan import LifespanManager
 from sqlalchemy import text
 from sqlalchemy.dialects import postgresql, sqlite
 
+from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.server.app import create_app
 from phoenix.server.mcp_server import MCP_MOUNT_PATH
-from phoenix.server.mcp_span_analytics import build_span_analytics_tools, compiler, registry
+from phoenix.server.mcp_span_analytics import (
+    build_span_analytics_tools,
+    compiler,
+    discovery,
+    registry,
+)
 from phoenix.server.mcp_span_analytics.compiler import (
     AggregateQuery,
     Calculation,
@@ -414,7 +421,9 @@ class TestCompilerValidation:
             compiler.compile_aggregate(query, 1, SupportedSQLDialect.SQLITE)
         assert info.value.code == "field_not_aggregatable"
 
-    def test_observed_field_not_aggregatable(self) -> None:
+    def test_observed_field_not_value_aggregatable(self) -> None:
+        """Value aggregation on an observed field is rejected with the
+        presence/value distinction named; presence aggregations compile."""
         query = AggregateQuery(
             project="p",
             time_range=TimeRange(**FULL_WINDOW),
@@ -423,6 +432,19 @@ class TestCompilerValidation:
         with pytest.raises(QueryError) as info:
             compiler.compile_aggregate(query, 1, SupportedSQLDialect.SQLITE)
         assert info.value.code == "field_not_aggregatable"
+        assert "presence aggregations (count, count_distinct)" in info.value.message
+        assert "value aggregations" in info.value.message
+
+        presence = AggregateQuery(
+            project="p",
+            time_range=TimeRange(**FULL_WINDOW),
+            calculations=[
+                Calculation(name="tenants", fn="count_distinct", field="metadata.tenant"),
+                Calculation(name="with_tenant", fn="count", field="metadata.tenant"),
+            ],
+        )
+        plan = compiler.compile_aggregate(presence, 1, SupportedSQLDialect.SQLITE)
+        assert [c.name for c in plan.calculations] == ["tenants", "with_tenant"]
 
     def test_limit_clamped_not_rejected(self) -> None:
         query = RowQuery(project="p", time_range=TimeRange(**FULL_WINDOW), limit=100_000)
@@ -556,12 +578,18 @@ async def test_tools_gate_with_spans_group_and_advertise_contracts(mcp_app: Any)
             statuses = [arm["properties"]["status"].get("const") for arm in arms]
             assert "ok" in statuses and "error" in statuses
 
-        # The filter documentation teaches only what the surface accepts:
-        # annotation lookups are rejected, so they are not advertised.
+        # The filter documentation teaches exactly what the surface accepts,
+        # annotation predicates included: the two supported comparison forms,
+        # the top-level-AND-only placement, and the any-annotator semantics
+        # with their disclosure field.
         for name in ("aggregateSpans", "querySpanRows"):
             filter_description = tools[name].inputSchema["properties"]["filter"]["description"]
-            assert "evals[" not in filter_description
-            assert "annotations[" not in filter_description
+            assert "evals['<name>'].score" in filter_description
+            assert "evals['<name>'].label" in filter_description
+            assert "top-level AND" in filter_description
+            assert "any-annotator" in filter_description
+            assert "annotation_semantics" in filter_description
+            assert "rejected" in filter_description
             assert "llm.model_name" in filter_description
             assert "time_range" in filter_description
 
@@ -592,7 +620,10 @@ async def test_describe_spans_effective_catalog(mcp_app: Any, seeded: Any) -> No
     release = entries["metadata.release"]
     assert release["source"] == "observed_attribute"
     assert release["observed_types"] == ["string"]
+    # Observed fields carry the presence-aggregation capability (count,
+    # count_distinct never compute on values) but not value aggregation.
     assert "aggregate" not in release["capabilities"]
+    assert "count" in release["capabilities"]
     # The discovery sample is drawn across the project's whole id range, so
     # dimension values that stopped occurring (the pre-cut release) are
     # visible alongside current ones — a recency-only sample would hide
@@ -604,10 +635,11 @@ async def test_describe_spans_effective_catalog(mcp_app: Any, seeded: Any) -> No
     assert tenant["source"] == "observed_attribute"
     assert {v["value"] for v in tenant["top_values"]} <= set(seed_incident.TENANTS)
 
-    # cost.total: a declared reduction, select-and-aggregate only.
+    # cost.total: a declared reduction, select-and-aggregate only (plus the
+    # universal presence-aggregation capability).
     cost_entry = entries["cost.total"]
     assert cost_entry["unit"] == "USD"
-    assert set(cost_entry["capabilities"]) == {"select", "aggregate"}
+    assert set(cost_entry["capabilities"]) == {"select", "aggregate", "count"}
 
     # The message fields appear as authored convention entries in
     # list-index subscript spelling, select-only, and the message lists
@@ -615,7 +647,7 @@ async def test_describe_spans_effective_catalog(mcp_app: Any, seeded: Any) -> No
     # omitted from observed discovery).
     first_content = entries["llm.input_messages[0].message.content"]
     assert first_content["source"] == "openinference_convention"
-    assert first_content["capabilities"] == ["select"]
+    assert first_content["capabilities"] == ["select", "count"]
     assert not any(
         e["source"] == "observed_attribute" and "input_messages" in e["field"]
         for e in result["fields"]
@@ -692,6 +724,24 @@ async def test_discovery_round_trip(mcp_app: Any, seeded: Any) -> None:
                     )
                 )
                 assert grouped["status"] == "ok", (field_id, grouped)
+            if "count" in capabilities:
+                counted = _payload(
+                    await client.call_tool(
+                        "aggregateSpans",
+                        {
+                            "project": seed_incident.MAIN_PROJECT_NAME,
+                            "time_range": FULL_WINDOW,
+                            "calculations": [
+                                {
+                                    "name": "distinct_values",
+                                    "fn": "count_distinct",
+                                    "field": field_id,
+                                }
+                            ],
+                        },
+                    )
+                )
+                assert counted["status"] == "ok", (field_id, counted)
 
 
 async def test_aggregate_error_rate_by_release_matches_ground_truth(
@@ -885,7 +935,7 @@ async def test_cost_field_top10_matches_answer_key_and_nulls(mcp_app: Any, seede
         )
         (costless_row,) = costless["rows"]
         assert costless_row["cost.total"] is None
-        assert "column_notes" not in costless
+        assert "field_notes" not in costless
 
         # cost.total is select-and-aggregate only: a filter reference is
         # rejected instead of silently reading a nonexistent attribute.
@@ -1223,6 +1273,154 @@ async def test_cohort_links_time_buckets_and_null_keys(mcp_app: Any, seeded: Any
     assert "filter" not in null_params
 
 
+async def test_cohort_links_carry_the_query_filter(mcp_app: Any, seeded: Any) -> None:
+    """The deep link selects the row's cohort, not just its breakdown slice:
+    the query's own filter is conjoined with the breakdown equalities, so
+    re-running the link's condition reproduces the row's exact count — for a
+    filtered breakdown and for a filtered time-bucket breakdown (the bucket
+    narrows the window, never the condition)."""
+    from urllib.parse import parse_qs, urlparse
+
+    from phoenix.trace.dsl.filter import SpanFilter
+
+    filter_condition = "metadata['release'] == 'v42' and status_code == 'ERROR'"
+
+    async def requery(client: Any, condition: str, window: dict[str, str]) -> int:
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": window,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "filter": condition,
+                },
+            )
+        )
+        assert result["status"] == "ok", result
+        return cast(int, result["overall"]["spans_n"])
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        filtered = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "filter": filter_condition,
+                    "breakdowns": ["metadata.tenant"],
+                    "limit": 200,
+                },
+            )
+        )
+        assert filtered["status"] == "ok"
+        keyed_rows = [r for r in filtered["rows"] if r["metadata.tenant"] is not None]
+        assert keyed_rows
+        for row in keyed_rows:
+            params = parse_qs(urlparse(row["ui_url"]).query)
+            condition = params["filter"][0]
+            assert condition.startswith(f"({filter_condition}) and ")
+            SpanFilter(condition)  # the UI grammar accepts the composed condition
+            window = {"start": params["start"][0], "end": params["end"][0]}
+            assert await requery(client, condition, window) == row["spans_n"], row
+
+        # The null group key is skipped by declared necessity, but the query
+        # filter itself must survive into the link. Orphan spans carry no
+        # metadata, so this breakdown yields exactly the null group.
+        orphan_filter = f"name == '{seed_incident.ORPHAN_SPAN_NAME}'"
+        orphans = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "filter": orphan_filter,
+                    "breakdowns": ["metadata.tenant"],
+                },
+            )
+        )
+        assert orphans["status"] == "ok"
+        null_row = next(r for r in orphans["rows"] if r["metadata.tenant"] is None)
+        null_condition = parse_qs(urlparse(null_row["ui_url"]).query)["filter"][0]
+        assert null_condition == orphan_filter
+
+        bucketed = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "filter": "status_code == 'ERROR'",
+                    "breakdowns": [{"bucket": "hour"}, "metadata.tenant"],
+                    "limit": 200,
+                },
+            )
+        )
+        assert bucketed["status"] == "ok"
+        bucket_row = next(r for r in bucketed["rows"] if r["metadata.tenant"] is not None)
+        params = parse_qs(urlparse(bucket_row["ui_url"]).query)
+        start = datetime.fromisoformat(params["start"][0])
+        end = datetime.fromisoformat(params["end"][0])
+        assert end - start == timedelta(hours=1)  # the bucket narrowed the window
+        condition = params["filter"][0]
+        assert condition.startswith("(status_code == 'ERROR') and ")
+        assert "time_bucket" not in condition  # buckets scope time, not the condition
+        window = {"start": params["start"][0], "end": params["end"][0]}
+        assert await requery(client, condition, window) == bucket_row["spans_n"]
+
+
+async def test_presence_aggregations_on_observed_fields(mcp_app: Any, seeded_copilot: Any) -> None:
+    """count and count_distinct never compute on values, so they work on any
+    scalar field — 'how many distinct users' is one aggregate over the
+    observed user.id — while value aggregation on the same field stays
+    rejected with the presence/value distinction named."""
+    spans_with_user = [
+        span for span in seeded_copilot.spans if isinstance(span.attributes.get("user"), dict)
+    ]
+    expected_users = {span.attributes["user"]["id"] for span in spans_with_user}
+    expected_names = {span.name for span in seeded_copilot.spans}
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_support_copilot.PROJECT_NAME,
+                    "time_range": COPILOT_WINDOW,
+                    "calculations": [
+                        {"name": "distinct_users", "fn": "count_distinct", "field": "user.id"},
+                        {"name": "spans_with_user", "fn": "count", "field": "user.id"},
+                        {"name": "distinct_names", "fn": "count_distinct", "field": "name"},
+                    ],
+                },
+            )
+        )
+        assert result["status"] == "ok"
+        overall = result["overall"]
+        assert overall["distinct_users"] == len(expected_users)
+        assert overall["spans_with_user"] == len(spans_with_user)
+        assert overall["distinct_names"] == len(expected_names)
+
+        rejected = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_support_copilot.PROJECT_NAME,
+                    "time_range": COPILOT_WINDOW,
+                    "calculations": [{"name": "s", "fn": "sum", "field": "user.id"}],
+                },
+            )
+        )
+        assert rejected["status"] == "error"
+        assert rejected["code"] == "field_not_aggregatable"
+        assert "presence aggregations (count, count_distinct)" in rejected["message"]
+        assert "latency_ms" in rejected["suggestions"]
+
+
 async def test_message_fields_select_and_clip(mcp_app: Any, seeded: Any) -> None:
     """The first-two-input-message fields read the OpenInference message
     lists: correct role/content for messages 0 and 1, NULL second message on
@@ -1288,9 +1486,9 @@ async def test_message_fields_select_and_clip(mcp_app: Any, seeded: Any) -> None
 
 
 async def test_silent_null_projection_note(mcp_app: Any, seeded: Any) -> None:
-    """A selected observed path that is NULL on every returned row gets a
-    per-column note (it is indistinguishable from a misspelling); a sparse
-    path with some values present does not."""
+    """A selected observed path the discovery sample never saw gets a
+    per-field not_observed note (a misspelling is indistinguishable from a
+    real-but-absent path); a sparse path with some values present does not."""
     async with _mcp_client(mcp_app) as client:
         await _enable_spans(client)
         missing = _payload(
@@ -1306,8 +1504,10 @@ async def test_silent_null_projection_note(mcp_app: Any, seeded: Any) -> None:
         )
         assert missing["status"] == "ok"
         assert any(
-            note["column"] == "metadata.nonexistent_key" and "describeSpans" in note["note"]
-            for note in missing["column_notes"]
+            note["field"] == "metadata.nonexistent_key"
+            and note["code"] == "not_observed"
+            and "describeSpans" in note["note"]
+            for note in missing["field_notes"]
         )
 
         # A genuinely sparse path: orphan spans carry no metadata, ordinary
@@ -1331,7 +1531,205 @@ async def test_silent_null_projection_note(mcp_app: Any, seeded: Any) -> None:
         assert sparse["status"] == "ok"
         values = [row["metadata.tenant"] for row in sparse["rows"]]
         assert any(v is None for v in values) and any(v is not None for v in values)
-        assert "column_notes" not in sparse
+        assert "field_notes" not in sparse
+
+
+async def test_all_null_slice_of_observed_path_is_noted(mcp_app: Any, seeded: Any) -> None:
+    """A path the sample did observe but the returned slice never carries
+    draws an all_null note — in rows (every returned row NULL) and in
+    aggregates (only a null group key)."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        # Orphan spans carry no metadata at all, so this slice is all-NULL
+        # for a path that exists everywhere else in the project.
+        rows = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["metadata.tenant", "name"],
+                    "filter": f"name == '{seed_incident.ORPHAN_SPAN_NAME}'",
+                    "limit": 200,
+                },
+            )
+        )
+        assert rows["status"] == "ok"
+        assert rows["rows"] and all(r["metadata.tenant"] is None for r in rows["rows"])
+        (note,) = rows["field_notes"]
+        assert note["field"] == "metadata.tenant"
+        assert note["code"] == "all_null"
+        assert "observed" in note["note"]
+
+        grouped = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "filter": f"name == '{seed_incident.ORPHAN_SPAN_NAME}'",
+                    "breakdowns": ["metadata.tenant"],
+                },
+            )
+        )
+        assert grouped["status"] == "ok"
+        (row,) = grouped["rows"]
+        assert row["metadata.tenant"] is None
+        (grouped_note,) = grouped["field_notes"]
+        assert (grouped_note["field"], grouped_note["code"]) == ("metadata.tenant", "all_null")
+
+
+async def test_not_observed_breakdown_teaches_instead_of_silence(mcp_app: Any, seeded: Any) -> None:
+    """The misspelled-breakdown trap: a typo'd observed path still succeeds
+    (open admission — a path can be real but unsampled) but the response
+    carries a not_observed note with nearest observed-path suggestions,
+    instead of one silent null group presented as a complete answer."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "breakdowns": ["metadata.releas"],
+                },
+            )
+        )
+        assert result["status"] == "ok"
+        (row,) = result["rows"]
+        assert row["metadata.releas"] is None  # the silent null group, now disclosed
+        (note,) = result["field_notes"]
+        assert note["field"] == "metadata.releas"
+        assert note["code"] == "not_observed"
+        assert "describeSpans" in note["note"]
+        assert "metadata.release" in note["suggestions"]
+
+        # The same typo as a projection: one not_observed note, no duplicate
+        # all_null note for the same field.
+        projected = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["metadata.releas", "name"],
+                    "limit": 20,
+                },
+            )
+        )
+        assert projected["status"] == "ok"
+        typo_notes = [n for n in projected["field_notes"] if n["field"] == "metadata.releas"]
+        (projected_note,) = typo_notes
+        assert projected_note["code"] == "not_observed"
+        assert "metadata.release" in projected_note["suggestions"]
+
+        # A typo'd filter path draws the note too.
+        filtered = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "filter": "metadata['releas'] == 'v42'",
+                },
+            )
+        )
+        assert filtered["status"] == "ok"
+        assert any(
+            n["code"] == "not_observed" and "metadata.release" in n["suggestions"]
+            for n in filtered["field_notes"]
+        )
+
+
+async def test_validate_only_surfaces_not_observed_warnings(mcp_app: Any, seeded: Any) -> None:
+    """validate_only checks observed paths against the discovery sample and
+    returns structured warnings for unsampled ones — a warning, never an
+    error, because open admission stands."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "calculations": [{"name": "spans_n", "fn": "count"}],
+                    "breakdowns": ["metadata.releas"],
+                    "validate_only": True,
+                },
+            )
+        )
+        assert result["status"] == "ok" and result["valid"] is True
+        (warning,) = result["warnings"]
+        assert warning["field"] == "metadata.releas"
+        assert warning["code"] == "not_observed"
+        assert "metadata.release" in warning["suggestions"]
+
+
+async def test_real_but_unsampled_path_succeeds_with_note(
+    mcp_app: Any, seeded: Any, db: DbSessionFactory
+) -> None:
+    """Open admission is real: a path present in the data but absent from
+    the bounded discovery sample still returns its values — accompanied by
+    the not_observed note, which is sampled evidence, not proof of absence."""
+    async with db() as session:
+        span_ids = list(
+            (
+                await session.execute(
+                    sqlalchemy.select(models.Span.id)
+                    .join(
+                        models.Trace,
+                        models.Span.trace_rowid == models.Trace.id,
+                    )
+                    .join(
+                        models.Project,
+                        models.Trace.project_rowid == models.Project.id,
+                    )
+                    .where(models.Project.name == seed_incident.MAIN_PROJECT_NAME)
+                )
+            ).scalars()
+        )
+        # Replicate the seeded discovery draw exactly and plant the rare
+        # path on a span the draw provably skips.
+        id_range = range(min(span_ids), max(span_ids) + 1)
+        assert len(id_range) > discovery.SAMPLE_SIZE  # the draw actually samples
+        sampled = set(random.Random(discovery.SAMPLE_SEED).sample(id_range, discovery.SAMPLE_SIZE))
+        unsampled_rowid = next(i for i in span_ids if i not in sampled)
+        span = (
+            await session.execute(
+                sqlalchemy.select(models.Span).where(models.Span.id == unsampled_rowid)
+            )
+        ).scalar_one()
+        attributes = dict(span.attributes)
+        attributes.setdefault("metadata", {})
+        attributes["metadata"] = {**attributes["metadata"], "rare_flag": "on"}
+        span.attributes = attributes
+        planted_span_id = span.span_id
+        await session.commit()
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_incident.MAIN_PROJECT_NAME,
+                    "time_range": FULL_WINDOW,
+                    "fields": ["metadata.rare_flag"],
+                    "filter": f"span_id == '{planted_span_id}'",
+                },
+            )
+        )
+    assert result["status"] == "ok"
+    (row,) = result["rows"]
+    assert row["metadata.rare_flag"] == "on"  # the value comes back
+    assert any(
+        n["field"] == "metadata.rare_flag" and n["code"] == "not_observed"
+        for n in result["field_notes"]
+    )
 
 
 async def test_get_span_fields_match_row_values(mcp_app: Any, seeded: Any) -> None:
@@ -1564,6 +1962,27 @@ async def test_nearest_name_error_surfaces_through_the_client(mcp_app: Any, seed
     assert "latency_ms" in result["suggestions"]
 
 
+async def test_project_not_found_suggests_near_names(mcp_app: Any, seeded: Any) -> None:
+    """A near-miss project name gets nearest-name suggestions from the
+    project list — safe while every project is listable by every caller
+    (getProjects discloses the same names); under per-project authorization
+    the candidate list must first be filtered to the caller's visible set."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": "payment-agent",
+                    "time_range": FULL_WINDOW,
+                },
+            )
+        )
+    assert result["status"] == "error"
+    assert result["code"] == "project_not_found"
+    assert seed_incident.MAIN_PROJECT_NAME in result["suggestions"]
+
+
 async def test_malformed_order_shape_is_structured(mcp_app: Any, seeded: Any) -> None:
     """A wrong parameter shape must surface on the error union with a plain
     message and a usable path — never as raw validation text with internal
@@ -1680,6 +2099,11 @@ async def test_two_control_beat_clamping_and_admission(
         assert rejected["status"] == "error"
         assert rejected["code"] == "field_not_groupable"
         assert rejected["suggestions"]
+        # The suggestions include the project's own discovered dimensions —
+        # the breakdowns an agent actually reaches for — beside authored ids.
+        assert "metadata.tenant" in rejected["suggestions"]
+        assert "metadata.release" in rejected["suggestions"]
+        assert "Observed dimensions" in rejected["message"]
 
 
 async def test_filter_grammar_rejections_are_structured(mcp_app: Any, seeded: Any) -> None:

--- a/tests/unit/server/test_mcp_span_analytics.py
+++ b/tests/unit/server/test_mcp_span_analytics.py
@@ -36,6 +36,7 @@ from phoenix.server.mcp_span_analytics import (
     build_span_analytics_tools,
     compiler,
     discovery,
+    grains,
     registry,
 )
 from phoenix.server.mcp_span_analytics.compiler import (
@@ -74,6 +75,15 @@ seed_support_copilot: Any = importlib.util.module_from_spec(_copilot_spec)
 sys.modules["seed_support_copilot"] = seed_support_copilot
 _copilot_spec.loader.exec_module(seed_support_copilot)
 
+_QUALITY_PATH = (
+    Path(__file__).parents[3] / "scripts" / "span_analytics_seeds" / "seed_eval_quality.py"
+)
+_quality_spec = importlib.util.spec_from_file_location("seed_eval_quality", _QUALITY_PATH)
+assert _quality_spec is not None and _quality_spec.loader is not None
+seed_eval_quality: Any = importlib.util.module_from_spec(_quality_spec)
+sys.modules["seed_eval_quality"] = seed_eval_quality
+_quality_spec.loader.exec_module(seed_eval_quality)
+
 FIXED_NOW = datetime(2026, 7, 23, 12, 0, 0, tzinfo=timezone.utc)
 CUT = FIXED_NOW - timedelta(hours=seed_incident.RELEASE_CUT_HOURS_AGO)
 FULL_WINDOW = {
@@ -101,6 +111,33 @@ async def seeded(db: DbSessionFactory, incident: Any) -> Any:
     async with db() as session:
         await seed_incident.insert_incident(session, incident)
     return incident
+
+
+QUALITY_CUT = FIXED_NOW - timedelta(hours=seed_eval_quality.HOURS_PER_VERSION)
+QUALITY_WINDOW = {
+    "start": (FIXED_NOW - timedelta(hours=25)).isoformat(),
+    "end": (FIXED_NOW + timedelta(hours=1)).isoformat(),
+}
+PRE_CUT_QUALITY_WINDOW = {
+    "start": (FIXED_NOW - timedelta(hours=25)).isoformat(),
+    "end": QUALITY_CUT.isoformat(),
+}
+POST_CUT_QUALITY_WINDOW = {
+    "start": QUALITY_CUT.isoformat(),
+    "end": (FIXED_NOW + timedelta(hours=1)).isoformat(),
+}
+
+
+@pytest.fixture(scope="module")
+def quality() -> Any:
+    return seed_eval_quality.build_eval_quality(FIXED_NOW, seed_eval_quality.DEFAULT_SEED)
+
+
+@pytest.fixture
+async def seeded_quality(db: DbSessionFactory, quality: Any) -> Any:
+    async with db() as session:
+        await seed_eval_quality.insert_eval_quality(session, quality)
+    return quality
 
 
 @pytest.fixture(scope="module")
@@ -2210,20 +2247,37 @@ async def test_annotation_filter_end_to_end(mcp_app: Any, seeded: Any) -> None:
         )
         assert labeled["overall"]["n"] == len(incorrect_spans)
 
-        # Annotation values stay refused — with the decomposition route.
+        # Annotation values now resolve as declared reductions, under the
+        # filter grammar's own evals[...] spelling, and every response that
+        # uses one says which rule produced it.
         value_select = _payload(
             await client.call_tool(
                 "querySpanRows",
                 {
                     "project": seed_incident.MAIN_PROJECT_NAME,
                     "time_range": FULL_WINDOW,
-                    "fields": ["evals['correctness'].score"],
+                    "fields": ["span_id", "evals['correctness'].score"],
+                    "filter": "evals['correctness'].score < 0.5",
+                    "limit": 200,
                 },
             )
         )
-        assert value_select["status"] == "error"
-        assert value_select["code"] == "annotation_values_not_supported"
-        assert "listSpanAnnotationsBySpanIds" in value_select["message"]
+        assert value_select["status"] == "ok"
+        canonical = 'annotations["correctness"].score'
+        assert [column["id"] for column in value_select["columns"]] == ["span_id", canonical]
+        assert {row["span_id"] for row in value_select["rows"]} == low_spans
+        # Every returned value is the mean of that span's correctness scores.
+        by_span: dict[str, list[float]] = {}
+        for annotation in annotations:
+            if annotation.name == "correctness" and annotation.score is not None:
+                by_span.setdefault(annotation.span_id, []).append(annotation.score)
+        for row in value_select["rows"]:
+            scores = by_span[row["span_id"]]
+            assert row[canonical] == pytest.approx(sum(scores) / len(scores))
+        disclosure = value_select["annotation_reductions"]
+        assert disclosure[0]["field"] == canonical
+        assert disclosure[0]["reduction"] == "mean_over_annotators"
+        assert disclosure[0]["annotator_kind"] is None
 
         value_calc = _payload(
             await client.call_tool(
@@ -2241,8 +2295,21 @@ async def test_annotation_filter_end_to_end(mcp_app: Any, seeded: Any) -> None:
                 },
             )
         )
-        assert value_calc["status"] == "error"
-        assert value_calc["code"] == "annotation_values_not_supported"
+        assert value_calc["status"] == "ok"
+        span_means = [sum(scores) / len(scores) for scores in by_span.values()]
+        assert value_calc["overall"]["avg_score"] == pytest.approx(
+            sum(span_means) / len(span_means)
+        )
+        # The blended number never travels alone: the annotator composition
+        # behind it rides in the same response.
+        composition = value_calc["overall"]["annotation_composition"]["correctness"]
+        assert composition == {
+            kind: sum(
+                1 for a in annotations if a.name == "correctness" and a.annotator_kind == kind
+            )
+            for kind in ("LLM", "HUMAN")
+            if any(a.name == "correctness" and a.annotator_kind == kind for a in annotations)
+        }
 
 
 async def test_sample_order_is_deterministic_per_seed(mcp_app: Any, seeded: Any) -> None:
@@ -2314,3 +2381,530 @@ async def test_code_mode_catalog_includes_the_tools(
             listing = (await client.call_tool("list_tools", {})).content[0].text
             for name in ANALYTICS_TOOLS:
                 assert name in listing
+
+
+# ---------------------------------------------------------------------------
+# The annotations grain and annotation enrichment
+# ---------------------------------------------------------------------------
+
+
+def _quality_truth(quality: Any) -> dict[str, dict[str, Any]]:
+    return cast("dict[str, dict[str, Any]]", seed_eval_quality.correctness_ground_truth(quality))
+
+
+def _span_reduced_by_kind(quality: Any, version: str, kind: str) -> float:
+    """Mean over spans of each span's mean score from one annotator kind.
+
+    The spans grain reduces per span before averaging, so a kind-restricted
+    reduction is not the same number as that kind's annotation-weighted
+    mean whenever one span carries two annotators of the same kind — which
+    the disagreement span does, deliberately.
+    """
+    version_by_trace = {t.trace_id: t.prompt_version for t in quality.main.traces}
+    trace_by_span = {s.span_id: s.trace_id for s in quality.main.spans}
+    per_span: dict[str, list[float]] = {}
+    for annotation in quality.main.annotations:
+        if annotation.target != "span" or annotation.name != seed_eval_quality.ANNOTATION_NAME:
+            continue
+        if annotation.score is None or annotation.annotator_kind != kind:
+            continue
+        if version_by_trace[trace_by_span[annotation.target_key]] != version:
+            continue
+        per_span.setdefault(annotation.target_key, []).append(annotation.score)
+    means = [sum(scores) / len(scores) for scores in per_span.values()]
+    return sum(means) / len(means)
+
+
+class TestAnnotationsGrainCompilation:
+    @pytest.mark.parametrize("sql_dialect", [sqlite.dialect(), postgresql.dialect()])  # type: ignore[no-untyped-call]
+    def test_every_grain_field_compiles(self, sql_dialect: Any) -> None:
+        supported = SupportedSQLDialect(sql_dialect.name)
+        for field in grains.ANNOTATIONS_GRAIN.fields:
+            compiled = str(sqlalchemy.select(field.expr(supported)).compile(dialect=sql_dialect))
+            assert compiled
+
+    @pytest.mark.parametrize("sql_dialect", [sqlite.dialect(), postgresql.dialect()])  # type: ignore[no-untyped-call]
+    def test_enrichment_expressions_compile(self, sql_dialect: Any) -> None:
+        supported = SupportedSQLDialect(sql_dialect.name)
+        for attribute in registry.ANNOTATION_ATTRIBUTES:
+            for kind in (None, "HUMAN"):
+                field = registry.annotation_enrichment_field(
+                    registry.AnnotationRef(
+                        name="correctness", annotator_kind=kind, attribute=attribute
+                    )
+                )
+                assert str(sqlalchemy.select(field.expr(supported)).compile(dialect=sql_dialect))
+
+    def test_enrichment_identifiers_round_trip(self) -> None:
+        for identifier, expected in (
+            ('annotations["correctness"].score', (None, "score")),
+            ('annotations["correctness", "HUMAN"].score', ("HUMAN", "score")),
+            ("evals['correctness'].label", (None, "label")),
+            ('annotations["correctness"].count', (None, "count")),
+        ):
+            reference = registry.parse_annotation_field(identifier)
+            assert reference is not None
+            assert (reference.annotator_kind, reference.attribute) == expected
+            assert reference.name == "correctness"
+        # Both spellings canonicalize onto one id, so a result column never
+        # depends on which head the caller wrote.
+        eval_spelling = registry.parse_annotation_field("evals['correctness'].score")
+        annotation_spelling = registry.parse_annotation_field('annotations["correctness"].score')
+        assert eval_spelling is not None and annotation_spelling is not None
+        assert eval_spelling.id == annotation_spelling.id
+        assert registry.parse_annotation_field("metadata.release") is None
+
+
+async def test_annotations_grain_returns_every_target(mcp_app: Any, seeded_quality: Any) -> None:
+    """One row per annotation, unioned across the targets Phoenix annotates."""
+    expected = Counter(a.target for a in seeded_quality.main.annotations)
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        counted = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "from": "annotations",
+                    "time_range": QUALITY_WINDOW,
+                    "calculations": [{"name": "rows", "fn": "count"}],
+                    "breakdowns": ["target"],
+                },
+            )
+        )
+        assert counted["status"] == "ok"
+        assert {row["target"]: row["rows"] for row in counted["rows"]} == dict(expected)
+
+        rows = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "from": "annotations",
+                    "time_range": QUALITY_WINDOW,
+                    "filter": "target == 'document'",
+                    "fields": ["target", "target_id", "name", "score", "document_position"],
+                    "order": [{"field": "target_id", "direction": "asc"}],
+                    "limit": 50,
+                },
+            )
+        )
+        assert rows["status"] == "ok"
+        # Identity is added implicitly, and the document arm carries the
+        # position that distinguishes two annotations of one span.
+        assert rows["columns"][0]["id"] == "annotation_id"
+        assert all(row["annotation_id"].startswith("document:") for row in rows["rows"])
+        assert {row["document_position"] for row in rows["rows"]} == {0, 1}
+        assert rows["row_count"] == expected["document"]
+
+
+async def test_annotation_mix_shift_is_visible_on_both_grains(
+    mcp_app: Any, seeded_quality: Any
+) -> None:
+    """The demo's showpiece: a blended average that moved because the
+    annotator mix moved, decomposed per annotator kind on the annotations
+    grain and disclosed by composition metadata on the spans grain."""
+    truth = _quality_truth(seeded_quality)
+    old, new = seed_eval_quality.OLD_VERSION, seed_eval_quality.NEW_VERSION
+
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+
+        async def annotation_grain(window: dict[str, str]) -> dict[str, Any]:
+            return _payload(
+                await client.call_tool(
+                    "aggregateSpans",
+                    {
+                        "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                        "from": "annotations",
+                        "time_range": window,
+                        "filter": "name == 'correctness'",
+                        "calculations": [
+                            {"name": "mean_score", "fn": "avg", "field": "score"},
+                            {"name": "n", "fn": "count", "field": "score"},
+                        ],
+                        "breakdowns": ["annotator_kind"],
+                    },
+                )
+            )
+
+        before = await annotation_grain(PRE_CUT_QUALITY_WINDOW)
+        after = await annotation_grain(POST_CUT_QUALITY_WINDOW)
+        assert before["status"] == "ok" and after["status"] == "ok"
+
+        # The blended number: what an average over annotation rows says.
+        assert before["overall"]["mean_score"] == pytest.approx(truth[old]["annotation_weighted"])
+        assert after["overall"]["mean_score"] == pytest.approx(truth[new]["annotation_weighted"])
+        blended_drop = (truth[old]["annotation_weighted"] - truth[new]["annotation_weighted"]) * 100
+
+        # The decomposed truth: per annotator kind, the drop is far smaller,
+        # and the counts show the mix that produced the difference.
+        for payload, version in ((before, old), (after, new)):
+            by_kind = {row["annotator_kind"]: row for row in payload["rows"]}
+            for kind, expected_mean in truth[version]["by_kind"].items():
+                assert by_kind[kind]["mean_score"] == pytest.approx(expected_mean)
+                assert by_kind[kind]["n"] == truth[version]["counts_by_kind"][kind]
+        per_kind_drops = [
+            (truth[old]["by_kind"][kind] - truth[new]["by_kind"][kind]) * 100
+            for kind in truth[old]["by_kind"]
+        ]
+        assert blended_drop > 2 * max(per_kind_drops)
+
+        # The spans grain reduces per span first, so it answers a third
+        # question — and it reports the reduction and the mix behind it.
+        reduced = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "time_range": QUALITY_WINDOW,
+                    "calculations": [
+                        {
+                            "name": "correctness",
+                            "fn": "avg",
+                            "field": 'annotations["correctness"].score',
+                        }
+                    ],
+                    "breakdowns": ["metadata.prompt_version"],
+                },
+            )
+        )
+        assert reduced["status"] == "ok"
+        by_version = {row["metadata.prompt_version"]: row for row in reduced["rows"]}
+        for version in (old, new):
+            assert by_version[version]["correctness"] == pytest.approx(
+                truth[version]["span_reduced"]
+            )
+            assert (
+                by_version[version]["annotation_composition"]["correctness"]
+                == truth[version]["counts_by_kind"]
+            )
+        disclosure = reduced["annotation_reductions"]
+        assert [entry["reduction"] for entry in disclosure] == ["mean_over_annotators"]
+        assert disclosure[0]["annotator_kind"] is None
+        assert "composition" in reduced["note"]
+
+
+async def test_kind_restricted_reduction_carries_no_composition(
+    mcp_app: Any, seeded_quality: Any
+) -> None:
+    """Restricting the reduction to one annotator kind removes the mix, so
+    the disclosure that exists to expose a mix is not attached."""
+    old, new = seed_eval_quality.OLD_VERSION, seed_eval_quality.NEW_VERSION
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "time_range": QUALITY_WINDOW,
+                    "calculations": [
+                        {
+                            "name": "human_only",
+                            "fn": "avg",
+                            "field": 'annotations["correctness", "HUMAN"].score',
+                        }
+                    ],
+                    "breakdowns": ["metadata.prompt_version"],
+                },
+            )
+        )
+        assert result["status"] == "ok"
+        by_version = {row["metadata.prompt_version"]: row for row in result["rows"]}
+        for version in (old, new):
+            assert by_version[version]["human_only"] == pytest.approx(
+                _span_reduced_by_kind(seeded_quality, version, "HUMAN")
+            )
+            assert "annotation_composition" not in by_version[version]
+        assert result["annotation_reductions"][0]["annotator_kind"] == "HUMAN"
+
+
+async def test_label_only_annotations_read_null_not_zero(mcp_app: Any, seeded_quality: Any) -> None:
+    """An annotation name that carries labels and no scores averages to
+    NULL on both backends, and its rows remain countable."""
+    tone_rows = [
+        a
+        for a in seeded_quality.main.annotations
+        if a.name == seed_eval_quality.TONE_ANNOTATION_NAME
+    ]
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        result = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "from": "annotations",
+                    "time_range": QUALITY_WINDOW,
+                    "filter": f"name == '{seed_eval_quality.TONE_ANNOTATION_NAME}'",
+                    "calculations": [
+                        {"name": "rows", "fn": "count"},
+                        {"name": "scored", "fn": "count", "field": "score"},
+                        {"name": "mean_score", "fn": "avg", "field": "score"},
+                    ],
+                    "breakdowns": ["label"],
+                },
+            )
+        )
+        assert result["status"] == "ok"
+        assert result["overall"]["rows"] == len(tone_rows)
+        assert result["overall"]["scored"] == 0
+        assert result["overall"]["mean_score"] is None
+        assert {row["label"] for row in result["rows"]} == {a.label for a in tone_rows}
+
+
+async def test_annotations_grain_is_project_isolated(mcp_app: Any, seeded_quality: Any) -> None:
+    """The decoy project's annotations share the name and differ in value;
+    neither grain may leak them."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        rows = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "from": "annotations",
+                    "time_range": QUALITY_WINDOW,
+                    "filter": "identifier == 'decoy-judge'",
+                    "limit": 10,
+                },
+            )
+        )
+        assert rows["status"] == "ok"
+        assert rows["rows"] == []
+        assert rows["guidance"]["cause"] == "no_matches"
+
+        counted = _payload(
+            await client.call_tool(
+                "aggregateSpans",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "from": "annotations",
+                    "time_range": QUALITY_WINDOW,
+                    "calculations": [{"name": "rows", "fn": "count"}],
+                },
+            )
+        )
+        assert counted["overall"]["rows"] == len(seeded_quality.main.annotations)
+
+
+async def test_annotation_grain_rejections_teach_the_namespace(
+    mcp_app: Any, seeded_quality: Any
+) -> None:
+    """Each rejection names the legal alternative rather than the failure."""
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+
+        async def rows(**overrides: Any) -> dict[str, Any]:
+            request = {
+                "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                "from": "annotations",
+                "time_range": QUALITY_WINDOW,
+                "limit": 5,
+            }
+            request.update(overrides)
+            return _payload(await client.call_tool("querySpanRows", request))
+
+        # A spans-grain field asked for on the annotations grain names the
+        # grain that has it instead of reporting nonexistence.
+        wrong_grain = await rows(fields=["latency_ms"])
+        assert wrong_grain["code"] == "field_not_on_grain"
+        assert "spans" in wrong_grain["message"]
+
+        # Temporal predicates keep one home on every grain.
+        temporal = await rows(filter="created_at > '2026-01-01'")
+        assert temporal["code"] == "temporal_filter"
+        assert "time_range" in temporal["suggestions"]
+
+        # A type mismatch is refused before the database sees it, where the
+        # two backends would disagree about what to do with it.
+        mistyped = await rows(filter="score == 'high'")
+        assert mistyped["code"] == "invalid_filter"
+        assert "number" in mistyped["message"]
+
+        # The filter grammar admits comparisons, not calls.
+        called = await rows(filter="len(label) > 2")
+        assert called["code"] == "invalid_filter"
+
+        # Sampling is published as absent on this grain, with the route.
+        sampled = await rows(order={"sample": {"seed": 3}})
+        assert sampled["code"] == "sample_not_supported"
+        assert "start_time" in sampled["suggestions"][0]
+
+        # An unknown grain lists what the grains are, not just their names.
+        unknown = await rows(**{"from": "annotation"})
+        assert unknown["code"] == "unknown_grain"
+        assert "annotations" in unknown["suggestions"]
+
+        # Enrichment belongs to the grain where the span is the subject.
+        enrichment = await rows(fields=['annotations["correctness"].score'])
+        assert enrichment["code"] == "field_not_on_grain"
+        assert "score" in enrichment["suggestions"]
+
+
+async def test_enrichment_rejections_name_the_legal_values(
+    mcp_app: Any, seeded_quality: Any
+) -> None:
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+
+        async def rows(fields: list[str]) -> dict[str, Any]:
+            return _payload(
+                await client.call_tool(
+                    "querySpanRows",
+                    {
+                        "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                        "time_range": QUALITY_WINDOW,
+                        "fields": fields,
+                        "limit": 5,
+                    },
+                )
+            )
+
+        bad_attribute = await rows(['annotations["correctness"].value'])
+        assert bad_attribute["code"] == "unknown_annotation_attribute"
+        assert 'annotations["correctness"].score' in bad_attribute["suggestions"]
+
+        bad_kind = await rows(['annotations["correctness", "human"].score'])
+        assert bad_kind["code"] == "unknown_annotator_kind"
+        assert 'annotations["correctness", "HUMAN"].score' in bad_kind["suggestions"]
+
+
+async def test_count_and_label_reductions_are_declared(mcp_app: Any, seeded_quality: Any) -> None:
+    """The non-numeric reductions: cardinality, and recency for labels."""
+    disputed = next(
+        a.target_key for a in seeded_quality.main.annotations if a.identifier == "human-reviewer-b"
+    )
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        rows = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "time_range": QUALITY_WINDOW,
+                    "fields": [
+                        "span_id",
+                        'annotations["correctness"].count',
+                        'annotations["correctness"].label',
+                    ],
+                    "filter": f"span_id == '{disputed}'",
+                    "limit": 5,
+                },
+            )
+        )
+        assert rows["status"] == "ok"
+        row = rows["rows"][0]
+        expected_count = sum(
+            1
+            for a in seeded_quality.main.annotations
+            if a.target_key == disputed and a.name == seed_eval_quality.ANNOTATION_NAME
+        )
+        assert row['annotations["correctness"].count'] == expected_count
+        # Recency is the declared rule; the most recently written row of the
+        # three wins, ties broken by annotation id.
+        assert row['annotations["correctness"].label'] == "correct"
+        reductions = {entry["field"]: entry["reduction"] for entry in rows["annotation_reductions"]}
+        assert reductions == {
+            'annotations["correctness"].count': "cardinality",
+            'annotations["correctness"].label': "latest_by_updated_at",
+        }
+
+
+async def test_describe_spans_publishes_grains_and_annotation_names(
+    mcp_app: Any, seeded_quality: Any
+) -> None:
+    """Annotation names are project data, so discovery enumerates them —
+    with the composition that decides whether a blended value is safe."""
+    expected_names = Counter(a.name for a in seeded_quality.main.annotations)
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        described = _payload(
+            await client.call_tool(
+                "describeSpans", {"project": seed_eval_quality.MAIN_PROJECT_NAME}
+            )
+        )
+        assert described["status"] == "ok"
+
+        names = {entry["name"]: entry for entry in described["annotations"]["names"]}
+        assert set(names) == set(expected_names)
+        for name, count in expected_names.items():
+            assert names[name]["count"] == count
+        correctness = names[seed_eval_quality.ANNOTATION_NAME]
+        assert correctness["annotator_kinds"]["LLM"] > correctness["annotator_kinds"]["HUMAN"]
+        assert correctness["targets"] == {"span": correctness["count"]}
+        tone = names[seed_eval_quality.TONE_ANNOTATION_NAME]
+        assert tone["scored"] == 0
+
+        # Every advertised enrichment id is usable verbatim.
+        enrichment = {
+            entry["field"]: entry
+            for entry in described["fields"]
+            if entry["source"] == "annotation_enrichment"
+        }
+        assert 'annotations["correctness"].score' in enrichment
+        assert enrichment['annotations["correctness"].score']["reduction"] == (
+            "mean_over_annotators"
+        )
+        assert "aggregate" in enrichment['annotations["correctness"].score']["capabilities"]
+        assert "filter" not in enrichment['annotations["correctness"].score']["capabilities"]
+
+        published = {entry["grain"]: entry for entry in described["grains"]}
+        assert set(published) == {"spans", "annotations"}
+        assert published["annotations"]["identity_field"] == "annotation_id"
+        assert published["annotations"]["supports_sampling"] is False
+        annotation_fields = {f["field"] for f in published["annotations"]["fields"]}
+        assert {"score", "annotator_kind", "target", "explanation"} <= annotation_fields
+        assert published["spans"]["fields"] is None
+
+
+async def test_get_span_recovers_clipped_annotation_explanations(
+    mcp_app: Any, seeded_quality: Any
+) -> None:
+    """A clipped explanation on the annotations grain has a named recovery
+    path, and following it returns the whole text."""
+    long_annotation = max(
+        (a for a in seeded_quality.main.annotations if a.explanation),
+        key=lambda a: len(a.explanation),
+    )
+    async with _mcp_client(mcp_app) as client:
+        await _enable_spans(client)
+        rows = _payload(
+            await client.call_tool(
+                "querySpanRows",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "from": "annotations",
+                    "time_range": QUALITY_WINDOW,
+                    "fields": ["target", "target_id", "identifier", "explanation"],
+                    "filter": f"identifier == '{long_annotation.identifier}'",
+                    "max_cell_chars": 200,
+                    "limit": 5,
+                },
+            )
+        )
+        assert rows["status"] == "ok"
+        row = rows["rows"][0]
+        assert "clipped" in row["explanation"]
+        assert rows["clipped"][0]["field"] == "explanation"
+        assert rows["clipped"][0]["row"] == row["annotation_id"]
+        assert "getSpan" in rows["note"]
+
+        recovered = _payload(
+            await client.call_tool(
+                "getSpan",
+                {
+                    "project": seed_eval_quality.MAIN_PROJECT_NAME,
+                    "span_id": row["target_id"],
+                },
+            )
+        )
+        assert recovered["status"] == "ok"
+        annotations = {a["identifier"]: a for a in recovered["span"]["annotations"]}
+        assert annotations[long_annotation.identifier]["explanation"] == (
+            long_annotation.explanation
+        )
+        # The drill-down carries every annotator of the disputed span, which
+        # is what makes the disagreement legible at the end of the loop.
+        assert len(annotations) >= 3


### PR DESCRIPTION
## Summary

An agent-facing analytical query surface for spans, served over the Phoenix MCP server: five tools backed by a semantic field registry and a dual-dialect compiler.

- **`describeSpans`** — an effective catalog merging authored fields (physical columns, computed scalars, OpenInference-convention attributes imported from `openinference-semconv` constants) with attribute paths observed in an id-spread sample of the project's data, each entry carrying type, capabilities, provenance, and top values; every returned identifier works verbatim in the query tools.
- **`aggregateSpans`** — named calculations (`count`, `count_distinct`, `sum`, `avg`, `min`, `max`, p50–p99) over breakdowns and hourly time buckets, bounded top-K with group totals, overall row, share-of-total, and per-group UI deep links.
- **`querySpanRows`** — deterministic ordered rows or a seeded random sample, with cell clipping and a per-row recovery path.
- **`getSpan` / `getTrace`** — full-fidelity drill-down (attributes, exception events, UI link), echoing flat registry field values so survey and drill-down share one naming scheme.

Design decisions of note: project scoping compiled into every statement (behaviorally tested with a decoy project); wrongly-typed JSON values read as NULL on both backends via type-guarded casts instead of aborting (Postgres) or silently zeroing (SQLite); annotation predicates in filters compile as EXISTS — safe under annotator multiplicity — with the any-annotator semantics disclosed in the response; structured error envelopes with nearest-name suggestions; cost as a declared sum-reduction field; percentiles via `percentile_cont` on Postgres and sqlean `stats` on SQLite (interpolation verified equivalent).

Also included: deterministic dual-backend seed scripts and a participant runbook under `scripts/span_analytics_seeds/`, and frontend support for opening the project spans table from URL `filter`/`start`/`end` params (write-back included) so server-composed cohort links open pre-filtered views.

## Testing

- `tests/unit/server/test_mcp_span_analytics.py`: 65 passing under `--db sqlite`, 66 under `--db postgresql` (includes behavioral project-isolation, guarded-cast, differential percentile, and round-trip discovery tests).
- Playwright deep-link spec authored (`app/tests/span-deep-link.spec.ts`); its final e2e run was interrupted — treat as pending a green run.
- A follow-up commit series is in progress on this branch (module split of `tools.py`, observed-path admission notes, presence aggregations on observed fields, cohort-link completeness).