### PR TITLE
feat: Auto-format restricted input

### DIFF
--- a/app/src/components/core/combobox/ComboBox.tsx
+++ b/app/src/components/core/combobox/ComboBox.tsx
@@ -1,7 +1,8 @@
 import { css } from "@emotion/react";
-import React from "react";
+import React, { type Ref } from "react";
 import type {
   ComboBoxProps as AriaComboBoxProps,
+  InputProps,
   ListBoxItemProps as AriaListBoxItemProps,
   ListBoxProps,
   ValidationResult,
@@ -45,6 +46,13 @@ export interface ComboBoxProps<T extends object>
    * but should be used sparingly.
    */
   stopPropagation?: boolean;
+  /** Props forwarded to the native text input rendered by the combobox. */
+  inputProps?: Omit<
+    InputProps,
+    "defaultValue" | "onChange" | "placeholder" | "value"
+  > & {
+    ref?: Ref<HTMLInputElement>;
+  };
 }
 
 /**
@@ -65,6 +73,7 @@ export function ComboBox<T extends object>({
   size = "M",
   width,
   stopPropagation,
+  inputProps,
   renderEmptyState,
   isInvalid,
   menuTrigger = "focus",
@@ -91,7 +100,7 @@ export function ComboBox<T extends object>({
         onKeyDown={stopPropagation ? stopPropagationHandler : undefined}
         onKeyUp={stopPropagation ? stopPropagationHandler : undefined}
       >
-        <Input placeholder={placeholder} />
+        <Input placeholder={placeholder} {...inputProps} />
         <Button>
           <SelectChevronUpDownIcon />
         </Button>

--- a/app/src/components/core/combobox/__tests__/ComboBox.test.tsx
+++ b/app/src/components/core/combobox/__tests__/ComboBox.test.tsx
@@ -1,4 +1,4 @@
-import { act } from "react";
+import { act, createRef } from "react";
 import type { Root } from "react-dom/client";
 import { createRoot } from "react-dom/client";
 import { userEvent } from "storybook/test";
@@ -67,5 +67,34 @@ describe("ComboBox", () => {
 
     expect(onParentKeyDown).not.toHaveBeenCalled();
     expect(onParentKeyUp).not.toHaveBeenCalled();
+  });
+
+  it("forwards native input props and refs", () => {
+    const inputRef = createRef<HTMLInputElement>();
+    const onCompositionStart = vi.fn();
+    act(() => {
+      root.render(
+        <ComboBox
+          label="Prompt"
+          inputProps={{ ref: inputRef, onCompositionStart }}
+        >
+          <ComboBoxItem id="support" textValue="Customer support">
+            Customer support
+          </ComboBoxItem>
+        </ComboBox>
+      );
+    });
+
+    const promptInput = container.querySelector<HTMLInputElement>(
+      'input[role="combobox"]'
+    );
+    expect(inputRef.current).toBe(promptInput);
+
+    act(() => {
+      promptInput?.dispatchEvent(
+        new Event("compositionstart", { bubbles: true })
+      );
+    });
+    expect(onCompositionStart).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/components/evaluators/EvaluatorNameInput.tsx
+++ b/app/src/components/evaluators/EvaluatorNameInput.tsx
@@ -3,10 +3,7 @@ import { Controller, useForm, type ValidateResult } from "react-hook-form";
 
 import { FieldError, Input, Label, Text } from "@phoenix/components";
 import { TextField, type TextFieldProps } from "@phoenix/components/core/field";
-import {
-  IDENTIFIER_DESCRIPTION,
-  IDENTIFIER_ERROR_MESSAGES,
-} from "@phoenix/constants";
+import { IDENTIFIER_DESCRIPTION } from "@phoenix/constants";
 import {
   useEvaluatorStore,
   useEvaluatorStoreInstance,
@@ -114,11 +111,8 @@ export const EvaluatorNameInput = ({
       control={control}
       rules={{ validate }}
       render={({ field, fieldState: { error } }) => {
-        // Only show blur-specific errors after the field has been blurred
-        const shouldShowError =
-          error?.message &&
-          (hasBlurredRef.current ||
-            error.message !== IDENTIFIER_ERROR_MESSAGES.leadingTrailing);
+        // Identifier errors are deferred until blur or parent-form submission.
+        const shouldShowError = error?.message && hasBlurredRef.current;
         const displayedError = shouldShowError ? error.message : undefined;
 
         const handleChange = (value: string) => {

--- a/app/src/components/evaluators/EvaluatorNameInput.tsx
+++ b/app/src/components/evaluators/EvaluatorNameInput.tsx
@@ -8,6 +8,7 @@ import {
   useEvaluatorStore,
   useEvaluatorStoreInstance,
 } from "@phoenix/contexts/EvaluatorContext";
+import { TransformingInputController } from "@phoenix/hooks/useTransformingInput";
 import type { EvaluatorStoreProps } from "@phoenix/store/evaluatorStore";
 import {
   transformIdentifierInput,
@@ -83,7 +84,6 @@ export const EvaluatorNameInput = ({
   const form = useEvaluatorNameInputForm();
   const store = useEvaluatorStoreInstance();
   const { control, trigger } = form;
-  const inputRef = useRef<HTMLInputElement>(null);
   const hasBlurredRef = useRef(false);
 
   // Register with the evaluator store so the parent can trigger
@@ -115,25 +115,6 @@ export const EvaluatorNameInput = ({
         const shouldShowError = error?.message && hasBlurredRef.current;
         const displayedError = shouldShowError ? error.message : undefined;
 
-        const handleChange = (value: string) => {
-          const input = inputRef.current;
-          const selectionStart = input?.selectionStart ?? value.length;
-
-          const transformed = transformIdentifierInput(value);
-
-          // Calculate new cursor position by transforming the text before cursor
-          const beforeCursor = value.slice(0, selectionStart);
-          const newCursorPosition =
-            transformIdentifierInput(beforeCursor).length;
-
-          field.onChange(transformed);
-
-          // Restore cursor position after React updates the DOM
-          requestAnimationFrame(() => {
-            input?.setSelectionRange(newCursorPosition, newCursorPosition);
-          });
-        };
-
         const handleFocus = () => {
           // Reset blur state so deferred validation doesn't run while typing
           hasBlurredRef.current = false;
@@ -147,21 +128,33 @@ export const EvaluatorNameInput = ({
         };
 
         return (
-          <TextField
-            {...field}
-            onChange={handleChange}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            autoComplete="off"
-            isInvalid={!!displayedError}
-            autoFocus
-            {...props}
+          <TransformingInputController
+            value={field.value}
+            onValueChange={field.onChange}
+            transformValue={transformIdentifierInput}
           >
-            <Label>Name</Label>
-            <Input ref={inputRef} placeholder={placeholder} />
-            <Text slot="description">{IDENTIFIER_DESCRIPTION}</Text>
-            <FieldError>{displayedError}</FieldError>
-          </TextField>
+            {(transformingInput) => (
+              <TextField
+                {...field}
+                value={transformingInput.displayValue}
+                onChange={transformingInput.handleValueChange}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                autoComplete="off"
+                isInvalid={!!displayedError}
+                autoFocus
+                {...props}
+              >
+                <Label>Name</Label>
+                <Input
+                  {...transformingInput.inputProps}
+                  placeholder={placeholder}
+                />
+                <Text slot="description">{IDENTIFIER_DESCRIPTION}</Text>
+                <FieldError>{displayedError}</FieldError>
+              </TextField>
+            )}
+          </TransformingInputController>
         );
       }}
     />

--- a/app/src/components/evaluators/EvaluatorNameInput.tsx
+++ b/app/src/components/evaluators/EvaluatorNameInput.tsx
@@ -1,15 +1,19 @@
 import { useCallback, useEffect, useRef } from "react";
 import { Controller, useForm, type ValidateResult } from "react-hook-form";
 
-import { FieldError, Input, Label } from "@phoenix/components";
+import { FieldError, Input, Label, Text } from "@phoenix/components";
 import { TextField, type TextFieldProps } from "@phoenix/components/core/field";
+import {
+  IDENTIFIER_DESCRIPTION,
+  IDENTIFIER_ERROR_MESSAGES,
+} from "@phoenix/constants";
 import {
   useEvaluatorStore,
   useEvaluatorStoreInstance,
 } from "@phoenix/contexts/EvaluatorContext";
 import type { EvaluatorStoreProps } from "@phoenix/store/evaluatorStore";
 import {
-  IDENTIFIER_ERROR_MESSAGES,
+  transformIdentifierInput,
   validateIdentifier,
 } from "@phoenix/utils/identifierUtils";
 
@@ -17,16 +21,6 @@ import {
  * The field name used by react-hook-form and as the error key in the validation registry.
  */
 const FIELD_NAME = "name" as const;
-
-/**
- * Transforms an evaluator name by lowercasing, converting spaces to dashes,
- * and stripping disallowed characters.
- */
-const transformEvaluatorName = (value: string) =>
-  value
-    .toLowerCase()
-    .replace(/ /g, "-")
-    .replace(/[^_a-z0-9-]/g, "");
 
 /**
  * Whether to use the user-facing name (for dataset evaluators) vs the global name.
@@ -131,11 +125,12 @@ export const EvaluatorNameInput = ({
           const input = inputRef.current;
           const selectionStart = input?.selectionStart ?? value.length;
 
-          const transformed = transformEvaluatorName(value);
+          const transformed = transformIdentifierInput(value);
 
           // Calculate new cursor position by transforming the text before cursor
           const beforeCursor = value.slice(0, selectionStart);
-          const newCursorPosition = transformEvaluatorName(beforeCursor).length;
+          const newCursorPosition =
+            transformIdentifierInput(beforeCursor).length;
 
           field.onChange(transformed);
 
@@ -170,6 +165,7 @@ export const EvaluatorNameInput = ({
           >
             <Label>Name</Label>
             <Input ref={inputRef} placeholder={placeholder} />
+            <Text slot="description">{IDENTIFIER_DESCRIPTION}</Text>
             <FieldError>{displayedError}</FieldError>
           </TextField>
         );

--- a/app/src/constants/identifierConstants.ts
+++ b/app/src/constants/identifierConstants.ts
@@ -1,0 +1,24 @@
+/**
+ * Identifier character set: lowercase alphanumerics, dashes, and underscores.
+ * The empty string matches so partial input is permitted while a user types.
+ */
+export const ALLOWED_IDENTIFIER_CHARACTERS_PATTERN = /^[_a-z0-9-]*$/;
+
+/**
+ * Identifiers must begin and end with a lowercase alphanumeric character.
+ * The empty string and single alphanumerics are permitted.
+ */
+export const LEADING_AND_TRAILING_ALPHANUMERIC_CHARACTERS_PATTERN =
+  /^([a-z0-9](.*[a-z0-9])?)?$/;
+
+/** Canonical help text for every user-editable Phoenix identifier field. */
+export const IDENTIFIER_DESCRIPTION =
+  "Lowercase letters, digits, dashes, and underscores. Must start and end with a letter or digit.";
+
+/** Human-readable errors surfaced by the shared identifier validators. */
+export const IDENTIFIER_ERROR_MESSAGES = {
+  empty: "Cannot be empty",
+  allowedChars:
+    "Must have only lowercase alphanumeric characters, dashes, and underscores",
+  leadingTrailing: "Must start and end with lowercase alphanumeric characters",
+} as const;

--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -3,6 +3,7 @@ export * from "./timeConstants";
 export * from "./numberConstants";
 export * from "./promptConstants";
 export * from "./feedbackConstants";
+export * from "./identifierConstants";
 export * from "./uriConstants";
 export * from "./secretsConstants";
 export * from "./annotationConstants";

--- a/app/src/hooks/__tests__/useTransformingInput.test.tsx
+++ b/app/src/hooks/__tests__/useTransformingInput.test.tsx
@@ -3,6 +3,10 @@ import { createRoot, type Root } from "react-dom/client";
 import { userEvent } from "storybook/test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { transformEnvironmentVariableInput } from "@phoenix/utils/environmentVariableUtils";
+import { transformIdentifierInput } from "@phoenix/utils/identifierUtils";
+import { transformURISafeInput } from "@phoenix/utils/uriUtils";
+
 import { useTransformingInput } from "../useTransformingInput";
 
 function setNativeInputValue({
@@ -29,10 +33,12 @@ function TransformingInputHarness({
   initialValue,
   onValueCommitted,
   transformValue,
+  shouldWireInputProps = true,
 }: {
   initialValue: string;
   onValueCommitted: (value: string) => void;
   transformValue: (value: string) => string;
+  shouldWireInputProps?: boolean;
 }) {
   const [value, setValue] = useState(initialValue);
   const transformingInput = useTransformingInput({
@@ -45,7 +51,7 @@ function TransformingInputHarness({
   });
   return (
     <input
-      {...transformingInput.inputProps}
+      {...(shouldWireInputProps ? transformingInput.inputProps : {})}
       value={transformingInput.displayValue}
       onChange={(event) =>
         transformingInput.handleValueChange(event.currentTarget.value)
@@ -97,10 +103,12 @@ describe("useTransformingInput", () => {
         .toLowerCase()
         .replace(/\s+/g, "-")
         .replace(/[^a-z0-9-]/g, ""),
+    shouldWireInputProps = true,
   }: {
     initialValue: string;
     onValueCommitted?: (value: string) => void;
     transformValue?: (value: string) => string;
+    shouldWireInputProps?: boolean;
   }) => {
     act(() => {
       root.render(
@@ -108,6 +116,7 @@ describe("useTransformingInput", () => {
           initialValue={initialValue}
           onValueCommitted={onValueCommitted}
           transformValue={transformValue}
+          shouldWireInputProps={shouldWireInputProps}
         />
       );
     });
@@ -133,6 +142,70 @@ describe("useTransformingInput", () => {
     expect(input.selectionStart).toBe(6);
     expect(input.selectionEnd).toBe(6);
   });
+
+  it("restores the caret when a dropped character leaves the value unchanged", () => {
+    const input = renderHarness({ initialValue: "alpha-beta" });
+
+    act(() => {
+      setNativeInputValue({
+        input,
+        value: "alpha!-beta",
+        selectionStart: 6,
+      });
+    });
+    flushAnimationFrames();
+
+    expect(input.value).toBe("alpha-beta");
+    expect(input.selectionStart).toBe(5);
+    expect(input.selectionEnd).toBe(5);
+  });
+
+  it.each([
+    {
+      name: "identifier",
+      transformValue: transformIdentifierInput,
+      rawValue: "Alpha Beta",
+      selectionStart: 6,
+      expectedValue: "alpha-beta",
+      expectedSelectionStart: 6,
+    },
+    {
+      name: "environment variable",
+      transformValue: transformEnvironmentVariableInput,
+      rawValue: "API KEY",
+      selectionStart: 4,
+      expectedValue: "API_KEY",
+      expectedSelectionStart: 4,
+    },
+    {
+      name: "URI-safe",
+      transformValue: transformURISafeInput,
+      rawValue: "My Project",
+      selectionStart: 3,
+      expectedValue: "My-Project",
+      expectedSelectionStart: 3,
+    },
+  ])(
+    "maps the caret through the production $name transform",
+    ({
+      transformValue,
+      rawValue,
+      selectionStart,
+      expectedValue,
+      expectedSelectionStart,
+    }) => {
+      const input = renderHarness({ initialValue: "", transformValue });
+
+      act(() => {
+        setNativeInputValue({ input, value: rawValue, selectionStart });
+      });
+      flushAnimationFrames();
+
+      expect(input.value).toBe(expectedValue);
+      expect(input.selectionStart).toBe(expectedSelectionStart);
+      expect(input.selectionEnd).toBe(expectedSelectionStart);
+    }
+  );
 
   it("maps a selection through expanding and collapsing transforms", () => {
     const input = renderHarness({
@@ -213,5 +286,25 @@ describe("useTransformingInput", () => {
     expect(scheduledFrames.size).toBe(1);
     flushAnimationFrames();
     expect(input.selectionStart).toBe(8);
+  });
+
+  it("warns once when inputProps are not wired to the native input", () => {
+    const consoleWarning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const input = renderHarness({
+      initialValue: "alpha",
+      shouldWireInputProps: false,
+    });
+
+    act(() => {
+      setNativeInputValue({ input, value: "Alpha" });
+      setNativeInputValue({ input, value: "Alpha Beta" });
+    });
+
+    expect(consoleWarning).toHaveBeenCalledTimes(1);
+    expect(consoleWarning).toHaveBeenCalledWith(
+      "useTransformingInput could not access the native input. Spread the returned inputProps onto the Input element to preserve selection and IME composition."
+    );
   });
 });

--- a/app/src/hooks/__tests__/useTransformingInput.test.tsx
+++ b/app/src/hooks/__tests__/useTransformingInput.test.tsx
@@ -1,0 +1,217 @@
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { userEvent } from "storybook/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTransformingInput } from "../useTransformingInput";
+
+function setNativeInputValue({
+  input,
+  value,
+  selectionStart = value.length,
+  selectionEnd = selectionStart,
+}: {
+  input: HTMLInputElement;
+  value: string;
+  selectionStart?: number;
+  selectionEnd?: number;
+}) {
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value"
+  )?.set;
+  setValue?.call(input, value);
+  input.setSelectionRange(selectionStart, selectionEnd);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function TransformingInputHarness({
+  initialValue,
+  onValueCommitted,
+  transformValue,
+}: {
+  initialValue: string;
+  onValueCommitted: (value: string) => void;
+  transformValue: (value: string) => string;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const transformingInput = useTransformingInput({
+    value,
+    onValueChange: (nextValue) => {
+      onValueCommitted(nextValue);
+      setValue(nextValue);
+    },
+    transformValue,
+  });
+  return (
+    <input
+      {...transformingInput.inputProps}
+      value={transformingInput.displayValue}
+      onChange={(event) =>
+        transformingInput.handleValueChange(event.currentTarget.value)
+      }
+    />
+  );
+}
+
+describe("useTransformingInput", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let scheduledFrames: Map<number, FrameRequestCallback>;
+  let nextFrameId: number;
+
+  const flushAnimationFrames = () => {
+    const frames = [...scheduledFrames.values()];
+    scheduledFrames.clear();
+    act(() => frames.forEach((callback) => callback(0)));
+  };
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    scheduledFrames = new Map();
+    nextFrameId = 1;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      const frameId = nextFrameId++;
+      scheduledFrames.set(frameId, callback);
+      return frameId;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frameId) => {
+      scheduledFrames.delete(frameId);
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderHarness = ({
+    initialValue,
+    onValueCommitted = vi.fn(),
+    transformValue = (value: string) =>
+      value
+        .toLowerCase()
+        .replace(/\s+/g, "-")
+        .replace(/[^a-z0-9-]/g, ""),
+  }: {
+    initialValue: string;
+    onValueCommitted?: (value: string) => void;
+    transformValue?: (value: string) => string;
+  }) => {
+    act(() => {
+      root.render(
+        <TransformingInputHarness
+          initialValue={initialValue}
+          onValueCommitted={onValueCommitted}
+          transformValue={transformValue}
+        />
+      );
+    });
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+    act(() => input?.focus());
+    return input as HTMLInputElement;
+  };
+
+  it("preserves the caret after a transform in the middle of the value", () => {
+    const input = renderHarness({ initialValue: "alphabet" });
+
+    act(() => {
+      setNativeInputValue({
+        input,
+        value: "alpha bet",
+        selectionStart: 6,
+      });
+    });
+    flushAnimationFrames();
+
+    expect(input.value).toBe("alpha-bet");
+    expect(input.selectionStart).toBe(6);
+    expect(input.selectionEnd).toBe(6);
+  });
+
+  it("maps a selection through expanding and collapsing transforms", () => {
+    const input = renderHarness({
+      initialValue: "a& bc",
+      transformValue: (value) =>
+        value.replaceAll("&", "and").replace(/ +/g, "-"),
+    });
+
+    act(() => {
+      setNativeInputValue({
+        input,
+        value: "a&  bc",
+        selectionStart: 2,
+        selectionEnd: 4,
+      });
+    });
+    flushAnimationFrames();
+
+    expect(input.value).toBe("aand-bc");
+    expect(input.selectionStart).toBe(4);
+    expect(input.selectionEnd).toBe(5);
+  });
+
+  it("preserves the caret after pasting over a middle selection", async () => {
+    const input = renderHarness({ initialValue: "alpha-beta-gamma" });
+    input.setSelectionRange(6, 10);
+
+    const user = userEvent.setup();
+    await act(async () => user.paste("New Value"));
+    flushAnimationFrames();
+
+    expect(input.value).toBe("alpha-new-value-gamma");
+    expect(input.selectionStart).toBe(15);
+    expect(input.selectionEnd).toBe(15);
+  });
+
+  it("keeps composition text raw and commits it when composition ends", () => {
+    const onValueCommitted = vi.fn();
+    const input = renderHarness({
+      initialValue: "alpha",
+      onValueCommitted,
+    });
+
+    act(() => {
+      input.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+      setNativeInputValue({ input, value: "Alpha Z" });
+    });
+
+    expect(input.value).toBe("Alpha Z");
+    expect(onValueCommitted).not.toHaveBeenCalled();
+
+    act(() => {
+      input.dispatchEvent(new Event("compositionend", { bubbles: true }));
+    });
+    flushAnimationFrames();
+
+    expect(onValueCommitted).toHaveBeenCalledTimes(1);
+    expect(onValueCommitted).toHaveBeenCalledWith("alpha-z");
+    expect(input.value).toBe("alpha-z");
+  });
+
+  it("cancels a stale selection restoration when another edit occurs", () => {
+    const input = renderHarness({ initialValue: "alphabet" });
+
+    act(() => {
+      setNativeInputValue({
+        input,
+        value: "alpha bet",
+        selectionStart: 6,
+      });
+      setNativeInputValue({
+        input,
+        value: "alpha b et",
+        selectionStart: 8,
+      });
+    });
+
+    expect(scheduledFrames.size).toBe(1);
+    flushAnimationFrames();
+    expect(input.selectionStart).toBe(8);
+  });
+});

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -15,3 +15,4 @@ export * from "./usePersistedState";
 export * from "./useOwnedPreloadedQuery";
 export * from "./useLabelFilterSearchParams";
 export * from "./useMediaQuery";
+export * from "./useTransformingInput";

--- a/app/src/hooks/useTransformingInput.ts
+++ b/app/src/hooks/useTransformingInput.ts
@@ -1,0 +1,175 @@
+import {
+  useRef,
+  useState,
+  type CompositionEvent,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type RefObject,
+} from "react";
+
+type SelectionDirection = "backward" | "forward" | "none";
+
+type TextSelection = {
+  start: number;
+  end: number;
+  direction?: SelectionDirection;
+};
+
+type ScheduledSelection = TextSelection & {
+  value: string;
+};
+
+export type TransformingInputProps = Pick<
+  InputHTMLAttributes<HTMLInputElement>,
+  "onCompositionStart" | "onCompositionEnd"
+> & {
+  ref: RefObject<HTMLInputElement | null>;
+};
+
+export type UseTransformingInputOptions = {
+  value: string;
+  onValueChange: (value: string) => void;
+  transformValue: (value: string) => string;
+};
+
+/**
+ * Applies a live text transform without disrupting the user's selection or an
+ * in-progress input-method-editor (IME) composition.
+ *
+ * Selection mapping assumes the transform is prefix-stable: transforming a
+ * prefix must produce the same prefix as transforming the complete value. The
+ * identifier, environment-variable, and URI-safe transforms satisfy this.
+ *
+ * @param params - Controlled input configuration.
+ * @param params.value - The committed controlled value.
+ * @param params.onValueChange - Receives transformed, committed values.
+ * @param params.transformValue - Pure function that transforms input text.
+ */
+export function useTransformingInput({
+  value,
+  onValueChange,
+  transformValue,
+}: UseTransformingInputOptions) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isComposingRef = useRef(false);
+  const scheduledAnimationFrameRef = useRef<number | null>(null);
+  const [compositionValue, setCompositionValue] = useState<string | null>(null);
+
+  const cancelScheduledSelection = () => {
+    if (scheduledAnimationFrameRef.current == null) {
+      return;
+    }
+    cancelAnimationFrame(scheduledAnimationFrameRef.current);
+    scheduledAnimationFrameRef.current = null;
+  };
+
+  const scheduleSelection = ({
+    value: expectedValue,
+    start,
+    end,
+    direction,
+  }: ScheduledSelection) => {
+    cancelScheduledSelection();
+    scheduledAnimationFrameRef.current = requestAnimationFrame(() => {
+      scheduledAnimationFrameRef.current = null;
+      const input = inputRef.current;
+      const canRestoreSelection =
+        input != null &&
+        document.activeElement === input &&
+        input.value === expectedValue;
+      if (canRestoreSelection) {
+        input.setSelectionRange(start, end, direction);
+      }
+    });
+  };
+
+  const getCurrentSelection = (rawValue: string): TextSelection => {
+    const input = inputRef.current;
+    return {
+      start: input?.selectionStart ?? rawValue.length,
+      end: input?.selectionEnd ?? rawValue.length,
+      direction: input?.selectionDirection ?? undefined,
+    };
+  };
+
+  const commitValue = ({
+    rawValue,
+    selection,
+  }: {
+    rawValue: string;
+    selection: TextSelection;
+  }) => {
+    const transformedValue = transformValue(rawValue);
+    const transformedSelection = {
+      start: transformValue(rawValue.slice(0, selection.start)).length,
+      end: transformValue(rawValue.slice(0, selection.end)).length,
+      direction: selection.direction,
+    };
+
+    onValueChange(transformedValue);
+
+    if (transformedValue !== rawValue) {
+      scheduleSelection({
+        value: transformedValue,
+        ...transformedSelection,
+      });
+    }
+  };
+
+  const handleValueChange = (rawValue: string) => {
+    cancelScheduledSelection();
+    if (isComposingRef.current) {
+      setCompositionValue(rawValue);
+      return;
+    }
+    commitValue({
+      rawValue,
+      selection: getCurrentSelection(rawValue),
+    });
+  };
+
+  const handleCompositionStart = (
+    event: CompositionEvent<HTMLInputElement>
+  ) => {
+    cancelScheduledSelection();
+    isComposingRef.current = true;
+    setCompositionValue(event.currentTarget.value);
+  };
+
+  const handleCompositionEnd = (event: CompositionEvent<HTMLInputElement>) => {
+    const rawValue = event.currentTarget.value;
+    const selection = getCurrentSelection(rawValue);
+    isComposingRef.current = false;
+    setCompositionValue(null);
+    commitValue({ rawValue, selection });
+  };
+
+  const inputProps: TransformingInputProps = {
+    ref: inputRef,
+    onCompositionStart: handleCompositionStart,
+    onCompositionEnd: handleCompositionEnd,
+  };
+
+  return {
+    displayValue: compositionValue ?? value,
+    handleValueChange,
+    inputProps,
+  };
+}
+
+export type TransformingInputControllerState = ReturnType<
+  typeof useTransformingInput
+>;
+
+/**
+ * Headless adapter for using {@link useTransformingInput} where a form library
+ * supplies the controlled value inside a render callback.
+ */
+export function TransformingInputController({
+  children,
+  ...options
+}: UseTransformingInputOptions & {
+  children: (state: TransformingInputControllerState) => ReactNode;
+}) {
+  return children(useTransformingInput(options));
+}

--- a/app/src/hooks/useTransformingInput.ts
+++ b/app/src/hooks/useTransformingInput.ts
@@ -36,9 +36,12 @@ export type UseTransformingInputOptions = {
  * Applies a live text transform without disrupting the user's selection or an
  * in-progress input-method-editor (IME) composition.
  *
- * Selection mapping assumes the transform is prefix-stable: transforming a
- * prefix must produce the same prefix as transforming the complete value. The
- * identifier, environment-variable, and URI-safe transforms satisfy this.
+ * Selection mapping applies the transform to the raw text before each
+ * selection boundary. The transform must therefore map every raw prefix to
+ * the correct selection boundary in the complete transformed value. Transforms
+ * that depend on trailing context, such as `trim()`, are not supported. The
+ * identifier, environment-variable, and URI-safe transforms satisfy this
+ * requirement.
  *
  * @param params - Controlled input configuration.
  * @param params.value - The committed controlled value.
@@ -53,6 +56,7 @@ export function useTransformingInput({
   const inputRef = useRef<HTMLInputElement>(null);
   const isComposingRef = useRef(false);
   const scheduledAnimationFrameRef = useRef<number | null>(null);
+  const hasWarnedAboutMissingInputPropsRef = useRef(false);
   const [compositionValue, setCompositionValue] = useState<string | null>(null);
 
   const cancelScheduledSelection = () => {
@@ -85,6 +89,17 @@ export function useTransformingInput({
 
   const getCurrentSelection = (rawValue: string): TextSelection => {
     const input = inputRef.current;
+    if (
+      import.meta.env.DEV &&
+      input == null &&
+      !hasWarnedAboutMissingInputPropsRef.current
+    ) {
+      hasWarnedAboutMissingInputPropsRef.current = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "useTransformingInput could not access the native input. Spread the returned inputProps onto the Input element to preserve selection and IME composition."
+      );
+    }
     return {
       start: input?.selectionStart ?? rawValue.length,
       end: input?.selectionEnd ?? rawValue.length,

--- a/app/src/pages/playground/SavePromptForm.tsx
+++ b/app/src/pages/playground/SavePromptForm.tsx
@@ -87,6 +87,7 @@ export function SavePromptForm({
   const [promptInputValue, setPromptInputValue] = useState<string>(
     selectedPrompt?.prompt?.name ?? ""
   );
+  const [isPromptInputFocused, setIsPromptInputFocused] = useState(false);
 
   const mode: "create" | "update" = selectedPrompt ? "update" : "create";
   const submitButtonText =
@@ -110,7 +111,7 @@ export function SavePromptForm({
     handleSubmit,
     setValue,
     getValues,
-    formState: { isDirty, isValid },
+    formState: { isDirty, isSubmitted },
   } = useForm<SavePromptFormValues>({
     values: {
       promptId: selectedPromptId ?? undefined,
@@ -155,30 +156,40 @@ export function SavePromptForm({
           rules={{
             validate: validateIdentifier,
           }}
-          render={({ field: { onBlur, onChange }, fieldState }) => (
-            <PromptComboBox
-              label="Prompt"
-              description={`Select a prompt, or enter a new name. ${IDENTIFIER_DESCRIPTION}`}
-              placeholder="Select or enter new prompt name"
-              isRequired
-              onBlur={onBlur}
-              inputValue={promptInputValue}
-              onInputChange={(value) => {
-                const transformedValue = transformIdentifierInput(value);
-                setPromptInputValue(transformedValue);
-                onChange(transformedValue);
-              }}
-              errorMessage={fieldState.error?.message}
-              allowsCustomValue
-              onChange={(promptId) => {
-                onChange(promptId);
-                setSelectedPromptId(
-                  typeof promptId === "string" ? promptId : null
-                );
-              }}
-              promptId={selectedPromptId}
-            />
-          )}
+          render={({ field: { onBlur, onChange }, fieldState }) => {
+            const shouldShowError =
+              (fieldState.isTouched && !isPromptInputFocused) || isSubmitted;
+            return (
+              <PromptComboBox
+                label="Prompt"
+                description={`Select a prompt, or enter a new name. ${IDENTIFIER_DESCRIPTION}`}
+                placeholder="Select or enter new prompt name"
+                isRequired
+                onFocus={() => setIsPromptInputFocused(true)}
+                onBlur={() => {
+                  setIsPromptInputFocused(false);
+                  onBlur();
+                }}
+                inputValue={promptInputValue}
+                onInputChange={(value) => {
+                  const transformedValue = transformIdentifierInput(value);
+                  setPromptInputValue(transformedValue);
+                  onChange(transformedValue);
+                }}
+                errorMessage={
+                  shouldShowError ? fieldState.error?.message : undefined
+                }
+                allowsCustomValue
+                onChange={(promptId) => {
+                  onChange(promptId);
+                  setSelectedPromptId(
+                    typeof promptId === "string" ? promptId : null
+                  );
+                }}
+                promptId={selectedPromptId}
+              />
+            );
+          }}
         />
       </View>
       <Form onSubmit={handleSubmit(onSubmit)}>
@@ -310,7 +321,7 @@ export function SavePromptForm({
             <Button
               variant={isDirty ? "primary" : "default"}
               size="S"
-              isDisabled={isSubmitting || !isValid}
+              isDisabled={isSubmitting}
               type="submit"
             >
               {submitButtonText}
@@ -330,6 +341,7 @@ function NewTagInlineForm({
   onAdd: (tagName: string) => void;
 }) {
   const [inputValue, setInputValue] = useState("");
+  const [hasStoppedEditing, setHasStoppedEditing] = useState(false);
 
   const error = useMemo(() => {
     const trimmed = inputValue.trim();
@@ -342,10 +354,16 @@ function NewTagInlineForm({
 
   const handleAdd = useCallback(() => {
     const trimmed = inputValue.trim();
-    if (!trimmed || error) return;
+    if (!trimmed || error) {
+      setHasStoppedEditing(true);
+      return;
+    }
     onAdd(trimmed);
     setInputValue("");
+    setHasStoppedEditing(false);
   }, [inputValue, error, onAdd]);
+
+  const displayedError = hasStoppedEditing ? error : null;
 
   return (
     <Flex direction="row" gap="size-100" alignItems="start">
@@ -354,7 +372,9 @@ function NewTagInlineForm({
         aria-label="New tag name"
         value={inputValue}
         onChange={(value) => setInputValue(transformIdentifierInput(value))}
-        isInvalid={!!error}
+        onFocus={() => setHasStoppedEditing(false)}
+        onBlur={() => setHasStoppedEditing(true)}
+        isInvalid={!!displayedError}
         css={css`
           flex: 1 1 auto;
         `}
@@ -366,8 +386,8 @@ function NewTagInlineForm({
         }}
       >
         <Input placeholder="New tag name" />
-        {error ? (
-          <FieldError>{error}</FieldError>
+        {displayedError ? (
+          <FieldError>{displayedError}</FieldError>
         ) : (
           <Text slot="description">{IDENTIFIER_DESCRIPTION}</Text>
         )}
@@ -376,7 +396,7 @@ function NewTagInlineForm({
         size="S"
         leadingVisual={<Icon svg={<Icons.Plus />} />}
         onPress={handleAdd}
-        isDisabled={!inputValue.trim() || !!error}
+        isDisabled={!inputValue.trim()}
       >
         Add
       </Button>

--- a/app/src/pages/playground/SavePromptForm.tsx
+++ b/app/src/pages/playground/SavePromptForm.tsx
@@ -19,10 +19,16 @@ import {
   View,
 } from "@phoenix/components";
 import { CodeEditorFieldWrapper, JSONEditor } from "@phoenix/components/code";
-import { DEFAULT_PROMPT_VERSION_TAGS } from "@phoenix/constants";
+import {
+  DEFAULT_PROMPT_VERSION_TAGS,
+  IDENTIFIER_DESCRIPTION,
+} from "@phoenix/constants";
 import type { SavePromptFormQuery } from "@phoenix/pages/playground/__generated__/SavePromptFormQuery.graphql";
 import { PromptComboBox } from "@phoenix/pages/playground/PromptComboBox";
-import { validateIdentifier } from "@phoenix/utils/identifierUtils";
+import {
+  transformIdentifierInput,
+  validateIdentifier,
+} from "@phoenix/utils/identifierUtils";
 import { isJSONObjectString } from "@phoenix/utils/jsonUtils";
 
 export type SavePromptSubmitHandler = (
@@ -152,14 +158,15 @@ export function SavePromptForm({
           render={({ field: { onBlur, onChange }, fieldState }) => (
             <PromptComboBox
               label="Prompt"
-              description="The prompt to update, or prompt name to create"
+              description={`Select a prompt, or enter a new name. ${IDENTIFIER_DESCRIPTION}`}
               placeholder="Select or enter new prompt name"
               isRequired
               onBlur={onBlur}
-              defaultInputValue={promptInputValue}
+              inputValue={promptInputValue}
               onInputChange={(value) => {
-                setPromptInputValue(value);
-                onChange(value);
+                const transformedValue = transformIdentifierInput(value);
+                setPromptInputValue(transformedValue);
+                onChange(transformedValue);
               }}
               errorMessage={fieldState.error?.message}
               allowsCustomValue
@@ -346,7 +353,7 @@ function NewTagInlineForm({
         size="S"
         aria-label="New tag name"
         value={inputValue}
-        onChange={setInputValue}
+        onChange={(value) => setInputValue(transformIdentifierInput(value))}
         isInvalid={!!error}
         css={css`
           flex: 1 1 auto;
@@ -359,7 +366,11 @@ function NewTagInlineForm({
         }}
       >
         <Input placeholder="New tag name" />
-        {error ? <FieldError>{error}</FieldError> : null}
+        {error ? (
+          <FieldError>{error}</FieldError>
+        ) : (
+          <Text slot="description">{IDENTIFIER_DESCRIPTION}</Text>
+        )}
       </TextField>
       <Button
         size="S"

--- a/app/src/pages/playground/SavePromptForm.tsx
+++ b/app/src/pages/playground/SavePromptForm.tsx
@@ -23,6 +23,10 @@ import {
   DEFAULT_PROMPT_VERSION_TAGS,
   IDENTIFIER_DESCRIPTION,
 } from "@phoenix/constants";
+import {
+  TransformingInputController,
+  useTransformingInput,
+} from "@phoenix/hooks/useTransformingInput";
 import type { SavePromptFormQuery } from "@phoenix/pages/playground/__generated__/SavePromptFormQuery.graphql";
 import { PromptComboBox } from "@phoenix/pages/playground/PromptComboBox";
 import {
@@ -160,34 +164,42 @@ export function SavePromptForm({
             const shouldShowError =
               (fieldState.isTouched && !isPromptInputFocused) || isSubmitted;
             return (
-              <PromptComboBox
-                label="Prompt"
-                description={`Select a prompt, or enter a new name. ${IDENTIFIER_DESCRIPTION}`}
-                placeholder="Select or enter new prompt name"
-                isRequired
-                onFocus={() => setIsPromptInputFocused(true)}
-                onBlur={() => {
-                  setIsPromptInputFocused(false);
-                  onBlur();
+              <TransformingInputController
+                value={promptInputValue}
+                onValueChange={(value) => {
+                  setPromptInputValue(value);
+                  onChange(value);
                 }}
-                inputValue={promptInputValue}
-                onInputChange={(value) => {
-                  const transformedValue = transformIdentifierInput(value);
-                  setPromptInputValue(transformedValue);
-                  onChange(transformedValue);
-                }}
-                errorMessage={
-                  shouldShowError ? fieldState.error?.message : undefined
-                }
-                allowsCustomValue
-                onChange={(promptId) => {
-                  onChange(promptId);
-                  setSelectedPromptId(
-                    typeof promptId === "string" ? promptId : null
-                  );
-                }}
-                promptId={selectedPromptId}
-              />
+                transformValue={transformIdentifierInput}
+              >
+                {(transformingInput) => (
+                  <PromptComboBox
+                    label="Prompt"
+                    description={`Select a prompt, or enter a new name. ${IDENTIFIER_DESCRIPTION}`}
+                    placeholder="Select or enter new prompt name"
+                    isRequired
+                    onFocus={() => setIsPromptInputFocused(true)}
+                    onBlur={() => {
+                      setIsPromptInputFocused(false);
+                      onBlur();
+                    }}
+                    inputValue={transformingInput.displayValue}
+                    onInputChange={transformingInput.handleValueChange}
+                    inputProps={transformingInput.inputProps}
+                    errorMessage={
+                      shouldShowError ? fieldState.error?.message : undefined
+                    }
+                    allowsCustomValue
+                    onChange={(promptId) => {
+                      onChange(promptId);
+                      setSelectedPromptId(
+                        typeof promptId === "string" ? promptId : null
+                      );
+                    }}
+                    promptId={selectedPromptId}
+                  />
+                )}
+              </TransformingInputController>
             );
           }}
         />
@@ -342,6 +354,11 @@ function NewTagInlineForm({
 }) {
   const [inputValue, setInputValue] = useState("");
   const [hasStoppedEditing, setHasStoppedEditing] = useState(false);
+  const transformingInput = useTransformingInput({
+    value: inputValue,
+    onValueChange: setInputValue,
+    transformValue: transformIdentifierInput,
+  });
 
   const error = useMemo(() => {
     const trimmed = inputValue.trim();
@@ -370,8 +387,8 @@ function NewTagInlineForm({
       <TextField
         size="S"
         aria-label="New tag name"
-        value={inputValue}
-        onChange={(value) => setInputValue(transformIdentifierInput(value))}
+        value={transformingInput.displayValue}
+        onChange={transformingInput.handleValueChange}
         onFocus={() => setHasStoppedEditing(false)}
         onBlur={() => setHasStoppedEditing(true)}
         isInvalid={!!displayedError}
@@ -385,7 +402,7 @@ function NewTagInlineForm({
           }
         }}
       >
-        <Input placeholder="New tag name" />
+        <Input {...transformingInput.inputProps} placeholder="New tag name" />
         {displayedError ? (
           <FieldError>{displayedError}</FieldError>
         ) : (

--- a/app/src/pages/playground/__tests__/SavePromptForm.test.tsx
+++ b/app/src/pages/playground/__tests__/SavePromptForm.test.tsx
@@ -19,17 +19,17 @@ vi.mock("@phoenix/components/code", () => ({
 
 vi.mock("@phoenix/pages/playground/PromptComboBox", () => ({
   PromptComboBox: ({
-    defaultInputValue,
+    inputValue,
     onBlur,
     onInputChange,
   }: {
-    defaultInputValue?: string;
+    inputValue?: string;
     onBlur?: () => void;
     onInputChange?: (value: string) => void;
   }) => (
     <input
       data-testid="prompt-picker"
-      defaultValue={defaultInputValue}
+      value={inputValue}
       onBlur={onBlur}
       onChange={(event) => onInputChange?.(event.target.value)}
     />
@@ -111,8 +111,10 @@ describe("SavePromptForm", () => {
     expect(promptInput).not.toBeNull();
 
     await act(async () => {
-      setInputValue(promptInput as HTMLInputElement, "new-prompt");
+      setInputValue(promptInput as HTMLInputElement, "New Prompt.v2!");
     });
+
+    expect(promptInput?.value).toBe("new-promptv2");
 
     const form = container.querySelector("form");
     expect(form).not.toBeNull();
@@ -124,7 +126,7 @@ describe("SavePromptForm", () => {
 
     expect(onCreate).toHaveBeenCalledOnce();
     expect(onCreate.mock.calls[0]?.[0]).toMatchObject({
-      name: "new-prompt",
+      name: "new-promptv2",
       description: undefined,
     });
   });

--- a/app/src/pages/playground/__tests__/SavePromptForm.test.tsx
+++ b/app/src/pages/playground/__tests__/SavePromptForm.test.tsx
@@ -19,20 +19,30 @@ vi.mock("@phoenix/components/code", () => ({
 
 vi.mock("@phoenix/pages/playground/PromptComboBox", () => ({
   PromptComboBox: ({
+    errorMessage,
     inputValue,
     onBlur,
+    onFocus,
     onInputChange,
   }: {
+    errorMessage?: string;
     inputValue?: string;
     onBlur?: () => void;
+    onFocus?: () => void;
     onInputChange?: (value: string) => void;
   }) => (
-    <input
-      data-testid="prompt-picker"
-      value={inputValue}
-      onBlur={onBlur}
-      onChange={(event) => onInputChange?.(event.target.value)}
-    />
+    <>
+      <input
+        data-testid="prompt-picker"
+        value={inputValue}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onChange={(event) => onInputChange?.(event.target.value)}
+      />
+      {errorMessage ? (
+        <span data-testid="prompt-error">{errorMessage}</span>
+      ) : null}
+    </>
   ),
 }));
 
@@ -129,6 +139,64 @@ describe("SavePromptForm", () => {
       name: "new-promptv2",
       description: undefined,
     });
+  });
+
+  it("ignores leading spaces and defers trailing-dash errors until blur", async () => {
+    await act(async () => {
+      root.render(
+        <RelayEnvironmentProvider environment={createTestEnvironment({})}>
+          <Suspense fallback={null}>
+            <SavePromptForm
+              onCreate={vi.fn()}
+              onUpdate={vi.fn()}
+              onClose={vi.fn()}
+            />
+          </Suspense>
+        </RelayEnvironmentProvider>
+      );
+    });
+
+    const promptInput = container.querySelector<HTMLInputElement>(
+      '[data-testid="prompt-picker"]'
+    );
+    expect(promptInput).not.toBeNull();
+
+    await act(async () => {
+      promptInput?.focus();
+      setInputValue(promptInput as HTMLInputElement, " ");
+    });
+    expect(promptInput?.value).toBe("");
+    expect(container.querySelector('[data-testid="prompt-error"]')).toBeNull();
+
+    await act(async () => {
+      setInputValue(promptInput as HTMLInputElement, "A ");
+    });
+    expect(promptInput?.value).toBe("a-");
+    expect(container.querySelector('[data-testid="prompt-error"]')).toBeNull();
+
+    await act(async () => {
+      promptInput?.blur();
+    });
+    expect(
+      container.querySelector('[data-testid="prompt-error"]')?.textContent
+    ).toBe("Must start and end with lowercase alphanumeric characters");
+
+    await act(async () => {
+      promptInput?.focus();
+      setInputValue(promptInput as HTMLInputElement, "B ");
+    });
+    expect(container.querySelector('[data-testid="prompt-error"]')).toBeNull();
+
+    await act(async () => {
+      container
+        .querySelector("form")
+        ?.dispatchEvent(
+          new SubmitEvent("submit", { bubbles: true, cancelable: true })
+        );
+    });
+    expect(
+      container.querySelector('[data-testid="prompt-error"]')?.textContent
+    ).toBe("Must start and end with lowercase alphanumeric characters");
   });
 
   it("updates a prompt without a change description", async () => {

--- a/app/src/pages/projects/NewProjectButton.tsx
+++ b/app/src/pages/projects/NewProjectButton.tsx
@@ -38,6 +38,7 @@ import { SelectChevronUpDownIcon } from "@phoenix/components/core/icon";
 import { GradientCircle } from "@phoenix/components/project/GradientCircle";
 import { URI_SAFE_PATTERN } from "@phoenix/constants";
 import { useNotifySuccess } from "@phoenix/contexts";
+import { TransformingInputController } from "@phoenix/hooks/useTransformingInput";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 import { transformURISafeInput } from "@phoenix/utils/uriUtils";
 
@@ -189,25 +190,34 @@ function NewProjectDialog({
                       field: { onChange, onBlur, value },
                       fieldState: { invalid, error: fieldError },
                     }) => (
-                      <TextField
-                        isInvalid={invalid}
-                        onChange={(value) =>
-                          onChange(transformURISafeInput(value))
-                        }
-                        onBlur={onBlur}
+                      <TransformingInputController
                         value={value}
-                        autoFocus
+                        onValueChange={onChange}
+                        transformValue={transformURISafeInput}
                       >
-                        <Label>Name</Label>
-                        <Input placeholder="e.g. customer-feedback" />
-                        {fieldError?.message ? (
-                          <FieldError>{fieldError.message}</FieldError>
-                        ) : (
-                          <Text slot="description">
-                            URI characters only, max 100 characters
-                          </Text>
+                        {(transformingInput) => (
+                          <TextField
+                            isInvalid={invalid}
+                            onChange={transformingInput.handleValueChange}
+                            onBlur={onBlur}
+                            value={transformingInput.displayValue}
+                            autoFocus
+                          >
+                            <Label>Name</Label>
+                            <Input
+                              {...transformingInput.inputProps}
+                              placeholder="e.g. customer-feedback"
+                            />
+                            {fieldError?.message ? (
+                              <FieldError>{fieldError.message}</FieldError>
+                            ) : (
+                              <Text slot="description">
+                                URI characters only, max 100 characters
+                              </Text>
+                            )}
+                          </TextField>
                         )}
-                      </TextField>
+                      </TransformingInputController>
                     )}
                   />
                 </View>

--- a/app/src/pages/projects/NewProjectButton.tsx
+++ b/app/src/pages/projects/NewProjectButton.tsx
@@ -39,6 +39,7 @@ import { GradientCircle } from "@phoenix/components/project/GradientCircle";
 import { URI_SAFE_PATTERN } from "@phoenix/constants";
 import { useNotifySuccess } from "@phoenix/contexts";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
+import { transformURISafeInput } from "@phoenix/utils/uriUtils";
 
 import type { NewProjectButtonCreateProjectMutation } from "./__generated__/NewProjectButtonCreateProjectMutation.graphql";
 import { GRADIENT_PRESETS } from "./ProjectForm";
@@ -190,7 +191,9 @@ function NewProjectDialog({
                     }) => (
                       <TextField
                         isInvalid={invalid}
-                        onChange={onChange}
+                        onChange={(value) =>
+                          onChange(transformURISafeInput(value))
+                        }
                         onBlur={onBlur}
                         value={value}
                         autoFocus

--- a/app/src/pages/projects/ProjectForm.tsx
+++ b/app/src/pages/projects/ProjectForm.tsx
@@ -19,6 +19,7 @@ import {
   GradientCircleRadioGroup,
 } from "@phoenix/components/project";
 import { URI_SAFE_PATTERN } from "@phoenix/constants";
+import { TransformingInputController } from "@phoenix/hooks/useTransformingInput";
 import { transformURISafeInput } from "@phoenix/utils/uriUtils";
 
 export type ProjectFormParams = {
@@ -226,23 +227,34 @@ export function ProjectForm({
               field: { onChange, onBlur, value },
               fieldState: { invalid, error },
             }) => (
-              <TextField
-                isInvalid={invalid}
-                onChange={(value) => onChange(transformURISafeInput(value))}
-                onBlur={onBlur}
+              <TransformingInputController
                 value={value.toString()}
+                onValueChange={onChange}
+                transformValue={transformURISafeInput}
               >
-                <Label>Project Name</Label>
-                <Input placeholder="e.x. my-ai-project" />
-                {error?.message ? (
-                  <FieldError>{error.message}</FieldError>
-                ) : (
-                  <Text slot="description">
-                    The name of the project. Must be URI safe (letters, numbers,
-                    hyphens, underscores, dots only).
-                  </Text>
+                {(transformingInput) => (
+                  <TextField
+                    isInvalid={invalid}
+                    onChange={transformingInput.handleValueChange}
+                    onBlur={onBlur}
+                    value={transformingInput.displayValue}
+                  >
+                    <Label>Project Name</Label>
+                    <Input
+                      {...transformingInput.inputProps}
+                      placeholder="e.x. my-ai-project"
+                    />
+                    {error?.message ? (
+                      <FieldError>{error.message}</FieldError>
+                    ) : (
+                      <Text slot="description">
+                        The name of the project. Must be URI safe (letters,
+                        numbers, hyphens, underscores, dots only).
+                      </Text>
+                    )}
+                  </TextField>
                 )}
-              </TextField>
+              </TransformingInputController>
             )}
           />
         )}

--- a/app/src/pages/projects/ProjectForm.tsx
+++ b/app/src/pages/projects/ProjectForm.tsx
@@ -19,6 +19,7 @@ import {
   GradientCircleRadioGroup,
 } from "@phoenix/components/project";
 import { URI_SAFE_PATTERN } from "@phoenix/constants";
+import { transformURISafeInput } from "@phoenix/utils/uriUtils";
 
 export type ProjectFormParams = {
   name: string;
@@ -227,7 +228,7 @@ export function ProjectForm({
             }) => (
               <TextField
                 isInvalid={invalid}
-                onChange={onChange}
+                onChange={(value) => onChange(transformURISafeInput(value))}
                 onBlur={onBlur}
                 value={value.toString()}
               >

--- a/app/src/pages/prompt/ClonePromptDialog.tsx
+++ b/app/src/pages/prompt/ClonePromptDialog.tsx
@@ -26,6 +26,7 @@ import {
 } from "@phoenix/components/core/dialog";
 import { IDENTIFIER_DESCRIPTION } from "@phoenix/constants";
 import { useNotifySuccess } from "@phoenix/contexts/NotificationContext";
+import { TransformingInputController } from "@phoenix/hooks/useTransformingInput";
 import type { ClonePromptDialogMutation } from "@phoenix/pages/prompt/__generated__/ClonePromptDialogMutation.graphql";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 import {
@@ -158,31 +159,38 @@ export const ClonePromptDialog = ({
                           ? error
                           : undefined;
                       return (
-                        <TextField isInvalid={!!displayedError?.message}>
-                          <Label>Name</Label>
-                          <Input
-                            name="name"
-                            type="text"
-                            onChange={(event) =>
-                              onChange(
-                                transformIdentifierInput(event.target.value)
-                              )
-                            }
-                            onFocus={() => setIsNameFocused(true)}
-                            onBlur={() => {
-                              setIsNameFocused(false);
-                              onBlur();
-                            }}
-                            value={value}
-                            disabled={disabled}
-                          />
-                          {!displayedError && (
-                            <Text slot="description">
-                              {IDENTIFIER_DESCRIPTION}
-                            </Text>
+                        <TransformingInputController
+                          value={value}
+                          onValueChange={onChange}
+                          transformValue={transformIdentifierInput}
+                        >
+                          {(transformingInput) => (
+                            <TextField
+                              isInvalid={!!displayedError?.message}
+                              name="name"
+                              value={transformingInput.displayValue}
+                              onChange={transformingInput.handleValueChange}
+                              onFocus={() => setIsNameFocused(true)}
+                              onBlur={() => {
+                                setIsNameFocused(false);
+                                onBlur();
+                              }}
+                              isDisabled={disabled}
+                            >
+                              <Label>Name</Label>
+                              <Input
+                                {...transformingInput.inputProps}
+                                type="text"
+                              />
+                              {!displayedError && (
+                                <Text slot="description">
+                                  {IDENTIFIER_DESCRIPTION}
+                                </Text>
+                              )}
+                              <FieldError>{displayedError?.message}</FieldError>
+                            </TextField>
                           )}
-                          <FieldError>{displayedError?.message}</FieldError>
-                        </TextField>
+                        </TransformingInputController>
                       );
                     }}
                   />

--- a/app/src/pages/prompt/ClonePromptDialog.tsx
+++ b/app/src/pages/prompt/ClonePromptDialog.tsx
@@ -24,10 +24,14 @@ import {
   DialogTitle,
   DialogTitleExtra,
 } from "@phoenix/components/core/dialog";
+import { IDENTIFIER_DESCRIPTION } from "@phoenix/constants";
 import { useNotifySuccess } from "@phoenix/contexts/NotificationContext";
 import type { ClonePromptDialogMutation } from "@phoenix/pages/prompt/__generated__/ClonePromptDialogMutation.graphql";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
-import { validateIdentifier } from "@phoenix/utils/identifierUtils";
+import {
+  transformIdentifierInput,
+  validateIdentifier,
+} from "@phoenix/utils/identifierUtils";
 import { isJSONObjectString } from "@phoenix/utils/jsonUtils";
 
 export const ClonePromptDialog = ({
@@ -153,14 +157,18 @@ export const ClonePromptDialog = ({
                         <Input
                           name="name"
                           type="text"
-                          onChange={onChange}
+                          onChange={(event) =>
+                            onChange(
+                              transformIdentifierInput(event.target.value)
+                            )
+                          }
                           onBlur={onBlur}
                           value={value}
                           disabled={disabled}
                         />
                         {!error && (
                           <Text slot="description">
-                            A name for the cloned prompt.
+                            {IDENTIFIER_DESCRIPTION}
                           </Text>
                         )}
                         <FieldError>{error?.message}</FieldError>

--- a/app/src/pages/prompt/ClonePromptDialog.tsx
+++ b/app/src/pages/prompt/ClonePromptDialog.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { graphql, useMutation } from "react-relay";
 import { useNavigate } from "react-router";
@@ -47,6 +47,7 @@ export const ClonePromptDialog = ({
 }) => {
   const notifySuccess = useNotifySuccess();
   const navigate = useNavigate();
+  const [isNameFocused, setIsNameFocused] = useState(false);
   const [clonePrompt, isClonePending] = useMutation<ClonePromptDialogMutation>(
     graphql`
       mutation ClonePromptDialogMutation($input: ClonePromptInput!) {
@@ -68,7 +69,7 @@ export const ClonePromptDialog = ({
   const {
     control,
     handleSubmit,
-    formState: { isValid, errors },
+    formState: { errors, isSubmitted },
     setError,
   } = form;
   const onSubmit = (close: () => void) =>
@@ -150,30 +151,40 @@ export const ClonePromptDialog = ({
                     }}
                     render={({
                       field: { onChange, onBlur, value, disabled },
-                      fieldState: { error },
-                    }) => (
-                      <TextField isInvalid={!!error?.message}>
-                        <Label>Name</Label>
-                        <Input
-                          name="name"
-                          type="text"
-                          onChange={(event) =>
-                            onChange(
-                              transformIdentifierInput(event.target.value)
-                            )
-                          }
-                          onBlur={onBlur}
-                          value={value}
-                          disabled={disabled}
-                        />
-                        {!error && (
-                          <Text slot="description">
-                            {IDENTIFIER_DESCRIPTION}
-                          </Text>
-                        )}
-                        <FieldError>{error?.message}</FieldError>
-                      </TextField>
-                    )}
+                      fieldState: { error, isTouched },
+                    }) => {
+                      const displayedError =
+                        (isTouched && !isNameFocused) || isSubmitted
+                          ? error
+                          : undefined;
+                      return (
+                        <TextField isInvalid={!!displayedError?.message}>
+                          <Label>Name</Label>
+                          <Input
+                            name="name"
+                            type="text"
+                            onChange={(event) =>
+                              onChange(
+                                transformIdentifierInput(event.target.value)
+                              )
+                            }
+                            onFocus={() => setIsNameFocused(true)}
+                            onBlur={() => {
+                              setIsNameFocused(false);
+                              onBlur();
+                            }}
+                            value={value}
+                            disabled={disabled}
+                          />
+                          {!displayedError && (
+                            <Text slot="description">
+                              {IDENTIFIER_DESCRIPTION}
+                            </Text>
+                          )}
+                          <FieldError>{displayedError?.message}</FieldError>
+                        </TextField>
+                      );
+                    }}
                   />
                   <Controller
                     control={control}
@@ -247,7 +258,6 @@ export const ClonePromptDialog = ({
                   <Button
                     type="submit"
                     variant="primary"
-                    isDisabled={!isValid}
                     isPending={isClonePending}
                   >
                     Clone

--- a/app/src/pages/prompt/NewPromptVersionTagDialog.tsx
+++ b/app/src/pages/prompt/NewPromptVersionTagDialog.tsx
@@ -23,8 +23,12 @@ import {
   TextField,
   View,
 } from "@phoenix/components";
+import { IDENTIFIER_DESCRIPTION } from "@phoenix/constants";
 
-import { validateIdentifier } from "../../utils/identifierUtils";
+import {
+  transformIdentifierInput,
+  validateIdentifier,
+} from "../../utils/identifierUtils";
 
 type PromptVersionTagFormParams = {
   name: string;
@@ -120,7 +124,9 @@ export function NewPromptVersionDialog({
                   }) => (
                     <TextField
                       isInvalid={invalid}
-                      onChange={onChange}
+                      onChange={(value) =>
+                        onChange(transformIdentifierInput(value))
+                      }
                       onBlur={onBlur}
                       name={name}
                       value={value}
@@ -130,9 +136,7 @@ export function NewPromptVersionDialog({
                       {error?.message ? (
                         <FieldError>{error.message}</FieldError>
                       ) : (
-                        <Text slot="description">
-                          The identifier of the tag
-                        </Text>
+                        <Text slot="description">{IDENTIFIER_DESCRIPTION}</Text>
                       )}
                     </TextField>
                   )}

--- a/app/src/pages/prompt/NewPromptVersionTagDialog.tsx
+++ b/app/src/pages/prompt/NewPromptVersionTagDialog.tsx
@@ -24,6 +24,7 @@ import {
   View,
 } from "@phoenix/components";
 import { IDENTIFIER_DESCRIPTION } from "@phoenix/constants";
+import { TransformingInputController } from "@phoenix/hooks/useTransformingInput";
 
 import {
   transformIdentifierInput,
@@ -128,29 +129,38 @@ export function NewPromptVersionDialog({
                         ? error
                         : undefined;
                     return (
-                      <TextField
-                        isInvalid={!!displayedError}
-                        onChange={(value) =>
-                          onChange(transformIdentifierInput(value))
-                        }
-                        onFocus={() => setIsNameFocused(true)}
-                        onBlur={() => {
-                          setIsNameFocused(false);
-                          onBlur();
-                        }}
-                        name={name}
+                      <TransformingInputController
                         value={value}
+                        onValueChange={onChange}
+                        transformValue={transformIdentifierInput}
                       >
-                        <Label>Tag Name</Label>
-                        <Input placeholder="e.x. prod" />
-                        {displayedError?.message ? (
-                          <FieldError>{displayedError.message}</FieldError>
-                        ) : (
-                          <Text slot="description">
-                            {IDENTIFIER_DESCRIPTION}
-                          </Text>
+                        {(transformingInput) => (
+                          <TextField
+                            isInvalid={!!displayedError}
+                            onChange={transformingInput.handleValueChange}
+                            onFocus={() => setIsNameFocused(true)}
+                            onBlur={() => {
+                              setIsNameFocused(false);
+                              onBlur();
+                            }}
+                            name={name}
+                            value={transformingInput.displayValue}
+                          >
+                            <Label>Tag Name</Label>
+                            <Input
+                              {...transformingInput.inputProps}
+                              placeholder="e.x. prod"
+                            />
+                            {displayedError?.message ? (
+                              <FieldError>{displayedError.message}</FieldError>
+                            ) : (
+                              <Text slot="description">
+                                {IDENTIFIER_DESCRIPTION}
+                              </Text>
+                            )}
+                          </TextField>
                         )}
-                      </TextField>
+                      </TransformingInputController>
                     );
                   }}
                 />

--- a/app/src/pages/prompt/NewPromptVersionTagDialog.tsx
+++ b/app/src/pages/prompt/NewPromptVersionTagDialog.tsx
@@ -47,10 +47,11 @@ export function NewPromptVersionDialog({
   onNewTagCreated: (tag: PromptVersionTagFormParams) => void;
   onDismiss: () => void;
 }) {
+  const [isNameFocused, setIsNameFocused] = useState(false);
   const {
     control,
     handleSubmit,
-    formState: { isDirty },
+    formState: { isDirty, isSubmitted },
   } = useForm<PromptVersionTagFormParams>({
     defaultValues: {
       name: "",
@@ -120,26 +121,38 @@ export function NewPromptVersionDialog({
                   }}
                   render={({
                     field: { name, onChange, onBlur, value },
-                    fieldState: { invalid, error },
-                  }) => (
-                    <TextField
-                      isInvalid={invalid}
-                      onChange={(value) =>
-                        onChange(transformIdentifierInput(value))
-                      }
-                      onBlur={onBlur}
-                      name={name}
-                      value={value}
-                    >
-                      <Label>Tag Name</Label>
-                      <Input placeholder="e.x. prod" />
-                      {error?.message ? (
-                        <FieldError>{error.message}</FieldError>
-                      ) : (
-                        <Text slot="description">{IDENTIFIER_DESCRIPTION}</Text>
-                      )}
-                    </TextField>
-                  )}
+                    fieldState: { error, isTouched },
+                  }) => {
+                    const displayedError =
+                      (isTouched && !isNameFocused) || isSubmitted
+                        ? error
+                        : undefined;
+                    return (
+                      <TextField
+                        isInvalid={!!displayedError}
+                        onChange={(value) =>
+                          onChange(transformIdentifierInput(value))
+                        }
+                        onFocus={() => setIsNameFocused(true)}
+                        onBlur={() => {
+                          setIsNameFocused(false);
+                          onBlur();
+                        }}
+                        name={name}
+                        value={value}
+                      >
+                        <Label>Tag Name</Label>
+                        <Input placeholder="e.x. prod" />
+                        {displayedError?.message ? (
+                          <FieldError>{displayedError.message}</FieldError>
+                        ) : (
+                          <Text slot="description">
+                            {IDENTIFIER_DESCRIPTION}
+                          </Text>
+                        )}
+                      </TextField>
+                    );
+                  }}
                 />
                 <Controller
                   name="description"

--- a/app/src/pages/settings/ModelForm.tsx
+++ b/app/src/pages/settings/ModelForm.tsx
@@ -21,6 +21,7 @@ import {
 } from "@phoenix/components";
 import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
 import { RegexField } from "@phoenix/components/RegexField";
+import { useTransformingInput } from "@phoenix/hooks/useTransformingInput";
 import { ModelTokenCostControlTable } from "@phoenix/pages/settings/ModelTokenCostControlTable";
 import type { ModelTokenKind } from "@phoenix/pages/settings/ModelTokenTypeComboBox";
 import {
@@ -100,6 +101,11 @@ function ModelProviderComboBox({
   invalid: boolean;
   description?: string;
 }) {
+  const transformingInput = useTransformingInput({
+    value,
+    onValueChange: onChange,
+    transformValue: (inputValue) => inputValue.toLowerCase(),
+  });
   return (
     <ComboBox
       label="Provider"
@@ -107,16 +113,15 @@ function ModelProviderComboBox({
       selectedKey={
         PROVIDER_OPTIONS.find((option) => option.value === value)?.key || ""
       }
-      inputValue={value}
+      inputValue={transformingInput.displayValue}
       onSelectionChange={(key) => {
         const provider = PROVIDER_OPTIONS.find((option) => option.key === key);
         if (provider) {
           onChange(provider.value);
         }
       }}
-      onInputChange={(value) => {
-        onChange(value?.toLowerCase());
-      }}
+      onInputChange={transformingInput.handleValueChange}
+      inputProps={transformingInput.inputProps}
       onBlur={onBlur}
       isInvalid={invalid}
       size="M"

--- a/app/src/pages/settings/ModelTokenTypeComboBox.tsx
+++ b/app/src/pages/settings/ModelTokenTypeComboBox.tsx
@@ -1,4 +1,5 @@
 import { ComboBox, ComboBoxItem, Flex } from "@phoenix/components";
+import { useTransformingInput } from "@phoenix/hooks/useTransformingInput";
 
 export type ModelTokenKind = "PROMPT" | "COMPLETION";
 
@@ -69,26 +70,25 @@ export function ModelTokenTypeComboBox<
   isRequired?: boolean;
 }) {
   const selectedOption = options.find((option) => option.tokenType === value);
+  const transformingInput = useTransformingInput({
+    value: value ?? "",
+    onValueChange: (inputValue) => onChange(inputValue || null),
+    transformValue: (inputValue) => inputValue.toLowerCase(),
+  });
   return (
     <ComboBox
       aria-label="Token type"
       placeholder="Choose or enter a token type"
       selectedKey={selectedOption?.tokenType ?? ""}
-      inputValue={value ?? ""}
+      inputValue={transformingInput.displayValue}
       onSelectionChange={(tokenType) => {
         const option = options.find((option) => option.tokenType === tokenType);
         if (option) {
           onChange(option.tokenType);
         }
       }}
-      onInputChange={(_value) => {
-        const value = _value.toLowerCase();
-        if (value) {
-          onChange(value);
-        } else {
-          onChange(null);
-        }
-      }}
+      onInputChange={transformingInput.handleValueChange}
+      inputProps={transformingInput.inputProps}
       onBlur={onBlur}
       isInvalid={invalid}
       isRequired={isRequired}

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -42,7 +42,9 @@ import {
   SandboxProviderSelect,
   SandboxProviderSelectFallback,
 } from "@phoenix/components/sandbox/SandboxProviderSelect";
+import { IDENTIFIER_DESCRIPTION } from "@phoenix/constants";
 import { useNotifySuccess } from "@phoenix/contexts";
+import { transformEnvironmentVariableInput } from "@phoenix/utils/environmentVariableUtils";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 import {
   getIdentifier,
@@ -554,8 +556,7 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                     <Label>Name</Label>
                     <Input />
                     <Text slot="description" size="S" color="text-700">
-                      Lowercase letters, digits, dashes, and underscores. Must
-                      start and end with a letter or digit.
+                      {IDENTIFIER_DESCRIPTION}
                     </Text>
                     {fieldState.error ? (
                       <FieldError>{fieldState.error.message}</FieldError>
@@ -768,12 +769,22 @@ function EnvVarRow({
         control={form.control}
         rules={{ required: "Name is required" }}
         render={({ field, fieldState }) => (
-          <TextField {...field} isInvalid={fieldState.invalid}>
+          <TextField
+            {...field}
+            onChange={(value) =>
+              field.onChange(transformEnvironmentVariableInput(value))
+            }
+            isInvalid={fieldState.invalid}
+          >
             <Label>Variable Name</Label>
             <Input placeholder="MY_VAR" />
             {fieldState.error ? (
               <FieldError>{fieldState.error.message}</FieldError>
-            ) : null}
+            ) : (
+              <Text slot="description">
+                Uppercase letters, digits, and underscores
+              </Text>
+            )}
           </TextField>
         )}
       />

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -199,6 +199,7 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
   const defaultProvider = mode === "create" ? props.defaultProvider : undefined;
   const notifySuccess = useNotifySuccess();
   const [error, setError] = useState<string | null>(null);
+  const [isNameFocused, setIsNameFocused] = useState(false);
 
   const existingBackend = mode === "edit" ? props.backend : undefined;
   const existingConfig = mode === "edit" ? props.config : undefined;
@@ -545,24 +546,38 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                   required: "Name is required",
                   validate: validateIdentifier,
                 }}
-                render={({ field, fieldState }) => (
-                  <TextField
-                    {...field}
-                    onChange={(value) =>
-                      field.onChange(transformIdentifierInput(value))
-                    }
-                    isInvalid={fieldState.invalid}
-                  >
-                    <Label>Name</Label>
-                    <Input />
-                    <Text slot="description" size="S" color="text-700">
-                      {IDENTIFIER_DESCRIPTION}
-                    </Text>
-                    {fieldState.error ? (
-                      <FieldError>{fieldState.error.message}</FieldError>
-                    ) : null}
-                  </TextField>
-                )}
+                render={({ field, fieldState }) => {
+                  const shouldShowError =
+                    (fieldState.isTouched && !isNameFocused) ||
+                    form.formState.isSubmitted;
+                  const displayedError = shouldShowError
+                    ? fieldState.error
+                    : undefined;
+                  return (
+                    <TextField
+                      {...field}
+                      onChange={(value) =>
+                        field.onChange(transformIdentifierInput(value))
+                      }
+                      onFocus={() => setIsNameFocused(true)}
+                      onBlur={() => {
+                        setIsNameFocused(false);
+                        field.onBlur();
+                        void form.trigger("name");
+                      }}
+                      isInvalid={!!displayedError}
+                    >
+                      <Label>Name</Label>
+                      <Input />
+                      <Text slot="description" size="S" color="text-700">
+                        {IDENTIFIER_DESCRIPTION}
+                      </Text>
+                      {displayedError ? (
+                        <FieldError>{displayedError.message}</FieldError>
+                      ) : null}
+                    </TextField>
+                  );
+                }}
               />
             )}
             <Controller

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -44,6 +44,7 @@ import {
 } from "@phoenix/components/sandbox/SandboxProviderSelect";
 import { IDENTIFIER_DESCRIPTION } from "@phoenix/constants";
 import { useNotifySuccess } from "@phoenix/contexts";
+import { TransformingInputController } from "@phoenix/hooks/useTransformingInput";
 import { transformEnvironmentVariableInput } from "@phoenix/utils/environmentVariableUtils";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 import {
@@ -554,28 +555,35 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                     ? fieldState.error
                     : undefined;
                   return (
-                    <TextField
-                      {...field}
-                      onChange={(value) =>
-                        field.onChange(transformIdentifierInput(value))
-                      }
-                      onFocus={() => setIsNameFocused(true)}
-                      onBlur={() => {
-                        setIsNameFocused(false);
-                        field.onBlur();
-                        void form.trigger("name");
-                      }}
-                      isInvalid={!!displayedError}
+                    <TransformingInputController
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      transformValue={transformIdentifierInput}
                     >
-                      <Label>Name</Label>
-                      <Input />
-                      <Text slot="description" size="S" color="text-700">
-                        {IDENTIFIER_DESCRIPTION}
-                      </Text>
-                      {displayedError ? (
-                        <FieldError>{displayedError.message}</FieldError>
-                      ) : null}
-                    </TextField>
+                      {(transformingInput) => (
+                        <TextField
+                          {...field}
+                          value={transformingInput.displayValue}
+                          onChange={transformingInput.handleValueChange}
+                          onFocus={() => setIsNameFocused(true)}
+                          onBlur={() => {
+                            setIsNameFocused(false);
+                            field.onBlur();
+                            void form.trigger("name");
+                          }}
+                          isInvalid={!!displayedError}
+                        >
+                          <Label>Name</Label>
+                          <Input {...transformingInput.inputProps} />
+                          <Text slot="description" size="S" color="text-700">
+                            {IDENTIFIER_DESCRIPTION}
+                          </Text>
+                          {displayedError ? (
+                            <FieldError>{displayedError.message}</FieldError>
+                          ) : null}
+                        </TextField>
+                      )}
+                    </TransformingInputController>
                   );
                 }}
               />
@@ -784,23 +792,30 @@ function EnvVarRow({
         control={form.control}
         rules={{ required: "Name is required" }}
         render={({ field, fieldState }) => (
-          <TextField
-            {...field}
-            onChange={(value) =>
-              field.onChange(transformEnvironmentVariableInput(value))
-            }
-            isInvalid={fieldState.invalid}
+          <TransformingInputController
+            value={field.value}
+            onValueChange={field.onChange}
+            transformValue={transformEnvironmentVariableInput}
           >
-            <Label>Variable Name</Label>
-            <Input placeholder="MY_VAR" />
-            {fieldState.error ? (
-              <FieldError>{fieldState.error.message}</FieldError>
-            ) : (
-              <Text slot="description">
-                Uppercase letters, digits, and underscores
-              </Text>
+            {(transformingInput) => (
+              <TextField
+                {...field}
+                value={transformingInput.displayValue}
+                onChange={transformingInput.handleValueChange}
+                isInvalid={fieldState.invalid}
+              >
+                <Label>Variable Name</Label>
+                <Input {...transformingInput.inputProps} placeholder="MY_VAR" />
+                {fieldState.error ? (
+                  <FieldError>{fieldState.error.message}</FieldError>
+                ) : (
+                  <Text slot="description">
+                    Uppercase letters, digits, and underscores
+                  </Text>
+                )}
+              </TextField>
             )}
-          </TextField>
+          </TransformingInputController>
         )}
       />
     </div>

--- a/app/src/pages/settings/secrets/SecretMutationForm.tsx
+++ b/app/src/pages/settings/secrets/SecretMutationForm.tsx
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import {
@@ -14,6 +13,7 @@ import {
   View,
 } from "@phoenix/components";
 import { SECRET_KEY_PATTERN } from "@phoenix/constants";
+import { TransformingInputController } from "@phoenix/hooks/useTransformingInput";
 import { transformEnvironmentVariableInput } from "@phoenix/utils/environmentVariableUtils";
 
 import type { SecretFormParams } from "./types";
@@ -33,7 +33,6 @@ export function SecretMutationForm({
   isSubmitting: boolean;
   onSubmit: (params: SecretFormParams) => void;
 }) {
-  const keyInputRef = useRef<HTMLInputElement>(null);
   const {
     control,
     handleSubmit,
@@ -76,53 +75,35 @@ export function SecretMutationForm({
               render={({
                 field: { onChange, onBlur, value },
                 fieldState: { invalid, error },
-              }) => {
-                const handleChange = (value: string) => {
-                  const input = keyInputRef.current;
-                  const selectionStart = input?.selectionStart ?? value.length;
-
-                  // Normalize live input to env-var style as the user types.
-                  const transformed = transformEnvironmentVariableInput(value);
-
-                  // Preserve the cursor after the transformed value is committed.
-                  const beforeCursor = value.slice(0, selectionStart);
-                  const newCursorPosition =
-                    transformEnvironmentVariableInput(beforeCursor).length;
-
-                  onChange(transformed);
-
-                  // Wait for React to commit the transformed input value before
-                  // restoring the cursor, or the selection update is lost.
-                  requestAnimationFrame(() => {
-                    input?.setSelectionRange(
-                      newCursorPosition,
-                      newCursorPosition
-                    );
-                  });
-                };
-
-                return (
-                  <TextField
-                    isInvalid={invalid}
-                    onChange={handleChange}
-                    onBlur={onBlur}
-                    value={value}
-                  >
-                    <Label>Key</Label>
-                    <Input
-                      ref={keyInputRef}
-                      placeholder="e.g. OPENAI_API_KEY"
-                    />
-                    {error?.message ? (
-                      <FieldError>{error.message}</FieldError>
-                    ) : (
-                      <Text slot="description">
-                        Use the same format as an environment variable name.
-                      </Text>
-                    )}
-                  </TextField>
-                );
-              }}
+              }) => (
+                <TransformingInputController
+                  value={value}
+                  onValueChange={onChange}
+                  transformValue={transformEnvironmentVariableInput}
+                >
+                  {(transformingInput) => (
+                    <TextField
+                      isInvalid={invalid}
+                      onChange={transformingInput.handleValueChange}
+                      onBlur={onBlur}
+                      value={transformingInput.displayValue}
+                    >
+                      <Label>Key</Label>
+                      <Input
+                        {...transformingInput.inputProps}
+                        placeholder="e.g. OPENAI_API_KEY"
+                      />
+                      {error?.message ? (
+                        <FieldError>{error.message}</FieldError>
+                      ) : (
+                        <Text slot="description">
+                          Use the same format as an environment variable name.
+                        </Text>
+                      )}
+                    </TextField>
+                  )}
+                </TransformingInputController>
+              )}
             />
           )}
           <Controller

--- a/app/src/pages/settings/secrets/SecretMutationForm.tsx
+++ b/app/src/pages/settings/secrets/SecretMutationForm.tsx
@@ -14,12 +14,9 @@ import {
   View,
 } from "@phoenix/components";
 import { SECRET_KEY_PATTERN } from "@phoenix/constants";
+import { transformEnvironmentVariableInput } from "@phoenix/utils/environmentVariableUtils";
 
 import type { SecretFormParams } from "./types";
-
-function normalizeSecretKey(value: string) {
-  return value.toUpperCase().replace(/\s+/g, "_");
-}
 
 export function SecretMutationForm({
   title,
@@ -85,12 +82,12 @@ export function SecretMutationForm({
                   const selectionStart = input?.selectionStart ?? value.length;
 
                   // Normalize live input to env-var style as the user types.
-                  const transformed = normalizeSecretKey(value);
+                  const transformed = transformEnvironmentVariableInput(value);
 
                   // Preserve the cursor after the transformed value is committed.
                   const beforeCursor = value.slice(0, selectionStart);
                   const newCursorPosition =
-                    normalizeSecretKey(beforeCursor).length;
+                    transformEnvironmentVariableInput(beforeCursor).length;
 
                   onChange(transformed);
 

--- a/app/src/utils/__tests__/environmentVariableUtils.test.ts
+++ b/app/src/utils/__tests__/environmentVariableUtils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { transformEnvironmentVariableInput } from "../environmentVariableUtils";
+
+describe("transformEnvironmentVariableInput", () => {
+  it("uppercases and converts common separators to underscores", () => {
+    expect(transformEnvironmentVariableInput("openai-api key.value")).toBe(
+      "OPENAI_API_KEY_VALUE"
+    );
+  });
+
+  it("removes unsupported characters", () => {
+    expect(transformEnvironmentVariableInput("api@key!")).toBe("APIKEY");
+  });
+
+  it("preserves a leading digit for validation", () => {
+    expect(transformEnvironmentVariableInput("1 api key")).toBe("1_API_KEY");
+  });
+});

--- a/app/src/utils/__tests__/identifierUtils.test.ts
+++ b/app/src/utils/__tests__/identifierUtils.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from "vitest";
 
-import { validateIdentifier } from "../identifierUtils";
+import {
+  getIdentifier,
+  transformIdentifierInput,
+  validateIdentifier,
+} from "../identifierUtils";
+
+describe("transformIdentifierInput", () => {
+  it("normalizes case, whitespace, and unsupported characters", () => {
+    expect(transformIdentifierInput("My  New.Prompt!")).toBe("my-newprompt");
+  });
+
+  it("preserves leading and trailing separators while typing", () => {
+    expect(transformIdentifierInput("_My Prompt ")).toBe("_my-prompt-");
+  });
+});
+
+describe("getIdentifier", () => {
+  it("trims leading and trailing separators from a final slug", () => {
+    expect(getIdentifier(" _My Prompt_ ")).toBe("my-prompt");
+  });
+});
 
 describe("validateIdentifier", () => {
   describe("valid identifiers", () => {

--- a/app/src/utils/__tests__/identifierUtils.test.ts
+++ b/app/src/utils/__tests__/identifierUtils.test.ts
@@ -11,8 +11,13 @@ describe("transformIdentifierInput", () => {
     expect(transformIdentifierInput("My  New.Prompt!")).toBe("my-newprompt");
   });
 
-  it("preserves leading and trailing separators while typing", () => {
-    expect(transformIdentifierInput("_My Prompt ")).toBe("_my-prompt-");
+  it("discards leading separators and preserves trailing separators", () => {
+    expect(transformIdentifierInput("_My Prompt ")).toBe("my-prompt-");
+  });
+
+  it("ignores whitespace on a blank field and inserts a dash after text", () => {
+    expect(transformIdentifierInput(" ")).toBe("");
+    expect(transformIdentifierInput("A ")).toBe("a-");
   });
 });
 

--- a/app/src/utils/__tests__/uriUtils.test.ts
+++ b/app/src/utils/__tests__/uriUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { transformURISafeInput } from "../uriUtils";
+
+describe("transformURISafeInput", () => {
+  it("converts whitespace to dashes and removes unsupported characters", () => {
+    expect(transformURISafeInput("My Project.v2 / test")).toBe(
+      "My-Project.v2--test"
+    );
+  });
+
+  it("preserves valid separators and letter case", () => {
+    expect(transformURISafeInput("My_Project-v2.test")).toBe(
+      "My_Project-v2.test"
+    );
+  });
+});

--- a/app/src/utils/environmentVariableUtils.ts
+++ b/app/src/utils/environmentVariableUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Converts user input to conventional environment-variable form. Common
+ * human-readable separators become underscores and unsupported characters are
+ * removed. A leading digit is intentionally preserved so validation can flag
+ * it without silently changing the key's meaning.
+ */
+export function transformEnvironmentVariableInput(value: string): string {
+  return value
+    .toUpperCase()
+    .replace(/[.\s-]+/g, "_")
+    .replace(/[^A-Z0-9_]/g, "");
+}

--- a/app/src/utils/identifierUtils.ts
+++ b/app/src/utils/identifierUtils.ts
@@ -57,10 +57,11 @@ export function validateIdentifier(value: string): ValidateResult {
 
 /**
  * Lowercases `value`, collapses whitespace runs into single dashes, and drops
- * any character outside the allowed identifier set. Leading and trailing
- * separators are preserved so the caller can keep typing (e.g. typing
- * "foo " should yield "foo-" without the dash being stripped mid-edit and
- * jumping the cursor).
+ * any character outside the allowed identifier set. Leading separators are
+ * discarded because they can never form a valid identifier. Trailing
+ * separators are preserved so the caller can keep typing (e.g. typing "foo "
+ * should yield "foo-" without the dash being stripped mid-edit and jumping
+ * the cursor).
  *
  * Use this as a controlled-input transformer; for one-shot conversion of an
  * arbitrary string into a final identifier, use {@link getIdentifier}.
@@ -69,7 +70,8 @@ export function transformIdentifierInput(value: string): string {
   return value
     .toLowerCase()
     .replace(/\s+/g, "-")
-    .replace(/[^_a-z0-9-]/g, "");
+    .replace(/[^_a-z0-9-]/g, "")
+    .replace(/^[_-]+/, "");
 }
 
 /**

--- a/app/src/utils/identifierUtils.ts
+++ b/app/src/utils/identifierUtils.ts
@@ -1,27 +1,10 @@
 import type { ValidateResult } from "react-hook-form";
 
-/**
- * Identifier character set: lowercase alphanumerics, dashes, and underscores.
- * The empty string matches so partial input is permitted while a user types.
- */
-export const allowedIdentifierCharactersRegex = /^[_a-z0-9-]*$/;
-
-/**
- * Identifiers must begin and end with a lowercase alphanumeric character.
- * The empty string and single alphanumerics are permitted.
- */
-export const leadingAndTrailingAlphanumericCharactersRegex =
-  /^([a-z0-9](.*[a-z0-9])?)?$/;
-
-/**
- * Human-readable error messages surfaced by the identifier validators below.
- */
-export const IDENTIFIER_ERROR_MESSAGES = {
-  empty: "Cannot be empty",
-  allowedChars:
-    "Must have only lowercase alphanumeric characters, dashes, and underscores",
-  leadingTrailing: "Must start and end with lowercase alphanumeric characters",
-} as const;
+import {
+  ALLOWED_IDENTIFIER_CHARACTERS_PATTERN,
+  IDENTIFIER_ERROR_MESSAGES,
+  LEADING_AND_TRAILING_ALPHANUMERIC_CHARACTERS_PATTERN,
+} from "@phoenix/constants";
 
 /**
  * Checks that `value` is non-empty and only uses the allowed identifier
@@ -35,7 +18,7 @@ export function validateIdentifierAllowedChars(value: string): ValidateResult {
   if (!value || value.trim() === "") {
     return IDENTIFIER_ERROR_MESSAGES.empty;
   }
-  if (!allowedIdentifierCharactersRegex.test(value)) {
+  if (!ALLOWED_IDENTIFIER_CHARACTERS_PATTERN.test(value)) {
     return IDENTIFIER_ERROR_MESSAGES.allowedChars;
   }
   return true;
@@ -52,7 +35,7 @@ export function validateIdentifierAllowedChars(value: string): ValidateResult {
 export function validateIdentifierLeadingTrailing(
   value: string
 ): ValidateResult {
-  if (!leadingAndTrailingAlphanumericCharactersRegex.test(value)) {
+  if (!LEADING_AND_TRAILING_ALPHANUMERIC_CHARACTERS_PATTERN.test(value)) {
     return IDENTIFIER_ERROR_MESSAGES.leadingTrailing;
   }
   return true;

--- a/app/src/utils/uriUtils.ts
+++ b/app/src/utils/uriUtils.ts
@@ -1,0 +1,8 @@
+/**
+ * Converts whitespace to dashes and removes characters that are not accepted
+ * by Phoenix's URI-safe project-name fields. Letter case and valid separators
+ * are preserved.
+ */
+export function transformURISafeInput(value: string): string {
+  return value.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9._-]/g, "");
+}


### PR DESCRIPTION
Some of our fields have requirements that disallow things like spaces or uppercase characters. Previously, they would allow this input and immediately turn the form red. This massages inputs to these restrictive fields into a valid shape where possible, and defers invalidation until blur otherwise.

This behavior requires deliberate touch in cases like mid-word paste, where the clipboard sends some number of characters into the field, but a smaller subset are able to be applied. The cursor then needs to be located at the end of the inserted string, but can't be naively set to the end of the input.

`TransformingInputController` is added to manage edits in a way that preserves selection and protects from corruption during IME/compound inputs.

#14675 was filed as part of this work but is out of scope for the purposes of this PR.

Test it against relevant locations using a string with invalid beginning, middle, and end. Both input transform and validation timing are correct. 

https://github.com/user-attachments/assets/cb56241b-7fe6-4c74-80a3-4530a4d7e212

https://github.com/user-attachments/assets/2aa0059d-466d-41a8-9b42-2f1b6b007607

https://github.com/user-attachments/assets/bdef7eaa-7ea3-4bb1-b4a0-2d1973ee71f3


