### PR TITLE
chore(evals): add changeset for the built-in toxicity evaluator

### DIFF
--- a/js/.changeset/toxicity-evaluator.md
+++ b/js/.changeset/toxicity-evaluator.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-evals": minor
+---
+
+Add a built-in toxicity evaluator (createToxicityEvaluator) for classifying text as toxic or non-toxic.


### PR DESCRIPTION
The toxicity evaluator was added to @arizeai/phoenix-evals in #14636, but that PR didn't include a changeset, so the TypeScript changes wouldn't make it into an npm release. This adds a minor changeset for @arizeai/phoenix-evals so createToxicityEvaluator ships in the next release.
