### PR TITLE
chore(js): add changeset to re-trigger publish after failed release

### DIFF
--- a/js/.changeset/rare-hoops-repeat.md
+++ b/js/.changeset/rare-hoops-repeat.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/phoenix-cli": patch
+"@arizeai/phoenix-client": patch
+"@arizeai/phoenix-mcp": patch
+---
+
+Re-release to recover from a failed publish (versions were already on npm)


### PR DESCRIPTION
The last JS publish run failed with a 403 — `@arizeai/phoenix-cli@1.11.0` (along with `phoenix-client@7.1.0` and `phoenix-mcp@4.2.6`) had already landed on npm from a prior partial run, so `pnpm publish -r` aborted before completing.

This adds a patch changeset for all three packages so the next Version Packages PR cuts fresh versions and the publish workflow runs cleanly end-to-end (including tags/releases).