### PR TITLE
feat(online-eval): consumer throughput env knobs, TTL-vs-drain warning, expired-work gauge

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -70,6 +70,21 @@ input AddExamplesToDatasetInput {
   datasetVersionMetadata: JSON
 }
 
+input AddProjectCodeEvaluatorInput {
+  projectId: ID!
+  evaluatorId: ID!
+  name: Identifier!
+  samplingRate: Float!
+  evaluationTarget: EvaluationTarget!
+
+  """
+  Project-specific CODE input mapping. Null inherits the evaluator input mapping; an object overrides it.
+  """
+  inputMapping: EvaluatorInputMappingInput = null
+  filterCondition: String! = ""
+  enabled: Boolean! = true
+}
+
 input AddSpansToDatasetInput {
   datasetId: ID!
   spanIds: [ID!]!
@@ -2467,12 +2482,17 @@ type Mutation {
   updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
+  Bind an existing CODE evaluator to a project. The evaluator's configuration is shared with every project and dataset it is bound to. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  """
+  addProjectCodeEvaluator(input: AddProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
+
+  """
   Create a CODE project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
   """
   createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
 
   """
-  Update a CODE project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  Update a CODE project evaluator. Editing changes the underlying evaluator, which applies to every project and dataset it is bound to. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
   """
   updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
   deleteProjectEvaluators(input: DeleteProjectEvaluatorsInput!): DeleteProjectEvaluatorsPayload!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2893,7 +2893,7 @@ type ProjectEvaluator implements Node {
   samplingRate: Float!
 
   """
-  Evaluation grain. SPAN is currently executable; TRACE and SESSION are stored but remain inactive until their runtimes are available.
+  SPAN is currently executable; TRACE and SESSION are stored but remain inactive until their runtimes are available.
   """
   evaluationTarget: EvaluationTarget!
   inputMapping: EvaluatorInputMapping!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -827,11 +827,45 @@ type CreateModelMutationPayload {
   query: Query!
 }
 
+input CreateProjectCodeEvaluatorInput {
+  projectId: ID!
+  name: Identifier!
+  sourceCode: String!
+  language: Language!
+  sandboxConfigId: ID!
+  evaluatorInputMapping: EvaluatorInputMappingInput!
+  samplingRate: Float!
+  evaluationTarget: EvaluationTarget!
+  description: String = null
+  outputConfigs: [AnnotationConfigInput!] = null
+
+  """
+  Project-specific CODE input mapping. Null inherits the evaluator input mapping; an object overrides it.
+  """
+  inputMapping: EvaluatorInputMappingInput = null
+  filterCondition: String! = ""
+  enabled: Boolean! = true
+}
+
 input CreateProjectInput {
   name: String!
   description: String
   gradientStartColor: String
   gradientEndColor: String
+}
+
+input CreateProjectLLMEvaluatorInput {
+  projectId: ID!
+  name: Identifier!
+  promptVersion: ChatPromptVersionInput!
+  outputConfigs: [AnnotationConfigInput!]!
+  inputMapping: EvaluatorInputMappingInput!
+  samplingRate: Float!
+  evaluationTarget: EvaluationTarget!
+  description: String = null
+  promptVersionId: ID
+  filterCondition: String! = ""
+  enabled: Boolean! = true
 }
 
 input CreateProjectSessionAnnotationInput {
@@ -1386,6 +1420,16 @@ input DeleteProjectAnnotationsInput {
   timeRangeField: AnnotationTimeRangeField! = ANNOTATION_CREATED_AT
 }
 
+input DeleteProjectEvaluatorsInput {
+  projectEvaluatorIds: [ID!]!
+  deleteAssociatedPrompt: Boolean! = true
+}
+
+type DeleteProjectEvaluatorsPayload {
+  projectEvaluatorIds: [ID!]!
+  query: Query!
+}
+
 input DeleteProjectTraceRetentionPolicyInput {
   id: ID!
 }
@@ -1581,6 +1625,12 @@ type EvaluationResult {
   annotation: ExperimentRunAnnotation
   trace: Trace
   error: String
+}
+
+enum EvaluationTarget {
+  SPAN
+  TRACE
+  SESSION
 }
 
 interface Evaluator implements Node {
@@ -2405,6 +2455,27 @@ type Mutation {
   createDocumentAnnotations(input: [CreateDocumentAnnotationInput!]!): DocumentAnnotationMutationPayload!
   patchDocumentAnnotations(input: [PatchAnnotationInput!]!): DocumentAnnotationMutationPayload!
   deleteDocumentAnnotations(input: DeleteAnnotationsInput!): DocumentAnnotationMutationPayload!
+
+  """
+  Create an LLM project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  """
+  createProjectLlmEvaluator(input: CreateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
+
+  """
+  Update an LLM project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  """
+  updateProjectLlmEvaluator(input: UpdateProjectLLMEvaluatorInput!): ProjectEvaluatorMutationPayload!
+
+  """
+  Create a CODE project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  """
+  createProjectCodeEvaluator(input: CreateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
+
+  """
+  Update a CODE project evaluator. SPAN is executable; TRACE and SESSION are stored but inactive until their runtimes are available.
+  """
+  updateProjectCodeEvaluator(input: UpdateProjectCodeEvaluatorInput!): ProjectEvaluatorMutationPayload!
+  deleteProjectEvaluators(input: DeleteProjectEvaluatorsInput!): DeleteProjectEvaluatorsPayload!
   createDatasetLlmEvaluator(input: CreateDatasetLLMEvaluatorInput!): DatasetEvaluatorMutationPayload!
   updateDatasetLlmEvaluator(input: UpdateDatasetLLMEvaluatorInput!): DatasetEvaluatorMutationPayload!
   deleteDatasetEvaluators(input: DeleteDatasetEvaluatorsInput!): DeleteDatasetEvaluatorsPayload!
@@ -2715,6 +2786,7 @@ type Project implements Node {
   id: ID!
   name: String!
   description: String
+  evaluators(first: Int = 30, last: Int = null, after: String = null, before: String = null): ProjectEvaluatorConnection!
   gradientStartColor: String!
   gradientEndColor: String!
   startTime: DateTime
@@ -2809,6 +2881,48 @@ type ProjectEdge {
 
   """The item at the end of the edge"""
   node: Project!
+}
+
+type ProjectEvaluator implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+  project: Project!
+  evaluator: Evaluator!
+  name: Identifier!
+  filterCondition: String!
+  samplingRate: Float!
+
+  """
+  Evaluation grain. SPAN is currently executable; TRACE and SESSION are stored but remain inactive until their runtimes are available.
+  """
+  evaluationTarget: EvaluationTarget!
+  inputMapping: EvaluatorInputMapping!
+  enabled: Boolean!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+"""A connection to a list of items."""
+type ProjectEvaluatorConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ProjectEvaluatorEdge!]!
+}
+
+"""An edge in a connection."""
+type ProjectEvaluatorEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: ProjectEvaluator!
+}
+
+type ProjectEvaluatorMutationPayload {
+  evaluator: ProjectEvaluator!
+  query: Query!
 }
 
 """The filter key and value for project connections"""
@@ -4522,6 +4636,39 @@ input UpdateModelMutationInput {
 type UpdateModelMutationPayload {
   model: GenerativeModel!
   query: Query!
+}
+
+input UpdateProjectCodeEvaluatorInput {
+  projectEvaluatorId: ID!
+  name: Identifier!
+  evaluatorInputMapping: EvaluatorInputMappingInput!
+  samplingRate: Float!
+  evaluationTarget: EvaluationTarget!
+  filterCondition: String!
+  enabled: Boolean!
+  description: String = null
+  sourceCode: String
+  sandboxConfigId: ID
+  outputConfigs: [AnnotationConfigInput!]
+
+  """
+  Project-specific CODE input mapping patch. Omit to preserve the current setting, use null to inherit the evaluator input mapping, or provide an object to override it.
+  """
+  inputMapping: EvaluatorInputMappingInput
+}
+
+input UpdateProjectLLMEvaluatorInput {
+  projectEvaluatorId: ID!
+  name: Identifier!
+  promptVersion: ChatPromptVersionInput!
+  outputConfigs: [AnnotationConfigInput!]!
+  inputMapping: EvaluatorInputMappingInput!
+  samplingRate: Float!
+  evaluationTarget: EvaluationTarget!
+  filterCondition: String!
+  enabled: Boolean!
+  description: String = null
+  promptVersionId: ID
 }
 
 input UpdateSandboxConfigInput {

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -66,6 +66,7 @@ import {
   PlaygroundPage,
   playgroundPageLoader,
   ProfilePage,
+  ProjectEvaluatorsPage,
   ProjectIndexPage,
   projectLoader,
   ProjectMetricsPage,
@@ -305,6 +306,17 @@ export const appRouteObjects = createRoutesFromElements(
                     label: "Project Metrics",
                     description:
                       "View project time-series metrics, token usage breakdowns, cache read/write token charts, and observability panels.",
+                  },
+                }}
+              />
+              <Route
+                path="evaluators"
+                element={<ProjectEvaluatorsPage />}
+                handle={{
+                  agentRoute: {
+                    label: "Project Evaluators",
+                    description:
+                      "View and add project evaluators — online evals that automatically run against live spans, traces, and sessions.",
                   },
                 }}
               />

--- a/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditBuiltInEvaluatorDialogContent.tsx
@@ -9,8 +9,11 @@ import {
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
+import { CodeEvaluatorForm } from "@phoenix/components/evaluators/CodeEvaluatorForm";
+import { EvaluatorDatasetTestPanel } from "@phoenix/components/evaluators/EvaluatorDatasetTestPanel";
 import { EvaluatorForm } from "@phoenix/components/evaluators/EvaluatorForm";
 import { CodeEvaluatorInputVariablesProvider } from "@phoenix/components/evaluators/EvaluatorInputVariablesContext/CodeEvaluatorInputVariablesProvider";
+import { EvaluatorNameAndDescriptionFields } from "@phoenix/components/evaluators/EvaluatorNameAndDescriptionFields";
 import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 
 export const EditBuiltInEvaluatorDialogContent = ({
@@ -95,7 +98,15 @@ export const EditBuiltInEvaluatorDialogContent = ({
         <CodeEvaluatorInputVariablesProvider
           evaluatorInputSchema={evaluatorInputSchema}
         >
-          <EvaluatorForm />
+          <EvaluatorForm
+            left={
+              <>
+                <EvaluatorNameAndDescriptionFields />
+                <CodeEvaluatorForm />
+              </>
+            }
+            right={<EvaluatorDatasetTestPanel />}
+          />
         </CodeEvaluatorInputVariablesProvider>
       </fieldset>
     </DialogContent>

--- a/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditLLMEvaluatorDialogContent.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { useMemo, useRef, useState } from "react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
 import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
@@ -11,8 +11,11 @@ import {
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
+import { EvaluatorDatasetTestPanel } from "@phoenix/components/evaluators/EvaluatorDatasetTestPanel";
 import { EvaluatorForm } from "@phoenix/components/evaluators/EvaluatorForm";
 import { LLMEvaluatorInputVariablesProvider } from "@phoenix/components/evaluators/EvaluatorInputVariablesContext/LLMEvaluatorInputVariablesProvider";
+import { EvaluatorNameAndDescriptionFields } from "@phoenix/components/evaluators/EvaluatorNameAndDescriptionFields";
+import { LLMEvaluatorForm } from "@phoenix/components/evaluators/LLMEvaluatorForm";
 import { useLlmEvaluatorDraftRegistration } from "@phoenix/components/evaluators/useLlmEvaluatorDraftRegistration";
 import { useEvaluatorStoreInstance } from "@phoenix/contexts/EvaluatorContext";
 
@@ -22,6 +25,8 @@ export const EditLLMEvaluatorDialogContent = ({
   mode,
   error,
   evaluatorNodeId,
+  formLeftPanelExtra,
+  formRightPanel,
 }: {
   onClose: () => void;
   onSubmit: () => Promise<EvaluatorSubmitResult>;
@@ -29,6 +34,14 @@ export const EditLLMEvaluatorDialogContent = ({
   mode: "create" | "update";
   error?: string;
   evaluatorNodeId?: string | null;
+  /**
+   * Optional section rendered in the form's left panel below name/description.
+   */
+  formLeftPanelExtra?: ReactNode;
+  /**
+   * Replaces the form's right (test) panel.
+   */
+  formRightPanel?: ReactNode;
 }) => {
   const store = useEvaluatorStoreInstance();
 
@@ -117,7 +130,16 @@ export const EditLLMEvaluatorDialogContent = ({
           </Alert>
         )}
         <LLMEvaluatorInputVariablesProvider>
-          <EvaluatorForm />
+          <EvaluatorForm
+            left={
+              <>
+                <EvaluatorNameAndDescriptionFields />
+                {formLeftPanelExtra}
+                <LLMEvaluatorForm />
+              </>
+            }
+            right={formRightPanel ?? <EvaluatorDatasetTestPanel />}
+          />
         </LLMEvaluatorInputVariablesProvider>
       </fieldset>
     </DialogContent>

--- a/app/src/components/evaluators/EvaluatorDatasetTestPanel.tsx
+++ b/app/src/components/evaluators/EvaluatorDatasetTestPanel.tsx
@@ -1,0 +1,20 @@
+import { Flex, View } from "@phoenix/components";
+import { EvaluatorExampleDataset } from "@phoenix/components/evaluators/EvaluatorExampleDataset";
+import { EvaluatorInputPreview } from "@phoenix/components/evaluators/EvaluatorInputPreview";
+import { EvaluatorOutputPreview } from "@phoenix/components/evaluators/EvaluatorOutputPreview";
+
+/**
+ * Test an evaluator against dataset examples.
+ * Requires `dataset` to be set in the evaluator store.
+ */
+export const EvaluatorDatasetTestPanel = () => (
+  <Flex direction="column" gap="size-200">
+    <View paddingX="size-200">
+      <Flex direction="column" gap="size-100">
+        <EvaluatorOutputPreview />
+        <EvaluatorExampleDataset />
+      </Flex>
+    </View>
+    <EvaluatorInputPreview />
+  </Flex>
+);

--- a/app/src/components/evaluators/EvaluatorForm.tsx
+++ b/app/src/components/evaluators/EvaluatorForm.tsx
@@ -1,25 +1,12 @@
 import { css } from "@emotion/react";
-import type { PropsWithChildren } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Group, Panel, Separator } from "react-resizable-panels";
-import { useShallow } from "zustand/react/shallow";
 
-import { Flex, View } from "@phoenix/components";
-import { CodeEvaluatorForm } from "@phoenix/components/evaluators/CodeEvaluatorForm";
-import { EvaluatorDescriptionInput } from "@phoenix/components/evaluators/EvaluatorDescriptionInput";
-import { EvaluatorExampleDataset } from "@phoenix/components/evaluators/EvaluatorExampleDataset";
-import { EvaluatorInputPreview } from "@phoenix/components/evaluators/EvaluatorInputPreview";
-import { EvaluatorNameInput } from "@phoenix/components/evaluators/EvaluatorNameInput";
-import { EvaluatorOutputPreview } from "@phoenix/components/evaluators/EvaluatorOutputPreview";
 import { EvaluatorPlaygroundProvider } from "@phoenix/components/evaluators/EvaluatorPlaygroundProvider";
-import { LLMEvaluatorForm } from "@phoenix/components/evaluators/LLMEvaluatorForm";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
-import { useEvaluatorStore } from "@phoenix/contexts/EvaluatorContext";
 import type { fetchPlaygroundPrompt_promptVersionToInstance_promptVersion$key } from "@phoenix/pages/playground/__generated__/fetchPlaygroundPrompt_promptVersionToInstance_promptVersion.graphql";
-import {
-  DEFAULT_STORE_VALUES,
-  type EvaluatorStore,
-} from "@phoenix/store/evaluatorStore";
+import { DEFAULT_STORE_VALUES } from "@phoenix/store/evaluatorStore";
 import type { ClassificationEvaluatorAnnotationConfig } from "@phoenix/types";
 import type {
   EvaluatorInputMapping as EvaluatorInputMappingType,
@@ -95,30 +82,31 @@ export const EvaluatorFormProvider = ({
   );
 };
 
-const evaluatorFormSelector = (state: EvaluatorStore) => ({
-  evaluatorKind: state.evaluator.kind,
-  isBuiltin: state.evaluator.isBuiltin,
-});
-
 /**
- * A form for configuring evaluators.
- * Depends on the EvaluatorFormProvider to provide the react-hook-form instance for the evaluator form and new
- * default playground state for the evaluator chat template.
+ * The two-panel resizable layout for configuring evaluators. Callers provide
+ * the content of each panel.
  *
  * @example
  * ```tsx
- * const form = useEvaluatorForm();
- * return (
- *   <EvaluatorFormProvider form={form}>
- *     <EvaluatorForm />
- *   </EvaluatorFormProvider>
- * );
+ * <EvaluatorForm
+ *   left={<LLMEvaluatorForm />}
+ *   right={<EvaluatorDatasetTestPanel />}
+ * />
  * ```
  */
-export const EvaluatorForm = () => {
-  const { evaluatorKind } = useEvaluatorStore(
-    useShallow(evaluatorFormSelector)
-  );
+export const EvaluatorForm = ({
+  left,
+  right,
+}: {
+  /**
+   * The content of the left (configuration) panel.
+   */
+  left: ReactNode;
+  /**
+   * The content of the right (test) panel.
+   */
+  right: ReactNode;
+}) => {
   return (
     <Group orientation="horizontal" style={{ flex: 1, minHeight: 0 }}>
       <Panel
@@ -132,19 +120,7 @@ export const EvaluatorForm = () => {
           box-sizing: border-box;
         `}
       >
-        <View marginBottom="size-200" flex="none">
-          <Flex
-            direction="row"
-            alignItems="baseline"
-            width="100%"
-            gap="size-100"
-          >
-            <EvaluatorNameInput />
-            <EvaluatorDescriptionInput />
-          </Flex>
-        </View>
-        {evaluatorKind === "LLM" && <LLMEvaluatorForm />}
-        {evaluatorKind === "BUILTIN" && <CodeEvaluatorForm />}
+        {left}
       </Panel>
       <Separator css={compactResizeHandleCSS} />
       <Panel
@@ -158,15 +134,7 @@ export const EvaluatorForm = () => {
           box-sizing: border-box;
         `}
       >
-        <Flex direction="column" gap="size-200">
-          <View paddingX="size-200">
-            <Flex direction="column" gap="size-100">
-              <EvaluatorOutputPreview />
-              <EvaluatorExampleDataset />
-            </Flex>
-          </View>
-          <EvaluatorInputPreview />
-        </Flex>
+        {right}
       </Panel>
     </Group>
   );

--- a/app/src/components/evaluators/EvaluatorNameAndDescriptionFields.tsx
+++ b/app/src/components/evaluators/EvaluatorNameAndDescriptionFields.tsx
@@ -1,0 +1,16 @@
+import { Flex, View } from "@phoenix/components";
+import { EvaluatorDescriptionInput } from "@phoenix/components/evaluators/EvaluatorDescriptionInput";
+import { EvaluatorNameInput } from "@phoenix/components/evaluators/EvaluatorNameInput";
+
+/**
+ * The name and description inputs rendered at the top of an evaluator form's
+ * left panel.
+ */
+export const EvaluatorNameAndDescriptionFields = () => (
+  <View marginBottom="size-200" flex="none">
+    <Flex direction="row" alignItems="baseline" width="100%" gap="size-100">
+      <EvaluatorNameInput />
+      <EvaluatorDescriptionInput />
+    </Flex>
+  </View>
+);

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -83,7 +83,14 @@ export function ProjectPage() {
   );
 }
 
-const TABS = ["spans", "traces", "sessions", "config", "metrics"] as const;
+const TABS = [
+  "spans",
+  "traces",
+  "sessions",
+  "config",
+  "metrics",
+  "evaluators",
+] as const;
 
 /**
  * Type guard for the tab path in the URL
@@ -98,6 +105,7 @@ const TAB_INDEX_MAP: Record<(typeof TABS)[number], number> = {
   sessions: 2,
   metrics: 3,
   config: 4,
+  evaluators: 5,
 };
 
 const TAB_PATH_BY_INDEX = Object.fromEntries(
@@ -246,6 +254,7 @@ function ProjectPageContentBody({
             <Tab id="traces">Traces</Tab>
             <Tab id="sessions">Sessions</Tab>
             <Tab id="metrics">Metrics</Tab>
+            <Tab id="evaluators">Evaluators</Tab>
             <Tab id="config">Config</Tab>
           </TabList>
           <LazyTabPanel padded={false} id="spans">
@@ -261,6 +270,9 @@ function ProjectPageContentBody({
             <Outlet />
           </LazyTabPanel>
           <LazyTabPanel padded={false} id="config">
+            <Outlet />
+          </LazyTabPanel>
+          <LazyTabPanel padded={false} id="evaluators">
             <Outlet />
           </LazyTabPanel>
         </Tabs>

--- a/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
+++ b/app/src/pages/project/evaluators/AddProjectEvaluatorMenu.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import type { MenuTriggerProps } from "react-aria-components";
+import { MenuSection } from "react-aria-components";
+
+import type { ButtonProps } from "@phoenix/components/core/button";
+import { Button } from "@phoenix/components/core/button";
+import { Icon, Icons } from "@phoenix/components/core/icon";
+import {
+  Menu,
+  MenuContainer,
+  MenuItem,
+  MenuSectionTitle,
+  MenuTrigger,
+} from "@phoenix/components/core/menu";
+import { CreateLLMProjectEvaluatorSlideover } from "@phoenix/pages/project/evaluators/CreateLLMProjectEvaluatorSlideover";
+
+/**
+ * Entry point for adding evaluators to a project. Only LLM evaluators are
+ * supported for now; code, built-in, and template options will be added as
+ * additional menu sections like AddEvaluatorMenu does for datasets.
+ */
+export const AddProjectEvaluatorMenu = ({
+  size,
+  projectId,
+  ...props
+}: {
+  size: ButtonProps["size"];
+  projectId: string;
+} & Omit<MenuTriggerProps, "children">) => {
+  const [isCreateLLMEvaluatorOpen, setIsCreateLLMEvaluatorOpen] =
+    useState(false);
+  return (
+    <>
+      <MenuTrigger {...props}>
+        <Button
+          variant="primary"
+          size={size}
+          leadingVisual={<Icon svg={<Icons.Plus />} />}
+        >
+          Add evaluator
+        </Button>
+        {/* TODO: Remove minHeight once we have more items in the menu */}
+        <MenuContainer minHeight={"auto"}>
+          <Menu
+            aria-label="Add evaluator"
+            onAction={(action) => {
+              if (action === "createEvaluator") {
+                setIsCreateLLMEvaluatorOpen(true);
+              }
+            }}
+          >
+            <MenuSection>
+              <MenuSectionTitle title="New LLM evaluator" />
+              <MenuItem
+                leadingContent={<Icon svg={<Icons.Plus />} />}
+                id="createEvaluator"
+              >
+                Create new LLM evaluator
+              </MenuItem>
+            </MenuSection>
+          </Menu>
+        </MenuContainer>
+      </MenuTrigger>
+      <CreateLLMProjectEvaluatorSlideover
+        isOpen={isCreateLLMEvaluatorOpen}
+        onOpenChange={setIsCreateLLMEvaluatorOpen}
+        projectId={projectId}
+      />
+    </>
+  );
+};

--- a/app/src/pages/project/evaluators/CreateLLMProjectEvaluatorSlideover.tsx
+++ b/app/src/pages/project/evaluators/CreateLLMProjectEvaluatorSlideover.tsx
@@ -1,0 +1,138 @@
+import { Suspense, useState } from "react";
+import type { ModalOverlayProps } from "react-aria-components";
+import invariant from "tiny-invariant";
+
+import type { EvaluatorSubmitResult } from "@phoenix/agent/tools/llmEvaluatorDraft";
+import { Dialog } from "@phoenix/components/core/dialog";
+import { Loading } from "@phoenix/components/core/loading";
+import { Modal, ModalOverlay } from "@phoenix/components/core/overlay/Modal";
+import { EditLLMEvaluatorDialogContent } from "@phoenix/components/evaluators/EditLLMEvaluatorDialogContent";
+import { EvaluatorPlaygroundProvider } from "@phoenix/components/evaluators/EvaluatorPlaygroundProvider";
+import { getOutputConfigValidationErrors } from "@phoenix/components/evaluators/utils";
+import { EvaluatorStoreProvider } from "@phoenix/contexts/EvaluatorContext";
+import { useNotifySuccess } from "@phoenix/contexts/NotificationContext";
+import { createProjectLlmEvaluator } from "@phoenix/pages/project/evaluators/createProjectLlmEvaluator";
+import { ProjectEvaluatorTargetField } from "@phoenix/pages/project/evaluators/ProjectEvaluatorTargetField";
+import { ProjectEvaluatorTestPlaceholder } from "@phoenix/pages/project/evaluators/ProjectEvaluatorTestPlaceholder";
+import type { ProjectEvaluatorTarget } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+import {
+  DEFAULT_LLM_EVALUATOR_STORE_VALUES,
+  type EvaluatorStoreInstance,
+  type EvaluatorStoreProps,
+} from "@phoenix/store/evaluatorStore";
+
+export const CreateLLMProjectEvaluatorSlideover = ({
+  projectId,
+  ...props
+}: {
+  projectId: string;
+} & ModalOverlayProps) => {
+  return (
+    <ModalOverlay {...props}>
+      <Modal variant="slideover" size="fullscreen">
+        <Dialog>
+          {({ close }) => (
+            <Suspense fallback={<Loading />}>
+              <EvaluatorPlaygroundProvider>
+                <CreateProjectEvaluatorDialog
+                  onClose={close}
+                  projectId={projectId}
+                />
+              </EvaluatorPlaygroundProvider>
+            </Suspense>
+          )}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+};
+
+const CreateProjectEvaluatorDialog = ({
+  onClose,
+  projectId,
+}: {
+  onClose: () => void;
+  projectId: string;
+}) => {
+  const notifySuccess = useNotifySuccess();
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [targetType, setTargetType] = useState<ProjectEvaluatorTarget>("span");
+
+  const defaultOutputConfig =
+    DEFAULT_LLM_EVALUATOR_STORE_VALUES.outputConfigs[0];
+  const defaultEvaluatorName =
+    DEFAULT_LLM_EVALUATOR_STORE_VALUES.evaluator.globalName;
+  const initialState = {
+    ...DEFAULT_LLM_EVALUATOR_STORE_VALUES,
+    // Keep the output config name in sync with the evaluator name, as the
+    // dataset create dialog does
+    outputConfigs: [{ ...defaultOutputConfig, name: defaultEvaluatorName }],
+  } satisfies EvaluatorStoreProps;
+
+  const onSubmit = async (
+    store: EvaluatorStoreInstance
+  ): Promise<EvaluatorSubmitResult> => {
+    const {
+      evaluator: { globalName },
+      outputConfigs,
+    } = store.getState();
+    invariant(
+      outputConfigs && outputConfigs.length > 0,
+      "At least one output config is required"
+    );
+
+    const validationErrors = getOutputConfigValidationErrors(outputConfigs);
+    if (validationErrors.length > 0) {
+      const message = validationErrors.join("\n");
+      setError(message);
+      return { ok: false, error: message };
+    }
+
+    setIsSubmitting(true);
+    try {
+      const evaluator = await createProjectLlmEvaluator({
+        projectId,
+        targetType,
+        name: globalName.trim(),
+      });
+      onClose();
+      notifySuccess({
+        title: "Evaluator created",
+      });
+      return {
+        ok: true,
+        acceptedBy: "user",
+        evaluator,
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to create evaluator";
+      setError(message);
+      return { ok: false, error: message };
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <EvaluatorStoreProvider initialState={initialState}>
+      {({ store }) => (
+        <EditLLMEvaluatorDialogContent
+          onClose={onClose}
+          onSubmit={() => onSubmit(store)}
+          isSubmitting={isSubmitting}
+          mode="create"
+          error={error}
+          formLeftPanelExtra={
+            <ProjectEvaluatorTargetField
+              value={targetType}
+              onChange={setTargetType}
+            />
+          }
+          formRightPanel={<ProjectEvaluatorTestPlaceholder />}
+        />
+      )}
+    </EvaluatorStoreProvider>
+  );
+};

--- a/app/src/pages/project/evaluators/ProjectEvaluatorTargetField.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorTargetField.tsx
@@ -1,0 +1,60 @@
+import {
+  Flex,
+  Heading,
+  Radio,
+  RadioGroup,
+  Text,
+  View,
+} from "@phoenix/components";
+import {
+  isProjectEvaluatorTarget,
+  PROJECT_EVALUATOR_TARGETS,
+  type ProjectEvaluatorTarget,
+} from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+
+const TARGET_LABELS: Record<ProjectEvaluatorTarget, string> = {
+  span: "Span",
+  trace: "Trace",
+  session: "Session",
+};
+
+/**
+ * Picks the artifact type a project evaluator runs against. This section is
+ * where project-evaluator settings such as sampling rate, filters, and
+ * completion behavior will be added later.
+ */
+export const ProjectEvaluatorTargetField = ({
+  value,
+  onChange,
+}: {
+  value: ProjectEvaluatorTarget;
+  onChange: (target: ProjectEvaluatorTarget) => void;
+}) => {
+  return (
+    <View marginBottom="size-200" flex="none">
+      <Flex direction="column" gap="size-100">
+        <Heading level={2} weight="heavy">
+          Target
+        </Heading>
+        <Text color="text-500">
+          Choose what this evaluator runs against as new data arrives.
+        </Text>
+        <RadioGroup
+          value={value}
+          aria-label="Evaluator target"
+          onChange={(newValue) => {
+            if (isProjectEvaluatorTarget(newValue)) {
+              onChange(newValue);
+            }
+          }}
+        >
+          {PROJECT_EVALUATOR_TARGETS.map((target) => (
+            <Radio key={target} value={target}>
+              {TARGET_LABELS[target]}
+            </Radio>
+          ))}
+        </RadioGroup>
+      </Flex>
+    </View>
+  );
+};

--- a/app/src/pages/project/evaluators/ProjectEvaluatorTestPlaceholder.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorTestPlaceholder.tsx
@@ -1,0 +1,19 @@
+import { Empty, Flex, Heading, View } from "@phoenix/components";
+
+/**
+ * Placeholder for the project evaluator test section. Unlike dataset
+ * evaluators, which test against dataset examples, project evaluators will
+ * test against recent spans, traces, or sessions — that flow is not built yet.
+ */
+export const ProjectEvaluatorTestPlaceholder = () => {
+  return (
+    <View paddingX="size-200">
+      <Flex direction="column" gap="size-100">
+        <Heading level={2} weight="heavy">
+          Test
+        </Heading>
+        <Empty message="Testing against live spans, traces, and sessions is coming soon." />
+      </Flex>
+    </View>
+  );
+};

--- a/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
+++ b/app/src/pages/project/evaluators/ProjectEvaluatorsPage.tsx
@@ -1,0 +1,33 @@
+import { css } from "@emotion/react";
+import { useParams } from "react-router";
+import invariant from "tiny-invariant";
+
+import { Empty, Flex, View } from "@phoenix/components";
+import { AddProjectEvaluatorMenu } from "@phoenix/pages/project/evaluators/AddProjectEvaluatorMenu";
+
+/**
+ * Lists the evaluators that run against a project's live spans, traces, and
+ * sessions. The list itself is not built yet — the tab currently offers the
+ * create flow with a stubbed submit.
+ */
+export function ProjectEvaluatorsPage() {
+  const { projectId } = useParams();
+  invariant(projectId, "projectId is required");
+  return (
+    <main
+      css={css`
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      `}
+    >
+      <View padding="size-100" flex="none">
+        <Flex direction="row" justifyContent="end">
+          <AddProjectEvaluatorMenu size="M" projectId={projectId} />
+        </Flex>
+      </View>
+      <Empty message="No evaluators are set up for this project" />
+    </main>
+  );
+}

--- a/app/src/pages/project/evaluators/createProjectLlmEvaluator.ts
+++ b/app/src/pages/project/evaluators/createProjectLlmEvaluator.ts
@@ -1,0 +1,25 @@
+import type { ProjectEvaluatorTarget } from "@phoenix/pages/project/evaluators/projectEvaluatorTypes";
+
+export type CreateProjectLLMEvaluatorResult = {
+  id: string;
+  name: string;
+};
+
+/**
+ * TODO(project-evaluators): replace with a createProjectLlmEvaluator Relay
+ * mutation once the project-evaluator GraphQL schema lands. Building the full
+ * mutation input (prompt version, output configs, input mapping) comes with
+ * that swap — see CreateLLMDatasetEvaluatorSlideover for the pattern.
+ */
+export async function createProjectLlmEvaluator({
+  name,
+}: {
+  projectId: string;
+  targetType: ProjectEvaluatorTarget;
+  name: string;
+}): Promise<CreateProjectLLMEvaluatorResult> {
+  return {
+    id: `stub-project-evaluator:${name}`,
+    name,
+  };
+}

--- a/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
+++ b/app/src/pages/project/evaluators/projectEvaluatorTypes.ts
@@ -1,0 +1,11 @@
+/**
+ * The artifact types a project evaluator can run against.
+ */
+export const PROJECT_EVALUATOR_TARGETS = ["span", "trace", "session"] as const;
+
+export type ProjectEvaluatorTarget = (typeof PROJECT_EVALUATOR_TARGETS)[number];
+
+export const isProjectEvaluatorTarget = (
+  value: string
+): value is ProjectEvaluatorTarget =>
+  PROJECT_EVALUATOR_TARGETS.includes(value as ProjectEvaluatorTarget);

--- a/app/src/pages/project/index.tsx
+++ b/app/src/pages/project/index.tsx
@@ -4,4 +4,5 @@ export * from "./ProjectSessionsPage";
 export * from "./ProjectSpansPage";
 export * from "./ProjectTracesPage";
 export * from "./projectLoader";
+export * from "./evaluators/ProjectEvaluatorsPage";
 export * from "./metrics/ProjectMetricsPage";

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -132,8 +132,6 @@ CREATE TABLE public.project_annotation_configs (
 
 CREATE INDEX ix_project_annotation_configs_annotation_config_id ON public.project_annotation_configs
     USING btree (annotation_config_id);
-CREATE INDEX ix_project_annotation_configs_project_id ON public.project_annotation_configs
-    USING btree (project_id);
 
 
 -- Table: project_sessions
@@ -153,8 +151,8 @@ CREATE TABLE public.project_sessions (
         ON DELETE CASCADE
 );
 
-CREATE INDEX ix_project_sessions_end_time ON public.project_sessions
-    USING btree (end_time);
+CREATE INDEX ix_project_sessions_project_id_end_time ON public.project_sessions
+    USING btree (project_id, end_time DESC);
 CREATE INDEX ix_project_sessions_project_id_start_time ON public.project_sessions
     USING btree (project_id, start_time DESC);
 
@@ -218,8 +216,6 @@ CREATE TABLE public.prompts_prompt_labels (
 
 CREATE INDEX ix_prompts_prompt_labels_prompt_id ON public.prompts_prompt_labels
     USING btree (prompt_id);
-CREATE INDEX ix_prompts_prompt_labels_prompt_label_id ON public.prompts_prompt_labels
-    USING btree (prompt_label_id);
 
 
 -- Table: token_prices
@@ -239,9 +235,6 @@ CREATE TABLE public.token_prices (
         REFERENCES public.generative_models (id)
         ON DELETE CASCADE
 );
-
-CREATE INDEX ix_token_prices_model_id ON public.token_prices
-    USING btree (model_id);
 
 
 -- Table: traces
@@ -521,6 +514,9 @@ CREATE TABLE public.datasets (
         ON DELETE SET NULL
 );
 
+CREATE INDEX ix_datasets_user_id ON public.datasets
+    USING btree (user_id);
+
 
 -- Table: dataset_examples
 -- -----------------------
@@ -543,10 +539,6 @@ CREATE TABLE public.dataset_examples (
         ON DELETE SET NULL
 );
 
-CREATE INDEX ix_dataset_examples_dataset_id ON public.dataset_examples
-    USING btree (dataset_id);
-CREATE INDEX ix_dataset_examples_external_id ON public.dataset_examples
-    USING btree (external_id);
 CREATE INDEX ix_dataset_examples_span_rowid ON public.dataset_examples
     USING btree (span_rowid);
 
@@ -595,6 +587,8 @@ CREATE TABLE public.dataset_versions (
 
 CREATE INDEX ix_dataset_versions_dataset_id ON public.dataset_versions
     USING btree (dataset_id);
+CREATE INDEX ix_dataset_versions_user_id ON public.dataset_versions
+    USING btree (user_id);
 
 
 -- Table: dataset_example_revisions
@@ -697,6 +691,8 @@ CREATE TABLE public.document_annotations (
 
 CREATE INDEX ix_document_annotations_span_rowid ON public.document_annotations
     USING btree (span_rowid);
+CREATE INDEX ix_document_annotations_user_id ON public.document_annotations
+    USING btree (user_id);
 
 
 -- Table: evaluators
@@ -784,8 +780,6 @@ CREATE TABLE public.dataset_evaluators (
         ON DELETE SET NULL
 );
 
-CREATE INDEX ix_dataset_evaluators_dataset_id ON public.dataset_evaluators
-    USING btree (dataset_id);
 CREATE INDEX ix_dataset_evaluators_evaluator_id ON public.dataset_evaluators
     USING btree (evaluator_id);
 CREATE INDEX ix_dataset_evaluators_project_id ON public.dataset_evaluators
@@ -831,6 +825,8 @@ CREATE INDEX ix_experiments_ephemeral_updated_at ON public.experiments
     USING btree (updated_at) WHERE (is_ephemeral IS TRUE);
 CREATE INDEX ix_experiments_project_name ON public.experiments
     USING btree (project_name);
+CREATE INDEX ix_experiments_user_id ON public.experiments
+    USING btree (user_id);
 
 
 -- Table: experiment_jobs
@@ -916,6 +912,8 @@ CREATE TABLE public.experiment_logs (
         ON DELETE CASCADE
 );
 
+CREATE INDEX ix_experiment_logs_experiment_id ON public.experiment_logs
+    USING btree (experiment_id);
 CREATE INDEX ix_experiment_logs_experiment_id_occurred_at_errors ON public.experiment_logs
     USING btree (experiment_id, occurred_at DESC) WHERE ((level)::text = 'ERROR'::text);
 
@@ -977,6 +975,11 @@ CREATE TABLE public.experiment_eval_logs (
         REFERENCES public.experiment_runs (id)
         ON DELETE CASCADE
 );
+
+CREATE INDEX ix_experiment_eval_logs_dataset_evaluator_id ON public.experiment_eval_logs
+    USING btree (dataset_evaluator_id);
+CREATE INDEX ix_experiment_eval_logs_experiment_run_id ON public.experiment_eval_logs
+    USING btree (experiment_run_id);
 
 
 -- Table: experiment_run_annotations
@@ -1062,6 +1065,9 @@ CREATE TABLE public.experiment_task_logs (
         REFERENCES public.dataset_examples (id)
         ON DELETE CASCADE
 );
+
+CREATE INDEX ix_experiment_task_logs_dataset_example_id ON public.experiment_task_logs
+    USING btree (dataset_example_id);
 
 
 -- Table: experiments_dataset_examples
@@ -1165,15 +1171,22 @@ CREATE TABLE public.project_evaluator_criteria (
     id bigserial NOT NULL,
     project_id BIGINT NOT NULL,
     evaluator_id BIGINT NOT NULL,
-    annotation_name VARCHAR NOT NULL,
+    name VARCHAR NOT NULL,
     filter_condition VARCHAR NOT NULL DEFAULT ''::character varying,
     sampling_rate DOUBLE PRECISION NOT NULL,
+    evaluation_target VARCHAR NOT NULL,
+    input_mapping JSONB,
     enabled BOOLEAN NOT NULL DEFAULT true,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_project_evaluator_criteria PRIMARY KEY (id),
-    CONSTRAINT uq_project_evaluator_criteria_project_id_annotation_name
-        UNIQUE (project_id, annotation_name),
+    CONSTRAINT uq_project_evaluator_criteria_project_id_name
+        UNIQUE (project_id, name),
+    CHECK (((evaluation_target)::text = ANY ((ARRAY[
+            'SPAN'::character varying,
+            'TRACE'::character varying,
+            'SESSION'::character varying
+        ])::text[]))),
     CHECK ((((0.0)::double precision <= sampling_rate) AND (sampling_rate <= (1.0)::double precision))),
     CONSTRAINT fk_project_evaluator_criteria_evaluator_id_evaluators
         FOREIGN KEY
@@ -1287,6 +1300,8 @@ CREATE TABLE public.project_session_annotations (
 
 CREATE INDEX ix_project_session_annotations_project_session_id ON public.project_session_annotations
     USING btree (project_session_id);
+CREATE INDEX ix_project_session_annotations_user_id ON public.project_session_annotations
+    USING btree (user_id);
 
 
 -- Table: prompt_versions
@@ -1667,6 +1682,8 @@ CREATE TABLE public.span_annotations (
 
 CREATE INDEX ix_span_annotations_span_rowid ON public.span_annotations
     USING btree (span_rowid);
+CREATE INDEX ix_span_annotations_user_id ON public.span_annotations
+    USING btree (user_id);
 
 
 -- Table: system_settings
@@ -1727,3 +1744,5 @@ CREATE TABLE public.trace_annotations (
 
 CREATE INDEX ix_trace_annotations_trace_rowid ON public.trace_annotations
     USING btree (trace_rowid);
+CREATE INDEX ix_trace_annotations_user_id ON public.trace_annotations
+    USING btree (user_id);

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -18,6 +18,30 @@ CREATE TABLE public.annotation_configs (
 );
 
 
+-- Table: eval_work_cursors
+-- ------------------------
+CREATE TABLE public.eval_work_cursors (
+    id bigserial NOT NULL,
+    grain VARCHAR NOT NULL,
+    consumer_group VARCHAR NOT NULL,
+    produced_through_id BIGINT NOT NULL DEFAULT '0'::bigint,
+    observed_high_water_id BIGINT,
+    observed_at TIMESTAMP WITH TIME ZONE,
+    claimed_at TIMESTAMP WITH TIME ZONE,
+    claimed_by VARCHAR,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT pk_eval_work_cursors PRIMARY KEY (id),
+    CONSTRAINT uq_eval_work_cursors_grain_consumer_group
+        UNIQUE (grain, consumer_group),
+    CHECK (((grain)::text = ANY ((ARRAY[
+            'SPAN'::character varying,
+            'TRACE'::character varying,
+            'SESSION'::character varying
+        ])::text[])))
+);
+
+
 -- Table: generative_models
 -- ------------------------
 CREATE TABLE public.generative_models (
@@ -1133,6 +1157,93 @@ CREATE INDEX ix_password_reset_tokens_expires_at ON public.password_reset_tokens
     USING btree (expires_at);
 CREATE UNIQUE INDEX ix_password_reset_tokens_user_id ON public.password_reset_tokens
     USING btree (user_id);
+
+
+-- Table: project_evaluator_criteria
+-- ---------------------------------
+CREATE TABLE public.project_evaluator_criteria (
+    id bigserial NOT NULL,
+    project_id BIGINT NOT NULL,
+    evaluator_id BIGINT NOT NULL,
+    annotation_name VARCHAR NOT NULL,
+    filter_condition VARCHAR NOT NULL DEFAULT ''::character varying,
+    sampling_rate DOUBLE PRECISION NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT pk_project_evaluator_criteria PRIMARY KEY (id),
+    CONSTRAINT uq_project_evaluator_criteria_project_id_annotation_name
+        UNIQUE (project_id, annotation_name),
+    CHECK ((((0.0)::double precision <= sampling_rate) AND (sampling_rate <= (1.0)::double precision))),
+    CONSTRAINT fk_project_evaluator_criteria_evaluator_id_evaluators
+        FOREIGN KEY
+        (evaluator_id)
+        REFERENCES public.evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_project_evaluator_criteria_project_id_projects
+        FOREIGN KEY
+        (project_id)
+        REFERENCES public.projects (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_project_evaluator_criteria_evaluator_id ON public.project_evaluator_criteria
+    USING btree (evaluator_id);
+CREATE INDEX ix_project_evaluator_criteria_project_id ON public.project_evaluator_criteria
+    USING btree (project_id);
+
+
+-- Table: eval_work_units
+-- ----------------------
+CREATE TABLE public.eval_work_units (
+    id bigserial NOT NULL,
+    span_rowid BIGINT NOT NULL,
+    evaluator_id BIGINT NOT NULL,
+    criteria_id BIGINT NOT NULL,
+    config_fingerprint VARCHAR NOT NULL,
+    status VARCHAR NOT NULL DEFAULT 'PENDING'::character varying,
+    claimed_at TIMESTAMP WITH TIME ZONE,
+    claimed_by VARCHAR,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    error VARCHAR,
+    cooldown_until TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT pk_eval_work_units PRIMARY KEY (id),
+    CONSTRAINT uq_eval_work_units_span_rowid_evaluator_id_config_fingerprint
+        UNIQUE (span_rowid, evaluator_id, config_fingerprint),
+    CHECK (((status)::text = ANY ((ARRAY[
+            'PENDING'::character varying,
+            'RUNNING'::character varying,
+            'DONE'::character varying,
+            'ERROR'::character varying,
+            'EXPIRED'::character varying
+        ])::text[]))),
+    CONSTRAINT fk_eval_work_units_criteria_id_project_evaluator_criteria
+        FOREIGN KEY
+        (criteria_id)
+        REFERENCES public.project_evaluator_criteria (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_eval_work_units_evaluator_id_evaluators FOREIGN KEY
+        (evaluator_id)
+        REFERENCES public.evaluators (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_eval_work_units_span_rowid_spans FOREIGN KEY
+        (span_rowid)
+        REFERENCES public.spans (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_eval_work_units_claimable ON public.eval_work_units
+    USING btree (status, id) WHERE ((status)::text <> ALL ((ARRAY['DONE'::character varying, 'EXPIRED'::character varying])::text[]));
+CREATE INDEX ix_eval_work_units_criteria_id ON public.eval_work_units
+    USING btree (criteria_id);
+CREATE INDEX ix_eval_work_units_error_attempts ON public.eval_work_units
+    USING btree (attempts) WHERE ((status)::text = 'ERROR'::text);
+CREATE INDEX ix_eval_work_units_evaluator_id ON public.eval_work_units
+    USING btree (evaluator_id);
+CREATE INDEX ix_eval_work_units_terminal ON public.eval_work_units
+    USING btree (updated_at) WHERE ((status)::text = ANY ((ARRAY['DONE'::character varying, 'EXPIRED'::character varying])::text[]));
 
 
 -- Table: project_session_annotations

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -360,6 +360,20 @@ ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING = "PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING"
 The outstanding work-unit count above which the online-eval producer stops materializing
 new work units: PENDING + RUNNING + retryable ERROR (non-terminal work). Defaults to 10000.
 """
+ENV_PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE = "PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE"
+"""
+The maximum number of work units an online-eval consumer claims per tick. Together with
+PHOENIX_ONLINE_EVAL_CONSUMER_TICK_INTERVAL_SECONDS this bounds per-replica evaluation
+throughput at claim_batch_size / tick_interval evaluations per second. Defaults to 10.
+"""
+ENV_PHOENIX_ONLINE_EVAL_CONSUMER_TICK_INTERVAL_SECONDS = (
+    "PHOENIX_ONLINE_EVAL_CONSUMER_TICK_INTERVAL_SECONDS"
+)
+"""
+Seconds an online-eval consumer sleeps between claim cycles. Together with
+PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE this bounds per-replica evaluation throughput.
+Defaults to 5.0.
+"""
 ENV_LOGGING_MODE = "PHOENIX_LOGGING_MODE"
 """
 The logging mode (either 'default' or 'structured').
@@ -3332,6 +3346,35 @@ def get_env_online_eval_max_outstanding() -> int:
             f"{max_outstanding}. Value must be a positive integer."
         )
     return max_outstanding
+
+
+def get_env_online_eval_claim_batch_size() -> int:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE environment variable.
+    """
+    batch_size = _int_val(ENV_PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE, 10)
+    if batch_size < 1:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE}: "
+            f"{batch_size}. Value must be a positive integer."
+        )
+    return batch_size
+
+
+def get_env_online_eval_consumer_tick_interval_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_CONSUMER_TICK_INTERVAL_SECONDS
+    environment variable.
+    """
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_CONSUMER_TICK_INTERVAL_SECONDS, 5.0)
+    if not isfinite(seconds) or seconds <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_CONSUMER_TICK_INTERVAL_SECONDS}: "
+            f"{seconds}. Value must be a finite positive number."
+        )
+    return seconds
 
 
 def get_env_client_headers() -> dict[str, str]:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 from importlib.metadata import version
+from math import isfinite
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -306,7 +307,58 @@ Defaults to 20000.
 """
 ENV_PHOENIX_ONLINE_EVAL_ENABLED = "PHOENIX_ONLINE_EVAL_ENABLED"
 """
-Whether to run the online-eval producer daemon. Defaults to false.
+Whether to run the online-eval producer and consumer daemons. Defaults to false.
+"""
+ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS = "PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS"
+"""
+How long an observed span high-water id must age before the online-eval producer scans up
+to it. Defaults to 60.
+"""
+ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS = "PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS"
+"""
+How often the online-eval producer re-sweeps recent spans for work units missed by the
+frontier scan. Defaults to 3600.
+
+Configure this together with PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS: gap-free
+re-coverage requires the lookback span ids to be at least the instance-wide ingest rate
+multiplied by this interval. Spans share one id sequence, so the relevant rate is the sum
+across all projects and tenants.
+"""
+ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS = (
+    "PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS"
+)
+"""
+How far behind the producer watermark, measured in span ids, the backstop sweep looks.
+Defaults to 100000.
+
+With the default 3600-second interval, 100000 ids provides gap-free re-coverage only below
+about 28 spans per second instance-wide. Above that rate, rows can leave the lookback between
+sweeps, so the backstop no longer bounds exceptional loss from late-visible spans or skipped
+criteria. The reaper floor is aligned to this lookback; changes to the lookback and interval
+must preserve the coverage relationship and move the reaper floor with them.
+"""
+ENV_PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK = "PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK"
+"""
+The maximum span-id range the online-eval producer advances through in one tick.
+Defaults to 10000.
+
+Higher values increase catch-up throughput at the cost of larger per-tick transactions;
+lower values reduce transaction size but take longer to catch up to the observed frontier.
+"""
+ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS = "PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS"
+"""
+How long a PENDING online-eval work unit may wait before the reaper marks it EXPIRED.
+Defaults to 0 (disabled).
+"""
+ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS = "PHOENIX_ONLINE_EVAL_RETENTION_SECONDS"
+"""
+How long terminal online-eval work units are kept before the reaper deletes them.
+Defaults to 604800 (7 days).
+"""
+ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING = "PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING"
+"""
+The outstanding work-unit count above which the online-eval producer stops materializing
+new work units: PENDING + RUNNING + retryable ERROR (non-terminal work). Defaults to 10000.
 """
 ENV_LOGGING_MODE = "PHOENIX_LOGGING_MODE"
 """
@@ -3171,6 +3223,115 @@ def get_env_online_eval_enabled() -> bool:
     Gets the value of the PHOENIX_ONLINE_EVAL_ENABLED environment variable.
     """
     return _bool_val(ENV_PHOENIX_ONLINE_EVAL_ENABLED, False)
+
+
+def get_env_online_eval_frontier_lag_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS environment variable.
+    """
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS, 60.0)
+    if not isfinite(seconds) or seconds < 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS}: "
+            f"{seconds}. Value must be a finite non-negative number."
+        )
+    return seconds
+
+
+def get_env_online_eval_backstop_interval_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS environment variable.
+    """
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS, 3600.0)
+    if not isfinite(seconds) or seconds <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS}: "
+            f"{seconds}. Value must be a finite positive number."
+        )
+    return seconds
+
+
+def get_env_online_eval_backstop_lookback_span_ids() -> int:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS environment variable.
+    """
+    span_ids = _int_val(ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS, 100_000)
+    if span_ids < 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS}: "
+            f"{span_ids}. Value must be a non-negative integer."
+        )
+    return span_ids
+
+
+def get_env_online_eval_max_span_ids_per_tick() -> int:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK environment variable.
+
+    Raises:
+        ValueError: If the value is not a positive integer.
+    """
+    max_span_ids = _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK, 10_000)
+    if max_span_ids <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK}: "
+            f"{max_span_ids}. Value must be a positive integer."
+        )
+    return max_span_ids
+
+
+def get_env_online_eval_pending_ttl_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS environment variable.
+
+    Defaults to 0, which disables TTL-based shedding: pending work units wait
+    until a consumer claims them, however long that takes (the admission gate
+    bounds queue growth). Setting a positive TTL opts into load shedding —
+    pending units older than the TTL are expired terminally and are NEVER
+    evaluated or re-materialized, so only set this if dropping evals on old
+    spans under sustained backlog is acceptable.
+    """
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS, 0.0)
+    if not isfinite(seconds) or seconds < 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS}: "
+            f"{seconds}. Value must be a finite non-negative number."
+        )
+    return seconds
+
+
+def get_env_online_eval_retention_seconds() -> float:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_RETENTION_SECONDS environment variable.
+    """
+    seconds = _float_val(ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS, 604_800.0)
+    if not isfinite(seconds) or seconds <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable "
+            f"{ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS}: "
+            f"{seconds}. Value must be a finite positive number."
+        )
+    return seconds
+
+
+def get_env_online_eval_max_outstanding() -> int:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING environment variable.
+
+    Counts PENDING + RUNNING + retryable ERROR (non-terminal work).
+    """
+    max_outstanding = _int_val(ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING, 10_000)
+    if max_outstanding <= 0:
+        raise ValueError(
+            f"Invalid value for environment variable {ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING}: "
+            f"{max_outstanding}. Value must be a positive integer."
+        )
+    return max_outstanding
 
 
 def get_env_client_headers() -> dict[str, str]:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -304,6 +304,10 @@ throughput.
 
 Defaults to 20000.
 """
+ENV_PHOENIX_ONLINE_EVAL_ENABLED = "PHOENIX_ONLINE_EVAL_ENABLED"
+"""
+Whether to run the online-eval producer daemon. Defaults to false.
+"""
 ENV_LOGGING_MODE = "PHOENIX_LOGGING_MODE"
 """
 The logging mode (either 'default' or 'structured').
@@ -3160,6 +3164,13 @@ def get_env_max_spans_queue_size() -> int:
             f"{max_size}. Value must be a positive integer."
         )
     return max_size
+
+
+def get_env_online_eval_enabled() -> bool:
+    """
+    Gets the value of the PHOENIX_ONLINE_EVAL_ENABLED environment variable.
+    """
+    return _bool_val(ENV_PHOENIX_ONLINE_EVAL_ENABLED, False)
 
 
 def get_env_client_headers() -> dict[str, str]:

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -47,9 +47,11 @@ def upgrade() -> None:
             primary_key=True,
         ),
         sa.Column(
-            "grain",
+            "evaluation_target",
             sa.String(),
-            sa.CheckConstraint("grain IN ('SPAN', 'TRACE', 'SESSION')", name="valid_grain"),
+            sa.CheckConstraint(
+                "evaluation_target IN ('SPAN', 'TRACE', 'SESSION')", name="valid_evaluation_target"
+            ),
             nullable=False,
         ),
         sa.Column("consumer_group", sa.String(), nullable=False),
@@ -75,7 +77,7 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint("grain", "consumer_group"),
+        sa.UniqueConstraint("evaluation_target", "consumer_group"),
     )
     op.create_table(
         "project_evaluator_criteria",

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -6,15 +6,30 @@ Create Date: 2026-06-17 00:00:00.000000
 
 """
 
-from typing import Sequence, Union
+from typing import Any, Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import JSON
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.compiler import compiles
 
 _Integer = sa.Integer().with_variant(
     sa.BigInteger(),
     "postgresql",
 )
+
+
+class JSONB(JSON):
+    __visit_name__ = "JSONB"
+
+
+@compiles(JSONB, "sqlite")
+def _(*args: Any, **kwargs: Any) -> str:
+    return "JSONB"
+
+
+JSON_ = JSON().with_variant(postgresql.JSONB(), "postgresql").with_variant(JSONB(), "sqlite")
 
 # revision identifiers, used by Alembic.
 revision: str = "a7f1c3e9d2b4"
@@ -81,7 +96,7 @@ def upgrade() -> None:
             sa.ForeignKey("evaluators.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("annotation_name", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
         sa.Column("filter_condition", sa.String(), nullable=False, server_default=""),
         sa.Column(
             "sampling_rate",
@@ -92,6 +107,16 @@ def upgrade() -> None:
             ),
             nullable=False,
         ),
+        sa.Column(
+            "evaluation_target",
+            sa.String(),
+            sa.CheckConstraint(
+                "evaluation_target IN ('SPAN', 'TRACE', 'SESSION')",
+                name="valid_evaluation_target",
+            ),
+            nullable=False,
+        ),
+        sa.Column("input_mapping", JSON_, nullable=True),
         sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
         sa.Column(
             "created_at",
@@ -105,7 +130,7 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint("project_id", "annotation_name"),
+        sa.UniqueConstraint("project_id", "name"),
     )
     op.create_index(
         "ix_project_evaluator_criteria_project_id",

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -1,0 +1,222 @@
+"""add online eval coordination
+
+Revision ID: a7f1c3e9d2b4
+Revises: d4e5f6a7b8c9
+Create Date: 2026-06-17 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+_Integer = sa.Integer().with_variant(
+    sa.BigInteger(),
+    "postgresql",
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "a7f1c3e9d2b4"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "eval_work_cursors",
+        sa.Column(
+            "id",
+            _Integer,
+            primary_key=True,
+        ),
+        sa.Column(
+            "grain",
+            sa.String(),
+            sa.CheckConstraint("grain IN ('SPAN', 'TRACE', 'SESSION')", name="valid_grain"),
+            nullable=False,
+        ),
+        sa.Column("consumer_group", sa.String(), nullable=False),
+        sa.Column(
+            "produced_through_id",
+            _Integer,
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("observed_high_water_id", _Integer, nullable=True),
+        sa.Column("observed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("claimed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("claimed_by", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("grain", "consumer_group"),
+    )
+    op.create_table(
+        "project_evaluator_criteria",
+        sa.Column(
+            "id",
+            _Integer,
+            primary_key=True,
+        ),
+        sa.Column(
+            "project_id",
+            _Integer,
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "evaluator_id",
+            _Integer,
+            sa.ForeignKey("evaluators.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("annotation_name", sa.String(), nullable=False),
+        sa.Column("filter_condition", sa.String(), nullable=False, server_default=""),
+        sa.Column(
+            "sampling_rate",
+            sa.Float(),
+            sa.CheckConstraint(
+                "0.0 <= sampling_rate AND sampling_rate <= 1.0",
+                name="valid_sampling_rate",
+            ),
+            nullable=False,
+        ),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("project_id", "annotation_name"),
+    )
+    op.create_index(
+        "ix_project_evaluator_criteria_project_id",
+        "project_evaluator_criteria",
+        ["project_id"],
+    )
+    op.create_index(
+        "ix_project_evaluator_criteria_evaluator_id",
+        "project_evaluator_criteria",
+        ["evaluator_id"],
+    )
+    op.create_table(
+        "eval_work_units",
+        sa.Column(
+            "id",
+            _Integer,
+            primary_key=True,
+        ),
+        sa.Column(
+            "span_rowid",
+            _Integer,
+            sa.ForeignKey("spans.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "evaluator_id",
+            _Integer,
+            sa.ForeignKey("evaluators.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "criteria_id",
+            _Integer,
+            sa.ForeignKey("project_evaluator_criteria.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("config_fingerprint", sa.String(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(),
+            sa.CheckConstraint(
+                "status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')",
+                name="valid_eval_work_status",
+            ),
+            nullable=False,
+            server_default="PENDING",
+        ),
+        sa.Column("claimed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("claimed_by", sa.String(), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error", sa.String(), nullable=True),
+        sa.Column("cooldown_until", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("span_rowid", "evaluator_id", "config_fingerprint"),
+    )
+    op.create_index(
+        "ix_eval_work_units_claimable",
+        "eval_work_units",
+        ["status", "id"],
+        postgresql_where=sa.text("status NOT IN ('DONE', 'EXPIRED')"),
+        sqlite_where=sa.text("status NOT IN ('DONE', 'EXPIRED')"),
+    )
+    op.create_index(
+        "ix_eval_work_units_terminal",
+        "eval_work_units",
+        ["updated_at"],
+        postgresql_where=sa.text("status IN ('DONE', 'EXPIRED')"),
+        sqlite_where=sa.text("status IN ('DONE', 'EXPIRED')"),
+    )
+    op.create_index(
+        "ix_eval_work_units_error_attempts",
+        "eval_work_units",
+        ["attempts"],
+        postgresql_where=sa.text("status = 'ERROR'"),
+        sqlite_where=sa.text("status = 'ERROR'"),
+    )
+    op.create_index(
+        "ix_eval_work_units_evaluator_id",
+        "eval_work_units",
+        ["evaluator_id"],
+    )
+    op.create_index(
+        "ix_eval_work_units_criteria_id",
+        "eval_work_units",
+        ["criteria_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_eval_work_units_criteria_id", table_name="eval_work_units")
+    op.drop_index("ix_eval_work_units_evaluator_id", table_name="eval_work_units")
+    op.drop_index("ix_eval_work_units_error_attempts", table_name="eval_work_units")
+    op.drop_index("ix_eval_work_units_terminal", table_name="eval_work_units")
+    op.drop_index("ix_eval_work_units_claimable", table_name="eval_work_units")
+    op.drop_table("eval_work_units")
+    op.drop_index(
+        "ix_project_evaluator_criteria_evaluator_id", table_name="project_evaluator_criteria"
+    )
+    op.drop_index(
+        "ix_project_evaluator_criteria_project_id", table_name="project_evaluator_criteria"
+    )
+    op.drop_table("project_evaluator_criteria")
+    op.drop_table("eval_work_cursors")

--- a/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
+++ b/src/phoenix/db/migrations/versions/a7f1c3e9d2b4_add_online_eval_coordination.py
@@ -1,7 +1,7 @@
 """add online eval coordination
 
 Revision ID: a7f1c3e9d2b4
-Revises: d4e5f6a7b8c9
+Revises: eaf1907ae453
 Create Date: 2026-06-17 00:00:00.000000
 
 """
@@ -18,7 +18,7 @@ _Integer = sa.Integer().with_variant(
 
 # revision identifiers, used by Alembic.
 revision: str = "a7f1c3e9d2b4"
-down_revision: Union[str, None] = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "eaf1907ae453"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/phoenix/db/migrations/versions/eaf1907ae453_add_composite_index_on_project_sessions_.py
+++ b/src/phoenix/db/migrations/versions/eaf1907ae453_add_composite_index_on_project_sessions_.py
@@ -1,0 +1,225 @@
+"""add composite index on project_sessions project_id end_time
+
+Revision ID: eaf1907ae453
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-02 18:34:04.568348
+
+Restructures indexes in one migration:
+
+- Creates the composite ``(project_id, end_time DESC)`` index that the sessions
+  interval-overlap filter relies on.
+- Creates four FK indexes on the experiment log tables whose delete paths
+  otherwise run as sequential scans: experiment_logs.experiment_id (the
+  runner's bulk DELETE and the cascade from experiment deletion — the existing
+  partial ERROR index cannot serve either), experiment_eval_logs
+  .experiment_run_id and .dataset_evaluator_id, and experiment_task_logs
+  .dataset_example_id (all ON DELETE CASCADE targets that fire once per
+  deleted parent row).
+- Creates ``user_id`` indexes on seven tables with an unindexed
+  ``ON DELETE SET NULL`` FK to users (the four annotation tables, datasets,
+  dataset_versions, and experiments), so a user deletion no longer sequential-
+  scans each of them.
+- Drops seven redundant single-column indexes. Five are served by the leading
+  columns of existing unique indexes. ``ix_dataset_examples_external_id`` is
+  not (``external_id`` is the second column of the unique ``(dataset_id,
+  external_id)`` index); it is dropped because no query filters by
+  ``external_id`` without ``dataset_id``, and dataset-scoped lookups are
+  served by that unique index. ``ix_project_sessions_end_time`` is superseded
+  by the composite created above (creation precedes the drop so there is
+  never a window without an end_time index); the one query filtering
+  ``end_time`` without ``project_id`` is deliberately non-selective and does
+  not benefit from an index.
+
+CONCURRENTLY support (opt-in via PHOENIX_MIGRATE_INDEX_CONCURRENTLY=true):
+
+  CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction, but Alembic's
+  env.py wraps each migration in one. The workaround is to commit the current
+  transaction and enable autocommit at the DBAPI level (psycopg) before issuing
+  the DDL, then restore transactional mode afterward. See the equivalent handling
+  in the spans session.id index migration (f1a6b2f0c9d5) for the rationale and
+  tradeoffs. Concurrent builds avoid the write-blocking lock a plain CREATE INDEX
+  takes, at the cost of a slower build and a non-transactional migration. Every
+  create uses IF NOT EXISTS and every drop IF EXISTS, so an interrupted
+  non-transactional run converges on rerun.
+
+  A failed concurrent build leaves an INVALID index behind. On rerun,
+  IF NOT EXISTS matches the INVALID leftover by name and skips the create, so
+  this migration checks the validity of every index it creates — before
+  dropping anything and before stamping itself successful — and fails with
+  recovery instructions instead of proceeding with an unusable index.
+
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "eaf1907ae453"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (index_name, table_name, [columns]) for the FK indexes on the experiment log
+# tables, whose delete paths (bulk DELETEs and ON DELETE CASCADEs) otherwise run
+# as sequential scans.
+_LOG_TABLE_FK_INDEXES: list[tuple[str, str, list[str]]] = [
+    ("ix_experiment_logs_experiment_id", "experiment_logs", ["experiment_id"]),
+    ("ix_experiment_eval_logs_experiment_run_id", "experiment_eval_logs", ["experiment_run_id"]),
+    (
+        "ix_experiment_eval_logs_dataset_evaluator_id",
+        "experiment_eval_logs",
+        ["dataset_evaluator_id"],
+    ),
+    ("ix_experiment_task_logs_dataset_example_id", "experiment_task_logs", ["dataset_example_id"]),
+]
+
+# (index_name, table_name, [columns]) for the previously unindexed
+# ON DELETE SET NULL user_id FKs: a user deletion runs one
+# UPDATE ... SET user_id = NULL ... WHERE user_id = :id per table, which is a
+# sequential scan without these (the annotation tables can be large).
+_USER_ID_FK_INDEXES: list[tuple[str, str, list[str]]] = [
+    ("ix_span_annotations_user_id", "span_annotations", ["user_id"]),
+    ("ix_trace_annotations_user_id", "trace_annotations", ["user_id"]),
+    ("ix_document_annotations_user_id", "document_annotations", ["user_id"]),
+    ("ix_project_session_annotations_user_id", "project_session_annotations", ["user_id"]),
+    ("ix_datasets_user_id", "datasets", ["user_id"]),
+    ("ix_dataset_versions_user_id", "dataset_versions", ["user_id"]),
+    ("ix_experiments_user_id", "experiments", ["user_id"]),
+]
+
+# (index_name, table_name, [columns]) for every redundant single-column index
+# this migration drops; see the module docstring for the per-index rationale.
+_REDUNDANT_INDEXES: list[tuple[str, str, list[str]]] = [
+    ("ix_project_annotation_configs_project_id", "project_annotation_configs", ["project_id"]),
+    ("ix_prompts_prompt_labels_prompt_label_id", "prompts_prompt_labels", ["prompt_label_id"]),
+    ("ix_token_prices_model_id", "token_prices", ["model_id"]),
+    ("ix_dataset_examples_dataset_id", "dataset_examples", ["dataset_id"]),
+    ("ix_dataset_examples_external_id", "dataset_examples", ["external_id"]),
+    ("ix_dataset_evaluators_dataset_id", "dataset_evaluators", ["dataset_id"]),
+    ("ix_project_sessions_end_time", "project_sessions", ["end_time"]),
+]
+
+
+def _use_concurrently() -> bool:
+    """CONCURRENTLY is opt-in (PostgreSQL only) via PHOENIX_MIGRATE_INDEX_CONCURRENTLY."""
+    connection = op.get_bind()
+    if connection.dialect.name != "postgresql":
+        return False
+    return os.environ.get("PHOENIX_MIGRATE_INDEX_CONCURRENTLY", "").lower() == "true"
+
+
+def _enable_autocommit() -> None:
+    """Exit the current transaction and enable autocommit at the DBAPI level."""
+    dbapi_conn = op.get_bind().connection.dbapi_connection
+    assert dbapi_conn is not None
+    dbapi_conn.commit()
+    dbapi_conn.autocommit = True
+
+
+def _disable_autocommit() -> None:
+    """Restore transactional mode at the DBAPI level."""
+    dbapi_conn = op.get_bind().connection.dbapi_connection
+    assert dbapi_conn is not None
+    dbapi_conn.autocommit = False
+
+
+def _assert_index_is_valid(index_name: str) -> None:
+    """Fail loudly if the named index exists but is INVALID (PostgreSQL only).
+
+    A failed CREATE INDEX CONCURRENTLY leaves an INVALID index behind, and a
+    build still in progress on another replica is INVALID until it completes.
+    In both cases IF NOT EXISTS matches the catalog entry by name and skips the
+    create, so without this check the migration could drop a superseded index
+    and stamp itself successful while the replacement is unusable — a silent
+    perf regression. This check turns that into a loud failure with a fix.
+    """
+    connection = op.get_bind()
+    if connection.dialect.name != "postgresql":
+        return
+    is_valid = connection.execute(
+        sa.text("SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(:name)"),
+        {"name": index_name},
+    ).scalar()
+    if is_valid is False:
+        raise RuntimeError(
+            f"Index {index_name} exists but is INVALID: a previous CONCURRENTLY build "
+            "failed, or another replica is still building it. If no build is in "
+            f"progress, run DROP INDEX CONCURRENTLY IF EXISTS {index_name} and rerun "
+            "the migration."
+        )
+
+
+def upgrade() -> None:
+    concurrently = _use_concurrently()
+    if concurrently:
+        _enable_autocommit()
+    try:
+        # Create everything first: the composite must exist (and be valid) before
+        # the superseded single-column end_time index is dropped below.
+        op.execute(
+            f"CREATE INDEX {'CONCURRENTLY ' if concurrently else ''}IF NOT EXISTS "
+            "ix_project_sessions_project_id_end_time "
+            "ON project_sessions (project_id, end_time DESC)"
+        )
+        for index_name, table_name, columns in _LOG_TABLE_FK_INDEXES + _USER_ID_FK_INDEXES:
+            op.create_index(
+                index_name,
+                table_name,
+                columns,
+                if_not_exists=True,
+                postgresql_concurrently=concurrently,
+            )
+        # Refuse to drop anything (or stamp this migration successful) while any
+        # created index is INVALID — a failed concurrent build satisfies
+        # IF NOT EXISTS above.
+        _assert_index_is_valid("ix_project_sessions_project_id_end_time")
+        for index_name, _, _ in _LOG_TABLE_FK_INDEXES + _USER_ID_FK_INDEXES:
+            _assert_index_is_valid(index_name)
+        for index_name, table_name, _ in _REDUNDANT_INDEXES:
+            op.drop_index(
+                index_name,
+                table_name=table_name,
+                if_exists=True,
+                postgresql_concurrently=concurrently,
+            )
+    finally:
+        if concurrently:
+            _disable_autocommit()
+
+
+def downgrade() -> None:
+    concurrently = _use_concurrently()
+    if concurrently:
+        _enable_autocommit()
+    try:
+        # Mirror image: recreate the single-column indexes and verify them before
+        # dropping the composite and the log-table FK indexes.
+        for index_name, table_name, columns in _REDUNDANT_INDEXES:
+            op.create_index(
+                index_name,
+                table_name,
+                columns,
+                if_not_exists=True,
+                postgresql_concurrently=concurrently,
+            )
+        for index_name, _, _ in _REDUNDANT_INDEXES:
+            _assert_index_is_valid(index_name)
+        op.drop_index(
+            "ix_project_sessions_project_id_end_time",
+            table_name="project_sessions",
+            if_exists=True,
+            postgresql_concurrently=concurrently,
+        )
+        for index_name, table_name, _ in _LOG_TABLE_FK_INDEXES + _USER_ID_FK_INDEXES:
+            op.drop_index(
+                index_name,
+                table_name=table_name,
+                if_exists=True,
+                postgresql_concurrently=concurrently,
+            )
+    finally:
+        if concurrently:
+            _disable_autocommit()

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -182,6 +182,8 @@ GenerativeModelSDK: TypeAlias = Literal[
     "aws_bedrock",
 ]
 ExperimentStatus: TypeAlias = Literal["RUNNING", "COMPLETED", "STOPPED", "ERROR"]
+EvalWorkStatus: TypeAlias = Literal["PENDING", "RUNNING", "DONE", "ERROR", "EXPIRED"]
+EvalWorkGrain: TypeAlias = Literal["SPAN"]
 ExperimentLogCategory: TypeAlias = Literal["TASK", "EVAL", "EXPERIMENT"]
 ExperimentLogLevel: TypeAlias = Literal["ERROR", "WARN", "INFO"]
 SystemSettingKey: TypeAlias = Literal[
@@ -3066,3 +3068,137 @@ def validate_provider_config(_: Any, __: Any, target: "GenerativeModelCustomProv
     """
     if not is_encrypted(target.config):
         raise ValueError("Config is not encrypted")
+
+
+class ProjectEvaluatorCriteria(HasId):
+    """Attaches an evaluator to a project for online evaluation: which spans to
+    match, how they are sampled, and the annotation name results are written under."""
+
+    __tablename__ = "project_evaluator_criteria"
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    evaluator_id: Mapped[int] = mapped_column(
+        ForeignKey("evaluators.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    annotation_name: Mapped[Identifier] = mapped_column(_Identifier, nullable=False)
+    filter_condition: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    sampling_rate: Mapped[float] = mapped_column(
+        Float,
+        CheckConstraint(
+            "0.0 <= sampling_rate AND sampling_rate <= 1.0",
+            name="valid_sampling_rate",
+        ),
+        nullable=False,
+    )
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
+
+    project: Mapped["Project"] = relationship("Project")
+    evaluator: Mapped["Evaluator"] = relationship("Evaluator")
+
+    __table_args__ = (UniqueConstraint("project_id", "annotation_name"),)
+
+
+class EvalWorkCursor(HasId):
+    """Producer lease and position in the span arrival log, one row per
+    (grain, consumer_group). For every grain, produced_through_id is a Span.id
+    position in the shared arrival log rather than a grain-specific entity id."""
+
+    __tablename__ = "eval_work_cursors"
+    grain: Mapped[EvalWorkGrain] = mapped_column(
+        CheckConstraint("grain IN ('SPAN', 'TRACE', 'SESSION')", name="valid_grain"),
+        nullable=False,
+    )
+    consumer_group: Mapped[str] = mapped_column(String, nullable=False)
+
+    produced_through_id: Mapped[int] = mapped_column(_Integer, nullable=False, server_default="0")
+    observed_high_water_id: Mapped[Optional[int]] = mapped_column(_Integer)
+    observed_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+
+    claimed_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+    claimed_by: Mapped[Optional[str]] = mapped_column(String)
+
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (UniqueConstraint("grain", "consumer_group"),)
+
+
+class EvalWorkUnit(HasId):
+    """A span-grain eval task — run one evaluator against one span. The producer
+    materializes rows here; consumers claim, run, and complete them."""
+
+    __tablename__ = "eval_work_units"
+    span_rowid: Mapped[int] = mapped_column(
+        ForeignKey("spans.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    evaluator_id: Mapped[int] = mapped_column(
+        ForeignKey("evaluators.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    criteria_id: Mapped[int] = mapped_column(
+        ForeignKey("project_evaluator_criteria.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    config_fingerprint: Mapped[str] = mapped_column(String, nullable=False)
+
+    status: Mapped[EvalWorkStatus] = mapped_column(
+        CheckConstraint(
+            "status IN ('PENDING', 'RUNNING', 'DONE', 'ERROR', 'EXPIRED')",
+            name="valid_eval_work_status",
+        ),
+        default="PENDING",
+        server_default="PENDING",
+    )
+
+    claimed_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+    claimed_by: Mapped[Optional[str]] = mapped_column(String)
+
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    error: Mapped[Optional[str]] = mapped_column(String)
+    cooldown_until: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
+
+    span: Mapped["Span"] = relationship("Span")
+    evaluator: Mapped["Evaluator"] = relationship("Evaluator")
+    criteria: Mapped["ProjectEvaluatorCriteria"] = relationship("ProjectEvaluatorCriteria")
+
+    __table_args__ = (
+        UniqueConstraint("span_rowid", "evaluator_id", "config_fingerprint"),
+        Index(
+            "ix_eval_work_units_claimable",
+            "status",
+            "id",
+            postgresql_where=text("status NOT IN ('DONE', 'EXPIRED')"),
+            sqlite_where=text("status NOT IN ('DONE', 'EXPIRED')"),
+        ),
+        Index(
+            "ix_eval_work_units_terminal",
+            "updated_at",
+            postgresql_where=text("status IN ('DONE', 'EXPIRED')"),
+            sqlite_where=text("status IN ('DONE', 'EXPIRED')"),
+        ),
+        Index(
+            "ix_eval_work_units_error_attempts",
+            "attempts",
+            postgresql_where=text("status = 'ERROR'"),
+            sqlite_where=text("status = 'ERROR'"),
+        ),
+    )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -184,6 +184,7 @@ GenerativeModelSDK: TypeAlias = Literal[
 ExperimentStatus: TypeAlias = Literal["RUNNING", "COMPLETED", "STOPPED", "ERROR"]
 EvalWorkStatus: TypeAlias = Literal["PENDING", "RUNNING", "DONE", "ERROR", "EXPIRED"]
 EvalWorkGrain: TypeAlias = Literal["SPAN"]
+EvaluationTarget: TypeAlias = Literal["SPAN", "TRACE", "SESSION"]
 ExperimentLogCategory: TypeAlias = Literal["TASK", "EVAL", "EXPERIMENT"]
 ExperimentLogLevel: TypeAlias = Literal["ERROR", "WARN", "INFO"]
 SystemSettingKey: TypeAlias = Literal[
@@ -587,6 +588,25 @@ class _InputMapping(TypeDecorator[InputMapping]):
     def process_result_value(self, value: Optional[dict[str, Any]], _: Dialect) -> InputMapping:
         if value is None:
             return InputMapping(literal_mapping={}, path_mapping={})
+        return InputMapping.model_validate(value)
+
+
+class _OptionalInputMapping(TypeDecorator[Optional[InputMapping]]):
+    cache_ok = True
+    impl = JSON_
+
+    def process_bind_param(
+        self, value: Optional[InputMapping], _: Dialect
+    ) -> Optional[dict[str, Any]]:
+        if value is None:
+            return None
+        return value.model_dump()
+
+    def process_result_value(
+        self, value: Optional[dict[str, Any]], _: Dialect
+    ) -> Optional[InputMapping]:
+        if value is None:
+            return None
         return InputMapping.model_validate(value)
 
 
@@ -3085,8 +3105,18 @@ class ProjectEvaluatorCriteria(HasId):
         nullable=False,
         index=True,
     )
-    annotation_name: Mapped[Identifier] = mapped_column(_Identifier, nullable=False)
+    name: Mapped[Identifier] = mapped_column(_Identifier, nullable=False)
     filter_condition: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    evaluation_target: Mapped[EvaluationTarget] = mapped_column(
+        CheckConstraint(
+            "evaluation_target IN ('SPAN', 'TRACE', 'SESSION')",
+            name="valid_evaluation_target",
+        ),
+        nullable=False,
+    )
+    input_mapping: Mapped[Optional[InputMapping]] = mapped_column(
+        _OptionalInputMapping, nullable=True
+    )
     sampling_rate: Mapped[float] = mapped_column(
         Float,
         CheckConstraint(
@@ -3104,7 +3134,7 @@ class ProjectEvaluatorCriteria(HasId):
     project: Mapped["Project"] = relationship("Project")
     evaluator: Mapped["Evaluator"] = relationship("Evaluator")
 
-    __table_args__ = (UniqueConstraint("project_id", "annotation_name"),)
+    __table_args__ = (UniqueConstraint("project_id", "name"),)
 
 
 class EvalWorkCursor(HasId):

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -183,7 +183,6 @@ GenerativeModelSDK: TypeAlias = Literal[
 ]
 ExperimentStatus: TypeAlias = Literal["RUNNING", "COMPLETED", "STOPPED", "ERROR"]
 EvalWorkStatus: TypeAlias = Literal["PENDING", "RUNNING", "DONE", "ERROR", "EXPIRED"]
-EvalWorkGrain: TypeAlias = Literal["SPAN"]
 EvaluationTarget: TypeAlias = Literal["SPAN", "TRACE", "SESSION"]
 ExperimentLogCategory: TypeAlias = Literal["TASK", "EVAL", "EXPERIMENT"]
 ExperimentLogLevel: TypeAlias = Literal["ERROR", "WARN", "INFO"]
@@ -3139,12 +3138,14 @@ class ProjectEvaluatorCriteria(HasId):
 
 class EvalWorkCursor(HasId):
     """Producer lease and position in the span arrival log, one row per
-    (grain, consumer_group). For every grain, produced_through_id is a Span.id
-    position in the shared arrival log rather than a grain-specific entity id."""
+    (evaluation_target, consumer_group). For each target, produced_through_id is a Span.id
+    position in the shared arrival log rather than a target-specific entity id."""
 
     __tablename__ = "eval_work_cursors"
-    grain: Mapped[EvalWorkGrain] = mapped_column(
-        CheckConstraint("grain IN ('SPAN', 'TRACE', 'SESSION')", name="valid_grain"),
+    evaluation_target: Mapped[EvaluationTarget] = mapped_column(
+        CheckConstraint(
+            "evaluation_target IN ('SPAN', 'TRACE', 'SESSION')", name="valid_evaluation_target"
+        ),
         nullable=False,
     )
     consumer_group: Mapped[str] = mapped_column(String, nullable=False)
@@ -3161,11 +3162,11 @@ class EvalWorkCursor(HasId):
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
     )
 
-    __table_args__ = (UniqueConstraint("grain", "consumer_group"),)
+    __table_args__ = (UniqueConstraint("evaluation_target", "consumer_group"),)
 
 
 class EvalWorkUnit(HasId):
-    """A span-grain eval task — run one evaluator against one span. The producer
+    """A span-level eval task — run one evaluator against one span. The producer
     materializes rows here; consumers claim, run, and complete them."""
 
     __tablename__ = "eval_work_units"

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -61,6 +61,7 @@ from .min_start_or_max_end_times import MinStartOrMaxEndTimeCache, MinStartOrMax
 from .num_child_spans import NumChildSpansDataLoader
 from .num_spans_per_trace import NumSpansPerTraceDataLoader
 from .project_by_name import ProjectByNameDataLoader
+from .project_evaluator_criteria_by_id import ProjectEvaluatorCriteriaByIdDataLoader
 from .project_has_traces import ProjectHasTracesDataLoader
 from .project_ids_by_trace_retention_policy_id import ProjectIdsByTraceRetentionPolicyIdDataLoader
 from .prompt_label_usage_counts import PromptLabelUsageCountsDataLoader
@@ -207,6 +208,7 @@ class DataLoaders:
     project_by_name: ProjectByNameDataLoader
     project_has_traces: ProjectHasTracesDataLoader
     project_fields: TableFieldsDataLoader
+    project_evaluator_criteria_by_id: ProjectEvaluatorCriteriaByIdDataLoader
     project_trace_retention_policy_fields: TableFieldsDataLoader
     projects_by_trace_retention_policy_id: ProjectIdsByTraceRetentionPolicyIdDataLoader
     prompt_fields: TableFieldsDataLoader
@@ -364,6 +366,7 @@ def build_data_loaders(
         num_child_spans=NumChildSpansDataLoader(db),
         num_spans_per_trace=NumSpansPerTraceDataLoader(db),
         project_fields=TableFieldsDataLoader(db, models.Project),
+        project_evaluator_criteria_by_id=ProjectEvaluatorCriteriaByIdDataLoader(db),
         projects_by_trace_retention_policy_id=ProjectIdsByTraceRetentionPolicyIdDataLoader(db),
         prompt_fields=TableFieldsDataLoader(db, models.Prompt),
         prompt_label_fields=TableFieldsDataLoader(db, models.PromptLabel),

--- a/src/phoenix/server/api/dataloaders/project_evaluator_criteria_by_id.py
+++ b/src/phoenix/server/api/dataloaders/project_evaluator_criteria_by_id.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+
+class ProjectEvaluatorCriteriaByIdDataLoader(
+    DataLoader[int, Optional[models.ProjectEvaluatorCriteria]]
+):
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[int]) -> list[Optional[models.ProjectEvaluatorCriteria]]:
+        records_by_id: dict[int, models.ProjectEvaluatorCriteria] = {}
+        async with self._db.read() as session:
+            records = await session.scalars(
+                select(models.ProjectEvaluatorCriteria).where(
+                    models.ProjectEvaluatorCriteria.id.in_(keys)
+                )
+            )
+            for record in records:
+                records_by_id[record.id] = record
+        return [records_by_id.get(key) for key in keys]

--- a/src/phoenix/server/api/helpers/evaluators.py
+++ b/src/phoenix/server/api/helpers/evaluators.py
@@ -56,7 +56,7 @@ def validate_evaluator_prompt_and_configs(
         raise ValueError(_LLMEvaluatorPromptErrorMessage.TOOL_CHOICE_REQUIRED)
     if isinstance(prompt_tools.tool_choice, PromptToolChoiceSpecificFunctionTool):
         if not prompt_tools.tools or not isinstance(prompt_tools.tools[0], PromptToolFunction):
-            raise ValueError(f"Tool {prompt_tools.tools[0]} is not a function tool")
+            raise ValueError(_LLMEvaluatorPromptErrorMessage.FUNCTION_TOOLS_REQUIRED)
         if prompt_tools.tool_choice.function_name != prompt_tools.tools[0].function.name:
             raise ValueError(
                 _LLMEvaluatorPromptErrorMessage.TOOL_CHOICE_SPECIFIC_FUNCTION_NAME_MUST_MATCH_DEFINED_FUNCTION_NAME
@@ -66,7 +66,7 @@ def validate_evaluator_prompt_and_configs(
     tools_by_name: dict[str, PromptToolFunction] = {}
     for tool in prompt_tools.tools:
         if not isinstance(tool, PromptToolFunction):
-            raise ValueError(f"Tool {tool} is not a function tool")
+            raise ValueError(_LLMEvaluatorPromptErrorMessage.FUNCTION_TOOLS_REQUIRED)
         tools_by_name[tool.function.name] = tool
 
     # Validate each config against its matched tool
@@ -236,6 +236,7 @@ class _LLMEvaluatorPromptErrorMessage:
         "Number of prompt tool definitions must match number of output configs"
     )
     TOOL_CHOICE_REQUIRED = "Evaluator prompts must require a tool choice"
+    FUNCTION_TOOLS_REQUIRED = "Evaluator prompts require function tools"
     TOOL_CHOICE_SPECIFIC_FUNCTION_NAME_MUST_MATCH_DEFINED_FUNCTION_NAME = (
         "Evaluator tool choice specific function name must match defined function name"
     )

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -435,6 +435,24 @@ class UpdateProjectLLMEvaluatorInput:
 
 
 @strawberry.input
+class AddProjectCodeEvaluatorInput:
+    project_id: GlobalID
+    evaluator_id: GlobalID
+    name: Identifier
+    sampling_rate: float
+    evaluation_target: EvaluationTarget
+    input_mapping: Optional[EvaluatorInputMappingInput] = strawberry.field(
+        default=None,
+        description=(
+            "Project-specific CODE input mapping. Null inherits the evaluator input mapping; "
+            "an object overrides it."
+        ),
+    )
+    filter_condition: str = ""
+    enabled: bool = True
+
+
+@strawberry.input
 class CreateProjectCodeEvaluatorInput:
     project_id: GlobalID
     name: Identifier
@@ -781,6 +799,62 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
+            "Bind an existing CODE evaluator to a project. The evaluator's configuration is "
+            "shared with every project and dataset it is bound to. SPAN is executable; TRACE "
+            "and SESSION are stored but inactive until their runtimes are available."
+        ),
+    )  # type: ignore
+    async def add_project_code_evaluator(
+        self, info: Info[Context, None], input: AddProjectCodeEvaluatorInput
+    ) -> ProjectEvaluatorMutationPayload:
+        try:
+            project_id = from_global_id_with_expected_type(input.project_id, Project.__name__)
+        except ValueError:
+            raise BadRequest(f"Invalid project id: {input.project_id}")
+        try:
+            evaluator_id, evaluator_kind = _parse_evaluator_id(input.evaluator_id)
+        except ValueError as error:
+            raise BadRequest(f"Invalid evaluator id: {input.evaluator_id}. {error}")
+        if evaluator_kind != "CODE":
+            raise BadRequest("Evaluator must be a CODE evaluator")
+        try:
+            name = IdentifierModel.model_validate(input.name)
+        except ValidationError as error:
+            raise BadRequest(str(error))
+        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_sampling_rate(input.sampling_rate)
+
+        try:
+            async with info.context.db() as session:
+                if await session.get(models.Project, project_id) is None:
+                    raise NotFound(f"Project not found: {input.project_id}")
+                if await session.get(models.CodeEvaluator, evaluator_id) is None:
+                    raise BadRequest("CODE evaluator not found")
+                criteria = models.ProjectEvaluatorCriteria(
+                    project_id=project_id,
+                    evaluator_id=evaluator_id,
+                    name=name,
+                    filter_condition=input.filter_condition,
+                    sampling_rate=input.sampling_rate,
+                    evaluation_target=input.evaluation_target.value,
+                    input_mapping=(
+                        input.input_mapping.to_orm() if input.input_mapping is not None else None
+                    ),
+                    enabled=input.enabled,
+                )
+                session.add(criteria)
+                await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise Conflict("A project evaluator with this name already exists for this project")
+
+        return ProjectEvaluatorMutationPayload(
+            evaluator=ProjectEvaluator(id=criteria.id, db_record=criteria),
+            query=Query(),
+        )
+
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
+        description=(
             "Create a CODE project evaluator. SPAN is executable; TRACE and SESSION "
             "are stored but inactive until their runtimes are available."
         ),
@@ -866,8 +940,9 @@ class EvaluatorMutationMixin:
     @strawberry.mutation(
         permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
         description=(
-            "Update a CODE project evaluator. SPAN is executable; TRACE and SESSION "
-            "are stored but inactive until their runtimes are available."
+            "Update a CODE project evaluator. Editing changes the underlying evaluator, which "
+            "applies to every project and dataset it is bound to. SPAN is executable; TRACE and "
+            "SESSION are stored but inactive until their runtimes are available."
         ),
     )  # type: ignore
     async def update_project_code_evaluator(

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -50,15 +50,19 @@ from phoenix.server.api.types.Evaluator import (
     BuiltInEvaluator,
     CodeEvaluator,
     DatasetEvaluator,
+    EvaluationTarget,
     LLMEvaluator,
+    ProjectEvaluator,
 )
 from phoenix.server.api.types.node import from_global_id, from_global_id_with_expected_type
+from phoenix.server.api.types.Project import Project
 from phoenix.server.api.types.PromptVersion import PromptVersion
 from phoenix.server.api.types.SandboxConfig import (
     Language,
     SandboxConfig,
 )
 from phoenix.server.bearer_auth import PhoenixUser
+from phoenix.trace.dsl.filter import validate_span_filter_condition
 
 
 def _output_config_input_to_pydantic(input: AnnotationConfigInput) -> OutputConfigType:
@@ -247,6 +251,48 @@ async def _ensure_evaluator_prompt_label(
         session.add(association)
 
 
+def _validate_project_evaluator_filter(filter_condition: str) -> None:
+    try:
+        validate_span_filter_condition(filter_condition)
+    except Exception:
+        raise BadRequest("Invalid filter condition: unable to compile for supported databases")
+
+
+def _validate_project_evaluator_sampling_rate(sampling_rate: float) -> None:
+    if not 0.0 <= sampling_rate <= 1.0:
+        raise BadRequest("samplingRate must be between 0.0 and 1.0")
+
+
+async def _garbage_collect_evaluators(
+    session: AsyncSession,
+    *,
+    evaluator_ids: set[int],
+    prompt_ids: set[int],
+    delete_associated_prompt: bool,
+) -> None:
+    if evaluator_ids:
+        await session.execute(
+            delete(models.Evaluator).where(
+                models.Evaluator.id.in_(evaluator_ids),
+                ~select(models.DatasetEvaluators.id)
+                .where(models.DatasetEvaluators.evaluator_id == models.Evaluator.id)
+                .exists(),
+                ~select(models.ProjectEvaluatorCriteria.id)
+                .where(models.ProjectEvaluatorCriteria.evaluator_id == models.Evaluator.id)
+                .exists(),
+            )
+        )
+    if delete_associated_prompt and prompt_ids:
+        await session.execute(
+            delete(models.Prompt).where(
+                models.Prompt.id.in_(prompt_ids),
+                ~select(models.LLMEvaluator.id)
+                .where(models.LLMEvaluator.prompt_id == models.Prompt.id)
+                .exists(),
+            )
+        )
+
+
 def _parse_evaluator_id(global_id: GlobalID) -> tuple[int, EvaluatorKind]:
     """
     Parse evaluator ID accepting LLMEvaluator, CodeEvaluator and BuiltInEvaluator types.
@@ -359,6 +405,99 @@ class DeleteDatasetEvaluatorsPayload:
 
 
 @strawberry.input
+class CreateProjectLLMEvaluatorInput:
+    project_id: GlobalID
+    name: Identifier
+    prompt_version: ChatPromptVersionInput
+    output_configs: list[AnnotationConfigInput]
+    input_mapping: EvaluatorInputMappingInput
+    sampling_rate: float
+    evaluation_target: EvaluationTarget
+    description: Optional[str] = None
+    prompt_version_id: Optional[GlobalID] = UNSET
+    filter_condition: str = ""
+    enabled: bool = True
+
+
+@strawberry.input
+class UpdateProjectLLMEvaluatorInput:
+    project_evaluator_id: GlobalID
+    name: Identifier
+    prompt_version: ChatPromptVersionInput
+    output_configs: list[AnnotationConfigInput]
+    input_mapping: EvaluatorInputMappingInput
+    sampling_rate: float
+    evaluation_target: EvaluationTarget
+    filter_condition: str
+    enabled: bool
+    description: Optional[str] = None
+    prompt_version_id: Optional[GlobalID] = UNSET
+
+
+@strawberry.input
+class CreateProjectCodeEvaluatorInput:
+    project_id: GlobalID
+    name: Identifier
+    source_code: str
+    language: Language
+    sandbox_config_id: GlobalID
+    evaluator_input_mapping: EvaluatorInputMappingInput
+    sampling_rate: float
+    evaluation_target: EvaluationTarget
+    description: Optional[str] = None
+    output_configs: Optional[list[AnnotationConfigInput]] = None
+    input_mapping: Optional[EvaluatorInputMappingInput] = strawberry.field(
+        default=None,
+        description=(
+            "Project-specific CODE input mapping. Null inherits the evaluator input mapping; "
+            "an object overrides it."
+        ),
+    )
+    filter_condition: str = ""
+    enabled: bool = True
+
+
+@strawberry.input
+class UpdateProjectCodeEvaluatorInput:
+    project_evaluator_id: GlobalID
+    name: Identifier
+    evaluator_input_mapping: EvaluatorInputMappingInput
+    sampling_rate: float
+    evaluation_target: EvaluationTarget
+    filter_condition: str
+    enabled: bool
+    description: Optional[str] = None
+    source_code: Optional[str] = UNSET
+    sandbox_config_id: Optional[GlobalID] = UNSET
+    output_configs: Optional[list[AnnotationConfigInput]] = UNSET
+    input_mapping: Optional[EvaluatorInputMappingInput] = strawberry.field(
+        default=UNSET,
+        description=(
+            "Project-specific CODE input mapping patch. Omit to preserve the current setting, "
+            "use null to inherit the evaluator input mapping, or provide an object to override it."
+        ),
+    )
+
+
+@strawberry.type
+class ProjectEvaluatorMutationPayload:
+    evaluator: ProjectEvaluator
+    query: Query
+
+
+@strawberry.input
+class DeleteProjectEvaluatorsInput:
+    project_evaluator_ids: list[GlobalID]
+    delete_associated_prompt: bool = True
+
+
+@strawberry.type
+class DeleteProjectEvaluatorsPayload:
+    project_evaluator_ids: list[GlobalID]
+    query: Query
+
+
+@strawberry.input
 class CreateCodeEvaluatorInput:
     name: Identifier
     source_code: str
@@ -405,6 +544,503 @@ class CreateCodeEvaluatorVersionPayload:
 
 @strawberry.type
 class EvaluatorMutationMixin:
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
+        description=(
+            "Create an LLM project evaluator. SPAN is executable; TRACE and SESSION "
+            "are stored but inactive until their runtimes are available."
+        ),
+    )  # type: ignore
+    async def create_project_llm_evaluator(
+        self, info: Info[Context, None], input: CreateProjectLLMEvaluatorInput
+    ) -> ProjectEvaluatorMutationPayload:
+        try:
+            project_id = from_global_id_with_expected_type(input.project_id, Project.__name__)
+        except ValueError:
+            raise BadRequest(f"Invalid project id: {input.project_id}")
+        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        try:
+            name = IdentifierModel.model_validate(input.name)
+            prompt_version = input.prompt_version.to_orm_prompt_version(None)
+            output_configs = list(
+                LLMEvaluatorOutputConfigs.from_inputs(input.output_configs).configs
+            )
+        except (ValueError, ValidationError) as error:
+            raise BadRequest(str(error))
+
+        user_id: Optional[int] = None
+        assert isinstance(request := info.context.request, Request)
+        if "user" in request.scope:
+            assert isinstance(user := request.user, PhoenixUser)
+            user_id = int(user.identity)
+            prompt_version.user_id = user_id
+
+        try:
+            async with info.context.db() as session:
+                if await session.get(models.Project, project_id) is None:
+                    raise NotFound(f"Project not found: {input.project_id}")
+                evaluator_name = await _generate_unique_evaluator_name(session, name)
+
+                target_prompt_version_id: Optional[int] = None
+                if input.prompt_version_id is not UNSET and input.prompt_version_id is not None:
+                    prompt_version_id = from_global_id_with_expected_type(
+                        input.prompt_version_id, PromptVersion.__name__
+                    )
+                    existing_prompt_version = await session.get(
+                        models.PromptVersion, prompt_version_id
+                    )
+                    if existing_prompt_version is None:
+                        raise NotFound(f"Prompt version not found: {input.prompt_version_id}")
+                    prompt = await session.get(models.Prompt, existing_prompt_version.prompt_id)
+                    if prompt is None:
+                        raise NotFound("Prompt for the selected version was not found")
+                    if existing_prompt_version.has_identical_content(prompt_version):
+                        target_prompt_version_id = existing_prompt_version.id
+                    else:
+                        prompt_version.prompt_id = prompt.id
+                        session.add(prompt_version)
+                        await session.flush()
+                        target_prompt_version_id = prompt_version.id
+                else:
+                    prompt = models.Prompt(
+                        name=IdentifierModel.model_validate(
+                            f"{input.name}-evaluator-{token_hex(4)}"
+                        ),
+                        description=input.description,
+                        prompt_versions=[prompt_version],
+                    )
+
+                evaluator = models.LLMEvaluator(
+                    name=evaluator_name,
+                    description=input.description,
+                    kind="LLM",
+                    output_configs=output_configs,
+                    user_id=user_id,
+                    prompt=prompt,
+                )
+                try:
+                    validate_consistent_llm_evaluator_and_prompt_version(prompt_version, evaluator)
+                except ValueError as error:
+                    raise BadRequest(str(error))
+                session.add(evaluator)
+                await session.flush()
+                await _ensure_evaluator_prompt_label(session, prompt.id)
+                evaluator.prompt_version_tag = models.PromptVersionTag(
+                    name=IdentifierModel.model_validate(f"{input.name}-evaluator-{token_hex(4)}"),
+                    prompt_id=prompt.id,
+                    prompt_version_id=target_prompt_version_id or prompt_version.id,
+                )
+                criteria = models.ProjectEvaluatorCriteria(
+                    project_id=project_id,
+                    evaluator_id=evaluator.id,
+                    name=name,
+                    filter_condition=input.filter_condition,
+                    sampling_rate=input.sampling_rate,
+                    evaluation_target=input.evaluation_target.value,
+                    input_mapping=input.input_mapping.to_orm(),
+                    enabled=input.enabled,
+                )
+                session.add(criteria)
+                await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise Conflict("A project evaluator with this name already exists for this project")
+
+        return ProjectEvaluatorMutationPayload(
+            evaluator=ProjectEvaluator(id=criteria.id, db_record=criteria),
+            query=Query(),
+        )
+
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
+        description=(
+            "Update an LLM project evaluator. SPAN is executable; TRACE and SESSION "
+            "are stored but inactive until their runtimes are available."
+        ),
+    )  # type: ignore
+    async def update_project_llm_evaluator(
+        self, info: Info[Context, None], input: UpdateProjectLLMEvaluatorInput
+    ) -> ProjectEvaluatorMutationPayload:
+        try:
+            criteria_id = from_global_id_with_expected_type(
+                input.project_evaluator_id, ProjectEvaluator.__name__
+            )
+        except ValueError:
+            raise BadRequest(f"Invalid project evaluator id: {input.project_evaluator_id}")
+        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        try:
+            name = IdentifierModel.model_validate(input.name)
+            prompt_version = input.prompt_version.to_orm_prompt_version(None)
+            output_configs = list(
+                LLMEvaluatorOutputConfigs.from_inputs(input.output_configs).configs
+            )
+        except (ValueError, ValidationError) as error:
+            raise BadRequest(str(error))
+
+        user_id: Optional[int] = None
+        assert isinstance(request := info.context.request, Request)
+        if "user" in request.scope:
+            assert isinstance(user := request.user, PhoenixUser)
+            user_id = int(user.identity)
+            prompt_version.user_id = user_id
+
+        try:
+            async with info.context.db() as session:
+                pair = (
+                    await session.execute(
+                        select(models.ProjectEvaluatorCriteria, models.LLMEvaluator)
+                        .join(
+                            models.LLMEvaluator,
+                            models.ProjectEvaluatorCriteria.evaluator_id == models.LLMEvaluator.id,
+                        )
+                        .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+                    )
+                ).one_or_none()
+                if pair is None:
+                    raise NotFound(f"LLM project evaluator not found: {input.project_evaluator_id}")
+                criteria, evaluator = pair
+                if criteria.name != name:
+                    evaluator.name = await _generate_unique_evaluator_name(session, name)
+
+                selected_version: Optional[models.PromptVersion] = None
+                if input.prompt_version_id is not UNSET and input.prompt_version_id is not None:
+                    selected_version_id = from_global_id_with_expected_type(
+                        input.prompt_version_id, PromptVersion.__name__
+                    )
+                    selected_version = await session.get(models.PromptVersion, selected_version_id)
+                    if selected_version is None:
+                        raise NotFound(f"Prompt version not found: {input.prompt_version_id}")
+                elif evaluator.prompt_version_tag_id is not None:
+                    selected_version = await session.scalar(
+                        select(models.PromptVersion)
+                        .join(
+                            models.PromptVersionTag,
+                            models.PromptVersionTag.prompt_version_id == models.PromptVersion.id,
+                        )
+                        .where(models.PromptVersionTag.id == evaluator.prompt_version_tag_id)
+                    )
+
+                target_prompt_id = (
+                    selected_version.prompt_id
+                    if selected_version is not None
+                    else evaluator.prompt_id
+                )
+                final_prompt_version_id: Optional[int] = None
+                if selected_version is not None and selected_version.has_identical_content(
+                    prompt_version
+                ):
+                    final_prompt_version_id = selected_version.id
+                else:
+                    prompt_version.prompt_id = target_prompt_id
+                    session.add(prompt_version)
+                    await session.flush()
+                    final_prompt_version_id = prompt_version.id
+
+                evaluator.description = input.description
+                evaluator.output_configs = output_configs
+                evaluator.user_id = user_id
+                evaluator.prompt_id = target_prompt_id
+                evaluator.updated_at = datetime.now(timezone.utc)
+                try:
+                    validate_consistent_llm_evaluator_and_prompt_version(prompt_version, evaluator)
+                except ValueError as error:
+                    raise BadRequest(str(error))
+                if evaluator.prompt_version_tag_id is None:
+                    evaluator.prompt_version_tag = models.PromptVersionTag(
+                        name=IdentifierModel.model_validate(
+                            f"{input.name}-evaluator-{token_hex(4)}"
+                        ),
+                        prompt_id=target_prompt_id,
+                        prompt_version_id=final_prompt_version_id,
+                    )
+                else:
+                    prompt_version_tag = await session.get(
+                        models.PromptVersionTag, evaluator.prompt_version_tag_id
+                    )
+                    if prompt_version_tag is None:
+                        raise NotFound("Prompt version tag was not found")
+                    prompt_version_tag.prompt_id = target_prompt_id
+                    prompt_version_tag.prompt_version_id = final_prompt_version_id
+
+                criteria.name = name
+                criteria.filter_condition = input.filter_condition
+                criteria.sampling_rate = input.sampling_rate
+                criteria.evaluation_target = input.evaluation_target.value
+                criteria.input_mapping = input.input_mapping.to_orm()
+                criteria.enabled = input.enabled
+                await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise Conflict("A project evaluator with this name already exists for this project")
+
+        return ProjectEvaluatorMutationPayload(
+            evaluator=ProjectEvaluator(id=criteria.id, db_record=criteria),
+            query=Query(),
+        )
+
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
+        description=(
+            "Create a CODE project evaluator. SPAN is executable; TRACE and SESSION "
+            "are stored but inactive until their runtimes are available."
+        ),
+    )  # type: ignore
+    async def create_project_code_evaluator(
+        self, info: Info[Context, None], input: CreateProjectCodeEvaluatorInput
+    ) -> ProjectEvaluatorMutationPayload:
+        try:
+            project_id = from_global_id_with_expected_type(input.project_id, Project.__name__)
+            name = IdentifierModel.model_validate(input.name)
+        except (ValueError, ValidationError) as error:
+            raise BadRequest(str(error))
+        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        _raise_on_uninferable_evaluate_signature(input.source_code, input.language)
+        if input.output_configs is not None:
+            try:
+                validate_unique_config_names(input.output_configs)
+            except ValueError as error:
+                raise BadRequest(str(error))
+        output_configs = cast(
+            list[AnnotationConfigType],
+            _convert_output_config_inputs_to_pydantic(input.output_configs or []),
+        )
+
+        user_id: Optional[int] = None
+        assert isinstance(request := info.context.request, Request)
+        if "user" in request.scope:
+            assert isinstance(user := request.user, PhoenixUser)
+            user_id = int(user.identity)
+
+        try:
+            async with info.context.db() as session:
+                if await session.get(models.Project, project_id) is None:
+                    raise NotFound(f"Project not found: {input.project_id}")
+                evaluator_name = await _generate_unique_evaluator_name(session, name)
+                sandbox_config_id = await _validate_code_evaluator_sandbox_config(
+                    session,
+                    sandbox_config_global_id=input.sandbox_config_id,
+                    language=input.language.value,
+                    action="creating this evaluator",
+                )
+                evaluator = models.CodeEvaluator(
+                    name=evaluator_name,
+                    description=input.description,
+                    language=input.language.value,
+                    user_id=user_id,
+                    sandbox_config_id=sandbox_config_id,
+                    input_mapping=input.evaluator_input_mapping.to_orm(),
+                    output_configs=output_configs,
+                )
+                session.add(evaluator)
+                await session.flush()
+                session.add(
+                    models.CodeEvaluatorVersion(
+                        code_evaluator_id=evaluator.id,
+                        source_code=input.source_code,
+                        user_id=user_id,
+                    )
+                )
+                criteria = models.ProjectEvaluatorCriteria(
+                    project_id=project_id,
+                    evaluator_id=evaluator.id,
+                    name=name,
+                    filter_condition=input.filter_condition,
+                    sampling_rate=input.sampling_rate,
+                    evaluation_target=input.evaluation_target.value,
+                    input_mapping=(
+                        input.input_mapping.to_orm() if input.input_mapping is not None else None
+                    ),
+                    enabled=input.enabled,
+                )
+                session.add(criteria)
+                await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise Conflict("A project evaluator with this name already exists for this project")
+
+        return ProjectEvaluatorMutationPayload(
+            evaluator=ProjectEvaluator(id=criteria.id, db_record=criteria),
+            query=Query(),
+        )
+
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked],
+        description=(
+            "Update a CODE project evaluator. SPAN is executable; TRACE and SESSION "
+            "are stored but inactive until their runtimes are available."
+        ),
+    )  # type: ignore
+    async def update_project_code_evaluator(
+        self, info: Info[Context, None], input: UpdateProjectCodeEvaluatorInput
+    ) -> ProjectEvaluatorMutationPayload:
+        try:
+            criteria_id = from_global_id_with_expected_type(
+                input.project_evaluator_id, ProjectEvaluator.__name__
+            )
+            name = IdentifierModel.model_validate(input.name)
+        except (ValueError, ValidationError) as error:
+            raise BadRequest(str(error))
+        _validate_project_evaluator_filter(input.filter_condition)
+        _validate_project_evaluator_sampling_rate(input.sampling_rate)
+        if input.source_code is not UNSET and input.source_code is None:
+            raise BadRequest("source_code cannot be set to null")
+        if input.output_configs is None:
+            raise BadRequest("output_configs cannot be set to null")
+        if input.output_configs is not UNSET:
+            try:
+                validate_unique_config_names(input.output_configs)
+            except ValueError as error:
+                raise BadRequest(str(error))
+
+        user_id: Optional[int] = None
+        assert isinstance(request := info.context.request, Request)
+        if "user" in request.scope:
+            assert isinstance(user := request.user, PhoenixUser)
+            user_id = int(user.identity)
+
+        try:
+            async with info.context.db() as session:
+                pair = (
+                    await session.execute(
+                        select(models.ProjectEvaluatorCriteria, models.CodeEvaluator)
+                        .join(
+                            models.CodeEvaluator,
+                            models.ProjectEvaluatorCriteria.evaluator_id == models.CodeEvaluator.id,
+                        )
+                        .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+                    )
+                ).one_or_none()
+                if pair is None:
+                    raise NotFound(
+                        f"CODE project evaluator not found: {input.project_evaluator_id}"
+                    )
+                criteria, evaluator = pair
+                if criteria.name != name:
+                    evaluator.name = await _generate_unique_evaluator_name(session, name)
+                evaluator.description = input.description
+                evaluator.user_id = user_id
+                evaluator.input_mapping = input.evaluator_input_mapping.to_orm()
+
+                if input.sandbox_config_id is not UNSET:
+                    if input.sandbox_config_id is None:
+                        evaluator.sandbox_config_id = None
+                    else:
+                        evaluator.sandbox_config_id = await _validate_code_evaluator_sandbox_config(
+                            session,
+                            sandbox_config_global_id=input.sandbox_config_id,
+                            language=evaluator.language,
+                            action="updating this evaluator",
+                        )
+                if input.output_configs is not UNSET:
+                    evaluator.output_configs = cast(
+                        list[AnnotationConfigType],
+                        _convert_output_config_inputs_to_pydantic(input.output_configs),
+                    )
+                if input.source_code is not UNSET and input.source_code is not None:
+                    _raise_on_uninferable_evaluate_signature(
+                        input.source_code, Language(evaluator.language)
+                    )
+                    locked = await code_evaluator_with_latest_version_for_update(
+                        session, evaluator.id
+                    )
+                    if locked is None:
+                        raise NotFound(
+                            f"CODE project evaluator not found: {input.project_evaluator_id}"
+                        )
+                    _, current_version = locked
+                    candidate = models.CodeEvaluatorVersion(
+                        code_evaluator_id=evaluator.id,
+                        source_code=input.source_code,
+                        user_id=user_id,
+                    )
+                    if current_version is None or not current_version.has_identical_content(
+                        candidate
+                    ):
+                        session.add(candidate)
+
+                criteria.name = name
+                criteria.filter_condition = input.filter_condition
+                criteria.sampling_rate = input.sampling_rate
+                criteria.evaluation_target = input.evaluation_target.value
+                if input.input_mapping is not UNSET:
+                    criteria.input_mapping = (
+                        input.input_mapping.to_orm() if input.input_mapping is not None else None
+                    )
+                criteria.enabled = input.enabled
+                await session.flush()
+        except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+            raise Conflict("A project evaluator with this name already exists for this project")
+
+        return ProjectEvaluatorMutationPayload(
+            evaluator=ProjectEvaluator(id=criteria.id, db_record=criteria),
+            query=Query(),
+        )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
+    async def delete_project_evaluators(
+        self, info: Info[Context, None], input: DeleteProjectEvaluatorsInput
+    ) -> DeleteProjectEvaluatorsPayload:
+        criteria_ids: list[int] = []
+        for global_id in input.project_evaluator_ids:
+            try:
+                criteria_ids.append(
+                    from_global_id_with_expected_type(global_id, ProjectEvaluator.__name__)
+                )
+            except ValueError:
+                raise BadRequest(f"Invalid project evaluator id: {global_id}")
+        if not criteria_ids:
+            return DeleteProjectEvaluatorsPayload(project_evaluator_ids=[], query=Query())
+
+        deleted_ids: list[GlobalID] = []
+        async with info.context.db() as session:
+            llm_evaluator_alias = aliased(models.LLMEvaluator, flat=True)
+            rows = (
+                await session.execute(
+                    select(
+                        models.ProjectEvaluatorCriteria.id,
+                        models.ProjectEvaluatorCriteria.evaluator_id,
+                        models.Evaluator.kind,
+                        llm_evaluator_alias.prompt_id,
+                    )
+                    .join(
+                        models.Evaluator,
+                        models.ProjectEvaluatorCriteria.evaluator_id == models.Evaluator.id,
+                    )
+                    .outerjoin(
+                        llm_evaluator_alias,
+                        models.ProjectEvaluatorCriteria.evaluator_id == llm_evaluator_alias.id,
+                    )
+                    .where(models.ProjectEvaluatorCriteria.id.in_(criteria_ids))
+                )
+            ).all()
+            evaluator_ids: set[int] = set()
+            prompt_ids: set[int] = set()
+            actual_criteria_ids: list[int] = []
+            for criteria_id, evaluator_id, kind, prompt_id in rows:
+                actual_criteria_ids.append(criteria_id)
+                deleted_ids.append(GlobalID(ProjectEvaluator.__name__, str(criteria_id)))
+                if kind != "BUILTIN":
+                    evaluator_ids.add(evaluator_id)
+                    if prompt_id is not None:
+                        prompt_ids.add(prompt_id)
+            if actual_criteria_ids:
+                await session.execute(
+                    delete(models.ProjectEvaluatorCriteria).where(
+                        models.ProjectEvaluatorCriteria.id.in_(actual_criteria_ids)
+                    )
+                )
+                await _garbage_collect_evaluators(
+                    session,
+                    evaluator_ids=evaluator_ids,
+                    prompt_ids=prompt_ids,
+                    delete_associated_prompt=input.delete_associated_prompt,
+                )
+
+        return DeleteProjectEvaluatorsPayload(
+            project_evaluator_ids=deleted_ids,
+            query=Query(),
+        )
+
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
     async def create_dataset_llm_evaluator(
         self, info: Info[Context, None], input: CreateDatasetLLMEvaluatorInput
@@ -857,6 +1493,31 @@ class EvaluatorMutationMixin:
                     if prompt_id is not None:
                         candidate_prompt_ids.add(prompt_id)
 
+            if project_ids:
+                cascade_rows = (
+                    await session.execute(
+                        select(
+                            models.ProjectEvaluatorCriteria.evaluator_id,
+                            models.Evaluator.kind,
+                            llm_evaluator_alias.prompt_id,
+                        )
+                        .join(
+                            models.Evaluator,
+                            models.ProjectEvaluatorCriteria.evaluator_id == models.Evaluator.id,
+                        )
+                        .outerjoin(
+                            llm_evaluator_alias,
+                            models.ProjectEvaluatorCriteria.evaluator_id == llm_evaluator_alias.id,
+                        )
+                        .where(models.ProjectEvaluatorCriteria.project_id.in_(project_ids))
+                    )
+                ).all()
+                for evaluator_id, kind, prompt_id in cascade_rows:
+                    if kind != "BUILTIN":
+                        gc_candidate_evaluator_ids.add(evaluator_id)
+                        if prompt_id is not None:
+                            candidate_prompt_ids.add(prompt_id)
+
             if not link_ids:
                 return DeleteDatasetEvaluatorsPayload(
                     dataset_evaluator_ids=[],
@@ -874,36 +1535,17 @@ class EvaluatorMutationMixin:
                     )
                 )
 
-            # Garbage collect non-BUILTIN evaluators that no DatasetEvaluators
-            # row still references. The correlated NOT EXISTS skips evaluators that
-            # remain in use by other datasets.
-            if gc_candidate_evaluator_ids:
-                await session.execute(
-                    delete(models.Evaluator).where(
-                        models.Evaluator.id.in_(gc_candidate_evaluator_ids),
-                        ~select(models.DatasetEvaluators.id)
-                        .where(models.DatasetEvaluators.evaluator_id == models.Evaluator.id)
-                        .exists(),
-                    )
-                )
-
-            # Garbage collect prompts of LLM evaluators we just deleted. Prompts whose
-            # LLMEvaluator was *not* garbage collected (still referenced) keep their
-            # LLMEvaluator row, so the NOT EXISTS predicate spares them.
-            if input.delete_associated_prompt and candidate_prompt_ids:
-                await session.execute(
-                    delete(models.Prompt).where(
-                        models.Prompt.id.in_(candidate_prompt_ids),
-                        ~select(models.LLMEvaluator.id)
-                        .where(models.LLMEvaluator.prompt_id == models.Prompt.id)
-                        .exists(),
-                    )
-                )
-
             if project_ids:
                 await session.execute(
                     delete(models.Project).where(models.Project.id.in_(project_ids))
                 )
+
+            await _garbage_collect_evaluators(
+                session,
+                evaluator_ids=gc_candidate_evaluator_ids,
+                prompt_ids=candidate_prompt_ids,
+                delete_associated_prompt=input.delete_associated_prompt,
+            )
 
         return DeleteDatasetEvaluatorsPayload(
             dataset_evaluator_ids=deleted_gids,

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -1130,7 +1130,7 @@ class ProjectEvaluator(Node):
 
     @strawberry.field(  # type: ignore[untyped-decorator]
         description=(
-            "Evaluation grain. SPAN is currently executable; TRACE and SESSION are "
+            "SPAN is currently executable; TRACE and SESSION are "
             "stored but remain inactive until their runtimes are available."
         )
     )

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -54,6 +54,13 @@ class EvaluatorKind(Enum):
     BUILTIN = "BUILTIN"
 
 
+@strawberry.enum
+class EvaluationTarget(Enum):
+    SPAN = "SPAN"
+    TRACE = "TRACE"
+    SESSION = "SESSION"
+
+
 @strawberry.type
 class EvaluatorInputMapping:
     literal_mapping: JSON
@@ -1075,5 +1082,95 @@ class DatasetEvaluator(Node):
         record = await info.context.data_loaders.dataset_evaluators_by_id.load(self.id)
         if record is None:
             raise NotFound(f"DatasetEvaluator not found: {self.id}")
+        self.db_record = record
+        return record
+
+
+@strawberry.type
+class ProjectEvaluator(Node):
+    """An evaluator and its project-specific online evaluation policy."""
+
+    id: NodeID[int]
+    db_record: strawberry.Private[Optional[models.ProjectEvaluatorCriteria]] = None
+
+    @strawberry.field
+    async def project(
+        self, info: Info[Context, None]
+    ) -> Annotated["Project", strawberry.lazy(".Project")]:
+        record = await self._get_record(info)
+        from .Project import Project
+
+        return Project(id=record.project_id)
+
+    @strawberry.field
+    async def evaluator(self, info: Info[Context, None]) -> Evaluator:
+        record = await self._get_record(info)
+        evaluator = await info.context.data_loaders.evaluator_by_id.load(record.evaluator_id)
+        if isinstance(evaluator, models.LLMEvaluator):
+            return LLMEvaluator(id=evaluator.id)
+        if isinstance(evaluator, models.CodeEvaluator):
+            return CodeEvaluator(id=evaluator.id)
+        if isinstance(evaluator, models.BuiltinEvaluator):
+            return BuiltInEvaluator(id=evaluator.id)
+        project_evaluator_id = GlobalID(ProjectEvaluator.__name__, str(self.id))
+        raise NotFound(f"Evaluator not found for project evaluator: {project_evaluator_id}")
+
+    @strawberry.field
+    async def name(self, info: Info[Context, None]) -> Identifier:
+        record = await self._get_record(info)
+        return Identifier(record.name.root)
+
+    @strawberry.field
+    async def filter_condition(self, info: Info[Context, None]) -> str:
+        return (await self._get_record(info)).filter_condition
+
+    @strawberry.field
+    async def sampling_rate(self, info: Info[Context, None]) -> float:
+        return (await self._get_record(info)).sampling_rate
+
+    @strawberry.field(  # type: ignore[untyped-decorator]
+        description=(
+            "Evaluation grain. SPAN is currently executable; TRACE and SESSION are "
+            "stored but remain inactive until their runtimes are available."
+        )
+    )
+    async def evaluation_target(self, info: Info[Context, None]) -> EvaluationTarget:
+        record = await self._get_record(info)
+        return EvaluationTarget(record.evaluation_target)
+
+    @strawberry.field
+    async def input_mapping(self, info: Info[Context, None]) -> EvaluatorInputMapping:
+        record = await self._get_record(info)
+        input_mapping = record.input_mapping
+        if input_mapping is None:
+            evaluator = await info.context.data_loaders.evaluator_by_id.load(record.evaluator_id)
+            if isinstance(evaluator, models.CodeEvaluator):
+                input_mapping = evaluator.input_mapping
+        if input_mapping is None:
+            return EvaluatorInputMapping(literal_mapping=JSON({}), path_mapping=JSON({}))
+        return EvaluatorInputMapping(
+            literal_mapping=JSON(input_mapping.literal_mapping),
+            path_mapping=JSON(input_mapping.path_mapping),
+        )
+
+    @strawberry.field
+    async def enabled(self, info: Info[Context, None]) -> bool:
+        return (await self._get_record(info)).enabled
+
+    @strawberry.field
+    async def created_at(self, info: Info[Context, None]) -> datetime:
+        return (await self._get_record(info)).created_at
+
+    @strawberry.field
+    async def updated_at(self, info: Info[Context, None]) -> datetime:
+        return (await self._get_record(info)).updated_at
+
+    async def _get_record(self, info: Info[Context, None]) -> models.ProjectEvaluatorCriteria:
+        if self.db_record is not None:
+            return self.db_record
+        record = await info.context.data_loaders.project_evaluator_criteria_by_id.load(self.id)
+        if record is None:
+            project_evaluator_id = GlobalID(ProjectEvaluator.__name__, str(self.id))
+            raise NotFound(f"ProjectEvaluator not found: {project_evaluator_id}")
         self.db_record = record
         return record

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -6,7 +6,6 @@ import strawberry
 from aioitertools.itertools import groupby, islice
 from openinference.semconv.trace import SpanAttributes
 from sqlalchemy import Select, and_, case, desc, distinct, exists, func, or_, select
-from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql.expression import tuple_
 from sqlalchemy.sql.functions import percentile_cont
@@ -33,6 +32,7 @@ from phoenix.server.api.types.AnnotationNameCount import AnnotationNameCount
 from phoenix.server.api.types.AnnotationSummary import AnnotationSummary
 from phoenix.server.api.types.CostBreakdown import CostBreakdown
 from phoenix.server.api.types.DocumentEvaluationSummary import DocumentEvaluationSummary
+from phoenix.server.api.types.Evaluator import ProjectEvaluator
 from phoenix.server.api.types.GenerativeModel import GenerativeModel
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.pagination import (
@@ -54,6 +54,7 @@ from phoenix.server.api.types.ValidationResult import ValidationResult
 from phoenix.server.session_filters import get_filtered_session_rowids_subquery
 from phoenix.server.types import DbSessionFactory
 from phoenix.trace.dsl import SpanFilter
+from phoenix.trace.dsl.filter import validate_span_filter_condition
 
 DEFAULT_PAGE_SIZE = 30
 _TOKEN_COUNT_DETAIL_EPSILON = 1e-9
@@ -178,6 +179,37 @@ class Project(Node):
                 ),
             )
         return description
+
+    @strawberry.field
+    async def evaluators(
+        self,
+        info: Info[Context, None],
+        first: Optional[int] = DEFAULT_PAGE_SIZE,
+        last: Optional[int] = None,
+        after: Optional[str] = None,
+        before: Optional[str] = None,
+    ) -> Connection[ProjectEvaluator]:
+        args = ConnectionArgs(
+            first=first,
+            after=after if isinstance(after, CursorString) else None,
+            last=last,
+            before=before if isinstance(before, CursorString) else None,
+        )
+        async with info.context.db.read() as session:
+            records = list(
+                await session.scalars(
+                    select(models.ProjectEvaluatorCriteria)
+                    .where(models.ProjectEvaluatorCriteria.project_id == self.id)
+                    .order_by(
+                        models.ProjectEvaluatorCriteria.name,
+                        models.ProjectEvaluatorCriteria.id,
+                    )
+                )
+            )
+        return connection_from_list(
+            data=[ProjectEvaluator(id=record.id, db_record=record) for record in records],
+            args=args,
+        )
 
     @strawberry.field
     async def gradient_start_color(
@@ -845,18 +877,7 @@ class Project(Node):
         # This query is too expensive to run on every validation
         # valid_eval_names = await self.span_annotation_names()
         try:
-            span_filter = SpanFilter(
-                condition=condition,
-                # valid_eval_names=valid_eval_names,
-            )
-            stmt = span_filter(select(models.Span))
-            dialect = info.context.db.dialect
-            if dialect is SupportedSQLDialect.POSTGRESQL:
-                str(stmt.compile(dialect=sqlite.dialect()))
-            elif dialect is SupportedSQLDialect.SQLITE:
-                str(stmt.compile(dialect=postgresql.dialect()))  # type: ignore[no-untyped-call]
-            else:
-                assert_never(dialect)
+            validate_span_filter_condition(condition)
             return ValidationResult(is_valid=True, error_message=None)
         except Exception as e:
             return ValidationResult(

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -73,7 +73,11 @@ from phoenix.config import (
     get_env_grpc_port,
     get_env_host,
     get_env_max_spans_queue_size,
+    get_env_online_eval_claim_batch_size,
+    get_env_online_eval_consumer_tick_interval_seconds,
     get_env_online_eval_enabled,
+    get_env_online_eval_max_outstanding,
+    get_env_online_eval_pending_ttl_seconds,
     get_env_phoenix_agents_disable_bash,
     get_env_port,
     get_env_support_email,
@@ -967,12 +971,35 @@ def create_app(
     online_eval_producer: Optional[OnlineEvalProducer] = None
     online_eval_consumer: Optional[OnlineEvalConsumer] = None
     if get_env_online_eval_enabled() and not read_only:
+        claim_batch_size = get_env_online_eval_claim_batch_size()
+        tick_interval_seconds = get_env_online_eval_consumer_tick_interval_seconds()
+        pending_ttl_seconds = get_env_online_eval_pending_ttl_seconds()
+        # Worst case, a full admission-gate backlog drains at claim_batch_size /
+        # tick_interval per replica; a smaller TTL sheds work during routine
+        # backpressure rather than only when consumers are down.
+        min_safe_ttl_seconds = (
+            get_env_online_eval_max_outstanding() * tick_interval_seconds / claim_batch_size
+        )
+        if 0 < pending_ttl_seconds < min_safe_ttl_seconds:
+            logger.warning(
+                "PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS (%s) is below the time a full "
+                "online-eval backlog needs to drain on one replica (%s seconds at %s claims "
+                "per %s-second tick). Pending evaluations can expire unevaluated during "
+                "normal backpressure; raise the TTL, the claim batch size, or the replica "
+                "count, or set the TTL to 0 to disable shedding.",
+                pending_ttl_seconds,
+                round(min_safe_ttl_seconds),
+                claim_batch_size,
+                tick_interval_seconds,
+            )
         online_eval_producer = OnlineEvalProducer(db)
         online_eval_consumer = OnlineEvalConsumer(
             db,
             decrypt=encryption_service.decrypt,
             sandbox_session_manager=sandbox_session_manager,
             event_queue=dml_event_handler,
+            tick_interval_seconds=tick_interval_seconds,
+            claim_batch_size=claim_batch_size,
         )
     graphql_schema = build_graphql_schema(graphql_schema_extensions)
     graphql_router = create_graphql_router(

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -112,6 +112,7 @@ from phoenix.server.grpc_server import GrpcServer
 from phoenix.server.jwt_store import JwtStore
 from phoenix.server.middleware.gzip import GZipMiddleware
 from phoenix.server.oauth2 import OAuth2Clients
+from phoenix.server.online_eval.consumer import OnlineEvalConsumer
 from phoenix.server.online_eval.producer import OnlineEvalProducer
 from phoenix.server.prometheus import SPAN_QUEUE_REJECTIONS
 from phoenix.server.redaction import Redactor, current_redactor
@@ -581,6 +582,7 @@ def _lifespan(
     experiment_runner: ExperimentRunner,
     sandbox_session_manager: SandboxSessionManager,
     online_eval_producer: Optional[OnlineEvalProducer] = None,
+    online_eval_consumer: Optional[OnlineEvalConsumer] = None,
     token_store: Optional[TokenStore] = None,
     tracer_provider: Optional["TracerProvider"] = None,
     enable_prometheus: bool = False,
@@ -640,10 +642,10 @@ def _lifespan(
             # shutdown snapshot would leak a provider session past the daemon.
             await stack.enter_async_context(sandbox_session_manager)
             await stack.enter_async_context(experiment_runner)
-            # Entered after sandbox_session_manager so the stacked consumer PR
-            # can enter its consumer next to the producer with the teardown
-            # ordering it needs (code evals run through sandbox sessions, so
-            # the consumer must stop before the manager does).
+            # Enter the consumer before the producer so teardown stops admission
+            # before draining work; both stop before sandbox_session_manager.
+            if online_eval_consumer is not None:
+                await stack.enter_async_context(online_eval_consumer)
             if online_eval_producer is not None:
                 await stack.enter_async_context(online_eval_producer)
             if docs_mcp_server is not None:
@@ -963,8 +965,15 @@ def create_app(
         sandbox_session_manager=sandbox_session_manager,
     )
     online_eval_producer: Optional[OnlineEvalProducer] = None
-    if get_env_online_eval_enabled():
+    online_eval_consumer: Optional[OnlineEvalConsumer] = None
+    if get_env_online_eval_enabled() and not read_only:
         online_eval_producer = OnlineEvalProducer(db)
+        online_eval_consumer = OnlineEvalConsumer(
+            db,
+            decrypt=encryption_service.decrypt,
+            sandbox_session_manager=sandbox_session_manager,
+            event_queue=dml_event_handler,
+        )
     graphql_schema = build_graphql_schema(graphql_schema_extensions)
     graphql_router = create_graphql_router(
         db=db,
@@ -1014,6 +1023,7 @@ def create_app(
             experiment_runner=experiment_runner,
             sandbox_session_manager=sandbox_session_manager,
             online_eval_producer=online_eval_producer,
+            online_eval_consumer=online_eval_consumer,
             grpc_interceptors=grpc_interceptors,
             token_store=token_store,
             tracer_provider=tracer_provider,
@@ -1142,6 +1152,7 @@ def create_app(
     app.state.docs_mcp_server = docs_mcp_server
     app.state.sandbox_session_manager = sandbox_session_manager
     app.state.online_eval_producer = online_eval_producer
+    app.state.online_eval_consumer = online_eval_consumer
     app.state.graphql_schema = graphql_schema
     app.state.build_graphql_context = _get_build_graphql_context_function(
         db=db,

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -73,6 +73,7 @@ from phoenix.config import (
     get_env_grpc_port,
     get_env_host,
     get_env_max_spans_queue_size,
+    get_env_online_eval_enabled,
     get_env_phoenix_agents_disable_bash,
     get_env_port,
     get_env_support_email,
@@ -111,6 +112,7 @@ from phoenix.server.grpc_server import GrpcServer
 from phoenix.server.jwt_store import JwtStore
 from phoenix.server.middleware.gzip import GZipMiddleware
 from phoenix.server.oauth2 import OAuth2Clients
+from phoenix.server.online_eval.producer import OnlineEvalProducer
 from phoenix.server.prometheus import SPAN_QUEUE_REJECTIONS
 from phoenix.server.redaction import Redactor, current_redactor
 from phoenix.server.retention import TraceDataSweeper
@@ -578,6 +580,7 @@ def _lifespan(
     db_disk_usage_monitor: DbDiskUsageMonitor,
     experiment_runner: ExperimentRunner,
     sandbox_session_manager: SandboxSessionManager,
+    online_eval_producer: Optional[OnlineEvalProducer] = None,
     token_store: Optional[TokenStore] = None,
     tracer_provider: Optional["TracerProvider"] = None,
     enable_prometheus: bool = False,
@@ -637,6 +640,12 @@ def _lifespan(
             # shutdown snapshot would leak a provider session past the daemon.
             await stack.enter_async_context(sandbox_session_manager)
             await stack.enter_async_context(experiment_runner)
+            # Entered after sandbox_session_manager so the stacked consumer PR
+            # can enter its consumer next to the producer with the teardown
+            # ordering it needs (code evals run through sandbox sessions, so
+            # the consumer must stop before the manager does).
+            if online_eval_producer is not None:
+                await stack.enter_async_context(online_eval_producer)
             if docs_mcp_server is not None:
                 # The docs MCP server connects to an external host during
                 # startup. Never let its initialization (which can hang until a
@@ -953,6 +962,9 @@ def create_app(
         tracer_factory=lambda: Tracer(span_cost_calculator=span_cost_calculator),
         sandbox_session_manager=sandbox_session_manager,
     )
+    online_eval_producer: Optional[OnlineEvalProducer] = None
+    if get_env_online_eval_enabled():
+        online_eval_producer = OnlineEvalProducer(db)
     graphql_schema = build_graphql_schema(graphql_schema_extensions)
     graphql_router = create_graphql_router(
         db=db,
@@ -1001,6 +1013,7 @@ def create_app(
             db_disk_usage_monitor=DbDiskUsageMonitor(db, email_sender),
             experiment_runner=experiment_runner,
             sandbox_session_manager=sandbox_session_manager,
+            online_eval_producer=online_eval_producer,
             grpc_interceptors=grpc_interceptors,
             token_store=token_store,
             tracer_provider=tracer_provider,
@@ -1128,6 +1141,7 @@ def create_app(
     app.state.span_queue_is_full = lambda: bulk_inserter.is_full
     app.state.docs_mcp_server = docs_mcp_server
     app.state.sandbox_session_manager = sandbox_session_manager
+    app.state.online_eval_producer = online_eval_producer
     app.state.graphql_schema = graphql_schema
     app.state.build_graphql_context = _get_build_graphql_context_function(
         db=db,

--- a/src/phoenix/server/online_eval/consumer.py
+++ b/src/phoenix/server/online_eval/consumer.py
@@ -31,6 +31,7 @@ from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
 from phoenix.server.online_eval.executor import HydratedWorkUnit, OnlineEvalExecutor
 from phoenix.server.prometheus import (
     ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS,
+    ONLINE_EVAL_EXPIRED_WORK_UNITS,
     ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS,
     ONLINE_EVAL_INGEST_SPANS_PER_SECOND,
     ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS,
@@ -157,6 +158,7 @@ class OnlineEvalConsumer(DaemonTask):
         ONLINE_EVAL_RUNNING_WORK_UNITS.set(lag.running_count)
         ONLINE_EVAL_RETRYABLE_ERROR_WORK_UNITS.set(lag.retryable_error_count)
         ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS.set(lag.exhausted_error_count)
+        ONLINE_EVAL_EXPIRED_WORK_UNITS.set(lag.expired_count)
         ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS.set(lag.frontier_gap)
         ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS.set(lag.oldest_pending_age_seconds or 0.0)
         async with self._db.read() as session:

--- a/src/phoenix/server/online_eval/consumer.py
+++ b/src/phoenix/server/online_eval/consumer.py
@@ -1,0 +1,349 @@
+"""Online-eval consumer daemon.
+
+Runs on every replica; instances compete for work through coordinator claims.
+Each cycle claims a batch of work units and processes them concurrently:
+hydrate behind the staleness guard (stale units are expired, never executed),
+evaluate with lease heartbeats, write annotations, then complete — or fail
+with a cooldown. Shutdown gives in-flight evals a grace period, then cancels
+stragglers before sandbox teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+from typing import Awaitable, Callable, Optional
+
+import httpx
+from sqlalchemy import select
+
+from phoenix.config import get_env_enable_prometheus
+from phoenix.db import models
+from phoenix.server.dml_event import DmlEvent
+from phoenix.server.online_eval.coordinator import (
+    HEARTBEAT_INTERVAL_SECONDS,
+    ClaimedWorkUnit,
+    EvalWorkCoordinator,
+)
+from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
+from phoenix.server.online_eval.executor import HydratedWorkUnit, OnlineEvalExecutor
+from phoenix.server.prometheus import (
+    ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS,
+    ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS,
+    ONLINE_EVAL_INGEST_SPANS_PER_SECOND,
+    ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS,
+    ONLINE_EVAL_PENDING_WORK_UNITS,
+    ONLINE_EVAL_RETRYABLE_ERROR_WORK_UNITS,
+    ONLINE_EVAL_RUNNING_WORK_UNITS,
+)
+from phoenix.server.sandbox.session_manager import SandboxSessionManager
+from phoenix.server.types import CanPutItem, DaemonTask, DbSessionFactory
+
+logger = logging.getLogger(__name__)
+
+TICK_INTERVAL_SECONDS = 5.0
+CLAIM_BATCH_SIZE = 10
+ERROR_COOLDOWN_SECONDS = 60.0
+DRAIN_TIMEOUT_SECONDS = 10.0
+EXECUTION_DEADLINE_SECONDS = 600.0
+_CONSUMER_GROUP = "default"
+
+_TRANSIENT_HTTP_STATUS_CODES = frozenset({408, 429})
+_TRANSITION_RETRY_DELAYS_SECONDS = (1.0, 2.0, 4.0)
+
+
+class EvalExecutionTimeout(Exception):
+    """An online evaluation exceeded its per-unit execution deadline."""
+
+
+async def _cancel_and_await(task: asyncio.Task[None]) -> None:
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+def is_transient_error(exc: BaseException) -> bool:
+    """Best-effort classification of failures that heal on their own —
+    provider outages, rate limits, network partitions. Transient failures
+    retry after a flat cooldown WITHOUT counting toward MAX_ATTEMPTS, so an
+    outage longer than the retry budget cannot permanently exhaust queued
+    work. Anything unrecognized counts attempts as usual, which keeps poison
+    units bounded (fail-safe default). Walks the exception chain so wrapped
+    errors (e.g. ``EvalExecutionError`` raised from an httpx timeout)
+    classify by their root cause."""
+    seen: set[int] = set()
+    node: Optional[BaseException] = exc
+    while node is not None and id(node) not in seen:
+        seen.add(id(node))
+        # asyncio.TimeoutError is an alias of TimeoutError on 3.11+ but a
+        # distinct class on 3.10.
+        if isinstance(node, (ConnectionError, TimeoutError, asyncio.TimeoutError)):
+            return True
+        if isinstance(node, httpx.TransportError):
+            return True
+        # Provider SDK errors (openai, anthropic, ...) expose status_code
+        # directly; httpx.HTTPStatusError exposes it via .response.
+        status_code = getattr(node, "status_code", None)
+        if status_code is None:
+            status_code = getattr(getattr(node, "response", None), "status_code", None)
+        if isinstance(status_code, int) and (
+            status_code >= 500 or status_code in _TRANSIENT_HTTP_STATUS_CODES
+        ):
+            return True
+        if node.__cause__ is not None:
+            node = node.__cause__
+        elif node.__suppress_context__:
+            node = None
+        else:
+            node = node.__context__
+    return False
+
+
+class OnlineEvalConsumer(DaemonTask):
+    """Per-replica daemon claiming and executing online-eval work units."""
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        decrypt: Callable[[bytes], bytes],
+        sandbox_session_manager: Optional[SandboxSessionManager] = None,
+        event_queue: Optional[CanPutItem[DmlEvent]] = None,
+        coordinator: Optional[EvalWorkCoordinator] = None,
+        tick_interval_seconds: float = TICK_INTERVAL_SECONDS,
+        claim_batch_size: int = CLAIM_BATCH_SIZE,
+        execution_deadline_seconds: float = EXECUTION_DEADLINE_SECONDS,
+    ) -> None:
+        super().__init__()
+        self._db = db
+        self._grain: models.EvalWorkGrain = "SPAN"
+        self._coordinator: EvalWorkCoordinator = coordinator or DbEvalWorkCoordinator(
+            db, grain=self._grain
+        )
+        self._executor = OnlineEvalExecutor(
+            db,
+            decrypt=decrypt,
+            sandbox_session_manager=sandbox_session_manager,
+            event_queue=event_queue,
+        )
+        self._consumer_id = f"consumer-{token_hex(8)}"
+        self._tick_interval_seconds = tick_interval_seconds
+        self._claim_batch_size = claim_batch_size
+        self._execution_deadline_seconds = execution_deadline_seconds
+        self._pending_tasks: set[asyncio.Task[None]] = set()
+        self._publish_metrics = get_env_enable_prometheus()
+        self._last_ingest_sample: Optional[tuple[int, datetime]] = None
+
+    async def _run(self) -> None:
+        while self._running:
+            try:
+                await self._cycle()
+            except Exception:
+                logger.exception("Online-eval consumer cycle failed")
+            if self._publish_metrics:
+                try:
+                    await self._publish_queue_metrics()
+                except Exception:
+                    logger.exception("Online-eval queue metrics publish failed")
+            await asyncio.sleep(self._tick_interval_seconds)
+
+    async def _publish_queue_metrics(self) -> None:
+        lag = await self._coordinator.lag()
+        ONLINE_EVAL_PENDING_WORK_UNITS.set(lag.pending_count)
+        ONLINE_EVAL_RUNNING_WORK_UNITS.set(lag.running_count)
+        ONLINE_EVAL_RETRYABLE_ERROR_WORK_UNITS.set(lag.retryable_error_count)
+        ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS.set(lag.exhausted_error_count)
+        ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS.set(lag.frontier_gap)
+        ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS.set(lag.oldest_pending_age_seconds or 0.0)
+        async with self._db.read() as session:
+            sample = (
+                await session.execute(
+                    select(
+                        models.EvalWorkCursor.observed_high_water_id,
+                        models.EvalWorkCursor.observed_at,
+                    ).where(
+                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
+                    )
+                )
+            ).first()
+        if sample is None or sample.observed_high_water_id is None or sample.observed_at is None:
+            return
+        if self._last_ingest_sample is not None:
+            last_high_water, last_observed_at = self._last_ingest_sample
+            elapsed = (sample.observed_at - last_observed_at).total_seconds()
+            if elapsed > 0:
+                ONLINE_EVAL_INGEST_SPANS_PER_SECOND.set(
+                    max(sample.observed_high_water_id - last_high_water, 0) / elapsed
+                )
+        self._last_ingest_sample = (sample.observed_high_water_id, sample.observed_at)
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._pending_tasks:
+            _, pending = await asyncio.wait(set(self._pending_tasks), timeout=DRAIN_TIMEOUT_SECONDS)
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+        await super().stop()
+
+    async def _cycle(self) -> None:
+        units = await self._coordinator.claim(
+            claimed_by=self._consumer_id,
+            limit=self._claim_batch_size,
+        )
+        if not units:
+            return
+        tasks = [asyncio.create_task(self._process_unit(unit)) for unit in units]
+        for task in tasks:
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._pending_tasks.discard)
+        # asyncio.wait does not propagate this task's cancellation to the unit
+        # tasks; a shutdown mid-cycle leaves them to the stop() drain.
+        done, _ = await asyncio.wait(tasks)
+        for task in done:
+            if not task.cancelled() and (exc := task.exception()) is not None:
+                logger.error("Online-eval work unit task failed", exc_info=exc)
+
+    async def _process_unit(self, unit: ClaimedWorkUnit) -> None:
+        try:
+            hydrated = await self._executor.hydrate(unit)
+            if hydrated is None:
+                expired = await self._coordinator.expire(
+                    work_unit_id=unit.work_unit_id,
+                    claimed_by=self._consumer_id,
+                )
+                if not expired:
+                    logger.warning(
+                        f"Online-eval work unit {unit.work_unit_id} could not expire after its "
+                        "claim was lost"
+                    )
+                return
+            await self._evaluate_with_heartbeat(unit, hydrated)
+        except Exception as exc:
+            transient = is_transient_error(exc)
+            logger.exception(
+                f"Online-eval work unit {unit.work_unit_id} failed "
+                f"({'transient — will retry without counting an attempt' if transient else 'counting an attempt'})"  # noqa: E501
+            )
+            # Transient failures cool down flat and don't count attempts (an
+            # outage retries until it heals); everything else backs off
+            # exponentially on the attempt count and exhausts at MAX_ATTEMPTS.
+            cooldown_seconds = (
+                ERROR_COOLDOWN_SECONDS if transient else ERROR_COOLDOWN_SECONDS * (2**unit.attempts)
+            )
+            cooldown_until = datetime.now(timezone.utc) + timedelta(seconds=cooldown_seconds)
+            error = str(exc)
+            failed = await self._retry_transition(
+                action="record failure",
+                work_unit_id=unit.work_unit_id,
+                transition=lambda: self._coordinator.fail(
+                    work_unit_id=unit.work_unit_id,
+                    claimed_by=self._consumer_id,
+                    error=error,
+                    cooldown_until=cooldown_until,
+                    count_attempt=not transient,
+                ),
+            )
+            if failed is False:
+                logger.warning(
+                    f"Online-eval work unit {unit.work_unit_id} failure was not recorded "
+                    "after its claim was lost"
+                )
+        else:
+            completed = await self._retry_transition(
+                action="complete",
+                work_unit_id=unit.work_unit_id,
+                transition=lambda: self._coordinator.complete(
+                    work_unit_id=unit.work_unit_id,
+                    claimed_by=self._consumer_id,
+                ),
+            )
+            if completed is False:
+                logger.warning(
+                    f"Online-eval work unit {unit.work_unit_id} finished after its claim "
+                    "was lost; the annotation write is idempotent"
+                )
+
+    async def _retry_transition(
+        self,
+        *,
+        action: str,
+        work_unit_id: int,
+        transition: Callable[[], Awaitable[bool]],
+    ) -> Optional[bool]:
+        for delay_seconds in _TRANSITION_RETRY_DELAYS_SECONDS:
+            try:
+                return await transition()
+            except Exception:
+                logger.warning(
+                    f"Failed to {action} for online-eval work unit {work_unit_id}; "
+                    f"retrying in {delay_seconds:g}s",
+                    exc_info=True,
+                )
+                await asyncio.sleep(delay_seconds)
+        try:
+            return await transition()
+        except Exception:
+            logger.exception(
+                f"Failed to {action} for online-eval work unit {work_unit_id} after "
+                "3 retries; leaving the row for lease-lapse reclaim"
+            )
+            return None
+
+    async def _evaluate_with_heartbeat(
+        self,
+        unit: ClaimedWorkUnit,
+        hydrated: HydratedWorkUnit,
+    ) -> None:
+        eval_task = asyncio.create_task(self._executor.evaluate_and_annotate(unit, hydrated))
+        heartbeat_enabled = True
+        deadline_at = asyncio.get_running_loop().time() + self._execution_deadline_seconds
+        try:
+            while True:
+                remaining_seconds = deadline_at - asyncio.get_running_loop().time()
+                if remaining_seconds <= 0:
+                    await _cancel_and_await(eval_task)
+                    raise EvalExecutionTimeout(
+                        f"evaluation exceeded {self._execution_deadline_seconds:g}s deadline"
+                    ) from None
+                done, _ = await asyncio.wait(
+                    {eval_task},
+                    timeout=min(HEARTBEAT_INTERVAL_SECONDS, remaining_seconds),
+                )
+                if done:
+                    break
+                if asyncio.get_running_loop().time() >= deadline_at:
+                    await _cancel_and_await(eval_task)
+                    raise EvalExecutionTimeout(
+                        f"evaluation exceeded {self._execution_deadline_seconds:g}s deadline"
+                    ) from None
+                # A lost claim does not cancel the eval: the result is still
+                # valid under this unit's identifier and the write dedupes
+                # against whichever consumer got there first.
+                if not heartbeat_enabled:
+                    continue
+                try:
+                    heartbeat_succeeded = await self._coordinator.heartbeat(
+                        work_unit_id=unit.work_unit_id,
+                        claimed_by=self._consumer_id,
+                    )
+                    if not heartbeat_succeeded:
+                        logger.warning(
+                            f"Online-eval work unit {unit.work_unit_id} heartbeat stopped after "
+                            "its claim was lost"
+                        )
+                        heartbeat_enabled = False
+                except Exception:
+                    logger.exception(
+                        f"Heartbeat failed for online-eval work unit {unit.work_unit_id}"
+                    )
+        finally:
+            if not eval_task.done():
+                await _cancel_and_await(eval_task)
+        await eval_task

--- a/src/phoenix/server/online_eval/consumer.py
+++ b/src/phoenix/server/online_eval/consumer.py
@@ -120,9 +120,9 @@ class OnlineEvalConsumer(DaemonTask):
     ) -> None:
         super().__init__()
         self._db = db
-        self._grain: models.EvalWorkGrain = "SPAN"
+        self._evaluation_target: models.EvaluationTarget = "SPAN"
         self._coordinator: EvalWorkCoordinator = coordinator or DbEvalWorkCoordinator(
-            db, grain=self._grain
+            db, evaluation_target=self._evaluation_target
         )
         self._executor = OnlineEvalExecutor(
             db,
@@ -166,7 +166,7 @@ class OnlineEvalConsumer(DaemonTask):
                         models.EvalWorkCursor.observed_high_water_id,
                         models.EvalWorkCursor.observed_at,
                     ).where(
-                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                         models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     )
                 )

--- a/src/phoenix/server/online_eval/coordinator.py
+++ b/src/phoenix/server/online_eval/coordinator.py
@@ -51,6 +51,7 @@ class QueueLag:
     running_count: int
     retryable_error_count: int
     exhausted_error_count: int
+    expired_count: int
     frontier_gap: int
     oldest_pending_age_seconds: Optional[float]
 

--- a/src/phoenix/server/online_eval/coordinator.py
+++ b/src/phoenix/server/online_eval/coordinator.py
@@ -1,0 +1,124 @@
+"""Consumer-side coordination seam for online-eval work distribution over the
+``eval_work_units`` table: claim/heartbeat/complete/fail transitions plus queue-lag
+observability. Producer-side operations (cursor lease, watermark advance, work-row
+materialization) are not part of this interface.
+
+Work-unit lifecycle:
+
+    PENDING --claim--> RUNNING --complete--> DONE
+                       RUNNING --fail-----> ERROR
+                       RUNNING --expire---> EXPIRED
+    RUNNING (lease lapsed) --> reclaimable
+    ERROR (cooldown elapsed, attempts remain) --> retried
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Protocol
+
+LEASE_TTL_SECONDS = 90
+HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class ClaimedWorkUnit:
+    """A leased work unit. ``identifier`` keys the annotation write so re-runs of the
+    same (span, evaluator, config) collide on the annotation unique constraint;
+    ``lease_expires_at`` is the claim time plus ``LEASE_TTL_SECONDS``."""
+
+    work_unit_id: int
+    span_rowid: int
+    evaluator_id: int
+    criteria_id: int
+    config_fingerprint: str
+    identifier: str
+    attempts: int
+    claimed_by: str
+    lease_expires_at: datetime
+
+
+@dataclass(frozen=True)
+class QueueLag:
+    """Observable backlog; all fields are zero when no cursor or work rows exist.
+    ``frontier_gap`` is the spans.id distance between the producer's eligible frontier
+    and its watermark; ``oldest_pending_age_seconds`` covers PENDING and retryable ERROR
+    work and is None when that backlog is empty."""
+
+    pending_count: int
+    running_count: int
+    retryable_error_count: int
+    exhausted_error_count: int
+    frontier_gap: int
+    oldest_pending_age_seconds: Optional[float]
+
+
+class EvalWorkCoordinator(Protocol):
+    """Coordinates online-eval work across replicas behind a swappable backend."""
+
+    async def claim(
+        self,
+        *,
+        claimed_by: str,
+        limit: int,
+    ) -> Sequence[ClaimedWorkUnit]:
+        """Lease up to ``limit`` claimable work units for ``claimed_by``. A unit is
+        claimable when it is PENDING, or RUNNING with a lapsed lease, or ERROR past
+        its cooldown with attempts remaining. Returns an empty sequence when no
+        claimable work exists."""
+        ...
+
+    async def heartbeat(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        """Renew the lease on a claimed unit. Returns False if the claim was lost —
+        never silent success."""
+        ...
+
+    async def complete(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        """Transition a claimed unit RUNNING -> DONE. Returns True when the unit is
+        already DONE so callers can safely retry an ambiguous commit. Returns False for
+        any other lost claim."""
+        ...
+
+    async def fail(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+        error: str,
+        cooldown_until: Optional[datetime] = None,
+        count_attempt: bool = True,
+    ) -> bool:
+        """Transition a claimed unit RUNNING -> ERROR, recording the error and setting an
+        optional retry cooldown. ``count_attempt=True`` (the default) increments attempts,
+        walking the unit toward the max-attempts claimability bar; pass False for transient
+        infrastructure failures (provider outage, network timeout) so the unit retries after
+        its cooldown without ever being exhausted by an outage. Returns False if the claim
+        was lost."""
+        ...
+
+    async def expire(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        """Transition a claimed unit RUNNING -> EXPIRED. Terminal: for work that must
+        never run (stale config fingerprint, missing or disabled criteria), unlike the
+        retryable ERROR from ``fail``. Returns False if the claim was lost."""
+        ...
+
+    async def lag(self) -> QueueLag:
+        """Report current queue backlog. Returns zeroed metrics when the queue is empty."""
+        ...

--- a/src/phoenix/server/online_eval/db_coordinator.py
+++ b/src/phoenix/server/online_eval/db_coordinator.py
@@ -261,7 +261,11 @@ class DbEvalWorkCoordinator:
                 for status, exhausted, count in (
                     await session.execute(
                         select(models.EvalWorkUnit.status, error_exhausted, func.count())
-                        .where(models.EvalWorkUnit.status.in_(["PENDING", "RUNNING", "ERROR"]))
+                        .where(
+                            models.EvalWorkUnit.status.in_(
+                                ["PENDING", "RUNNING", "ERROR", "EXPIRED"]
+                            )
+                        )
                         .group_by(models.EvalWorkUnit.status, error_exhausted)
                     )
                 ).all()
@@ -304,6 +308,7 @@ class DbEvalWorkCoordinator:
             running_count=counts.get(("RUNNING", False), 0),
             retryable_error_count=counts.get(("ERROR", False), 0),
             exhausted_error_count=counts.get(("ERROR", True), 0),
+            expired_count=counts.get(("EXPIRED", False), 0),
             frontier_gap=frontier_gap,
             oldest_pending_age_seconds=oldest_pending_age_seconds,
         )

--- a/src/phoenix/server/online_eval/db_coordinator.py
+++ b/src/phoenix/server/online_eval/db_coordinator.py
@@ -1,0 +1,309 @@
+"""Database-backed ``EvalWorkCoordinator`` over the ``eval_work_units`` table.
+
+Claiming is dialect-split: PostgreSQL locks candidate rows with ``FOR UPDATE SKIP
+LOCKED`` so competing consumers never block on each other's claims; SQLite (no row
+locks) claims each candidate with a per-id compare-and-swap and keeps only the rows
+whose update landed. Every post-claim transition (heartbeat / complete / fail /
+expire) is fenced by ``claimed_by == me AND status == 'RUNNING'`` and reports a lost
+claim as False via the update rowcount.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional, Sequence
+
+from sqlalchemy import and_, case, func, or_, select, update
+from sqlalchemy.sql.elements import ColumnElement
+
+from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.server.online_eval.coordinator import (
+    LEASE_TTL_SECONDS,
+    ClaimedWorkUnit,
+    QueueLag,
+)
+from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, annotation_identifier
+from phoenix.server.types import DbSessionFactory
+
+_CONSUMER_GROUP = "default"
+TRANSIENT_RETRY_MAX_AGE_SECONDS = 86_400.0
+STALE_FINGERPRINT_ERROR = "stale config fingerprint"
+
+
+def work_unit_lease_lapsed(now: datetime) -> ColumnElement[bool]:
+    return models.EvalWorkUnit.claimed_at < now - timedelta(seconds=LEASE_TTL_SECONDS)
+
+
+class DbEvalWorkCoordinator:
+    """Coordinates online-eval consumers through ``eval_work_units`` row state."""
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        grain: models.EvalWorkGrain = "SPAN",
+        max_attempts: int = MAX_ATTEMPTS,
+    ) -> None:
+        self._db = db
+        self._grain = grain
+        self._max_attempts = max_attempts
+
+    def _claimable(self, now: datetime) -> ColumnElement[bool]:
+        return or_(
+            models.EvalWorkUnit.status == "PENDING",
+            and_(
+                models.EvalWorkUnit.status == "RUNNING",
+                models.EvalWorkUnit.attempts < self._max_attempts - 1,
+                work_unit_lease_lapsed(now),
+            ),
+            and_(
+                models.EvalWorkUnit.status == "ERROR",
+                models.EvalWorkUnit.attempts < self._max_attempts,
+                or_(
+                    models.EvalWorkUnit.cooldown_until.is_(None),
+                    models.EvalWorkUnit.cooldown_until <= now,
+                ),
+            ),
+        )
+
+    async def claim(
+        self,
+        *,
+        claimed_by: str,
+        limit: int,
+    ) -> Sequence[ClaimedWorkUnit]:
+        now = datetime.now(timezone.utc)
+        async with self._db() as session:
+            candidates = select(models.EvalWorkUnit.id).where(self._claimable(now))
+            candidates = candidates.order_by(models.EvalWorkUnit.id).limit(limit)
+            claim_values = {
+                "status": "RUNNING",
+                "claimed_at": now,
+                "claimed_by": claimed_by,
+                # A straggler outliving the stop() drain is counted.
+                "attempts": case(
+                    (
+                        models.EvalWorkUnit.status == "RUNNING",
+                        models.EvalWorkUnit.attempts + 1,
+                    ),
+                    else_=models.EvalWorkUnit.attempts,
+                ),
+            }
+            claimed_ids: list[int] = []
+            if self._db.dialect is SupportedSQLDialect.POSTGRESQL:
+                locked_ids = (
+                    await session.scalars(candidates.with_for_update(skip_locked=True))
+                ).all()
+                if locked_ids:
+                    await session.execute(
+                        update(models.EvalWorkUnit)
+                        .where(models.EvalWorkUnit.id.in_(locked_ids))
+                        .values(**claim_values)
+                    )
+                    claimed_ids = list(locked_ids)
+            else:
+                for unit_id in (await session.scalars(candidates)).all():
+                    cas = await session.execute(
+                        update(models.EvalWorkUnit)
+                        .where(models.EvalWorkUnit.id == unit_id, self._claimable(now))
+                        .values(**claim_values)
+                    )
+                    if cas.rowcount == 1:  # type: ignore[attr-defined]
+                        claimed_ids.append(unit_id)
+            rows = (
+                (
+                    await session.execute(
+                        select(
+                            models.EvalWorkUnit.id,
+                            models.EvalWorkUnit.span_rowid,
+                            models.EvalWorkUnit.evaluator_id,
+                            models.EvalWorkUnit.criteria_id,
+                            models.EvalWorkUnit.config_fingerprint,
+                            models.EvalWorkUnit.attempts,
+                        )
+                        .where(models.EvalWorkUnit.id.in_(claimed_ids))
+                        .order_by(models.EvalWorkUnit.id)
+                    )
+                ).all()
+                if claimed_ids
+                else []
+            )
+            await session.commit()
+        lease_expires_at = now + timedelta(seconds=LEASE_TTL_SECONDS)
+        return [
+            ClaimedWorkUnit(
+                work_unit_id=row.id,
+                span_rowid=row.span_rowid,
+                evaluator_id=row.evaluator_id,
+                criteria_id=row.criteria_id,
+                config_fingerprint=row.config_fingerprint,
+                identifier=annotation_identifier(row.config_fingerprint),
+                attempts=row.attempts,
+                claimed_by=claimed_by,
+                lease_expires_at=lease_expires_at,
+            )
+            for row in rows
+        ]
+
+    async def heartbeat(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        return await self._fenced_transition(
+            work_unit_id=work_unit_id,
+            claimed_by=claimed_by,
+            claimed_at=datetime.now(timezone.utc),
+        )
+
+    async def complete(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        """Complete a claimed unit, treating an already-DONE row as success."""
+        return await self._fenced_transition(
+            work_unit_id=work_unit_id,
+            claimed_by=claimed_by,
+            already_status="DONE",
+            status="DONE",
+        )
+
+    async def fail(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+        error: str,
+        cooldown_until: Optional[datetime] = None,
+        count_attempt: bool = True,
+    ) -> bool:
+        values: dict[str, Any] = {
+            "error": error,
+            "cooldown_until": cooldown_until,
+        }
+        if count_attempt:
+            values["attempts"] = models.EvalWorkUnit.attempts + 1
+        else:
+            retry_age_cutoff = datetime.now(timezone.utc) - timedelta(
+                seconds=TRANSIENT_RETRY_MAX_AGE_SECONDS
+            )
+            values["attempts"] = case(
+                (models.EvalWorkUnit.created_at < retry_age_cutoff, self._max_attempts),
+                else_=models.EvalWorkUnit.attempts,
+            )
+        return await self._fenced_transition(
+            work_unit_id=work_unit_id,
+            claimed_by=claimed_by,
+            status="ERROR",
+            **values,
+        )
+
+    async def expire(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+    ) -> bool:
+        return await self._fenced_transition(
+            work_unit_id=work_unit_id,
+            claimed_by=claimed_by,
+            status="EXPIRED",
+            error=STALE_FINGERPRINT_ERROR,
+        )
+
+    async def _fenced_transition(
+        self,
+        *,
+        work_unit_id: int,
+        claimed_by: str,
+        already_status: Optional[str] = None,
+        **values: Any,
+    ) -> bool:
+        async with self._db() as session:
+            result = await session.execute(
+                update(models.EvalWorkUnit)
+                .where(
+                    models.EvalWorkUnit.id == work_unit_id,
+                    models.EvalWorkUnit.claimed_by == claimed_by,
+                    models.EvalWorkUnit.status == "RUNNING",
+                )
+                .values(**values)
+            )
+            rowcount = result.rowcount  # type: ignore[attr-defined]
+            transitioned = bool(rowcount == 1)
+            if not transitioned and already_status is not None:
+                status = await session.scalar(
+                    select(models.EvalWorkUnit.status).where(models.EvalWorkUnit.id == work_unit_id)
+                )
+                transitioned = status == already_status
+            await session.commit()
+            return transitioned
+
+    async def lag(self) -> QueueLag:
+        now = datetime.now(timezone.utc)
+        async with self._db.read() as session:
+            error_exhausted = case(
+                (
+                    and_(
+                        models.EvalWorkUnit.status == "ERROR",
+                        models.EvalWorkUnit.attempts >= self._max_attempts,
+                    ),
+                    True,
+                ),
+                else_=False,
+            ).label("error_exhausted")
+            counts: dict[tuple[str, bool], int] = {
+                (status, exhausted): count
+                for status, exhausted, count in (
+                    await session.execute(
+                        select(models.EvalWorkUnit.status, error_exhausted, func.count())
+                        .where(models.EvalWorkUnit.status.in_(["PENDING", "RUNNING", "ERROR"]))
+                        .group_by(models.EvalWorkUnit.status, error_exhausted)
+                    )
+                ).all()
+            }
+            oldest_work_created_at = await session.scalar(
+                select(models.EvalWorkUnit.created_at)
+                .where(
+                    or_(
+                        models.EvalWorkUnit.status == "PENDING",
+                        and_(
+                            models.EvalWorkUnit.status == "ERROR",
+                            models.EvalWorkUnit.attempts < self._max_attempts,
+                        ),
+                    )
+                )
+                .order_by(models.EvalWorkUnit.created_at)
+                .limit(1)
+            )
+            cursor = (
+                await session.execute(
+                    select(
+                        models.EvalWorkCursor.produced_through_id,
+                        models.EvalWorkCursor.observed_high_water_id,
+                    ).where(
+                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
+                    )
+                )
+            ).first()
+        frontier_gap = 0
+        if cursor is not None and cursor.observed_high_water_id is not None:
+            frontier_gap = max(cursor.observed_high_water_id - cursor.produced_through_id, 0)
+        oldest_pending_age_seconds = (
+            max((now - oldest_work_created_at).total_seconds(), 0.0)
+            if oldest_work_created_at is not None
+            else None
+        )
+        return QueueLag(
+            pending_count=counts.get(("PENDING", False), 0),
+            running_count=counts.get(("RUNNING", False), 0),
+            retryable_error_count=counts.get(("ERROR", False), 0),
+            exhausted_error_count=counts.get(("ERROR", True), 0),
+            frontier_gap=frontier_gap,
+            oldest_pending_age_seconds=oldest_pending_age_seconds,
+        )

--- a/src/phoenix/server/online_eval/db_coordinator.py
+++ b/src/phoenix/server/online_eval/db_coordinator.py
@@ -42,11 +42,11 @@ class DbEvalWorkCoordinator:
         self,
         db: DbSessionFactory,
         *,
-        grain: models.EvalWorkGrain = "SPAN",
+        evaluation_target: models.EvaluationTarget = "SPAN",
         max_attempts: int = MAX_ATTEMPTS,
     ) -> None:
         self._db = db
-        self._grain = grain
+        self._evaluation_target = evaluation_target
         self._max_attempts = max_attempts
 
     def _claimable(self, now: datetime) -> ColumnElement[bool]:
@@ -286,7 +286,7 @@ class DbEvalWorkCoordinator:
                         models.EvalWorkCursor.produced_through_id,
                         models.EvalWorkCursor.observed_high_water_id,
                     ).where(
-                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                         models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     )
                 )

--- a/src/phoenix/server/online_eval/derivation.py
+++ b/src/phoenix/server/online_eval/derivation.py
@@ -1,0 +1,94 @@
+"""Shared derivation recipes for online-eval coordination. The producer, consumer, and
+backstop all compute config fingerprints, annotation identifiers, and sampling keys
+through this module — an independent recipe that drifts from these re-materializes the
+work backlog (fingerprint mismatch) or breaks annotation idempotency (identifier
+mismatch). It also holds the shared work-unit retry budget (``MAX_ATTEMPTS``), which
+the producer's reaper/backstop and the consumer's claim predicate must agree on. All
+functions are pure; version resolution and any DB access happen in callers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any
+
+_IDENTIFIER_PREFIX = "online:"
+_IDENTIFIER_FINGERPRINT_CHARS = 16
+
+# Retry budget for a work unit before its ERROR state becomes terminal. The producer
+# excludes attempt-exhausted rows from reaping and backstop re-materialization using
+# this value, and the consumer-side coordinator stops reclaiming ERROR rows at it —
+# the two sides drifting apart either resurrects dead work or strands retryable work.
+MAX_ATTEMPTS = 3
+
+
+@dataclass(frozen=True)
+class ResolvedCriteria:
+    """Fingerprint inputs for one evaluator criteria, resolved by the caller.
+
+    ``version_ref`` must name an immutable version, never a mutable pointer: the
+    concrete ``PromptVersion.id`` for LLM evaluators (resolving the tag), the current
+    ``CodeEvaluatorVersion.id`` for CODE, and ``(key, synced_at ISO string)`` for
+    BUILTIN. Every field must be JSON-serializable — pass the stored column form of
+    ``output_configs`` / ``input_mapping``, not model objects.
+    """
+
+    criteria_id: int
+    annotation_name: str
+    evaluator_id: int
+    version_ref: Any
+    output_configs: Any
+    input_mapping: Any
+    filter_condition: str
+    sampling_rate: float
+
+
+def _canonical_default(obj: Any) -> Any:
+    # Evaluator config model_dump() output carries enum members (e.g.
+    # OptimizationDirection); coerce to value exactly as the DB engine's JSON
+    # serializer does, so the fingerprint sees the stored-column shape.
+    if isinstance(obj, Enum):
+        return obj.value
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def config_fingerprint(resolved: ResolvedCriteria) -> str:
+    """Full 64-char sha256 hex over the canonical JSON form of the resolved criteria.
+
+    Serves as both the work-unit dedup key component and the consumer's staleness
+    guard: the consumer re-resolves the same inputs at claim time and refuses to
+    execute a unit whose recomputed fingerprint no longer matches the stored one.
+    """
+    canonical = json.dumps(
+        asdict(resolved),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=_canonical_default,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def annotation_identifier(fingerprint: str) -> str:
+    """Identifier keying the idempotent annotation write for a work unit.
+
+    Collides re-runs of the same (span, evaluator, config) on the annotation table's
+    (name, span_rowid, identifier) unique constraint.
+    """
+    return _IDENTIFIER_PREFIX + fingerprint[:_IDENTIFIER_FINGERPRINT_CHARS]
+
+
+def sample_key(span_id: int) -> float:
+    """Uniform-in-[0,1) sampling key derived from the span id's decimal string.
+
+    A span is sampled for a criteria iff ``sample_key(span_id) < sampling_rate``. The
+    key is deliberately unsalted and shared across all criteria so lower-rate samples
+    nest inside higher-rate ones (every 20% sample is a subset of every 60% sample).
+    """
+    digest = hashlib.sha256(str(span_id).encode("ascii")).digest()
+    # Top 53 bits only: dividing the full digest by 2**256 can round up to exactly 1.0,
+    # violating the half-open interval; 53-bit numerators are exact in a float.
+    return (int.from_bytes(digest[:8], "big") >> 11) / (1 << 53)

--- a/src/phoenix/server/online_eval/derivation.py
+++ b/src/phoenix/server/online_eval/derivation.py
@@ -37,11 +37,13 @@ class ResolvedCriteria:
     """
 
     criteria_id: int
-    annotation_name: str
+    name: str
     evaluator_id: int
     version_ref: Any
     output_configs: Any
     input_mapping: Any
+    evaluation_target: str
+    sandbox_config_id: int | None
     filter_condition: str
     sampling_rate: float
 

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -69,18 +69,17 @@ class HydratedWorkUnit:
 
 
 def span_eval_context(span: models.Span) -> dict[str, Any]:
-    """Span-level evaluation context. ``input`` / ``output`` surface the span's
-    IO values for direct template-variable binding; ``attributes`` exposes the
-    full attribute tree to ``path_mapping`` expressions."""
+    """Span context; ``metadata.attributes`` roots attribute ``path_mapping`` expressions."""
     return {
         "input": span.input_value,
         "output": span.output_value,
-        "metadata": span.metadata_,
-        "attributes": span.attributes,
-        "name": span.name,
-        "span_kind": span.span_kind,
-        "status_code": span.status_code,
-        "status_message": span.status_message,
+        "metadata": {
+            "attributes": span.attributes,
+            "name": span.name,
+            "span_kind": span.span_kind,
+            "status_code": span.status_code,
+            "status_message": span.status_message,
+        },
     }
 
 

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -1,0 +1,375 @@
+"""Execution glue for claimed online-eval work units: criteria-first hydration
+behind the staleness guard, span-grain context assembly, ``BaseEvaluator.evaluate()``
+invocation, and the idempotent EvaluationResult -> SpanAnnotation write. Work-unit
+lifecycle transitions (complete/fail/expire) stay with the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import with_polymorphic
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.db.types.annotation_configs import (
+    CategoricalOutputConfig,
+    ContinuousOutputConfig,
+    FreeformOutputConfig,
+    OutputConfig,
+    OutputConfigType,
+)
+from phoenix.db.types.evaluators import InputMapping
+from phoenix.db.types.prompts import PromptChatTemplate
+from phoenix.server.api.evaluators import (
+    BaseEvaluator,
+    CodeEvaluatorRunner,
+    LLMEvaluator,
+    get_builtin_evaluator_by_key,
+)
+from phoenix.server.api.helpers.playground_clients import get_playground_client
+from phoenix.server.dml_event import DmlEvent, SpanAnnotationInsertEvent
+from phoenix.server.online_eval.coordinator import ClaimedWorkUnit
+from phoenix.server.online_eval.derivation import config_fingerprint
+from phoenix.server.online_eval.producer import resolve_criteria
+from phoenix.server.sandbox import SecretsContext, build_sandbox_backend
+from phoenix.server.sandbox.session_manager import SandboxSessionManager
+from phoenix.server.types import CanPutItem, DbSessionFactory
+
+logger = logging.getLogger(__name__)
+
+_EMPTY_INPUT_MAPPING = InputMapping(literal_mapping={}, path_mapping={})
+
+AnnotatorKind = Literal["LLM", "CODE"]
+EvaluatorKind = Literal["LLM", "CODE", "BUILTIN"]
+
+
+class EvalExecutionError(Exception):
+    """The evaluator ran but produced no writable result."""
+
+
+@dataclass(frozen=True)
+class HydratedWorkUnit:
+    """Everything one eval needs, copied out of the mutable criteria/evaluator
+    rows while the staleness guard held. The executor never re-reads those rows
+    after hydration, so the eval runs under snapshot semantics."""
+
+    annotation_name: str
+    annotator_kind: AnnotatorKind
+    evaluator_kind: EvaluatorKind
+    evaluator: BaseEvaluator
+    input_mapping: InputMapping
+    output_configs: Sequence[OutputConfigType]
+    context: dict[str, Any]
+
+
+def span_eval_context(span: models.Span) -> dict[str, Any]:
+    """Span-grain evaluation context. ``input`` / ``output`` surface the span's
+    IO values for direct template-variable binding; ``attributes`` exposes the
+    full attribute tree to ``path_mapping`` expressions."""
+    return {
+        "input": span.input_value,
+        "output": span.output_value,
+        "metadata": span.metadata_,
+        "attributes": span.attributes,
+        "name": span.name,
+        "span_kind": span.span_kind,
+        "status_code": span.status_code,
+        "status_message": span.status_message,
+    }
+
+
+class OnlineEvalExecutor:
+    """Hydrates and executes claimed work units against the eval runtime."""
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        decrypt: Callable[[bytes], bytes],
+        sandbox_session_manager: Optional[SandboxSessionManager] = None,
+        event_queue: Optional[CanPutItem[DmlEvent]] = None,
+    ) -> None:
+        self._db = db
+        self._decrypt = decrypt
+        self._sandbox_session_manager = sandbox_session_manager
+        self._event_queue = event_queue
+
+    async def hydrate(self, unit: ClaimedWorkUnit) -> Optional[HydratedWorkUnit]:
+        """Load and snapshot everything the eval needs, returning None when the
+        unit is stale: the criteria row is gone or disabled, the referenced span
+        is gone, or the fingerprint recomputed from current criteria/evaluator/
+        version state no longer matches the one materialized on the unit. Stale
+        units must be expired, never executed. The session closes before any
+        LLM call happens; hydration failures that are not staleness raise and
+        take the retryable failure path."""
+        async with self._db() as session:
+            criteria = await session.get(models.ProjectEvaluatorCriteria, unit.criteria_id)
+            if criteria is None or not criteria.enabled:
+                return None
+            polymorphic = with_polymorphic(
+                models.Evaluator,
+                [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+            )
+            evaluator_orm = await session.scalar(
+                select(polymorphic).where(polymorphic.id == criteria.evaluator_id)
+            )
+            if evaluator_orm is None:
+                return None
+            resolved = await resolve_criteria(session, criteria, evaluator_orm)
+            if resolved is None or config_fingerprint(resolved) != unit.config_fingerprint:
+                return None
+            span = await session.get(models.Span, unit.span_rowid)
+            if span is None:
+                return None
+            context = span_eval_context(span)
+            input_mapping = (
+                InputMapping.model_validate(resolved.input_mapping)
+                if resolved.input_mapping is not None
+                else _EMPTY_INPUT_MAPPING
+            )
+            if isinstance(evaluator_orm, models.LLMEvaluator):
+                return await self._hydrate_llm(
+                    session,
+                    evaluator_orm,
+                    resolved.name,
+                    resolved.version_ref,
+                    input_mapping,
+                    context,
+                )
+            if isinstance(evaluator_orm, models.CodeEvaluator):
+                return await self._hydrate_code(
+                    session,
+                    evaluator_orm,
+                    resolved.name,
+                    resolved.version_ref,
+                    input_mapping,
+                    context,
+                )
+            if isinstance(evaluator_orm, models.BuiltinEvaluator):
+                return self._hydrate_builtin(evaluator_orm, resolved.name, input_mapping, context)
+            return None
+
+    async def _hydrate_llm(
+        self,
+        session: AsyncSession,
+        evaluator_orm: models.LLMEvaluator,
+        annotation_name: str,
+        prompt_version_id: int,
+        input_mapping: InputMapping,
+        context: dict[str, Any],
+    ) -> Optional[HydratedWorkUnit]:
+        prompt_version = await session.get(models.PromptVersion, prompt_version_id)
+        if prompt_version is None:
+            return None
+        prompt = await session.get(models.Prompt, evaluator_orm.prompt_id)
+        if prompt is None:
+            return None
+        template = prompt_version.template
+        if not isinstance(template, PromptChatTemplate):
+            raise ValueError(
+                f"LLM evaluator {evaluator_orm.id}: prompt version {prompt_version.id} "
+                "does not carry a chat template"
+            )
+        tools = prompt_version.tools
+        if tools is None:
+            raise ValueError(
+                f"LLM evaluator {evaluator_orm.id}: prompt version {prompt_version.id} has no tools"
+            )
+        llm_client = await get_playground_client(
+            model_provider=prompt_version.model_provider,
+            model_name=prompt_version.model_name,
+            session=session,
+            decrypt=self._decrypt,
+            connection=prompt_version.custom_provider_id,
+        )
+        evaluator = LLMEvaluator(
+            name=evaluator_orm.name.root,
+            description=evaluator_orm.description,
+            template=template,
+            template_format=prompt_version.template_format,
+            tools=tools,
+            invocation_parameters=prompt_version.invocation_parameters,
+            model_provider=prompt_version.model_provider,
+            llm_client=llm_client,
+            output_configs=evaluator_orm.output_configs,
+            prompt_name=prompt.name.root,
+        )
+        return HydratedWorkUnit(
+            annotation_name=annotation_name,
+            annotator_kind="LLM",
+            evaluator_kind="LLM",
+            evaluator=evaluator,
+            input_mapping=input_mapping,
+            output_configs=evaluator_orm.output_configs,
+            context=context,
+        )
+
+    async def _hydrate_code(
+        self,
+        session: AsyncSession,
+        evaluator_orm: models.CodeEvaluator,
+        annotation_name: str,
+        code_version_id: int,
+        input_mapping: InputMapping,
+        context: dict[str, Any],
+    ) -> Optional[HydratedWorkUnit]:
+        if self._sandbox_session_manager is None:
+            raise ValueError(
+                f"Code evaluator {evaluator_orm.id}: no sandbox session manager available"
+            )
+        code_version = await session.get(models.CodeEvaluatorVersion, code_version_id)
+        if code_version is None:
+            return None
+        if evaluator_orm.sandbox_config_id is None:
+            raise ValueError(f"Code evaluator {evaluator_orm.id} has no sandbox config")
+        sandbox_config = await session.get(models.SandboxConfig, evaluator_orm.sandbox_config_id)
+        if sandbox_config is None or not sandbox_config.enabled:
+            raise ValueError(
+                f"Code evaluator {evaluator_orm.id}: sandbox config "
+                f"{evaluator_orm.sandbox_config_id} is missing or disabled"
+            )
+        provider = await session.get(models.SandboxProvider, sandbox_config.backend_type)
+        if provider is None or not provider.enabled:
+            raise ValueError(
+                f"Code evaluator {evaluator_orm.id}: sandbox provider "
+                f"{sandbox_config.backend_type!r} is missing or disabled"
+            )
+        backend = await build_sandbox_backend(
+            sandbox_config,
+            secrets=SecretsContext(session=session, decrypt=self._decrypt),
+        )
+        if backend is None:
+            raise ValueError(
+                f"Code evaluator {evaluator_orm.id}: no sandbox backend available for "
+                f"config {sandbox_config.id}"
+            )
+        output_configs: list[OutputConfigType] = []
+        for config in evaluator_orm.output_configs:
+            if config.name is None:
+                continue
+            output_config = OutputConfig.model_validate(config.model_dump()).root
+            if isinstance(
+                output_config,
+                (CategoricalOutputConfig, ContinuousOutputConfig, FreeformOutputConfig),
+            ):
+                output_configs.append(output_config)
+        evaluator = CodeEvaluatorRunner(
+            name=evaluator_orm.name.root,
+            description=evaluator_orm.description,
+            source_code=code_version.source_code,
+            stored_output_configs=output_configs,
+            sandbox_backend=backend,
+            language=evaluator_orm.language,
+            sandbox_session_manager=self._sandbox_session_manager,
+            timeout=sandbox_config.timeout,
+            evaluator_version_id=str(GlobalID("CodeEvaluatorVersion", str(code_version.id))),
+            session_key=(
+                f"online-eval:{evaluator_orm.id}:{self._sandbox_session_manager.replica_id}"
+            ),
+        )
+        return HydratedWorkUnit(
+            annotation_name=annotation_name,
+            annotator_kind="CODE",
+            evaluator_kind="CODE",
+            evaluator=evaluator,
+            input_mapping=input_mapping,
+            output_configs=output_configs,
+            context=context,
+        )
+
+    def _hydrate_builtin(
+        self,
+        evaluator_orm: models.BuiltinEvaluator,
+        annotation_name: str,
+        input_mapping: InputMapping,
+        context: dict[str, Any],
+    ) -> HydratedWorkUnit:
+        evaluator_cls = get_builtin_evaluator_by_key(evaluator_orm.key)
+        if evaluator_cls is None:
+            raise ValueError(f"Built-in evaluator key {evaluator_orm.key!r} is not in the registry")
+        return HydratedWorkUnit(
+            annotation_name=annotation_name,
+            annotator_kind="CODE",
+            evaluator_kind="BUILTIN",
+            evaluator=evaluator_cls(),
+            input_mapping=input_mapping,
+            output_configs=evaluator_orm.output_configs,
+            context=context,
+        )
+
+    async def evaluate_and_annotate(
+        self, unit: ClaimedWorkUnit, hydrated: HydratedWorkUnit
+    ) -> None:
+        """Run the eval and write successful results as span annotations under
+        the unit's identifier. DO_NOTHING makes the write first-write-wins, so
+        re-runs of the same unit are no-ops. Raises before writing unless the
+        evaluator returns one complete, error-free result set. No DB session is
+        open while the evaluator runs."""
+        results = await hydrated.evaluator.evaluate(
+            context=hydrated.context,
+            input_mapping=hydrated.input_mapping,
+            name=hydrated.annotation_name,
+            output_configs=hydrated.output_configs,
+        )
+        errored = [result for result in results if result["error"] is not None]
+        if errored:
+            raise EvalExecutionError(errored[0]["error"]) from errored[0].get("error_exc")
+        if hydrated.evaluator_kind != "BUILTIN":
+            # Built-ins retain their evaluator-defined result-name contract.
+            multi_output = len(hydrated.output_configs) > 1
+            expected_names = {
+                (
+                    f"{hydrated.annotation_name}.{config.name}"
+                    if multi_output
+                    else hydrated.annotation_name
+                )
+                for config in hydrated.output_configs
+            }
+            returned_names = {result["name"] for result in results}
+            if returned_names != expected_names:
+                missing = sorted(expected_names - returned_names)
+                unexpected = sorted(returned_names - expected_names)
+                raise EvalExecutionError(
+                    "evaluator returned an incomplete result set: "
+                    f"missing={missing}, unexpected={unexpected}"
+                )
+        records = [
+            {
+                "span_rowid": unit.span_rowid,
+                "name": result["name"],
+                "label": result["label"],
+                "score": result["score"],
+                "explanation": result["explanation"],
+                "metadata_": result["metadata"],
+                "annotator_kind": hydrated.annotator_kind,
+                "identifier": unit.identifier,
+                "source": "API",
+                "user_id": None,
+            }
+            for result in results
+        ]
+        if records:
+            async with self._db() as session:
+                inserted_ids = (
+                    await session.scalars(
+                        insert_on_conflict(
+                            *records,
+                            table=models.SpanAnnotation,
+                            dialect=self._db.dialect,
+                            unique_by=("name", "span_rowid", "identifier"),
+                            on_conflict=OnConflict.DO_NOTHING,
+                        ).returning(models.SpanAnnotation.id)
+                    )
+                ).all()
+            # DO_NOTHING returns only rows actually inserted, so a deduped
+            # re-run emits no event and dataloader caches aren't re-invalidated.
+            if self._event_queue is not None and inserted_ids:
+                self._event_queue.put(SpanAnnotationInsertEvent(tuple(inserted_ids)))
+        if not records:
+            raise EvalExecutionError("evaluator returned no results")

--- a/src/phoenix/server/online_eval/executor.py
+++ b/src/phoenix/server/online_eval/executor.py
@@ -1,5 +1,5 @@
 """Execution glue for claimed online-eval work units: criteria-first hydration
-behind the staleness guard, span-grain context assembly, ``BaseEvaluator.evaluate()``
+behind the staleness guard, span-level context assembly, ``BaseEvaluator.evaluate()``
 invocation, and the idempotent EvaluationResult -> SpanAnnotation write. Work-unit
 lifecycle transitions (complete/fail/expire) stay with the caller.
 """
@@ -69,7 +69,7 @@ class HydratedWorkUnit:
 
 
 def span_eval_context(span: models.Span) -> dict[str, Any]:
-    """Span-grain evaluation context. ``input`` / ``output`` surface the span's
+    """Span-level evaluation context. ``input`` / ``output`` surface the span's
     IO values for direct template-variable binding; ``attributes`` exposes the
     full attribute tree to ``path_mapping`` expressions."""
     return {

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -1,0 +1,547 @@
+"""Online-eval producer daemon.
+
+Materializes span-grain eval work units from enabled project evaluator criteria.
+The producer runs on every replica but self-elects each tick via the
+``eval_work_cursors`` CAS lease, so exactly one replica per (grain, consumer_group)
+scans spans and writes work rows at a time. Each tick: renew the lease, reap
+expired/aged work rows, scan the lag-gated span id window per criteria, and
+idempotently insert surviving (span, evaluator, config) work units. A slow-cadence
+backstop sweep re-covers a bounded id window behind the watermark to catch spans
+that became visible after their window was scanned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+from typing import Any, Optional
+
+from sqlalchemy import Select, and_, delete, exists, func, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import with_polymorphic
+
+from phoenix.db import models
+from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.server.online_eval.derivation import (
+    MAX_ATTEMPTS,
+    ResolvedCriteria,
+    annotation_identifier,
+    config_fingerprint,
+    sample_key,
+)
+from phoenix.server.types import DaemonTask, DbSessionFactory
+from phoenix.trace.dsl.filter import SpanFilter
+
+logger = logging.getLogger(__name__)
+
+CURSOR_LEASE_TTL_SECONDS = 90.0
+TICK_INTERVAL_SECONDS = 10.0
+
+_INSERT_BATCH_SIZE = 1000
+_WORK_UNIT_UNIQUE_BY = ("span_rowid", "evaluator_id", "config_fingerprint")
+
+
+async def resolve_criteria(
+    session: AsyncSession,
+    criteria: models.ProjectEvaluatorCriteria,
+    evaluator: models.Evaluator,
+) -> Optional[ResolvedCriteria]:
+    """Resolve one criteria row's fingerprint inputs, pinning mutable pointers to
+    immutable version identities: the tagged (or latest) PromptVersion id for LLM
+    evaluators, the latest CodeEvaluatorVersion id for CODE, and (key, synced_at)
+    for BUILTIN. Returns None when no version is resolvable.
+
+    The consumer's staleness guard must recompute fingerprints through this same
+    function — an independent resolution recipe re-materializes the backlog.
+    """
+    version_ref: Any
+    input_mapping: Any = None
+    if isinstance(evaluator, models.LLMEvaluator):
+        if evaluator.prompt_version_tag_id is not None:
+            version_ref = await session.scalar(
+                select(models.PromptVersionTag.prompt_version_id).where(
+                    models.PromptVersionTag.id == evaluator.prompt_version_tag_id
+                )
+            )
+        else:
+            version_ref = await session.scalar(
+                select(models.PromptVersion.id)
+                .where(models.PromptVersion.prompt_id == evaluator.prompt_id)
+                .order_by(models.PromptVersion.id.desc())
+                .limit(1)
+            )
+    elif isinstance(evaluator, models.CodeEvaluator):
+        version_ref = await session.scalar(
+            select(models.CodeEvaluatorVersion.id)
+            .where(models.CodeEvaluatorVersion.code_evaluator_id == evaluator.id)
+            .order_by(models.CodeEvaluatorVersion.id.desc())
+            .limit(1)
+        )
+        input_mapping = evaluator.input_mapping.model_dump()
+    elif isinstance(evaluator, models.BuiltinEvaluator):
+        version_ref = [evaluator.key, evaluator.synced_at.isoformat()]
+    else:
+        return None
+    if version_ref is None:
+        return None
+    return ResolvedCriteria(
+        criteria_id=criteria.id,
+        annotation_name=criteria.annotation_name.root,
+        evaluator_id=evaluator.id,
+        version_ref=version_ref,
+        output_configs=[config.model_dump() for config in evaluator.output_configs],
+        input_mapping=input_mapping,
+        filter_condition=criteria.filter_condition,
+        sampling_rate=criteria.sampling_rate,
+    )
+
+
+@dataclass(frozen=True)
+class _ActiveCriteria:
+    criteria_id: int
+    project_id: int
+    evaluator_id: int
+    annotation_name: str
+    sampling_rate: float
+    fingerprint: str
+    identifier: str
+    span_filter: SpanFilter
+
+    def scan_stmt(self, low_exclusive: int, high_inclusive: int) -> Select[tuple[int]]:
+        stmt = (
+            select(models.Span.id)
+            .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+            .where(models.Trace.project_rowid == self.project_id)
+            .where(models.Span.id > low_exclusive, models.Span.id <= high_inclusive)
+        )
+        return self.span_filter(stmt)
+
+    def sampled(self, span_ids: list[int]) -> list[int]:
+        return [sid for sid in span_ids if sample_key(sid) < self.sampling_rate]
+
+
+class OnlineEvalProducer(DaemonTask):
+    """Materialize online-eval work from the span arrival log.
+
+    For every grain, ``produced_through_id`` is a position in the span arrival
+    log; trace and session producers consume the same log before applying their
+    readiness rules.
+    """
+
+    def __init__(
+        self,
+        db: DbSessionFactory,
+        *,
+        consumer_group: str = "default",
+        tick_interval_seconds: float = TICK_INTERVAL_SECONDS,
+    ) -> None:
+        super().__init__()
+        self._db = db
+        self._grain: models.EvalWorkGrain = "SPAN"
+        self._consumer_group = consumer_group
+        self._tick_interval_seconds = tick_interval_seconds
+        self._producer_id = f"producer-{token_hex(8)}"
+        # Config knobs are hardcoded to their defaults until the online-eval env-var surface lands.
+        self._frontier_lag_seconds = 60.0
+        # The backstop's coverage guarantee is rate-dependent: gap-free re-coverage
+        # requires lookback_span_ids >= instance_wide_ingest_rate * interval_seconds.
+        # Spans draw from a single id sequence, so the rate that matters is the sum
+        # across all projects and tenants — 100k ids per 3600s sweep only protects
+        # deployments ingesting under ~28 spans/sec instance-wide. Above that, rows
+        # can age out of the lookback between sweeps and the backstop stops bounding
+        # the exceptional loss modes it exists to catch (late-visible spans, skipped
+        # criteria). The reaper's floor (``_reap``) is aligned to this lookback, so
+        # any change here must move both together.
+        self._backstop_interval_seconds = 3600.0
+        self._backstop_lookback_span_ids = 100_000
+        self._max_span_ids_per_tick = 10_000
+        # Disabled because expiry is terminal and blocks backstop re-materialization.
+        self._pending_ttl_seconds = 0.0
+        self._retention_seconds = 604_800.0
+        self._max_pending = 10_000
+        self._last_backstop_at = time.monotonic()
+        self._lease_held = False
+
+    async def _run(self) -> None:
+        try:
+            while self._running:
+                try:
+                    await self._tick()
+                except Exception:
+                    logger.exception("Online-eval producer tick failed")
+                await asyncio.sleep(self._tick_interval_seconds)
+        finally:
+            await self._release_lease()
+
+    async def _tick(self) -> None:
+        now = datetime.now(timezone.utc)
+        cursor = await self._acquire_cursor(now)
+        if cursor is None:
+            return
+        cursor = await self._clamp_cursor(cursor)
+        if cursor is None:
+            return
+        produced_through_id = cursor.produced_through_id
+
+        await self._reap(now, produced_through_id)
+
+        observed_high_water_id = cursor.observed_high_water_id
+        pending_observation = (
+            observed_high_water_id is not None
+            and cursor.observed_at is not None
+            and observed_high_water_id > produced_through_id
+        )
+        frontier: Optional[int] = None
+        if (
+            pending_observation
+            and observed_high_water_id is not None
+            and cursor.observed_at is not None
+            and (now - cursor.observed_at).total_seconds() >= self._frontier_lag_seconds
+        ):
+            frontier = min(
+                observed_high_water_id,
+                produced_through_id + self._max_span_ids_per_tick,
+            )
+
+        gate_open = await self._admission_gate_open()
+        active = await self._load_active_criteria() if gate_open else []
+
+        advanced = False
+        if gate_open and frontier is not None:
+            advanced = await self._materialize_and_advance(active, produced_through_id, frontier)
+            if advanced:
+                produced_through_id = frontier
+
+        observation_consumed = advanced and frontier == observed_high_water_id
+        if not pending_observation or observation_consumed:
+            await self._record_observation(produced_through_id)
+
+        if gate_open and time.monotonic() - self._last_backstop_at >= (
+            self._backstop_interval_seconds
+        ):
+            self._last_backstop_at = time.monotonic()
+            await self._backstop_sweep(active, produced_through_id)
+
+    async def _acquire_cursor(self, now: datetime) -> Optional[models.EvalWorkCursor]:
+        stale = now - timedelta(seconds=CURSOR_LEASE_TTL_SECONDS)
+        for _ in range(2):
+            async with self._db() as session:
+                cursor: Optional[models.EvalWorkCursor] = await session.scalar(
+                    update(models.EvalWorkCursor)
+                    .where(
+                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        or_(
+                            models.EvalWorkCursor.claimed_by.is_(None),
+                            models.EvalWorkCursor.claimed_by == self._producer_id,
+                            models.EvalWorkCursor.claimed_at < stale,
+                        ),
+                    )
+                    .values(claimed_by=self._producer_id, claimed_at=now)
+                    .returning(models.EvalWorkCursor)
+                )
+            if cursor is not None:
+                self._lease_held = True
+                return cursor
+            async with self._db() as session:
+                row_exists = await session.scalar(
+                    select(models.EvalWorkCursor.id).where(
+                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    )
+                )
+                if row_exists is not None:
+                    break
+                produced_through_id = await session.scalar(select(func.max(models.Span.id))) or 0
+                await session.execute(
+                    insert_on_conflict(
+                        {
+                            "grain": self._grain,
+                            "consumer_group": self._consumer_group,
+                            "produced_through_id": produced_through_id,
+                        },
+                        table=models.EvalWorkCursor,
+                        dialect=self._db.dialect,
+                        unique_by=("grain", "consumer_group"),
+                        on_conflict=OnConflict.DO_NOTHING,
+                    )
+                )
+        self._lease_held = False
+        return None
+
+    async def _clamp_cursor(self, cursor: models.EvalWorkCursor) -> Optional[models.EvalWorkCursor]:
+        async with self._db() as session:
+            max_span_id = await session.scalar(select(func.max(models.Span.id))) or 0
+            if max_span_id >= cursor.produced_through_id:
+                return cursor
+            clamped: Optional[models.EvalWorkCursor] = await session.scalar(
+                update(models.EvalWorkCursor)
+                .where(
+                    models.EvalWorkCursor.id == cursor.id,
+                    models.EvalWorkCursor.claimed_by == self._producer_id,
+                )
+                .values(
+                    produced_through_id=max_span_id,
+                    observed_high_water_id=None,
+                    observed_at=None,
+                )
+                .returning(models.EvalWorkCursor)
+            )
+        if clamped is None:
+            self._lease_held = False
+            logger.warning("Online-eval producer lost its lease; cursor not clamped")
+        return clamped
+
+    async def _release_lease(self) -> None:
+        if not self._lease_held:
+            return
+        self._lease_held = False
+        try:
+            async with self._db() as session:
+                await session.execute(
+                    update(models.EvalWorkCursor)
+                    .where(
+                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.claimed_by == self._producer_id,
+                    )
+                    .values(claimed_by=None, claimed_at=None)
+                )
+        except Exception:
+            logger.exception("Failed to release online-eval producer lease")
+
+    async def _reap(self, now: datetime, produced_through_id: int) -> None:
+        retention_cutoff = now - timedelta(seconds=self._retention_seconds)
+        # Terminal rows inside the backstop lookback window are never deleted,
+        # regardless of age — they must remain to block backstop resurrection.
+        reap_floor = produced_through_id - self._backstop_lookback_span_ids
+        async with self._db() as session:
+            if self._pending_ttl_seconds > 0:
+                pending_cutoff = now - timedelta(seconds=self._pending_ttl_seconds)
+                await session.execute(
+                    update(models.EvalWorkUnit)
+                    .where(
+                        models.EvalWorkUnit.status == "PENDING",
+                        models.EvalWorkUnit.created_at < pending_cutoff,
+                    )
+                    .values(status="EXPIRED")
+                )
+            await session.execute(
+                delete(models.EvalWorkUnit).where(
+                    models.EvalWorkUnit.status.in_(("DONE", "EXPIRED")),
+                    models.EvalWorkUnit.updated_at < retention_cutoff,
+                    models.EvalWorkUnit.span_rowid < reap_floor,
+                )
+            )
+            await session.execute(
+                delete(models.EvalWorkUnit).where(
+                    models.EvalWorkUnit.status == "ERROR",
+                    models.EvalWorkUnit.attempts >= MAX_ATTEMPTS,
+                    models.EvalWorkUnit.updated_at < retention_cutoff,
+                    models.EvalWorkUnit.span_rowid < reap_floor,
+                )
+            )
+
+    async def _admission_gate_open(self) -> bool:
+        # The gate bounds the backlog that will eventually demand consumer
+        # capacity — every non-terminal row, not just PENDING: RUNNING rows are
+        # claimed but unfinished, and retryable ERROR rows return to the claim
+        # pool after cooldown. Under a provider outage the entire pending
+        # population migrates into retryable ERROR; a PENDING-only count would
+        # see an empty queue and keep materializing into the outage. Exhausted
+        # ERROR rows are terminal (awaiting the reaper) and excluded.
+        async with self._db() as session:
+            outstanding_count = (
+                await session.scalar(
+                    select(func.count())
+                    .select_from(models.EvalWorkUnit)
+                    .where(
+                        or_(
+                            models.EvalWorkUnit.status.in_(("PENDING", "RUNNING")),
+                            and_(
+                                models.EvalWorkUnit.status == "ERROR",
+                                models.EvalWorkUnit.attempts < MAX_ATTEMPTS,
+                            ),
+                        )
+                    )
+                )
+                or 0
+            )
+        if outstanding_count > self._max_pending:
+            logger.warning(
+                f"Online-eval producer admission gate closed: "
+                f"{outstanding_count} outstanding work units exceeds {self._max_pending}"
+            )
+            return False
+        return True
+
+    async def _load_active_criteria(self) -> list[_ActiveCriteria]:
+        """Load and resolve enabled criteria into scan-ready form.
+
+        Skip policy: only *persistent* per-criteria conditions (no resolvable
+        version, filter fails to compile) are logged and skipped, so one bad
+        criteria cannot stall the shared cursor forever. Anything else — e.g. a
+        transient DB error during version resolution — propagates and aborts
+        the tick without advancing the cursor (fail closed): advancing is an
+        implicit claim that every enabled criteria either materialized or
+        deliberately skipped the window, and a criteria that failed to load
+        transiently did neither.
+        """
+        polymorphic_evaluator = with_polymorphic(
+            models.Evaluator,
+            [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+        )
+        active: list[_ActiveCriteria] = []
+        async with self._db() as session:
+            rows = (
+                await session.execute(
+                    select(models.ProjectEvaluatorCriteria, polymorphic_evaluator)
+                    .join(
+                        polymorphic_evaluator,
+                        models.ProjectEvaluatorCriteria.evaluator_id == polymorphic_evaluator.id,
+                    )
+                    .where(models.ProjectEvaluatorCriteria.enabled)
+                )
+            ).all()
+            for criteria, evaluator in rows:
+                # NOT wrapped in a per-criteria except: an unexpected exception
+                # here (e.g. a transient DB error on a version lookup) must
+                # abort the tick so the cursor cannot advance past a window
+                # this criteria never scanned. See the docstring's skip policy.
+                resolved = await resolve_criteria(session, criteria, evaluator)
+                if resolved is None:
+                    logger.warning(
+                        f"Skipping criteria {criteria.id}: "
+                        f"no resolvable version for evaluator {evaluator.id}"
+                    )
+                    continue
+                try:
+                    span_filter = SpanFilter(resolved.filter_condition)
+                except Exception:
+                    # SpanFilter construction is pure parsing (no I/O), so a
+                    # failure here is deterministic — a persistent condition,
+                    # same as an unresolvable version: skip-and-advance rather
+                    # than stalling every other criteria on one bad DSL string.
+                    logger.exception(
+                        f"Skipping criteria {criteria.id}: filter_condition failed to compile"
+                    )
+                    continue
+                fingerprint = config_fingerprint(resolved)
+                active.append(
+                    _ActiveCriteria(
+                        criteria_id=criteria.id,
+                        project_id=criteria.project_id,
+                        evaluator_id=criteria.evaluator_id,
+                        annotation_name=resolved.annotation_name,
+                        sampling_rate=criteria.sampling_rate,
+                        fingerprint=fingerprint,
+                        identifier=annotation_identifier(fingerprint),
+                        span_filter=span_filter,
+                    )
+                )
+        return active
+
+    async def _materialize_and_advance(
+        self,
+        active: list[_ActiveCriteria],
+        low_exclusive: int,
+        frontier: int,
+    ) -> bool:
+        async with self._db() as session:
+            for criteria in active:
+                span_ids = list(await session.scalars(criteria.scan_stmt(low_exclusive, frontier)))
+                await self._insert_work_units(session, criteria, criteria.sampled(span_ids))
+            advanced = await session.scalar(
+                update(models.EvalWorkCursor)
+                .where(
+                    models.EvalWorkCursor.grain == self._grain,
+                    models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    models.EvalWorkCursor.claimed_by == self._producer_id,
+                )
+                .values(produced_through_id=frontier)
+                .returning(models.EvalWorkCursor.id)
+            )
+        if advanced is None:
+            logger.warning("Online-eval producer lost its lease; watermark not advanced")
+            return False
+        return True
+
+    async def _record_observation(self, produced_through_id: int) -> None:
+        async with self._db() as session:
+            high_water = await session.scalar(select(func.max(models.Span.id)))
+            if high_water is None or high_water <= produced_through_id:
+                return
+            # Stamp the observation with a timestamp taken AFTER the high-water
+            # read, never the tick-start time: the reap/gate/materialize work
+            # preceding this call can consume a large fraction of the frontier
+            # lag (unboundedly so on a first-run backfill), and a stale stamp
+            # makes the next tick over-age the observation — eroding the
+            # commit-visibility guard that is the only defense against the
+            # id-vs-commit-order race. A post-read stamp errs conservative.
+            observed_at = datetime.now(timezone.utc)
+            await session.execute(
+                update(models.EvalWorkCursor)
+                .where(
+                    models.EvalWorkCursor.grain == self._grain,
+                    models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    models.EvalWorkCursor.claimed_by == self._producer_id,
+                )
+                .values(observed_high_water_id=high_water, observed_at=observed_at)
+            )
+
+    async def _backstop_sweep(self, active: list[_ActiveCriteria], watermark: int) -> None:
+        if watermark <= 0:
+            return
+        # Window is [watermark - lookback, watermark], matching the reaper's floor
+        # exactly so every retained terminal row is inside the swept range.
+        low_exclusive = max(watermark - self._backstop_lookback_span_ids - 1, 0)
+        async with self._db() as session:
+            for criteria in active:
+                stmt = criteria.scan_stmt(low_exclusive, watermark).where(
+                    ~exists(
+                        select(1).where(
+                            models.SpanAnnotation.span_rowid == models.Span.id,
+                            models.SpanAnnotation.name == criteria.annotation_name,
+                            models.SpanAnnotation.identifier == criteria.identifier,
+                        )
+                    ),
+                    ~exists(
+                        select(1).where(
+                            models.EvalWorkUnit.span_rowid == models.Span.id,
+                            models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
+                            models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
+                        )
+                    ),
+                )
+                span_ids = list(await session.scalars(stmt))
+                await self._insert_work_units(session, criteria, criteria.sampled(span_ids))
+
+    async def _insert_work_units(
+        self,
+        session: AsyncSession,
+        criteria: _ActiveCriteria,
+        span_ids: list[int],
+    ) -> None:
+        records = [
+            {
+                "span_rowid": span_rowid,
+                "evaluator_id": criteria.evaluator_id,
+                "criteria_id": criteria.criteria_id,
+                "config_fingerprint": criteria.fingerprint,
+            }
+            for span_rowid in span_ids
+        ]
+        for start in range(0, len(records), _INSERT_BATCH_SIZE):
+            await session.execute(
+                insert_on_conflict(
+                    *records[start : start + _INSERT_BATCH_SIZE],
+                    table=models.EvalWorkUnit,
+                    dialect=self._db.dialect,
+                    unique_by=_WORK_UNIT_UNIQUE_BY,
+                    on_conflict=OnConflict.DO_NOTHING,
+                )
+            )

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -1,8 +1,8 @@
 """Online-eval producer daemon.
 
-Materializes span-grain eval work units from enabled project evaluator criteria.
+Materializes span-level eval work units from enabled project evaluator criteria.
 The producer runs on every replica but self-elects each tick via the
-``eval_work_cursors`` CAS lease, so exactly one replica per grain
+``eval_work_cursors`` CAS lease, so exactly one replica per evaluation target
 scans spans and writes work rows at a time. Each tick: renew the lease, reap
 expired/aged work rows, scan the lag-gated span id window per criteria, and
 idempotently insert surviving (span, evaluator, config) work units. A slow-cadence
@@ -185,7 +185,7 @@ class _ActiveCriteria:
 class OnlineEvalProducer(DaemonTask):
     """Materialize online-eval work from the span arrival log.
 
-    For every grain, ``produced_through_id`` is a position in the span arrival
+    For each evaluation target, ``produced_through_id`` is a position in the span arrival
     log; trace and session producers consume the same log before applying their
     readiness rules.
     """
@@ -198,7 +198,7 @@ class OnlineEvalProducer(DaemonTask):
     ) -> None:
         super().__init__()
         self._db = db
-        self._grain: models.EvalWorkGrain = "SPAN"
+        self._evaluation_target: models.EvaluationTarget = "SPAN"
         self._tick_interval_seconds = tick_interval_seconds
         self._producer_id = f"producer-{token_hex(8)}"
         self._frontier_lag_seconds = get_env_online_eval_frontier_lag_seconds()
@@ -287,7 +287,7 @@ class OnlineEvalProducer(DaemonTask):
                 cursor: Optional[models.EvalWorkCursor] = await session.scalar(
                     update(models.EvalWorkCursor)
                     .where(
-                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                         models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                         or_(
                             models.EvalWorkCursor.claimed_by.is_(None),
@@ -304,7 +304,7 @@ class OnlineEvalProducer(DaemonTask):
             async with self._db() as session:
                 row_exists = await session.scalar(
                     select(models.EvalWorkCursor.id).where(
-                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                         models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     )
                 )
@@ -314,13 +314,13 @@ class OnlineEvalProducer(DaemonTask):
                 await session.execute(
                     insert_on_conflict(
                         {
-                            "grain": self._grain,
+                            "evaluation_target": self._evaluation_target,
                             "consumer_group": _CONSUMER_GROUP,
                             "produced_through_id": produced_through_id,
                         },
                         table=models.EvalWorkCursor,
                         dialect=self._db.dialect,
-                        unique_by=("grain", "consumer_group"),
+                        unique_by=("evaluation_target", "consumer_group"),
                         on_conflict=OnConflict.DO_NOTHING,
                     )
                 )
@@ -359,7 +359,7 @@ class OnlineEvalProducer(DaemonTask):
                 await session.execute(
                     update(models.EvalWorkCursor)
                     .where(
-                        models.EvalWorkCursor.grain == self._grain,
+                        models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                         models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                         models.EvalWorkCursor.claimed_by == self._producer_id,
                     )
@@ -373,7 +373,7 @@ class OnlineEvalProducer(DaemonTask):
             renewed = await session.scalar(
                 update(models.EvalWorkCursor)
                 .where(
-                    models.EvalWorkCursor.grain == self._grain,
+                    models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                     models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     models.EvalWorkCursor.claimed_by == self._producer_id,
                 )
@@ -571,7 +571,7 @@ class OnlineEvalProducer(DaemonTask):
             advanced = await session.scalar(
                 update(models.EvalWorkCursor)
                 .where(
-                    models.EvalWorkCursor.grain == self._grain,
+                    models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                     models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     models.EvalWorkCursor.claimed_by == self._producer_id,
                 )
@@ -599,7 +599,7 @@ class OnlineEvalProducer(DaemonTask):
             await session.execute(
                 update(models.EvalWorkCursor)
                 .where(
-                    models.EvalWorkCursor.grain == self._grain,
+                    models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                     models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     models.EvalWorkCursor.claimed_by == self._producer_id,
                 )
@@ -640,7 +640,7 @@ class OnlineEvalProducer(DaemonTask):
         renewed = await session.scalar(
             update(models.EvalWorkCursor)
             .where(
-                models.EvalWorkCursor.grain == self._grain,
+                models.EvalWorkCursor.evaluation_target == self._evaluation_target,
                 models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                 models.EvalWorkCursor.claimed_by == self._producer_id,
             )

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -2,7 +2,7 @@
 
 Materializes span-grain eval work units from enabled project evaluator criteria.
 The producer runs on every replica but self-elects each tick via the
-``eval_work_cursors`` CAS lease, so exactly one replica per (grain, consumer_group)
+``eval_work_cursors`` CAS lease, so exactly one replica per grain
 scans spans and writes work rows at a time. Each tick: renew the lease, reap
 expired/aged work rows, scan the lag-gated span id window per criteria, and
 idempotently insert surviving (span, evaluator, config) work units. A slow-cadence
@@ -24,8 +24,21 @@ from sqlalchemy import Select, and_, delete, exists, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_polymorphic
 
+from phoenix.config import (
+    get_env_online_eval_backstop_interval_seconds,
+    get_env_online_eval_backstop_lookback_span_ids,
+    get_env_online_eval_frontier_lag_seconds,
+    get_env_online_eval_max_outstanding,
+    get_env_online_eval_max_span_ids_per_tick,
+    get_env_online_eval_pending_ttl_seconds,
+    get_env_online_eval_retention_seconds,
+)
 from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.server.online_eval.db_coordinator import (
+    STALE_FINGERPRINT_ERROR,
+    work_unit_lease_lapsed,
+)
 from phoenix.server.online_eval.derivation import (
     MAX_ATTEMPTS,
     ResolvedCriteria,
@@ -43,6 +56,12 @@ TICK_INTERVAL_SECONDS = 10.0
 
 _INSERT_BATCH_SIZE = 1000
 _WORK_UNIT_UNIQUE_BY = ("span_rowid", "evaluator_id", "config_fingerprint")
+_CONSUMER_GROUP = "default"
+_PENDING_TTL_EXCEEDED_ERROR = "pending ttl exceeded"
+
+
+class _CursorLeaseLost(Exception):
+    pass
 
 
 async def resolve_criteria(
@@ -128,6 +147,37 @@ class _ActiveCriteria:
         )
         return self.span_filter(stmt)
 
+    def materializable_scan_stmt(
+        self, low_exclusive: int, high_inclusive: int
+    ) -> Select[tuple[int]]:
+        return self.scan_stmt(low_exclusive, high_inclusive).where(
+            ~exists(
+                select(1).where(
+                    models.SpanAnnotation.span_rowid == models.Span.id,
+                    models.SpanAnnotation.name == self.name,
+                    models.SpanAnnotation.identifier == self.identifier,
+                )
+            ),
+            or_(
+                ~exists(
+                    select(1).where(
+                        models.EvalWorkUnit.span_rowid == models.Span.id,
+                        models.EvalWorkUnit.evaluator_id == self.evaluator_id,
+                        models.EvalWorkUnit.config_fingerprint == self.fingerprint,
+                    )
+                ),
+                exists(
+                    select(1).where(
+                        models.EvalWorkUnit.span_rowid == models.Span.id,
+                        models.EvalWorkUnit.evaluator_id == self.evaluator_id,
+                        models.EvalWorkUnit.config_fingerprint == self.fingerprint,
+                        models.EvalWorkUnit.status == "EXPIRED",
+                        models.EvalWorkUnit.error == STALE_FINGERPRINT_ERROR,
+                    )
+                ),
+            ),
+        )
+
     def sampled(self, span_ids: list[int]) -> list[int]:
         return [sid for sid in span_ids if sample_key(sid) < self.sampling_rate]
 
@@ -144,33 +194,21 @@ class OnlineEvalProducer(DaemonTask):
         self,
         db: DbSessionFactory,
         *,
-        consumer_group: str = "default",
         tick_interval_seconds: float = TICK_INTERVAL_SECONDS,
     ) -> None:
         super().__init__()
         self._db = db
         self._grain: models.EvalWorkGrain = "SPAN"
-        self._consumer_group = consumer_group
         self._tick_interval_seconds = tick_interval_seconds
         self._producer_id = f"producer-{token_hex(8)}"
-        # Config knobs are hardcoded to their defaults until the online-eval env-var surface lands.
-        self._frontier_lag_seconds = 60.0
-        # The backstop's coverage guarantee is rate-dependent: gap-free re-coverage
-        # requires lookback_span_ids >= instance_wide_ingest_rate * interval_seconds.
-        # Spans draw from a single id sequence, so the rate that matters is the sum
-        # across all projects and tenants — 100k ids per 3600s sweep only protects
-        # deployments ingesting under ~28 spans/sec instance-wide. Above that, rows
-        # can age out of the lookback between sweeps and the backstop stops bounding
-        # the exceptional loss modes it exists to catch (late-visible spans, skipped
-        # criteria). The reaper's floor (``_reap``) is aligned to this lookback, so
-        # any change here must move both together.
-        self._backstop_interval_seconds = 3600.0
-        self._backstop_lookback_span_ids = 100_000
-        self._max_span_ids_per_tick = 10_000
-        # Disabled because expiry is terminal and blocks backstop re-materialization.
-        self._pending_ttl_seconds = 0.0
-        self._retention_seconds = 604_800.0
-        self._max_pending = 10_000
+        self._frontier_lag_seconds = get_env_online_eval_frontier_lag_seconds()
+        self._backstop_interval_seconds = get_env_online_eval_backstop_interval_seconds()
+        self._backstop_lookback_span_ids = get_env_online_eval_backstop_lookback_span_ids()
+        self._max_span_ids_per_tick = get_env_online_eval_max_span_ids_per_tick()
+        # Disabled by default because expiry is terminal and blocks backstop re-materialization.
+        self._pending_ttl_seconds = get_env_online_eval_pending_ttl_seconds()
+        self._retention_seconds = get_env_online_eval_retention_seconds()
+        self._max_outstanding = get_env_online_eval_max_outstanding()
         self._last_backstop_at = time.monotonic()
         self._lease_held = False
 
@@ -186,53 +224,61 @@ class OnlineEvalProducer(DaemonTask):
             await self._release_lease()
 
     async def _tick(self) -> None:
-        now = datetime.now(timezone.utc)
-        cursor = await self._acquire_cursor(now)
-        if cursor is None:
-            return
-        cursor = await self._clamp_cursor(cursor)
-        if cursor is None:
-            return
-        produced_through_id = cursor.produced_through_id
+        try:
+            now = datetime.now(timezone.utc)
+            cursor = await self._acquire_cursor(now)
+            if cursor is None:
+                return
+            cursor = await self._clamp_cursor(cursor)
+            if cursor is None:
+                return
+            produced_through_id = cursor.produced_through_id
 
-        await self._reap(now, produced_through_id)
+            await self._reap(now, produced_through_id)
+            await self._renew_lease(datetime.now(timezone.utc))
 
-        observed_high_water_id = cursor.observed_high_water_id
-        pending_observation = (
-            observed_high_water_id is not None
-            and cursor.observed_at is not None
-            and observed_high_water_id > produced_through_id
-        )
-        frontier: Optional[int] = None
-        if (
-            pending_observation
-            and observed_high_water_id is not None
-            and cursor.observed_at is not None
-            and (now - cursor.observed_at).total_seconds() >= self._frontier_lag_seconds
-        ):
-            frontier = min(
-                observed_high_water_id,
-                produced_through_id + self._max_span_ids_per_tick,
+            observed_high_water_id = cursor.observed_high_water_id
+            pending_observation = (
+                observed_high_water_id is not None
+                and cursor.observed_at is not None
+                and observed_high_water_id > produced_through_id
             )
+            frontier: Optional[int] = None
+            if (
+                pending_observation
+                and observed_high_water_id is not None
+                and cursor.observed_at is not None
+                and (now - cursor.observed_at).total_seconds() >= self._frontier_lag_seconds
+            ):
+                frontier = min(
+                    observed_high_water_id,
+                    produced_through_id + self._max_span_ids_per_tick,
+                )
 
-        gate_open = await self._admission_gate_open()
-        active = await self._load_active_criteria() if gate_open else []
+            budget = await self._admission_budget()
+            active = await self._load_active_criteria() if budget > 0 else []
 
-        advanced = False
-        if gate_open and frontier is not None:
-            advanced = await self._materialize_and_advance(active, produced_through_id, frontier)
-            if advanced:
-                produced_through_id = frontier
+            advanced = False
+            if budget > 0 and frontier is not None:
+                await self._renew_lease(datetime.now(timezone.utc))
+                advanced, budget = await self._materialize_and_advance(
+                    active, produced_through_id, frontier, budget
+                )
+                if advanced:
+                    produced_through_id = frontier
 
-        observation_consumed = advanced and frontier == observed_high_water_id
-        if not pending_observation or observation_consumed:
-            await self._record_observation(produced_through_id)
+            observation_consumed = advanced and frontier == observed_high_water_id
+            if not pending_observation or observation_consumed:
+                await self._record_observation(produced_through_id)
 
-        if gate_open and time.monotonic() - self._last_backstop_at >= (
-            self._backstop_interval_seconds
-        ):
-            self._last_backstop_at = time.monotonic()
-            await self._backstop_sweep(active, produced_through_id)
+            if budget > 0 and time.monotonic() - self._last_backstop_at >= (
+                self._backstop_interval_seconds
+            ):
+                await self._renew_lease(datetime.now(timezone.utc))
+                await self._backstop_sweep(active, produced_through_id, budget)
+                self._last_backstop_at = time.monotonic()
+        except _CursorLeaseLost:
+            logger.warning("Online-eval producer tick aborted after losing its lease")
 
     async def _acquire_cursor(self, now: datetime) -> Optional[models.EvalWorkCursor]:
         stale = now - timedelta(seconds=CURSOR_LEASE_TTL_SECONDS)
@@ -242,7 +288,7 @@ class OnlineEvalProducer(DaemonTask):
                     update(models.EvalWorkCursor)
                     .where(
                         models.EvalWorkCursor.grain == self._grain,
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                         or_(
                             models.EvalWorkCursor.claimed_by.is_(None),
                             models.EvalWorkCursor.claimed_by == self._producer_id,
@@ -259,7 +305,7 @@ class OnlineEvalProducer(DaemonTask):
                 row_exists = await session.scalar(
                     select(models.EvalWorkCursor.id).where(
                         models.EvalWorkCursor.grain == self._grain,
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     )
                 )
                 if row_exists is not None:
@@ -269,7 +315,7 @@ class OnlineEvalProducer(DaemonTask):
                     insert_on_conflict(
                         {
                             "grain": self._grain,
-                            "consumer_group": self._consumer_group,
+                            "consumer_group": _CONSUMER_GROUP,
                             "produced_through_id": produced_through_id,
                         },
                         table=models.EvalWorkCursor,
@@ -314,7 +360,7 @@ class OnlineEvalProducer(DaemonTask):
                     update(models.EvalWorkCursor)
                     .where(
                         models.EvalWorkCursor.grain == self._grain,
-                        models.EvalWorkCursor.consumer_group == self._consumer_group,
+                        models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                         models.EvalWorkCursor.claimed_by == self._producer_id,
                     )
                     .values(claimed_by=None, claimed_at=None)
@@ -322,12 +368,44 @@ class OnlineEvalProducer(DaemonTask):
         except Exception:
             logger.exception("Failed to release online-eval producer lease")
 
+    async def _renew_lease(self, now: datetime) -> None:
+        async with self._db() as session:
+            renewed = await session.scalar(
+                update(models.EvalWorkCursor)
+                .where(
+                    models.EvalWorkCursor.grain == self._grain,
+                    models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
+                    models.EvalWorkCursor.claimed_by == self._producer_id,
+                )
+                .values(claimed_at=now)
+                .returning(models.EvalWorkCursor.id)
+            )
+        if renewed is None:
+            self._lease_held = False
+            raise _CursorLeaseLost
+
     async def _reap(self, now: datetime, produced_through_id: int) -> None:
         retention_cutoff = now - timedelta(seconds=self._retention_seconds)
         # Terminal rows inside the backstop lookback window are never deleted,
         # regardless of age — they must remain to block backstop resurrection.
         reap_floor = produced_through_id - self._backstop_lookback_span_ids
         async with self._db() as session:
+            await session.execute(
+                update(models.EvalWorkUnit)
+                .where(
+                    models.EvalWorkUnit.status == "RUNNING",
+                    models.EvalWorkUnit.attempts >= MAX_ATTEMPTS - 1,
+                    work_unit_lease_lapsed(now),
+                )
+                .values(
+                    status="ERROR",
+                    attempts=MAX_ATTEMPTS,
+                    error=func.coalesce(
+                        models.EvalWorkUnit.error,
+                        "lease lapsed with attempts exhausted",
+                    ),
+                )
+            )
             if self._pending_ttl_seconds > 0:
                 pending_cutoff = now - timedelta(seconds=self._pending_ttl_seconds)
                 await session.execute(
@@ -336,7 +414,13 @@ class OnlineEvalProducer(DaemonTask):
                         models.EvalWorkUnit.status == "PENDING",
                         models.EvalWorkUnit.created_at < pending_cutoff,
                     )
-                    .values(status="EXPIRED")
+                    .values(
+                        status="EXPIRED",
+                        error=func.coalesce(
+                            models.EvalWorkUnit.error,
+                            _PENDING_TTL_EXCEEDED_ERROR,
+                        ),
+                    )
                 )
             await session.execute(
                 delete(models.EvalWorkUnit).where(
@@ -354,7 +438,7 @@ class OnlineEvalProducer(DaemonTask):
                 )
             )
 
-    async def _admission_gate_open(self) -> bool:
+    async def _admission_budget(self) -> int:
         # The gate bounds the backlog that will eventually demand consumer
         # capacity — every non-terminal row, not just PENDING: RUNNING rows are
         # claimed but unfinished, and retryable ERROR rows return to the claim
@@ -379,13 +463,14 @@ class OnlineEvalProducer(DaemonTask):
                 )
                 or 0
             )
-        if outstanding_count > self._max_pending:
+        budget = max(0, self._max_outstanding - outstanding_count)
+        if budget == 0:
             logger.warning(
                 f"Online-eval producer admission gate closed: "
-                f"{outstanding_count} outstanding work units exceeds {self._max_pending}"
+                f"{outstanding_count} outstanding work units reached "
+                f"{self._max_outstanding}"
             )
-            return False
-        return True
+        return budget
 
     async def _load_active_criteria(self) -> list[_ActiveCriteria]:
         """Load and resolve enabled criteria into scan-ready form.
@@ -461,25 +546,42 @@ class OnlineEvalProducer(DaemonTask):
         active: list[_ActiveCriteria],
         low_exclusive: int,
         frontier: int,
-    ) -> bool:
+        budget: int,
+    ) -> tuple[bool, int]:
         async with self._db() as session:
-            for criteria in active:
-                span_ids = list(await session.scalars(criteria.scan_stmt(low_exclusive, frontier)))
-                await self._insert_work_units(session, criteria, criteria.sampled(span_ids))
+            for index, criteria in enumerate(active):
+                span_ids = list(
+                    await session.scalars(
+                        criteria.materializable_scan_stmt(low_exclusive, frontier)
+                    )
+                )
+                sampled_span_ids = criteria.sampled(span_ids)
+                admitted_span_ids = sampled_span_ids[:budget]
+                await self._insert_work_units(session, criteria, admitted_span_ids)
+                budget -= len(admitted_span_ids)
+                if len(admitted_span_ids) < len(sampled_span_ids) or (
+                    budget == 0 and index < len(active) - 1
+                ):
+                    logger.warning(
+                        f"Online-eval producer frontier truncated at insertion budget; "
+                        f"{budget} budget remaining"
+                    )
+                    await self._fence_mutating_session(session)
+                    return False, budget
             advanced = await session.scalar(
                 update(models.EvalWorkCursor)
                 .where(
                     models.EvalWorkCursor.grain == self._grain,
-                    models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     models.EvalWorkCursor.claimed_by == self._producer_id,
                 )
                 .values(produced_through_id=frontier)
                 .returning(models.EvalWorkCursor.id)
             )
-        if advanced is None:
-            logger.warning("Online-eval producer lost its lease; watermark not advanced")
-            return False
-        return True
+            if advanced is None:
+                self._lease_held = False
+                raise _CursorLeaseLost
+        return True, budget
 
     async def _record_observation(self, produced_through_id: int) -> None:
         async with self._db() as session:
@@ -498,38 +600,56 @@ class OnlineEvalProducer(DaemonTask):
                 update(models.EvalWorkCursor)
                 .where(
                     models.EvalWorkCursor.grain == self._grain,
-                    models.EvalWorkCursor.consumer_group == self._consumer_group,
+                    models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
                     models.EvalWorkCursor.claimed_by == self._producer_id,
                 )
                 .values(observed_high_water_id=high_water, observed_at=observed_at)
             )
 
-    async def _backstop_sweep(self, active: list[_ActiveCriteria], watermark: int) -> None:
+    async def _backstop_sweep(
+        self,
+        active: list[_ActiveCriteria],
+        watermark: int,
+        budget: int,
+    ) -> int:
         if watermark <= 0:
-            return
+            return budget
         # Window is [watermark - lookback, watermark], matching the reaper's floor
         # exactly so every retained terminal row is inside the swept range.
         low_exclusive = max(watermark - self._backstop_lookback_span_ids - 1, 0)
         async with self._db() as session:
-            for criteria in active:
-                stmt = criteria.scan_stmt(low_exclusive, watermark).where(
-                    ~exists(
-                        select(1).where(
-                            models.SpanAnnotation.span_rowid == models.Span.id,
-                            models.SpanAnnotation.name == criteria.name,
-                            models.SpanAnnotation.identifier == criteria.identifier,
-                        )
-                    ),
-                    ~exists(
-                        select(1).where(
-                            models.EvalWorkUnit.span_rowid == models.Span.id,
-                            models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
-                            models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
-                        )
-                    ),
-                )
+            for index, criteria in enumerate(active):
+                stmt = criteria.materializable_scan_stmt(low_exclusive, watermark)
                 span_ids = list(await session.scalars(stmt))
-                await self._insert_work_units(session, criteria, criteria.sampled(span_ids))
+                sampled_span_ids = criteria.sampled(span_ids)
+                admitted_span_ids = sampled_span_ids[:budget]
+                await self._insert_work_units(session, criteria, admitted_span_ids)
+                budget -= len(admitted_span_ids)
+                if len(admitted_span_ids) < len(sampled_span_ids) or (
+                    budget == 0 and index < len(active) - 1
+                ):
+                    logger.warning(
+                        f"Online-eval producer backstop truncated at insertion budget; "
+                        f"{budget} budget remaining"
+                    )
+                    break
+            await self._fence_mutating_session(session)
+        return budget
+
+    async def _fence_mutating_session(self, session: AsyncSession) -> None:
+        renewed = await session.scalar(
+            update(models.EvalWorkCursor)
+            .where(
+                models.EvalWorkCursor.grain == self._grain,
+                models.EvalWorkCursor.consumer_group == _CONSUMER_GROUP,
+                models.EvalWorkCursor.claimed_by == self._producer_id,
+            )
+            .values(claimed_at=datetime.now(timezone.utc))
+            .returning(models.EvalWorkCursor.id)
+        )
+        if renewed is None:
+            self._lease_held = False
+            raise _CursorLeaseLost
 
     async def _insert_work_units(
         self,
@@ -547,9 +667,36 @@ class OnlineEvalProducer(DaemonTask):
             for span_rowid in span_ids
         ]
         for start in range(0, len(records), _INSERT_BATCH_SIZE):
+            batch = records[start : start + _INSERT_BATCH_SIZE]
+            batch_span_ids = [record["span_rowid"] for record in batch]
+            await session.execute(
+                update(models.EvalWorkUnit)
+                .where(
+                    models.EvalWorkUnit.span_rowid.in_(batch_span_ids),
+                    models.EvalWorkUnit.evaluator_id == criteria.evaluator_id,
+                    models.EvalWorkUnit.config_fingerprint == criteria.fingerprint,
+                    models.EvalWorkUnit.status == "EXPIRED",
+                    models.EvalWorkUnit.error == STALE_FINGERPRINT_ERROR,
+                    ~exists(
+                        select(1).where(
+                            models.SpanAnnotation.span_rowid == models.EvalWorkUnit.span_rowid,
+                            models.SpanAnnotation.name == criteria.name,
+                            models.SpanAnnotation.identifier == criteria.identifier,
+                        )
+                    ),
+                )
+                .values(
+                    status="PENDING",
+                    attempts=0,
+                    error=None,
+                    claimed_by=None,
+                    claimed_at=None,
+                    cooldown_until=None,
+                )
+            )
             await session.execute(
                 insert_on_conflict(
-                    *records[start : start + _INSERT_BATCH_SIZE],
+                    *batch,
                     table=models.EvalWorkUnit,
                     dialect=self._db.dialect,
                     unique_by=_WORK_UNIT_UNIQUE_BY,

--- a/src/phoenix/server/online_eval/producer.py
+++ b/src/phoenix/server/online_eval/producer.py
@@ -60,6 +60,7 @@ async def resolve_criteria(
     """
     version_ref: Any
     input_mapping: Any = None
+    sandbox_config_id: Optional[int] = None
     if isinstance(evaluator, models.LLMEvaluator):
         if evaluator.prompt_version_tag_id is not None:
             version_ref = await session.scalar(
@@ -81,20 +82,27 @@ async def resolve_criteria(
             .order_by(models.CodeEvaluatorVersion.id.desc())
             .limit(1)
         )
-        input_mapping = evaluator.input_mapping.model_dump()
+        sandbox_config_id = evaluator.sandbox_config_id
     elif isinstance(evaluator, models.BuiltinEvaluator):
         version_ref = [evaluator.key, evaluator.synced_at.isoformat()]
     else:
         return None
     if version_ref is None:
         return None
+    effective_input_mapping = criteria.input_mapping
+    if effective_input_mapping is None and isinstance(evaluator, models.CodeEvaluator):
+        effective_input_mapping = evaluator.input_mapping
+    if effective_input_mapping is not None:
+        input_mapping = effective_input_mapping.model_dump()
     return ResolvedCriteria(
         criteria_id=criteria.id,
-        annotation_name=criteria.annotation_name.root,
+        name=criteria.name.root,
         evaluator_id=evaluator.id,
         version_ref=version_ref,
         output_configs=[config.model_dump() for config in evaluator.output_configs],
         input_mapping=input_mapping,
+        evaluation_target=criteria.evaluation_target,
+        sandbox_config_id=sandbox_config_id,
         filter_condition=criteria.filter_condition,
         sampling_rate=criteria.sampling_rate,
     )
@@ -105,7 +113,7 @@ class _ActiveCriteria:
     criteria_id: int
     project_id: int
     evaluator_id: int
-    annotation_name: str
+    name: str
     sampling_rate: float
     fingerprint: str
     identifier: str
@@ -404,7 +412,10 @@ class OnlineEvalProducer(DaemonTask):
                         polymorphic_evaluator,
                         models.ProjectEvaluatorCriteria.evaluator_id == polymorphic_evaluator.id,
                     )
-                    .where(models.ProjectEvaluatorCriteria.enabled)
+                    .where(
+                        models.ProjectEvaluatorCriteria.enabled,
+                        models.ProjectEvaluatorCriteria.evaluation_target == "SPAN",
+                    )
                 )
             ).all()
             for criteria, evaluator in rows:
@@ -436,7 +447,7 @@ class OnlineEvalProducer(DaemonTask):
                         criteria_id=criteria.id,
                         project_id=criteria.project_id,
                         evaluator_id=criteria.evaluator_id,
-                        annotation_name=resolved.annotation_name,
+                        name=resolved.name,
                         sampling_rate=criteria.sampling_rate,
                         fingerprint=fingerprint,
                         identifier=annotation_identifier(fingerprint),
@@ -505,7 +516,7 @@ class OnlineEvalProducer(DaemonTask):
                     ~exists(
                         select(1).where(
                             models.SpanAnnotation.span_rowid == models.Span.id,
-                            models.SpanAnnotation.name == criteria.annotation_name,
+                            models.SpanAnnotation.name == criteria.name,
                             models.SpanAnnotation.identifier == criteria.identifier,
                         )
                     ),

--- a/src/phoenix/server/prometheus.py
+++ b/src/phoenix/server/prometheus.py
@@ -155,6 +155,13 @@ ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS = Gauge(
     name="online_eval_exhausted_error_work_units",
     documentation="Current number of exhausted online-eval work units in ERROR status",
 )
+ONLINE_EVAL_EXPIRED_WORK_UNITS = Gauge(
+    namespace="phoenix",
+    name="online_eval_expired_work_units",
+    documentation="Current number of online-eval work units in EXPIRED status: work shed "
+    "unevaluated by the pending TTL and still within the retention window. A nonzero value "
+    "means evaluations were dropped.",
+)
 ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS = Gauge(
     namespace="phoenix",
     name="online_eval_frontier_gap_span_ids",

--- a/src/phoenix/server/prometheus.py
+++ b/src/phoenix/server/prometheus.py
@@ -135,6 +135,35 @@ RETENTION_POLICY_EXECUTIONS = Counter(
     labelnames=["status"],
 )
 
+ONLINE_EVAL_PENDING_WORK_UNITS = Gauge(
+    namespace="phoenix",
+    name="online_eval_pending_work_units",
+    documentation="Current number of online-eval work units in PENDING status",
+)
+ONLINE_EVAL_RUNNING_WORK_UNITS = Gauge(
+    namespace="phoenix",
+    name="online_eval_running_work_units",
+    documentation="Current number of online-eval work units in RUNNING status",
+)
+ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS = Gauge(
+    namespace="phoenix",
+    name="online_eval_frontier_gap_span_ids",
+    documentation="Distance in span ids between the online-eval producer's observed "
+    "high-water mark and its produced-through watermark",
+)
+ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS = Gauge(
+    namespace="phoenix",
+    name="online_eval_oldest_pending_age_seconds",
+    documentation="Age in seconds of the oldest PENDING online-eval work unit "
+    "(0 when the queue is empty)",
+)
+ONLINE_EVAL_INGEST_SPANS_PER_SECOND = Gauge(
+    namespace="phoenix",
+    name="online_eval_ingest_spans_per_second",
+    documentation="Span ingest rate derived from successive online-eval cursor "
+    "high-water observations",
+)
+
 
 def _join_paths(prefix: str, path: str) -> str:
     if not prefix:

--- a/src/phoenix/server/prometheus.py
+++ b/src/phoenix/server/prometheus.py
@@ -145,6 +145,16 @@ ONLINE_EVAL_RUNNING_WORK_UNITS = Gauge(
     name="online_eval_running_work_units",
     documentation="Current number of online-eval work units in RUNNING status",
 )
+ONLINE_EVAL_RETRYABLE_ERROR_WORK_UNITS = Gauge(
+    namespace="phoenix",
+    name="online_eval_retryable_error_work_units",
+    documentation="Current number of retryable online-eval work units in ERROR status",
+)
+ONLINE_EVAL_EXHAUSTED_ERROR_WORK_UNITS = Gauge(
+    namespace="phoenix",
+    name="online_eval_exhausted_error_work_units",
+    documentation="Current number of exhausted online-eval work units in ERROR status",
+)
 ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS = Gauge(
     namespace="phoenix",
     name="online_eval_frontier_gap_span_ids",
@@ -154,8 +164,8 @@ ONLINE_EVAL_FRONTIER_GAP_SPAN_IDS = Gauge(
 ONLINE_EVAL_OLDEST_PENDING_AGE_SECONDS = Gauge(
     namespace="phoenix",
     name="online_eval_oldest_pending_age_seconds",
-    documentation="Age in seconds of the oldest PENDING online-eval work unit "
-    "(0 when the queue is empty)",
+    documentation="Age in seconds of the oldest PENDING or retryable ERROR online-eval work unit "
+    "(0 when the backlog is empty)",
 )
 ONLINE_EVAL_INGEST_SPANS_PER_SECOND = Gauge(
     namespace="phoenix",

--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import sqlalchemy
 from sqlalchemy import case, literal
+from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.orm import Mapped, aliased
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql.expression import ColumnElement, Select
@@ -245,6 +246,13 @@ class SpanFilter:
                 ),
             )
         return stmt
+
+
+def validate_span_filter_condition(condition: str) -> None:
+    span_filter = SpanFilter(condition=condition)
+    stmt = span_filter(sqlalchemy.select(models.Span))
+    stmt.compile(dialect=sqlite.dialect())
+    stmt.compile(dialect=postgresql.dialect())  # type: ignore[no-untyped-call]
 
 
 _VALID_PROJECTION_NODE_TYPES: tuple[type, ...] = (

--- a/tests/integration/_mock_llm_server.py
+++ b/tests/integration/_mock_llm_server.py
@@ -328,6 +328,13 @@ def _estimate_tokens(text: str) -> int:
     return max(1, len(text) // 4)
 
 
+def _input_tokens_details() -> InputTokensDetails:
+    values = {"cached_tokens": 0}
+    if "cache_write_tokens" in InputTokensDetails.model_fields:
+        values["cache_write_tokens"] = 0
+    return InputTokensDetails.model_validate(values)
+
+
 def _google_schema_to_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Convert Google GenAI schema format to standard JSON Schema.
 
@@ -1061,7 +1068,7 @@ class _LLMRequestHandler(BaseHTTPRequestHandler):
             input_tokens=10,
             output_tokens=output_tokens,
             total_tokens=10 + output_tokens,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=_input_tokens_details(),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         )
         return Response(
@@ -1111,7 +1118,7 @@ class _LLMRequestHandler(BaseHTTPRequestHandler):
             input_tokens=10,
             output_tokens=output_tokens,
             total_tokens=10 + output_tokens,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=_input_tokens_details(),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         )
         return Response(
@@ -1268,7 +1275,7 @@ class _LLMRequestHandler(BaseHTTPRequestHandler):
             input_tokens=10,
             output_tokens=output_tokens,
             total_tokens=10 + output_tokens,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=_input_tokens_details(),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         )
         completed_event = ResponseCompletedEvent(
@@ -1400,7 +1407,7 @@ class _LLMRequestHandler(BaseHTTPRequestHandler):
             input_tokens=10,
             output_tokens=output_tokens,
             total_tokens=10 + output_tokens,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=_input_tokens_details(),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         )
         completed_event = ResponseCompletedEvent(

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -110,9 +110,11 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
             "id",
             "project_id",
             "evaluator_id",
-            "annotation_name",
+            "name",
             "filter_condition",
             "sampling_rate",
+            "evaluation_target",
+            "input_mapping",
             "enabled",
             "created_at",
             "updated_at",
@@ -123,16 +125,17 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
         }
         constraint_names = {
             "pk_project_evaluator_criteria",
-            "uq_project_evaluator_criteria_project_id_annotation_name",
+            "uq_project_evaluator_criteria_project_id_name",
             "fk_project_evaluator_criteria_project_id_projects",
             "fk_project_evaluator_criteria_evaluator_id_evaluators",
             "ck_project_evaluator_criteria_`valid_sampling_rate`",
+            "ck_project_evaluator_criteria_`valid_evaluation_target`",
         }
         if db_backend == "postgresql":
             index_names.update(
                 {
                     "pk_project_evaluator_criteria",
-                    "uq_project_evaluator_criteria_project_id_annotation_name",
+                    "uq_project_evaluator_criteria_project_id_name",
                 }
             )
         elif db_backend == "sqlite":
@@ -144,7 +147,7 @@ class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
             column_names=frozenset(column_names),
             index_names=frozenset(index_names),
             constraint_names=frozenset(constraint_names),
-            nullable_column_names=frozenset(),
+            nullable_column_names=frozenset(["input_mapping"]),
         )
 
 

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -1,0 +1,206 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from alembic.config import Config
+from sqlalchemy import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine
+from typing_extensions import assert_never, override
+
+from . import (
+    _DBBackend,
+    _down,
+    _get_table_schema_info,
+    _run_async,
+    _TableSchemaInfo,
+    _up,
+    _verify_clean_state,
+)
+
+_DOWN = "d4e5f6a7b8c9"
+_UP = "a7f1c3e9d2b4"
+
+
+class _OnlineEvalSchemaTest(ABC):
+    table_name: str
+
+    @classmethod
+    @abstractmethod
+    def _get_upgraded_schema_info(cls, db_backend: _DBBackend) -> Optional[_TableSchemaInfo]: ...
+
+    async def test_db_schema(
+        self,
+        _engine: AsyncEngine,
+        _alembic_config: Config,
+        _db_backend: _DBBackend,
+        _schema: str,
+    ) -> None:
+        await _verify_clean_state(_engine, _schema)
+
+        # The tables do not exist before this migration.
+        await _up(_engine, _alembic_config, _DOWN, _schema)
+
+        def _get(conn: Connection) -> Optional[_TableSchemaInfo]:
+            return _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+
+        assert (await _run_async(_engine, _get)) is None
+
+        await _up(_engine, _alembic_config, _UP, _schema)
+        final_info = await _run_async(_engine, _get)
+        assert final_info == self._get_upgraded_schema_info(_db_backend), (
+            "Final schema info does not match expected upgraded schema info"
+        )
+
+        await _down(_engine, _alembic_config, _DOWN, _schema)
+        assert (await _run_async(_engine, _get)) is None, "Table should not exist after downgrade"
+
+
+class TestEvalWorkCursors(_OnlineEvalSchemaTest):
+    table_name = "eval_work_cursors"
+
+    @override
+    @classmethod
+    def _get_upgraded_schema_info(cls, db_backend: _DBBackend) -> Optional[_TableSchemaInfo]:
+        column_names = {
+            "id",
+            "grain",
+            "consumer_group",
+            "produced_through_id",
+            "observed_high_water_id",
+            "observed_at",
+            "claimed_at",
+            "claimed_by",
+            "created_at",
+            "updated_at",
+        }
+        index_names: set[str] = set()
+        constraint_names = {
+            "pk_eval_work_cursors",
+            "uq_eval_work_cursors_grain_consumer_group",
+            "ck_eval_work_cursors_`valid_grain`",
+        }
+        if db_backend == "postgresql":
+            index_names.update(
+                {
+                    "pk_eval_work_cursors",
+                    "uq_eval_work_cursors_grain_consumer_group",
+                }
+            )
+        elif db_backend == "sqlite":
+            index_names.update({"sqlite_autoindex_eval_work_cursors_1"})
+        else:
+            assert_never(db_backend)
+        return _TableSchemaInfo(
+            table_name=cls.table_name,
+            column_names=frozenset(column_names),
+            index_names=frozenset(index_names),
+            constraint_names=frozenset(constraint_names),
+            nullable_column_names=frozenset(
+                ["observed_high_water_id", "observed_at", "claimed_at", "claimed_by"]
+            ),
+        )
+
+
+class TestProjectEvaluatorCriteria(_OnlineEvalSchemaTest):
+    table_name = "project_evaluator_criteria"
+
+    @override
+    @classmethod
+    def _get_upgraded_schema_info(cls, db_backend: _DBBackend) -> Optional[_TableSchemaInfo]:
+        column_names = {
+            "id",
+            "project_id",
+            "evaluator_id",
+            "annotation_name",
+            "filter_condition",
+            "sampling_rate",
+            "enabled",
+            "created_at",
+            "updated_at",
+        }
+        index_names = {
+            "ix_project_evaluator_criteria_project_id",
+            "ix_project_evaluator_criteria_evaluator_id",
+        }
+        constraint_names = {
+            "pk_project_evaluator_criteria",
+            "uq_project_evaluator_criteria_project_id_annotation_name",
+            "fk_project_evaluator_criteria_project_id_projects",
+            "fk_project_evaluator_criteria_evaluator_id_evaluators",
+            "ck_project_evaluator_criteria_`valid_sampling_rate`",
+        }
+        if db_backend == "postgresql":
+            index_names.update(
+                {
+                    "pk_project_evaluator_criteria",
+                    "uq_project_evaluator_criteria_project_id_annotation_name",
+                }
+            )
+        elif db_backend == "sqlite":
+            index_names.update({"sqlite_autoindex_project_evaluator_criteria_1"})
+        else:
+            assert_never(db_backend)
+        return _TableSchemaInfo(
+            table_name=cls.table_name,
+            column_names=frozenset(column_names),
+            index_names=frozenset(index_names),
+            constraint_names=frozenset(constraint_names),
+            nullable_column_names=frozenset(),
+        )
+
+
+class TestEvalWorkUnits(_OnlineEvalSchemaTest):
+    table_name = "eval_work_units"
+
+    @override
+    @classmethod
+    def _get_upgraded_schema_info(cls, db_backend: _DBBackend) -> Optional[_TableSchemaInfo]:
+        column_names = {
+            "id",
+            "span_rowid",
+            "evaluator_id",
+            "criteria_id",
+            "config_fingerprint",
+            "status",
+            "claimed_at",
+            "claimed_by",
+            "attempts",
+            "error",
+            "cooldown_until",
+            "created_at",
+            "updated_at",
+        }
+        index_names = {
+            "ix_eval_work_units_claimable",
+            "ix_eval_work_units_evaluator_id",
+            "ix_eval_work_units_criteria_id",
+            "ix_eval_work_units_error_attempts",
+            "ix_eval_work_units_terminal",
+        }
+        constraint_names = {
+            "pk_eval_work_units",
+            "uq_eval_work_units_span_rowid_evaluator_id_config_fingerprint",
+            "fk_eval_work_units_span_rowid_spans",
+            "fk_eval_work_units_evaluator_id_evaluators",
+            "fk_eval_work_units_criteria_id_project_evaluator_criteria",
+            "ck_eval_work_units_`valid_eval_work_status`",
+        }
+        if db_backend == "postgresql":
+            index_names.update(
+                {
+                    "pk_eval_work_units",
+                    "uq_eval_work_units_span_rowid_evaluator_id_config_fingerprint",
+                }
+            )
+        elif db_backend == "sqlite":
+            index_names.update({"sqlite_autoindex_eval_work_units_1"})
+        else:
+            assert_never(db_backend)
+        return _TableSchemaInfo(
+            table_name=cls.table_name,
+            column_names=frozenset(column_names),
+            index_names=frozenset(index_names),
+            constraint_names=frozenset(constraint_names),
+            nullable_column_names=frozenset(
+                ["claimed_at", "claimed_by", "error", "cooldown_until"]
+            ),
+        )

--- a/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
+++ b/tests/integration/db_migrations/test_db_schema_a7f1c3e9d2b4_online_eval_coordination.py
@@ -62,7 +62,7 @@ class TestEvalWorkCursors(_OnlineEvalSchemaTest):
     def _get_upgraded_schema_info(cls, db_backend: _DBBackend) -> Optional[_TableSchemaInfo]:
         column_names = {
             "id",
-            "grain",
+            "evaluation_target",
             "consumer_group",
             "produced_through_id",
             "observed_high_water_id",
@@ -75,14 +75,14 @@ class TestEvalWorkCursors(_OnlineEvalSchemaTest):
         index_names: set[str] = set()
         constraint_names = {
             "pk_eval_work_cursors",
-            "uq_eval_work_cursors_grain_consumer_group",
-            "ck_eval_work_cursors_`valid_grain`",
+            "uq_eval_work_cursors_evaluation_target_consumer_group",
+            "ck_eval_work_cursors_`valid_evaluation_target`",
         }
         if db_backend == "postgresql":
             index_names.update(
                 {
                     "pk_eval_work_cursors",
-                    "uq_eval_work_cursors_grain_consumer_group",
+                    "uq_eval_work_cursors_evaluation_target_consumer_group",
                 }
             )
         elif db_backend == "sqlite":

--- a/tests/integration/db_migrations/test_db_schema_for_annotations.py
+++ b/tests/integration/db_migrations/test_db_schema_for_annotations.py
@@ -282,7 +282,7 @@ def _get_expected_schema_info(
 
     # Build index names
     foreign_key_index = _get_foreign_key_index_name(table_name, foreign_key_column)
-    index_names = {foreign_key_index}
+    index_names = {foreign_key_index, f"ix_{table_name}_user_id"}
 
     # Build constraint names
     constraint_names = _get_common_constraint_names(table_name)

--- a/tests/unit/db/test_eval_work_coordination.py
+++ b/tests/unit/db/test_eval_work_coordination.py
@@ -5,6 +5,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
 from phoenix.db import models
+from phoenix.db.types.evaluators import InputMapping
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.types import DbSessionFactory
 
@@ -30,9 +31,10 @@ async def _seed_span_evaluator_and_criteria(db: DbSessionFactory) -> tuple[int, 
         criteria = models.ProjectEvaluatorCriteria(
             project_id=project.id,
             evaluator_id=evaluator.id,
-            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
             filter_condition="",
             sampling_rate=1.0,
+            evaluation_target="SPAN",
         )
         session.add(criteria)
         await session.flush()
@@ -185,8 +187,10 @@ async def test_project_evaluator_criteria_defaults_and_relationships(
         )
         assert fetched is not None
         assert fetched.enabled is True
-        assert fetched.annotation_name.root.startswith("criteria-")
+        assert fetched.name.root.startswith("criteria-")
         assert fetched.filter_condition == ""
+        assert fetched.evaluation_target == "SPAN"
+        assert fetched.input_mapping is None
         assert fetched.sampling_rate == 1.0
         assert fetched.evaluator.id == evaluator_id
         assert fetched.project is not None
@@ -208,15 +212,16 @@ async def test_project_evaluator_criteria_rejects_out_of_range_sampling_rate(
                 models.ProjectEvaluatorCriteria(
                     project_id=project_id,
                     evaluator_id=evaluator_id,
-                    annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+                    name=Identifier(root=f"criteria-{token_hex(4)}"),
                     filter_condition="",
                     sampling_rate=1.5,
+                    evaluation_target="SPAN",
                 )
             )
             await session.flush()
 
 
-async def test_project_evaluator_criteria_annotation_name_is_unique_per_project(
+async def test_project_evaluator_criteria_name_is_unique_per_project(
     db: DbSessionFactory,
 ) -> None:
     _, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
@@ -225,7 +230,7 @@ async def test_project_evaluator_criteria_annotation_name_is_unique_per_project(
         existing = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
         assert existing is not None
         project_id = existing.project_id
-        annotation_name = existing.annotation_name
+        name = existing.name
 
     with pytest.raises(Exception):
         async with db() as session:
@@ -233,9 +238,60 @@ async def test_project_evaluator_criteria_annotation_name_is_unique_per_project(
                 models.ProjectEvaluatorCriteria(
                     project_id=project_id,
                     evaluator_id=evaluator_id,
-                    annotation_name=annotation_name,
+                    name=name,
                     filter_condition="",
                     sampling_rate=0.5,
+                    evaluation_target="SPAN",
+                )
+            )
+            await session.flush()
+
+
+async def test_project_evaluator_criteria_preserves_empty_input_mapping(
+    db: DbSessionFactory,
+) -> None:
+    _, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+    async with db() as session:
+        existing = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert existing is not None
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=existing.project_id,
+            evaluator_id=evaluator_id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="TRACE",
+            input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+        )
+        session.add(criteria)
+        await session.flush()
+        criteria_id = criteria.id
+
+    async with db() as session:
+        fetched = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert fetched is not None
+        assert fetched.input_mapping == InputMapping(literal_mapping={}, path_mapping={})
+
+
+async def test_project_evaluator_criteria_rejects_unknown_target(
+    db: DbSessionFactory,
+) -> None:
+    _, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+    async with db() as session:
+        existing = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert existing is not None
+        project_id = existing.project_id
+
+    with pytest.raises(Exception):
+        async with db() as session:
+            session.add(
+                models.ProjectEvaluatorCriteria(
+                    project_id=project_id,
+                    evaluator_id=evaluator_id,
+                    name=Identifier(root=f"criteria-{token_hex(4)}"),
+                    filter_condition="",
+                    sampling_rate=1.0,
+                    evaluation_target="DOCUMENT",
                 )
             )
             await session.flush()

--- a/tests/unit/db/test_eval_work_coordination.py
+++ b/tests/unit/db/test_eval_work_coordination.py
@@ -299,7 +299,7 @@ async def test_project_evaluator_criteria_rejects_unknown_target(
 
 async def test_eval_work_cursor_defaults(db: DbSessionFactory) -> None:
     async with db() as session:
-        cursor = models.EvalWorkCursor(grain="SPAN", consumer_group="default")
+        cursor = models.EvalWorkCursor(evaluation_target="SPAN", consumer_group="default")
         session.add(cursor)
         await session.flush()
         cursor_id = cursor.id
@@ -315,23 +315,23 @@ async def test_eval_work_cursor_defaults(db: DbSessionFactory) -> None:
         assert fetched.claimed_by is None
 
 
-async def test_eval_work_cursor_unique_grain_group(db: DbSessionFactory) -> None:
+async def test_eval_work_cursor_unique_target_group(db: DbSessionFactory) -> None:
     async with db() as session:
-        session.add(models.EvalWorkCursor(grain="SPAN", consumer_group="default"))
+        session.add(models.EvalWorkCursor(evaluation_target="SPAN", consumer_group="default"))
         await session.flush()
 
     with pytest.raises(Exception):
         async with db() as session:
-            session.add(models.EvalWorkCursor(grain="SPAN", consumer_group="default"))
+            session.add(models.EvalWorkCursor(evaluation_target="SPAN", consumer_group="default"))
             await session.flush()
 
 
-async def test_eval_work_cursor_rejects_unknown_grain(db: DbSessionFactory) -> None:
+async def test_eval_work_cursor_rejects_unknown_evaluation_target(db: DbSessionFactory) -> None:
     with pytest.raises(Exception):
         async with db() as session:
             session.add(
                 models.EvalWorkCursor(
-                    grain="DOCUMENT",
+                    evaluation_target="DOCUMENT",
                     consumer_group="default",
                 )
             )

--- a/tests/unit/db/test_eval_work_coordination.py
+++ b/tests/unit/db/test_eval_work_coordination.py
@@ -1,0 +1,282 @@
+from secrets import token_hex
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import selectinload
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
+from phoenix.server.types import DbSessionFactory
+
+from .._helpers import _add_project, _add_span, _add_trace
+
+
+async def _seed_span_evaluator_and_criteria(db: DbSessionFactory) -> tuple[int, int, int]:
+    """Create a span, a builtin evaluator, and a criteria row, returning
+    (span_rowid, evaluator_id, criteria_id)."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator.id,
+            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+        )
+        session.add(criteria)
+        await session.flush()
+        return span.id, evaluator.id, criteria.id
+
+
+async def test_eval_work_unit_defaults_and_relationships(db: DbSessionFactory) -> None:
+    span_rowid, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+
+    async with db() as session:
+        work_unit = models.EvalWorkUnit(
+            span_rowid=span_rowid,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint="fp-1",
+        )
+        session.add(work_unit)
+        await session.flush()
+        work_unit_id = work_unit.id
+
+    async with db() as session:
+        fetched = await session.scalar(
+            select(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == work_unit_id)
+            .options(
+                selectinload(models.EvalWorkUnit.span),
+                selectinload(models.EvalWorkUnit.evaluator),
+                selectinload(models.EvalWorkUnit.criteria),
+            )
+        )
+        assert fetched is not None
+        assert fetched.status == "PENDING"
+        assert fetched.attempts == 0
+        assert fetched.claimed_at is None
+        assert fetched.claimed_by is None
+        assert fetched.cooldown_until is None
+        assert fetched.span.id == span_rowid
+        assert fetched.evaluator.id == evaluator_id
+        assert fetched.criteria.id == criteria_id
+
+
+async def test_eval_work_unit_distinct_fingerprints_coexist(db: DbSessionFactory) -> None:
+    span_rowid, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+    async with db() as session:
+        session.add_all(
+            [
+                models.EvalWorkUnit(
+                    span_rowid=span_rowid,
+                    evaluator_id=evaluator_id,
+                    criteria_id=criteria_id,
+                    config_fingerprint="fp-a",
+                ),
+                models.EvalWorkUnit(
+                    span_rowid=span_rowid,
+                    evaluator_id=evaluator_id,
+                    criteria_id=criteria_id,
+                    config_fingerprint="fp-b",
+                ),
+            ]
+        )
+        await session.flush()
+        count = await session.scalar(
+            select(func.count())
+            .select_from(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.span_rowid == span_rowid)
+        )
+        assert count == 2
+
+
+async def test_eval_work_unit_work_key_is_unique(db: DbSessionFactory) -> None:
+    span_rowid, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+
+    async with db() as session:
+        session.add(
+            models.EvalWorkUnit(
+                span_rowid=span_rowid,
+                evaluator_id=evaluator_id,
+                criteria_id=criteria_id,
+                config_fingerprint="fp-dup",
+            )
+        )
+        await session.flush()
+
+    with pytest.raises(Exception):
+        async with db() as session:
+            session.add(
+                models.EvalWorkUnit(
+                    span_rowid=span_rowid,
+                    evaluator_id=evaluator_id,
+                    criteria_id=criteria_id,
+                    config_fingerprint="fp-dup",
+                )
+            )
+            await session.flush()
+
+
+async def test_eval_work_unit_rejects_unknown_status(db: DbSessionFactory) -> None:
+    span_rowid, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+
+    with pytest.raises(Exception):
+        async with db() as session:
+            session.add(
+                models.EvalWorkUnit(
+                    span_rowid=span_rowid,
+                    evaluator_id=evaluator_id,
+                    criteria_id=criteria_id,
+                    config_fingerprint="fp-bad-status",
+                    status="FINISHED",
+                )
+            )
+            await session.flush()
+
+
+async def test_eval_work_unit_accepts_expired_status(db: DbSessionFactory) -> None:
+    span_rowid, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+
+    async with db() as session:
+        work_unit = models.EvalWorkUnit(
+            span_rowid=span_rowid,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint="fp-expired",
+            status="EXPIRED",
+        )
+        session.add(work_unit)
+        await session.flush()
+        work_unit_id = work_unit.id
+
+    async with db() as session:
+        fetched = await session.scalar(
+            select(models.EvalWorkUnit).where(models.EvalWorkUnit.id == work_unit_id)
+        )
+        assert fetched is not None
+        assert fetched.status == "EXPIRED"
+
+
+async def test_project_evaluator_criteria_defaults_and_relationships(
+    db: DbSessionFactory,
+) -> None:
+    _, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+
+    async with db() as session:
+        fetched = await session.scalar(
+            select(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .options(
+                selectinload(models.ProjectEvaluatorCriteria.project),
+                selectinload(models.ProjectEvaluatorCriteria.evaluator),
+            )
+        )
+        assert fetched is not None
+        assert fetched.enabled is True
+        assert fetched.annotation_name.root.startswith("criteria-")
+        assert fetched.filter_condition == ""
+        assert fetched.sampling_rate == 1.0
+        assert fetched.evaluator.id == evaluator_id
+        assert fetched.project is not None
+
+
+async def test_project_evaluator_criteria_rejects_out_of_range_sampling_rate(
+    db: DbSessionFactory,
+) -> None:
+    _, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+
+    async with db() as session:
+        existing = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert existing is not None
+        project_id = existing.project_id
+
+    with pytest.raises(Exception):
+        async with db() as session:
+            session.add(
+                models.ProjectEvaluatorCriteria(
+                    project_id=project_id,
+                    evaluator_id=evaluator_id,
+                    annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+                    filter_condition="",
+                    sampling_rate=1.5,
+                )
+            )
+            await session.flush()
+
+
+async def test_project_evaluator_criteria_annotation_name_is_unique_per_project(
+    db: DbSessionFactory,
+) -> None:
+    _, evaluator_id, criteria_id = await _seed_span_evaluator_and_criteria(db)
+
+    async with db() as session:
+        existing = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert existing is not None
+        project_id = existing.project_id
+        annotation_name = existing.annotation_name
+
+    with pytest.raises(Exception):
+        async with db() as session:
+            session.add(
+                models.ProjectEvaluatorCriteria(
+                    project_id=project_id,
+                    evaluator_id=evaluator_id,
+                    annotation_name=annotation_name,
+                    filter_condition="",
+                    sampling_rate=0.5,
+                )
+            )
+            await session.flush()
+
+
+async def test_eval_work_cursor_defaults(db: DbSessionFactory) -> None:
+    async with db() as session:
+        cursor = models.EvalWorkCursor(grain="SPAN", consumer_group="default")
+        session.add(cursor)
+        await session.flush()
+        cursor_id = cursor.id
+
+    async with db() as session:
+        fetched = await session.scalar(
+            select(models.EvalWorkCursor).where(models.EvalWorkCursor.id == cursor_id)
+        )
+        assert fetched is not None
+        assert fetched.produced_through_id == 0
+        assert fetched.observed_high_water_id is None
+        assert fetched.observed_at is None
+        assert fetched.claimed_by is None
+
+
+async def test_eval_work_cursor_unique_grain_group(db: DbSessionFactory) -> None:
+    async with db() as session:
+        session.add(models.EvalWorkCursor(grain="SPAN", consumer_group="default"))
+        await session.flush()
+
+    with pytest.raises(Exception):
+        async with db() as session:
+            session.add(models.EvalWorkCursor(grain="SPAN", consumer_group="default"))
+            await session.flush()
+
+
+async def test_eval_work_cursor_rejects_unknown_grain(db: DbSessionFactory) -> None:
+    with pytest.raises(Exception):
+        async with db() as session:
+            session.add(
+                models.EvalWorkCursor(
+                    grain="DOCUMENT",
+                    consumer_group="default",
+                )
+            )
+            await session.flush()

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -47,6 +47,7 @@ from phoenix.db.types.prompts import (
     PromptToolChoiceZeroOrMore,
     PromptToolFunction,
     PromptToolFunctionDefinition,
+    PromptToolRaw,
     PromptTools,
     TextContentPart,
 )
@@ -277,6 +278,22 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
             match=_LLMEvaluatorPromptErrorMessage.TOOL_CHOICE_SPECIFIC_FUNCTION_NAME_MUST_MATCH_DEFINED_FUNCTION_NAME,
         ):
             validate_consistent_llm_evaluator_and_prompt_version(prompt_version, output_config)
+
+    def test_raw_tool_error_does_not_echo_submitted_json(
+        self,
+        output_config: CategoricalOutputConfig,
+        prompt_version: models.PromptVersion,
+    ) -> None:
+        assert prompt_version.tools is not None
+        prompt_version.tools.tools = [
+            PromptToolRaw(type="raw", raw={"api_key": "secret", "type": "web_search"})
+        ]
+        with pytest.raises(
+            ValueError,
+            match=f"^{_LLMEvaluatorPromptErrorMessage.FUNCTION_TOOLS_REQUIRED}$",
+        ) as error:
+            validate_consistent_llm_evaluator_and_prompt_version(prompt_version, output_config)
+        assert "secret" not in str(error.value)
 
     def test_function_parameters_type_not_object_raises(
         self,

--- a/tests/unit/server/api/mutations/test_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_evaluator_mutations.py
@@ -3088,6 +3088,149 @@ class TestDeleteDatasetEvaluators:
             deleted_project = await session.get(models.Project, project_id)
             assert deleted_project is None
 
+    async def test_delete_collects_project_cascade_evaluators_before_gc(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        empty_dataset: models.Dataset,
+        sandbox_config: models.SandboxConfig,
+        synced_builtin_evaluators: None,
+    ) -> None:
+        async with db() as session:
+            builtin_evaluator_id = await session.scalar(select(models.BuiltinEvaluator.id).limit(1))
+            assert builtin_evaluator_id is not None
+
+            owned_project = models.Project(
+                name=f"cascade-owned-project-{token_hex(4)}",
+                description="Project owned by a dataset evaluator",
+            )
+            survivor_project = models.Project(
+                name=f"cascade-survivor-project-{token_hex(4)}",
+                description="Project that keeps a shared evaluator alive",
+            )
+            dataset_evaluator = models.DatasetEvaluators(
+                dataset_id=empty_dataset.id,
+                evaluator_id=builtin_evaluator_id,
+                name=IdentifierModel.model_validate(f"cascade-owner-{token_hex(4)}"),
+                input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+                project=owned_project,
+            )
+            session.add_all([dataset_evaluator, survivor_project])
+            await session.flush()
+
+            dedicated_code = models.CodeEvaluator(
+                name=IdentifierModel.model_validate(f"cascade-code-{token_hex(4)}"),
+                description="Dedicated CODE evaluator",
+                metadata_={},
+                language=sandbox_config.language,
+                sandbox_config_id=sandbox_config.id,
+                input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+                output_configs=[],
+                versions=[
+                    models.CodeEvaluatorVersion(
+                        source_code="def evaluate(output):\n    return {'score': 1.0}"
+                    )
+                ],
+            )
+            dedicated_prompt = models.Prompt(
+                name=IdentifierModel.model_validate(f"cascade-prompt-{token_hex(4)}"),
+                description="Prompt owned by the dedicated LLM evaluator",
+                metadata_={},
+            )
+            dedicated_llm = models.LLMEvaluator(
+                name=IdentifierModel.model_validate(f"cascade-llm-{token_hex(4)}"),
+                description="Dedicated LLM evaluator",
+                metadata_={},
+                output_configs=[
+                    CategoricalOutputConfig(
+                        type="CATEGORICAL",
+                        name="correctness",
+                        optimization_direction=OptimizationDirection.MAXIMIZE,
+                        values=[
+                            CategoricalAnnotationValue(label="correct", score=1.0),
+                            CategoricalAnnotationValue(label="incorrect", score=0.0),
+                        ],
+                    )
+                ],
+                prompt=dedicated_prompt,
+            )
+            shared_code = models.CodeEvaluator(
+                name=IdentifierModel.model_validate(f"cascade-shared-{token_hex(4)}"),
+                description="CODE evaluator shared across projects",
+                metadata_={},
+                language=sandbox_config.language,
+                sandbox_config_id=sandbox_config.id,
+                input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+                output_configs=[],
+            )
+            session.add_all([dedicated_code, dedicated_llm, shared_code])
+            await session.flush()
+
+            owned_criteria = [
+                models.ProjectEvaluatorCriteria(
+                    project_id=owned_project.id,
+                    evaluator_id=evaluator.id,
+                    name=IdentifierModel.model_validate(name),
+                    filter_condition="",
+                    sampling_rate=1.0,
+                    evaluation_target="SPAN",
+                    input_mapping=None,
+                    enabled=True,
+                )
+                for evaluator, name in (
+                    (dedicated_code, "dedicated-code"),
+                    (dedicated_llm, "dedicated-llm"),
+                    (shared_code, "shared-code-owned-project"),
+                )
+            ]
+            survivor_criteria = models.ProjectEvaluatorCriteria(
+                project_id=survivor_project.id,
+                evaluator_id=shared_code.id,
+                name=IdentifierModel.model_validate("shared-code-survivor-project"),
+                filter_condition="",
+                sampling_rate=1.0,
+                evaluation_target="SPAN",
+                input_mapping=None,
+                enabled=True,
+            )
+            session.add_all([*owned_criteria, survivor_criteria])
+            await session.flush()
+
+            dataset_evaluator_id = dataset_evaluator.id
+            dataset_evaluator_gid = str(GlobalID("DatasetEvaluator", str(dataset_evaluator_id)))
+            owned_project_id = owned_project.id
+            survivor_project_id = survivor_project.id
+            owned_criteria_ids = [criteria.id for criteria in owned_criteria]
+            survivor_criteria_id = survivor_criteria.id
+            dedicated_code_id = dedicated_code.id
+            dedicated_llm_id = dedicated_llm.id
+            dedicated_prompt_id = dedicated_prompt.id
+            shared_code_id = shared_code.id
+
+        result = await gql_client.execute(
+            self._DELETE_MUTATION,
+            {"input": {"datasetEvaluatorIds": [dataset_evaluator_gid]}},
+        )
+
+        assert result.data and not result.errors
+        assert result.data["deleteDatasetEvaluators"]["datasetEvaluatorIds"] == [
+            dataset_evaluator_gid
+        ]
+        async with db() as session:
+            assert await session.get(models.DatasetEvaluators, dataset_evaluator_id) is None
+            assert await session.get(models.Project, owned_project_id) is None
+            for criteria_id in owned_criteria_ids:
+                assert await session.get(models.ProjectEvaluatorCriteria, criteria_id) is None
+            assert await session.get(models.Evaluator, dedicated_code_id) is None
+            assert await session.get(models.Evaluator, dedicated_llm_id) is None
+            assert await session.get(models.Prompt, dedicated_prompt_id) is None
+
+            assert await session.get(models.Project, survivor_project_id) is not None
+            assert (
+                await session.get(models.ProjectEvaluatorCriteria, survivor_criteria_id) is not None
+            )
+            assert await session.get(models.CodeEvaluator, shared_code_id) is not None
+
     async def test_delete_multiple_evaluators_mixed(
         self,
         db: DbSessionFactory,

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -17,6 +17,7 @@ evaluationTarget
 enabled
 inputMapping { literalMapping pathMapping }
 evaluator {
+  id
   kind
   name
   ... on CodeEvaluator { currentVersion { sourceCode } }
@@ -27,6 +28,14 @@ evaluator {
 _CREATE_CODE = f"""
 mutation($input: CreateProjectCodeEvaluatorInput!) {{
   createProjectCodeEvaluator(input: $input) {{
+    evaluator {{ {_PROJECT_EVALUATOR_FIELDS} }}
+  }}
+}}
+"""
+
+_ADD_CODE = f"""
+mutation($input: AddProjectCodeEvaluatorInput!) {{
+  addProjectCodeEvaluator(input: $input) {{
     evaluator {{ {_PROJECT_EVALUATOR_FIELDS} }}
   }}
 }}
@@ -110,6 +119,24 @@ def _code_create_input(
         "inputMapping": None,
         "filterCondition": filter_condition,
         "enabled": True,
+    }
+
+
+def _code_add_input(
+    project: models.Project,
+    evaluator_id: str,
+    *,
+    name: str = "attached-code",
+) -> dict[str, Any]:
+    return {
+        "projectId": str(GlobalID("Project", str(project.id))),
+        "evaluatorId": evaluator_id,
+        "name": name,
+        "samplingRate": 0.25,
+        "evaluationTarget": "SESSION",
+        "inputMapping": _mapping(context="override"),
+        "filterCondition": "span_kind == 'LLM'",
+        "enabled": False,
     }
 
 
@@ -282,6 +309,149 @@ async def test_project_code_evaluator_crud_and_connection(
     assert delete_result.data["deleteProjectEvaluators"]["projectEvaluatorIds"] == [created["id"]]
     async with db() as session:
         assert await session.get(models.Project, project.id) is not None
+
+
+async def test_add_project_code_evaluator_binds_existing_core(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    source_project = await _add_project(db)
+    create_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(source_project, sandbox_config)},
+    )
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
+    core_id = created["evaluator"]["id"]
+
+    async with db() as session:
+        evaluator_count_before = await session.scalar(
+            select(func.count()).select_from(models.Evaluator)
+        )
+        version_count_before = await session.scalar(
+            select(func.count()).select_from(models.CodeEvaluatorVersion)
+        )
+
+    add_result = await gql_client.execute(
+        _ADD_CODE,
+        {"input": _code_add_input(source_project, core_id)},
+    )
+    assert add_result.data and not add_result.errors
+    attached = add_result.data["addProjectCodeEvaluator"]["evaluator"]
+    assert attached["evaluator"]["id"] == core_id
+    assert attached["name"] == "attached-code"
+    assert attached["samplingRate"] == 0.25
+    assert attached["evaluationTarget"] == "SESSION"
+    assert attached["inputMapping"] == _mapping(context="override")
+    assert attached["filterCondition"] == "span_kind == 'LLM'"
+    assert attached["enabled"] is False
+
+    project_result = await gql_client.execute(
+        _PROJECT_EVALUATORS,
+        {"id": str(GlobalID("Project", str(source_project.id)))},
+    )
+    assert project_result.data and not project_result.errors
+    nodes = [edge["node"] for edge in project_result.data["node"]["evaluators"]["edges"]]
+    assert {node["id"] for node in nodes} == {created["id"], attached["id"]}
+
+    async with db() as session:
+        criteria_id = int(GlobalID.from_id(attached["id"]).node_id)
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.evaluator_id == int(GlobalID.from_id(core_id).node_id)
+        assert await session.scalar(select(func.count()).select_from(models.Evaluator)) == (
+            evaluator_count_before
+        )
+        assert (
+            await session.scalar(select(func.count()).select_from(models.CodeEvaluatorVersion))
+            == version_count_before
+        )
+
+
+async def test_add_project_code_evaluator_rejects_non_code_evaluator(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    source_project = await _add_project(db)
+    target_project = await _add_project(db)
+    create_result = await gql_client.execute(
+        _CREATE_LLM,
+        {"input": _llm_input(source_project, name="shared-llm", text="Evaluate {{input}}")},
+    )
+    assert create_result.data and not create_result.errors
+    evaluator_id = create_result.data["createProjectLlmEvaluator"]["evaluator"]["evaluator"]["id"]
+    criteria_count_before = await _project_evaluator_criteria_count(db)
+
+    result = await gql_client.execute(
+        _ADD_CODE,
+        {"input": _code_add_input(target_project, evaluator_id)},
+    )
+
+    assert result.errors
+    assert result.errors[0].message == "Evaluator must be a CODE evaluator"
+    assert await _project_evaluator_criteria_count(db) == criteria_count_before
+
+
+async def test_add_project_code_evaluator_rejects_missing_evaluator(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    project = await _add_project(db)
+    criteria_count_before = await _project_evaluator_criteria_count(db)
+
+    result = await gql_client.execute(
+        _ADD_CODE,
+        {
+            "input": _code_add_input(
+                project,
+                str(GlobalID("CodeEvaluator", "999999999")),
+            )
+        },
+    )
+
+    assert result.errors
+    assert result.errors[0].message == "CODE evaluator not found"
+    assert await _project_evaluator_criteria_count(db) == criteria_count_before
+
+
+async def test_delete_project_binding_preserves_core_attached_to_another_project(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    source_project = await _add_project(db)
+    target_project = await _add_project(db)
+    create_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(source_project, sandbox_config)},
+    )
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
+    core_id = created["evaluator"]["id"]
+
+    add_result = await gql_client.execute(
+        _ADD_CODE,
+        {"input": _code_add_input(target_project, core_id)},
+    )
+    assert add_result.data and not add_result.errors
+    attached = add_result.data["addProjectCodeEvaluator"]["evaluator"]
+
+    delete_result = await gql_client.execute(
+        _DELETE,
+        {"input": {"projectEvaluatorIds": [created["id"]]}},
+    )
+    assert delete_result.data and not delete_result.errors
+
+    async with db() as session:
+        core_rowid = int(GlobalID.from_id(core_id).node_id)
+        created_criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+        attached_criteria_id = int(GlobalID.from_id(attached["id"]).node_id)
+        assert await session.get(models.ProjectEvaluatorCriteria, created_criteria_id) is None
+        attached_criteria = await session.get(models.ProjectEvaluatorCriteria, attached_criteria_id)
+        assert attached_criteria is not None
+        assert attached_criteria.evaluator_id == core_rowid
+        assert await session.get(models.CodeEvaluator, core_rowid) is not None
 
 
 async def test_project_llm_evaluator_create_update_delete(
@@ -559,3 +729,11 @@ async def _row_counts(db: DbSessionFactory) -> dict[str, int]:
             or 0
             for model_type in model_types
         }
+
+
+async def _project_evaluator_criteria_count(db: DbSessionFactory) -> int:
+    async with db() as session:
+        return (
+            await session.scalar(select(func.count()).select_from(models.ProjectEvaluatorCriteria))
+            or 0
+        )

--- a/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_evaluator_mutations.py
@@ -1,0 +1,561 @@
+from secrets import token_hex
+from typing import Any
+
+from sqlalchemy import func, select
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+_PROJECT_EVALUATOR_FIELDS = """
+id
+name
+filterCondition
+samplingRate
+evaluationTarget
+enabled
+inputMapping { literalMapping pathMapping }
+evaluator {
+  kind
+  name
+  ... on CodeEvaluator { currentVersion { sourceCode } }
+  ... on LLMEvaluator { promptVersion { id } }
+}
+"""
+
+_CREATE_CODE = f"""
+mutation($input: CreateProjectCodeEvaluatorInput!) {{
+  createProjectCodeEvaluator(input: $input) {{
+    evaluator {{ {_PROJECT_EVALUATOR_FIELDS} }}
+  }}
+}}
+"""
+
+_UPDATE_CODE = f"""
+mutation($input: UpdateProjectCodeEvaluatorInput!) {{
+  updateProjectCodeEvaluator(input: $input) {{
+    evaluator {{ {_PROJECT_EVALUATOR_FIELDS} }}
+  }}
+}}
+"""
+
+_CREATE_LLM = f"""
+mutation($input: CreateProjectLLMEvaluatorInput!) {{
+  createProjectLlmEvaluator(input: $input) {{
+    evaluator {{ {_PROJECT_EVALUATOR_FIELDS} }}
+  }}
+}}
+"""
+
+_UPDATE_LLM = f"""
+mutation($input: UpdateProjectLLMEvaluatorInput!) {{
+  updateProjectLlmEvaluator(input: $input) {{
+    evaluator {{ {_PROJECT_EVALUATOR_FIELDS} }}
+  }}
+}}
+"""
+
+_DELETE = """
+mutation($input: DeleteProjectEvaluatorsInput!) {
+  deleteProjectEvaluators(input: $input) {
+    projectEvaluatorIds
+  }
+}
+"""
+
+_PROJECT_EVALUATORS = f"""
+query($id: ID!) {{
+  node(id: $id) {{
+    ... on Project {{
+      name
+      evaluators {{ edges {{ node {{ {_PROJECT_EVALUATOR_FIELDS} }} }} }}
+    }}
+  }}
+}}
+"""
+
+
+async def _add_project(db: DbSessionFactory) -> models.Project:
+    async with db() as session:
+        project = models.Project(name=f"project-{token_hex(4)}")
+        session.add(project)
+        await session.flush()
+        project_id = project.id
+    async with db() as session:
+        loaded_project = await session.get(models.Project, project_id)
+        assert loaded_project is not None
+        return loaded_project
+
+
+def _mapping(**literal_mapping: Any) -> dict[str, Any]:
+    return {"literalMapping": literal_mapping, "pathMapping": {}}
+
+
+def _code_create_input(
+    project: models.Project,
+    sandbox_config: models.SandboxConfig,
+    *,
+    filter_condition: str = "",
+) -> dict[str, Any]:
+    return {
+        "projectId": str(GlobalID("Project", str(project.id))),
+        "name": f"code-{token_hex(4)}",
+        "sourceCode": "def evaluate(output):\n    return {'score': 1.0}",
+        "language": "PYTHON",
+        "sandboxConfigId": str(GlobalID("SandboxConfig", str(sandbox_config.id))),
+        "evaluatorInputMapping": _mapping(output="value"),
+        "samplingRate": 0.5,
+        "evaluationTarget": "SPAN",
+        "inputMapping": None,
+        "filterCondition": filter_condition,
+        "enabled": True,
+    }
+
+
+def _prompt_version(text: str) -> dict[str, Any]:
+    return {
+        "description": "prompt version",
+        "templateFormat": "MUSTACHE",
+        "template": {"messages": [{"role": "USER", "content": [{"text": {"text": text}}]}]},
+        "invocationParameters": {"openai": {"temperature": 0.0}},
+        "tools": {
+            "tools": [
+                {
+                    "function": {
+                        "name": "correctness",
+                        "description": "correctness",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "label": {
+                                    "type": "string",
+                                    "description": "correctness",
+                                    "enum": ["correct", "incorrect"],
+                                }
+                            },
+                            "required": ["label"],
+                        },
+                    }
+                }
+            ],
+            "toolChoice": {"functionName": "correctness"},
+        },
+        "modelProvider": "OPENAI",
+        "modelName": "gpt-4",
+    }
+
+
+def _llm_input(project: models.Project, *, name: str, text: str) -> dict[str, Any]:
+    return {
+        "projectId": str(GlobalID("Project", str(project.id))),
+        "name": name,
+        "promptVersion": _prompt_version(text),
+        "outputConfigs": [
+            {
+                "categorical": {
+                    "name": "correctness",
+                    "optimizationDirection": "MAXIMIZE",
+                    "values": [
+                        {"label": "correct", "score": 1},
+                        {"label": "incorrect", "score": 0},
+                    ],
+                }
+            }
+        ],
+        "inputMapping": _mapping(input="value"),
+        "samplingRate": 1.0,
+        "evaluationTarget": "TRACE",
+        "filterCondition": "",
+        "enabled": True,
+    }
+
+
+async def test_project_code_evaluator_crud_and_connection(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    create_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(project, sandbox_config)},
+    )
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectCodeEvaluator"]["evaluator"]
+    assert created["evaluationTarget"] == "SPAN"
+    assert created["inputMapping"] == _mapping(output="value")
+    assert created["evaluator"]["kind"] == "CODE"
+
+    project_result = await gql_client.execute(
+        _PROJECT_EVALUATORS,
+        {"id": str(GlobalID("Project", str(project.id)))},
+    )
+    assert project_result.data and not project_result.errors
+    nodes = [edge["node"] for edge in project_result.data["node"]["evaluators"]["edges"]]
+    assert [node["id"] for node in nodes] == [created["id"]]
+
+    update_result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": created["id"],
+                "name": "updated-code",
+                "description": "updated",
+                "sourceCode": "def evaluate(output):\n    return {'score': 0.5}",
+                "evaluatorInputMapping": _mapping(output="updated"),
+                "inputMapping": _mapping(context="override"),
+                "samplingRate": 0.25,
+                "evaluationTarget": "SESSION",
+                "filterCondition": "span_kind == 'LLM'",
+                "enabled": False,
+            }
+        },
+    )
+    assert update_result.data and not update_result.errors
+    updated = update_result.data["updateProjectCodeEvaluator"]["evaluator"]
+    assert updated["name"] == "updated-code"
+    assert updated["evaluationTarget"] == "SESSION"
+    assert updated["inputMapping"] == _mapping(context="override")
+    assert updated["evaluator"]["name"] == "updated-code"
+
+    criteria_id = int(GlobalID.from_id(created["id"]).node_id)
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.input_mapping is not None
+        assert criteria.input_mapping.literal_mapping == {"context": "override"}
+
+    omitted_result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": created["id"],
+                "name": "updated-code",
+                "description": "updated again",
+                "evaluatorInputMapping": _mapping(output="changed-while-omitted"),
+                "samplingRate": 0.75,
+                "evaluationTarget": "TRACE",
+                "filterCondition": "",
+                "enabled": True,
+            }
+        },
+    )
+    assert omitted_result.data and not omitted_result.errors
+    omitted = omitted_result.data["updateProjectCodeEvaluator"]["evaluator"]
+    assert omitted["inputMapping"] == _mapping(context="override")
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.input_mapping is not None
+        assert criteria.input_mapping.literal_mapping == {"context": "override"}
+
+    inherited_result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": created["id"],
+                "name": "updated-code",
+                "description": "updated with inheritance",
+                "evaluatorInputMapping": _mapping(output="inherited"),
+                "inputMapping": None,
+                "samplingRate": 1.0,
+                "evaluationTarget": "SPAN",
+                "filterCondition": "",
+                "enabled": True,
+            }
+        },
+    )
+    assert inherited_result.data and not inherited_result.errors
+    inherited = inherited_result.data["updateProjectCodeEvaluator"]["evaluator"]
+    assert inherited["inputMapping"] == _mapping(output="inherited")
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert criteria.input_mapping is None
+
+    delete_result = await gql_client.execute(
+        _DELETE,
+        {"input": {"projectEvaluatorIds": [created["id"]]}},
+    )
+    assert delete_result.data and not delete_result.errors
+    assert delete_result.data["deleteProjectEvaluators"]["projectEvaluatorIds"] == [created["id"]]
+    async with db() as session:
+        assert await session.get(models.Project, project.id) is not None
+
+
+async def test_project_llm_evaluator_create_update_delete(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+) -> None:
+    project = await _add_project(db)
+    create_input = _llm_input(project, name="llm-evaluator", text="Evaluate {{input}}")
+    create_result = await gql_client.execute(_CREATE_LLM, {"input": create_input})
+    assert create_result.data and not create_result.errors
+    created = create_result.data["createProjectLlmEvaluator"]["evaluator"]
+    assert created["evaluationTarget"] == "TRACE"
+    assert created["evaluator"]["kind"] == "LLM"
+
+    update_input = _llm_input(project, name="updated-llm", text="Updated {{input}}")
+    update_input.pop("projectId")
+    update_input["projectEvaluatorId"] = created["id"]
+    update_input["evaluationTarget"] = "SPAN"
+    update_result = await gql_client.execute(_UPDATE_LLM, {"input": update_input})
+    assert update_result.data and not update_result.errors
+    updated = update_result.data["updateProjectLlmEvaluator"]["evaluator"]
+    assert updated["evaluator"]["name"] == "updated-llm"
+    assert updated["evaluationTarget"] == "SPAN"
+
+    delete_result = await gql_client.execute(
+        _DELETE,
+        {"input": {"projectEvaluatorIds": [created["id"]]}},
+    )
+    assert delete_result.data and not delete_result.errors
+
+
+async def test_invalid_filter_rejects_before_project_evaluator_writes(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    before = await _row_counts(db)
+    result = await gql_client.execute(
+        _CREATE_CODE,
+        {
+            "input": _code_create_input(
+                project,
+                sandbox_config,
+                filter_condition="span_kind === 'LLM'",
+            )
+        },
+    )
+    assert result.errors
+    assert "Invalid filter condition:" in str(result.errors)
+    assert await _row_counts(db) == before
+
+
+async def test_sampling_rate_rejected_at_project_evaluator_input_boundary(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    error_message = "samplingRate must be between 0.0 and 1.0"
+
+    create_code_input = _code_create_input(project, sandbox_config)
+    create_code_input["samplingRate"] = 1.5
+    before = await _row_counts(db)
+    create_code_result = await gql_client.execute(_CREATE_CODE, {"input": create_code_input})
+    assert create_code_result.errors
+    assert create_code_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+    create_llm_input = _llm_input(project, name="invalid-rate-llm", text="Evaluate {{input}}")
+    create_llm_input["samplingRate"] = -0.1
+    create_llm_result = await gql_client.execute(_CREATE_LLM, {"input": create_llm_input})
+    assert create_llm_result.errors
+    assert create_llm_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+    valid_code_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(project, sandbox_config)},
+    )
+    assert valid_code_result.data and not valid_code_result.errors
+    code_evaluator_id = valid_code_result.data["createProjectCodeEvaluator"]["evaluator"]["id"]
+    update_code_input = {
+        "projectEvaluatorId": code_evaluator_id,
+        "name": f"invalid-rate-code-{token_hex(4)}",
+        "evaluatorInputMapping": _mapping(output="value"),
+        "samplingRate": -0.1,
+        "evaluationTarget": "SPAN",
+        "filterCondition": "",
+        "enabled": True,
+    }
+    before = await _row_counts(db)
+    update_code_result = await gql_client.execute(_UPDATE_CODE, {"input": update_code_input})
+    assert update_code_result.errors
+    assert update_code_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+    valid_llm_input = _llm_input(project, name="valid-rate-llm", text="Evaluate {{input}}")
+    valid_llm_result = await gql_client.execute(_CREATE_LLM, {"input": valid_llm_input})
+    assert valid_llm_result.data and not valid_llm_result.errors
+    llm_evaluator_id = valid_llm_result.data["createProjectLlmEvaluator"]["evaluator"]["id"]
+    update_llm_input = _llm_input(project, name="updated-rate-llm", text="Update {{input}}")
+    update_llm_input.pop("projectId")
+    update_llm_input["projectEvaluatorId"] = llm_evaluator_id
+    update_llm_input["samplingRate"] = 1.1
+    before = await _row_counts(db)
+    update_llm_result = await gql_client.execute(_UPDATE_LLM, {"input": update_llm_input})
+    assert update_llm_result.errors
+    assert update_llm_result.errors[0].message == error_message
+    assert await _row_counts(db) == before
+
+
+async def test_update_code_evaluator_rejects_explicit_null_source_code(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    create_result = await gql_client.execute(
+        _CREATE_CODE,
+        {"input": _code_create_input(project, sandbox_config)},
+    )
+    assert create_result.data and not create_result.errors
+    evaluator_id = create_result.data["createProjectCodeEvaluator"]["evaluator"]["id"]
+
+    result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": evaluator_id,
+                "name": f"null-source-{token_hex(4)}",
+                "sourceCode": None,
+                "evaluatorInputMapping": _mapping(output="value"),
+                "samplingRate": 0.5,
+                "evaluationTarget": "SPAN",
+                "filterCondition": "",
+                "enabled": True,
+            }
+        },
+    )
+    assert result.errors
+    assert result.errors[0].message == "source_code cannot be set to null"
+
+
+async def test_create_rolls_back_all_llm_resources_on_late_name_conflict(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    existing_input = _code_create_input(project, sandbox_config)
+    existing_input["name"] = "duplicate-project-evaluator"
+    existing_result = await gql_client.execute(_CREATE_CODE, {"input": existing_input})
+    assert existing_result.data and not existing_result.errors
+
+    before = await _row_counts(db)
+    create_input = _llm_input(project, name="rolled-back-llm", text="Evaluate {{input}}")
+    create_input["name"] = "duplicate-project-evaluator"
+    result = await gql_client.execute(_CREATE_LLM, {"input": create_input})
+
+    assert result.errors
+    assert result.errors[0].message == (
+        "A project evaluator with this name already exists for this project"
+    )
+    assert await _row_counts(db) == before
+
+
+async def test_update_rolls_back_code_version_and_state_on_late_name_conflict(
+    gql_client: AsyncGraphQLClient,
+    db: DbSessionFactory,
+    sandbox_config: models.SandboxConfig,
+) -> None:
+    project = await _add_project(db)
+    first_input = _code_create_input(project, sandbox_config)
+    first_input["name"] = "first-project-evaluator"
+    first_result = await gql_client.execute(_CREATE_CODE, {"input": first_input})
+    assert first_result.data and not first_result.errors
+    first = first_result.data["createProjectCodeEvaluator"]["evaluator"]
+
+    second_input = _code_create_input(project, sandbox_config)
+    second_input["name"] = "second-project-evaluator"
+    second_result = await gql_client.execute(_CREATE_CODE, {"input": second_input})
+    assert second_result.data and not second_result.errors
+
+    criteria_id = int(GlobalID.from_id(first["id"]).node_id)
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        evaluator = await session.get(models.CodeEvaluator, criteria.evaluator_id)
+        assert evaluator is not None
+        evaluator_id = evaluator.id
+        state_before = (
+            str(evaluator.name),
+            evaluator.description,
+            evaluator.input_mapping.model_dump(mode="json"),
+            str(criteria.name),
+            criteria.filter_condition,
+            criteria.sampling_rate,
+            criteria.evaluation_target,
+            criteria.input_mapping,
+            criteria.enabled,
+        )
+        versions_before = tuple(
+            await session.scalars(
+                select(models.CodeEvaluatorVersion.source_code)
+                .where(models.CodeEvaluatorVersion.code_evaluator_id == evaluator_id)
+                .order_by(models.CodeEvaluatorVersion.id)
+            )
+        )
+    counts_before = await _row_counts(db)
+
+    result = await gql_client.execute(
+        _UPDATE_CODE,
+        {
+            "input": {
+                "projectEvaluatorId": first["id"],
+                "name": "second-project-evaluator",
+                "description": "must roll back",
+                "sourceCode": "def evaluate(output):\n    return {'score': 0.0}",
+                "evaluatorInputMapping": _mapping(changed="value"),
+                "inputMapping": _mapping(override="value"),
+                "samplingRate": 0.9,
+                "evaluationTarget": "TRACE",
+                "filterCondition": "span_kind == 'LLM'",
+                "enabled": False,
+            }
+        },
+    )
+    assert result.errors
+    assert result.errors[0].message == (
+        "A project evaluator with this name already exists for this project"
+    )
+    assert await _row_counts(db) == counts_before
+
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        evaluator = await session.get(models.CodeEvaluator, evaluator_id)
+        assert criteria is not None and evaluator is not None
+        state_after = (
+            str(evaluator.name),
+            evaluator.description,
+            evaluator.input_mapping.model_dump(mode="json"),
+            str(criteria.name),
+            criteria.filter_condition,
+            criteria.sampling_rate,
+            criteria.evaluation_target,
+            criteria.input_mapping,
+            criteria.enabled,
+        )
+        versions_after = tuple(
+            await session.scalars(
+                select(models.CodeEvaluatorVersion.source_code)
+                .where(models.CodeEvaluatorVersion.code_evaluator_id == evaluator_id)
+                .order_by(models.CodeEvaluatorVersion.id)
+            )
+        )
+    assert state_after == state_before
+    assert versions_after == versions_before
+
+
+async def _row_counts(db: DbSessionFactory) -> dict[str, int]:
+    async with db() as session:
+        model_types = (
+            models.Evaluator,
+            models.Prompt,
+            models.PromptVersion,
+            models.PromptVersionTag,
+            models.PromptLabel,
+            models.PromptPromptLabel,
+            models.CodeEvaluatorVersion,
+            models.ProjectEvaluatorCriteria,
+        )
+        return {
+            model_type.__name__: await session.scalar(select(func.count()).select_from(model_type))
+            or 0
+            for model_type in model_types
+        }

--- a/tests/unit/server/online_eval/test_app_wiring.py
+++ b/tests/unit/server/online_eval/test_app_wiring.py
@@ -1,10 +1,10 @@
-"""End-to-end wiring test for the online-eval producer daemon behind
-``PHOENIX_ONLINE_EVAL_ENABLED``: the enabled app starts and stops the producer
+"""End-to-end wiring test for the online-eval daemons behind
+``PHOENIX_ONLINE_EVAL_ENABLED``: the enabled app starts and stops both daemons
 through the lifespan, and a seeded criteria + span flows producer tick →
-PENDING work unit. (The consumer daemon and its wiring land in the stacked
-follow-up PR; until then materialized units rest as PENDING.)
+consumer cycle → span annotation with the work unit DONE.
 """
 
+import asyncio
 from contextlib import AsyncExitStack
 from datetime import datetime, timedelta, timezone
 
@@ -16,6 +16,7 @@ from phoenix.config import ENV_PHOENIX_ONLINE_EVAL_ENABLED
 from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.app import create_app
+from phoenix.server.online_eval.consumer import OnlineEvalConsumer
 from phoenix.server.online_eval.producer import OnlineEvalProducer
 from phoenix.server.types import DbSessionFactory
 from tests.unit.conftest import (
@@ -25,34 +26,49 @@ from tests.unit.conftest import (
 )
 
 from ..._helpers import _add_project, _add_span, _add_trace
-from .test_producer import _seed_criteria
+from .test_consumer import _patch_playground_client, _seed_llm_criteria, _StubLLMClient
 
 
-def _create_app(db: DbSessionFactory):  # type: ignore[no-untyped-def]
+def _create_app(db: DbSessionFactory, *, read_only: bool = False):  # type: ignore[no-untyped-def]
     return create_app(
         db=db,
         authentication_enabled=False,
         serve_ui=False,
         bulk_inserter_factory=TestBulkInserter,
+        read_only=read_only,
     )
 
 
-async def test_online_eval_producer_absent_by_default(db: DbSessionFactory) -> None:
+async def test_online_eval_daemons_absent_by_default(db: DbSessionFactory) -> None:
     app = _create_app(db)
     assert app.state.online_eval_producer is None
+    assert app.state.online_eval_consumer is None
 
 
-async def test_enabled_app_materializes_seeded_criteria(
+async def test_online_eval_daemons_absent_in_read_only_mode(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_ENABLED, "true")
+
+    app = _create_app(db, read_only=True)
+    assert app.state.online_eval_producer is None
+    assert app.state.online_eval_consumer is None
+
+
+async def test_enabled_app_runs_seeded_criteria_end_to_end(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_ENABLED, "true")
+    _patch_playground_client(monkeypatch, _StubLLMClient())
 
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(patch_batched_caller())
         await stack.enter_async_context(patch_grpc_server())
         app = _create_app(db)
         producer = app.state.online_eval_producer
+        consumer = app.state.online_eval_consumer
         assert isinstance(producer, OnlineEvalProducer)
+        assert isinstance(consumer, OnlineEvalConsumer)
         await stack.enter_async_context(LifespanManager(app))
 
         async with db() as session:
@@ -63,7 +79,7 @@ async def test_enabled_app_materializes_seeded_criteria(
                 trace,
                 attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
             )
-        _, criteria_id = await _seed_criteria(db, project.id)
+        _, criteria_id = await _seed_llm_criteria(db, project.id)
 
         # Age the cursor's high-water observation past the frontier lag so the
         # next tick's scan window covers the seeded span. The daemon's own
@@ -98,4 +114,26 @@ async def test_enabled_app_materializes_seeded_criteria(
             )
         assert unit is not None
         assert unit.criteria_id == criteria_id
-        assert unit.status == "PENDING"
+
+        await consumer._cycle()
+
+        # The daemon's own background cycle may have claimed the unit ahead of
+        # the explicit cycle above; either path lands on DONE within moments.
+        deadline = asyncio.get_running_loop().time() + 10
+        while True:
+            async with db() as session:
+                refreshed = await session.get(models.EvalWorkUnit, unit.id)
+                assert refreshed is not None
+                status = refreshed.status
+            if status == "DONE" or asyncio.get_running_loop().time() > deadline:
+                break
+            await asyncio.sleep(0.05)
+        assert status == "DONE"
+
+        async with db() as session:
+            annotation = await session.scalar(
+                select(models.SpanAnnotation).where(models.SpanAnnotation.span_rowid == span.id)
+            )
+        assert annotation is not None
+        assert annotation.label == "good"
+        assert annotation.source == "API"

--- a/tests/unit/server/online_eval/test_app_wiring.py
+++ b/tests/unit/server/online_eval/test_app_wiring.py
@@ -1,0 +1,101 @@
+"""End-to-end wiring test for the online-eval producer daemon behind
+``PHOENIX_ONLINE_EVAL_ENABLED``: the enabled app starts and stops the producer
+through the lifespan, and a seeded criteria + span flows producer tick →
+PENDING work unit. (The consumer daemon and its wiring land in the stacked
+follow-up PR; until then materialized units rest as PENDING.)
+"""
+
+from contextlib import AsyncExitStack
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from asgi_lifespan import LifespanManager
+from sqlalchemy import select, update
+
+from phoenix.config import ENV_PHOENIX_ONLINE_EVAL_ENABLED
+from phoenix.db import models
+from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
+from phoenix.server.app import create_app
+from phoenix.server.online_eval.producer import OnlineEvalProducer
+from phoenix.server.types import DbSessionFactory
+from tests.unit.conftest import (
+    TestBulkInserter,
+    patch_batched_caller,
+    patch_grpc_server,
+)
+
+from ..._helpers import _add_project, _add_span, _add_trace
+from .test_producer import _seed_criteria
+
+
+def _create_app(db: DbSessionFactory):  # type: ignore[no-untyped-def]
+    return create_app(
+        db=db,
+        authentication_enabled=False,
+        serve_ui=False,
+        bulk_inserter_factory=TestBulkInserter,
+    )
+
+
+async def test_online_eval_producer_absent_by_default(db: DbSessionFactory) -> None:
+    app = _create_app(db)
+    assert app.state.online_eval_producer is None
+
+
+async def test_enabled_app_materializes_seeded_criteria(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ENV_PHOENIX_ONLINE_EVAL_ENABLED, "true")
+
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        app = _create_app(db)
+        producer = app.state.online_eval_producer
+        assert isinstance(producer, OnlineEvalProducer)
+        await stack.enter_async_context(LifespanManager(app))
+
+        async with db() as session:
+            project = await _add_project(session)
+            trace = await _add_trace(session, project)
+            span = await _add_span(
+                session,
+                trace,
+                attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+            )
+        _, criteria_id = await _seed_criteria(db, project.id)
+
+        # Age the cursor's high-water observation past the frontier lag so the
+        # next tick's scan window covers the seeded span. The daemon's own
+        # startup tick may already have created (and leased) the cursor row.
+        async with db() as session:
+            await session.execute(
+                insert_on_conflict(
+                    {"grain": "SPAN", "consumer_group": "default", "produced_through_id": 0},
+                    table=models.EvalWorkCursor,
+                    dialect=db.dialect,
+                    unique_by=("grain", "consumer_group"),
+                    on_conflict=OnConflict.DO_NOTHING,
+                )
+            )
+            await session.execute(
+                update(models.EvalWorkCursor)
+                .where(
+                    models.EvalWorkCursor.grain == "SPAN",
+                    models.EvalWorkCursor.consumer_group == "default",
+                )
+                .values(
+                    produced_through_id=0,
+                    observed_high_water_id=span.id,
+                    observed_at=datetime.now(timezone.utc) - timedelta(seconds=120),
+                )
+            )
+
+        await producer._tick()
+        async with db() as session:
+            unit = await session.scalar(
+                select(models.EvalWorkUnit).where(models.EvalWorkUnit.span_rowid == span.id)
+            )
+        assert unit is not None
+        assert unit.criteria_id == criteria_id
+        assert unit.status == "PENDING"

--- a/tests/unit/server/online_eval/test_app_wiring.py
+++ b/tests/unit/server/online_eval/test_app_wiring.py
@@ -87,17 +87,21 @@ async def test_enabled_app_runs_seeded_criteria_end_to_end(
         async with db() as session:
             await session.execute(
                 insert_on_conflict(
-                    {"grain": "SPAN", "consumer_group": "default", "produced_through_id": 0},
+                    {
+                        "evaluation_target": "SPAN",
+                        "consumer_group": "default",
+                        "produced_through_id": 0,
+                    },
                     table=models.EvalWorkCursor,
                     dialect=db.dialect,
-                    unique_by=("grain", "consumer_group"),
+                    unique_by=("evaluation_target", "consumer_group"),
                     on_conflict=OnConflict.DO_NOTHING,
                 )
             )
             await session.execute(
                 update(models.EvalWorkCursor)
                 .where(
-                    models.EvalWorkCursor.grain == "SPAN",
+                    models.EvalWorkCursor.evaluation_target == "SPAN",
                     models.EvalWorkCursor.consumer_group == "default",
                 )
                 .values(

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -52,6 +52,7 @@ from phoenix.server.online_eval.executor import (
     EvalExecutionError,
     HydratedWorkUnit,
     OnlineEvalExecutor,
+    span_eval_context,
 )
 from phoenix.server.online_eval.producer import resolve_criteria
 from phoenix.server.sandbox.types import ExecutionResult
@@ -425,6 +426,36 @@ async def _annotations(db: DbSessionFactory) -> list[models.SpanAnnotation]:
         return list(await session.scalars(select(models.SpanAnnotation)))
 
 
+async def test_span_eval_context_nests_span_fields_under_metadata(
+    db: DbSessionFactory,
+) -> None:
+    attributes = {
+        "input": {"value": "span input"},
+        "output": {"value": "span output"},
+        "metadata": {"user": "value"},
+        "custom": {"nested": "value"},
+    }
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace, attributes=attributes)
+
+        context = span_eval_context(span)
+
+    assert set(context) == {"input", "output", "metadata"}
+    assert context == {
+        "input": "span input",
+        "output": "span output",
+        "metadata": {
+            "attributes": attributes,
+            "name": span.name,
+            "span_kind": "LLM",
+            "status_code": "OK",
+            "status_message": "test_status_message",
+        },
+    }
+
+
 async def test_happy_path_claims_evaluates_annotates_and_completes(
     db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -481,7 +512,7 @@ async def test_llm_criteria_input_mapping_override_is_used_during_execution(
         project.id,
         template_content="Question: {{question}}\nAnswer: {{answer}}",
         criteria_input_mapping=InputMapping(
-            path_mapping={"question": "attributes.remapped.question"},
+            path_mapping={"question": "metadata.attributes.remapped.question"},
             literal_mapping={"answer": "literal answer"},
         ),
     )
@@ -522,7 +553,7 @@ async def test_builtin_criteria_input_mapping_override_is_used_during_execution(
             sampling_rate=1.0,
             evaluation_target="SPAN",
             input_mapping=InputMapping(
-                path_mapping={"text": "attributes.remapped.text"},
+                path_mapping={"text": "metadata.attributes.remapped.text"},
                 literal_mapping={"words": "mapped value"},
             ),
         )
@@ -555,7 +586,7 @@ async def test_code_criteria_input_mapping_override_is_used_during_execution(
         db,
         project.id,
         criteria_input_mapping=InputMapping(
-            path_mapping={"output": "attributes.remapped.value"},
+            path_mapping={"output": "metadata.attributes.remapped.value"},
             literal_mapping={"metadata": "criteria literal"},
         ),
     )

--- a/tests/unit/server/online_eval/test_consumer.py
+++ b/tests/unit/server/online_eval/test_consumer.py
@@ -1,0 +1,1147 @@
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from queue import SimpleQueue
+from secrets import token_hex
+from typing import Any, AsyncIterator, Optional, Sequence, cast
+
+import httpx
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.orm import with_polymorphic
+
+from phoenix.db import models
+from phoenix.db.types.annotation_configs import (
+    CategoricalAnnotationValue,
+    CategoricalOutputConfig,
+    ContinuousOutputConfig,
+    OptimizationDirection,
+    OutputConfigType,
+)
+from phoenix.db.types.evaluators import InputMapping
+from phoenix.db.types.identifier import Identifier
+from phoenix.db.types.model_provider import ModelProvider
+from phoenix.db.types.prompts import (
+    PromptChatTemplate,
+    PromptMessage,
+    PromptOpenAIInvocationParameters,
+    PromptOpenAIInvocationParametersContent,
+    PromptTemplateFormat,
+    PromptTemplateType,
+    PromptToolChoiceOneOrMore,
+    PromptToolFunction,
+    PromptToolFunctionDefinition,
+    PromptTools,
+)
+from phoenix.server.api.types.ChatCompletionSubscriptionPayload import (
+    FunctionCallChunk,
+    ToolCallChunk,
+)
+from phoenix.server.dml_event import DmlEvent, SpanAnnotationInsertEvent
+from phoenix.server.online_eval import consumer as consumer_module
+from phoenix.server.online_eval import executor as executor_module
+from phoenix.server.online_eval.consumer import (
+    EvalExecutionTimeout,
+    OnlineEvalConsumer,
+    is_transient_error,
+)
+from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS, ClaimedWorkUnit
+from phoenix.server.online_eval.db_coordinator import DbEvalWorkCoordinator
+from phoenix.server.online_eval.derivation import annotation_identifier, config_fingerprint
+from phoenix.server.online_eval.executor import (
+    EvalExecutionError,
+    HydratedWorkUnit,
+    OnlineEvalExecutor,
+)
+from phoenix.server.online_eval.producer import resolve_criteria
+from phoenix.server.sandbox.types import ExecutionResult
+from phoenix.server.types import DbSessionFactory
+
+from ..._helpers import _add_project, _add_span, _add_trace
+
+
+class _StubLLMClient:
+    """Streams a single canned tool call, or raises to simulate a provider error."""
+
+    def __init__(
+        self,
+        tool_name: str = "quality",
+        arguments: str = '{"label": "good", "explanation": "looks good"}',
+        error: Optional[Exception] = None,
+    ) -> None:
+        self._tool_name = tool_name
+        self._arguments = arguments
+        self._error = error
+        self.requests: list[dict[str, Any]] = []
+
+    async def chat_completion_create(self, **kwargs: Any) -> AsyncIterator[Any]:
+        self.requests.append(kwargs)
+        if self._error is not None:
+            raise self._error
+        yield ToolCallChunk(
+            id="call-1",
+            function=FunctionCallChunk(name=self._tool_name, arguments=self._arguments),
+        )
+
+
+def _patch_playground_client(monkeypatch: pytest.MonkeyPatch, client: _StubLLMClient) -> None:
+    async def _get_client(**_: Any) -> _StubLLMClient:
+        return client
+
+    monkeypatch.setattr("phoenix.server.online_eval.executor.get_playground_client", _get_client)
+
+
+class _StubSandboxBackend:
+    secret_values: tuple[str, ...] = ()
+
+
+class _StubSandboxSession:
+    def __init__(self) -> None:
+        self.executed_code: list[str] = []
+
+    async def execute(self, code: str, *, timeout: Optional[int] = None) -> ExecutionResult:
+        self.executed_code.append(code)
+        return ExecutionResult(
+            stdout="===PHOENIX_RESULT_BEGIN===\n0.75\n===PHOENIX_RESULT_END===\n",
+            stderr="",
+        )
+
+
+class _StubSandboxSessionManager:
+    replica_id = "test-replica"
+
+    def __init__(self) -> None:
+        self.session = _StubSandboxSession()
+        self.session_keys: list[str] = []
+
+    @asynccontextmanager
+    async def acquire(self, _backend: Any, session_key: str) -> AsyncIterator[_StubSandboxSession]:
+        self.session_keys.append(session_key)
+        yield self.session
+
+
+class _StubEvaluator:
+    def __init__(self, results: list[dict[str, Any]]) -> None:
+        self._results = results
+
+    async def evaluate(self, **_: Any) -> list[dict[str, Any]]:
+        return self._results
+
+
+def _output_config(name: str) -> CategoricalOutputConfig:
+    return CategoricalOutputConfig(
+        type="CATEGORICAL",
+        name=name,
+        optimization_direction=OptimizationDirection.MAXIMIZE,
+        description=None,
+        values=[
+            CategoricalAnnotationValue(label="good", score=1.0),
+            CategoricalAnnotationValue(label="bad", score=0.0),
+        ],
+    )
+
+
+def _evaluation_result(
+    name: str,
+    *,
+    error: Optional[str] = None,
+    error_exc: Optional[Exception] = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "name": name,
+        "label": None if error else "good",
+        "score": None if error else 1.0,
+        "explanation": None,
+        "metadata": {},
+        "error": error,
+    }
+    if error_exc is not None:
+        result["error_exc"] = error_exc
+    return result
+
+
+def _hydrated_stub(
+    *,
+    results: list[dict[str, Any]],
+    evaluator_kind: str,
+    output_configs: Sequence[OutputConfigType],
+    annotation_name: str = "criterion",
+) -> HydratedWorkUnit:
+    return HydratedWorkUnit(
+        annotation_name=annotation_name,
+        annotator_kind="LLM" if evaluator_kind == "LLM" else "CODE",
+        evaluator_kind=cast(Any, evaluator_kind),
+        evaluator=cast(Any, _StubEvaluator(results)),
+        input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+        output_configs=output_configs,
+        context={},
+    )
+
+
+def _claimed_unit(span_rowid: int, *, work_unit_id: int = 1) -> ClaimedWorkUnit:
+    now = datetime.now(timezone.utc)
+    return ClaimedWorkUnit(
+        work_unit_id=work_unit_id,
+        span_rowid=span_rowid,
+        evaluator_id=1,
+        criteria_id=1,
+        config_fingerprint="fingerprint",
+        identifier="online:fingerprint",
+        attempts=0,
+        claimed_by="consumer",
+        lease_expires_at=now + timedelta(seconds=LEASE_TTL_SECONDS),
+    )
+
+
+async def _seed_llm_criteria(
+    db: DbSessionFactory,
+    project_id: int,
+    *,
+    template_content: str = "Input: {{input}}\n\nOutput: {{output}}\n\nGood?",
+    criteria_input_mapping: Optional[InputMapping] = None,
+) -> tuple[int, int]:
+    """Create an LLM evaluator (prompt + version + tools) and an enabled criteria
+    row, returning (evaluator_id, criteria_id)."""
+    async with db() as session:
+        prompt = models.Prompt(
+            name=Identifier(root=f"prompt-{token_hex(4)}"),
+            description=None,
+            prompt_versions=[
+                models.PromptVersion(
+                    template_type=PromptTemplateType.CHAT,
+                    template_format=PromptTemplateFormat.MUSTACHE,
+                    template=PromptChatTemplate(
+                        type="chat",
+                        messages=[
+                            PromptMessage(
+                                role="user",
+                                content=template_content,
+                            ),
+                        ],
+                    ),
+                    invocation_parameters=PromptOpenAIInvocationParameters(
+                        type="openai", openai=PromptOpenAIInvocationParametersContent()
+                    ),
+                    tools=PromptTools(
+                        type="tools",
+                        tools=[
+                            PromptToolFunction(
+                                type="function",
+                                function=PromptToolFunctionDefinition(
+                                    name="quality",
+                                    description="rates output quality",
+                                    parameters={
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {
+                                                "type": "string",
+                                                "enum": ["good", "bad"],
+                                            },
+                                        },
+                                        "required": ["label"],
+                                    },
+                                ),
+                            )
+                        ],
+                        tool_choice=PromptToolChoiceOneOrMore(type="one_or_more"),
+                    ),
+                    response_format=None,
+                    model_provider=ModelProvider.OPENAI,
+                    model_name="gpt-4",
+                    metadata_={},
+                )
+            ],
+        )
+        evaluator = models.LLMEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            description=None,
+            kind="LLM",
+            output_configs=[
+                CategoricalOutputConfig(
+                    type="CATEGORICAL",
+                    name="quality",
+                    optimization_direction=OptimizationDirection.MAXIMIZE,
+                    description=None,
+                    values=[
+                        CategoricalAnnotationValue(label="good", score=1.0),
+                        CategoricalAnnotationValue(label="bad", score=0.0),
+                    ],
+                )
+            ],
+            prompt=prompt,
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project_id,
+            evaluator_id=evaluator.id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SPAN",
+            input_mapping=criteria_input_mapping,
+        )
+        session.add(criteria)
+        await session.flush()
+        return evaluator.id, criteria.id
+
+
+async def _seed_code_criteria(
+    db: DbSessionFactory,
+    project_id: int,
+    *,
+    criteria_input_mapping: InputMapping,
+) -> tuple[int, int]:
+    async with db() as session:
+        language = await session.get(models.Language, "PYTHON")
+        if language is None:
+            session.add(models.Language(name="PYTHON"))
+        provider = await session.get(models.SandboxProvider, "WASM")
+        if provider is None:
+            session.add(
+                models.SandboxProvider(
+                    backend_type="WASM",
+                    enabled=True,
+                    config={},
+                )
+            )
+        await session.flush()
+        sandbox_config = models.SandboxConfig(
+            backend_type="WASM",
+            language="PYTHON",
+            name=Identifier(root=f"sandbox-{token_hex(4)}"),
+            description=None,
+            config={},
+            timeout=30,
+        )
+        session.add(sandbox_config)
+        await session.flush()
+        evaluator = models.CodeEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            description=None,
+            kind="CODE",
+            language="PYTHON",
+            sandbox_config_id=sandbox_config.id,
+            input_mapping=InputMapping(
+                literal_mapping={
+                    "output": "evaluator default",
+                    "metadata": "evaluator default",
+                },
+                path_mapping={},
+            ),
+            output_configs=[
+                ContinuousOutputConfig(
+                    type="CONTINUOUS",
+                    name="score",
+                    optimization_direction=OptimizationDirection.MAXIMIZE,
+                    description=None,
+                    lower_bound=0.0,
+                    upper_bound=1.0,
+                )
+            ],
+            versions=[
+                models.CodeEvaluatorVersion(
+                    source_code="def evaluate(output, metadata): return 0.75"
+                )
+            ],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project_id,
+            evaluator_id=evaluator.id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SPAN",
+            input_mapping=criteria_input_mapping,
+        )
+        session.add(criteria)
+        await session.flush()
+        return evaluator.id, criteria.id
+
+
+async def _seed_builtin_criteria(db: DbSessionFactory, project_id: int) -> tuple[int, int]:
+    async with db() as session:
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project_id,
+            evaluator_id=evaluator.id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SPAN",
+        )
+        session.add(criteria)
+        await session.flush()
+        return evaluator.id, criteria.id
+
+
+async def _materialize_unit(
+    db: DbSessionFactory, span_rowid: int, evaluator_id: int, criteria_id: int
+) -> tuple[int, str]:
+    """Materialize one PENDING work unit exactly as the producer would, returning
+    (work_unit_id, config_fingerprint)."""
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        polymorphic = with_polymorphic(
+            models.Evaluator,
+            [models.LLMEvaluator, models.CodeEvaluator, models.BuiltinEvaluator],
+        )
+        evaluator = await session.scalar(select(polymorphic).where(polymorphic.id == evaluator_id))
+        assert evaluator is not None
+        resolved = await resolve_criteria(session, criteria, evaluator)
+        assert resolved is not None
+        fingerprint = config_fingerprint(resolved)
+        unit = models.EvalWorkUnit(
+            span_rowid=span_rowid,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=fingerprint,
+        )
+        session.add(unit)
+        await session.flush()
+        return unit.id, fingerprint
+
+
+async def _get_unit(db: DbSessionFactory, unit_id: int) -> models.EvalWorkUnit:
+    async with db() as session:
+        unit = await session.get(models.EvalWorkUnit, unit_id)
+        assert unit is not None
+        return unit
+
+
+async def _annotations(db: DbSessionFactory) -> list[models.SpanAnnotation]:
+    async with db() as session:
+        return list(await session.scalars(select(models.SpanAnnotation)))
+
+
+async def test_happy_path_claims_evaluates_annotates_and_completes(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(db, project.id)
+    unit_id, fingerprint = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    _patch_playground_client(monkeypatch, _StubLLMClient())
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "DONE"
+    annotations = await _annotations(db)
+    assert len(annotations) == 1
+    annotation = annotations[0]
+    async with db() as session:
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        assert annotation.name == criteria.name.root
+    assert annotation.span_rowid == span.id
+    assert annotation.label == "good"
+    assert annotation.score == 1.0
+    assert annotation.explanation == "looks good"
+    assert annotation.annotator_kind == "LLM"
+    assert annotation.source == "API"
+    assert annotation.identifier == annotation_identifier(fingerprint)
+
+    # Nothing is claimable afterwards; a repeat cycle writes nothing new.
+    await consumer._cycle()
+    assert len(await _annotations(db)) == 1
+
+
+async def test_llm_criteria_input_mapping_override_is_used_during_execution(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"remapped": {"question": "mapped question"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(
+        db,
+        project.id,
+        template_content="Question: {{question}}\nAnswer: {{answer}}",
+        criteria_input_mapping=InputMapping(
+            path_mapping={"question": "attributes.remapped.question"},
+            literal_mapping={"answer": "literal answer"},
+        ),
+    )
+    await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    client = _StubLLMClient()
+    _patch_playground_client(monkeypatch, client)
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    await consumer._cycle()
+
+    assert len(client.requests) == 1
+    messages = client.requests[0]["messages"]
+    assert messages[0]["content"] == "Question: mapped question\nAnswer: literal answer"
+    assert len(await _annotations(db)) == 1
+
+
+async def test_builtin_criteria_input_mapping_override_is_used_during_execution(
+    db: DbSessionFactory,
+    synced_builtin_evaluators: None,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"remapped": {"text": "the mapped value is present"}},
+        )
+        evaluator_id = await session.scalar(
+            select(models.BuiltinEvaluator.id).where(models.BuiltinEvaluator.key == "contains")
+        )
+        assert evaluator_id is not None
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator_id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SPAN",
+            input_mapping=InputMapping(
+                path_mapping={"text": "attributes.remapped.text"},
+                literal_mapping={"words": "mapped value"},
+            ),
+        )
+        session.add(criteria)
+        await session.flush()
+        criteria_id = criteria.id
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    await consumer._cycle()
+
+    assert (await _get_unit(db, unit_id)).status == "DONE"
+    (annotation,) = await _annotations(db)
+    assert annotation.label == "true"
+    assert annotation.score == 1.0
+
+
+async def test_code_criteria_input_mapping_override_is_used_during_execution(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"remapped": {"value": "mapped context"}},
+        )
+    evaluator_id, criteria_id = await _seed_code_criteria(
+        db,
+        project.id,
+        criteria_input_mapping=InputMapping(
+            path_mapping={"output": "attributes.remapped.value"},
+            literal_mapping={"metadata": "criteria literal"},
+        ),
+    )
+    await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    coordinator = DbEvalWorkCoordinator(db)
+    (unit,) = await coordinator.claim(claimed_by="consumer", limit=1)
+    manager = _StubSandboxSessionManager()
+
+    async def _build_backend(*_: Any, **__: Any) -> _StubSandboxBackend:
+        return _StubSandboxBackend()
+
+    monkeypatch.setattr(executor_module, "build_sandbox_backend", _build_backend)
+    executor = OnlineEvalExecutor(
+        db,
+        decrypt=lambda value: value,
+        sandbox_session_manager=cast(Any, manager),
+    )
+    hydrated = await executor.hydrate(unit)
+    assert hydrated is not None
+
+    await executor.evaluate_and_annotate(unit, hydrated)
+
+    (executed_code,) = manager.session.executed_code
+    assert "mapped context" in executed_code
+    assert "criteria literal" in executed_code
+    assert "evaluator default" not in executed_code
+    assert manager.session_keys == [f"online-eval:{evaluator_id}:test-replica"]
+    annotation = (await _annotations(db))[0]
+    assert annotation.score == 0.75
+
+
+@pytest.mark.parametrize(
+    ("configuration_state", "error_message"),
+    [
+        ("missing", "has no sandbox config"),
+        ("disabled", "is missing or disabled"),
+        ("provider_disabled", "sandbox provider 'WASM' is missing or disabled"),
+    ],
+)
+async def test_code_hydration_configuration_failure_counts_attempt(
+    db: DbSessionFactory,
+    configuration_state: str,
+    error_message: str,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_code_criteria(
+        db,
+        project.id,
+        criteria_input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
+    )
+    async with db() as session:
+        evaluator = await session.get(models.CodeEvaluator, evaluator_id)
+        assert evaluator is not None
+        if configuration_state == "missing":
+            evaluator.sandbox_config_id = None
+        else:
+            assert evaluator.sandbox_config_id is not None
+            sandbox_config = await session.get(models.SandboxConfig, evaluator.sandbox_config_id)
+            assert sandbox_config is not None
+            if configuration_state == "disabled":
+                sandbox_config.enabled = False
+            else:
+                provider = await session.get(models.SandboxProvider, sandbox_config.backend_type)
+                assert provider is not None
+                provider.enabled = False
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+
+    consumer = OnlineEvalConsumer(
+        db,
+        decrypt=lambda value: value,
+        sandbox_session_manager=cast(Any, _StubSandboxSessionManager()),
+    )
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "ERROR"
+    assert unit.attempts == 1
+    assert unit.error is not None
+    assert error_message in unit.error
+    assert await _annotations(db) == []
+
+
+async def test_reclaimed_execution_writes_one_annotation_and_one_insert_event(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    _patch_playground_client(monkeypatch, _StubLLMClient())
+    coordinator = DbEvalWorkCoordinator(db)
+
+    (first_claim,) = await coordinator.claim(claimed_by="consumer-1", limit=1)
+    lapsed = datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(claimed_at=lapsed)
+        )
+    (reclaimed,) = await coordinator.claim(claimed_by="consumer-2", limit=1)
+    assert reclaimed.work_unit_id == first_claim.work_unit_id
+    assert reclaimed.identifier == first_claim.identifier
+
+    events: SimpleQueue[DmlEvent] = SimpleQueue()
+    executor = OnlineEvalExecutor(db, decrypt=lambda b: b, event_queue=events)
+    first_hydrated = await executor.hydrate(first_claim)
+    reclaimed_hydrated = await executor.hydrate(reclaimed)
+    assert first_hydrated is not None
+    assert reclaimed_hydrated is not None
+
+    await executor.evaluate_and_annotate(first_claim, first_hydrated)
+    await executor.evaluate_and_annotate(reclaimed, reclaimed_hydrated)
+
+    annotations = await _annotations(db)
+    assert len(annotations) == 1
+    assert events.get_nowait() == SpanAnnotationInsertEvent((annotations[0].id,))
+    assert events.empty()
+
+
+async def test_llm_incomplete_result_set_writes_nothing(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    output_configs = [_output_config("quality"), _output_config("relevance")]
+    hydrated = _hydrated_stub(
+        results=[_evaluation_result("criterion.quality")],
+        evaluator_kind="LLM",
+        output_configs=output_configs,
+    )
+    executor = OnlineEvalExecutor(db, decrypt=lambda value: value)
+
+    with pytest.raises(EvalExecutionError, match="incomplete result set"):
+        await executor.evaluate_and_annotate(_claimed_unit(span.id), hydrated)
+
+    assert await _annotations(db) == []
+
+
+async def test_code_mixed_result_set_writes_nothing(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    output_configs = [_output_config("quality"), _output_config("relevance")]
+    original_error = RuntimeError("second output failed")
+    hydrated = _hydrated_stub(
+        results=[
+            _evaluation_result("criterion.quality"),
+            _evaluation_result(
+                "criterion.relevance",
+                error="second output failed",
+                error_exc=original_error,
+            ),
+        ],
+        evaluator_kind="CODE",
+        output_configs=output_configs,
+    )
+    executor = OnlineEvalExecutor(db, decrypt=lambda value: value)
+
+    with pytest.raises(EvalExecutionError, match="second output failed") as exc_info:
+        await executor.evaluate_and_annotate(_claimed_unit(span.id), hydrated)
+
+    assert exc_info.value.__cause__ is original_error
+    assert await _annotations(db) == []
+
+
+async def test_complete_result_set_is_written_atomically(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    output_configs = [_output_config("quality"), _output_config("relevance")]
+    hydrated = _hydrated_stub(
+        results=[
+            _evaluation_result("criterion.quality"),
+            _evaluation_result("criterion.relevance"),
+        ],
+        evaluator_kind="CODE",
+        output_configs=output_configs,
+    )
+    executor = OnlineEvalExecutor(db, decrypt=lambda value: value)
+
+    await executor.evaluate_and_annotate(_claimed_unit(span.id), hydrated)
+
+    annotations = await _annotations(db)
+    assert {annotation.name for annotation in annotations} == {
+        "criterion.quality",
+        "criterion.relevance",
+    }
+
+
+async def test_evaluator_error_fails_unit_with_cooldown_and_no_annotation(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    _patch_playground_client(monkeypatch, _StubLLMClient(error=RuntimeError("provider is down")))
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    before = datetime.now(timezone.utc)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "ERROR"
+    assert unit.attempts == 1
+    assert unit.error is not None
+    assert "provider is down" in unit.error
+    assert unit.cooldown_until is not None
+    assert unit.cooldown_until > before
+    assert await _annotations(db) == []
+
+
+async def test_transient_provider_error_retries_without_burning_attempts(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A provider outage (network/timeout/5xx) must not walk a unit toward
+    MAX_ATTEMPTS: an outage longer than the retry budget would otherwise turn
+    every claimed unit terminally ERROR — permanent silent eval loss. Transient
+    failures cool down without counting an attempt, then complete once the
+    provider heals."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(
+            session,
+            trace,
+            attributes={"input": {"value": "hi"}, "output": {"value": "there"}},
+        )
+    evaluator_id, criteria_id = await _seed_llm_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    _patch_playground_client(
+        monkeypatch, _StubLLMClient(error=httpx.ConnectError("provider unreachable"))
+    )
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "ERROR"
+    assert unit.attempts == 0  # the outage did not consume a retry
+    assert unit.error is not None
+    assert "provider unreachable" in unit.error
+    assert unit.cooldown_until is not None
+    assert await _annotations(db) == []
+
+    # Once the cooldown lapses and the provider heals, the unit completes.
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(cooldown_until=datetime.now(timezone.utc))
+        )
+    _patch_playground_client(monkeypatch, _StubLLMClient())
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "DONE"
+    assert unit.attempts == 0
+    assert len(await _annotations(db)) == 1
+
+
+def test_is_transient_error_classification() -> None:
+    request = httpx.Request("POST", "http://provider.test")
+    assert is_transient_error(TimeoutError("llm timed out"))
+    assert is_transient_error(asyncio.TimeoutError())
+    assert is_transient_error(ConnectionError("reset"))
+    assert is_transient_error(httpx.ConnectTimeout("t", request=request))
+    assert is_transient_error(
+        httpx.HTTPStatusError("503", request=request, response=httpx.Response(503, request=request))
+    )
+    # Wrapped errors classify by their root cause through the exception chain.
+    try:
+        try:
+            raise TimeoutError("llm timed out")
+        except TimeoutError as inner:
+            raise EvalExecutionError("wrapped") from inner
+    except EvalExecutionError as wrapped:
+        assert is_transient_error(wrapped)
+    # Fail-safe default: anything unrecognized counts attempts as usual.
+    assert not is_transient_error(RuntimeError("provider is down"))
+    assert not is_transient_error(ValueError("bad config"))
+    assert not is_transient_error(EvalExecutionError("evaluator returned no results"))
+    assert not is_transient_error(
+        httpx.HTTPStatusError("400", request=request, response=httpx.Response(400, request=request))
+    )
+
+
+async def test_execution_deadline_cancels_eval_and_counts_attempt(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    consumer = OnlineEvalConsumer(
+        db,
+        decrypt=lambda value: value,
+        execution_deadline_seconds=0.01,
+    )
+    (unit,) = await consumer._coordinator.claim(
+        claimed_by=consumer._consumer_id,
+        limit=1,
+    )
+    hydrated = _hydrated_stub(results=[], evaluator_kind="BUILTIN", output_configs=[])
+    cancelled = asyncio.Event()
+
+    async def _hydrate(_: ClaimedWorkUnit) -> HydratedWorkUnit:
+        return hydrated
+
+    async def _never_resolves(*_: Any, **__: Any) -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    classified: list[BaseException] = []
+
+    def _classify(exc: BaseException) -> bool:
+        classified.append(exc)
+        return is_transient_error(exc)
+
+    monkeypatch.setattr(consumer._executor, "hydrate", _hydrate)
+    monkeypatch.setattr(consumer._executor, "evaluate_and_annotate", _never_resolves)
+    monkeypatch.setattr(consumer_module, "is_transient_error", _classify)
+
+    await consumer._process_unit(unit)
+
+    assert cancelled.is_set()
+    assert len(classified) == 1
+    timeout = classified[0]
+    assert isinstance(timeout, EvalExecutionTimeout)
+    assert timeout.__cause__ is None
+    assert timeout.__suppress_context__
+    assert not is_transient_error(timeout)
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.attempts == 1
+
+
+async def test_complete_retries_after_ambiguous_commit(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    (unit,) = await consumer._coordinator.claim(
+        claimed_by=consumer._consumer_id,
+        limit=1,
+    )
+    hydrated = _hydrated_stub(results=[], evaluator_kind="BUILTIN", output_configs=[])
+
+    async def _hydrate(_: ClaimedWorkUnit) -> HydratedWorkUnit:
+        return hydrated
+
+    async def _evaluate(*_: Any, **__: Any) -> None:
+        return None
+
+    original_complete = consumer._coordinator.complete
+    complete_calls = 0
+
+    async def _ambiguous_complete(**kwargs: Any) -> bool:
+        nonlocal complete_calls
+        complete_calls += 1
+        completed = await original_complete(**kwargs)
+        if complete_calls == 1:
+            raise ConnectionError("commit acknowledgement lost")
+        return completed
+
+    monkeypatch.setattr(consumer_module, "_TRANSITION_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
+    monkeypatch.setattr(consumer._executor, "hydrate", _hydrate)
+    monkeypatch.setattr(consumer._executor, "evaluate_and_annotate", _evaluate)
+    monkeypatch.setattr(consumer._coordinator, "complete", _ambiguous_complete)
+
+    await consumer._process_unit(unit)
+
+    assert complete_calls == 2
+    assert (await _get_unit(db, unit_id)).status == "DONE"
+
+
+async def test_failure_transition_retries_raised_exceptions(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    (unit,) = await consumer._coordinator.claim(
+        claimed_by=consumer._consumer_id,
+        limit=1,
+    )
+    hydrated = _hydrated_stub(results=[], evaluator_kind="BUILTIN", output_configs=[])
+
+    async def _hydrate(_: ClaimedWorkUnit) -> HydratedWorkUnit:
+        return hydrated
+
+    async def _evaluate(*_: Any, **__: Any) -> None:
+        raise ValueError("bad evaluator")
+
+    original_fail = consumer._coordinator.fail
+    fail_calls = 0
+
+    async def _flaky_fail(**kwargs: Any) -> bool:
+        nonlocal fail_calls
+        fail_calls += 1
+        if fail_calls <= 3:
+            raise ConnectionError("database unavailable")
+        return await original_fail(**kwargs)
+
+    monkeypatch.setattr(consumer_module, "_TRANSITION_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
+    monkeypatch.setattr(consumer._executor, "hydrate", _hydrate)
+    monkeypatch.setattr(consumer._executor, "evaluate_and_annotate", _evaluate)
+    monkeypatch.setattr(consumer._coordinator, "fail", _flaky_fail)
+
+    await consumer._process_unit(unit)
+
+    assert fail_calls == 4
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.attempts == 1
+
+
+async def test_failure_transition_retries_after_ambiguous_commit(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    (unit,) = await consumer._coordinator.claim(
+        claimed_by=consumer._consumer_id,
+        limit=1,
+    )
+
+    async def _hydrate(_: ClaimedWorkUnit) -> HydratedWorkUnit:
+        return _hydrated_stub(results=[], evaluator_kind="BUILTIN", output_configs=[])
+
+    async def _evaluate(*_: Any, **__: Any) -> None:
+        raise ValueError("bad evaluator")
+
+    original_fail = consumer._coordinator.fail
+    fail_calls = 0
+
+    async def _ambiguous_fail(**kwargs: Any) -> bool:
+        nonlocal fail_calls
+        fail_calls += 1
+        failed = await original_fail(**kwargs)
+        if fail_calls == 1:
+            raise ConnectionError("commit acknowledgement lost")
+        return failed
+
+    monkeypatch.setattr(consumer_module, "_TRANSITION_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
+    monkeypatch.setattr(consumer._executor, "hydrate", _hydrate)
+    monkeypatch.setattr(consumer._executor, "evaluate_and_annotate", _evaluate)
+    monkeypatch.setattr(consumer._coordinator, "fail", _ambiguous_fail)
+
+    await consumer._process_unit(unit)
+
+    assert fail_calls == 2
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.attempts == 1
+
+
+async def test_staleness_guard_expires_unit_without_annotating(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+
+    # A criteria edit between materialization and consumption changes the
+    # recomputed fingerprint, so the unit must be dropped, not executed.
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(sampling_rate=0.5)
+        )
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "EXPIRED"
+    assert await _annotations(db) == []
+
+
+async def test_stop_drains_in_flight_work_instead_of_cancelling(
+    db: DbSessionFactory,
+) -> None:
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    finished = asyncio.Event()
+
+    async def _in_flight() -> None:
+        await asyncio.sleep(0.05)
+        finished.set()
+
+    await consumer.start()
+    task = asyncio.create_task(_in_flight())
+    consumer._pending_tasks.add(task)
+    task.add_done_callback(consumer._pending_tasks.discard)
+
+    await consumer.stop()
+
+    assert finished.is_set()
+    assert not task.cancelled()
+
+
+async def test_stop_cancels_and_awaits_work_past_drain_timeout(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(consumer_module, "DRAIN_TIMEOUT_SECONDS", 0.01)
+    consumer = OnlineEvalConsumer(db, decrypt=lambda value: value)
+    started = asyncio.Event()
+    cancellation_finished = asyncio.Event()
+
+    async def _in_flight() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(0)
+            cancellation_finished.set()
+
+    task = asyncio.create_task(_in_flight())
+    consumer._pending_tasks.add(task)
+    task.add_done_callback(consumer._pending_tasks.discard)
+    await started.wait()
+
+    await consumer.stop()
+
+    assert task.cancelled()
+    assert cancellation_finished.is_set()
+
+
+async def test_disabled_criteria_expires_unit(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_builtin_criteria(db, project.id)
+    unit_id, _ = await _materialize_unit(db, span.id, evaluator_id, criteria_id)
+
+    async with db() as session:
+        await session.execute(
+            update(models.ProjectEvaluatorCriteria)
+            .where(models.ProjectEvaluatorCriteria.id == criteria_id)
+            .values(enabled=False)
+        )
+
+    consumer = OnlineEvalConsumer(db, decrypt=lambda b: b)
+    await consumer._cycle()
+
+    unit = await _get_unit(db, unit_id)
+    assert unit.status == "EXPIRED"
+    assert await _annotations(db) == []

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -312,10 +312,11 @@ async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
     assert empty.running_count == 0
     assert empty.retryable_error_count == 0
     assert empty.exhausted_error_count == 0
+    assert empty.expired_count == 0
     assert empty.frontier_gap == 0
     assert empty.oldest_pending_age_seconds is None
 
-    unit_ids = await _seed_work_units(db, 6)
+    unit_ids = await _seed_work_units(db, 7)
     now = datetime.now(timezone.utc)
     async with db() as session:
         await session.execute(
@@ -346,6 +347,11 @@ async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
                 created_at=now - timedelta(seconds=3600),
             )
         )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[6])
+            .values(status="EXPIRED", error="pending TTL exceeded")
+        )
         session.add(
             models.EvalWorkCursor(
                 evaluation_target="SPAN",
@@ -360,6 +366,7 @@ async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
     assert lag.running_count == 1
     assert lag.retryable_error_count == 1
     assert lag.exhausted_error_count == 1
+    assert lag.expired_count == 1
     assert lag.frontier_gap == 7
     assert lag.oldest_pending_age_seconds is not None
     assert 100.0 <= lag.oldest_pending_age_seconds < 300.0

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -348,7 +348,7 @@ async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
         )
         session.add(
             models.EvalWorkCursor(
-                grain="SPAN",
+                evaluation_target="SPAN",
                 consumer_group="default",
                 produced_through_id=5,
                 observed_high_water_id=12,

--- a/tests/unit/server/online_eval/test_db_coordinator.py
+++ b/tests/unit/server/online_eval/test_db_coordinator.py
@@ -1,0 +1,387 @@
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
+from phoenix.server.app import _db
+from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
+from phoenix.server.online_eval.db_coordinator import (
+    STALE_FINGERPRINT_ERROR,
+    TRANSIENT_RETRY_MAX_AGE_SECONDS,
+    DbEvalWorkCoordinator,
+)
+from phoenix.server.online_eval.derivation import MAX_ATTEMPTS
+from phoenix.server.types import DbSessionFactory
+
+from ..._helpers import _add_project, _add_span, _add_trace
+
+
+async def _seed_work_units(db: DbSessionFactory, n: int) -> list[int]:
+    """Create a span, evaluator, and criteria, plus ``n`` PENDING work units
+    (distinct fingerprints), returning the work unit ids in id order."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project.id,
+            evaluator_id=evaluator.id,
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition="",
+            sampling_rate=1.0,
+            evaluation_target="SPAN",
+        )
+        session.add(criteria)
+        await session.flush()
+        units = [
+            models.EvalWorkUnit(
+                span_rowid=span.id,
+                evaluator_id=evaluator.id,
+                criteria_id=criteria.id,
+                config_fingerprint=f"fp-{i}-{token_hex(8)}",
+            )
+            for i in range(n)
+        ]
+        session.add_all(units)
+        await session.flush()
+        return sorted(unit.id for unit in units)
+
+
+async def _get_unit(db: DbSessionFactory, unit_id: int) -> models.EvalWorkUnit:
+    async with db() as session:
+        unit = await session.get(models.EvalWorkUnit, unit_id)
+        assert unit is not None
+        return unit
+
+
+async def test_claim_and_complete_happy_path(db: DbSessionFactory) -> None:
+    unit_ids = await _seed_work_units(db, 2)
+    coordinator = DbEvalWorkCoordinator(db)
+    before = datetime.now(timezone.utc)
+
+    claimed = await coordinator.claim(claimed_by="consumer-1", limit=10)
+    assert [unit.work_unit_id for unit in claimed] == unit_ids
+    for claimed_unit in claimed:
+        assert claimed_unit.criteria_id > 0
+        assert claimed_unit.identifier == "online:" + claimed_unit.config_fingerprint[:16]
+        assert claimed_unit.attempts == 0
+        assert claimed_unit.claimed_by == "consumer-1"
+        assert claimed_unit.lease_expires_at >= before + timedelta(seconds=LEASE_TTL_SECONDS)
+        row = await _get_unit(db, claimed_unit.work_unit_id)
+        assert row.status == "RUNNING"
+        assert row.claimed_by == "consumer-1"
+
+    assert await coordinator.claim(claimed_by="consumer-2", limit=10) == []
+    assert await coordinator.heartbeat(work_unit_id=unit_ids[0], claimed_by="consumer-1")
+
+    for unit_id in unit_ids:
+        assert await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-1")
+        assert (await _get_unit(db, unit_id)).status == "DONE"
+    assert await coordinator.complete(work_unit_id=unit_ids[0], claimed_by="consumer-1")
+
+
+async def test_heartbeat_keeps_lapsed_unit_unavailable_to_competing_consumer(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    owner = DbEvalWorkCoordinator(db)
+    competitor = DbEvalWorkCoordinator(db)
+
+    await owner.claim(claimed_by="consumer-1", limit=1)
+    lapsed = datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(claimed_at=lapsed)
+        )
+
+    assert await owner.heartbeat(work_unit_id=unit_id, claimed_by="consumer-1")
+    assert await competitor.claim(claimed_by="consumer-2", limit=1) == []
+
+
+async def test_fail_sets_cooldown_and_unit_is_reclaimable_after_it(db: DbSessionFactory) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    future = datetime.now(timezone.utc) + timedelta(seconds=60)
+    assert await coordinator.fail(
+        work_unit_id=unit_id, claimed_by="consumer-1", error="boom", cooldown_until=future
+    )
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.error == "boom"
+    assert row.attempts == 1
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+
+    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(cooldown_until=past)
+        )
+    reclaimed = await coordinator.claim(claimed_by="consumer-2", limit=1)
+    assert [unit.work_unit_id for unit in reclaimed] == [unit_id]
+    assert reclaimed[0].attempts == 1
+
+
+async def test_failed_unit_with_exhausted_attempts_is_not_claimable(db: DbSessionFactory) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db, max_attempts=1)
+
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    assert await coordinator.fail(work_unit_id=unit_id, claimed_by="consumer-1", error="boom")
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+
+
+async def test_aged_transient_failure_is_parked_as_exhausted_error(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(
+                created_at=datetime.now(timezone.utc)
+                - timedelta(seconds=TRANSIENT_RETRY_MAX_AGE_SECONDS + 1)
+            )
+        )
+
+    assert await coordinator.fail(
+        work_unit_id=unit_id,
+        claimed_by="consumer-1",
+        error="provider unavailable",
+        cooldown_until=datetime.now(timezone.utc) - timedelta(seconds=1),
+        count_attempt=False,
+    )
+
+    row = await _get_unit(db, unit_id)
+    assert row.status == "ERROR"
+    assert row.attempts == MAX_ATTEMPTS
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+    lag = await coordinator.lag()
+    assert lag.retryable_error_count == 0
+    assert lag.exhausted_error_count == 1
+
+
+async def test_fresh_transient_failure_remains_retryable_after_cooldown(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    cooldown_until = datetime.now(timezone.utc) + timedelta(seconds=60)
+
+    assert await coordinator.fail(
+        work_unit_id=unit_id,
+        claimed_by="consumer-1",
+        error="provider unavailable",
+        cooldown_until=cooldown_until,
+        count_attempt=False,
+    )
+    row = await _get_unit(db, unit_id)
+    assert row.attempts == 0
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(cooldown_until=datetime.now(timezone.utc) - timedelta(seconds=1))
+        )
+    claimed = await coordinator.claim(claimed_by="consumer-2", limit=1)
+    assert [unit.work_unit_id for unit in claimed] == [unit_id]
+    assert claimed[0].attempts == 0
+
+
+async def test_expire_is_terminal(db: DbSessionFactory) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    assert await coordinator.expire(work_unit_id=unit_id, claimed_by="consumer-1")
+    row = await _get_unit(db, unit_id)
+    assert row.status == "EXPIRED"
+    assert row.error == STALE_FINGERPRINT_ERROR
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+    assert not await coordinator.expire(work_unit_id=unit_id, claimed_by="consumer-1")
+
+
+async def test_transitions_return_false_after_lapsed_lease_is_reclaimed(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+
+    await coordinator.claim(claimed_by="consumer-1", limit=1)
+    lapsed = datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(claimed_at=lapsed)
+        )
+
+    reclaimed = await coordinator.claim(claimed_by="consumer-2", limit=1)
+    assert [unit.work_unit_id for unit in reclaimed] == [unit_id]
+    assert reclaimed[0].attempts == 1
+
+    assert not await coordinator.heartbeat(work_unit_id=unit_id, claimed_by="consumer-1")
+    assert not await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-1")
+    assert not await coordinator.fail(work_unit_id=unit_id, claimed_by="consumer-1", error="late")
+    assert not await coordinator.expire(work_unit_id=unit_id, claimed_by="consumer-1")
+
+    row = await _get_unit(db, unit_id)
+    assert row.status == "RUNNING"
+    assert row.claimed_by == "consumer-2"
+    assert row.attempts == 1
+    assert await coordinator.complete(work_unit_id=unit_id, claimed_by="consumer-2")
+
+
+async def test_lapsed_lease_with_exhausted_attempts_is_not_claimable(
+    db: DbSessionFactory,
+) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db, max_attempts=1)
+    lapsed = datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_id)
+            .values(
+                status="RUNNING",
+                claimed_at=lapsed,
+                claimed_by="consumer-1",
+                attempts=1,
+            )
+        )
+
+    assert await coordinator.claim(claimed_by="consumer-2", limit=1) == []
+    row = await _get_unit(db, unit_id)
+    assert row.status == "RUNNING"
+    assert row.claimed_by == "consumer-1"
+    assert row.attempts == 1
+
+
+async def test_lapsed_unit_is_claimed_exactly_max_attempts_times(db: DbSessionFactory) -> None:
+    (unit_id,) = await _seed_work_units(db, 1)
+    coordinator = DbEvalWorkCoordinator(db)
+    execution_count = 0
+
+    for execution_count in range(1, MAX_ATTEMPTS + 1):
+        claimed = await coordinator.claim(claimed_by=f"consumer-{execution_count}", limit=1)
+        assert [unit.work_unit_id for unit in claimed] == [unit_id]
+        async with db() as session:
+            await session.execute(
+                update(models.EvalWorkUnit)
+                .where(models.EvalWorkUnit.id == unit_id)
+                .values(
+                    claimed_at=datetime.now(timezone.utc) - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+                )
+            )
+
+    assert execution_count == 3
+    assert await coordinator.claim(claimed_by="consumer-4", limit=1) == []
+
+
+async def test_lag_reports_counts_frontier_gap_and_oldest_pending_age(
+    db: DbSessionFactory,
+) -> None:
+    coordinator = DbEvalWorkCoordinator(db)
+
+    empty = await coordinator.lag()
+    assert empty.pending_count == 0
+    assert empty.running_count == 0
+    assert empty.retryable_error_count == 0
+    assert empty.exhausted_error_count == 0
+    assert empty.frontier_gap == 0
+    assert empty.oldest_pending_age_seconds is None
+
+    unit_ids = await _seed_work_units(db, 6)
+    now = datetime.now(timezone.utc)
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[0])
+            .values(status="RUNNING", claimed_at=datetime.now(timezone.utc), claimed_by="c")
+        )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[1])
+            .values(status="DONE")
+        )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[2])
+            .values(
+                status="ERROR",
+                attempts=MAX_ATTEMPTS - 1,
+                created_at=now - timedelta(seconds=120),
+            )
+        )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[3])
+            .values(
+                status="ERROR",
+                attempts=MAX_ATTEMPTS,
+                created_at=now - timedelta(seconds=3600),
+            )
+        )
+        session.add(
+            models.EvalWorkCursor(
+                grain="SPAN",
+                consumer_group="default",
+                produced_through_id=5,
+                observed_high_water_id=12,
+            )
+        )
+
+    lag = await coordinator.lag()
+    assert lag.pending_count == 2
+    assert lag.running_count == 1
+    assert lag.retryable_error_count == 1
+    assert lag.exhausted_error_count == 1
+    assert lag.frontier_gap == 7
+    assert lag.oldest_pending_age_seconds is not None
+    assert 100.0 <= lag.oldest_pending_age_seconds < 300.0
+
+
+@pytest.mark.postgres_only
+async def test_claim_skips_rows_locked_by_a_concurrent_transaction(
+    postgresql_engine: AsyncEngine,
+) -> None:
+    db = DbSessionFactory(db=_db(postgresql_engine), dialect="postgresql")
+    unit_ids = await _seed_work_units(db, 2)
+    coordinator = DbEvalWorkCoordinator(db)
+
+    async with db() as session:
+        locked = await session.scalar(
+            select(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == unit_ids[0])
+            .with_for_update()
+        )
+        assert locked is not None
+        claimed = await coordinator.claim(claimed_by="consumer-1", limit=10)
+        assert [unit.work_unit_id for unit in claimed] == [unit_ids[1]]
+
+    claimed = await coordinator.claim(claimed_by="consumer-1", limit=10)
+    assert [unit.work_unit_id for unit in claimed] == [unit_ids[0]]

--- a/tests/unit/server/online_eval/test_derivation.py
+++ b/tests/unit/server/online_eval/test_derivation.py
@@ -164,7 +164,7 @@ class TestConfigFingerprint:
                     ],
                 }
             ],
-            input_mapping={"input": "attributes.llm.input_messages"},
+            input_mapping={"input": "metadata.attributes.llm.input_messages"},
             evaluation_target="SPAN",
             sandbox_config_id=None,
             filter_condition="span_kind == 'LLM'",
@@ -172,7 +172,7 @@ class TestConfigFingerprint:
         )
         assert (
             config_fingerprint(resolved)
-            == "e6ca2ff2b09c452f4f1c9c6e846223e71a3955796ec86ce636c19d5215527f94"
+            == "a947137da632fef78f34554fcd4280c6a1207f96746f8667c9b578ea17ed3871"
         )
 
 

--- a/tests/unit/server/online_eval/test_derivation.py
+++ b/tests/unit/server/online_eval/test_derivation.py
@@ -1,0 +1,213 @@
+"""Property-based tests for the online-eval derivation recipes.
+
+Hypothesis is not a unit-test dependency, so each property is checked over inputs from
+seeded ``random.Random`` generators (deterministic across runs) plus explicit edge-case
+examples.
+"""
+
+import json
+import string
+from dataclasses import asdict, replace
+from random import Random
+from typing import Any
+
+from phoenix.server.online_eval.derivation import (
+    ResolvedCriteria,
+    annotation_identifier,
+    config_fingerprint,
+    sample_key,
+)
+
+_N_EXAMPLES = 200
+
+_SCALARS: list[Any] = [None, True, False, 0, 1, -17, 3.5, "", "a", "ünïcode ✓"]
+
+
+def _word(rng: Random) -> str:
+    return "".join(rng.choice(string.ascii_lowercase) for _ in range(rng.randint(1, 8)))
+
+
+def _json_value(rng: Random, depth: int = 0) -> Any:
+    if depth >= 2 or rng.random() < 0.5:
+        return rng.choice(_SCALARS)
+    if rng.random() < 0.5:
+        return [_json_value(rng, depth + 1) for _ in range(rng.randint(0, 3))]
+    return {_word(rng): _json_value(rng, depth + 1) for _ in range(rng.randint(0, 3))}
+
+
+def _criteria(rng: Random) -> ResolvedCriteria:
+    version_ref: Any = (
+        rng.randint(1, 10_000) if rng.random() < 0.5 else [_word(rng), "2026-07-01T00:00:00+00:00"]
+    )
+    return ResolvedCriteria(
+        criteria_id=rng.randint(1, 10_000),
+        annotation_name=_word(rng),
+        evaluator_id=rng.randint(1, 10_000),
+        version_ref=version_ref,
+        output_configs=[_json_value(rng) for _ in range(rng.randint(0, 3))],
+        input_mapping={_word(rng): _json_value(rng) for _ in range(rng.randint(0, 3))},
+        filter_condition=rng.choice(["", "span_kind == 'LLM'", "status_code == 'ERROR'"]),
+        sampling_rate=rng.random(),
+    )
+
+
+_EDGE_CRITERIA = [
+    ResolvedCriteria(
+        criteria_id=0,
+        annotation_name="",
+        evaluator_id=0,
+        version_ref=0,
+        output_configs=[],
+        input_mapping={},
+        filter_condition="",
+        sampling_rate=0.0,
+    ),
+    ResolvedCriteria(
+        criteria_id=1,
+        annotation_name="ünïcode ✓",
+        evaluator_id=1,
+        version_ref=["exact_match", "2026-07-01T00:00:00+00:00"],
+        output_configs=[{"nested": {"deep": [1, 2, 3]}}],
+        input_mapping={"input": None},
+        filter_condition="span_kind == 'LLM'",
+        sampling_rate=1.0,
+    ),
+]
+
+_EDGE_SPAN_IDS = [0, 1, 2, 7, 2**31, 2**63, 10**30]
+
+
+class TestConfigFingerprint:
+    def test_deterministic(self) -> None:
+        """Same resolved criteria always yields the same fingerprint, including across
+        an independently constructed equal instance."""
+        rng = Random(0)
+        for resolved in [_criteria(rng) for _ in range(_N_EXAMPLES)] + _EDGE_CRITERIA:
+            rebuilt = ResolvedCriteria(**asdict(resolved))
+            assert config_fingerprint(resolved) == config_fingerprint(resolved)
+            assert config_fingerprint(resolved) == config_fingerprint(rebuilt)
+
+    def test_format_is_full_sha256_hex(self) -> None:
+        rng = Random(1)
+        for resolved in [_criteria(rng) for _ in range(_N_EXAMPLES)] + _EDGE_CRITERIA:
+            fingerprint = config_fingerprint(resolved)
+            assert len(fingerprint) == 64
+            assert set(fingerprint) <= set(string.hexdigits.lower())
+
+    def test_key_order_invariance(self) -> None:
+        """Dicts that are equal but were built in different key-insertion orders
+        fingerprint identically."""
+        rng = Random(2)
+        for _ in range(_N_EXAMPLES):
+            resolved = _criteria(rng)
+            mapping = {_word(rng): _json_value(rng) for _ in range(rng.randint(2, 5))}
+            forward = replace(resolved, input_mapping=dict(mapping.items()))
+            backward = replace(resolved, input_mapping=dict(reversed(mapping.items())))
+            assert config_fingerprint(forward) == config_fingerprint(backward)
+
+    def test_whitespace_invariance_through_json_round_trip(self) -> None:
+        """Configs arriving via differently formatted JSON text (indentation, spacing)
+        fingerprint identically once parsed."""
+        rng = Random(3)
+        for _ in range(_N_EXAMPLES):
+            resolved = _criteria(rng)
+            pretty = json.loads(json.dumps(asdict(resolved), indent=4))
+            spaced = json.loads(json.dumps(asdict(resolved), separators=(" ,  ", " :   ")))
+            assert config_fingerprint(ResolvedCriteria(**pretty)) == config_fingerprint(resolved)
+            assert config_fingerprint(ResolvedCriteria(**spaced)) == config_fingerprint(resolved)
+
+    def test_any_field_change_changes_fingerprint(self) -> None:
+        """Every fingerprint input is load-bearing: mutating any single field yields a
+        different fingerprint."""
+        rng = Random(4)
+        for _ in range(_N_EXAMPLES // 10):
+            resolved = _criteria(rng)
+            mutations = [
+                replace(resolved, criteria_id=resolved.criteria_id + 1),
+                replace(resolved, annotation_name=resolved.annotation_name + "x"),
+                replace(resolved, evaluator_id=resolved.evaluator_id + 1),
+                replace(resolved, version_ref=[resolved.version_ref, "bumped"]),
+                replace(resolved, output_configs=[resolved.output_configs, "bumped"]),
+                replace(resolved, input_mapping={"bumped": resolved.input_mapping}),
+                replace(resolved, filter_condition=resolved.filter_condition + " "),
+                replace(resolved, sampling_rate=resolved.sampling_rate / 2 + 0.25),
+            ]
+            fingerprints = {config_fingerprint(m) for m in mutations}
+            fingerprints.add(config_fingerprint(resolved))
+            assert len(fingerprints) == len(mutations) + 1
+
+    def test_golden_vector(self) -> None:
+        """Pins the exact canonicalization recipe; producer/consumer fingerprint
+        agreement depends on these bytes never changing silently."""
+        resolved = ResolvedCriteria(
+            criteria_id=7,
+            annotation_name="toxicity",
+            evaluator_id=42,
+            version_ref=1301,
+            output_configs=[
+                {
+                    "name": "toxicity",
+                    "values": [
+                        {"label": "toxic", "score": 0.0},
+                        {"label": "non-toxic", "score": 1.0},
+                    ],
+                }
+            ],
+            input_mapping={"input": "attributes.llm.input_messages"},
+            filter_condition="span_kind == 'LLM'",
+            sampling_rate=0.25,
+        )
+        assert (
+            config_fingerprint(resolved)
+            == "6ba10d4ca474ac93266d5ea1d80a66e2f606c2d64ffe45bed22833f2c53bdb23"
+        )
+
+
+class TestAnnotationIdentifier:
+    def test_prefix_length_and_suffix(self) -> None:
+        rng = Random(5)
+        for _ in range(_N_EXAMPLES):
+            fingerprint = config_fingerprint(_criteria(rng))
+            identifier = annotation_identifier(fingerprint)
+            assert identifier.startswith("online:")
+            assert len(identifier) == len("online:") + 16
+            assert identifier == "online:" + fingerprint[:16]
+
+    def test_deterministic(self) -> None:
+        rng = Random(6)
+        for _ in range(_N_EXAMPLES):
+            fingerprint = config_fingerprint(_criteria(rng))
+            assert annotation_identifier(fingerprint) == annotation_identifier(fingerprint)
+
+
+class TestSampleKey:
+    def test_range_and_determinism(self) -> None:
+        rng = Random(7)
+        span_ids = [rng.randint(0, 2**63) for _ in range(_N_EXAMPLES)] + _EDGE_SPAN_IDS
+        for span_id in span_ids:
+            key = sample_key(span_id)
+            assert 0.0 <= key < 1.0
+            assert key == sample_key(span_id)
+
+    def test_nested_threshold_subset(self) -> None:
+        """For thresholds lo <= hi, the lo-sampled span set is a subset of the
+        hi-sampled set — sampling groups nest for free on the shared unsalted key."""
+        span_ids = range(1, 1001)
+        sampled_20 = {s for s in span_ids if sample_key(s) < 0.2}
+        sampled_60 = {s for s in span_ids if sample_key(s) < 0.6}
+        assert sampled_20 <= sampled_60
+        rng = Random(8)
+        for _ in range(_N_EXAMPLES):
+            lo, hi = sorted((rng.random(), rng.random()))
+            lo_set = {s for s in span_ids if sample_key(s) < lo}
+            hi_set = {s for s in span_ids if sample_key(s) < hi}
+            assert lo_set <= hi_set
+
+    def test_roughly_uniform(self) -> None:
+        """Keys over sequential span ids spread across [0,1) rather than clustering —
+        guards against a recipe change that quietly shrinks the effective range."""
+        keys = [sample_key(s) for s in range(2000)]
+        below_half = sum(1 for k in keys if k < 0.5) / len(keys)
+        assert 0.45 < below_half < 0.55
+        deciles = {int(k * 10) for k in keys}
+        assert deciles == set(range(10))

--- a/tests/unit/server/online_eval/test_derivation.py
+++ b/tests/unit/server/online_eval/test_derivation.py
@@ -41,11 +41,13 @@ def _criteria(rng: Random) -> ResolvedCriteria:
     )
     return ResolvedCriteria(
         criteria_id=rng.randint(1, 10_000),
-        annotation_name=_word(rng),
+        name=_word(rng),
         evaluator_id=rng.randint(1, 10_000),
         version_ref=version_ref,
         output_configs=[_json_value(rng) for _ in range(rng.randint(0, 3))],
         input_mapping={_word(rng): _json_value(rng) for _ in range(rng.randint(0, 3))},
+        evaluation_target=rng.choice(["SPAN", "TRACE", "SESSION"]),
+        sandbox_config_id=rng.choice([None, rng.randint(1, 10_000)]),
         filter_condition=rng.choice(["", "span_kind == 'LLM'", "status_code == 'ERROR'"]),
         sampling_rate=rng.random(),
     )
@@ -54,21 +56,25 @@ def _criteria(rng: Random) -> ResolvedCriteria:
 _EDGE_CRITERIA = [
     ResolvedCriteria(
         criteria_id=0,
-        annotation_name="",
+        name="",
         evaluator_id=0,
         version_ref=0,
         output_configs=[],
         input_mapping={},
+        evaluation_target="SPAN",
+        sandbox_config_id=None,
         filter_condition="",
         sampling_rate=0.0,
     ),
     ResolvedCriteria(
         criteria_id=1,
-        annotation_name="ünïcode ✓",
+        name="ünïcode ✓",
         evaluator_id=1,
         version_ref=["exact_match", "2026-07-01T00:00:00+00:00"],
         output_configs=[{"nested": {"deep": [1, 2, 3]}}],
         input_mapping={"input": None},
+        evaluation_target="SESSION",
+        sandbox_config_id=12,
         filter_condition="span_kind == 'LLM'",
         sampling_rate=1.0,
     ),
@@ -124,11 +130,16 @@ class TestConfigFingerprint:
             resolved = _criteria(rng)
             mutations = [
                 replace(resolved, criteria_id=resolved.criteria_id + 1),
-                replace(resolved, annotation_name=resolved.annotation_name + "x"),
+                replace(resolved, name=resolved.name + "x"),
                 replace(resolved, evaluator_id=resolved.evaluator_id + 1),
                 replace(resolved, version_ref=[resolved.version_ref, "bumped"]),
                 replace(resolved, output_configs=[resolved.output_configs, "bumped"]),
                 replace(resolved, input_mapping={"bumped": resolved.input_mapping}),
+                replace(
+                    resolved,
+                    evaluation_target=("SPAN" if resolved.evaluation_target != "SPAN" else "TRACE"),
+                ),
+                replace(resolved, sandbox_config_id=(resolved.sandbox_config_id or 0) + 1),
                 replace(resolved, filter_condition=resolved.filter_condition + " "),
                 replace(resolved, sampling_rate=resolved.sampling_rate / 2 + 0.25),
             ]
@@ -141,7 +152,7 @@ class TestConfigFingerprint:
         agreement depends on these bytes never changing silently."""
         resolved = ResolvedCriteria(
             criteria_id=7,
-            annotation_name="toxicity",
+            name="toxicity",
             evaluator_id=42,
             version_ref=1301,
             output_configs=[
@@ -154,12 +165,14 @@ class TestConfigFingerprint:
                 }
             ],
             input_mapping={"input": "attributes.llm.input_messages"},
+            evaluation_target="SPAN",
+            sandbox_config_id=None,
             filter_condition="span_kind == 'LLM'",
             sampling_rate=0.25,
         )
         assert (
             config_fingerprint(resolved)
-            == "6ba10d4ca474ac93266d5ea1d80a66e2f606c2d64ffe45bed22833f2c53bdb23"
+            == "e6ca2ff2b09c452f4f1c9c6e846223e71a3955796ec86ce636c19d5215527f94"
         )
 
 

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -28,6 +28,7 @@ async def _seed_criteria(
     *,
     filter_condition: str = "",
     sampling_rate: float = 1.0,
+    evaluation_target: models.EvaluationTarget = "SPAN",
 ) -> tuple[int, int]:
     """Create a builtin evaluator and a criteria row, returning
     (evaluator_id, criteria_id)."""
@@ -44,9 +45,10 @@ async def _seed_criteria(
         criteria = models.ProjectEvaluatorCriteria(
             project_id=project_id,
             evaluator_id=evaluator.id,
-            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            name=Identifier(root=f"criteria-{token_hex(4)}"),
             filter_condition=filter_condition,
             sampling_rate=sampling_rate,
+            evaluation_target=evaluation_target,
         )
         session.add(criteria)
         await session.flush()
@@ -178,6 +180,20 @@ async def test_tick_materializes_matching_spans_and_advances_watermark(
     assert len(await _work_unit_span_rowids(db)) == len(llm_spans)
 
 
+@pytest.mark.parametrize("evaluation_target", ["TRACE", "SESSION"])
+async def test_future_targets_are_not_loaded_by_span_producer(
+    db: DbSessionFactory,
+    evaluation_target: models.EvaluationTarget,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+    await _seed_criteria(db, project.id, evaluation_target=evaluation_target)
+
+    producer = OnlineEvalProducer(db)
+
+    assert await producer._load_active_criteria() == []
+
+
 async def test_tick_advances_at_most_one_id_chunk(db: DbSessionFactory) -> None:
     async with db() as session:
         project = await _add_project(session)
@@ -274,7 +290,7 @@ async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
         session.add(
             models.SpanAnnotation(
                 span_rowid=annotated_span.id,
-                name=criteria.annotation_name,
+                name=criteria.name,
                 label="ok",
                 score=1.0,
                 explanation=None,

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -75,7 +75,7 @@ async def _seed_cursor(
 ) -> int:
     async with db() as session:
         cursor = models.EvalWorkCursor(
-            grain="SPAN",
+            evaluation_target="SPAN",
             consumer_group="default",
             produced_through_id=produced_through_id,
             observed_high_water_id=observed_high_water_id,
@@ -116,7 +116,7 @@ async def test_cold_start_initializes_cursor_at_current_high_water(
         cursor = (
             await session.scalars(
                 select(models.EvalWorkCursor).where(
-                    models.EvalWorkCursor.grain == "SPAN",
+                    models.EvalWorkCursor.evaluation_target == "SPAN",
                     models.EvalWorkCursor.consumer_group == "default",
                 )
             )

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -8,7 +8,16 @@ from sqlalchemy import func, select, update
 from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.online_eval import producer as producer_module
-from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerprint
+from phoenix.server.online_eval.coordinator import LEASE_TTL_SECONDS
+from phoenix.server.online_eval.db_coordinator import (
+    STALE_FINGERPRINT_ERROR,
+    DbEvalWorkCoordinator,
+)
+from phoenix.server.online_eval.derivation import (
+    MAX_ATTEMPTS,
+    annotation_identifier,
+    config_fingerprint,
+)
 from phoenix.server.online_eval.producer import (
     OnlineEvalProducer,
     resolve_criteria,
@@ -194,7 +203,10 @@ async def test_future_targets_are_not_loaded_by_span_producer(
     assert await producer._load_active_criteria() == []
 
 
-async def test_tick_advances_at_most_one_id_chunk(db: DbSessionFactory) -> None:
+async def test_tick_advances_at_most_one_id_chunk(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK", "2")
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -210,7 +222,6 @@ async def test_tick_advances_at_most_one_id_chunk(db: DbSessionFactory) -> None:
     )
 
     producer = OnlineEvalProducer(db)
-    producer._max_span_ids_per_tick = 2
     await producer._tick()
 
     cursor = await _get_cursor(db, cursor_id)
@@ -224,6 +235,63 @@ async def test_tick_advances_at_most_one_id_chunk(db: DbSessionFactory) -> None:
     cursor = await _get_cursor(db, cursor_id)
     assert cursor.produced_through_id == low_exclusive + 4
     assert sorted(await _work_unit_span_rowids(db)) == [span.id for span in spans[:4]]
+
+
+async def test_materialization_budget_truncates_without_advancing(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING", "3")
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(2)]
+    await _seed_criteria(db, project.id)
+    await _seed_criteria(db, project.id)
+    low_exclusive = spans[0].id - 1
+    cursor_id = await _seed_cursor(
+        db,
+        produced_through_id=low_exclusive,
+        observed_high_water_id=spans[-1].id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    async with db() as session:
+        unit_count = await session.scalar(select(func.count()).select_from(models.EvalWorkUnit))
+    assert unit_count == 3
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == low_exclusive
+    assert await producer._admission_budget() == 0
+
+    coordinator = DbEvalWorkCoordinator(db)
+    admitted = await coordinator.claim(claimed_by="consumer", limit=3)
+    assert len(admitted) == 3
+    for unit in admitted:
+        assert await coordinator.complete(
+            work_unit_id=unit.work_unit_id,
+            claimed_by="consumer",
+        )
+
+    await producer._tick()
+
+    async with db() as session:
+        units = list(await session.scalars(select(models.EvalWorkUnit)))
+    assert len(units) == 4
+    assert sum(unit.status == "DONE" for unit in units) == 3
+    assert sum(unit.status == "PENDING" for unit in units) == 1
+    assert (await _get_cursor(db, cursor_id)).produced_through_id == spans[-1].id
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+async def test_max_span_ids_per_tick_must_be_positive(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_SPAN_IDS_PER_TICK", value)
+
+    with pytest.raises(ValueError, match="Value must be a positive integer"):
+        OnlineEvalProducer(db)
 
 
 async def test_cursor_regresses_to_live_span_high_water(db: DbSessionFactory) -> None:
@@ -279,9 +347,13 @@ async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
         expired_span = await _add_span(session, trace)
     evaluator_id, criteria_id = await _seed_criteria(db, project.id)
     watermark = expired_span.id
-    await _seed_cursor(db, produced_through_id=watermark)
-
     producer = OnlineEvalProducer(db)
+    await _seed_cursor(
+        db,
+        produced_through_id=watermark,
+        claimed_by=producer._producer_id,
+        claimed_at=_now(),
+    )
     active = await producer._load_active_criteria()
     assert len(active) == 1
     criteria = active[0]
@@ -311,7 +383,7 @@ async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
             )
         )
 
-    await producer._backstop_sweep(active, watermark)
+    await producer._backstop_sweep(active, watermark, 10)
 
     async with db() as session:
         units = list(await session.scalars(select(models.EvalWorkUnit)))
@@ -322,7 +394,172 @@ async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
     assert by_span[expired_span.id].status == "EXPIRED"
 
 
-async def test_reaper_transitions_and_deletes(db: DbSessionFactory) -> None:
+async def test_backstop_stops_at_insertion_budget(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(3)]
+    await _seed_criteria(db, project.id)
+
+    producer = OnlineEvalProducer(db)
+    await _seed_cursor(
+        db,
+        produced_through_id=spans[-1].id,
+        claimed_by=producer._producer_id,
+        claimed_at=_now(),
+    )
+    active = await producer._load_active_criteria()
+    remaining = await producer._backstop_sweep(active, spans[-1].id, 2)
+
+    assert remaining == 0
+    assert len(await _work_unit_span_rowids(db)) == 2
+
+
+async def test_stale_fingerprint_rows_are_resurrected_when_config_reverts(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(3)]
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+    await _seed_cursor(
+        db,
+        produced_through_id=spans[0].id - 1,
+        observed_high_water_id=spans[-1].id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    async with db() as session:
+        evaluator = await session.get(models.BuiltinEvaluator, evaluator_id)
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert evaluator is not None
+        assert criteria is not None
+        original_key = evaluator.key
+        original_synced_at = evaluator.synced_at
+        resolved = await resolve_criteria(session, criteria, evaluator)
+        assert resolved is not None
+        original_fingerprint = config_fingerprint(resolved)
+        evaluator.key = f"{original_key}-changed"
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.span_rowid == spans[0].id)
+            .values(attempts=2)
+        )
+
+    coordinator = DbEvalWorkCoordinator(db)
+    claimed = await coordinator.claim(claimed_by="consumer", limit=3)
+    assert len(claimed) == 3
+    for unit in claimed:
+        assert await coordinator.expire(
+            work_unit_id=unit.work_unit_id,
+            claimed_by="consumer",
+        )
+
+    async with db() as session:
+        evaluator = await session.get(models.BuiltinEvaluator, evaluator_id)
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert evaluator is not None
+        assert criteria is not None
+        evaluator.key = original_key
+        evaluator.synced_at = original_synced_at
+        session.add_all(
+            [
+                models.SpanAnnotation(
+                    span_rowid=spans[0].id,
+                    name=criteria.name.root,
+                    label="old",
+                    score=0.0,
+                    explanation=None,
+                    metadata_={},
+                    annotator_kind="LLM",
+                    identifier=annotation_identifier("different-fingerprint"),
+                    source="API",
+                    user_id=None,
+                ),
+                models.SpanAnnotation(
+                    span_rowid=spans[1].id,
+                    name=criteria.name.root,
+                    label="done",
+                    score=1.0,
+                    explanation=None,
+                    metadata_={},
+                    annotator_kind="LLM",
+                    identifier=annotation_identifier(original_fingerprint),
+                    source="API",
+                    user_id=None,
+                ),
+            ]
+        )
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.span_rowid == spans[2].id)
+            .values(status="DONE")
+        )
+
+    producer._backstop_interval_seconds = 0
+    await producer._tick()
+
+    async with db() as session:
+        units = list(
+            await session.scalars(
+                select(models.EvalWorkUnit).order_by(models.EvalWorkUnit.span_rowid)
+            )
+        )
+    assert [unit.config_fingerprint for unit in units] == [original_fingerprint] * 3
+    assert units[0].status == "PENDING"
+    assert units[0].attempts == 0
+    assert units[0].error is None
+    assert units[0].claimed_by is None
+    assert units[0].claimed_at is None
+    assert units[0].cooldown_until is None
+    assert units[1].status == "EXPIRED"
+    assert units[1].error == STALE_FINGERPRINT_ERROR
+    assert units[2].status == "DONE"
+
+
+async def test_ttl_expired_row_is_not_resurrected(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS", "1")
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    await _seed_cursor(
+        db,
+        produced_through_id=span.id - 1,
+        observed_high_water_id=span.id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit).values(created_at=_now() - timedelta(seconds=10))
+        )
+
+    await producer._reap(_now(), span.id)
+    active = await producer._load_active_criteria()
+    await producer._backstop_sweep(active, span.id, 10)
+
+    async with db() as session:
+        unit = (await session.scalars(select(models.EvalWorkUnit))).one()
+    assert unit.status == "EXPIRED"
+    assert unit.error == "pending ttl exceeded"
+
+
+async def test_reaper_transitions_and_deletes(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS", "2")
+    # TTL shedding is opt-in (default off); this test exercises the opted-in path.
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS", "3600")
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -378,28 +615,30 @@ async def test_reaper_transitions_and_deletes(db: DbSessionFactory) -> None:
         }
 
     producer = OnlineEvalProducer(db)
-    producer._backstop_lookback_span_ids = 2
-    # TTL shedding is opt-in (default off); this test exercises the opted-in path.
-    producer._pending_ttl_seconds = 3600.0
     await producer._reap(now, produced_through)
 
     async with db() as session:
         remaining = {
-            unit.id: unit.status for unit in await session.scalars(select(models.EvalWorkUnit))
+            unit.id: (unit.status, unit.error)
+            for unit in await session.scalars(select(models.EvalWorkUnit))
         }
-    assert remaining.get(ids["stale_pending"]) == "EXPIRED"
-    assert remaining.get(ids["fresh_pending"]) == "PENDING"
+    assert remaining.get(ids["stale_pending"]) == ("EXPIRED", "pending ttl exceeded")
+    assert remaining.get(ids["fresh_pending"]) == ("PENDING", None)
     assert ids["done_outside"] not in remaining
-    assert remaining.get(ids["done_inside"]) == "DONE"
+    assert remaining.get(ids["done_inside"]) == ("DONE", None)
     assert ids["exhausted_error_outside"] not in remaining
-    assert remaining.get(ids["retryable_error_outside"]) == "ERROR"
+    assert remaining.get(ids["retryable_error_outside"]) == ("ERROR", None)
 
 
-async def test_reaper_default_keeps_old_pending_work(db: DbSessionFactory) -> None:
+async def test_reaper_default_keeps_old_pending_work(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """With the pending TTL unset (the default), backlog never expires: a
     PENDING unit older than any drain window stays claimable instead of being
     shed. TTL expiry is terminal and blocks backstop re-materialization of the
     same fingerprint, so shedding must be an explicit operator opt-in."""
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS", "2")
+    monkeypatch.delenv("PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS", raising=False)
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -421,7 +660,6 @@ async def test_reaper_default_keeps_old_pending_work(db: DbSessionFactory) -> No
         unit_id = old_pending.id
 
     producer = OnlineEvalProducer(db)
-    producer._backstop_lookback_span_ids = 2
     await producer._reap(now, span.id)
 
     async with db() as session:
@@ -430,7 +668,82 @@ async def test_reaper_default_keeps_old_pending_work(db: DbSessionFactory) -> No
     assert unit.status == "PENDING"
 
 
-async def test_admission_gate_skips_materialization(db: DbSessionFactory) -> None:
+async def test_reaper_terminalizes_only_lapsed_exhausted_running_work(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+    now = _now()
+    lapsed = now - timedelta(seconds=LEASE_TTL_SECONDS + 1)
+
+    async with db() as session:
+        lapsed_unit = models.EvalWorkUnit(
+            span_rowid=span.id,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            status="RUNNING",
+            attempts=MAX_ATTEMPTS - 1,
+            claimed_at=lapsed,
+            claimed_by="consumer-1",
+        )
+        failed_lapsed_unit = models.EvalWorkUnit(
+            span_rowid=span.id,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            status="RUNNING",
+            attempts=MAX_ATTEMPTS - 1,
+            error="provider failed",
+            claimed_at=lapsed,
+            claimed_by="consumer-1",
+        )
+        fresh_unit = models.EvalWorkUnit(
+            span_rowid=span.id,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            status="RUNNING",
+            attempts=MAX_ATTEMPTS - 1,
+            claimed_at=now,
+            claimed_by="consumer-1",
+        )
+        session.add_all([lapsed_unit, failed_lapsed_unit, fresh_unit])
+        await session.flush()
+        lapsed_id, failed_lapsed_id, fresh_id = (
+            lapsed_unit.id,
+            failed_lapsed_unit.id,
+            fresh_unit.id,
+        )
+
+    producer = OnlineEvalProducer(db)
+    await producer._reap(now, span.id)
+
+    async with db() as session:
+        lapsed_row = await session.get(models.EvalWorkUnit, lapsed_id)
+        failed_lapsed_row = await session.get(models.EvalWorkUnit, failed_lapsed_id)
+        fresh_row = await session.get(models.EvalWorkUnit, fresh_id)
+    assert lapsed_row is not None
+    assert lapsed_row.status == "ERROR"
+    assert lapsed_row.attempts == MAX_ATTEMPTS
+    assert lapsed_row.error == "lease lapsed with attempts exhausted"
+    assert failed_lapsed_row is not None
+    assert failed_lapsed_row.status == "ERROR"
+    assert failed_lapsed_row.attempts == MAX_ATTEMPTS
+    assert failed_lapsed_row.error == "provider failed"
+    assert fresh_row is not None
+    assert fresh_row.status == "RUNNING"
+    competitor = DbEvalWorkCoordinator(db)
+    assert await competitor.claim(claimed_by="consumer-2", limit=2) == []
+
+
+async def test_admission_gate_skips_materialization(
+    db: DbSessionFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING", "1")
     async with db() as session:
         project = await _add_project(session)
         trace = await _add_trace(session, project)
@@ -438,13 +751,16 @@ async def test_admission_gate_skips_materialization(db: DbSessionFactory) -> Non
         backlog_span = await _add_span(session, trace)
     evaluator_id, criteria_id = await _seed_criteria(db, project.id)
     async with db() as session:
-        session.add(
-            models.EvalWorkUnit(
-                span_rowid=backlog_span.id,
-                evaluator_id=evaluator_id,
-                criteria_id=criteria_id,
-                config_fingerprint=f"fp-{token_hex(8)}",
-            )
+        session.add_all(
+            [
+                models.EvalWorkUnit(
+                    span_rowid=backlog_span.id,
+                    evaluator_id=evaluator_id,
+                    criteria_id=criteria_id,
+                    config_fingerprint=f"fp-{token_hex(8)}",
+                )
+                for _ in range(2)
+            ]
         )
     cursor_id = await _seed_cursor(
         db,
@@ -453,17 +769,16 @@ async def test_admission_gate_skips_materialization(db: DbSessionFactory) -> Non
     )
 
     producer = OnlineEvalProducer(db)
-    producer._max_pending = 0
     await producer._tick()
 
     async with db() as session:
         unit_count = await session.scalar(select(func.count()).select_from(models.EvalWorkUnit))
-    assert unit_count == 1
+    assert unit_count == 2
     cursor = await _get_cursor(db, cursor_id)
     assert cursor.produced_through_id == 0
 
 
-async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -> None:
+async def test_admission_budget_counts_nonterminal_backlog(db: DbSessionFactory) -> None:
     """The gate bounds all backlog that will eventually demand consumer
     capacity: RUNNING and retryable-ERROR rows count alongside PENDING (under
     a provider outage the pending population migrates into retryable ERROR),
@@ -485,12 +800,12 @@ async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -
         )
 
     producer = OnlineEvalProducer(db)
-    producer._max_pending = 0
-    assert await producer._admission_gate_open()
+    producer._max_outstanding = 1
+    assert await producer._admission_budget() == 1
 
     async with db() as session:
         session.add(_unit("ERROR", attempts=MAX_ATTEMPTS))
-    assert await producer._admission_gate_open()  # exhausted ERROR is terminal
+    assert await producer._admission_budget() == 1
 
     async with db() as session:
         session.add(_unit("RUNNING", claimed_by="consumer-1", claimed_at=_now()))
@@ -500,7 +815,7 @@ async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -
                 select(models.EvalWorkUnit.id).order_by(models.EvalWorkUnit.id.desc()).limit(1)
             )
         ).one()
-    assert not await producer._admission_gate_open()  # RUNNING counts
+    assert await producer._admission_budget() == 0
 
     async with db() as session:
         await session.execute(
@@ -508,11 +823,11 @@ async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -
             .where(models.EvalWorkUnit.id == running_id)
             .values(status="DONE")
         )
-    assert await producer._admission_gate_open()
+    assert await producer._admission_budget() == 1
 
     async with db() as session:
         session.add(_unit("ERROR", attempts=1))
-    assert not await producer._admission_gate_open()  # retryable ERROR counts
+    assert await producer._admission_budget() == 0
 
 
 async def test_unexpected_criteria_load_error_fails_closed(
@@ -610,3 +925,149 @@ async def test_lease_stand_down_and_stale_reclaim(db: DbSessionFactory) -> None:
     assert cursor.claimed_by == producer._producer_id
     assert cursor.produced_through_id == span.id
     assert sorted(await _work_unit_span_rowids(db)) == [span.id]
+
+
+async def test_lost_lease_rolls_back_materialization_and_aborts_tick(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    cursor_id = await _seed_cursor(
+        db,
+        produced_through_id=span.id - 1,
+        observed_high_water_id=span.id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    insert_work_units = producer._insert_work_units
+
+    async def _insert_then_lose_lease(
+        session: Any,
+        criteria: Any,
+        span_ids: list[int],
+    ) -> None:
+        await insert_work_units(session, criteria, span_ids)
+        await session.execute(
+            update(models.EvalWorkCursor)
+            .where(models.EvalWorkCursor.id == cursor_id)
+            .values(claimed_by="rival-producer")
+        )
+
+    monkeypatch.setattr(producer, "_insert_work_units", _insert_then_lose_lease)
+
+    with caplog.at_level("WARNING"):
+        await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == span.id - 1
+    assert cursor.claimed_by == producer._producer_id
+    assert (
+        sum("tick aborted after losing its lease" in record.message for record in caplog.records)
+        == 1
+    )
+
+
+async def test_separate_lease_steal_rolls_back_truncated_frontier(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING", "1")
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(2)]
+    await _seed_criteria(db, project.id)
+    cursor_id = await _seed_cursor(
+        db,
+        produced_through_id=spans[0].id - 1,
+        observed_high_water_id=spans[-1].id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    insert_work_units = producer._insert_work_units
+
+    async def _steal_then_insert(
+        session: Any,
+        criteria: Any,
+        span_ids: list[int],
+    ) -> None:
+        async with db() as rival_session:
+            await rival_session.execute(
+                update(models.EvalWorkCursor)
+                .where(models.EvalWorkCursor.id == cursor_id)
+                .values(claimed_by="rival-producer")
+            )
+        await insert_work_units(session, criteria, span_ids)
+
+    monkeypatch.setattr(producer, "_insert_work_units", _steal_then_insert)
+
+    with caplog.at_level("WARNING"):
+        await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    assert not producer._lease_held
+    assert any("tick aborted after losing its lease" in record.message for record in caplog.records)
+
+
+async def test_separate_lease_steal_rolls_back_backstop(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    cursor_id = await _seed_cursor(db, produced_through_id=span.id)
+
+    producer = OnlineEvalProducer(db)
+    producer._backstop_interval_seconds = 0
+    insert_work_units = producer._insert_work_units
+
+    async def _steal_then_insert(
+        session: Any,
+        criteria: Any,
+        span_ids: list[int],
+    ) -> None:
+        async with db() as rival_session:
+            await rival_session.execute(
+                update(models.EvalWorkCursor)
+                .where(models.EvalWorkCursor.id == cursor_id)
+                .values(claimed_by="rival-producer")
+            )
+        await insert_work_units(session, criteria, span_ids)
+
+    monkeypatch.setattr(producer, "_insert_work_units", _steal_then_insert)
+
+    with caplog.at_level("WARNING"):
+        await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    assert not producer._lease_held
+    assert any("tick aborted after losing its lease" in record.message for record in caplog.records)
+
+
+async def test_renew_lease_refreshes_claimed_at(db: DbSessionFactory) -> None:
+    producer = OnlineEvalProducer(db)
+    old = _now() - timedelta(seconds=60)
+    cursor_id = await _seed_cursor(
+        db,
+        claimed_by=producer._producer_id,
+        claimed_at=old,
+    )
+    renewed_at = _now()
+
+    await producer._renew_lease(renewed_at)
+
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.claimed_at == renewed_at

--- a/tests/unit/server/online_eval/test_producer.py
+++ b/tests/unit/server/online_eval/test_producer.py
@@ -1,0 +1,596 @@
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+from typing import Any
+
+import pytest
+from sqlalchemy import func, select, update
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
+from phoenix.server.online_eval import producer as producer_module
+from phoenix.server.online_eval.derivation import MAX_ATTEMPTS, config_fingerprint
+from phoenix.server.online_eval.producer import (
+    OnlineEvalProducer,
+    resolve_criteria,
+)
+from phoenix.server.types import DbSessionFactory
+
+from ..._helpers import _add_project, _add_span, _add_trace
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def _seed_criteria(
+    db: DbSessionFactory,
+    project_id: int,
+    *,
+    filter_condition: str = "",
+    sampling_rate: float = 1.0,
+) -> tuple[int, int]:
+    """Create a builtin evaluator and a criteria row, returning
+    (evaluator_id, criteria_id)."""
+    async with db() as session:
+        evaluator = models.BuiltinEvaluator(
+            name=Identifier(root=f"eval-{token_hex(4)}"),
+            kind="BUILTIN",
+            key=token_hex(8),
+            input_schema={},
+            output_configs=[],
+        )
+        session.add(evaluator)
+        await session.flush()
+        criteria = models.ProjectEvaluatorCriteria(
+            project_id=project_id,
+            evaluator_id=evaluator.id,
+            annotation_name=Identifier(root=f"criteria-{token_hex(4)}"),
+            filter_condition=filter_condition,
+            sampling_rate=sampling_rate,
+        )
+        session.add(criteria)
+        await session.flush()
+        return evaluator.id, criteria.id
+
+
+async def _seed_cursor(
+    db: DbSessionFactory,
+    *,
+    produced_through_id: int = 0,
+    observed_high_water_id: int | None = None,
+    observed_at: datetime | None = None,
+    claimed_by: str | None = None,
+    claimed_at: datetime | None = None,
+) -> int:
+    async with db() as session:
+        cursor = models.EvalWorkCursor(
+            grain="SPAN",
+            consumer_group="default",
+            produced_through_id=produced_through_id,
+            observed_high_water_id=observed_high_water_id,
+            observed_at=observed_at,
+            claimed_by=claimed_by,
+            claimed_at=claimed_at,
+        )
+        session.add(cursor)
+        await session.flush()
+        return cursor.id
+
+
+async def _get_cursor(db: DbSessionFactory, cursor_id: int) -> models.EvalWorkCursor:
+    async with db() as session:
+        cursor = await session.get(models.EvalWorkCursor, cursor_id)
+        assert cursor is not None
+        return cursor
+
+
+async def _work_unit_span_rowids(db: DbSessionFactory) -> list[int]:
+    async with db() as session:
+        return list(await session.scalars(select(models.EvalWorkUnit.span_rowid)))
+
+
+async def test_cold_start_initializes_cursor_at_current_high_water(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(3)]
+    await _seed_criteria(db, project.id)
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    async with db() as session:
+        cursor = (
+            await session.scalars(
+                select(models.EvalWorkCursor).where(
+                    models.EvalWorkCursor.grain == "SPAN",
+                    models.EvalWorkCursor.consumer_group == "default",
+                )
+            )
+        ).one()
+    assert cursor.produced_through_id == spans[-1].id
+    assert cursor.claimed_by == producer._producer_id
+    assert await _work_unit_span_rowids(db) == []
+
+
+async def test_tick_materializes_matching_spans_and_advances_watermark(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        llm_spans = [await _add_span(session, trace, span_kind="LLM") for _ in range(3)]
+        tool_span = await _add_span(session, trace, span_kind="TOOL")
+        other_project = await _add_project(session)
+        other_trace = await _add_trace(session, other_project)
+        other_span = await _add_span(session, other_trace, span_kind="LLM")
+    evaluator_id, criteria_id = await _seed_criteria(
+        db, project.id, filter_condition="span_kind == 'LLM'"
+    )
+    high_water = other_span.id
+    cursor_id = await _seed_cursor(
+        db,
+        observed_high_water_id=high_water,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    materialized = await _work_unit_span_rowids(db)
+    assert sorted(materialized) == sorted(span.id for span in llm_spans)
+    assert tool_span.id not in materialized
+    assert other_span.id not in materialized
+
+    async with db() as session:
+        units = list(await session.scalars(select(models.EvalWorkUnit)))
+        criteria = await session.get(models.ProjectEvaluatorCriteria, criteria_id)
+        assert criteria is not None
+        evaluator = await session.get(models.BuiltinEvaluator, evaluator_id)
+        assert evaluator is not None
+        resolved = await resolve_criteria(session, criteria, evaluator)
+        assert resolved is not None
+        expected_fingerprint = config_fingerprint(resolved)
+    for unit in units:
+        assert unit.status == "PENDING"
+        assert unit.evaluator_id == evaluator_id
+        assert unit.criteria_id == criteria_id
+        assert unit.config_fingerprint == expected_fingerprint
+
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == high_water
+    assert cursor.claimed_by == producer._producer_id
+
+    # Re-scanning the same window is idempotent under the work-key unique constraint.
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkCursor)
+            .where(models.EvalWorkCursor.id == cursor_id)
+            .values(
+                produced_through_id=0,
+                observed_high_water_id=high_water,
+                observed_at=_now() - timedelta(seconds=120),
+            )
+        )
+    await producer._tick()
+    assert len(await _work_unit_span_rowids(db)) == len(llm_spans)
+
+
+async def test_tick_advances_at_most_one_id_chunk(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(5)]
+    await _seed_criteria(db, project.id)
+    low_exclusive = spans[0].id - 1
+    observed_at = _now() - timedelta(seconds=120)
+    cursor_id = await _seed_cursor(
+        db,
+        produced_through_id=low_exclusive,
+        observed_high_water_id=spans[-1].id,
+        observed_at=observed_at,
+    )
+
+    producer = OnlineEvalProducer(db)
+    producer._max_span_ids_per_tick = 2
+    await producer._tick()
+
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == low_exclusive + 2
+    assert cursor.observed_high_water_id == spans[-1].id
+    assert cursor.observed_at == observed_at
+    assert sorted(await _work_unit_span_rowids(db)) == [span.id for span in spans[:2]]
+
+    await producer._tick()
+
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == low_exclusive + 4
+    assert sorted(await _work_unit_span_rowids(db)) == [span.id for span in spans[:4]]
+
+
+async def test_cursor_regresses_to_live_span_high_water(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    stale_high_water = span.id + 100
+    cursor_id = await _seed_cursor(
+        db,
+        produced_through_id=stale_high_water,
+        observed_high_water_id=stale_high_water,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == span.id
+    assert cursor.observed_high_water_id is None
+    assert cursor.observed_at is None
+
+
+async def test_frontier_gate_holds_until_lag_elapses(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    observed_at = _now()
+    cursor_id = await _seed_cursor(db, observed_high_water_id=span.id, observed_at=observed_at)
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == 0
+    # The pending observation is held so it can age past the lag gate — a tick
+    # must not reset observed_at while the observation is unconsumed.
+    assert cursor.observed_high_water_id == span.id
+    assert cursor.observed_at == observed_at
+
+
+async def test_backstop_catches_late_visible_span(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        late_span = await _add_span(session, trace)
+        annotated_span = await _add_span(session, trace)
+        expired_span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+    watermark = expired_span.id
+    await _seed_cursor(db, produced_through_id=watermark)
+
+    producer = OnlineEvalProducer(db)
+    active = await producer._load_active_criteria()
+    assert len(active) == 1
+    criteria = active[0]
+
+    async with db() as session:
+        session.add(
+            models.SpanAnnotation(
+                span_rowid=annotated_span.id,
+                name=criteria.annotation_name,
+                label="ok",
+                score=1.0,
+                explanation=None,
+                metadata_={},
+                annotator_kind="LLM",
+                identifier=criteria.identifier,
+                source="API",
+                user_id=None,
+            )
+        )
+        session.add(
+            models.EvalWorkUnit(
+                span_rowid=expired_span.id,
+                evaluator_id=evaluator_id,
+                criteria_id=criteria_id,
+                config_fingerprint=criteria.fingerprint,
+                status="EXPIRED",
+            )
+        )
+
+    await producer._backstop_sweep(active, watermark)
+
+    async with db() as session:
+        units = list(await session.scalars(select(models.EvalWorkUnit)))
+    by_span = {unit.span_rowid: unit for unit in units}
+    assert len(units) == 2
+    assert by_span[late_span.id].status == "PENDING"
+    assert annotated_span.id not in by_span
+    assert by_span[expired_span.id].status == "EXPIRED"
+
+
+async def test_reaper_transitions_and_deletes(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        spans = [await _add_span(session, trace) for _ in range(5)]
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+    produced_through = spans[-1].id
+    outside, inside = spans[0].id, spans[-1].id
+    now = _now()
+    ancient = now - timedelta(days=30)
+
+    def _unit(span_rowid: int, **kwargs: object) -> models.EvalWorkUnit:
+        return models.EvalWorkUnit(
+            span_rowid=span_rowid,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            **kwargs,
+        )
+
+    async with db() as session:
+        stale_pending = _unit(inside, status="PENDING", created_at=ancient)
+        fresh_pending = _unit(inside, status="PENDING")
+        done_outside = _unit(outside, status="DONE", created_at=ancient, updated_at=ancient)
+        done_inside = _unit(inside, status="DONE", created_at=ancient, updated_at=ancient)
+        exhausted_error_outside = _unit(
+            outside,
+            status="ERROR",
+            attempts=MAX_ATTEMPTS,
+            created_at=ancient,
+            updated_at=ancient,
+        )
+        retryable_error_outside = _unit(
+            outside, status="ERROR", attempts=1, created_at=ancient, updated_at=ancient
+        )
+        session.add_all(
+            [
+                stale_pending,
+                fresh_pending,
+                done_outside,
+                done_inside,
+                exhausted_error_outside,
+                retryable_error_outside,
+            ]
+        )
+        await session.flush()
+        ids = {
+            "stale_pending": stale_pending.id,
+            "fresh_pending": fresh_pending.id,
+            "done_outside": done_outside.id,
+            "done_inside": done_inside.id,
+            "exhausted_error_outside": exhausted_error_outside.id,
+            "retryable_error_outside": retryable_error_outside.id,
+        }
+
+    producer = OnlineEvalProducer(db)
+    producer._backstop_lookback_span_ids = 2
+    # TTL shedding is opt-in (default off); this test exercises the opted-in path.
+    producer._pending_ttl_seconds = 3600.0
+    await producer._reap(now, produced_through)
+
+    async with db() as session:
+        remaining = {
+            unit.id: unit.status for unit in await session.scalars(select(models.EvalWorkUnit))
+        }
+    assert remaining.get(ids["stale_pending"]) == "EXPIRED"
+    assert remaining.get(ids["fresh_pending"]) == "PENDING"
+    assert ids["done_outside"] not in remaining
+    assert remaining.get(ids["done_inside"]) == "DONE"
+    assert ids["exhausted_error_outside"] not in remaining
+    assert remaining.get(ids["retryable_error_outside"]) == "ERROR"
+
+
+async def test_reaper_default_keeps_old_pending_work(db: DbSessionFactory) -> None:
+    """With the pending TTL unset (the default), backlog never expires: a
+    PENDING unit older than any drain window stays claimable instead of being
+    shed. TTL expiry is terminal and blocks backstop re-materialization of the
+    same fingerprint, so shedding must be an explicit operator opt-in."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+    now = _now()
+    ancient = now - timedelta(days=30)
+    async with db() as session:
+        old_pending = models.EvalWorkUnit(
+            span_rowid=span.id,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            status="PENDING",
+            created_at=ancient,
+        )
+        session.add(old_pending)
+        await session.flush()
+        unit_id = old_pending.id
+
+    producer = OnlineEvalProducer(db)
+    producer._backstop_lookback_span_ids = 2
+    await producer._reap(now, span.id)
+
+    async with db() as session:
+        unit = await session.get(models.EvalWorkUnit, unit_id)
+    assert unit is not None
+    assert unit.status == "PENDING"
+
+
+async def test_admission_gate_skips_materialization(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+        backlog_span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+    async with db() as session:
+        session.add(
+            models.EvalWorkUnit(
+                span_rowid=backlog_span.id,
+                evaluator_id=evaluator_id,
+                criteria_id=criteria_id,
+                config_fingerprint=f"fp-{token_hex(8)}",
+            )
+        )
+    cursor_id = await _seed_cursor(
+        db,
+        observed_high_water_id=span.id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    producer._max_pending = 0
+    await producer._tick()
+
+    async with db() as session:
+        unit_count = await session.scalar(select(func.count()).select_from(models.EvalWorkUnit))
+    assert unit_count == 1
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == 0
+
+
+async def test_admission_gate_counts_nonterminal_backlog(db: DbSessionFactory) -> None:
+    """The gate bounds all backlog that will eventually demand consumer
+    capacity: RUNNING and retryable-ERROR rows count alongside PENDING (under
+    a provider outage the pending population migrates into retryable ERROR),
+    while exhausted ERROR is terminal and must not hold the gate closed."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    evaluator_id, criteria_id = await _seed_criteria(db, project.id)
+
+    def _unit(status: str, **kwargs: Any) -> models.EvalWorkUnit:
+        return models.EvalWorkUnit(
+            span_rowid=span.id,
+            evaluator_id=evaluator_id,
+            criteria_id=criteria_id,
+            config_fingerprint=f"fp-{token_hex(8)}",
+            status=status,
+            **kwargs,
+        )
+
+    producer = OnlineEvalProducer(db)
+    producer._max_pending = 0
+    assert await producer._admission_gate_open()
+
+    async with db() as session:
+        session.add(_unit("ERROR", attempts=MAX_ATTEMPTS))
+    assert await producer._admission_gate_open()  # exhausted ERROR is terminal
+
+    async with db() as session:
+        session.add(_unit("RUNNING", claimed_by="consumer-1", claimed_at=_now()))
+        await session.flush()
+        running_id = (
+            await session.scalars(
+                select(models.EvalWorkUnit.id).order_by(models.EvalWorkUnit.id.desc()).limit(1)
+            )
+        ).one()
+    assert not await producer._admission_gate_open()  # RUNNING counts
+
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkUnit)
+            .where(models.EvalWorkUnit.id == running_id)
+            .values(status="DONE")
+        )
+    assert await producer._admission_gate_open()
+
+    async with db() as session:
+        session.add(_unit("ERROR", attempts=1))
+    assert not await producer._admission_gate_open()  # retryable ERROR counts
+
+
+async def test_unexpected_criteria_load_error_fails_closed(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected exception during criteria resolution (e.g. a transient DB
+    error) must abort the tick without advancing the cursor — advancing would
+    silently skip the window for the criteria that failed to load."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    cursor_id = await _seed_cursor(
+        db,
+        observed_high_water_id=span.id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    async def _transient_boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("transient version-lookup failure")
+
+    monkeypatch.setattr(producer_module, "resolve_criteria", _transient_boom)
+
+    producer = OnlineEvalProducer(db)
+    with pytest.raises(RuntimeError, match="transient version-lookup failure"):
+        await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == 0
+
+
+async def test_uncompilable_filter_is_skipped_without_stalling(db: DbSessionFactory) -> None:
+    """A filter_condition that fails to compile is a persistent per-criteria
+    condition: the criteria is skipped (operator-visibly, via log) while the
+    cursor still advances for the healthy criteria — one bad DSL string must
+    not stall the shared cursor forever."""
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    good_evaluator_id, _ = await _seed_criteria(db, project.id)
+    bad_evaluator_id, _ = await _seed_criteria(db, project.id, filter_condition="span_kind ==")
+    cursor_id = await _seed_cursor(
+        db,
+        observed_high_water_id=span.id,
+        observed_at=_now() - timedelta(seconds=120),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    async with db() as session:
+        units = list(await session.scalars(select(models.EvalWorkUnit)))
+    assert {unit.evaluator_id for unit in units} == {good_evaluator_id}
+    assert bad_evaluator_id not in {unit.evaluator_id for unit in units}
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.produced_through_id == span.id
+
+
+async def test_lease_stand_down_and_stale_reclaim(db: DbSessionFactory) -> None:
+    async with db() as session:
+        project = await _add_project(session)
+        trace = await _add_trace(session, project)
+        span = await _add_span(session, trace)
+    await _seed_criteria(db, project.id)
+    observed_at = _now() - timedelta(seconds=120)
+    cursor_id = await _seed_cursor(
+        db,
+        observed_high_water_id=span.id,
+        observed_at=observed_at,
+        claimed_by="rival-producer",
+        claimed_at=_now(),
+    )
+
+    producer = OnlineEvalProducer(db)
+    await producer._tick()
+
+    assert await _work_unit_span_rowids(db) == []
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.claimed_by == "rival-producer"
+    assert cursor.produced_through_id == 0
+
+    async with db() as session:
+        await session.execute(
+            update(models.EvalWorkCursor)
+            .where(models.EvalWorkCursor.id == cursor_id)
+            .values(claimed_at=_now() - timedelta(seconds=300))
+        )
+    await producer._tick()
+
+    cursor = await _get_cursor(db, cursor_id)
+    assert cursor.claimed_by == producer._producer_id
+    assert cursor.produced_through_id == span.id
+    assert sorted(await _work_unit_span_rowids(db)) == [span.id]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -55,6 +55,12 @@ class TestGetEnvOnlineEval:
                 "0.001",
                 0.001,
             ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_CONSUMER_TICK_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_consumer_tick_interval_seconds,
+                "0.001",
+                0.001,
+            ),
         ],
     )
     def test_float_boundaries(
@@ -159,6 +165,12 @@ class TestGetEnvOnlineEval:
             (
                 phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING,
                 phoenix_config.get_env_online_eval_max_outstanding,
+                "1",
+                1,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE,
+                phoenix_config.get_env_online_eval_claim_batch_size,
                 "1",
                 1,
             ),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Optional, get_args
+from typing import Any, Callable, Optional, get_args
 from unittest.mock import MagicMock
 from urllib.parse import quote, unquote, urlparse
 
@@ -8,6 +8,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from starlette.datastructures import URL
 
+import phoenix.config as phoenix_config
 from phoenix.config import (
     AssignableUserRoleName,
     OAuth2ClientConfig,
@@ -24,6 +25,186 @@ from phoenix.config import (
     get_env_tls_enabled_for_http,
 )
 from phoenix.db.models import UserRoleName
+
+
+class TestGetEnvOnlineEval:
+    @pytest.mark.parametrize(
+        ("env_name", "getter", "value", "expected"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS,
+                phoenix_config.get_env_online_eval_frontier_lag_seconds,
+                "0",
+                0.0,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_backstop_interval_seconds,
+                "0.001",
+                0.001,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS,
+                phoenix_config.get_env_online_eval_pending_ttl_seconds,
+                "0",
+                0.0,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS,
+                phoenix_config.get_env_online_eval_retention_seconds,
+                "0.001",
+                0.001,
+            ),
+        ],
+    )
+    def test_float_boundaries(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], float],
+        value: str,
+        expected: float,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        assert getter() == expected
+
+    @pytest.mark.parametrize(
+        ("env_name", "getter", "value"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS,
+                phoenix_config.get_env_online_eval_frontier_lag_seconds,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_backstop_interval_seconds,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_backstop_interval_seconds,
+                "0",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS,
+                phoenix_config.get_env_online_eval_pending_ttl_seconds,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS,
+                phoenix_config.get_env_online_eval_retention_seconds,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS,
+                phoenix_config.get_env_online_eval_retention_seconds,
+                "0",
+            ),
+        ],
+    )
+    def test_float_domains(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], float],
+        value: str,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        with pytest.raises(ValueError, match=env_name):
+            getter()
+
+    @pytest.mark.parametrize(
+        ("env_name", "getter"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_FRONTIER_LAG_SECONDS,
+                phoenix_config.get_env_online_eval_frontier_lag_seconds,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_INTERVAL_SECONDS,
+                phoenix_config.get_env_online_eval_backstop_interval_seconds,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS,
+                phoenix_config.get_env_online_eval_pending_ttl_seconds,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_RETENTION_SECONDS,
+                phoenix_config.get_env_online_eval_retention_seconds,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+    def test_float_domains_reject_non_finite_values(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], float],
+        value: str,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        with pytest.raises(ValueError, match=env_name):
+            getter()
+
+    @pytest.mark.parametrize(
+        ("env_name", "getter", "value", "expected"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS,
+                phoenix_config.get_env_online_eval_backstop_lookback_span_ids,
+                "0",
+                0,
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_outstanding,
+                "1",
+                1,
+            ),
+        ],
+    )
+    def test_integer_boundaries(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], int],
+        value: str,
+        expected: int,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        assert getter() == expected
+
+    @pytest.mark.parametrize(
+        ("env_name", "getter", "value"),
+        [
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_BACKSTOP_LOOKBACK_SPAN_IDS,
+                phoenix_config.get_env_online_eval_backstop_lookback_span_ids,
+                "-1",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_outstanding,
+                "0",
+            ),
+            (
+                phoenix_config.ENV_PHOENIX_ONLINE_EVAL_MAX_OUTSTANDING,
+                phoenix_config.get_env_online_eval_max_outstanding,
+                "-1",
+            ),
+        ],
+    )
+    def test_integer_domains(
+        self,
+        monkeypatch: MonkeyPatch,
+        env_name: str,
+        getter: Callable[[], int],
+        value: str,
+    ) -> None:
+        monkeypatch.setenv(env_name, value)
+        with pytest.raises(ValueError, match=env_name):
+            getter()
 
 
 class TestPostgresConnectionString:


### PR DESCRIPTION
## Summary

Load testing the online-eval queue surfaced three related gaps in how the consumer's drain capacity interacts with the pending TTL. This PR makes throughput configurable, warns about self-defeating TTL configurations, and makes TTL shedding observable.

- **Consumer throughput env knobs.** `PHOENIX_ONLINE_EVAL_CLAIM_BATCH_SIZE` and `PHOENIX_ONLINE_EVAL_CONSUMER_TICK_INTERVAL_SECONDS` now configure the per-replica claim cycle (defaults 10 per 5.0s preserve current behavior). The prior hardcoded values capped every replica at 2 evaluations/s per target regardless of evaluator latency: a 100ms evaluator drains at exactly the same 2/s as a 10s one, and any sustained ingest above `2 × sampling_rate` spans/s grows the queue without bound.
- **Startup warning for TTL-below-drain-capacity.** With a positive `PHOENIX_ONLINE_EVAL_PENDING_TTL_SECONDS`, pending work older than the TTL is shed terminally. A full admission-gate backlog (default 10,000 units) needs `max_outstanding × tick / batch` seconds to drain on one replica — 5,000s at the defaults — so any smaller TTL sheds work during routine backpressure rather than only when consumers are down. The server now logs a warning at startup when the configured TTL is below that bound.
- **`phoenix_online_eval_expired_work_units` gauge.** Shed work was previously observable only by querying the database; expiry produced no metric, no annotation, and no error. The queue-lag aggregation now counts EXPIRED rows (those still inside the retention window) and the consumer publishes them alongside the existing queue gauges.

## Measurements

On a single replica with a 100ms-latency evaluator, 10 spans/s sustained for 120s with a 90s TTL:

| | prior behavior | with `CLAIM_BATCH_SIZE=50`, `TICK=1.0` |
|---|---|---|
| evaluated | 370 / 1195 (31%) | 1200 / 1200 (100%) |
| expired unevaluated | 825 (69%) | 0 |
| queue drained after load | no | yes, in 20s |

The expired gauge reads exactly 825 when pointed at the first run's database; the startup warning fires in both configurations (90s is below the worst-case backlog drain in each).

## Notes

- Defaults are unchanged: TTL remains 0 (shedding disabled) and the claim cycle remains 10 per 5s.
- Whether TTL-shed work should be recoverable (e.g. re-materialized by the backstop) is deliberately out of scope; this PR only makes the existing semantics visible and configurable.
