### PR TITLE
feat(client): add span_ids filter to get_spans in python and typescript clients

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -260,6 +260,7 @@ Trace
 px span list --limit 20                                    # recent spans (table view)
 px span list --last-n-minutes 60 --limit 50                # spans from last hour
 px span list --since 2025-01-15T00:00:00Z --limit 50       # spans since a timestamp
+px span list --since 2025-01-15T00:00:00Z --until 2025-01-16T00:00:00Z --limit 50  # time range (until is exclusive)
 px span list --span-kind LLM --limit 10                    # only LLM spans
 px span list --status-code ERROR --limit 20                # only errored spans
 px span list --name chat_completion --limit 10             # filter by span name

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -264,6 +264,7 @@ px span list --span-kind LLM --limit 10                    # only LLM spans
 px span list --status-code ERROR --limit 20                # only errored spans
 px span list --name chat_completion --limit 10             # filter by span name
 px span list --trace-id <id> --format raw --no-progress | jq .   # all spans for a trace
+px span list --span-id <id> <id> --format raw --no-progress | jq .  # fetch specific spans by ID (server >= 19.6.0)
 px span list --parent-id null --limit 10                   # only root spans
 px span list --parent-id <span-id> --limit 10              # only children of a span
 px span list --include-annotations --limit 10              # include annotation scores

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -212,6 +212,7 @@ px project get my-project --format raw --no-progress | jq -r '.id'  # extract pr
 px trace list --limit 20 --format raw --no-progress | jq .
 px trace list --last-n-minutes 60 --limit 20 --format raw --no-progress | jq '.[] | select(.status == "ERROR")'
 px trace list --since 2025-01-15T00:00:00Z --limit 50 --format raw --no-progress | jq .
+px trace list --since 2025-01-15T00:00:00Z --until 2025-01-16T00:00:00Z --limit 50 --format raw --no-progress | jq .  # time range (until is exclusive)
 px trace list --format raw --no-progress | jq 'sort_by(-.duration) | .[0:5]'
 px trace list --include-notes --format raw --no-progress | jq '.[].notes'
 px trace get <trace-id> --format raw | jq .

--- a/js/.changeset/olive-camels-look.md
+++ b/js/.changeset/olive-camels-look.md
@@ -2,4 +2,4 @@
 "@arizeai/phoenix-cli": minor
 ---
 
-Add `--span-id` filter to `px span list`, allowing spans to be fetched by OpenTelemetry span ID (requires Phoenix server >= 19.6.0). Add `--until` to bound `px span list` by an exclusive end timestamp, pairing with `--since` for time ranges.
+Add `--span-id` filter to `px span list`, allowing spans to be fetched by OpenTelemetry span ID (requires Phoenix server >= 19.6.0). Add `--until` to bound `px span list` and `px trace list` by an exclusive end timestamp, pairing with `--since` for time ranges.

--- a/js/.changeset/olive-camels-look.md
+++ b/js/.changeset/olive-camels-look.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add `--span-id` filter to `px span list`, allowing spans to be fetched by OpenTelemetry span ID (requires Phoenix server >= 19.6.0)

--- a/js/.changeset/olive-camels-look.md
+++ b/js/.changeset/olive-camels-look.md
@@ -2,4 +2,4 @@
 "@arizeai/phoenix-cli": minor
 ---
 
-Add `--span-id` filter to `px span list`, allowing spans to be fetched by OpenTelemetry span ID (requires Phoenix server >= 19.6.0)
+Add `--span-id` filter to `px span list`, allowing spans to be fetched by OpenTelemetry span ID (requires Phoenix server >= 19.6.0). Add `--until` to bound `px span list` by an exclusive end timestamp, pairing with `--since` for time ranges.

--- a/js/.changeset/spicy-donuts-tell.md
+++ b/js/.changeset/spicy-donuts-tell.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `spanIds` filter to `getSpans`, allowing spans to be fetched by span ID (requires Phoenix server >= 19.6.0)

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -232,17 +232,17 @@ px trace list --since 2026-01-13T10:00:00Z       # since ISO timestamp
 px trace list --since 2026-01-13T10:00:00Z --until 2026-01-14T10:00:00Z # time range
 ```
 
-| Option                      | Description                            | Default  |
-| --------------------------- | -------------------------------------- | -------- |
-| `[directory]`               | Save traces as JSON files to directory | stdout   |
-| `-n, --limit <number>`      | Number of traces (newest first)        | 10       |
-| `--last-n-minutes <number>` | Only traces from the last N minutes    | —        |
-| `--since <timestamp>`       | Traces since ISO timestamp             | —        |
-| `--until <timestamp>`       | Traces whose spans started before ISO timestamp (exclusive) | — |
-| `--format <format>`         | `pretty`, `json`, or `raw`             | `pretty` |
-| `--no-progress`             | Suppress progress output               | —        |
-| `--include-annotations`     | Include trace and span annotations     | —        |
-| `--include-notes`           | Include trace and span notes           | —        |
+| Option                      | Description                                                 | Default  |
+| --------------------------- | ----------------------------------------------------------- | -------- |
+| `[directory]`               | Save traces as JSON files to directory                      | stdout   |
+| `-n, --limit <number>`      | Number of traces (newest first)                             | 10       |
+| `--last-n-minutes <number>` | Only traces from the last N minutes                         | —        |
+| `--since <timestamp>`       | Traces since ISO timestamp                                  | —        |
+| `--until <timestamp>`       | Traces whose spans started before ISO timestamp (exclusive) | —        |
+| `--format <format>`         | `pretty`, `json`, or `raw`                                  | `pretty` |
+| `--no-progress`             | Suppress progress output                                    | —        |
+| `--include-annotations`     | Include trace and span annotations                          | —        |
+| `--include-notes`           | Include trace and span notes                                | —        |
 
 ```bash
 # Find ERROR traces

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -316,6 +316,7 @@ px span list --limit 50                                    # stdout (pretty)
 px span list --span-kind LLM --limit 20                    # only LLM spans
 px span list --status-code ERROR --format raw --no-progress # pipe-friendly error spans
 px span list --name chat_completion --trace-id abc123       # filter by name and trace
+px span list --span-id abc123 def456                        # fetch specific spans by ID
 px span list --parent-id null                               # root spans only
 px span list spans.json --limit 100 --include-annotations   # save to file with annotations
 px span list --last-n-minutes 30 --span-kind TOOL RETRIEVER # multiple span kinds
@@ -331,6 +332,7 @@ px span list --last-n-minutes 30 --span-kind TOOL RETRIEVER # multiple span kind
 | `--status-code <codes...>`  | Filter by status code (`OK`, `ERROR`, `UNSET`)                                                                                   | —        |
 | `--name <names...>`         | Filter by span name(s)                                                                                                           | —        |
 | `--trace-id <ids...>`       | Filter by trace ID(s)                                                                                                            | —        |
+| `--span-id <ids...>`        | Filter by OpenTelemetry span ID(s). Requires Phoenix server >= 19.6.0.                                                           | —        |
 | `--parent-id <id>`          | Filter by parent span ID (use `"null"` for root spans only)                                                                      | —        |
 | `--include-annotations`     | Include span annotations in the output                                                                                           | —        |
 | `--include-notes`           | Include span notes in the output                                                                                                 | —        |

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -229,6 +229,7 @@ px trace list --format raw --no-progress | jq    # pipe-friendly compact JSON
 px trace list ./my-traces --limit 50             # save as JSON files to directory
 px trace list --last-n-minutes 60 --limit 20     # filter by time window
 px trace list --since 2026-01-13T10:00:00Z       # since ISO timestamp
+px trace list --since 2026-01-13T10:00:00Z --until 2026-01-14T10:00:00Z # time range
 ```
 
 | Option                      | Description                            | Default  |
@@ -237,6 +238,7 @@ px trace list --since 2026-01-13T10:00:00Z       # since ISO timestamp
 | `-n, --limit <number>`      | Number of traces (newest first)        | 10       |
 | `--last-n-minutes <number>` | Only traces from the last N minutes    | —        |
 | `--since <timestamp>`       | Traces since ISO timestamp             | —        |
+| `--until <timestamp>`       | Traces whose spans started before ISO timestamp (exclusive) | — |
 | `--format <format>`         | `pretty`, `json`, or `raw`             | `pretty` |
 | `--no-progress`             | Suppress progress output               | —        |
 | `--include-annotations`     | Include trace and span annotations     | —        |

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -320,6 +320,7 @@ px span list --span-id abc123 def456                        # fetch specific spa
 px span list --parent-id null                               # root spans only
 px span list spans.json --limit 100 --include-annotations   # save to file with annotations
 px span list --last-n-minutes 30 --span-kind TOOL RETRIEVER # multiple span kinds
+px span list --since 2026-07-01T00:00:00Z --until 2026-07-02T00:00:00Z # time range
 ```
 
 | Option                      | Description                                                                                                                      | Default  |
@@ -328,6 +329,7 @@ px span list --last-n-minutes 30 --span-kind TOOL RETRIEVER # multiple span kind
 | `-n, --limit <number>`      | Maximum number of spans (newest first)                                                                                           | `100`    |
 | `--last-n-minutes <number>` | Only spans from the last N minutes                                                                                               | —        |
 | `--since <timestamp>`       | Spans since ISO timestamp                                                                                                        | —        |
+| `--until <timestamp>`       | Spans started before ISO timestamp (exclusive)                                                                                   | —        |
 | `--span-kind <kinds...>`    | Filter by span kind (`LLM`, `CHAIN`, `TOOL`, `RETRIEVER`, `EMBEDDING`, `AGENT`, `RERANKER`, `GUARDRAIL`, `EVALUATOR`, `UNKNOWN`) | —        |
 | `--status-code <codes...>`  | Filter by status code (`OK`, `ERROR`, `UNSET`)                                                                                   | —        |
 | `--name <names...>`         | Filter by span name(s)                                                                                                           | —        |

--- a/js/packages/phoenix-cli/src/commands/span.ts
+++ b/js/packages/phoenix-cli/src/commands/span.ts
@@ -105,6 +105,13 @@ interface SpanListOptions
    */
   traceId?: string[];
   /**
+   * `--span-id <ids...>`: Filter to spans with these OpenTelemetry span IDs.
+   * Requires a Phoenix server >= 19.6.0.
+   *
+   * @example ["4bf92f3577b34da6"]
+   */
+  spanId?: string[];
+  /**
    * `--parent-id <id>`: Filter by parent span ID. The literal string `"null"`
    * selects root spans only.
    *
@@ -131,6 +138,7 @@ async function fetchSpansForProject(
     startTime?: string;
     endTime?: string;
     traceIds?: string[];
+    spanIds?: string[];
     parentId?: string;
     names?: string[];
     spanKinds?: string[];
@@ -157,6 +165,7 @@ async function fetchSpansForProject(
             start_time: options.startTime,
             end_time: options.endTime,
             trace_id: options.traceIds,
+            span_id: options.spanIds,
             parent_id: options.parentId,
             name: options.names,
             span_kind: options.spanKinds,
@@ -257,6 +266,7 @@ async function spanListHandler(
         startTime,
         limit,
         traceIds: options.traceId,
+        spanIds: options.spanId,
         parentId: options.parentId,
         names: options.name,
         spanKinds: options.spanKind,
@@ -420,6 +430,10 @@ export function createSpanListCommand(): Command {
     )
     .option("--name <names...>", "Filter by span name(s)")
     .option("--trace-id <ids...>", "Filter by trace ID(s)")
+    .option(
+      "--span-id <ids...>",
+      "Filter by OpenTelemetry span ID(s). Requires Phoenix server >= 19.6.0."
+    )
     .option(
       "--parent-id <id>",
       'Filter by parent span ID (use "null" for root spans only)'

--- a/js/packages/phoenix-cli/src/commands/span.ts
+++ b/js/packages/phoenix-cli/src/commands/span.ts
@@ -77,6 +77,13 @@ interface SpanListOptions
    */
   since?: string;
   /**
+   * `--until <timestamp>`: Only fetch spans started before this ISO 8601
+   * timestamp (exclusive). Combine with `since` to select a time range.
+   *
+   * @example "2026-07-14T00:00:00Z"
+   */
+  until?: string;
+  /**
    * `--span-kind <kinds...>`: Filter by OpenInference span kind — `LLM`,
    * `CHAIN`, `TOOL`, `RETRIEVER`, `EMBEDDING`, `AGENT`, `RERANKER`,
    * `GUARDRAIL`, `EVALUATOR`, or `UNKNOWN`.
@@ -264,6 +271,7 @@ async function spanListHandler(
       projectId,
       {
         startTime,
+        endTime: options.until,
         limit,
         traceIds: options.traceId,
         spanIds: options.spanId,
@@ -420,6 +428,10 @@ export function createSpanListCommand(): Command {
       parseInt
     )
     .option("--since <timestamp>", "Fetch spans since this ISO timestamp")
+    .option(
+      "--until <timestamp>",
+      "Fetch spans started before this ISO timestamp (exclusive)"
+    )
     .option(
       "--span-kind <kinds...>",
       "Filter by span kind (LLM, CHAIN, TOOL, RETRIEVER, EMBEDDING, AGENT, RERANKER, GUARDRAIL, EVALUATOR, UNKNOWN)"

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -195,6 +195,14 @@ interface TraceListOptions
    */
   since?: string;
   /**
+   * `--until <timestamp>`: Only fetch traces whose spans started before this
+   * ISO 8601 timestamp (exclusive). Combine with `since` to select a time
+   * range.
+   *
+   * @example "2026-07-14T00:00:00Z"
+   */
+  until?: string;
+  /**
    * `--max-concurrent <number>`: Maximum concurrent requests when fetching
    * annotations/notes or writing trace files to a directory. Defaults to 10.
    *
@@ -317,6 +325,7 @@ async function getLastNTraces(
   options: {
     lastNMinutes?: number;
     since?: string;
+    until?: string;
   } = {}
 ): Promise<Trace[]> {
   let startTime: string | undefined;
@@ -331,6 +340,7 @@ async function getLastNTraces(
 
   const spans = await fetchProjectSpans(client, projectIdentifier, {
     startTime,
+    endTime: options.until,
     limit,
   });
 
@@ -625,6 +635,7 @@ async function traceListHandler(
     const traces = await getLastNTraces(client, projectId, limit, {
       lastNMinutes: options.lastNMinutes,
       since: options.since,
+      until: options.until,
     });
 
     if (traces.length === 0) {
@@ -786,6 +797,10 @@ export function createTraceListCommand(): Command {
       parseInt
     )
     .option("--since <timestamp>", "Fetch traces since this ISO timestamp")
+    .option(
+      "--until <timestamp>",
+      "Fetch traces whose spans started before this ISO timestamp (exclusive)"
+    )
     .option(
       "--max-concurrent <number>",
       "Maximum concurrent fetches for bulk operations",

--- a/js/packages/phoenix-cli/test/spanCommand.test.ts
+++ b/js/packages/phoenix-cli/test/spanCommand.test.ts
@@ -78,6 +78,8 @@ describe("span list", () => {
         "50",
         "--status-code",
         "ERROR",
+        "--until",
+        "2026-07-02T00:00:00Z",
         "--trace-id",
         TRACE_ID,
         "--span-id",
@@ -94,6 +96,7 @@ describe("span list", () => {
     // span list pages at min(limit, 1000), so --limit 50 is sent verbatim
     expect(capturedQuery?.get("limit")).toBe("50");
     expect(capturedQuery?.getAll("status_code")).toEqual(["ERROR"]);
+    expect(capturedQuery?.get("end_time")).toBe("2026-07-02T00:00:00Z");
     expect(capturedQuery?.getAll("trace_id")).toEqual([TRACE_ID]);
     expect(capturedQuery?.getAll("span_id")).toEqual(["aaaa000000000001"]);
     expect(capturedQuery?.get("parent_id")).toBe("null");

--- a/js/packages/phoenix-cli/test/spanCommand.test.ts
+++ b/js/packages/phoenix-cli/test/spanCommand.test.ts
@@ -80,6 +80,8 @@ describe("span list", () => {
         "ERROR",
         "--trace-id",
         TRACE_ID,
+        "--span-id",
+        "aaaa000000000001",
         "--parent-id",
         "null",
         ...PROJECT_ARGS,
@@ -93,6 +95,7 @@ describe("span list", () => {
     expect(capturedQuery?.get("limit")).toBe("50");
     expect(capturedQuery?.getAll("status_code")).toEqual(["ERROR"]);
     expect(capturedQuery?.getAll("trace_id")).toEqual([TRACE_ID]);
+    expect(capturedQuery?.getAll("span_id")).toEqual(["aaaa000000000001"]);
     expect(capturedQuery?.get("parent_id")).toBe("null");
 
     const output = io.stdout.mock.calls[0]?.[0];

--- a/js/packages/phoenix-cli/test/traceCommand.test.ts
+++ b/js/packages/phoenix-cli/test/traceCommand.test.ts
@@ -78,6 +78,8 @@ describe("trace list", () => {
         "5",
         "--since",
         "2026-07-01T00:00:00Z",
+        "--until",
+        "2026-07-02T00:00:00Z",
         ...PROJECT_ARGS,
         ...BASE_ARGS,
       ],
@@ -89,6 +91,7 @@ describe("trace list", () => {
     // user-facing limit is applied to the assembled traces client-side.
     expect(capturedQuery?.get("limit")).toBe("1000");
     expect(capturedQuery?.get("start_time")).toBe("2026-07-01T00:00:00Z");
+    expect(capturedQuery?.get("end_time")).toBe("2026-07-02T00:00:00Z");
     expect(capturedQuery?.get("cursor")).toBeNull();
 
     const output = io.stdout.mock.calls[0]?.[0];

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -75,6 +75,14 @@ export const GET_SPANS_TRACE_IDS: ParameterRequirement = {
   minServerVersion: [13, 9, 0],
 };
 
+export const GET_SPANS_SPAN_IDS: ParameterRequirement = {
+  kind: "parameter",
+  parameterName: "span_id",
+  parameterLocation: "query",
+  route: "GET /v1/projects/{id}/spans",
+  minServerVersion: [19, 6, 0],
+};
+
 export const GET_SPANS_FILTERS: ParameterRequirement = {
   kind: "parameter",
   parameterName: "span_kind",
@@ -145,6 +153,7 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   ADD_TRACE_NOTE,
   ADD_SESSION_NOTE,
   GET_SPANS_TRACE_IDS,
+  GET_SPANS_SPAN_IDS,
   GET_SPANS_FILTERS,
   GET_SPANS_BY_ATTRIBUTE,
   LIST_PROJECT_TRACES,

--- a/js/packages/phoenix-client/src/spans/getSpans.ts
+++ b/js/packages/phoenix-client/src/spans/getSpans.ts
@@ -3,6 +3,7 @@ import { createClient } from "../client";
 import {
   GET_SPANS_BY_ATTRIBUTE,
   GET_SPANS_FILTERS,
+  GET_SPANS_SPAN_IDS,
   GET_SPANS_TRACE_IDS,
 } from "../constants/serverRequirements";
 import type { ClientFn } from "../types/core";
@@ -59,6 +60,8 @@ export interface GetSpansParams extends ClientFn {
   limit?: number;
   /** Filter spans by one or more trace IDs */
   traceIds?: string[] | null;
+  /** Filter spans by one or more span IDs */
+  spanIds?: string[] | null;
   /** Filter by parent span ID. Use `null` or the string `"null"` to get root spans only. */
   parentId?: string | null;
   /** Filter by span name(s) */
@@ -96,6 +99,7 @@ export type GetSpansResult = {
  * @returns A paginated response containing spans and optional next cursor
  *
  * @requires Phoenix server >= 13.9.0 when filtering by `traceIds`
+ * @requires Phoenix server >= 19.6.0 when filtering by `spanIds`
  * @requires Phoenix server >= 14.9.0 when filtering by `attributes`
  *
  * @example
@@ -125,6 +129,13 @@ export type GetSpansResult = {
  *   traceIds: ["trace-abc-123", "trace-def-456"],
  * });
  *
+ * // Get specific spans by span ID (requires Phoenix server >= 19.6.0)
+ * const result = await getSpans({
+ *   client,
+ *   project: { projectName: "my-project" },
+ *   spanIds: ["span-abc-123", "span-def-456"],
+ * });
+ *
  * // Paginate through results
  * let cursor: string | undefined;
  * do {
@@ -152,6 +163,7 @@ export async function getSpans({
   startTime,
   endTime,
   traceIds,
+  spanIds,
   parentId,
   name,
   spanKind,
@@ -167,6 +179,9 @@ export async function getSpans({
       : undefined;
   if (traceIds) {
     await ensureServerCapability({ client, requirement: GET_SPANS_TRACE_IDS });
+  }
+  if (spanIds) {
+    await ensureServerCapability({ client, requirement: GET_SPANS_SPAN_IDS });
   }
   if (name != null || spanKind != null || statusCode != null) {
     await ensureServerCapability({ client, requirement: GET_SPANS_FILTERS });
@@ -198,6 +213,10 @@ export async function getSpans({
 
   if (traceIds) {
     params.trace_id = traceIds;
+  }
+
+  if (spanIds) {
+    params.span_id = spanIds;
   }
 
   if (parentId !== undefined) {

--- a/js/packages/phoenix-client/test/spans/getSpans.test.ts
+++ b/js/packages/phoenix-client/test/spans/getSpans.test.ts
@@ -227,6 +227,61 @@ describe("getSpans", () => {
     });
   });
 
+  describe("id filter parameters (traceIds, spanIds)", () => {
+    it("should send trace_id for each trace ID", async () => {
+      const captured = captureGetSpansRequest();
+
+      await getSpans({
+        client: createTestClient(),
+        project: { projectName: "test-project" },
+        traceIds: ["trace-a", "trace-b"],
+      });
+
+      expect(captured.query?.getAll("trace_id")).toEqual([
+        "trace-a",
+        "trace-b",
+      ]);
+    });
+
+    it("should send span_id for each span ID", async () => {
+      const captured = captureGetSpansRequest();
+
+      await getSpans({
+        client: createTestClient(),
+        project: { projectName: "test-project" },
+        spanIds: ["span-a", "span-b"],
+      });
+
+      expect(captured.query?.getAll("span_id")).toEqual(["span-a", "span-b"]);
+    });
+
+    it("should send trace_id and span_id together", async () => {
+      const captured = captureGetSpansRequest();
+
+      await getSpans({
+        client: createTestClient(),
+        project: { projectName: "test-project" },
+        traceIds: ["trace-a"],
+        spanIds: ["span-a"],
+      });
+
+      expect(captured.query?.getAll("trace_id")).toEqual(["trace-a"]);
+      expect(captured.query?.getAll("span_id")).toEqual(["span-a"]);
+    });
+
+    it("should not send trace_id or span_id when undefined", async () => {
+      const captured = captureGetSpansRequest();
+
+      await getSpans({
+        client: createTestClient(),
+        project: { projectName: "test-project" },
+      });
+
+      expect(captured.query?.has("trace_id")).toBe(false);
+      expect(captured.query?.has("span_id")).toBe(false);
+    });
+  });
+
   describe("attributes parameter", () => {
     it("should serialize a single attribute filter", async () => {
       const captured = captureGetSpansRequest();

--- a/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
+++ b/packages/phoenix-client/src/phoenix/client/constants/server_requirements.py
@@ -43,6 +43,13 @@ GET_SPANS_TRACE_IDS = ParameterRequirement(
     min_server_version=Version(13, 9, 0),
 )
 
+GET_SPANS_SPAN_IDS = ParameterRequirement(
+    parameter_name="span_id",
+    parameter_location="query",
+    route="GET /v1/projects/{id}/spans",
+    min_server_version=Version(19, 6, 0),
+)
+
 GET_SPANS_FILTERS = ParameterRequirement(
     parameter_name="span_kind",
     parameter_location="query",

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -1816,6 +1816,8 @@ class AsyncSpans:
         """
         if trace_ids:
             await self._guard.require(GET_SPANS_TRACE_IDS)
+        if span_ids:
+            await self._guard.require(GET_SPANS_SPAN_IDS)
         if name or span_kind or status_code:
             await self._guard.require(GET_SPANS_FILTERS)
         if attributes:

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -30,6 +30,7 @@ from phoenix.client.__generated__ import v1
 from phoenix.client.constants.server_requirements import (
     GET_SPANS_BY_ATTRIBUTE,
     GET_SPANS_FILTERS,
+    GET_SPANS_SPAN_IDS,
     GET_SPANS_TRACE_IDS,
 )
 from phoenix.client.exceptions import DuplicateSpanInfo, InvalidSpanInfo, SpanCreationError
@@ -480,6 +481,7 @@ class Spans:
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
         trace_ids: Optional[Sequence[str]] = None,
+        span_ids: Optional[Sequence[str]] = None,
         parent_id: Optional[str] = None,
         name: Optional[Union[str, Sequence[str]]] = None,
         span_kind: Optional[Union[str, Sequence[str]]] = None,
@@ -499,6 +501,8 @@ class Spans:
                 (exclusive upper bound).
             trace_ids (Optional[Sequence[str]]): Optional list of trace IDs to filter by.
                 Requires Phoenix server >= 13.9.0.
+            span_ids (Optional[Sequence[str]]): Optional list of span IDs to filter by.
+                Requires Phoenix server >= 19.6.0.
             parent_id (Optional[str]): Optional parent span ID to filter by.
                 Use "null" to get root spans only.
             name (Optional[Union[str, Sequence[str]]]): Optional span name(s) to filter by.
@@ -527,6 +531,8 @@ class Spans:
         """
         if trace_ids:
             self._guard.require(GET_SPANS_TRACE_IDS)
+        if span_ids:
+            self._guard.require(GET_SPANS_SPAN_IDS)
         if name or span_kind or status_code:
             self._guard.require(GET_SPANS_FILTERS)
         if attributes:
@@ -549,6 +555,8 @@ class Spans:
                 params["end_time"] = end_time.isoformat()
             if trace_ids:
                 params["trace_id"] = list(trace_ids)
+            if span_ids:
+                params["span_id"] = list(span_ids)
             if parent_id is not None:
                 params["parent_id"] = parent_id
             if name:
@@ -1758,6 +1766,7 @@ class AsyncSpans:
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
         trace_ids: Optional[Sequence[str]] = None,
+        span_ids: Optional[Sequence[str]] = None,
         parent_id: Optional[str] = None,
         name: Optional[Union[str, Sequence[str]]] = None,
         span_kind: Optional[Union[str, Sequence[str]]] = None,
@@ -1777,6 +1786,8 @@ class AsyncSpans:
                 (exclusive upper bound).
             trace_ids (Optional[Sequence[str]]): Optional list of trace IDs to filter by.
                 Requires Phoenix server >= 13.9.0.
+            span_ids (Optional[Sequence[str]]): Optional list of span IDs to filter by.
+                Requires Phoenix server >= 19.6.0.
             parent_id (Optional[str]): Optional parent span ID to filter by.
                 Use "null" to get root spans only.
             name (Optional[Union[str, Sequence[str]]]): Optional span name(s) to filter by.
@@ -1827,6 +1838,8 @@ class AsyncSpans:
                 params["end_time"] = end_time.isoformat()
             if trace_ids:
                 params["trace_id"] = list(trace_ids)
+            if span_ids:
+                params["span_id"] = list(span_ids)
             if parent_id is not None:
                 params["parent_id"] = parent_id
             if name:

--- a/packages/phoenix-client/tests/client/resources/spans/test_spans.py
+++ b/packages/phoenix-client/tests/client/resources/spans/test_spans.py
@@ -104,6 +104,8 @@ class TestGetSpansFilters:
             assert "name" not in query_string
             assert "span_kind" not in query_string
             assert "status_code" not in query_string
+            assert "trace_id" not in query_string
+            assert "span_id" not in query_string
             return httpx.Response(
                 200,
                 json={"data": [_make_span()], "next_cursor": None},
@@ -111,6 +113,45 @@ class TestGetSpansFilters:
 
         client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
         spans = Spans(client).get_spans(project_identifier="my-project")
+        assert len(spans) == 1
+
+
+class TestGetSpansIdFilters:
+    def test_single_span_id_filter(self) -> None:
+        transport = _make_handler(expected_params={"span_id": ["span-1"]})
+        client = httpx.Client(transport=transport, base_url="http://test")
+        spans = Spans(client).get_spans(
+            project_identifier="my-project",
+            span_ids=["span-1"],
+        )
+        assert len(spans) == 1
+
+    def test_multiple_span_id_filter(self) -> None:
+        transport = _make_handler(expected_params={"span_id": ["span-1", "span-2"]})
+        client = httpx.Client(transport=transport, base_url="http://test")
+        spans = Spans(client).get_spans(
+            project_identifier="my-project",
+            span_ids=["span-1", "span-2"],
+        )
+        assert len(spans) == 1
+
+    def test_trace_id_and_span_id_filters_combined(self) -> None:
+        transport = _make_handler(expected_params={"trace_id": ["trace-1"], "span_id": ["span-1"]})
+        client = httpx.Client(transport=transport, base_url="http://test")
+        spans = Spans(client).get_spans(
+            project_identifier="my-project",
+            trace_ids=["trace-1"],
+            span_ids=["span-1"],
+        )
+        assert len(spans) == 1
+
+    async def test_span_ids_wired_through_async_client(self) -> None:
+        transport = _make_handler(expected_params={"span_id": ["span-1", "span-2"]})
+        client = httpx.AsyncClient(transport=transport, base_url="http://test")
+        spans = await AsyncSpans(client).get_spans(
+            project_identifier="my-project",
+            span_ids=["span-1", "span-2"],
+        )
         assert len(spans) == 1
 
 

--- a/packages/phoenix-client/tests/client/resources/spans/test_spans.py
+++ b/packages/phoenix-client/tests/client/resources/spans/test_spans.py
@@ -380,3 +380,36 @@ async def test_async_get_spans_with_attributes_calls_guard_before_request() -> N
         await AsyncSpans(client, _guard=_Guard()).get_spans(  # type: ignore[arg-type]
             project_identifier="my-project", attributes={"k": "v"}
         )
+
+
+def test_get_spans_with_span_ids_calls_guard_before_request() -> None:
+    from phoenix.client.constants.server_requirements import GET_SPANS_SPAN_IDS
+
+    class _Guard:
+        def require(self, requirement: object) -> None:
+            if requirement is GET_SPANS_SPAN_IDS:
+                raise _GuardSentinel
+
+    transport = httpx.MockTransport(lambda r: pytest.fail("transport must not be reached"))
+    client = httpx.Client(transport=transport, base_url="http://test")
+    with pytest.raises(_GuardSentinel):
+        Spans(client, _guard=_Guard()).get_spans(  # type: ignore[arg-type]
+            project_identifier="my-project", span_ids=["span-1"]
+        )
+
+
+@pytest.mark.anyio
+async def test_async_get_spans_with_span_ids_calls_guard_before_request() -> None:
+    from phoenix.client.constants.server_requirements import GET_SPANS_SPAN_IDS
+
+    class _Guard:
+        async def require(self, requirement: object) -> None:
+            if requirement is GET_SPANS_SPAN_IDS:
+                raise _GuardSentinel
+
+    transport = httpx.MockTransport(lambda r: pytest.fail("transport must not be reached"))
+    client = httpx.AsyncClient(transport=transport, base_url="http://test")
+    with pytest.raises(_GuardSentinel):
+        await AsyncSpans(client, _guard=_Guard()).get_spans(  # type: ignore[arg-type]
+            project_identifier="my-project", span_ids=["span-1"]
+        )


### PR DESCRIPTION
The spans endpoint (`GET /v1/projects/{project_identifier}/spans`) now supports filtering by `span_id` in addition to `trace_id`. This surfaces that filter in both the Python and TypeScript clients, mirroring the existing `trace_ids` / `traceIds` filter.

## Changes

**Python client** (`packages/phoenix-client`)
- Added a `span_ids: Optional[Sequence[str]]` parameter to `Spans.get_spans` and `AsyncSpans.get_spans`, mapped to the singular `span_id` query param.
- Added a `GET_SPANS_SPAN_IDS` server-requirement constant (min server version 19.6.0) and guarded the parameter with it, matching the existing `GET_SPANS_TRACE_IDS` pattern.

**TypeScript client** (`js/packages/phoenix-client`)
- Added a `spanIds?: string[] | null` field to `GetSpansParams` in `getSpans`, mapped to the `span_id` query param.
- Added a `GET_SPANS_SPAN_IDS` requirement (min server version 19.6.0) and wired it through `ensureServerCapability`.

The generated OpenAPI types already included `span_id`, so no schema regeneration was needed.

## Tests
- Python: added `span_ids` filter tests (single, multiple, combined with `trace_ids`, async) — 30 tests pass.
- TypeScript: added `traceIds`/`spanIds` query-param tests — 28 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKiSm98jS8jkxTebqr4JLn)_