### PR TITLE
fix(pxi): report current context token usage

### DIFF
--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -65,7 +65,7 @@ from pydantic_ai.ui.vercel_ai.response_types import (
     ToolInputAvailableChunk,
     ToolOutputAvailableChunk,
 )
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RequestUsage
 from sqlalchemy import Insert, exists, func, select
 from sqlalchemy.dialects.postgresql import insert as insert_postgresql
 from sqlalchemy.dialects.sqlite import insert as insert_sqlite
@@ -471,7 +471,7 @@ def _build_message_metadata_chunk(
     span_context: SpanContext | None,
     turn_trace_context: TurnTraceContext | None,
     session_id: str,
-    usage: RunUsage,
+    usage: RequestUsage,
 ) -> MessageMetadataChunk:
     """Build the `MessageMetadataChunk` emitted at the end of an agent turn."""
     trace_ids = (
@@ -499,9 +499,8 @@ def _build_message_metadata_chunk(
     )
 
 
-def _build_usage_payload(usage: RunUsage) -> AssistantMessageMetadataUsage:
-    """Convert a run's token usage into the metadata payload, including cache
-    read/write details only when the run actually used the prompt cache."""
+def _build_usage_payload(usage: RequestUsage) -> AssistantMessageMetadataUsage:
+    """Convert the final model request's usage into the current context size."""
     usage_payload = AssistantMessageMetadataUsage(
         tokens=AssistantMessageMetadataUsageTokens(
             prompt=usage.input_tokens,
@@ -515,6 +514,11 @@ def _build_usage_payload(usage: RunUsage) -> AssistantMessageMetadataUsage:
             cache_write=usage.cache_write_tokens,
         )
     return usage_payload
+
+
+def _get_current_context_usage(result: AgentRunResult[Any]) -> RequestUsage:
+    """Return the tokens retained after the run's final model response."""
+    return result.response.usage
 
 
 def _get_span_context(context: Context | None) -> SpanContext | None:
@@ -1249,7 +1253,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                 span_context=agent_span_recorder.span_context if agent_span_recorder else None,
                 turn_trace_context=None,
                 session_id=session_id,
-                usage=result.usage,
+                usage=_get_current_context_usage(result),
             )
 
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
@@ -1498,7 +1502,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
                     else None
                 ),
                 session_id=session_id,
-                usage=result.usage,
+                usage=_get_current_context_usage(result),
             )
 
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -2,8 +2,8 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
-from pydantic_ai import RunUsage
 from pydantic_ai.ui.vercel_ai.request_types import UIMessage
+from pydantic_ai.usage import RequestUsage
 from sqlalchemy import func, select
 from sqlalchemy.exc import SAWarning
 
@@ -31,7 +31,7 @@ def test_message_metadata_can_use_propagated_root_span_context() -> None:
         span_context=_get_span_context(parent_context),
         turn_trace_context=None,
         session_id="session-1",
-        usage=RunUsage(input_tokens=1, output_tokens=2),
+        usage=RequestUsage(input_tokens=1, output_tokens=2),
     )
 
     metadata = metadata_chunk.message_metadata
@@ -58,7 +58,7 @@ def test_turn_trace_context_is_clamped_and_used_for_metadata() -> None:
         span_context=None,
         turn_trace_context=turn_trace_context,
         session_id="session-1",
-        usage=RunUsage(),
+        usage=RequestUsage(),
     ).message_metadata
     assert metadata is not None
     assert metadata.turn_trace_context == turn_trace_context

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from jinja2 import Template
 from opentelemetry.trace import (
@@ -14,7 +14,7 @@ from opentelemetry.trace import (
     format_trace_id,
 )
 from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, ToolOutputAvailableChunk
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RequestUsage
 from sqlalchemy import func, select
 
 from phoenix.db import models
@@ -27,6 +27,7 @@ from phoenix.server.agents.types import (
 from phoenix.server.api.routers.agents import (
     TurnTraceContext,
     _build_message_metadata_chunk,
+    _get_current_context_usage,
     _interleave_agent_and_subagent_message_chunks,
     _load_phoenix_user_email,
     _load_sandbox_availability,
@@ -158,7 +159,7 @@ class TestBuildMessageMetadataChunk:
             span_context=None,
             turn_trace_context=None,
             session_id="session-1",
-            usage=RunUsage(),
+            usage=RequestUsage(),
         )
         assert chunk.message_metadata.trace is None
 
@@ -172,7 +173,7 @@ class TestBuildMessageMetadataChunk:
             span_context=self._span_context(),
             turn_trace_context=turn_trace_context,
             session_id="session-1",
-            usage=RunUsage(),
+            usage=RequestUsage(),
         )
         assert chunk.message_metadata.trace is not None
         assert chunk.message_metadata.trace.trace_id == turn_trace_context.trace_id
@@ -184,11 +185,42 @@ class TestBuildMessageMetadataChunk:
             span_context=span_context,
             turn_trace_context=None,
             session_id="session-1",
-            usage=RunUsage(),
+            usage=RequestUsage(),
         )
         assert chunk.message_metadata.trace is not None
         assert chunk.message_metadata.trace.trace_id == format_trace_id(span_context.trace_id)
         assert chunk.message_metadata.trace.root_span_id == format_span_id(span_context.span_id)
+
+    def test_reports_the_final_request_as_the_current_context_size(self) -> None:
+        chunk = _build_message_metadata_chunk(
+            span_context=None,
+            turn_trace_context=None,
+            session_id="session-1",
+            usage=RequestUsage(
+                input_tokens=100,
+                output_tokens=20,
+                cache_read_tokens=60,
+                cache_write_tokens=10,
+            ),
+        )
+
+        usage = chunk.message_metadata.usage
+        assert usage is not None
+        assert usage.tokens.prompt == 100
+        assert usage.tokens.completion == 20
+        assert usage.tokens.total == 120
+        assert usage.prompt_details is not None
+        assert usage.prompt_details.cache_read == 60
+        assert usage.prompt_details.cache_write == 10
+
+    def test_uses_final_request_usage_instead_of_cumulative_run_usage(self) -> None:
+        final_request_usage = RequestUsage(input_tokens=100, output_tokens=20)
+        result = MagicMock()
+        result.response.usage = final_request_usage
+        result.usage.input_tokens = 250
+        result.usage.output_tokens = 40
+
+        assert _get_current_context_usage(result) is final_request_usage
 
 
 class TestLoadSandboxAvailability:


### PR DESCRIPTION
## Summary

- report the final model request usage in PXI assistant-message metadata instead of cumulative run usage
- make the chat token counter represent the context carried into the next request
- preserve final-request cache read and cache write details
- leave trace-level cumulative usage and cost accounting unchanged

## Testing

- `uv run pytest tests/unit/server/api/routers/test_agents.py tests/unit/server/agents/test_agents_router.py -q`
- `uv run ruff check src/phoenix/server/api/routers/agents.py tests/unit/server/api/routers/test_agents.py tests/unit/server/agents/test_agents_router.py`
- `uv run ruff format --check src/phoenix/server/api/routers/agents.py tests/unit/server/api/routers/test_agents.py tests/unit/server/agents/test_agents_router.py`
- `make typecheck-python`