### PR TITLE
fix(js): drain all workers in resumeExperiment/resumeEvaluation

### DIFF
--- a/js/.changeset/resume-drain-workers.md
+++ b/js/.changeset/resume-drain-workers.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Fix `resumeExperiment` and `resumeEvaluation` leaking detached workers on the first error. Both used `Promise.all([producer, ...workers])`, which rejects the instant one worker throws (e.g. under `stopOnFirstError`) while the remaining concurrent workers and the producer keep running — hitting the API and logging after the function has already returned or thrown. They now drain every task with `Promise.allSettled` and classify rejections by priority, so no background work outlives the call. This also fixes intermittent CI teardown errors (`Closing rpc while "onUserConsoleLog" was pending`) caused by that late console output.

--- a/js/packages/phoenix-client/src/experiments/resumeEvaluation.ts
+++ b/js/packages/phoenix-client/src/experiments/resumeEvaluation.ts
@@ -522,7 +522,7 @@ export async function resumeEvaluation({
     }
 
     // Start concurrent execution
-    // Wrap in try-finally to ensure channel is always closed, even if Promise.all throws
+    // Wrap in try-finally to ensure channel is always closed, even if a task throws
     let executionError: Error | null = null;
     try {
       const producerTask = fetchIncompleteEvaluations();
@@ -530,31 +530,61 @@ export async function resumeEvaluation({
         processEvaluationsFromChannel()
       );
 
-      // Wait for producer and all workers to finish
-      await Promise.all([producerTask, ...workerTasks]);
-    } catch (error) {
-      // Classify and handle errors based on their nature
-      const err = error instanceof Error ? error : new Error(String(error));
+      // Wait for the producer AND every worker to settle before continuing.
+      // Using allSettled (rather than Promise.all) is important: on the first
+      // worker error, Promise.all rejects immediately while the remaining
+      // workers keep running detached, logging and hitting the API after this
+      // function has already returned/thrown. Draining all tasks guarantees no
+      // background work outlives the call (and avoids teardown races in tests
+      // where late console output is flushed after the test completes).
+      const settled = await Promise.allSettled([producerTask, ...workerTasks]);
+      const rejections = settled
+        .filter(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected"
+        )
+        .map((result) => result.reason);
 
-      // Always surface producer/infrastructure errors
-      if (error instanceof EvaluationFetchError) {
-        // Producer failed - this is ALWAYS critical regardless of stopOnFirstError
-        logger.error(`Critical: Failed to fetch evaluations from server`);
-        executionError = err;
-      } else if (error instanceof ChannelError && signal.aborted) {
-        // Channel closed due to intentional abort - wrap in semantic error
-        executionError = new EvaluationAbortedError(
-          "Evaluation stopped due to error in concurrent evaluator",
-          err
+      if (rejections.length > 0) {
+        // Classify and handle errors based on their nature. When multiple tasks
+        // reject, prefer the most meaningful error over incidental fallout
+        // (e.g. a ChannelError raised in a blocked worker when the channel
+        // closes on abort).
+        const fetchError = rejections.find(
+          (reason) => reason instanceof EvaluationFetchError
         );
-      } else if (stopOnFirstError) {
-        // Worker error in stopOnFirstError mode - already logged by worker
-        executionError = err;
-      } else {
-        // Unexpected error (not from worker, not from producer fetch)
-        // This could be a bug in our code or infrastructure failure
-        logger.error(`Unexpected error during evaluation: ${err.message}`);
-        executionError = err;
+        const workerError = rejections.find(
+          (reason) =>
+            reason instanceof Error &&
+            !(reason instanceof EvaluationFetchError) &&
+            !(reason instanceof ChannelError)
+        );
+        const channelError = rejections.find(
+          (reason) => reason instanceof ChannelError
+        );
+
+        if (fetchError) {
+          // Producer failed - this is ALWAYS critical regardless of stopOnFirstError
+          logger.error(`Critical: Failed to fetch evaluations from server`);
+          executionError = fetchError;
+        } else if (workerError) {
+          // Worker error in stopOnFirstError mode - already logged by worker
+          executionError = workerError;
+        } else if (channelError && signal.aborted) {
+          // Channel closed due to intentional abort - wrap in semantic error
+          executionError = new EvaluationAbortedError(
+            "Evaluation stopped due to error in concurrent evaluator",
+            channelError
+          );
+        } else {
+          // Unexpected error (not from worker, not from producer fetch)
+          // This could be a bug in our code or infrastructure failure
+          const reason = rejections[0];
+          const err =
+            reason instanceof Error ? reason : new Error(String(reason));
+          logger.error(`Unexpected error during evaluation: ${err.message}`);
+          executionError = err;
+        }
       }
     } finally {
       // Ensure channel is closed even if there are unexpected errors

--- a/js/packages/phoenix-client/src/experiments/resumeExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/resumeExperiment.ts
@@ -489,7 +489,7 @@ export async function resumeExperiment({
     }
 
     // Start concurrent execution
-    // Wrap in try-finally to ensure channel is always closed, even if Promise.all throws
+    // Wrap in try-finally to ensure channel is always closed, even if a task throws
     let executionError: Error | null = null;
     try {
       const producerTask = fetchIncompleteRuns();
@@ -497,31 +497,63 @@ export async function resumeExperiment({
         processTasksFromChannel()
       );
 
-      // Wait for producer and all workers to finish
-      await Promise.all([producerTask, ...workerTasks]);
-    } catch (error) {
-      // Classify and handle errors based on their nature
-      const err = error instanceof Error ? error : new Error(String(error));
+      // Wait for the producer AND every worker to settle before continuing.
+      // Using allSettled (rather than Promise.all) is important: on the first
+      // worker error, Promise.all rejects immediately while the remaining
+      // workers keep running detached, logging and hitting the API after this
+      // function has already returned/thrown. Draining all tasks guarantees no
+      // background work outlives the call (and avoids teardown races in tests
+      // where late console output is flushed after the test completes).
+      const settled = await Promise.allSettled([producerTask, ...workerTasks]);
+      const rejections = settled
+        .filter(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected"
+        )
+        .map((result) => result.reason);
 
-      // Always surface producer/infrastructure errors
-      if (error instanceof TaskFetchError) {
-        // Producer failed - this is ALWAYS critical regardless of stopOnFirstError
-        logger.error(`Critical: Failed to fetch incomplete runs from server`);
-        executionError = err;
-      } else if (error instanceof ChannelError && signal.aborted) {
-        // Channel closed due to intentional abort - wrap in semantic error
-        executionError = new TaskAbortedError(
-          "Task execution stopped due to error in concurrent worker",
-          err
+      if (rejections.length > 0) {
+        // Classify and handle errors based on their nature. When multiple tasks
+        // reject, prefer the most meaningful error over incidental fallout
+        // (e.g. a ChannelError raised in a blocked worker when the channel
+        // closes on abort).
+        const fetchError = rejections.find(
+          (reason) => reason instanceof TaskFetchError
         );
-      } else if (stopOnFirstError) {
-        // Worker error in stopOnFirstError mode - already logged by worker
-        executionError = err;
-      } else {
-        // Unexpected error (not from worker, not from producer fetch)
-        // This could be a bug in our code or infrastructure failure
-        logger.error(`Unexpected error during task execution: ${err.message}`);
-        executionError = err;
+        const taskError = rejections.find(
+          (reason) =>
+            reason instanceof Error &&
+            !(reason instanceof TaskFetchError) &&
+            !(reason instanceof ChannelError)
+        );
+        const channelError = rejections.find(
+          (reason) => reason instanceof ChannelError
+        );
+
+        if (fetchError) {
+          // Producer failed - this is ALWAYS critical regardless of stopOnFirstError
+          logger.error(`Critical: Failed to fetch incomplete runs from server`);
+          executionError = fetchError;
+        } else if (taskError) {
+          // Worker error in stopOnFirstError mode - already logged by worker
+          executionError = taskError;
+        } else if (channelError && signal.aborted) {
+          // Channel closed due to intentional abort - wrap in semantic error
+          executionError = new TaskAbortedError(
+            "Task execution stopped due to error in concurrent worker",
+            channelError
+          );
+        } else {
+          // Unexpected error (not from worker, not from producer fetch)
+          // This could be a bug in our code or infrastructure failure
+          const reason = rejections[0];
+          const err =
+            reason instanceof Error ? reason : new Error(String(reason));
+          logger.error(
+            `Unexpected error during task execution: ${err.message}`
+          );
+          executionError = err;
+        }
       }
     } finally {
       // Ensure channel is closed even if there are unexpected errors


### PR DESCRIPTION
## Why this is needed

`resumeExperiment` and `resumeEvaluation` each run a producer plus `concurrency` worker tasks over a bounded channel, awaited with:

```ts
await Promise.all([producerTask, ...workerTasks]);
```

`Promise.all` **rejects the instant the first task rejects** — but it does *not* stop the other promises. So when a worker throws (the normal path under `stopOnFirstError: true`, and possible any time a task fails), the function unwinds and returns/throws while the **remaining workers and the producer keep running detached**. Those orphaned tasks continue to:

- call the Phoenix API (`POST .../runs`, fetch more pages), and
- write to the logger (console),

*after* the caller believes the operation is finished.

### The symptom that surfaced it

CI intermittently failed with:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
This error originated in "test/experiments/resumeExperiment.test.ts"
```

vitest forwards a worker's console output to the main process over RPC. The detached workers logged *after* the test had already resolved, so a console-log RPC was still in flight when vitest tore the worker down — producing the teardown error. It reproduced only under full-suite timing, which is why it looked flaky.

## The fix

Wait for **every** task to settle before continuing, so nothing outlives the call:

```ts
const settled = await Promise.allSettled([producerTask, ...workerTasks]);
const rejections = settled
  .filter((r): r is PromiseRejectedResult => r.status === "rejected")
  .map((r) => r.reason);
// classify by priority: fetch error > worker error > channel-abort > unexpected
```

Error semantics are preserved. When multiple tasks reject (e.g. a worker error plus a `ChannelError` from a blocked sender when the channel closes on abort), rejections are prioritized so the meaningful error wins over incidental shutdown fallout — same classification the previous single `catch` produced, now over the full set.

The same defect existed verbatim in **`resumeEvaluation.ts`** (which `resumeExperiment` calls for its evaluation phase), so the fix is applied to both.

## Scope

- `resumeExperiment.ts` — `Promise.all` → `Promise.allSettled` + drain/classify
- `resumeEvaluation.ts` — same fix (was the untouched structural twin carrying the identical bug)
- changeset (`patch` for `@arizeai/phoenix-client`)

## Follow-up (not in this PR)

Both files hand-roll the same "producer + N workers → drain → classify rejections" skeleton. A shared helper (ideally seeded by a `Channel.drain()` primitive that doesn't reject blocked senders on intentional shutdown) would let the two call sites stop duplicating this and prevent future drift. Left out to keep this change focused on the CI fix.

## Testing

- `test/experiments/` — 75 tests pass
- full `phoenix-client` suite — 466 pass / 1 skipped
- `tsc --noEmit`, `oxlint`, `oxfmt --check` all clean