### PR TITLE
fix: Fix prompt description tab sidebar scrolling

### DIFF
--- a/app/src/pages/prompt/PromptIndexPage.tsx
+++ b/app/src/pages/prompt/PromptIndexPage.tsx
@@ -109,10 +109,11 @@ function PromptIndexPageAside({
     <View
       flex="none"
       width={400}
+      height="100%"
       borderStartColor="default"
       borderStartWidth="thin"
     >
-      <View padding="size-200">
+      <View padding="size-200" overflow="auto" height="100%">
         <Flex
           direction="row"
           justifyContent="space-between"


### PR DESCRIPTION
## Summary
- make the prompt details aside fill available tab panel height
- enable vertical scrolling in the aside content container
- prevent large metadata JSON from pushing Labels and Latest Versions out of view

## Fixes
- fixes #14721

## Notes
- this follows the same overflow/height scrolling pattern used in other Phoenix side panels