### PR TITLE
feat(cli): add project name filter

### DIFF
--- a/js/.changeset/calm-projects-filter.md
+++ b/js/.changeset/calm-projects-filter.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add a case-insensitive `--name-contains` filter to `px project list`.

--- a/js/packages/phoenix-cli/src/commands/project.ts
+++ b/js/packages/phoenix-cli/src/commands/project.ts
@@ -25,6 +25,13 @@ interface ProjectListOptions extends CommonOptions<OutputFormat> {
    * @example 50
    */
   limit?: number;
+  /**
+   * `--name-contains <filter>`: Return projects whose names contain this
+   * substring. Matching is case-insensitive.
+   *
+   * @example production
+   */
+  nameContains?: string;
 }
 
 type ProjectSummary = {
@@ -34,15 +41,25 @@ type ProjectSummary = {
 };
 
 /**
- * Fetch all projects from Phoenix
+ * Fetch all matching projects from Phoenix.
+ *
+ * @param params - Project query parameters.
+ * @param params.client - Phoenix client used to fetch projects.
+ * @param params.limit - Maximum number of projects to fetch per page.
+ * @param params.nameContains - Optional case-insensitive project name filter.
  */
-async function fetchProjects(
-  client: PhoenixClient,
-  options: { limit?: number } = {}
-): Promise<ProjectSummary[]> {
+async function fetchProjects({
+  client,
+  limit: requestedLimit,
+  nameContains,
+}: {
+  client: PhoenixClient;
+  limit?: number;
+  nameContains?: string;
+}): Promise<ProjectSummary[]> {
   const allProjects: ProjectSummary[] = [];
   let cursor: string | undefined;
-  const limit = options.limit || 100;
+  const limit = requestedLimit || 100;
 
   do {
     const response = await client.GET("/v1/projects", {
@@ -51,6 +68,7 @@ async function fetchProjects(
           cursor,
           limit,
           include_experiment_projects: false,
+          name_contains: nameContains,
         },
       },
     });
@@ -87,8 +105,10 @@ async function projectListHandler(options: ProjectListOptions): Promise<void> {
     }
 
     const client = createPhoenixClient({ config });
-    const projects = await fetchProjects(client, {
+    const projects = await fetchProjects({
+      client,
       limit: options.limit,
+      nameContains: options.nameContains,
     });
 
     const output = formatProjectsOutput({
@@ -119,6 +139,10 @@ export function configureProjectListCommand(command: Command): Command {
       "--limit <number>",
       "Maximum number of projects to fetch per page",
       parseInt
+    )
+    .option(
+      "--name-contains <filter>",
+      "Filter projects by name substring (case-insensitive)"
     )
     .action(projectListHandler);
 }
@@ -263,7 +287,10 @@ async function projectGetHandler(
       noProgress: !options.progress,
     });
 
-    const projects = await fetchProjects(client, { limit: options.limit });
+    const projects = await fetchProjects({
+      client,
+      limit: options.limit,
+    });
     const match = projects.find((project) => project.name === name);
 
     if (!match) {

--- a/js/packages/phoenix-cli/test/projectList.test.ts
+++ b/js/packages/phoenix-cli/test/projectList.test.ts
@@ -18,10 +18,11 @@ afterEach(() => {
 });
 
 describe("project list", () => {
-  it("excludes experiment projects, propagates --limit, and prints raw JSON", async () => {
+  it("forwards list filters and prints raw JSON", async () => {
     const captured: {
       limit?: string | null;
       includeExperimentProjects?: string | null;
+      nameContains?: string | null;
       count: number;
     } = { count: 0 };
     mock.server.use(
@@ -32,29 +33,47 @@ describe("project list", () => {
         captured.includeExperimentProjects = searchParams.get(
           "include_experiment_projects"
         );
+        captured.nameContains = searchParams.get("name_contains");
         return response(200).json({ data: PROJECTS, next_cursor: null });
       })
     );
     const io = captureCliOutput();
 
     await createProjectCommand().parseAsync(
-      ["list", "--limit", "50", "--format", "raw", ...BASE_ARGS],
+      [
+        "list",
+        "--limit",
+        "50",
+        "--name-contains",
+        "ALPha",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
       { from: "user" }
     );
 
     expect(captured.count).toBe(1);
     expect(captured.limit).toBe("50");
     expect(captured.includeExperimentProjects).toBe("false");
+    expect(captured.nameContains).toBe("ALPha");
     const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual(PROJECTS);
   });
 
-  it("follows next_cursor across pages and concatenates the results", async () => {
-    const cursors: (string | null)[] = [];
+  it("forwards the name filter across paginated requests", async () => {
+    const requests: {
+      cursor: string | null;
+      nameContains: string | null;
+    }[] = [];
     mock.server.use(
       http.get("/v1/projects", ({ request, response }) => {
-        const cursor = new URL(request.url).searchParams.get("cursor");
-        cursors.push(cursor);
+        const searchParams = new URL(request.url).searchParams;
+        const cursor = searchParams.get("cursor");
+        requests.push({
+          cursor,
+          nameContains: searchParams.get("name_contains"),
+        });
         if (cursor === null) {
           return response(200).json({
             data: [PROJECTS[0]],
@@ -67,11 +86,14 @@ describe("project list", () => {
     const io = captureCliOutput();
 
     await createProjectCommand().parseAsync(
-      ["list", "--format", "raw", ...BASE_ARGS],
+      ["list", "--name-contains", "a", "--format", "raw", ...BASE_ARGS],
       { from: "user" }
     );
 
-    expect(cursors).toEqual([null, "cursor-2"]);
+    expect(requests).toEqual([
+      { cursor: null, nameContains: "a" },
+      { cursor: "cursor-2", nameContains: "a" },
+    ]);
     const parsed = JSON.parse(String(io.stdout.mock.calls[0]?.[0]));
     expect(parsed).toEqual(PROJECTS);
   });


### PR DESCRIPTION
## Summary

- add `--name-contains <filter>` to `px project list`
- forward the server-side filter on every paginated request
- add regression coverage and a CLI release changeset

## Why

Phoenix already supports case-insensitive project-name filtering through the `name_contains` API parameter, but the CLI did not expose it. This lets CLI users narrow large project lists without fetching and filtering every project locally.

Closes #12036.

## Validation

- `make build-ts`
- `make test-ts`
- `make typecheck-ts`
- `make lint-ts`
- `make format-ts`
