### PR TITLE
fix(evals): align online eval uv version

### DIFF
--- a/.github/workflows/pxi-online-evals.yml
+++ b/.github/workflows/pxi-online-evals.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          version: "0.11.8"
+          version: "0.11.12"
           enable-cache: true
       - name: Sync dependencies
         run: uv sync --frozen


### PR DESCRIPTION
## Summary

- update the PXI Online Evals workflow from uv 0.11.8 to the repository-required uv 0.11.12
- unblock the scheduled workflow before its dependency sync step

## Failure

All three scheduled runs since the online-evals PR merged failed during dependency sync because pyproject.toml requires uv 0.11.12 while this newly added workflow still installed 0.11.8. The evaluator step was never reached.

## Verification

- uv sync --frozen
- 66 targeted online-eval unit and sanitized-fixture tests pass
- read-only Phoenix Cloud dry run: 29 tool_count_per_turn evaluations, 0 errors, 0 annotations written
- synthetic GPT-5.5 user_friction judge smoke test succeeded