### PR TITLE
fix(ui): extend session annotation panel to full drawer height

### DIFF
--- a/app/src/components/trace/SessionAnnotationsEditor.tsx
+++ b/app/src/components/trace/SessionAnnotationsEditor.tsx
@@ -70,10 +70,8 @@ export type SessionAnnotationsEditorProps = {
 };
 
 /**
- * The editor's header bar. Its height is derived from the same tokens as a
- * session view tab (line height + vertical padding) so the bottom border lines
- * up with the tab bar in the sibling panel, regardless of the taller button it
- * contains.
+ * The editor's header bar, pinned to the top of the full-height annotations
+ * panel.
  */
 const annotateSessionHeaderCSS = css`
   box-sizing: border-box;
@@ -83,10 +81,7 @@ const annotateSessionHeaderCSS = css`
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  height: calc(
-    var(--global-line-height-s) + 2 * var(--global-dimension-size-100)
-  );
-  padding: 0 var(--global-dimension-size-100);
+  padding: var(--global-dimension-size-100);
   border-bottom: 1px solid var(--global-border-color-default);
 `;
 

--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -348,16 +348,6 @@ export function SessionDetails(props: SessionDetailsProps) {
         overflow: hidden;
       `}
     >
-      <SessionDetailsHeader
-        session={data.session}
-        costSummary={data.session.costSummary}
-        tokenUsage={data.session.tokenUsage}
-        latencyP50={data.session.latencyP50}
-        sessionId={sessionId}
-        projectId={projectId}
-        isAnnotating={isAnnotating}
-        onIsAnnotatingChange={setIsAnnotating}
-      />
       <Group
         orientation="horizontal"
         id="session-details-layout"
@@ -368,6 +358,16 @@ export function SessionDetails(props: SessionDetailsProps) {
       >
         <Panel>
           <Flex direction="column" height="100%">
+            <SessionDetailsHeader
+              session={data.session}
+              costSummary={data.session.costSummary}
+              tokenUsage={data.session.tokenUsage}
+              latencyP50={data.session.latencyP50}
+              sessionId={sessionId}
+              projectId={projectId}
+              isAnnotating={isAnnotating}
+              onIsAnnotatingChange={setIsAnnotating}
+            />
             <SessionViewTabs
               sessionView={sessionView}
               onSessionViewChange={handleSessionViewChange}


### PR DESCRIPTION
## Summary

The session annotation slideover previously started below the session metrics header (Total Tokens / Total Cost / Latency), leaving it awkwardly floating mid-dialog with dead space above it.

This moves the resizable panel `Group` to the top level of the session details layout so the annotation editor spans the full height of the drawer, directly under the dialog header. The metrics header now lives inside the left panel alongside the view tabs.

Also simplifies the editor's header bar to a natural padding-based height — its previous height was derived from tab-bar tokens to align its bottom border with the view tabs, an invariant that no longer applies now that the panel starts above the tab bar.

## Before

The panel started at the tab-bar level, below the full-width metrics header.

## After

The panel extends the entire height of the drawer on the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)