### PR TITLE
feat(agents): add session title editing

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2498,6 +2498,7 @@ type Mutation {
   createAgentSession(input: CreateAgentSessionInput!): CreateAgentSessionMutationPayload!
   truncateAgentSession(input: TruncateAgentSessionInput!): TruncateAgentSessionMutationPayload!
   branchAgentSession(input: BranchAgentSessionInput!): BranchAgentSessionMutationPayload!
+  updateAgentSessionTitle(input: UpdateAgentSessionTitleInput!): UpdateAgentSessionTitleMutationPayload!
   deleteAgentSession(input: DeleteAgentSessionInput!): DeleteAgentSessionMutationPayload!
   createAnnotationConfig(input: CreateAnnotationConfigInput!): CreateAnnotationConfigPayload!
   updateAnnotationConfig(input: UpdateAnnotationConfigInput!): UpdateAnnotationConfigPayload!
@@ -4718,6 +4719,16 @@ type UnparsableSecret {
 input UnsetPromptLabelsInput {
   promptId: ID!
   promptLabelIds: [ID!]!
+}
+
+input UpdateAgentSessionTitleInput {
+  id: ID!
+  title: String!
+}
+
+type UpdateAgentSessionTitleMutationPayload {
+  agentSession: AgentSession!
+  query: Query!
 }
 
 input UpdateAnnotationConfigInput {

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   Flex,
   Icon,
-  IconButton,
   Icons,
   LinkButton,
   RichTooltip,
@@ -76,6 +75,8 @@ const panelHeaderActionsCSS = css`
 `;
 
 const sessionHeadingCSS = css`
+  display: block;
+  width: 100%;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -85,14 +86,10 @@ const sessionHeadingCSS = css`
 
 const sessionHeadingWrapCSS = css`
   position: relative;
+  display: flex;
+  align-items: center;
   min-width: 0;
-  overflow: hidden;
   flex-shrink: 1;
-
-  &[data-can-edit="true"] {
-    box-sizing: border-box;
-    padding-right: var(--global-button-height-s);
-  }
 
   .agent-chat-panel__edit-title-button {
     position: absolute;
@@ -190,7 +187,7 @@ export function AgentChatHeader({
       <Flex direction="row" alignItems="center" gap="size-50" minWidth={0}>
         <PxiAnimatedGlyph isIconSized />
         <Flex direction="row" alignItems="center" gap="size-100" minWidth={0}>
-          <div css={sessionHeadingWrapCSS} data-can-edit={canEditTitle}>
+          <div css={sessionHeadingWrapCSS}>
             <Text
               weight="heavy"
               css={sessionHeadingCSS}
@@ -199,14 +196,13 @@ export function AgentChatHeader({
               {sessionDisplayName}
             </Text>
             {canEditTitle ? (
-              <IconButton
+              <Button
                 className="agent-chat-panel__edit-title-button"
                 size="S"
                 aria-label="Edit session title"
                 onPress={() => setEditingSessionId(activeSessionId)}
-              >
-                <Icon svg={<Icons.Edit />} />
-              </IconButton>
+                leadingVisual={<Icon svg={<Icons.Edit />} />}
+              />
             ) : null}
           </div>
           {isActiveSessionTemporary ? <TemporarySessionIcon /> : null}

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -96,7 +96,6 @@ const sessionHeadingWrapCSS = css`
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.1s ease-in-out;
-    background: var(--agent-chat-panel-background-color);
   }
 
   &:hover .agent-chat-panel__edit-title-button,

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
 import type { ReactNode, RefObject } from "react";
+import { useState } from "react";
 import { Pressable } from "react-aria";
 import { createPortal } from "react-dom";
 import { Panel, Separator } from "react-resizable-panels";
@@ -23,8 +24,11 @@ import type {
   AgentFabPlacement,
   AgentPosition,
 } from "@phoenix/store/agentStore";
+import { DRAFT_SESSION_ID } from "@phoenix/store/agentStore";
 import type { Size } from "@phoenix/types/geometry";
 
+import type { EditAgentSessionTitleDialog_session$key } from "./__generated__/EditAgentSessionTitleDialog_session.graphql";
+import { InlineEditAgentSessionTitle } from "./EditAgentSessionTitleDialog";
 import { PxiAnimatedGlyph } from "./PxiAnimatedGlyph";
 import { ResizableFloatingPanel } from "./ResizableFloatingPanel";
 import { SessionListMenu } from "./SessionListMenu";
@@ -62,6 +66,7 @@ const panelHeaderCSS = css`
   /* Inherit the panel surface so the header blends with whichever frame hosts
      it: the darker docked panel or the lighter floating panel. */
   background: transparent;
+  position: relative;
 `;
 
 const panelHeaderActionsCSS = css`
@@ -75,6 +80,38 @@ const sessionHeadingCSS = css`
   text-overflow: ellipsis;
   white-space: nowrap;
   flex-shrink: 1;
+`;
+
+const sessionHeadingWrapCSS = css`
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  flex-shrink: 1;
+
+  .agent-chat-panel__edit-title-button {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.1s ease-in-out;
+    background: var(--agent-chat-panel-background-color);
+  }
+
+  &:hover .agent-chat-panel__edit-title-button,
+  &:focus-within .agent-chat-panel__edit-title-button {
+    opacity: 1;
+    pointer-events: auto;
+  }
+`;
+
+const inlineTitleEditorCSS = css`
+  position: absolute;
+  top: calc(100% + var(--global-dimension-size-50));
+  left: var(--global-dimension-size-150);
+  right: var(--global-dimension-size-150);
+  z-index: 1;
 `;
 
 const panelContentCSS = css`
@@ -102,6 +139,7 @@ export function AgentChatHeader({
   sessionDisplayName,
   orderedSessions,
   activeSessionId,
+  activeSessionTitleFragment,
   isActiveSessionTemporary = false,
   position,
   isPositionChangeDisabled = false,
@@ -117,6 +155,7 @@ export function AgentChatHeader({
   sessionDisplayName: string;
   orderedSessions: AgentSessionListItem[];
   activeSessionId: string | null;
+  activeSessionTitleFragment?: EditAgentSessionTitleDialog_session$key | null;
   isActiveSessionTemporary?: boolean;
   position?: AgentPosition;
   isPositionChangeDisabled?: boolean;
@@ -129,25 +168,42 @@ export function AgentChatHeader({
   onPositionChange?: (position: AgentPosition) => void;
   onClose: () => void;
 }) {
+  const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const nextPosition = position === "pinned" ? "detached" : "pinned";
   const positionToggleLabel =
     position === "pinned"
       ? "Switch assistant to floating panel"
       : "Pin assistant to side";
   const showBetaBadge = sessionDisplayName === EMPTY_SESSION_DISPLAY_NAME;
+  const canEditTitle =
+    activeSessionId != null &&
+    activeSessionId !== DRAFT_SESSION_ID &&
+    activeSessionTitleFragment != null;
 
   return (
     <div className="agent-chat-panel__header" css={panelHeaderCSS}>
       <Flex direction="row" alignItems="center" gap="size-50" minWidth={0}>
         <PxiAnimatedGlyph isIconSized />
         <Flex direction="row" alignItems="center" gap="size-100" minWidth={0}>
-          <Text
-            weight="heavy"
-            css={sessionHeadingCSS}
-            title={sessionDisplayName}
-          >
-            {sessionDisplayName}
-          </Text>
+          <div css={sessionHeadingWrapCSS}>
+            <Text
+              weight="heavy"
+              css={sessionHeadingCSS}
+              title={sessionDisplayName}
+            >
+              {sessionDisplayName}
+            </Text>
+            {canEditTitle ? (
+              <Button
+                className="agent-chat-panel__edit-title-button"
+                variant="quiet"
+                size="S"
+                aria-label="Edit session title"
+                onPress={() => setEditingSessionId(activeSessionId)}
+                leadingVisual={<Icon svg={<Icons.Edit />} />}
+              />
+            ) : null}
+          </div>
           {isActiveSessionTemporary ? <TemporarySessionIcon /> : null}
         </Flex>
         {showBetaBadge ? (
@@ -174,6 +230,14 @@ export function AgentChatHeader({
           </TooltipTrigger>
         ) : null}
       </Flex>
+      {editingSessionId === activeSessionId && activeSessionTitleFragment ? (
+        <div css={inlineTitleEditorCSS}>
+          <InlineEditAgentSessionTitle
+            session={activeSessionTitleFragment}
+            onClose={() => setEditingSessionId(null)}
+          />
+        </div>
+      ) : null}
       <Flex
         direction="row"
         alignItems="center"

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Flex,
   Icon,
+  IconButton,
   Icons,
   LinkButton,
   RichTooltip,
@@ -87,6 +88,11 @@ const sessionHeadingWrapCSS = css`
   min-width: 0;
   overflow: hidden;
   flex-shrink: 1;
+
+  &[data-can-edit="true"] {
+    box-sizing: border-box;
+    padding-right: var(--global-button-height-s);
+  }
 
   .agent-chat-panel__edit-title-button {
     position: absolute;
@@ -184,7 +190,7 @@ export function AgentChatHeader({
       <Flex direction="row" alignItems="center" gap="size-50" minWidth={0}>
         <PxiAnimatedGlyph isIconSized />
         <Flex direction="row" alignItems="center" gap="size-100" minWidth={0}>
-          <div css={sessionHeadingWrapCSS}>
+          <div css={sessionHeadingWrapCSS} data-can-edit={canEditTitle}>
             <Text
               weight="heavy"
               css={sessionHeadingCSS}
@@ -193,14 +199,14 @@ export function AgentChatHeader({
               {sessionDisplayName}
             </Text>
             {canEditTitle ? (
-              <Button
+              <IconButton
                 className="agent-chat-panel__edit-title-button"
-                variant="quiet"
                 size="S"
                 aria-label="Edit session title"
                 onPress={() => setEditingSessionId(activeSessionId)}
-                leadingVisual={<Icon svg={<Icons.Edit />} />}
-              />
+              >
+                <Icon svg={<Icons.Edit />} />
+              </IconButton>
             ) : null}
           </div>
           {isActiveSessionTemporary ? <TemporarySessionIcon /> : null}

--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -19,6 +19,7 @@ import {
 } from "@phoenix/components";
 import { fadedDividerBottomCSS } from "@phoenix/components/core/layout";
 import { compactResizeHandleCSS } from "@phoenix/components/resize/styles";
+import { useViewerCanModify } from "@phoenix/contexts/ViewerContext";
 import { useActiveModalPortalContainerElement } from "@phoenix/hooks/useHasOpenModal";
 import type {
   AgentFabPlacement,
@@ -171,6 +172,7 @@ export function AgentChatHeader({
   onClose: () => void;
 }) {
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
+  const canModifySessions = useViewerCanModify();
   const nextPosition = position === "pinned" ? "detached" : "pinned";
   const positionToggleLabel =
     position === "pinned"
@@ -178,6 +180,7 @@ export function AgentChatHeader({
       : "Pin assistant to side";
   const showBetaBadge = sessionDisplayName === EMPTY_SESSION_DISPLAY_NAME;
   const canEditTitle =
+    canModifySessions &&
     activeSessionId != null &&
     activeSessionId !== DRAFT_SESSION_ID &&
     activeSessionTitleFragment != null;

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -122,6 +122,7 @@ function AgentSessionsContent({
             node {
               id
               title
+              ...EditAgentSessionTitleDialog_session
               isTemporary
               createdAt
               updatedAt
@@ -307,6 +308,13 @@ function AgentSessionsContent({
         sessionDisplayName={sessionDisplayName}
         orderedSessions={orderedSessions}
         activeSessionId={activeSessionId}
+        activeSessionTitleFragment={
+          activeSessionId == null
+            ? null
+            : data.agentSessions.edges.find(
+                ({ node }) => node.id === activeSessionId
+              )?.node
+        }
         isActiveSessionTemporary={activeSession?.isTemporary}
         position={position}
         isPositionChangeDisabled={isPositionChangeDisabled}

--- a/app/src/components/agent/EditAgentSessionTitleDialog.tsx
+++ b/app/src/components/agent/EditAgentSessionTitleDialog.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { graphql, useFragment, useMutation } from "react-relay";
+
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+  Form,
+  Input,
+  Label,
+  Text,
+  TextField,
+  View,
+} from "@phoenix/components";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
+
+import type { EditAgentSessionTitleDialog_session$key } from "./__generated__/EditAgentSessionTitleDialog_session.graphql";
+import type { EditAgentSessionTitleDialogMutation } from "./__generated__/EditAgentSessionTitleDialogMutation.graphql";
+
+export function EditAgentSessionTitleDialog({
+  session,
+  onClose,
+}: {
+  session: EditAgentSessionTitleDialog_session$key;
+  onClose: () => void;
+}) {
+  const data = useFragment(
+    graphql`
+      fragment EditAgentSessionTitleDialog_session on AgentSession {
+        id
+        title
+      }
+    `,
+    session
+  );
+  const [title, setTitle] = useState(data.title);
+  const [error, setError] = useState<string | null>(null);
+  const [commitUpdate, isUpdating] =
+    useMutation<EditAgentSessionTitleDialogMutation>(graphql`
+      mutation EditAgentSessionTitleDialogMutation(
+        $input: UpdateAgentSessionTitleInput!
+      ) {
+        updateAgentSessionTitle(input: $input) {
+          agentSession {
+            ...EditAgentSessionTitleDialog_session
+          }
+          query {
+            ...SettingsAgentSessionsCard_sessions @arguments(first: 20)
+          }
+        }
+      }
+    `);
+  const trimmedTitle = title.trim();
+  const isSaveDisabled =
+    isUpdating || !trimmedTitle || trimmedTitle === data.title;
+
+  const updateTitle = () => {
+    if (isSaveDisabled) {
+      return;
+    }
+    setError(null);
+    commitUpdate({
+      variables: {
+        input: {
+          id: data.id,
+          title: trimmedTitle,
+        },
+      },
+      onCompleted: onClose,
+      onError: (mutationError) => {
+        setError(
+          getErrorMessagesFromRelayMutationError(mutationError)?.[0] ??
+            "Failed to update assistant session title"
+        );
+      },
+    });
+  };
+
+  return (
+    <Dialog>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit session title</DialogTitle>
+          <DialogTitleExtra>
+            <DialogCloseButton slot="close" />
+          </DialogTitleExtra>
+        </DialogHeader>
+        {error ? (
+          <View paddingX="size-200" paddingTop="size-100">
+            <Alert variant="danger" banner>
+              {error}
+            </Alert>
+          </View>
+        ) : null}
+        <Form
+          onSubmit={(event) => {
+            event.preventDefault();
+            updateTitle();
+          }}
+        >
+          <View padding="size-200">
+            <TextField
+              value={title}
+              onChange={setTitle}
+              isDisabled={isUpdating}
+              isInvalid={!trimmedTitle}
+              autoFocus
+            >
+              <Label>Title</Label>
+              <Input />
+              <Text slot="description">The title cannot be empty.</Text>
+            </TextField>
+          </View>
+          <DialogFooter>
+            <Button
+              size="S"
+              variant="default"
+              slot="close"
+              isDisabled={isUpdating}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="S"
+              variant={isSaveDisabled ? "default" : "primary"}
+              type="submit"
+              isDisabled={isSaveDisabled}
+            >
+              {isUpdating ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/agent/EditAgentSessionTitleDialog.tsx
+++ b/app/src/components/agent/EditAgentSessionTitleDialog.tsx
@@ -26,6 +26,7 @@ import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtil
 
 import type { EditAgentSessionTitleDialog_session$key } from "./__generated__/EditAgentSessionTitleDialog_session.graphql";
 import type { EditAgentSessionTitleDialogMutation } from "./__generated__/EditAgentSessionTitleDialogMutation.graphql";
+import { MAX_AGENT_SESSION_TITLE_LENGTH } from "./agentSessionRelay";
 
 const inlineDialogCSS = css`
   border: var(--global-border-size-thin) solid
@@ -104,7 +105,10 @@ function EditAgentSessionTitleForm({
     `);
   const trimmedTitle = title.trim();
   const isSaveDisabled =
-    isUpdating || !trimmedTitle || trimmedTitle === data.title;
+    isUpdating ||
+    !trimmedTitle ||
+    trimmedTitle.length > MAX_AGENT_SESSION_TITLE_LENGTH ||
+    trimmedTitle === data.title;
 
   const updateTitle = () => {
     if (isSaveDisabled) {
@@ -196,12 +200,18 @@ function EditAgentSessionTitleForm({
             value={title}
             onChange={setTitle}
             isDisabled={isUpdating}
-            isInvalid={!trimmedTitle}
+            isInvalid={
+              !trimmedTitle ||
+              trimmedTitle.length > MAX_AGENT_SESSION_TITLE_LENGTH
+            }
             autoFocus
           >
             <Label>Title</Label>
-            <Input />
-            <Text slot="description">The title cannot be empty.</Text>
+            <Input maxLength={MAX_AGENT_SESSION_TITLE_LENGTH} />
+            <Text slot="description">
+              The title cannot be empty and must be at most{" "}
+              {MAX_AGENT_SESSION_TITLE_LENGTH} characters.
+            </Text>
           </TextField>
         </View>
         {presentation === "dialog" ? (

--- a/app/src/components/agent/EditAgentSessionTitleDialog.tsx
+++ b/app/src/components/agent/EditAgentSessionTitleDialog.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import { useState } from "react";
 import { graphql, useFragment, useMutation } from "react-relay";
 
@@ -11,7 +12,10 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTitleExtra,
+  Flex,
   Form,
+  Icon,
+  Icons,
   Input,
   Label,
   Text,
@@ -23,13 +27,55 @@ import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtil
 import type { EditAgentSessionTitleDialog_session$key } from "./__generated__/EditAgentSessionTitleDialog_session.graphql";
 import type { EditAgentSessionTitleDialogMutation } from "./__generated__/EditAgentSessionTitleDialogMutation.graphql";
 
-export function EditAgentSessionTitleDialog({
-  session,
-  onClose,
-}: {
+const inlineDialogCSS = css`
+  border: var(--global-border-size-thin) solid
+    var(--global-border-color-default);
+  border-radius: var(--global-rounding-medium);
+  background: var(--global-background-color-default);
+  color: var(--global-text-color-900);
+  overflow: hidden;
+`;
+
+const inlineHeaderCSS = css`
+  padding: var(--global-dimension-size-150) var(--global-dimension-size-200) 0;
+`;
+
+const inlineFooterCSS = css`
+  padding: 0 var(--global-dimension-size-200) var(--global-dimension-size-200);
+`;
+
+type EditAgentSessionTitleProps = {
   session: EditAgentSessionTitleDialog_session$key;
   onClose: () => void;
-}) {
+};
+
+export function EditAgentSessionTitleDialog(props: EditAgentSessionTitleProps) {
+  return (
+    <Dialog>
+      <DialogContent>
+        <EditAgentSessionTitleForm {...props} presentation="dialog" />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function InlineEditAgentSessionTitle(props: EditAgentSessionTitleProps) {
+  return (
+    <section
+      css={inlineDialogCSS}
+      role="dialog"
+      aria-label="Edit session title"
+    >
+      <EditAgentSessionTitleForm {...props} presentation="inline" />
+    </section>
+  );
+}
+
+function EditAgentSessionTitleForm({
+  session,
+  onClose,
+  presentation,
+}: EditAgentSessionTitleProps & { presentation: "dialog" | "inline" }) {
   const data = useFragment(
     graphql`
       fragment EditAgentSessionTitleDialog_session on AgentSession {
@@ -81,62 +127,91 @@ export function EditAgentSessionTitleDialog({
       },
     });
   };
+  const header =
+    presentation === "dialog" ? (
+      <DialogHeader>
+        <DialogTitle>Edit session title</DialogTitle>
+        <DialogTitleExtra>
+          <DialogCloseButton onPress={onClose} />
+        </DialogTitleExtra>
+      </DialogHeader>
+    ) : (
+      <Flex
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        css={inlineHeaderCSS}
+      >
+        <Text elementType="h3" size="L" weight="heavy">
+          Edit session title
+        </Text>
+        <Button
+          variant="quiet"
+          size="S"
+          aria-label="Close title editor"
+          onPress={onClose}
+          leadingVisual={<Icon svg={<Icons.Close />} />}
+        />
+      </Flex>
+    );
+  const actions = (
+    <>
+      <Button
+        size="S"
+        variant="default"
+        onPress={onClose}
+        isDisabled={isUpdating}
+      >
+        Cancel
+      </Button>
+      <Button
+        size="S"
+        variant={isSaveDisabled ? "default" : "primary"}
+        type="submit"
+        isDisabled={isSaveDisabled}
+      >
+        {isUpdating ? "Saving..." : "Save"}
+      </Button>
+    </>
+  );
 
   return (
-    <Dialog>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Edit session title</DialogTitle>
-          <DialogTitleExtra>
-            <DialogCloseButton slot="close" />
-          </DialogTitleExtra>
-        </DialogHeader>
-        {error ? (
-          <View paddingX="size-200" paddingTop="size-100">
-            <Alert variant="danger" banner>
-              {error}
-            </Alert>
-          </View>
-        ) : null}
-        <Form
-          onSubmit={(event) => {
-            event.preventDefault();
-            updateTitle();
-          }}
-        >
-          <View padding="size-200">
-            <TextField
-              value={title}
-              onChange={setTitle}
-              isDisabled={isUpdating}
-              isInvalid={!trimmedTitle}
-              autoFocus
-            >
-              <Label>Title</Label>
-              <Input />
-              <Text slot="description">The title cannot be empty.</Text>
-            </TextField>
-          </View>
-          <DialogFooter>
-            <Button
-              size="S"
-              variant="default"
-              slot="close"
-              isDisabled={isUpdating}
-            >
-              Cancel
-            </Button>
-            <Button
-              size="S"
-              variant={isSaveDisabled ? "default" : "primary"}
-              type="submit"
-              isDisabled={isSaveDisabled}
-            >
-              {isUpdating ? "Saving..." : "Save"}
-            </Button>
-          </DialogFooter>
-        </Form>
-      </DialogContent>
-    </Dialog>
+    <>
+      {header}
+      {error ? (
+        <View paddingX="size-200" paddingTop="size-100">
+          <Alert variant="danger" banner>
+            {error}
+          </Alert>
+        </View>
+      ) : null}
+      <Form
+        onSubmit={(event) => {
+          event.preventDefault();
+          updateTitle();
+        }}
+      >
+        <View padding="size-200">
+          <TextField
+            value={title}
+            onChange={setTitle}
+            isDisabled={isUpdating}
+            isInvalid={!trimmedTitle}
+            autoFocus
+          >
+            <Label>Title</Label>
+            <Input />
+            <Text slot="description">The title cannot be empty.</Text>
+          </TextField>
+        </View>
+        {presentation === "dialog" ? (
+          <DialogFooter>{actions}</DialogFooter>
+        ) : (
+          <Flex justifyContent="end" gap="size-100" css={inlineFooterCSS}>
+            {actions}
+          </Flex>
+        )}
+      </Form>
+    </>
   );
 }

--- a/app/src/components/agent/__generated__/AgentSessionsResourcePaginationQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourcePaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<40414e54817426e1478c45bbd6c7d006>>
+ * @generated SignedSource<<bfdffcbe36cfb053789650cc407b4866>>
  * @lightSyntaxTransform
  */
 
@@ -187,16 +187,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4156aeb7cd08dc4f430ff30803a1a7b0",
+    "cacheID": "ccc1a8ebf1cd1a20762752202bf217e9",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourcePaginationQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourcePaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...AgentSessionsResource_sessions_2HEEH6\n}\n\nfragment AgentSessionsResource_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after) {\n    edges {\n      node {\n        id\n        title\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query AgentSessionsResourcePaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...AgentSessionsResource_sessions_2HEEH6\n}\n\nfragment AgentSessionsResource_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "515fe0409f4dbcdc6ccaa745913ce438";
+(node as any).hash = "af28af2b0d4c3d22bbd920a5ae1c00f6";
 
 export default node;

--- a/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0ec8c025e40a1910ed3a8c4a36860a47>>
+ * @generated SignedSource<<10f8fa07eb58bf63347a620f624c0936>>
  * @lightSyntaxTransform
  */
 
@@ -224,12 +224,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7761787d5b0489b3a42e6d283e01d3af",
+    "cacheID": "cbd0f1f6f2d3f06bf44a736e3c1f968a",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourceQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7ead5780ccb000a3216df7f9aab5d9ac>>
+ * @generated SignedSource<<0ec8c025e40a1910ed3a8c4a36860a47>>
  * @lightSyntaxTransform
  */
 
@@ -224,12 +224,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4da327fc99ed86f8840d74314bcd6250",
+    "cacheID": "7761787d5b0489b3a42e6d283e01d3af",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourceQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/AgentSessionsResource_sessions.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResource_sessions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<032e23f02a5598562e8b44f06ffc614e>>
+ * @generated SignedSource<<0a787187bb107c264ebdf2cc48327cdd>>
  * @lightSyntaxTransform
  */
 
@@ -18,6 +18,7 @@ export type AgentSessionsResource_sessions$data = {
         readonly isTemporary: boolean;
         readonly title: string;
         readonly updatedAt: string;
+        readonly " $fragmentSpreads": FragmentRefs<"EditAgentSessionTitleDialog_session">;
       };
     }>;
   };
@@ -111,6 +112,11 @@ return {
                   "storageKey": null
                 },
                 {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "EditAgentSessionTitleDialog_session"
+                },
+                {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
@@ -185,6 +191,6 @@ return {
 };
 })();
 
-(node as any).hash = "515fe0409f4dbcdc6ccaa745913ce438";
+(node as any).hash = "af28af2b0d4c3d22bbd920a5ae1c00f6";
 
 export default node;

--- a/app/src/components/agent/__generated__/EditAgentSessionTitleDialogMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/EditAgentSessionTitleDialogMutation.graphql.ts
@@ -1,0 +1,310 @@
+/**
+ * @generated SignedSource<<155fc9cff0762456a98a176540550d86>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type UpdateAgentSessionTitleInput = {
+  id: string;
+  title: string;
+};
+export type EditAgentSessionTitleDialogMutation$variables = {
+  input: UpdateAgentSessionTitleInput;
+};
+export type EditAgentSessionTitleDialogMutation$data = {
+  readonly updateAgentSessionTitle: {
+    readonly agentSession: {
+      readonly " $fragmentSpreads": FragmentRefs<"EditAgentSessionTitleDialog_session">;
+    };
+    readonly query: {
+      readonly " $fragmentSpreads": FragmentRefs<"SettingsAgentSessionsCard_sessions">;
+    };
+  };
+};
+export type EditAgentSessionTitleDialogMutation = {
+  response: EditAgentSessionTitleDialogMutation$data;
+  variables: EditAgentSessionTitleDialogMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 20
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EditAgentSessionTitleDialogMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": "UpdateAgentSessionTitleMutationPayload",
+        "kind": "LinkedField",
+        "name": "updateAgentSessionTitle",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AgentSession",
+            "kind": "LinkedField",
+            "name": "agentSession",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "EditAgentSessionTitleDialog_session"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "args": (v2/*:: as any*/),
+                "kind": "FragmentSpread",
+                "name": "SettingsAgentSessionsCard_sessions"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "EditAgentSessionTitleDialogMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": "UpdateAgentSessionTitleMutationPayload",
+        "kind": "LinkedField",
+        "name": "updateAgentSessionTitle",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AgentSession",
+            "kind": "LinkedField",
+            "name": "agentSession",
+            "plural": false,
+            "selections": [
+              (v3/*:: as any*/),
+              (v4/*:: as any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Query",
+            "kind": "LinkedField",
+            "name": "query",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v2/*:: as any*/),
+                "concreteType": "AgentSessionConnection",
+                "kind": "LinkedField",
+                "name": "agentSessions",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AgentSessionEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AgentSession",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*:: as any*/),
+                          (v4/*:: as any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "User",
+                            "kind": "LinkedField",
+                            "name": "user",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "username",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "profilePictureUrl",
+                                "storageKey": null
+                              },
+                              (v3/*:: as any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "firstInput",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__typename",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "agentSessions(first:20)"
+              },
+              {
+                "alias": null,
+                "args": (v2/*:: as any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "SettingsAgentSessionsCard_agentSessions",
+                "kind": "LinkedHandle",
+                "name": "agentSessions"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2e0a472152d193c1fb6156a687888cc9",
+    "id": null,
+    "metadata": {},
+    "name": "EditAgentSessionTitleDialogMutation",
+    "operationKind": "mutation",
+    "text": "mutation EditAgentSessionTitleDialogMutation(\n  $input: UpdateAgentSessionTitleInput!\n) {\n  updateAgentSessionTitle(input: $input) {\n    agentSession {\n      ...EditAgentSessionTitleDialog_session\n      id\n    }\n    query {\n      ...SettingsAgentSessionsCard_sessions_3dfUwN\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3dfUwN on Query {\n  agentSessions(first: 20) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "7e6776097097bd9ca00ec4fcd184f760";
+
+export default node;

--- a/app/src/components/agent/__generated__/EditAgentSessionTitleDialog_session.graphql.ts
+++ b/app/src/components/agent/__generated__/EditAgentSessionTitleDialog_session.graphql.ts
@@ -1,0 +1,49 @@
+/**
+ * @generated SignedSource<<21078c4c5051adce62076b8135f48c22>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type EditAgentSessionTitleDialog_session$data = {
+  readonly id: string;
+  readonly title: string;
+  readonly " $fragmentType": "EditAgentSessionTitleDialog_session";
+};
+export type EditAgentSessionTitleDialog_session$key = {
+  readonly " $data"?: EditAgentSessionTitleDialog_session$data;
+  readonly " $fragmentSpreads": FragmentRefs<"EditAgentSessionTitleDialog_session">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "EditAgentSessionTitleDialog_session",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    }
+  ],
+  "type": "AgentSession",
+  "abstractKey": null
+};
+
+(node as any).hash = "779f5510101ca32616d33064e364d9a6";
+
+export default node;

--- a/app/src/components/agent/__generated__/useAgentChatBranchAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatBranchAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<66668c10a1ed98c8755ce3dd7e2e1b28>>
+ * @generated SignedSource<<8ed6863de084a4ed0efda81283259d64>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type BranchAgentSessionInput = {
   id: string;
   messageId: string;
@@ -31,6 +32,7 @@ export type useAgentChatBranchAgentSessionMutation$data = {
         readonly profilePictureUrl: string | null;
         readonly username: string;
       } | null;
+      readonly " $fragmentSpreads": FragmentRefs<"EditAgentSessionTitleDialog_session">;
     };
   };
 };
@@ -155,6 +157,11 @@ return {
             "selections": [
               (v3/*:: as any*/),
               (v4/*:: as any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "EditAgentSessionTitleDialog_session"
+              },
               (v5/*:: as any*/),
               (v6/*:: as any*/),
               (v7/*:: as any*/),
@@ -261,16 +268,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4c07c771e79bf94a275a8af33b5620f3",
+    "cacheID": "ee106d4c97f8f5c44af496a52566748a",
     "id": null,
     "metadata": {},
     "name": "useAgentChatBranchAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentChatBranchAgentSessionMutation(\n  $input: BranchAgentSessionInput!\n) {\n  branchAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      isTemporary\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n  }\n}\n"
+    "text": "mutation useAgentChatBranchAgentSessionMutation(\n  $input: BranchAgentSessionInput!\n) {\n  branchAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "328bad4b95eabe5ea39747b98b98eed3";
+(node as any).hash = "ea4b5de46dbc482c61564732e61b63f4";
 
 export default node;

--- a/app/src/components/agent/__generated__/useAgentChatCreateAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatCreateAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<01fb5c846f7a490c96971ccbc5c54fe9>>
+ * @generated SignedSource<<ca5e913d1bdf416fceb3c6a163b19943>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type CreateAgentSessionInput = {
   temporary?: boolean;
   title?: string;
@@ -30,6 +31,7 @@ export type useAgentChatCreateAgentSessionMutation$data = {
         readonly profilePictureUrl: string | null;
         readonly username: string;
       } | null;
+      readonly " $fragmentSpreads": FragmentRefs<"EditAgentSessionTitleDialog_session">;
     };
   };
 };
@@ -147,6 +149,11 @@ return {
             "selections": [
               (v3/*:: as any*/),
               (v4/*:: as any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "EditAgentSessionTitleDialog_session"
+              },
               (v5/*:: as any*/),
               (v6/*:: as any*/),
               (v7/*:: as any*/),
@@ -251,16 +258,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "22c30bad5a527c4177f45242cbc53535",
+    "cacheID": "54928aa36e9c467058c835f7a21e286e",
     "id": null,
     "metadata": {},
     "name": "useAgentChatCreateAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentChatCreateAgentSessionMutation(\n  $input: CreateAgentSessionInput!\n) {\n  createAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      isTemporary\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n    }\n  }\n}\n"
+    "text": "mutation useAgentChatCreateAgentSessionMutation(\n  $input: CreateAgentSessionInput!\n) {\n  createAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d3ff0e442d02e9ca6b87a79ded4c176a";
+(node as any).hash = "bf2a214d202d18185d935badc2e9e6f4";
 
 export default node;

--- a/app/src/components/agent/__generated__/useAgentChatTruncateAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatTruncateAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<63c9053cf396bf208a70906bb69b4e7e>>
+ * @generated SignedSource<<0e63621ffe6e6c5d2c3a9ec416503b3b>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TruncateAgentSessionInput = {
   id: string;
   messageId: string;
@@ -28,6 +29,7 @@ export type useAgentChatTruncateAgentSessionMutation$data = {
         readonly profilePictureUrl: string | null;
         readonly username: string;
       } | null;
+      readonly " $fragmentSpreads": FragmentRefs<"EditAgentSessionTitleDialog_session">;
     };
   };
 };
@@ -132,6 +134,11 @@ return {
             "selections": [
               (v2/*:: as any*/),
               (v3/*:: as any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "EditAgentSessionTitleDialog_session"
+              },
               (v4/*:: as any*/),
               (v5/*:: as any*/),
               (v6/*:: as any*/),
@@ -210,16 +217,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "98bfbd35dd72ed5286512282d8e9c892",
+    "cacheID": "4dcfa2811df577efcb8c6f90672d6500",
     "id": null,
     "metadata": {},
     "name": "useAgentChatTruncateAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentChatTruncateAgentSessionMutation(\n  $input: TruncateAgentSessionInput!\n) {\n  truncateAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n  }\n}\n"
+    "text": "mutation useAgentChatTruncateAgentSessionMutation(\n  $input: TruncateAgentSessionInput!\n) {\n  truncateAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "bba5fa00a2316c5e4ee6c723cb1877ff";
+(node as any).hash = "0d82577e9363cd95c8846fe499dd32e6";
 
 export default node;

--- a/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
@@ -144,6 +144,29 @@ describe("AgentChatHeader", () => {
     ).toBeNull();
   });
 
+  it("offers title editing for a persisted session", () => {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <AgentChatHeader
+            sessionDisplayName="Ping pong test"
+            orderedSessions={[]}
+            activeSessionId="session-1"
+            activeSessionTitleFragment={{} as never}
+            onSelectSession={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onCreateSession={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MemoryRouter>
+      );
+    });
+
+    expect(
+      container.querySelector('button[aria-label="Edit session title"]')
+    ).not.toBeNull();
+  });
+
   it("switches from pinned to floating mode", () => {
     const onPositionChange = vi.fn();
 

--- a/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
+++ b/app/src/components/agent/__tests__/AgentChatPanelView.test.tsx
@@ -12,6 +12,12 @@ import { ThemeProvider } from "@phoenix/contexts/ThemeContext";
 import { AgentChatHeader, FloatingAgentChatFrame } from "../AgentChatPanelView";
 import { EMPTY_SESSION_DISPLAY_NAME } from "../sessionTitleUtils";
 
+const viewerMocks = vi.hoisted(() => ({ canModify: true }));
+
+vi.mock("@phoenix/contexts/ViewerContext", () => ({
+  useViewerCanModify: () => viewerMocks.canModify,
+}));
+
 type TestBounds = {
   height: number;
   left: number;
@@ -46,6 +52,7 @@ describe("AgentChatHeader", () => {
   let root: Root;
 
   beforeEach(() => {
+    viewerMocks.canModify = true;
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -165,6 +172,31 @@ describe("AgentChatHeader", () => {
     expect(
       container.querySelector('button[aria-label="Edit session title"]')
     ).not.toBeNull();
+  });
+
+  it("hides title editing from viewers", () => {
+    viewerMocks.canModify = false;
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <AgentChatHeader
+            sessionDisplayName="Ping pong test"
+            orderedSessions={[]}
+            activeSessionId="session-1"
+            activeSessionTitleFragment={{} as never}
+            onSelectSession={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onCreateSession={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MemoryRouter>
+      );
+    });
+
+    expect(
+      container.querySelector('button[aria-label="Edit session title"]')
+    ).toBeNull();
   });
 
   it("switches from pinned to floating mode", () => {

--- a/app/src/components/agent/agentSessionRelay.ts
+++ b/app/src/components/agent/agentSessionRelay.ts
@@ -8,6 +8,7 @@ export const SETTINGS_AGENT_SESSIONS_CONNECTION_KEY =
   "SettingsAgentSessionsCard_agentSessions";
 
 export const SESSION_PAGE_SIZE = 20;
+export const MAX_AGENT_SESSION_TITLE_LENGTH = 100;
 
 type RelayEnvironment = Parameters<typeof fetchQuery>[0];
 

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -123,6 +123,7 @@ const createAgentSessionMutation = graphql`
         ) {
         id
         title
+        ...EditAgentSessionTitleDialog_session
         isTemporary
         createdAt
         updatedAt
@@ -145,6 +146,7 @@ const truncateAgentSessionMutation = graphql`
       agentSession {
         id
         title
+        ...EditAgentSessionTitleDialog_session
         updatedAt
         firstInput
         latestOutput
@@ -171,6 +173,7 @@ const branchAgentSessionMutation = graphql`
         ) {
         id
         title
+        ...EditAgentSessionTitleDialog_session
         isTemporary
         createdAt
         updatedAt

--- a/app/src/pages/settings/SettingsAgentSessionActionMenu.tsx
+++ b/app/src/pages/settings/SettingsAgentSessionActionMenu.tsx
@@ -170,7 +170,10 @@ export function SettingsAgentSessionActionMenu({
                   <Text>Edit title</Text>
                 </Flex>
               </MenuItem>
-              <MenuItem id={AgentSessionAction.Delete} textValue="Delete session">
+              <MenuItem
+                id={AgentSessionAction.Delete}
+                textValue="Delete session"
+              >
                 <Flex gap="size-75" alignItems="center">
                   <Icon svg={<Icons.Trash />} />
                   <Text>Delete</Text>

--- a/app/src/pages/settings/SettingsAgentSessionActionMenu.tsx
+++ b/app/src/pages/settings/SettingsAgentSessionActionMenu.tsx
@@ -12,23 +12,30 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTitleExtra,
+  Flex,
   Icon,
   Icons,
+  Menu,
+  MenuItem,
+  MenuTrigger,
   Modal,
   ModalOverlay,
+  Popover,
   Text,
   View,
 } from "@phoenix/components";
+import type { EditAgentSessionTitleDialog_session$key } from "@phoenix/components/agent/__generated__/EditAgentSessionTitleDialog_session.graphql";
 import {
   AGENT_SESSIONS_CONNECTION_KEY,
   SETTINGS_AGENT_SESSIONS_CONNECTION_KEY,
 } from "@phoenix/components/agent/agentSessionRelay";
+import { EditAgentSessionTitleDialog } from "@phoenix/components/agent/EditAgentSessionTitleDialog";
 import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import { DRAFT_SESSION_ID } from "@phoenix/store/agentStore";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
-import type { SettingsAgentSessionDeleteButtonMutation } from "./__generated__/SettingsAgentSessionDeleteButtonMutation.graphql";
+import type { SettingsAgentSessionActionMenuDeleteMutation } from "./__generated__/SettingsAgentSessionActionMenuDeleteMutation.graphql";
 
 const deleteBusyIndicatorCSS = css`
   display: inline-flex;
@@ -48,13 +55,21 @@ function DeleteBusyIndicator({ label }: { label: string }) {
   );
 }
 
-export function SettingsAgentSessionConditionalDeleteButton({
+enum AgentSessionAction {
+  EditTitle = "edit-title",
+  Delete = "delete",
+}
+
+export function SettingsAgentSessionActionMenu({
   sessionId,
   sessionTitle,
+  session,
 }: {
   sessionId: string;
   sessionTitle: string;
+  session: EditAgentSessionTitleDialog_session$key;
 }) {
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const store = useAgentStore();
@@ -80,8 +95,8 @@ export function SettingsAgentSessionConditionalDeleteButton({
     ),
   ];
   const [commitDelete, isDeleting] =
-    useMutation<SettingsAgentSessionDeleteButtonMutation>(graphql`
-      mutation SettingsAgentSessionDeleteButtonMutation(
+    useMutation<SettingsAgentSessionActionMenuDeleteMutation>(graphql`
+      mutation SettingsAgentSessionActionMenuDeleteMutation(
         $id: ID!
         $connectionIds: [ID!]!
       ) {
@@ -130,14 +145,52 @@ export function SettingsAgentSessionConditionalDeleteButton({
       {isDeleteBusy ? (
         <DeleteBusyIndicator label={deleteBusyLabel} />
       ) : (
-        <Button
-          size="S"
-          variant="danger"
-          aria-label={`Delete ${sessionTitle}`}
-          leadingVisual={<Icon svg={<Icons.Trash />} />}
-          onPress={() => setIsDeleteDialogOpen(true)}
-        />
+        <MenuTrigger>
+          <Button
+            size="S"
+            aria-label={`Actions for ${sessionTitle}`}
+            leadingVisual={<Icon svg={<Icons.MoreHorizontal />} />}
+          />
+          <Popover>
+            <Menu
+              onAction={(action) => {
+                if (action === AgentSessionAction.EditTitle) {
+                  setIsEditDialogOpen(true);
+                } else if (action === AgentSessionAction.Delete) {
+                  setIsDeleteDialogOpen(true);
+                }
+              }}
+            >
+              <MenuItem
+                id={AgentSessionAction.EditTitle}
+                textValue="Edit session title"
+              >
+                <Flex gap="size-75" alignItems="center">
+                  <Icon svg={<Icons.Edit />} />
+                  <Text>Edit title</Text>
+                </Flex>
+              </MenuItem>
+              <MenuItem id={AgentSessionAction.Delete} textValue="Delete session">
+                <Flex gap="size-75" alignItems="center">
+                  <Icon svg={<Icons.Trash />} />
+                  <Text>Delete</Text>
+                </Flex>
+              </MenuItem>
+            </Menu>
+          </Popover>
+        </MenuTrigger>
       )}
+      <ModalOverlay
+        isOpen={isEditDialogOpen}
+        onOpenChange={setIsEditDialogOpen}
+      >
+        <Modal size="S">
+          <EditAgentSessionTitleDialog
+            session={session}
+            onClose={() => setIsEditDialogOpen(false)}
+          />
+        </Modal>
+      </ModalOverlay>
       <ModalOverlay
         isOpen={isDeleteDialogOpen}
         onOpenChange={(isOpen) => {

--- a/app/src/pages/settings/SettingsAgentSessionsCard.tsx
+++ b/app/src/pages/settings/SettingsAgentSessionsCard.tsx
@@ -10,7 +10,7 @@ import { useTimeFormatters } from "@phoenix/hooks";
 
 import type { SettingsAgentSessionsCard_sessions$key } from "./__generated__/SettingsAgentSessionsCard_sessions.graphql";
 import type { SettingsAgentSessionsCardPaginationQuery } from "./__generated__/SettingsAgentSessionsCardPaginationQuery.graphql";
-import { SettingsAgentSessionConditionalDeleteButton } from "./SettingsAgentSessionConditionalDeleteButton";
+import { SettingsAgentSessionActionMenu } from "./SettingsAgentSessionActionMenu";
 import { SETTINGS_AGENT_SESSIONS_PAGE_SIZE } from "./settingsAgentSessionConstants";
 
 const sessionsTableWrapperCSS = css`
@@ -82,6 +82,7 @@ export function SettingsAgentSessionsCard({
             node {
               id
               title
+              ...EditAgentSessionTitleDialog_session
               user {
                 username
                 profilePictureUrl
@@ -152,9 +153,10 @@ export function SettingsAgentSessionsCard({
                   <td className="sessions-table__actions">
                     {canDeleteSessions ? (
                       <Flex justifyContent="end">
-                        <SettingsAgentSessionConditionalDeleteButton
+                        <SettingsAgentSessionActionMenu
                           sessionId={node.id}
                           sessionTitle={node.title}
+                          session={node}
                         />
                       </Flex>
                     ) : null}

--- a/app/src/pages/settings/__generated__/SettingsAgentSessionActionMenuDeleteMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAgentSessionActionMenuDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<051dd67472feffcb125232c5ab39636b>>
+ * @generated SignedSource<<14cb1416a26c7dfd72b2549c019949b5>>
  * @lightSyntaxTransform
  */
 
@@ -8,18 +8,18 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type SettingsAgentSessionDeleteButtonMutation$variables = {
+export type SettingsAgentSessionActionMenuDeleteMutation$variables = {
   connectionIds: ReadonlyArray<string>;
   id: string;
 };
-export type SettingsAgentSessionDeleteButtonMutation$data = {
+export type SettingsAgentSessionActionMenuDeleteMutation$data = {
   readonly deleteAgentSession: {
     readonly deletedAgentSessionId: string;
   };
 };
-export type SettingsAgentSessionDeleteButtonMutation = {
-  response: SettingsAgentSessionDeleteButtonMutation$data;
-  variables: SettingsAgentSessionDeleteButtonMutation$variables;
+export type SettingsAgentSessionActionMenuDeleteMutation = {
+  response: SettingsAgentSessionActionMenuDeleteMutation$data;
+  variables: SettingsAgentSessionActionMenuDeleteMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -61,7 +61,7 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "SettingsAgentSessionDeleteButtonMutation",
+    "name": "SettingsAgentSessionActionMenuDeleteMutation",
     "selections": [
       {
         "alias": null,
@@ -86,7 +86,7 @@ return {
       (v0/*:: as any*/)
     ],
     "kind": "Operation",
-    "name": "SettingsAgentSessionDeleteButtonMutation",
+    "name": "SettingsAgentSessionActionMenuDeleteMutation",
     "selections": [
       {
         "alias": null,
@@ -119,16 +119,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cc70a6a6f9058c995fb6c115acb7aefc",
+    "cacheID": "80eca0948839e7c0ad1aa1ad235acfb2",
     "id": null,
     "metadata": {},
-    "name": "SettingsAgentSessionDeleteButtonMutation",
+    "name": "SettingsAgentSessionActionMenuDeleteMutation",
     "operationKind": "mutation",
-    "text": "mutation SettingsAgentSessionDeleteButtonMutation(\n  $id: ID!\n) {\n  deleteAgentSession(input: {id: $id}) {\n    deletedAgentSessionId\n  }\n}\n"
+    "text": "mutation SettingsAgentSessionActionMenuDeleteMutation(\n  $id: ID!\n) {\n  deleteAgentSession(input: {id: $id}) {\n    deletedAgentSessionId\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a9fd01482eb8d068c586ff57d8638fbb";
+(node as any).hash = "f4a96034d7cf6ccd1984ae7bc7aa3f7e";
 
 export default node;

--- a/app/src/pages/settings/__generated__/SettingsAgentSessionsCardPaginationQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAgentSessionsCardPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6afc5d0494a500c197dad03813bf2962>>
+ * @generated SignedSource<<8c42952be4aec591095278d723b82e4c>>
  * @lightSyntaxTransform
  */
 
@@ -214,16 +214,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "121485761df44aa41f57339a2a67fbb8",
+    "cacheID": "af1106886dbee3356aa03310f2b0fdfa",
     "id": null,
     "metadata": {},
     "name": "SettingsAgentSessionsCardPaginationQuery",
     "operationKind": "query",
-    "text": "query SettingsAgentSessionsCardPaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...SettingsAgentSessionsCard_sessions_2HEEH6\n}\n\nfragment SettingsAgentSessionsCard_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after) {\n    edges {\n      node {\n        id\n        title\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SettingsAgentSessionsCardPaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...SettingsAgentSessionsCard_sessions_2HEEH6\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "efb76f37a87a4dc3e2b684e698e96faf";
+(node as any).hash = "ff5bc8370f3a4c07eb982c7b4d84f9e4";
 
 export default node;

--- a/app/src/pages/settings/__generated__/SettingsAgentSessionsCard_sessions.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAgentSessionsCard_sessions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<58c18d34272a71ad5e4162e7ed606d70>>
+ * @generated SignedSource<<f088648ebb449783dcfc954772a6bf9a>>
  * @lightSyntaxTransform
  */
 
@@ -22,6 +22,7 @@ export type SettingsAgentSessionsCard_sessions$data = {
           readonly profilePictureUrl: string | null;
           readonly username: string;
         } | null;
+        readonly " $fragmentSpreads": FragmentRefs<"EditAgentSessionTitleDialog_session">;
       };
     }>;
   };
@@ -113,6 +114,11 @@ return {
                   "kind": "ScalarField",
                   "name": "title",
                   "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "EditAgentSessionTitleDialog_session"
                 },
                 {
                   "alias": null,
@@ -214,6 +220,6 @@ return {
 };
 })();
 
-(node as any).hash = "efb76f37a87a4dc3e2b684e698e96faf";
+(node as any).hash = "ff5bc8370f3a4c07eb982c7b4d84f9e4";
 
 export default node;

--- a/app/src/pages/settings/__generated__/settingsAgentsPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/settingsAgentsPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<84066aa3a5e0eef1bd4224991af01be4>>
+ * @generated SignedSource<<19cc8f382015089cfbf84f9cef140146>>
  * @lightSyntaxTransform
  */
 
@@ -203,12 +203,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "65940b9d3b92e1e6fb1b38e6166f54bc",
+    "cacheID": "07f53e46b4522a049e2f0b61167ff26a",
     "id": null,
     "metadata": {},
     "name": "settingsAgentsPageLoaderQuery",
     "operationKind": "query",
-    "text": "query settingsAgentsPageLoaderQuery(\n  $first: Int!\n) {\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query settingsAgentsPageLoaderQuery(\n  $first: Int!\n) {\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -9351,6 +9351,7 @@
         "properties": {
           "title": {
             "type": "string",
+            "maxLength": 100,
             "title": "Title",
             "description": "Optional initial title.",
             "default": ""

--- a/src/phoenix/server/agents/prompts/summarization/SUMMARIZATION_PROMPT_INSTRUCTIONS.xml.j2
+++ b/src/phoenix/server/agents/prompts/summarization/SUMMARIZATION_PROMPT_INSTRUCTIONS.xml.j2
@@ -6,6 +6,7 @@
 </role>
 <rules>
   - 2-6 words. Shorter is better.
+  - At most {{ max_title_length }} characters.
   - Either a short noun phrase or a short imperative naming the user's
     task is acceptable.
   - Use sentence case: only the first letter of the title is

--- a/src/phoenix/server/agents/session_titles.py
+++ b/src/phoenix/server/agents/session_titles.py
@@ -1,0 +1,16 @@
+MAX_AGENT_SESSION_TITLE_LENGTH = 100
+
+
+def validate_agent_session_title(title: str, *, allow_empty: bool) -> str:
+    normalized_title = title.strip()
+    if not normalized_title and not allow_empty:
+        raise ValueError("Agent session title cannot be empty")
+    if len(normalized_title) > MAX_AGENT_SESSION_TITLE_LENGTH:
+        raise ValueError(
+            f"Agent session title cannot exceed {MAX_AGENT_SESSION_TITLE_LENGTH} characters"
+        )
+    return normalized_title
+
+
+def truncate_agent_session_title(title: str) -> str:
+    return title.strip()[:MAX_AGENT_SESSION_TITLE_LENGTH].rstrip()

--- a/src/phoenix/server/agents/summarization.py
+++ b/src/phoenix/server/agents/summarization.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_ai.messages import (
     InstructionPart,
     ModelMessage,
@@ -17,13 +17,22 @@ from phoenix.server.agents.prompts import (
     COMPACTION_MESSAGE_TEMPLATE,
     SUMMARIZATION_INSTRUCTIONS_TEMPLATE,
 )
+from phoenix.server.agents.session_titles import (
+    MAX_AGENT_SESSION_TITLE_LENGTH,
+    truncate_agent_session_title,
+)
 
 SUMMARY_TOOL_NAME = "summary"
 COMPACTION_TOOL_NAME = "conversation_checkpoint"
 
 
 class _Summary(BaseModel):
-    summary: str
+    summary: str = Field(max_length=MAX_AGENT_SESSION_TITLE_LENGTH)
+
+    @field_validator("summary", mode="before")
+    @classmethod
+    def truncate_summary(cls, value: object) -> object:
+        return truncate_agent_session_title(value) if isinstance(value, str) else value
 
 
 SUMMARY_TOOL_DEFINITION = ToolDefinition(
@@ -66,7 +75,12 @@ async def summarize_messages(
         output_mode="tool",
         allow_text_output=False,
         instruction_parts=[
-            InstructionPart(content=SUMMARIZATION_INSTRUCTIONS_TEMPLATE.render(), dynamic=False),
+            InstructionPart(
+                content=SUMMARIZATION_INSTRUCTIONS_TEMPLATE.render(
+                    max_title_length=MAX_AGENT_SESSION_TITLE_LENGTH
+                ),
+                dynamic=False,
+            ),
         ],
     )
     try:

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -87,6 +87,18 @@ class DeleteAgentSessionInput:
     id: GlobalID
 
 
+@strawberry.input
+class UpdateAgentSessionTitleInput:
+    id: GlobalID
+    title: str
+
+
+@strawberry.type
+class UpdateAgentSessionTitleMutationPayload:
+    agent_session: AgentSession
+    query: Query
+
+
 @strawberry.type
 class DeleteAgentSessionMutationPayload:
     deleted_agent_session_id: GlobalID
@@ -232,6 +244,39 @@ class AgentSessionMutationMixin:
             session.add_all(regenerated_message_rows)
         return BranchAgentSessionMutationPayload(
             agent_session=to_gql_agent_session(branch_session),
+            query=Query(),
+        )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    async def update_agent_session_title(
+        self,
+        info: Info[Context, None],
+        input: UpdateAgentSessionTitleInput,
+    ) -> UpdateAgentSessionTitleMutationPayload:
+        """Update a persisted session's title."""
+        title = input.title.strip()
+        if not title:
+            raise BadRequest("Agent session title cannot be empty")
+        try:
+            agent_session_rowid = from_global_id_with_expected_type(
+                input.id,
+                models.AgentSession.__name__,
+            )
+        except ValueError as exc:
+            raise BadRequest(str(exc)) from exc
+        lookup_stmt = select(models.AgentSession).where(
+            models.AgentSession.id == agent_session_rowid
+        )
+        if (owner_filter := get_agent_session_owner_filter(info.context)) is not None:
+            lookup_stmt = lookup_stmt.where(owner_filter)
+        async with info.context.db() as session:
+            agent_session = await session.scalar(lookup_stmt)
+            if agent_session is None:
+                raise NotFound(f"No agent session found for ID '{input.id}'")
+            agent_session.title = title
+            await session.flush()
+        return UpdateAgentSessionTitleMutationPayload(
+            agent_session=to_gql_agent_session(agent_session),
             query=Query(),
         )
 

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -16,6 +16,10 @@ from phoenix.config import (
 )
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
+from phoenix.server.agents.session_titles import (
+    truncate_agent_session_title,
+    validate_agent_session_title,
+)
 from phoenix.server.api.agent_helpers import get_agent_session_owner_filter
 from phoenix.server.api.auth import IsAgentAssistantEnabled, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
@@ -114,11 +118,15 @@ class AgentSessionMutationMixin:
         input: CreateAgentSessionInput,
     ) -> CreateAgentSessionMutationPayload:
         """Create an empty persisted session owned by the viewer."""
+        try:
+            title = validate_agent_session_title(input.title, allow_empty=True)
+        except ValueError as exc:
+            raise BadRequest(str(exc)) from exc
         async with info.context.db() as session:
             agent_session = models.AgentSession(
                 project_session_id=str(uuid4()),
                 user_id=info.context.user_id,
-                title=input.title.strip(),
+                title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
                 expires_at=(
                     datetime.now(timezone.utc)
@@ -222,7 +230,7 @@ class AgentSessionMutationMixin:
             branch_session = models.AgentSession(
                 project_session_id=str(uuid4()),
                 user_id=info.context.user_id,
-                title=source_session.title,
+                title=truncate_agent_session_title(source_session.title),
                 project_name=get_env_phoenix_agents_assistant_project_name(),
                 expires_at=(
                     datetime.now(timezone.utc)
@@ -254,9 +262,10 @@ class AgentSessionMutationMixin:
         input: UpdateAgentSessionTitleInput,
     ) -> UpdateAgentSessionTitleMutationPayload:
         """Update a persisted session's title."""
-        title = input.title.strip()
-        if not title:
-            raise BadRequest("Agent session title cannot be empty")
+        try:
+            title = validate_agent_session_title(input.title, allow_empty=False)
+        except ValueError as exc:
+            raise BadRequest(str(exc)) from exc
         try:
             agent_session_rowid = from_global_id_with_expected_type(
                 input.id,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -119,6 +119,11 @@ from phoenix.server.agents.model_factory import build_model
 from phoenix.server.agents.model_selection import AgentModelSelection
 from phoenix.server.agents.prompts import AgentPrompts, ServerAgentPrompts
 from phoenix.server.agents.server_agents import build_server_agent
+from phoenix.server.agents.session_titles import (
+    MAX_AGENT_SESSION_TITLE_LENGTH,
+    truncate_agent_session_title,
+    validate_agent_session_title,
+)
 from phoenix.server.agents.skill_requests import (
     inject_requested_skills,
     iter_requested_skill_response_chunks,
@@ -314,7 +319,11 @@ class ChatRequest(ChatSubmitMessage):
 class CreateAgentSessionRequestBody(V1RoutesBaseModel):
     """Request body for creating a persisted agent session."""
 
-    title: str = Field(default="", description="Optional initial title.")
+    title: str = Field(
+        default="",
+        max_length=MAX_AGENT_SESSION_TITLE_LENGTH,
+        description="Optional initial title.",
+    )
     temporary: bool = Field(
         default=False,
         description="Whether the session should expire after a period of inactivity.",
@@ -1350,7 +1359,7 @@ async def _persist_agent_session_title(
                 session,
                 agent_session_rowid=agent_session_rowid,
                 user_id=user_id,
-                title=title,
+                title=truncate_agent_session_title(title),
             )
     except Exception:
         logger.exception(
@@ -1575,13 +1584,17 @@ def create_agents_router(
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
         if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
             raise HTTPException(status_code=403, detail="Server agent is disabled")
+        try:
+            title = validate_agent_session_title(request_body.title, allow_empty=True)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         user = request.user if "user" in request.scope else None
         phoenix_user = user if isinstance(user, PhoenixUser) else None
         async with request.app.state.db() as session:
             agent_session = models.AgentSession(
                 project_session_id=str(uuid4()),
                 user_id=int(phoenix_user.identity) if phoenix_user is not None else None,
-                title=request_body.title.strip(),
+                title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
                 expires_at=(
                     datetime.now(timezone.utc)

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -53,6 +53,7 @@ from phoenix.server.agents.data_stream_protocol import (
     accumulate_ui_message_chunks_to_ui_messages,
 )
 from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
+from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
 from phoenix.server.api.routers.agents import (
     _build_message_metadata_chunk,
     _emit_turn_root_span,
@@ -1413,6 +1414,33 @@ async def test_chat_endpoint_rejects_regenerate_requests(
     assert response.status_code == 422
 
 
+async def test_generated_session_title_is_limited(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_id = "33333333-3333-4333-8333-333333333333"
+    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    generated_title = "x" * (MAX_AGENT_SESSION_TITLE_LENGTH + 20)
+    _mock_turn_models(monkeypatch, _scripted_model(summary=generated_title))
+
+    response = await httpx_client.post(
+        _chat_url(agent_session_id),
+        json=_chat_body(session_id, _user_message("first question")),
+    )
+
+    assert response.status_code == 200
+    expected_title = "x" * MAX_AGENT_SESSION_TITLE_LENGTH
+    summary_chunks = [
+        chunk
+        for chunk in _stream_chunks(response.text)
+        if chunk.get("type") == "data-session-summary"
+    ]
+    assert [chunk["data"] for chunk in summary_chunks] == [expected_title]
+    async with db() as session:
+        assert await session.scalar(select(models.AgentSession.title)) == expected_title
+
+
 async def test_failed_summary_leaves_session_untitled_until_a_later_turn(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
@@ -1718,6 +1746,17 @@ async def test_create_session_route_defaults_to_a_persistent_untitled_session(
         assert agent_session is not None
         assert agent_session.title == ""
         assert agent_session.expires_at is None
+
+
+async def test_create_session_route_rejects_long_title(
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    response = await httpx_client.post(
+        "/agents/assistant/sessions",
+        json={"title": "x" * (MAX_AGENT_SESSION_TITLE_LENGTH + 1)},
+    )
+
+    assert response.status_code == 422
 
 
 async def test_create_session_route_yields_a_chattable_session(

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -64,6 +64,17 @@ _DELETE_MUTATION = """
   }
 """
 
+_UPDATE_TITLE_MUTATION = """
+  mutation ($id: ID!, $title: String!) {
+    updateAgentSessionTitle(input: { id: $id, title: $title }) {
+      agentSession {
+        id
+        title
+      }
+    }
+  }
+"""
+
 
 @pytest.mark.parametrize(
     ("mutation", "variables"),
@@ -621,6 +632,60 @@ async def test_create_agent_session_mints_distinct_sessions(
             await session.scalars(select(models.AgentSession.project_session_id))
         ).all()
         assert len(set(project_session_ids)) == 2
+
+
+async def test_update_agent_session_title(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id="11111111-1111-4111-8111-111111111111",
+            user_id=None,
+            title="Old title",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_id = str(GlobalID("AgentSession", str(agent_session.id)))
+
+    response = await gql_client.execute(
+        query=_UPDATE_TITLE_MUTATION,
+        variables={"id": agent_session_id, "title": "  New title  "},
+    )
+
+    assert not response.errors
+    assert response.data == {
+        "updateAgentSessionTitle": {"agentSession": {"id": agent_session_id, "title": "New title"}}
+    }
+    async with db() as session:
+        assert await session.scalar(select(models.AgentSession.title)) == "New title"
+
+
+async def test_update_agent_session_title_rejects_empty_title(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id="11111111-1111-4111-8111-111111111111",
+            user_id=None,
+            title="Old title",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_id = str(GlobalID("AgentSession", str(agent_session.id)))
+
+    response = await gql_client.execute(
+        query=_UPDATE_TITLE_MUTATION,
+        variables={"id": agent_session_id, "title": "   "},
+    )
+
+    assert response.errors
+    assert response.errors[0].message == "Agent session title cannot be empty"
+    async with db() as session:
+        assert await session.scalar(select(models.AgentSession.title)) == "Old title"
 
 
 async def test_delete_agent_session_cascades_snapshot(

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -11,6 +11,7 @@ from phoenix.db.types.data_stream_protocol import (
     PhoenixUIMessage,
     TextUIPart,
 )
+from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
 from phoenix.server.api.routers.agents import (
     _build_compaction_message,
     _load_agent_session_history,
@@ -634,6 +635,20 @@ async def test_create_agent_session_mints_distinct_sessions(
         assert len(set(project_session_ids)) == 2
 
 
+async def test_create_agent_session_rejects_long_title(
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    response = await gql_client.execute(
+        query=_CREATE_MUTATION,
+        variables={"title": "x" * (MAX_AGENT_SESSION_TITLE_LENGTH + 1)},
+    )
+
+    assert response.errors
+    assert response.errors[0].message == (
+        f"Agent session title cannot exceed {MAX_AGENT_SESSION_TITLE_LENGTH} characters"
+    )
+
+
 async def test_update_agent_session_title(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
@@ -684,6 +699,37 @@ async def test_update_agent_session_title_rejects_empty_title(
 
     assert response.errors
     assert response.errors[0].message == "Agent session title cannot be empty"
+    async with db() as session:
+        assert await session.scalar(select(models.AgentSession.title)) == "Old title"
+
+
+async def test_update_agent_session_title_rejects_long_title(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id="11111111-1111-4111-8111-111111111111",
+            user_id=None,
+            title="Old title",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_id = str(GlobalID("AgentSession", str(agent_session.id)))
+
+    response = await gql_client.execute(
+        query=_UPDATE_TITLE_MUTATION,
+        variables={
+            "id": agent_session_id,
+            "title": "x" * (MAX_AGENT_SESSION_TITLE_LENGTH + 1),
+        },
+    )
+
+    assert response.errors
+    assert response.errors[0].message == (
+        f"Agent session title cannot exceed {MAX_AGENT_SESSION_TITLE_LENGTH} characters"
+    )
     async with db() as session:
         assert await session.scalar(select(models.AgentSession.title)) == "Old title"
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/09e918dd-8d69-4f18-a71c-b656e13023d6


## Summary
- add an authorized GraphQL mutation for updating assistant session titles
- add Edit title to the settings table action menu with fragment refresh
- add a hover pencil and panel-local inline editor to the PXI chat header

## Tests
- `uv run pytest tests/unit/server/api/mutations/test_agent_session_mutations.py -n auto`
- `make typecheck-python`
- `pnpm exec vitest run src/components/agent/__tests__/AgentChatPanelView.test.tsx`
- `pnpm typecheck`
- `pnpm build`