### PR TITLE
feat(cli): add pxi model picker

### DIFF
--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -25,6 +25,7 @@ import {
   type DraftEditorState,
 } from "./draftEditor";
 import { Markdown } from "./inkMarkdown";
+import { fetchRecommendedPxiModels } from "./preflight";
 import { formatTokenUsageLine, getLatestAssistantUsage } from "./tokenUsage";
 import {
   getToolProgressFromPart,
@@ -32,6 +33,7 @@ import {
   type ToolProgressState,
 } from "./toolProgress";
 import type {
+  ModelSelection,
   PxiChatClient,
   PxiMessage,
   PxiRuntimeOptions,
@@ -53,6 +55,13 @@ type PxiStatus = "idle" | "streaming";
 type SessionPickerState = {
   status: "loading" | "ready" | "restoring" | "error";
   sessions: PxiSessionSummary[];
+  query: string;
+  selectedIndex: number;
+  error: string | null;
+};
+type ModelPickerState = {
+  status: "loading" | "ready" | "error";
+  models: ModelSelection[];
   query: string;
   selectedIndex: number;
   error: string | null;
@@ -105,6 +114,11 @@ const INTERRUPTED_MESSAGE_TEXT = "\n\n[Interrupted by user before completion.]";
 export type PxiAppProps = {
   options: PxiRuntimeOptions;
   client?: PxiChatClient;
+  clientFactory?: (options: {
+    options: PxiRuntimeOptions;
+    agentSessionId: string;
+  }) => PxiChatClient;
+  modelLoader?: () => Promise<ModelSelection[]>;
   sessionClient?: PxiSessionClient;
   initialMessages?: PxiMessage[];
 };
@@ -152,12 +166,16 @@ function PxiBanner() {
   );
 }
 
-/** Format the active model for the status line (e.g. `ANTHROPIC/claude-opus-4-8`). */
-function getModelLabel(options: PxiRuntimeOptions): string {
-  if (options.modelSelection.providerType === "custom") {
-    return `custom:${options.modelSelection.providerId}/${options.modelSelection.modelName}`;
+/** Format a model selection for display (e.g. `ANTHROPIC/claude-opus-4-8`). */
+function getModelLabel({
+  modelSelection,
+}: {
+  modelSelection: ModelSelection;
+}): string {
+  if (modelSelection.providerType === "custom") {
+    return `custom:${modelSelection.providerId}/${modelSelection.modelName}`;
   }
-  return `${options.modelSelection.provider}/${options.modelSelection.modelName}`;
+  return `${modelSelection.provider}/${modelSelection.modelName}`;
 }
 
 /** Animated braille spinner shown while a tool call is still in flight. */
@@ -558,6 +576,83 @@ function getSessionTitle({ title }: { title: string }) {
   return title.trim() || "Untitled session";
 }
 
+function getFilteredModels({
+  models,
+  query,
+}: {
+  models: ModelSelection[];
+  query: string;
+}) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return models;
+  return models.filter((modelSelection) =>
+    getModelLabel({ modelSelection }).toLowerCase().includes(normalizedQuery)
+  );
+}
+
+/** Model-selection mode rendered in place of the normal composer. */
+function ModelPicker({ state }: { state: ModelPickerState }) {
+  const filteredModels = getFilteredModels({
+    models: state.models,
+    query: state.query,
+  });
+  const selectedIndex = Math.min(
+    state.selectedIndex,
+    Math.max(filteredModels.length - 1, 0)
+  );
+  const firstVisibleIndex = Math.max(0, selectedIndex - 7);
+  const visibleModels = filteredModels.slice(
+    firstVisibleIndex,
+    firstVisibleIndex + 8
+  );
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="cyan"
+      paddingX={1}
+      marginTop={1}
+    >
+      <Text bold>Recommended models</Text>
+      {state.status === "loading" ? (
+        <Text dimColor>Loading models…</Text>
+      ) : null}
+      {state.error ? <Text color="red">{state.error}</Text> : null}
+      {state.status !== "loading" && state.models.length > 0 ? (
+        <Text>
+          <Text dimColor>Filter: </Text>
+          {state.query}
+          <Text color="cyan">█</Text>
+        </Text>
+      ) : null}
+      {state.status !== "loading" && filteredModels.length === 0 ? (
+        <Text dimColor>
+          {state.models.length === 0
+            ? "No recommended models are available."
+            : "No models match this filter."}
+        </Text>
+      ) : null}
+      {visibleModels.map((modelSelection, visibleIndex) => {
+        const modelIndex = firstVisibleIndex + visibleIndex;
+        const isSelected = modelIndex === selectedIndex;
+        const label = getModelLabel({ modelSelection });
+        return (
+          <Text key={label} color={isSelected ? "cyan" : undefined}>
+            {isSelected ? "› " : "  "}
+            <Text bold={isSelected}>{label}</Text>
+          </Text>
+        );
+      })}
+      <Text dimColor>
+        {state.status === "error"
+          ? "esc close and retry"
+          : "type to filter · ↑↓ navigate · enter select · esc cancel"}
+      </Text>
+    </Box>
+  );
+}
+
 /** Session-selection mode rendered in place of the normal composer. */
 function SessionPicker({ state }: { state: SessionPickerState }) {
   const filteredSessions = getFilteredSessions({
@@ -729,6 +824,8 @@ export function ThinkingIndicator() {
 export function PxiApp({
   options,
   client,
+  clientFactory,
+  modelLoader,
   sessionClient,
   initialMessages = [],
 }: PxiAppProps) {
@@ -749,12 +846,16 @@ export function PxiApp({
   const [activeSession, setActiveSession] = useState<PxiSessionSummary | null>(
     null
   );
+  const [activeModelSelection, setActiveModelSelection] =
+    useState<ModelSelection>(options.modelSelection);
   const [isDraftTemporary, setIsDraftTemporary] = useState(false);
+  const [modelPicker, setModelPicker] = useState<ModelPickerState | null>(null);
   const [sessionPicker, setSessionPicker] = useState<SessionPickerState | null>(
     null
   );
   const abortControllerRef = useRef<AbortController | null>(null);
   const streamingAssistantMessageRef = useRef<PxiMessage | null>(null);
+  const modelRequestIdRef = useRef(0);
   const sessionRequestIdRef = useRef(0);
   const serverSessionClient = useMemo(
     () => sessionClient ?? createPxiSessionClient({ config: options.config }),
@@ -789,9 +890,11 @@ export function PxiApp({
   };
 
   const startNewSession = ({ temporary }: { temporary: boolean }) => {
+    modelRequestIdRef.current += 1;
     sessionRequestIdRef.current += 1;
     setActiveSession(null);
     setIsDraftTemporary(temporary);
+    setModelPicker(null);
     setSessionPicker(null);
     setMessages([]);
     setError(null);
@@ -804,6 +907,8 @@ export function PxiApp({
   };
 
   const openSessionPicker = () => {
+    modelRequestIdRef.current += 1;
+    setModelPicker(null);
     const requestId = sessionRequestIdRef.current + 1;
     sessionRequestIdRef.current = requestId;
     setDraft(EMPTY_DRAFT_EDITOR_STATE);
@@ -840,6 +945,67 @@ export function PxiApp({
               : String(sessionError),
         });
       });
+  };
+
+  const closeModelPicker = () => {
+    modelRequestIdRef.current += 1;
+    setModelPicker(null);
+  };
+
+  const openModelPicker = () => {
+    sessionRequestIdRef.current += 1;
+    setSessionPicker(null);
+    const requestId = modelRequestIdRef.current + 1;
+    modelRequestIdRef.current = requestId;
+    setDraft(EMPTY_DRAFT_EDITOR_STATE);
+    setError(null);
+    setModelPicker({
+      status: "loading",
+      models: [],
+      query: "",
+      selectedIndex: 0,
+      error: null,
+    });
+    const loadModels =
+      modelLoader ??
+      (() => fetchRecommendedPxiModels({ config: options.config }));
+    void loadModels()
+      .then((models) => {
+        if (modelRequestIdRef.current !== requestId) return;
+        setModelPicker({
+          status: "ready",
+          models,
+          query: "",
+          selectedIndex: 0,
+          error: null,
+        });
+      })
+      .catch((modelError: unknown) => {
+        if (modelRequestIdRef.current !== requestId) return;
+        setModelPicker({
+          status: "error",
+          models: [],
+          query: "",
+          selectedIndex: 0,
+          error:
+            modelError instanceof Error
+              ? modelError.message
+              : String(modelError),
+        });
+      });
+  };
+
+  const selectModel = () => {
+    if (!modelPicker || modelPicker.status !== "ready") return;
+    const filteredModels = getFilteredModels({
+      models: modelPicker.models,
+      query: modelPicker.query,
+    });
+    const selectedModel = filteredModels[modelPicker.selectedIndex];
+    if (!selectedModel) return;
+    setActiveModelSelection(selectedModel);
+    setModelPicker(null);
+    setError(null);
   };
 
   const restoreSelectedSession = () => {
@@ -894,6 +1060,7 @@ export function PxiApp({
       setDraft(EMPTY_DRAFT_EDITOR_STATE);
       const result = runSlashCommand(text, {
         startNewSession,
+        openModelPicker,
         openSessionPicker,
         exit: handleExit,
       });
@@ -933,20 +1100,25 @@ export function PxiApp({
     setMessages(nextMessages);
     void (async () => {
       let resolvedClient = client;
+      const activeOptions = {
+        ...options,
+        modelSelection: activeModelSelection,
+      };
+      const createClient = clientFactory ?? createPxiChatClient;
       if (!activeSession && (sessionClient || !resolvedClient)) {
         const session = await serverSessionClient.createSession({
           temporary: isDraftTemporary,
         });
         setActiveSession(session);
         if (!resolvedClient) {
-          resolvedClient = createPxiChatClient({
-            options,
+          resolvedClient = createClient({
+            options: activeOptions,
             agentSessionId: session.id,
           });
         }
       } else if (!resolvedClient && activeSession) {
-        resolvedClient = createPxiChatClient({
-          options,
+        resolvedClient = createClient({
+          options: activeOptions,
           agentSessionId: activeSession.id,
         });
       }
@@ -999,6 +1171,18 @@ export function PxiApp({
       return;
     }
     if (isBackspaceInput({ input })) {
+      if (modelPicker) {
+        setModelPicker((current) =>
+          current
+            ? {
+                ...current,
+                query: current.query.slice(0, -1),
+                selectedIndex: 0,
+              }
+            : null
+        );
+        return;
+      }
       if (sessionPicker) {
         setSessionPicker((current) =>
           current
@@ -1015,7 +1199,7 @@ export function PxiApp({
       return;
     }
     if (isForwardDeleteInput({ input })) {
-      if (sessionPicker) return;
+      if (modelPicker || sessionPicker) return;
       setDraft((value) => deleteDraftTextAtCursor({ draft: value }));
     }
   };
@@ -1035,6 +1219,73 @@ export function PxiApp({
   useInput((input, key) => {
     if ((key.ctrl && input === "c") || (key.ctrl && input === "d")) {
       handleExit();
+      return;
+    }
+    if (modelPicker) {
+      if (key.escape) {
+        closeModelPicker();
+        return;
+      }
+      if (modelPicker.status !== "ready") {
+        return;
+      }
+      const filteredModels = getFilteredModels({
+        models: modelPicker.models,
+        query: modelPicker.query,
+      });
+      if (key.upArrow) {
+        setModelPicker((current) =>
+          current
+            ? {
+                ...current,
+                selectedIndex: Math.max(0, current.selectedIndex - 1),
+              }
+            : null
+        );
+        return;
+      }
+      if (key.downArrow) {
+        setModelPicker((current) =>
+          current
+            ? {
+                ...current,
+                selectedIndex: Math.min(
+                  Math.max(filteredModels.length - 1, 0),
+                  current.selectedIndex + 1
+                ),
+              }
+            : null
+        );
+        return;
+      }
+      if (key.return) {
+        selectModel();
+        return;
+      }
+      if (
+        key.backspace ||
+        key.delete ||
+        isStrippedBracketedPasteMarkerInput({ input }) ||
+        isKeyboardProtocolResponseInput({ input })
+      ) {
+        return;
+      }
+      if (input) {
+        const text = getDraftInputText({ input }).replace(/\n/g, "");
+        if (text) {
+          setModelPicker((current) =>
+            current
+              ? {
+                  ...current,
+                  query: current.query + text,
+                  selectedIndex: 0,
+                  error: null,
+                  status: "ready",
+                }
+              : null
+          );
+        }
+      }
       return;
     }
     if (sessionPicker) {
@@ -1200,8 +1451,8 @@ export function PxiApp({
     <Box flexDirection="column" paddingX={1}>
       <PxiBanner />
       <Text dimColor>
-        endpoint: {options.config.endpoint} | model: {getModelLabel(options)} |
-        session:{" "}
+        endpoint: {options.config.endpoint} | model:{" "}
+        {getModelLabel({ modelSelection: activeModelSelection })} | session:{" "}
         {activeSession
           ? getSessionTitle({ title: activeSession.title })
           : isDraftTemporary
@@ -1220,14 +1471,16 @@ export function PxiApp({
         </Box>
       ) : null}
       {status === "streaming" ? <ThinkingIndicator /> : null}
-      {sessionPicker ? (
+      {modelPicker ? (
+        <ModelPicker state={modelPicker} />
+      ) : sessionPicker ? (
         <SessionPicker state={sessionPicker} />
       ) : (
         <InputPrompt
           draft={draft}
           status={status}
           usageLine={formatTokenUsageLine(getLatestAssistantUsage(messages))}
-          modelLabel={options.modelSelection.modelName}
+          modelLabel={activeModelSelection.modelName}
         />
       )}
     </Box>

--- a/js/packages/phoenix-cli/src/pxi/commands.ts
+++ b/js/packages/phoenix-cli/src/pxi/commands.ts
@@ -7,6 +7,7 @@
 
 export type CommandContext = {
   startNewSession: (options: { temporary: boolean }) => void;
+  openModelPicker: () => void;
   openSessionPicker: () => void;
   exit: () => void;
 };
@@ -23,6 +24,11 @@ export const SLASH_COMMANDS: PxiCommand[] = [
     name: "clear",
     description: "Start a new persisted session (alias for /new)",
     handler: (_args, ctx) => ctx.startNewSession({ temporary: false }),
+  },
+  {
+    name: "model",
+    description: "Switch models for this session",
+    handler: (_args, ctx) => ctx.openModelPicker(),
   },
   {
     name: "new",

--- a/js/packages/phoenix-cli/src/pxi/preflight.ts
+++ b/js/packages/phoenix-cli/src/pxi/preflight.ts
@@ -1,7 +1,11 @@
 import { buildGraphqlRequest } from "../commands/api";
 import type { PhoenixConfig } from "../config";
 import { InvalidArgumentError } from "../exitCodes";
-import type { ModelSelection, PxiRuntimeOptions } from "./types";
+import type {
+  BuiltInProvider,
+  ModelSelection,
+  PxiRuntimeOptions,
+} from "./types";
 
 /**
  * Pre-launch validation of the selected model.
@@ -67,7 +71,7 @@ type PxiCustomProvider = {
   modelNames: string[];
 };
 
-type PxiModelPreflightData = {
+export type PxiModelPreflightData = {
   modelProviders: PxiModelProvider[];
   playgroundModels: PxiPlaygroundModel[];
   generativeModelCustomProviders: {
@@ -76,6 +80,22 @@ type PxiModelPreflightData = {
     }>;
   };
 };
+
+const RECOMMENDED_PXI_MODELS = [
+  { provider: "ANTHROPIC", modelName: "claude-fable-5" },
+  { provider: "ANTHROPIC", modelName: "claude-opus-4-8" },
+  { provider: "ANTHROPIC", modelName: "claude-opus-4-6" },
+  { provider: "ANTHROPIC", modelName: "claude-sonnet-4-6" },
+  { provider: "OPENAI", modelName: "gpt-5.6-sol" },
+  { provider: "OPENAI", modelName: "gpt-5.4" },
+  { provider: "OPENAI", modelName: "gpt-5.4-mini" },
+  { provider: "OPENAI", modelName: "gpt-5.5" },
+  { provider: "GOOGLE", modelName: "gemini-3.1-pro-preview" },
+  { provider: "GOOGLE", modelName: "gemini-3.5-flash" },
+] as const satisfies readonly {
+  provider: BuiltInProvider;
+  modelName: string;
+}[];
 
 type GraphqlError = {
   message?: string;
@@ -287,6 +307,44 @@ export async function fetchPxiModelPreflight({
   const payload =
     (await response.json()) as GraphqlResponse<PxiModelPreflightData>;
   return assertPreflightData({ payload });
+}
+
+/** Return the main app's recommended models that exist in this server's catalog. */
+export function getRecommendedPxiModels({
+  data,
+}: {
+  data: PxiModelPreflightData;
+}): ModelSelection[] {
+  return RECOMMENDED_PXI_MODELS.filter(({ provider, modelName }) =>
+    data.playgroundModels.some(
+      (model) => model.providerKey === provider && model.name === modelName
+    )
+  ).map(({ provider, modelName }) =>
+    provider === "OPENAI"
+      ? {
+          providerType: "builtin",
+          provider,
+          modelName,
+          openaiApiType: "responses",
+        }
+      : {
+          providerType: "builtin",
+          provider,
+          modelName,
+        }
+  );
+}
+
+/** Fetch the recommended model choices displayed by the interactive picker. */
+export async function fetchRecommendedPxiModels({
+  config,
+  fetchImpl = globalThis.fetch,
+}: {
+  config: PhoenixConfig;
+  fetchImpl?: typeof globalThis.fetch;
+}): Promise<ModelSelection[]> {
+  const data = await fetchPxiModelPreflight({ config, fetchImpl });
+  return getRecommendedPxiModels({ data });
 }
 
 /**

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -5,8 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 import { PxiApp, ThinkingIndicator } from "../src/pxi/App";
 import { resolvePxiRuntimeOptions } from "../src/pxi/options";
 import type {
+  ModelSelection,
   PxiChatClient,
   PxiMessage,
+  PxiRuntimeOptions,
   PxiSessionClient,
 } from "../src/pxi/types";
 
@@ -1203,6 +1205,121 @@ describe("PXI app", () => {
     expect(getSession).toHaveBeenCalledWith({ sessionId: "session-2" });
     expect(stripAnsi(lastFrame() ?? "")).toContain("restored conversation");
     expect(stripAnsi(lastFrame() ?? "")).toContain("session: Second session");
+    unmount();
+  });
+
+  it("switches the active session model for the next request", async () => {
+    const existingMessage: PxiMessage = {
+      id: "existing-user",
+      role: "user",
+      parts: [{ type: "text", text: "keep this conversation" }],
+    };
+    const sessionClient: PxiSessionClient = {
+      createSession: async () => ({
+        id: "session-1",
+        title: "Existing session",
+        updatedAt: "2026-07-24T12:00:00Z",
+        isTemporary: false,
+        messages: [],
+      }),
+      listSessions: async () => [],
+      getSession: async () => {
+        throw new Error("not used");
+      },
+    };
+    const modelLoader = vi.fn(
+      async (): Promise<ModelSelection[]> => [
+        {
+          providerType: "builtin",
+          provider: "OPENAI",
+          modelName: "gpt-5.4",
+        },
+        {
+          providerType: "builtin",
+          provider: "GOOGLE",
+          modelName: "gemini-3.5-flash",
+        },
+      ]
+    );
+    const clientFactory = vi.fn(
+      ({
+        options,
+      }: {
+        options: PxiRuntimeOptions;
+        agentSessionId: string;
+      }): PxiChatClient => ({
+        sendMessage: async () => {
+          expect(options.modelSelection).toEqual({
+            providerType: "builtin",
+            provider: "GOOGLE",
+            modelName: "gemini-3.5-flash",
+          });
+          return null;
+        },
+      })
+    );
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        clientFactory={clientFactory}
+        modelLoader={modelLoader}
+        sessionClient={sessionClient}
+        initialMessages={[existingMessage]}
+      />
+    );
+
+    await writeInput({ stdin, input: "/model" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    expect(stripAnsi(lastFrame() ?? "")).toContain("Recommended models");
+    expect(stripAnsi(lastFrame() ?? "")).toContain("GOOGLE/gemini-3.5-flash");
+
+    await writeInput({ stdin, input: DOWN_ARROW });
+    await writeInput({ stdin, input: "\r" });
+
+    const selectedFrame = stripAnsi(lastFrame() ?? "");
+    expect(selectedFrame).toContain("model: GOOGLE/gemini-3.5-flash");
+    expect(selectedFrame).toContain("keep this conversation");
+
+    await writeInput({ stdin, input: "continue" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+
+    expect(clientFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          modelSelection: {
+            providerType: "builtin",
+            provider: "GOOGLE",
+            modelName: "gemini-3.5-flash",
+          },
+        }),
+        agentSessionId: "session-1",
+      })
+    );
+    unmount();
+  });
+
+  it("keeps model loading errors visible until the picker is retried", async () => {
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        modelLoader={async () => {
+          throw new Error("Could not load models");
+        }}
+      />
+    );
+
+    await writeInput({ stdin, input: "/model" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    await writeInput({ stdin, input: "ignored filter" });
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("Could not load models");
+    expect(frame).toContain("esc close and retry");
     unmount();
   });
 

--- a/js/packages/phoenix-cli/test/pxiCommands.test.ts
+++ b/js/packages/phoenix-cli/test/pxiCommands.test.ts
@@ -11,6 +11,7 @@ describe("SLASH_COMMANDS", () => {
   it("includes session lifecycle commands", () => {
     const names = SLASH_COMMANDS.map((c) => c.name);
     expect(names).toContain("clear");
+    expect(names).toContain("model");
     expect(names).toContain("new");
     expect(names).toContain("sessions");
     expect(names).toContain("temporary");
@@ -23,6 +24,7 @@ describe("runSlashCommand", () => {
   function createContext() {
     return {
       startNewSession: vi.fn(),
+      openModelPicker: vi.fn(),
       openSessionPicker: vi.fn(),
       exit: vi.fn(),
     };
@@ -51,6 +53,12 @@ describe("runSlashCommand", () => {
     const context = createContext();
     runSlashCommand("/sessions", context);
     expect(context.openSessionPicker).toHaveBeenCalledOnce();
+  });
+
+  it("opens the model picker for /model", () => {
+    const context = createContext();
+    runSlashCommand("/model", context);
+    expect(context.openModelPicker).toHaveBeenCalledOnce();
   });
 
   it("calls exit for /exit", () => {

--- a/js/packages/phoenix-cli/test/pxiPreflight.test.ts
+++ b/js/packages/phoenix-cli/test/pxiPreflight.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { resolvePxiRuntimeOptions } from "../src/pxi/options";
-import { runPxiModelPreflight } from "../src/pxi/preflight";
+import {
+  getRecommendedPxiModels,
+  runPxiModelPreflight,
+} from "../src/pxi/preflight";
 
 type FetchCall = {
   url: string;
@@ -100,6 +103,38 @@ function createFetch({
 }
 
 describe("PXI model preflight", () => {
+  it("returns available recommended models in the main app's curated order", () => {
+    const models = getRecommendedPxiModels({
+      data: createPreflightData({
+        playgroundModels: [
+          { providerKey: "GOOGLE", name: "gemini-3.5-flash" },
+          { providerKey: "OPENAI", name: "unrecommended-model" },
+          { providerKey: "OPENAI", name: "gpt-5.4" },
+          { providerKey: "ANTHROPIC", name: "claude-opus-4-8" },
+        ],
+      }),
+    });
+
+    expect(models).toEqual([
+      {
+        providerType: "builtin",
+        provider: "ANTHROPIC",
+        modelName: "claude-opus-4-8",
+      },
+      {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-5.4",
+        openaiApiType: "responses",
+      },
+      {
+        providerType: "builtin",
+        provider: "GOOGLE",
+        modelName: "gemini-3.5-flash",
+      },
+    ]);
+  });
+
   it("uses configured endpoint, API key, and custom headers", async () => {
     const options = createRuntimeOptions({ apiKey: "secret" });
     options.config.headers = { "X-Phoenix": "pxi" };


### PR DESCRIPTION


https://github.com/user-attachments/assets/f413797a-56d3-4583-810a-6be970092a14



## Summary

- add a `/model` slash command with a filterable keyboard model picker
- switch the active model for subsequent turns without clearing the transcript or replacing the session
- preserve loading, cancellation, and actionable model-catalog error states
- cover command dispatch, curated model ordering, picker behavior, and the next request model

## Recommended models

The main app defines an ordered `AGENT_CURATED_BUILT_IN_MODELS` list in `app/src/components/agent/agentCuratedModels.ts`, then intersects that list with the server-provided `playgroundModels` catalog. This PR takes the same approach for PXI: it reuses the GraphQL catalog already fetched by model preflight, filters it through the same ordered provider/model pairs, and displays only recommendations available in the connected Phoenix server.

The recommendation policy is currently frontend-owned, so this focused CLI PR mirrors the list. That creates a possible drift point. A follow-up should move the ordered policy to a server-owned module and expose a field such as `agentRecommendedModels`; both `AgentModelMenu` and PXI could then consume one authoritative ordered list while retaining server availability filtering.

OpenAI recommendations explicitly select the Responses API, matching the main app request construction.

## Testing

- `pnpm run test` (866 tests)
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm exec oxlint src/pxi/App.tsx src/pxi/commands.ts src/pxi/preflight.ts test/pxiApp.test.tsx test/pxiCommands.test.ts test/pxiPreflight.test.ts`

## Stack

Depends on #14711.