### PR TITLE
fix(ui): consistent span-detail input/output cards + session view polish

### DIFF
--- a/app/src/components/trace/SessionAnnotationsEditor.tsx
+++ b/app/src/components/trace/SessionAnnotationsEditor.tsx
@@ -69,6 +69,27 @@ export type SessionAnnotationsEditorProps = {
   projectId: string;
 };
 
+/**
+ * The editor's header bar. Its height is derived from the same tokens as a
+ * session view tab (line height + vertical padding) so the bottom border lines
+ * up with the tab bar in the sibling panel, regardless of the taller button it
+ * contains.
+ */
+const annotateSessionHeaderCSS = css`
+  box-sizing: border-box;
+  flex: none;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: calc(
+    var(--global-line-height-s) + 2 * var(--global-dimension-size-100)
+  );
+  padding: 0 var(--global-dimension-size-100);
+  border-bottom: 1px solid var(--global-border-color-default);
+`;
+
 export function SessionAnnotationsEditor(props: SessionAnnotationsEditorProps) {
   const { projectId, sessionNodeId } = props;
   const [refetchKey, setRefetchKey] = useState(0);
@@ -76,30 +97,16 @@ export function SessionAnnotationsEditor(props: SessionAnnotationsEditorProps) {
   return (
     <View height="100%" maxHeight="100%" overflow="auto">
       <Flex direction="column" height="100%">
-        <View
-          paddingY="size-100"
-          paddingX="size-100"
-          borderBottomWidth="thin"
-          borderColor="default"
-          width="100%"
-          flex="none"
-        >
-          <Flex
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            width="100%"
-          >
-            <Text elementType="h3" size="S" weight="heavy">
-              Annotate Session
-            </Text>
-            <NewAnnotationButton
-              projectId={projectId}
-              refetchKey={refetchKey}
-              onRefetchKeyChange={setRefetchKey}
-            />
-          </Flex>
-        </View>
+        <div css={annotateSessionHeaderCSS}>
+          <Text elementType="h3" size="S" weight="heavy">
+            Annotate Session
+          </Text>
+          <NewAnnotationButton
+            projectId={projectId}
+            refetchKey={refetchKey}
+            onRefetchKeyChange={setRefetchKey}
+          />
+        </div>
         <Suspense>
           <SessionAnnotationsList
             sessionId={sessionNodeId}

--- a/app/src/pages/trace/DocumentItem.tsx
+++ b/app/src/pages/trace/DocumentItem.tsx
@@ -23,16 +23,16 @@ export function DocumentItem({
   document,
   documentAnnotations,
   backgroundColor,
-  borderColor,
+  borderColor = "default",
   tokenColor,
   spanNodeId,
   documentPosition,
 }: {
   document: AttributeDocument;
   documentAnnotations?: DocumentAnnotation[] | null;
-  backgroundColor: ViewProps["backgroundColor"];
-  borderColor: ViewProps["borderColor"];
-  tokenColor: TokenProps["color"];
+  backgroundColor?: ViewProps["backgroundColor"];
+  borderColor?: ViewProps["borderColor"];
+  tokenColor?: TokenProps["color"];
   spanNodeId?: string;
   documentPosition?: number;
 }) {

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -107,7 +107,7 @@ const getSessionTraceUrl = ({
 
 const messageWrapCSS = css`
   width: fit-content;
-  max-width: 70%;
+  max-width: 80%;
 `;
 
 const outputMetadataMutedCSS = css`
@@ -125,6 +125,12 @@ const outputMetadataMutedCSS = css`
 `;
 
 const SESSION_TURN_MESSAGE_MAX_HEIGHT = 280;
+
+/**
+ * Max width of the turn content column. Wide enough to read long messages
+ * comfortably while keeping the conversation centered in wide panels.
+ */
+const SESSION_TURN_MAX_WIDTH = "1000px";
 
 type RootSpanMessageRole = "INPUT" | "OUTPUT";
 
@@ -771,7 +777,11 @@ export function SessionDetailsTraceList({
                   paddingBottom="size-200"
                   paddingX="size-200"
                 >
-                  <View width="100%" maxWidth="size-8500" marginX="auto">
+                  <View
+                    width="100%"
+                    maxWidth={SESSION_TURN_MAX_WIDTH}
+                    marginX="auto"
+                  >
                     <SessionTurnDetail
                       index={index}
                       traceId={traceId}
@@ -788,7 +798,11 @@ export function SessionDetailsTraceList({
               borderBottomWidth={"thin"}
               padding="size-200"
             >
-              <View width="100%" maxWidth="size-8500" marginX="auto">
+              <View
+                width="100%"
+                maxWidth={SESSION_TURN_MAX_WIDTH}
+                marginX="auto"
+              >
                 <Loading />
               </View>
             </View>

--- a/app/src/pages/trace/span/EmbeddingInput.tsx
+++ b/app/src/pages/trace/span/EmbeddingInput.tsx
@@ -14,17 +14,15 @@ import { defaultCardProps } from "./constants";
  * The input side of an embedding span — the texts that were embedded.
  */
 export function EmbeddingInput({
-  modelName,
   embeddings,
 }: {
-  modelName: string | null;
   embeddings: AttributeEmbeddingEmbedding[];
 }) {
+  const numTexts = embeddings.length;
   return (
     <Card
-      title={
-        "Embeddings" + (typeof modelName === "string" ? `: ${modelName}` : "")
-      }
+      title="Input"
+      subTitle={`${numTexts} ${numTexts === 1 ? "text" : "texts"}`}
       {...defaultCardProps}
     >
       {

--- a/app/src/pages/trace/span/EmbeddingSpanInfo.tsx
+++ b/app/src/pages/trace/span/EmbeddingSpanInfo.tsx
@@ -16,13 +16,13 @@ export function EmbeddingSpanInfo({
   span: SpanInfoData;
   spanAttributes: AttributeObject;
 }) {
-  const { modelName, embeddings } = getEmbeddingAttributes(spanAttributes);
+  const { embeddings } = getEmbeddingAttributes(spanAttributes);
 
   const hasEmbeddings = embeddings.length > 0;
   return (
     <Flex direction="column" gap="size-200">
       {hasEmbeddings ? (
-        <EmbeddingInput modelName={modelName} embeddings={embeddings} />
+        <EmbeddingInput embeddings={embeddings} />
       ) : (
         <SpanIO
           input={span.input}

--- a/app/src/pages/trace/span/LLMInput.tsx
+++ b/app/src/pages/trace/span/LLMInput.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { Card, CopyToClipboardButton, Flex, View } from "@phoenix/components";
+import { Card, CopyToClipboardButton, Flex } from "@phoenix/components";
 import { GenerativeProviderIcon } from "@phoenix/components/generative";
 import {
   ConnectedMarkdownModeSelect,
@@ -104,48 +104,43 @@ export function LLMInput({
     ),
   ].filter(Boolean);
 
+  const isRawView = view === "input" && hasInput;
+
   return (
-    <Card
-      collapsible
-      title="Input"
-      subTitle={modelNameEl}
-      extra={
-        views.length > 0 ? (
-          <LLMIOViewSelect
-            label="Input view"
-            views={views}
-            value={view ?? ""}
-            onChange={setView}
+    <MarkdownDisplayProvider>
+      <Card
+        collapsible
+        title="Input"
+        subTitle={modelNameEl}
+        extra={
+          <Flex direction="row" gap="size-100" alignItems="center">
+            {isRawView && (
+              <>
+                <ConnectedMarkdownModeSelect />
+                <CopyToClipboardButton text={input.value} />
+              </>
+            )}
+            {views.length > 0 && (
+              <LLMIOViewSelect
+                label="Input view"
+                views={views}
+                value={view ?? ""}
+                onChange={setView}
+              />
+            )}
+          </Flex>
+        }
+      >
+        {view === "input-messages" && (
+          <LLMMessagesList
+            messages={inputMessages}
+            leadingItems={messageLeadingItems}
           />
-        ) : undefined
-      }
-    >
-      {view === "input-messages" && (
-        <LLMMessagesList
-          messages={inputMessages}
-          leadingItems={messageLeadingItems}
-        />
-      )}
-      {view === "tools" && <LLMToolSchemasList toolSchemas={toolSchemas} />}
-      {view === "input" && hasInput && (
-        <View padding="size-200">
-          <MarkdownDisplayProvider>
-            <Card
-              {...defaultCardProps}
-              title="LLM Input"
-              extra={
-                <Flex direction="row" gap="size-100">
-                  <ConnectedMarkdownModeSelect />
-                  <CopyToClipboardButton text={input.value} />
-                </Flex>
-              }
-            >
-              <MimeTypeCodeBlock {...input} />
-            </Card>
-          </MarkdownDisplayProvider>
-        </View>
-      )}
-      {view === "prompts" && <LLMPromptsList prompts={prompts} />}
-    </Card>
+        )}
+        {view === "tools" && <LLMToolSchemasList toolSchemas={toolSchemas} />}
+        {isRawView && <MimeTypeCodeBlock {...input} />}
+        {view === "prompts" && <LLMPromptsList prompts={prompts} />}
+      </Card>
+    </MarkdownDisplayProvider>
   );
 }

--- a/app/src/pages/trace/span/LLMOutput.tsx
+++ b/app/src/pages/trace/span/LLMOutput.tsx
@@ -1,4 +1,4 @@
-import { Card, CopyToClipboardButton, Flex, View } from "@phoenix/components";
+import { Card, CopyToClipboardButton, Flex } from "@phoenix/components";
 import {
   ConnectedMarkdownModeSelect,
   MarkdownDisplayProvider,
@@ -37,42 +37,38 @@ export function LLMOutput({
   if (!hasOutput && !hasOutputMessages) {
     return null;
   }
+
+  const isRawView = view === "output" && hasOutput;
+
   return (
-    <Card
-      {...defaultCardProps}
-      title="Output"
-      extra={
-        views.length > 0 ? (
-          <LLMIOViewSelect
-            label="Output view"
-            views={views}
-            value={view ?? ""}
-            onChange={setView}
-          />
-        ) : undefined
-      }
-    >
-      {view === "output-messages" && (
-        <LLMMessagesList messages={outputMessages} />
-      )}
-      {view === "output" && hasOutput && (
-        <View padding="size-200">
-          <MarkdownDisplayProvider>
-            <Card
-              {...defaultCardProps}
-              title="LLM Output"
-              extra={
-                <Flex direction="row" gap="size-100">
-                  <ConnectedMarkdownModeSelect />
-                  <CopyToClipboardButton text={output.value} />
-                </Flex>
-              }
-            >
-              <MimeTypeCodeBlock {...output} />
-            </Card>
-          </MarkdownDisplayProvider>
-        </View>
-      )}
-    </Card>
+    <MarkdownDisplayProvider>
+      <Card
+        {...defaultCardProps}
+        title="Output"
+        extra={
+          <Flex direction="row" gap="size-100" alignItems="center">
+            {isRawView && (
+              <>
+                <ConnectedMarkdownModeSelect />
+                <CopyToClipboardButton text={output.value} />
+              </>
+            )}
+            {views.length > 0 && (
+              <LLMIOViewSelect
+                label="Output view"
+                views={views}
+                value={view ?? ""}
+                onChange={setView}
+              />
+            )}
+          </Flex>
+        }
+      >
+        {view === "output-messages" && (
+          <LLMMessagesList messages={outputMessages} />
+        )}
+        {isRawView && <MimeTypeCodeBlock {...output} />}
+      </Card>
+    </MarkdownDisplayProvider>
   );
 }

--- a/app/src/pages/trace/span/RerankerInput.tsx
+++ b/app/src/pages/trace/span/RerankerInput.tsx
@@ -1,6 +1,11 @@
-import { css } from "@emotion/react";
-
-import { Card, Counter, View } from "@phoenix/components";
+import {
+  Card,
+  Disclosure,
+  DisclosureGroup,
+  DisclosurePanel,
+  DisclosureTrigger,
+  View,
+} from "@phoenix/components";
 import {
   ConnectedMarkdownBlock,
   MarkdownDisplayProvider,
@@ -8,11 +13,12 @@ import {
 import type { AttributeDocument } from "@phoenix/openInference/tracing/types";
 
 import { DocumentItem } from "../DocumentItem";
-import { defaultCardProps } from "./constants";
+import { defaultCardProps, documentsListCSS } from "./constants";
 
 /**
  * The input side of a reranker span — the query and the documents that were
- * passed in to be reranked.
+ * passed in to be reranked, grouped under a single "Input" card so the reranker
+ * span details stay consistent with other span types.
  */
 export function RerankerInput({
   query,
@@ -23,46 +29,41 @@ export function RerankerInput({
 }) {
   const numInputDocuments = inputDocuments.length;
   return (
-    <>
+    <Card
+      title="Input"
+      subTitle={`${numInputDocuments} ${numInputDocuments === 1 ? "document" : "documents"}`}
+      {...defaultCardProps}
+    >
       <MarkdownDisplayProvider>
-        {query && (
-          <Card title="Query" {...defaultCardProps}>
-            <View padding="size-200">
-              <ConnectedMarkdownBlock>{query}</ConnectedMarkdownBlock>
-            </View>
-          </Card>
-        )}
+        <DisclosureGroup defaultExpandedKeys={["query"]}>
+          {query && (
+            <Disclosure id="query">
+              <DisclosureTrigger arrowPosition="start">Query</DisclosureTrigger>
+              <DisclosurePanel>
+                <View paddingX="size-200" paddingY="size-100">
+                  <ConnectedMarkdownBlock margin="none">
+                    {query}
+                  </ConnectedMarkdownBlock>
+                </View>
+              </DisclosurePanel>
+            </Disclosure>
+          )}
+          <Disclosure id="input-documents">
+            <DisclosureTrigger arrowPosition="start">
+              Documents
+            </DisclosureTrigger>
+            <DisclosurePanel>
+              <ul css={documentsListCSS}>
+                {inputDocuments.map((document, idx) => (
+                  <li key={idx}>
+                    <DocumentItem document={document} />
+                  </li>
+                ))}
+              </ul>
+            </DisclosurePanel>
+          </Disclosure>
+        </DisclosureGroup>
       </MarkdownDisplayProvider>
-      <Card
-        title={"Input Documents"}
-        titleExtra={<Counter>{numInputDocuments}</Counter>}
-        {...defaultCardProps}
-        defaultOpen={false}
-      >
-        {
-          <ul
-            css={css`
-              padding: var(--global-dimension-size-200);
-              display: flex;
-              flex-direction: column;
-              gap: var(--global-dimension-size-200);
-            `}
-          >
-            {inputDocuments.map((document, idx) => {
-              return (
-                <li key={idx}>
-                  <DocumentItem
-                    document={document}
-                    borderColor={"seafoam-300"}
-                    backgroundColor={"seafoam-100"}
-                    tokenColor="var(--global-color-seafoam-1000)"
-                  />
-                </li>
-              );
-            })}
-          </ul>
-        }
-      </Card>
-    </>
+    </Card>
   );
 }

--- a/app/src/pages/trace/span/RerankerOutput.tsx
+++ b/app/src/pages/trace/span/RerankerOutput.tsx
@@ -1,10 +1,8 @@
-import { css } from "@emotion/react";
-
-import { Card, Counter } from "@phoenix/components";
+import { Card } from "@phoenix/components";
 import type { AttributeDocument } from "@phoenix/openInference/tracing/types";
 
 import { DocumentItem } from "../DocumentItem";
-import { defaultCardProps } from "./constants";
+import { defaultCardProps, documentsListCSS } from "./constants";
 
 /**
  * The output side of a reranker span — the documents after reranking.
@@ -17,33 +15,17 @@ export function RerankerOutput({
   const numOutputDocuments = outputDocuments.length;
   return (
     <Card
-      title={"Output Documents"}
-      titleExtra={<Counter>{numOutputDocuments}</Counter>}
+      title={"Output"}
+      subTitle={`${numOutputDocuments} ${numOutputDocuments === 1 ? "document" : "documents"}`}
       {...defaultCardProps}
     >
-      {
-        <ul
-          css={css`
-            padding: var(--global-dimension-size-200);
-            display: flex;
-            flex-direction: column;
-            gap: var(--global-dimension-size-200);
-          `}
-        >
-          {outputDocuments.map((document, idx) => {
-            return (
-              <li key={idx}>
-                <DocumentItem
-                  document={document}
-                  borderColor={"celery-300"}
-                  backgroundColor={"celery-100"}
-                  tokenColor="var(--global-color-celery-500)"
-                />
-              </li>
-            );
-          })}
-        </ul>
-      }
+      <ul css={documentsListCSS}>
+        {outputDocuments.map((document, idx) => (
+          <li key={idx}>
+            <DocumentItem document={document} />
+          </li>
+        ))}
+      </ul>
     </Card>
   );
 }

--- a/app/src/pages/trace/span/SpanOutput.tsx
+++ b/app/src/pages/trace/span/SpanOutput.tsx
@@ -18,8 +18,6 @@ export function SpanOutput({ value, mimeType }: SpanIOValue) {
       <Card
         title="Output"
         {...defaultCardProps}
-        backgroundColor="green-100"
-        borderColor="green-300"
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isText ? <ConnectedMarkdownModeSelect /> : null}

--- a/app/src/pages/trace/span/__tests__/utils.test.ts
+++ b/app/src/pages/trace/span/__tests__/utils.test.ts
@@ -148,12 +148,11 @@ describe("getRerankerAttributes", () => {
 describe("getEmbeddingAttributes", () => {
   it("returns empty defaults when there are no embedding attributes", () => {
     expect(getEmbeddingAttributes({})).toEqual({
-      modelName: null,
       embeddings: [],
     });
   });
 
-  it("extracts the model name and embedded texts", () => {
+  it("extracts the embedded texts", () => {
     const result = getEmbeddingAttributes({
       embedding: {
         model_name: "text-embedding-3-small",
@@ -161,7 +160,6 @@ describe("getEmbeddingAttributes", () => {
       },
     });
     expect(result).toEqual({
-      modelName: "text-embedding-3-small",
       embeddings: [{ text: "embedded text" }],
     });
   });

--- a/app/src/pages/trace/span/constants.ts
+++ b/app/src/pages/trace/span/constants.ts
@@ -1,3 +1,5 @@
+import { css } from "@emotion/react";
+
 import type { CardProps } from "@phoenix/components";
 
 /**
@@ -6,3 +8,14 @@ import type { CardProps } from "@phoenix/components";
 export const defaultCardProps: Partial<CardProps> = {
   collapsible: true,
 };
+
+/**
+ * Styles for the vertical list of documents rendered inside a reranker span's
+ * input / output cards.
+ */
+export const documentsListCSS = css`
+  padding: var(--global-dimension-size-200);
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-200);
+`;

--- a/app/src/pages/trace/span/utils.ts
+++ b/app/src/pages/trace/span/utils.ts
@@ -182,18 +182,14 @@ export function getRerankerAttributes(spanAttributes: AttributeObject): {
  * Extract the embeddings from the parsed span attributes of an embedding span.
  */
 export function getEmbeddingAttributes(spanAttributes: AttributeObject): {
-  modelName: string | null;
   embeddings: AttributeEmbeddingEmbedding[];
 } {
   const embeddingAttributes =
     spanAttributes[SemanticAttributePrefixes.embedding] || null;
   if (embeddingAttributes == null) {
-    return { modelName: null, embeddings: [] };
+    return { embeddings: [] };
   }
-  const maybeModelName =
-    embeddingAttributes[EmbeddingAttributePostfixes.model_name];
   return {
-    modelName: typeof maybeModelName === "string" ? maybeModelName : null,
     embeddings: (embeddingAttributes[EmbeddingAttributePostfixes.embeddings]
       ?.map((obj) => obj[SemanticAttributePrefixes.embedding])
       .filter(Boolean) || []) as AttributeEmbeddingEmbedding[],


### PR DESCRIPTION
## Summary

Makes span-detail views present a consistent **Input** / **Output** card pattern, and polishes the session turn/annotation views.

### Span detail cards
- **Reranker**: merge query + input documents into a single **Input** card (Query/Documents accordion); output card retitled to **Output** · *N documents*.
- **Embedding**: input card retitled to **Input** with an *N texts* subtitle; dropped the now-unused `modelName` from `EmbeddingInput` and `getEmbeddingAttributes`.
- **LLM raw input/output**: removed the nested card; the format select + copy button now live in the parent card header when **Raw** is selected, sharing one `MarkdownDisplayProvider`.
- **Documents**: dropped the green/colored document cards — `DocumentItem` color props are now optional.
- Shared the documents-list CSS via `constants`.

### Session view
- Widened the turn content column (680px → 1000px) and set message bubbles to 80% max-width for readability.
- Aligned the "Annotate Session" header height with the session view tabs so the divider lines up across panels.

## Test plan
- `tsc --noEmit` clean
- `getEmbeddingAttributes` unit tests updated and passing
- Verified via HMR against a running Phoenix with the `demo_llama_index_rag` fixture (reranker/embedding/LLM spans)