### PR TITLE
feat(ui): add SegmentedControl component

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1080,6 +1080,59 @@ const checkboxCSS = (theme: Theme) => css`
   }
 `;
 
+const segmentedControlCSS = (theme: Theme) => css`
+  :root,
+  .theme--${theme} {
+    /* ── Segmented control semantic tokens ────────────────────────────
+       The SegmentedControl styles (components/core/segmentedControl)
+       reference only these tokens, never raw palette values. Retheme the
+       control by remapping here — component CSS stays untouched. */
+
+    /* The recessed track the segments sit in. It has to sit one clear step
+       below the thumb, since that gap is the only thing marking which segment
+       is selected. In dark the field surface already sits that far below the
+       thumb; in light the field surface is within ~3% of it, so the track drops
+       an extra step instead. The border is shared with fields in both themes,
+       which is what keeps the control from reading as a different system in a
+       toolbar. */
+    --global-segmented-control-background-color: ${theme === "dark"
+      ? "var(--global-input-field-background-color)"
+      : "var(--global-color-gray-200)"};
+    --global-segmented-control-border-color: var(
+      --global-input-field-border-color
+    );
+    /* Hairline between unselected segments; suppressed next to the thumb. It
+       follows the control's own border so the two never drift apart. */
+    --global-segmented-control-divider-color: var(
+      --global-segmented-control-border-color
+    );
+    /* The thumb behind the selected segment reads as a raised surface, so it
+       moves away from the track in whichever direction the theme has room:
+       lighter than the track in dark mode, brighter than the page in light. */
+    --global-segmented-control-thumb-background-color: ${theme === "dark"
+      ? "var(--global-color-gray-300)"
+      : "var(--global-color-gray-50)"};
+    --global-segmented-control-thumb-border-color: ${theme === "dark"
+      ? "var(--global-color-gray-400)"
+      : "var(--global-color-gray-300)"};
+    /* Segment labels: unselected segments recede, and hover brings a label
+       forward behind a soft pill without competing with the thumb. */
+    --global-segmented-control-item-text-color: var(--global-text-color-700);
+    --global-segmented-control-item-text-color-hover: var(
+      --global-text-color-900
+    );
+    --global-segmented-control-item-text-color-selected: var(
+      --global-text-color-900
+    );
+    --global-segmented-control-item-text-color-disabled: var(
+      --global-text-color-300
+    );
+    --global-segmented-control-item-background-color-hover: var(
+      --global-color-primary-50
+    );
+  }
+`;
+
 const disclosureCSS = (theme: Theme) => css`
   :root,
   .theme--${theme} {
@@ -1335,6 +1388,7 @@ export const derivedCSS = (theme: Theme) =>
     buttonCSS(theme),
     pxiCSS(theme),
     checkboxCSS(theme),
+    segmentedControlCSS(theme),
     disclosureCSS(theme),
     tooltipCSS(theme),
     dndCSS(theme),

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1083,40 +1083,24 @@ const checkboxCSS = (theme: Theme) => css`
 const segmentedControlCSS = (theme: Theme) => css`
   :root,
   .theme--${theme} {
-    /* ── Segmented control semantic tokens ────────────────────────────
-       The SegmentedControl styles (components/core/segmentedControl)
-       reference only these tokens, never raw palette values. Retheme the
-       control by remapping here — component CSS stays untouched. */
-
-    /* The recessed track the segments sit in. It has to sit one clear step
-       below the thumb, since that gap is the only thing marking which segment
-       is selected. In dark the field surface already sits that far below the
-       thumb; in light the field surface is within ~3% of it, so the track drops
-       an extra step instead. The border is shared with fields in both themes,
-       which is what keeps the control from reading as a different system in a
-       toolbar. */
+    /* The track has to sit one clear step below the thumb, since that gap is
+       the only thing marking which segment is selected. Dark's field surface
+       already sits that far below; light's is within ~3%, so it drops a step. */
     --global-segmented-control-background-color: ${theme === "dark"
       ? "var(--global-input-field-background-color)"
       : "var(--global-color-gray-200)"};
     --global-segmented-control-border-color: var(
       --global-input-field-border-color
     );
-    /* Hairline between unselected segments; suppressed next to the thumb. It
-       follows the control's own border so the two never drift apart. */
     --global-segmented-control-divider-color: var(
       --global-segmented-control-border-color
     );
-    /* The thumb behind the selected segment reads as a raised surface, so it
-       moves away from the track in whichever direction the theme has room:
-       lighter than the track in dark mode, brighter than the page in light. */
     --global-segmented-control-thumb-background-color: ${theme === "dark"
       ? "var(--global-color-gray-300)"
       : "var(--global-color-gray-50)"};
     --global-segmented-control-thumb-border-color: ${theme === "dark"
       ? "var(--global-color-gray-400)"
       : "var(--global-color-gray-300)"};
-    /* Segment labels: unselected segments recede, and hover brings a label
-       forward behind a soft pill without competing with the thumb. */
     --global-segmented-control-item-text-color: var(--global-text-color-700);
     --global-segmented-control-item-text-color-hover: var(
       --global-text-color-900

--- a/app/src/components/core/index.tsx
+++ b/app/src/components/core/index.tsx
@@ -23,6 +23,7 @@ export * from "./tag";
 export * from "./overlay";
 export * from "./radio";
 export * from "./toggleButtonGroup";
+export * from "./segmentedControl";
 export * from "./listbox";
 export * from "./gridlist";
 export * from "./token";

--- a/app/src/components/core/segmentedControl/SegmentedControl.tsx
+++ b/app/src/components/core/segmentedControl/SegmentedControl.tsx
@@ -9,18 +9,13 @@ import { classNames } from "@phoenix/utils/classNames";
 import { segmentedControlCSS } from "./styles";
 import type { SegmentedControlItemProps, SegmentedControlProps } from "./types";
 
-/**
- * The id of the first item the user could actually land on, used to seed the
- * selection when the caller doesn't name one.
- */
+/** The first item the user could land on, used when the caller names no default. */
 function getFirstEnabledItemId(children: ReactNode): Key | undefined {
   for (const child of Children.toArray(children)) {
     if (!isValidElement<Partial<SegmentedControlItemProps>>(child)) {
       continue;
     }
-    // `Children.toArray` flattens arrays but not fragments, so recurse into
-    // them — a caller who groups related segments in a fragment should still
-    // land on the first segment rather than on no selection at all.
+    // Children.toArray flattens arrays but not fragments.
     if (child.type === Fragment) {
       const nestedId = getFirstEnabledItemId(
         (child.props as { children?: ReactNode }).children
@@ -54,11 +49,9 @@ export function SegmentedControl({
   css: cssProp,
   ...props
 }: SegmentedControlProps) {
-  // A segmented control always reflects a current view, so when the caller
-  // doesn't name a default, start on the first segment. Computed lazily —
-  // react-aria only reads the default at mount, and this avoids re-walking
-  // the children on every render. Harmless when `selectedKey` is controlled,
-  // since the default is ignored entirely in that case.
+  // A segmented control always reflects a current view, so fall back to the
+  // first segment. Held in state because react-aria only reads the default at
+  // mount, so re-walking the children on later renders is wasted work.
   const [resolvedDefaultSelectedKey] = useState(
     () => defaultSelectedKey ?? getFirstEnabledItemId(children)
   );

--- a/app/src/components/core/segmentedControl/SegmentedControl.tsx
+++ b/app/src/components/core/segmentedControl/SegmentedControl.tsx
@@ -1,0 +1,92 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
+import { Children, Fragment, isValidElement, useState } from "react";
+import type { Key } from "react-aria-components";
+import { ToggleButtonGroup as AriaToggleButtonGroup } from "react-aria-components";
+
+import { classNames } from "@phoenix/utils/classNames";
+
+import { segmentedControlCSS } from "./styles";
+import type { SegmentedControlItemProps, SegmentedControlProps } from "./types";
+
+/**
+ * The id of the first item the user could actually land on, used to seed the
+ * selection when the caller doesn't name one.
+ */
+function getFirstEnabledItemId(children: ReactNode): Key | undefined {
+  for (const child of Children.toArray(children)) {
+    if (!isValidElement<Partial<SegmentedControlItemProps>>(child)) {
+      continue;
+    }
+    // `Children.toArray` flattens arrays but not fragments, so recurse into
+    // them — a caller who groups related segments in a fragment should still
+    // land on the first segment rather than on no selection at all.
+    if (child.type === Fragment) {
+      const nestedId = getFirstEnabledItemId(
+        (child.props as { children?: ReactNode }).children
+      );
+      if (nestedId != null) {
+        return nestedId;
+      }
+      continue;
+    }
+    const { id, isDisabled } = child.props;
+    if (id != null && !isDisabled) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * A SegmentedControl is a mutually exclusive group of buttons used for view
+ * switching. Unlike a `ToggleButtonGroup`, one segment is always selected — it
+ * shows the current view rather than toggling options on and off.
+ */
+export function SegmentedControl({
+  children,
+  size = "M",
+  isJustified = false,
+  selectedKey,
+  defaultSelectedKey,
+  onSelectionChange,
+  className,
+  css: cssProp,
+  ...props
+}: SegmentedControlProps) {
+  // A segmented control always reflects a current view, so when the caller
+  // doesn't name a default, start on the first segment. Computed lazily —
+  // react-aria only reads the default at mount, and this avoids re-walking
+  // the children on every render. Harmless when `selectedKey` is controlled,
+  // since the default is ignored entirely in that case.
+  const [resolvedDefaultSelectedKey] = useState(
+    () => defaultSelectedKey ?? getFirstEnabledItemId(children)
+  );
+
+  return (
+    <AriaToggleButtonGroup
+      {...props}
+      selectionMode="single"
+      disallowEmptySelection
+      orientation="horizontal"
+      selectedKeys={selectedKey !== undefined ? [selectedKey] : undefined}
+      defaultSelectedKeys={
+        resolvedDefaultSelectedKey != null
+          ? [resolvedDefaultSelectedKey]
+          : undefined
+      }
+      onSelectionChange={(keys) => {
+        const [firstKey] = keys;
+        if (firstKey != null) {
+          onSelectionChange?.(firstKey);
+        }
+      }}
+      data-size={size}
+      data-justified={isJustified}
+      className={classNames("segmented-control", className)}
+      css={css(segmentedControlCSS, cssProp)}
+    >
+      {children}
+    </AriaToggleButtonGroup>
+  );
+}

--- a/app/src/components/core/segmentedControl/SegmentedControlItem.tsx
+++ b/app/src/components/core/segmentedControl/SegmentedControlItem.tsx
@@ -1,0 +1,44 @@
+import { css } from "@emotion/react";
+import {
+  SelectionIndicator as AriaSelectionIndicator,
+  ToggleButton as AriaToggleButton,
+} from "react-aria-components";
+
+import { Text } from "@phoenix/components/core/content";
+import { classNames } from "@phoenix/utils/classNames";
+
+import {
+  segmentedControlItemContentCSS,
+  segmentedControlItemCSS,
+  segmentedControlThumbCSS,
+} from "./styles";
+import type { SegmentedControlItemProps } from "./types";
+
+/**
+ * A SegmentedControlItem represents an option within a SegmentedControl.
+ */
+export function SegmentedControlItem({
+  children,
+  className,
+  css: cssProp,
+  ...props
+}: SegmentedControlItemProps) {
+  return (
+    <AriaToggleButton
+      {...props}
+      className={classNames("segmented-control__item", className)}
+      css={css(segmentedControlItemCSS, cssProp)}
+    >
+      <div
+        className="segmented-control__item-content"
+        css={segmentedControlItemContentCSS}
+      >
+        {typeof children === "string" ? <Text>{children}</Text> : children}
+      </div>
+      <AriaSelectionIndicator
+        className="segmented-control__thumb"
+        css={segmentedControlThumbCSS}
+      />
+    </AriaToggleButton>
+  );
+}

--- a/app/src/components/core/segmentedControl/index.ts
+++ b/app/src/components/core/segmentedControl/index.ts
@@ -1,0 +1,3 @@
+export * from "./SegmentedControl";
+export * from "./SegmentedControlItem";
+export * from "./types";

--- a/app/src/components/core/segmentedControl/styles.ts
+++ b/app/src/components/core/segmentedControl/styles.ts
@@ -1,0 +1,292 @@
+import { css } from "@emotion/react";
+
+/**
+ * The track. Sizing tokens are declared here rather than on the item so the
+ * whole control scales from a single `data-size`, and so the item can stay
+ * agnostic of which size it was rendered at.
+ */
+export const segmentedControlCSS = css`
+  /* Matches buttons and fields — the control has to line up with them in a
+     toolbar. */
+  --segmented-control-rounding: var(--global-rounding-small);
+  /* Segments span the track's full height (no vertical inset), so the control
+     reads cleanly at any height and the thumb fills the corner it sits in.
+     With the thumb flush against the border, concentric rounding
+     (track − border) is exact rather than an approximation. */
+  --segmented-control-item-rounding: calc(
+    var(--segmented-control-rounding) - var(--global-border-size-thin)
+  );
+  /* One clock for every moving part — label color, divider fade, hover pill,
+     and the thumb itself. Mixed durations make pieces of the control arrive
+     at different times, which reads as stutter. */
+  --segmented-control-motion-duration: 200ms;
+  /* Leaves at full speed and decelerates into place, so motion reads as
+     following the click rather than winding up first. */
+  --segmented-control-motion-easing: cubic-bezier(0, 0, 0.4, 1);
+
+  position: relative;
+  box-sizing: border-box;
+  display: inline-flex;
+  /* Sized to its segments rather than left auto: a definite width opts the track
+     out of a flex parent's align-items: stretch, which would otherwise widen the
+     track without widening the segments and leave dead track past the last one.
+     The data-justified rule below overrides this to fill the container on
+     purpose. */
+  width: fit-content;
+  max-width: 100%;
+  /* Segments touch; a divider (on the item) separates unselected neighbors.
+     A gap here would put daylight between the thumb and its neighbors, which
+     reads as segments floating in the track rather than one control. */
+  gap: 0;
+  background-color: var(--global-segmented-control-background-color);
+  border: var(--global-border-size-thin) solid
+    var(--global-segmented-control-border-color);
+  border-radius: var(--segmented-control-rounding);
+
+  /* Labels hold at 14px from S to M, matching Button and Select, which use one
+     label size across those heights — a segmented control sits directly beside
+     them in a toolbar, and a smaller label there reads as a caption rather than
+     as a peer control. Only L steps up. */
+  &[data-size="S"] {
+    height: var(--global-button-height-s);
+    --segmented-control-item-padding-x: var(--global-dimension-size-100);
+    --segmented-control-item-font-size: var(--global-font-size-s);
+    --segmented-control-item-line-height: var(--global-line-height-s);
+  }
+
+  &[data-size="M"] {
+    height: var(--global-button-height-m);
+    --segmented-control-item-padding-x: var(--global-dimension-size-150);
+    --segmented-control-item-font-size: var(--global-font-size-s);
+    --segmented-control-item-line-height: var(--global-line-height-s);
+  }
+
+  &[data-size="L"] {
+    height: var(--global-button-height-l);
+    --segmented-control-item-padding-x: var(--global-dimension-size-200);
+    --segmented-control-item-font-size: var(--global-font-size-m);
+    --segmented-control-item-line-height: var(--global-line-height-m);
+  }
+
+  /* Justified items share the track evenly and truncate rather than pushing
+     the control wider than its container. */
+  &[data-justified="true"] {
+    width: 100%;
+
+    .segmented-control__item {
+      flex: 1 1 0;
+    }
+  }
+
+  /* Divider between adjacent segments, hidden on either side of the selected
+     one so the thumb's own edge does the separating there. Drawn on the item
+     (not the track) so it can follow the selection, and kept above the thumb's
+     z-index so it holds steady while the thumb slides underneath. Matched on
+     the stable BEM class rather than on the item's emotion class, so a segment
+     handed its own \`css\` prop — a different generated class — still divides
+     from its neighbors. */
+  .segmented-control__item + .segmented-control__item::before {
+    content: "";
+    position: absolute;
+    /* Centered on the seam between the two segments it separates. */
+    left: calc(-1 * var(--global-border-size-thin) / 2);
+    top: 25%;
+    height: 50%;
+    width: var(--global-border-size-thin);
+    background-color: var(--global-segmented-control-divider-color);
+    transition: opacity var(--segmented-control-motion-duration)
+      var(--segmented-control-motion-easing);
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  }
+
+  .segmented-control__item[data-selected]::before,
+  .segmented-control__item[data-selected] + .segmented-control__item::before {
+    opacity: 0;
+  }
+`;
+
+export const segmentedControlItemCSS = css`
+  position: relative;
+  /* The thumb lives inside the selected item and slides in from wherever the
+     previous selection was, so the selected item is dropped below its
+     siblings — otherwise an item late in the DOM would drag its thumb over
+     the labels it passes on the way. Each item's z-index also establishes the
+     stacking context that keeps its own thumb from escaping. */
+  z-index: 1;
+  box-sizing: border-box;
+  display: flex;
+  /* Shrinkable so a control that outgrows its container truncates its labels
+     (see the content box below) instead of spilling its segments outside the
+     track — the item itself can't clip, since the thumb has to escape it. */
+  flex: 0 1 auto;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  margin: 0;
+  padding: 0 var(--segmented-control-item-padding-x);
+  border: none;
+  background-color: transparent;
+  border-radius: var(--segmented-control-item-rounding);
+  color: var(--global-segmented-control-item-text-color);
+  font-family: inherit;
+  font-size: var(--segmented-control-item-font-size);
+  line-height: var(--segmented-control-item-line-height);
+  font-weight: 400;
+  white-space: nowrap;
+  /* Deliberately not clipped: the thumb is a child of the selected item and
+     spends the whole animation outside that item's box on its way over. */
+  overflow: visible;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  forced-color-adjust: none;
+  outline: none;
+  transition: color var(--segmented-control-motion-duration)
+    var(--segmented-control-motion-easing);
+
+  /* Reduced-motion overrides are declared alongside the transition they
+     cancel: a single block on the track would tie with these rules on
+     specificity and lose on source order, since the item and thumb styles are
+     inserted after the track's. */
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+
+  /* Hover pill: a small inset shape rather than washing the whole segment,
+     so hover reads as "this is clickable" without competing with the thumb.
+     Sits behind the label within the item's own stacking context. */
+  &::after {
+    content: "";
+    position: absolute;
+    inset: var(--global-dimension-size-50);
+    border-radius: var(--segmented-control-item-rounding);
+    background-color: transparent;
+    transition: background-color var(--segmented-control-motion-duration)
+      var(--segmented-control-motion-easing);
+    z-index: -1;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  }
+
+  /* Labels take the item's state color and size-driven font metrics rather
+     than the Text component's own defaults, so unselected segments recede and
+     the label tracks the control's data-size. Text always renders data-size,
+     and matching on it outranks Text's own font rules instead of tying with
+     them and depending on insertion order. */
+  .text[data-size] {
+    color: inherit;
+    font-size: inherit;
+    line-height: inherit;
+  }
+
+  &[data-hovered]:not([data-selected]):not([data-disabled]) {
+    color: var(--global-segmented-control-item-text-color-hover);
+
+    &::after {
+      background-color: var(
+        --global-segmented-control-item-background-color-hover
+      );
+    }
+  }
+
+  &[data-selected] {
+    color: var(--global-segmented-control-item-text-color-selected);
+    z-index: 0;
+  }
+
+  &[data-disabled] {
+    cursor: default;
+    color: var(--global-segmented-control-item-text-color-disabled);
+  }
+
+  /* Inset the ring so it reads as belonging to the segment instead of
+     spilling over the track's edge. */
+  &[data-focus-visible] {
+    outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    outline-offset: calc(-1 * var(--focus-ring-thickness));
+  }
+`;
+
+/**
+ * The label row. Kept as its own box so the press animation scales the
+ * content without disturbing the thumb's geometry.
+ */
+export const segmentedControlItemContentCSS = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--global-dimension-size-100);
+  min-width: 0;
+  /* Truncation lives here rather than on the item so that clipping the label
+     never clips the thumb sliding past. */
+  overflow: hidden;
+  transition: scale var(--segmented-control-motion-duration)
+    var(--segmented-control-motion-easing);
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+
+  .text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  [data-pressed] > & {
+    scale: 0.96;
+  }
+`;
+
+/**
+ * The thumb behind the selected segment. react-aria re-parents it into the
+ * newly selected item and seeds it with the previous segment's offset and
+ * width, so animating `translate` and `width` is what makes it appear to
+ * slide across and stretch into its new home. Segments are all the same
+ * height, so `height` is deliberately left out — animating it only adds
+ * jitter.
+ */
+export const segmentedControlThumbCSS = css`
+  position: absolute;
+  /* Bleed out by the track's border width so the thumb's border paints
+     exactly on top of it — otherwise the two borders sit side by side and
+     read as a doubled line around the selected segment. */
+  top: calc(-1 * var(--global-border-size-thin));
+  left: calc(-1 * var(--global-border-size-thin));
+  width: calc(100% + 2 * var(--global-border-size-thin));
+  height: calc(100% + 2 * var(--global-border-size-thin));
+  box-sizing: border-box;
+  z-index: -1;
+  /* The thumb has no content of its own; containing it keeps the slide from
+     invalidating layout or paint beyond its own box. */
+  contain: strict;
+  /* The resting translate is 0, but written with a percentage on purpose: a
+     box-size-dependent translate can't be lifted to the compositor, so the
+     slide stays on the main thread where it's resolved in the same style
+     recalc as the width stretch every frame. A compositable translate keeps
+     gliding whenever the main thread drops a frame (the click's re-render
+     guarantees it does) while width stalls — the two desync and the thumb
+     visibly wobbles, worst when segment widths differ a lot. Pinned to the
+     main thread they can only stall together, so the thumb stays rigid. */
+  translate: 0% 0px;
+  background-color: var(--global-segmented-control-thumb-background-color);
+  border: var(--global-border-size-thin) solid
+    var(--global-segmented-control-thumb-border-color);
+  /* The bleed puts the thumb's border in the same place as the track's, so
+     the two share one radius and the corners coincide exactly. */
+  border-radius: var(--segmented-control-rounding);
+  transition-property: translate, width;
+  transition-duration: var(--segmented-control-motion-duration);
+  transition-timing-function: var(--segmented-control-motion-easing);
+
+  /* "transition: none" rather than a zero duration: react-aria only snapshots
+     the outgoing thumb when the incoming one has a transition-property, so
+     this is what actually skips the slide instead of running it instantly. */
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;

--- a/app/src/components/core/segmentedControl/styles.ts
+++ b/app/src/components/core/segmentedControl/styles.ts
@@ -1,52 +1,29 @@
 import { css } from "@emotion/react";
 
-/**
- * The track. Sizing tokens are declared here rather than on the item so the
- * whole control scales from a single `data-size`, and so the item can stay
- * agnostic of which size it was rendered at.
- */
+/** Sizing lives on the track so the control scales from a single data-size. */
 export const segmentedControlCSS = css`
-  /* Matches buttons and fields — the control has to line up with them in a
-     toolbar. */
   --segmented-control-rounding: var(--global-rounding-small);
-  /* Segments span the track's full height (no vertical inset), so the control
-     reads cleanly at any height and the thumb fills the corner it sits in.
-     With the thumb flush against the border, concentric rounding
-     (track − border) is exact rather than an approximation. */
+  /* Concentric with the track, since segments span its full height. */
   --segmented-control-item-rounding: calc(
     var(--segmented-control-rounding) - var(--global-border-size-thin)
   );
-  /* One clock for every moving part — label color, divider fade, hover pill,
-     and the thumb itself. Mixed durations make pieces of the control arrive
-     at different times, which reads as stutter. */
+  /* One clock for every moving part; mixed durations read as stutter. */
   --segmented-control-motion-duration: 200ms;
-  /* Leaves at full speed and decelerates into place, so motion reads as
-     following the click rather than winding up first. */
   --segmented-control-motion-easing: cubic-bezier(0, 0, 0.4, 1);
 
   position: relative;
   box-sizing: border-box;
   display: inline-flex;
-  /* Sized to its segments rather than left auto: a definite width opts the track
-     out of a flex parent's align-items: stretch, which would otherwise widen the
-     track without widening the segments and leave dead track past the last one.
-     The data-justified rule below overrides this to fill the container on
-     purpose. */
+  /* A definite width opts out of a flex parent's align-items: stretch, which
+     would widen the track without widening the segments. */
   width: fit-content;
   max-width: 100%;
-  /* Segments touch; a divider (on the item) separates unselected neighbors.
-     A gap here would put daylight between the thumb and its neighbors, which
-     reads as segments floating in the track rather than one control. */
-  gap: 0;
   background-color: var(--global-segmented-control-background-color);
   border: var(--global-border-size-thin) solid
     var(--global-segmented-control-border-color);
   border-radius: var(--segmented-control-rounding);
 
-  /* Labels hold at 14px from S to M, matching Button and Select, which use one
-     label size across those heights — a segmented control sits directly beside
-     them in a toolbar, and a smaller label there reads as a caption rather than
-     as a peer control. Only L steps up. */
+  /* Labels hold at 14px through M to match Button and Select in a toolbar. */
   &[data-size="S"] {
     height: var(--global-button-height-s);
     --segmented-control-item-padding-x: var(--global-dimension-size-100);
@@ -68,8 +45,6 @@ export const segmentedControlCSS = css`
     --segmented-control-item-line-height: var(--global-line-height-m);
   }
 
-  /* Justified items share the track evenly and truncate rather than pushing
-     the control wider than its container. */
   &[data-justified="true"] {
     width: 100%;
 
@@ -78,17 +53,11 @@ export const segmentedControlCSS = css`
     }
   }
 
-  /* Divider between adjacent segments, hidden on either side of the selected
-     one so the thumb's own edge does the separating there. Drawn on the item
-     (not the track) so it can follow the selection, and kept above the thumb's
-     z-index so it holds steady while the thumb slides underneath. Matched on
-     the stable BEM class rather than on the item's emotion class, so a segment
-     handed its own \`css\` prop — a different generated class — still divides
-     from its neighbors. */
+  /* Keyed on the BEM class, not the item's emotion class, so an item given its
+     own css prop still divides from its neighbors. */
   .segmented-control__item + .segmented-control__item::before {
     content: "";
     position: absolute;
-    /* Centered on the seam between the two segments it separates. */
     left: calc(-1 * var(--global-border-size-thin) / 2);
     top: 25%;
     height: 50%;
@@ -102,6 +71,7 @@ export const segmentedControlCSS = css`
     }
   }
 
+  /* Beside the thumb, the thumb's own edge does the separating. */
   .segmented-control__item[data-selected]::before,
   .segmented-control__item[data-selected] + .segmented-control__item::before {
     opacity: 0;
@@ -110,17 +80,14 @@ export const segmentedControlCSS = css`
 
 export const segmentedControlItemCSS = css`
   position: relative;
-  /* The thumb lives inside the selected item and slides in from wherever the
-     previous selection was, so the selected item is dropped below its
-     siblings — otherwise an item late in the DOM would drag its thumb over
-     the labels it passes on the way. Each item's z-index also establishes the
-     stacking context that keeps its own thumb from escaping. */
+  /* The thumb is a child of the selected item and slides in from the previous
+     one, so the selected item drops below its siblings (see [data-selected]) to
+     keep the thumb from crossing over the labels it passes. */
   z-index: 1;
   box-sizing: border-box;
   display: flex;
-  /* Shrinkable so a control that outgrows its container truncates its labels
-     (see the content box below) instead of spilling its segments outside the
-     track — the item itself can't clip, since the thumb has to escape it. */
+  /* Shrinkable, so an oversized control truncates labels rather than spilling
+     segments outside the track. */
   flex: 0 1 auto;
   align-items: center;
   justify-content: center;
@@ -136,8 +103,7 @@ export const segmentedControlItemCSS = css`
   line-height: var(--segmented-control-item-line-height);
   font-weight: 400;
   white-space: nowrap;
-  /* Deliberately not clipped: the thumb is a child of the selected item and
-     spends the whole animation outside that item's box on its way over. */
+  /* Not clipped: the thumb spends the animation outside this box. */
   overflow: visible;
   cursor: pointer;
   user-select: none;
@@ -147,17 +113,14 @@ export const segmentedControlItemCSS = css`
   transition: color var(--segmented-control-motion-duration)
     var(--segmented-control-motion-easing);
 
-  /* Reduced-motion overrides are declared alongside the transition they
-     cancel: a single block on the track would tie with these rules on
-     specificity and lose on source order, since the item and thumb styles are
-     inserted after the track's. */
+  /* Every reduced-motion override sits with the transition it cancels: one
+     block on the track would tie on specificity and lose on source order. */
   @media (prefers-reduced-motion: reduce) {
     transition: none;
   }
 
-  /* Hover pill: a small inset shape rather than washing the whole segment,
-     so hover reads as "this is clickable" without competing with the thumb.
-     Sits behind the label within the item's own stacking context. */
+  /* Hover pill, inset so it reads as clickable without competing with the
+     thumb. */
   &::after {
     content: "";
     position: absolute;
@@ -173,10 +136,7 @@ export const segmentedControlItemCSS = css`
     }
   }
 
-  /* Labels take the item's state color and size-driven font metrics rather
-     than the Text component's own defaults, so unselected segments recede and
-     the label tracks the control's data-size. Text always renders data-size,
-     and matching on it outranks Text's own font rules instead of tying with
+  /* Matching on data-size outranks Text's own font rules instead of tying with
      them and depending on insertion order. */
   .text[data-size] {
     color: inherit;
@@ -204,26 +164,20 @@ export const segmentedControlItemCSS = css`
     color: var(--global-segmented-control-item-text-color-disabled);
   }
 
-  /* Inset the ring so it reads as belonging to the segment instead of
-     spilling over the track's edge. */
   &[data-focus-visible] {
     outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
 `;
 
-/**
- * The label row. Kept as its own box so the press animation scales the
- * content without disturbing the thumb's geometry.
- */
+/** Its own box so the press animation leaves the thumb's geometry alone. */
 export const segmentedControlItemContentCSS = css`
   display: flex;
   align-items: center;
   justify-content: center;
   gap: var(--global-dimension-size-100);
   min-width: 0;
-  /* Truncation lives here rather than on the item so that clipping the label
-     never clips the thumb sliding past. */
+  /* Here rather than on the item, so clipping the label never clips the thumb. */
   overflow: hidden;
   transition: scale var(--segmented-control-motion-duration)
     var(--segmented-control-motion-easing);
@@ -243,49 +197,38 @@ export const segmentedControlItemContentCSS = css`
 `;
 
 /**
- * The thumb behind the selected segment. react-aria re-parents it into the
- * newly selected item and seeds it with the previous segment's offset and
- * width, so animating `translate` and `width` is what makes it appear to
- * slide across and stretch into its new home. Segments are all the same
- * height, so `height` is deliberately left out — animating it only adds
- * jitter.
+ * react-aria re-parents the thumb into the newly selected item and seeds it with
+ * the previous segment's offset and width, so animating translate and width is
+ * what makes it slide across and stretch. Height is deliberately left out —
+ * segments are all the same height, and animating it only adds jitter.
  */
 export const segmentedControlThumbCSS = css`
   position: absolute;
-  /* Bleed out by the track's border width so the thumb's border paints
-     exactly on top of it — otherwise the two borders sit side by side and
-     read as a doubled line around the selected segment. */
+  /* Bleeds out by the track's border width so the two borders paint on top of
+     each other instead of reading as a doubled line. */
   top: calc(-1 * var(--global-border-size-thin));
   left: calc(-1 * var(--global-border-size-thin));
   width: calc(100% + 2 * var(--global-border-size-thin));
   height: calc(100% + 2 * var(--global-border-size-thin));
   box-sizing: border-box;
   z-index: -1;
-  /* The thumb has no content of its own; containing it keeps the slide from
-     invalidating layout or paint beyond its own box. */
   contain: strict;
-  /* The resting translate is 0, but written with a percentage on purpose: a
-     box-size-dependent translate can't be lifted to the compositor, so the
-     slide stays on the main thread where it's resolved in the same style
-     recalc as the width stretch every frame. A compositable translate keeps
-     gliding whenever the main thread drops a frame (the click's re-render
-     guarantees it does) while width stalls — the two desync and the thumb
-     visibly wobbles, worst when segment widths differ a lot. Pinned to the
-     main thread they can only stall together, so the thumb stays rigid. */
+  /* Zero, but written as a percentage on purpose: a box-size-dependent translate
+     can't be lifted to the compositor, so it stays on the main thread and
+     resolves in the same style recalc as the width stretch. Left compositable,
+     it keeps gliding through dropped frames while width stalls, and the thumb
+     visibly wobbles. */
   translate: 0% 0px;
   background-color: var(--global-segmented-control-thumb-background-color);
   border: var(--global-border-size-thin) solid
     var(--global-segmented-control-thumb-border-color);
-  /* The bleed puts the thumb's border in the same place as the track's, so
-     the two share one radius and the corners coincide exactly. */
   border-radius: var(--segmented-control-rounding);
   transition-property: translate, width;
   transition-duration: var(--segmented-control-motion-duration);
   transition-timing-function: var(--segmented-control-motion-easing);
 
-  /* "transition: none" rather than a zero duration: react-aria only snapshots
-     the outgoing thumb when the incoming one has a transition-property, so
-     this is what actually skips the slide instead of running it instantly. */
+  /* none, not a zero duration: react-aria only snapshots the outgoing thumb when
+     the incoming one has a transition-property. */
   @media (prefers-reduced-motion: reduce) {
     transition: none;
   }

--- a/app/src/components/core/segmentedControl/types.ts
+++ b/app/src/components/core/segmentedControl/types.ts
@@ -1,0 +1,70 @@
+import type { ReactNode, Ref } from "react";
+import type {
+  Key,
+  ToggleButtonGroupProps as AriaToggleButtonGroupProps,
+  ToggleButtonProps as AriaToggleButtonProps,
+} from "react-aria-components";
+
+import type {
+  SizingProps,
+  StylableProps,
+} from "@phoenix/components/core/types";
+
+/**
+ * The segmented control owns selection, orientation, and layout, so the
+ * underlying multi-select toggle group API is not passed through.
+ */
+type InheritedGroupProps = Omit<
+  AriaToggleButtonGroupProps,
+  | "children"
+  | "className"
+  | "defaultSelectedKeys"
+  | "disallowEmptySelection"
+  | "onSelectionChange"
+  | "orientation"
+  | "selectedKeys"
+  | "selectionMode"
+>;
+
+export interface SegmentedControlProps
+  extends InheritedGroupProps, SizingProps, StylableProps {
+  /**
+   * The content to display in the segmented control. Expects `SegmentedControlItem` children.
+   */
+  children: ReactNode;
+  /**
+   * Whether the items should divide the container width equally.
+   * @default false
+   */
+  isJustified?: boolean;
+  /** The id of the currently selected item (controlled). */
+  selectedKey?: Key;
+  /** The id of the initial selected item (uncontrolled). */
+  defaultSelectedKey?: Key;
+  /** Handler that is called when the selection changes. */
+  onSelectionChange?: (id: Key) => void;
+  className?: string;
+  ref?: Ref<HTMLDivElement>;
+}
+
+/**
+ * Selection lives on the group, so the standalone toggle props are not
+ * passed through to the item.
+ */
+type InheritedItemProps = Omit<
+  AriaToggleButtonProps,
+  "children" | "className" | "defaultSelected" | "isSelected" | "onChange"
+>;
+
+export interface SegmentedControlItemProps
+  extends InheritedItemProps, StylableProps {
+  /**
+   * The content to display in the segmented control item. A string is wrapped
+   * in a `Text` for you; otherwise compose an `Icon`, a `Text`, or both.
+   */
+  children: ReactNode;
+  /** The id of the item, matching the value used in SegmentedControl's `selectedKey` prop. */
+  id: Key;
+  className?: string;
+  ref?: Ref<HTMLButtonElement>;
+}

--- a/app/src/components/core/segmentedControl/types.ts
+++ b/app/src/components/core/segmentedControl/types.ts
@@ -10,10 +10,7 @@ import type {
   StylableProps,
 } from "@phoenix/components/core/types";
 
-/**
- * The segmented control owns selection, orientation, and layout, so the
- * underlying multi-select toggle group API is not passed through.
- */
+/** Selection, orientation, and layout are the control's, not the caller's. */
 type InheritedGroupProps = Omit<
   AriaToggleButtonGroupProps,
   | "children"
@@ -28,9 +25,7 @@ type InheritedGroupProps = Omit<
 
 export interface SegmentedControlProps
   extends InheritedGroupProps, SizingProps, StylableProps {
-  /**
-   * The content to display in the segmented control. Expects `SegmentedControlItem` children.
-   */
+  /** Expects `SegmentedControlItem` children. */
   children: ReactNode;
   /**
    * Whether the items should divide the container width equally.
@@ -47,10 +42,7 @@ export interface SegmentedControlProps
   ref?: Ref<HTMLDivElement>;
 }
 
-/**
- * Selection lives on the group, so the standalone toggle props are not
- * passed through to the item.
- */
+/** Selection lives on the group, so the standalone toggle props are dropped. */
 type InheritedItemProps = Omit<
   AriaToggleButtonProps,
   "children" | "className" | "defaultSelected" | "isSelected" | "onChange"
@@ -58,12 +50,9 @@ type InheritedItemProps = Omit<
 
 export interface SegmentedControlItemProps
   extends InheritedItemProps, StylableProps {
-  /**
-   * The content to display in the segmented control item. A string is wrapped
-   * in a `Text` for you; otherwise compose an `Icon`, a `Text`, or both.
-   */
+  /** A string is wrapped in a `Text`; otherwise compose an `Icon`, a `Text`, or both. */
   children: ReactNode;
-  /** The id of the item, matching the value used in SegmentedControl's `selectedKey` prop. */
+  /** Matches the value used in SegmentedControl's `selectedKey`. */
   id: Key;
   className?: string;
   ref?: Ref<HTMLButtonElement>;

--- a/app/src/components/markdown/MarkdownModeSelect.tsx
+++ b/app/src/components/markdown/MarkdownModeSelect.tsx
@@ -1,14 +1,4 @@
-import { css } from "@emotion/react";
-
-import {
-  Button,
-  ListBox,
-  Popover,
-  Select,
-  SelectChevronUpDownIcon,
-  SelectItem,
-  SelectValue,
-} from "@phoenix/components";
+import { SegmentedControl, SegmentedControlItem } from "@phoenix/components";
 
 import { useMarkdownMode } from "./MarkdownDisplayContext";
 import type { MarkdownDisplayMode } from "./types";
@@ -33,17 +23,11 @@ export function MarkdownModeSelect({
   onModeChange: (newMode: MarkdownDisplayMode) => void;
 }) {
   return (
-    <Select
+    <SegmentedControl
       aria-label="Markdown Mode"
-      value={mode}
-      css={css`
-        button {
-          width: 140px;
-          min-width: 140px;
-        }
-      `}
       size="S"
-      onChange={(key) => {
+      selectedKey={mode}
+      onSelectionChange={(key) => {
         if (isMarkdownDisplayMode(key)) {
           onModeChange(key);
         } else {
@@ -51,21 +35,9 @@ export function MarkdownModeSelect({
         }
       }}
     >
-      <Button>
-        <SelectValue />
-        <SelectChevronUpDownIcon />
-      </Button>
-      <Popover>
-        <ListBox>
-          <SelectItem key="text" id="text">
-            Text
-          </SelectItem>
-          <SelectItem key="markdown" id="markdown">
-            Markdown
-          </SelectItem>
-        </ListBox>
-      </Popover>
-    </Select>
+      <SegmentedControlItem id="text">Text</SegmentedControlItem>
+      <SegmentedControlItem id="markdown">Markdown</SegmentedControlItem>
+    </SegmentedControl>
   );
 }
 

--- a/app/src/pages/playground/TemplateFormatRadioGroup.tsx
+++ b/app/src/pages/playground/TemplateFormatRadioGroup.tsx
@@ -1,6 +1,4 @@
-import { css } from "@emotion/react";
-
-import { ToggleButton, ToggleButtonGroup } from "@phoenix/components";
+import { SegmentedControl, SegmentedControlItem } from "@phoenix/components";
 import type { SizingProps } from "@phoenix/components/core/types";
 import { TemplateFormats } from "@phoenix/components/templateEditor/constants";
 import { isTemplateFormat } from "@phoenix/components/templateEditor/types";
@@ -23,40 +21,27 @@ export function TemplateFormatRadioGroup({
     (state) => state.setTemplateFormat
   );
   return (
-    <div
-      css={css`
-        & * {
-          white-space: nowrap;
+    <SegmentedControl
+      size={size}
+      selectedKey={templateFormat}
+      aria-label="Template Format"
+      onSelectionChange={(format) => {
+        if (typeof format === "string" && isTemplateFormat(format)) {
+          setTemplateFormat(format);
         }
-      `}
+      }}
     >
-      <ToggleButtonGroup
-        size={size}
-        selectedKeys={[templateFormat]}
-        disallowEmptySelection
-        aria-label="Template Format"
-        onSelectionChange={(v) => {
-          if (v.size === 0) {
-            return;
-          }
-          const format = v.keys().next().value;
-          if (typeof format === "string" && isTemplateFormat(format)) {
-            setTemplateFormat(format);
-          }
-        }}
-      >
-        <ToggleButton aria-label="Mustache" id={TemplateFormats.Mustache}>
-          Mustache
-        </ToggleButton>
-        <ToggleButton aria-label="F-String" id={TemplateFormats.FString}>
-          F-String
-        </ToggleButton>
-        {showNoneOption && (
-          <ToggleButton aria-label="None" id={TemplateFormats.NONE}>
-            None
-          </ToggleButton>
-        )}
-      </ToggleButtonGroup>
-    </div>
+      <SegmentedControlItem aria-label="Mustache" id={TemplateFormats.Mustache}>
+        Mustache
+      </SegmentedControlItem>
+      <SegmentedControlItem aria-label="F-String" id={TemplateFormats.FString}>
+        F-String
+      </SegmentedControlItem>
+      {showNoneOption && (
+        <SegmentedControlItem aria-label="None" id={TemplateFormats.NONE}>
+          None
+        </SegmentedControlItem>
+      )}
+    </SegmentedControl>
   );
 }

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -26,9 +26,9 @@ import {
   Icon,
   Icons,
   Link,
+  SegmentedControl,
+  SegmentedControlItem,
   Text,
-  ToggleButton,
-  ToggleButtonGroup,
   View,
 } from "@phoenix/components";
 import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/AnnotationSummaryGroup";
@@ -917,15 +917,10 @@ export function SpansTable(props: SpansTableProps) {
           <Flex direction="row" gap="size-100" width="100%" alignItems="center">
             <SpanFilterConditionField onValidCondition={setFilterCondition} />
 
-            <ToggleButtonGroup
+            <SegmentedControl
               aria-label="Toggle between root and all spans"
-              selectionMode="single"
-              selectedKeys={[rootSpansOnly ? "root" : "all"]}
-              onSelectionChange={(selection) => {
-                if (selection.size === 0) {
-                  return;
-                }
-                const selectedKey = selection.keys().next().value;
+              selectedKey={rootSpansOnly ? "root" : "all"}
+              onSelectionChange={(selectedKey) => {
                 if (isRootSpanFilterValue(selectedKey)) {
                   setRootSpansOnly(selectedKey === "root");
                 } else {
@@ -935,13 +930,13 @@ export function SpansTable(props: SpansTableProps) {
                 }
               }}
             >
-              <ToggleButton aria-label="root spans" id="root">
+              <SegmentedControlItem aria-label="root spans" id="root">
                 Root Spans
-              </ToggleButton>
-              <ToggleButton aria-label="all spans" id="all">
+              </SegmentedControlItem>
+              <SegmentedControlItem aria-label="all spans" id="all">
                 All
-              </ToggleButton>
-            </ToggleButtonGroup>
+              </SegmentedControlItem>
+            </SegmentedControl>
             <TableMetricsChartSelector view="spans" />
             <SpanColumnSelector columns={table.getAllColumns()} query={data} />
             <ProjectFilterConfigButton />

--- a/app/src/pages/trace/span/LLMIOViewSelect.tsx
+++ b/app/src/pages/trace/span/LLMIOViewSelect.tsx
@@ -1,14 +1,6 @@
 import { useState } from "react";
 
-import {
-  Button,
-  ListBox,
-  Popover,
-  Select,
-  SelectChevronUpDownIcon,
-  SelectItem,
-  SelectValue,
-} from "@phoenix/components";
+import { SegmentedControl, SegmentedControlItem } from "@phoenix/components";
 
 export type LLMIOView = {
   /** The stable id of the view, used as the select key */
@@ -34,8 +26,8 @@ export function useLLMIOView(views: LLMIOView[]) {
 }
 
 /**
- * A compact select rendered in the header of an LLM Input / Output card that
- * switches which view is shown in the card body, replacing the previous tabs.
+ * A compact segmented control rendered in the header of an LLM Input / Output
+ * card that switches which view is shown in the card body.
  */
 export function LLMIOViewSelect({
   label,
@@ -43,7 +35,7 @@ export function LLMIOViewSelect({
   value,
   onChange,
 }: {
-  /** Accessible label for the select */
+  /** Accessible label for the control */
   label: string;
   /** The available views to choose from */
   views: LLMIOView[];
@@ -53,25 +45,17 @@ export function LLMIOViewSelect({
   onChange: (view: string) => void;
 }) {
   return (
-    <Select
+    <SegmentedControl
       aria-label={label}
-      value={value}
       size="S"
-      onChange={(key) => onChange(String(key))}
+      selectedKey={value}
+      onSelectionChange={(key) => onChange(String(key))}
     >
-      <Button>
-        <SelectValue />
-        <SelectChevronUpDownIcon />
-      </Button>
-      <Popover placement="bottom end">
-        <ListBox>
-          {views.map((view) => (
-            <SelectItem key={view.id} id={view.id}>
-              {view.label}
-            </SelectItem>
-          ))}
-        </ListBox>
-      </Popover>
-    </Select>
+      {views.map((view) => (
+        <SegmentedControlItem key={view.id} id={view.id}>
+          {view.label}
+        </SegmentedControlItem>
+      ))}
+    </SegmentedControl>
   );
 }

--- a/app/stories/Gallery.stories.tsx
+++ b/app/stories/Gallery.stories.tsx
@@ -20,6 +20,8 @@ import {
   ListBox,
   ListBoxItem,
   Popover,
+  SegmentedControl,
+  SegmentedControlItem,
   Select,
   SelectChevronUpDownIcon,
   SelectValue,
@@ -95,6 +97,11 @@ const Template: StoryFn = () => {
             <ToggleButton>Option 2</ToggleButton>
             <ToggleButton>Option 3</ToggleButton>
           </ToggleButtonGroup>
+          <SegmentedControl size="S" aria-label="Time granularity">
+            <SegmentedControlItem id="day">Day</SegmentedControlItem>
+            <SegmentedControlItem id="week">Week</SegmentedControlItem>
+            <SegmentedControlItem id="month">Month</SegmentedControlItem>
+          </SegmentedControl>
         </Flex>
       </View>
       <View
@@ -195,6 +202,16 @@ const Template: StoryFn = () => {
           <Select size="L">
             <SelectContent />
           </Select>
+          <SegmentedControl aria-label="View">
+            <SegmentedControlItem id="list">List</SegmentedControlItem>
+            <SegmentedControlItem id="grid">Grid</SegmentedControlItem>
+            <SegmentedControlItem id="chart">Chart</SegmentedControlItem>
+          </SegmentedControl>
+          <SegmentedControl size="L" aria-label="Time granularity">
+            <SegmentedControlItem id="day">Day</SegmentedControlItem>
+            <SegmentedControlItem id="week">Week</SegmentedControlItem>
+            <SegmentedControlItem id="month">Month</SegmentedControlItem>
+          </SegmentedControl>
           <Button size="M">Button</Button>
         </Flex>
       </View>

--- a/app/stories/SegmentedControl.stories.tsx
+++ b/app/stories/SegmentedControl.stories.tsx
@@ -1,0 +1,250 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useState } from "react";
+import type { Key } from "react-aria-components";
+
+import type { SegmentedControlProps } from "@phoenix/components";
+import {
+  Flex,
+  Icon,
+  Icons,
+  SegmentedControl,
+  SegmentedControlItem,
+  Text,
+  View,
+} from "@phoenix/components";
+
+const meta: Meta<SegmentedControlProps> = {
+  title: "Core/Actions/Segmented Control",
+  component: SegmentedControl,
+  parameters: {
+    layout: "centered",
+    controls: { expanded: true },
+  },
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["S", "M", "L"],
+      description: "The size of the control",
+    },
+    isDisabled: {
+      control: "boolean",
+      description: "Whether the segmented control is disabled",
+    },
+    isJustified: {
+      control: "boolean",
+      description:
+        "Whether the items should divide the container width equally",
+    },
+  },
+};
+
+export default meta;
+
+const Template: StoryFn<SegmentedControlProps> = (args) => (
+  <SegmentedControl aria-label="Time granularity" {...args}>
+    <SegmentedControlItem id="day">Day</SegmentedControlItem>
+    <SegmentedControlItem id="week">Week</SegmentedControlItem>
+    <SegmentedControlItem id="month">Month</SegmentedControlItem>
+    <SegmentedControlItem id="year">Year</SegmentedControlItem>
+  </SegmentedControl>
+);
+
+export const Default = {
+  render: Template,
+  args: {
+    size: "M",
+    isDisabled: false,
+    isJustified: false,
+  },
+};
+
+export const Sizes = () => (
+  <Flex direction="column" gap="size-200" alignItems="start">
+    {(["S", "M", "L"] as const).map((size) => (
+      <SegmentedControl key={size} size={size} aria-label={`Size ${size}`}>
+        <SegmentedControlItem id="day">Day</SegmentedControlItem>
+        <SegmentedControlItem id="week">Week</SegmentedControlItem>
+        <SegmentedControlItem id="month">Month</SegmentedControlItem>
+      </SegmentedControl>
+    ))}
+  </Flex>
+);
+
+export const WithIcons = () => (
+  <SegmentedControl aria-label="View" defaultSelectedKey="list">
+    <SegmentedControlItem id="list">
+      <Icon svg={<Icons.List />} />
+      <Text>List</Text>
+    </SegmentedControlItem>
+    <SegmentedControlItem id="grid">
+      <Icon svg={<Icons.Grid />} />
+      <Text>Grid</Text>
+    </SegmentedControlItem>
+    <SegmentedControlItem id="chart">
+      <Icon svg={<Icons.BarChart />} />
+      <Text>Chart</Text>
+    </SegmentedControlItem>
+  </SegmentedControl>
+);
+
+export const IconOnly = () => (
+  <SegmentedControl aria-label="View" defaultSelectedKey="list">
+    <SegmentedControlItem id="list" aria-label="List view">
+      <Icon svg={<Icons.List />} />
+    </SegmentedControlItem>
+    <SegmentedControlItem id="grid" aria-label="Grid view">
+      <Icon svg={<Icons.Grid />} />
+    </SegmentedControlItem>
+    <SegmentedControlItem id="chart" aria-label="Chart view">
+      <Icon svg={<Icons.BarChart />} />
+    </SegmentedControlItem>
+  </SegmentedControl>
+);
+
+/**
+ * Segments with very different label widths stress the thumb's slide-and-
+ * stretch animation — the width delta is as large as the travel distance.
+ */
+export const MixedWidths = () => (
+  <SegmentedControl aria-label="Span filter" defaultSelectedKey="all">
+    <SegmentedControlItem id="all">All</SegmentedControlItem>
+    <SegmentedControlItem id="root">Root Spans</SegmentedControlItem>
+    <SegmentedControlItem id="long">
+      A Much Longer Segment Label
+    </SegmentedControlItem>
+  </SegmentedControl>
+);
+
+export const Justified = () => (
+  <View width="600px">
+    <SegmentedControl isJustified aria-label="Time granularity">
+      <SegmentedControlItem id="day">Day</SegmentedControlItem>
+      <SegmentedControlItem id="week">Week</SegmentedControlItem>
+      <SegmentedControlItem id="month">Month</SegmentedControlItem>
+      <SegmentedControlItem id="year">Year</SegmentedControlItem>
+    </SegmentedControl>
+  </View>
+);
+
+export const DisabledItem = () => (
+  <SegmentedControl aria-label="Time granularity" defaultSelectedKey="day">
+    <SegmentedControlItem id="day">Day</SegmentedControlItem>
+    <SegmentedControlItem id="week" isDisabled>
+      Week
+    </SegmentedControlItem>
+    <SegmentedControlItem id="month">Month</SegmentedControlItem>
+    <SegmentedControlItem id="year">Year</SegmentedControlItem>
+  </SegmentedControl>
+);
+
+export const Disabled = () => (
+  <SegmentedControl isDisabled aria-label="Time granularity">
+    <SegmentedControlItem id="day">Day</SegmentedControlItem>
+    <SegmentedControlItem id="week">Week</SegmentedControlItem>
+    <SegmentedControlItem id="month">Month</SegmentedControlItem>
+  </SegmentedControl>
+);
+
+const GalleryTemplate: StoryFn<SegmentedControlProps> = (args) => (
+  <Flex direction="column" gap="size-300" alignItems="start">
+    <Flex direction="column" gap="size-100" alignItems="start">
+      <Text size="XS" color="text-700">
+        Text only
+      </Text>
+      <SegmentedControl aria-label="Time granularity" {...args}>
+        <SegmentedControlItem id="day">Day</SegmentedControlItem>
+        <SegmentedControlItem id="week">Week</SegmentedControlItem>
+        <SegmentedControlItem id="month">Month</SegmentedControlItem>
+        <SegmentedControlItem id="year">Year</SegmentedControlItem>
+      </SegmentedControl>
+    </Flex>
+    <Flex direction="column" gap="size-100" alignItems="start">
+      <Text size="XS" color="text-700">
+        Icon and text
+      </Text>
+      <SegmentedControl aria-label="View" {...args}>
+        <SegmentedControlItem id="list">
+          <Icon svg={<Icons.List />} />
+          <Text>List</Text>
+        </SegmentedControlItem>
+        <SegmentedControlItem id="grid">
+          <Icon svg={<Icons.Grid />} />
+          <Text>Grid</Text>
+        </SegmentedControlItem>
+        <SegmentedControlItem id="chart">
+          <Icon svg={<Icons.BarChart />} />
+          <Text>Chart</Text>
+        </SegmentedControlItem>
+      </SegmentedControl>
+    </Flex>
+    <Flex direction="column" gap="size-100" alignItems="start">
+      <Text size="XS" color="text-700">
+        Icon only
+      </Text>
+      <SegmentedControl aria-label="View" {...args}>
+        <SegmentedControlItem id="list" aria-label="List view">
+          <Icon svg={<Icons.List />} />
+        </SegmentedControlItem>
+        <SegmentedControlItem id="grid" aria-label="Grid view">
+          <Icon svg={<Icons.Grid />} />
+        </SegmentedControlItem>
+        <SegmentedControlItem id="chart" aria-label="Chart view">
+          <Icon svg={<Icons.BarChart />} />
+        </SegmentedControlItem>
+      </SegmentedControl>
+    </Flex>
+    <Flex direction="column" gap="size-100" alignItems="start">
+      <Text size="XS" color="text-700">
+        Disabled item
+      </Text>
+      <SegmentedControl aria-label="Time granularity" {...args}>
+        <SegmentedControlItem id="day">Day</SegmentedControlItem>
+        <SegmentedControlItem id="week" isDisabled>
+          Week
+        </SegmentedControlItem>
+        <SegmentedControlItem id="month">Month</SegmentedControlItem>
+      </SegmentedControl>
+    </Flex>
+    <Flex direction="column" gap="size-100" alignItems="start">
+      <Text size="XS" color="text-700">
+        Justified
+      </Text>
+      <View width="400px">
+        <SegmentedControl aria-label="Time granularity" {...args} isJustified>
+          <SegmentedControlItem id="day">Day</SegmentedControlItem>
+          <SegmentedControlItem id="week">Week</SegmentedControlItem>
+          <SegmentedControlItem id="month">Month</SegmentedControlItem>
+        </SegmentedControl>
+      </View>
+    </Flex>
+  </Flex>
+);
+
+/** Every variant at once, driven by the shared `size` and `isDisabled` controls. */
+export const Gallery = {
+  render: GalleryTemplate,
+  args: {
+    size: "M",
+    isDisabled: false,
+  },
+};
+
+export const Controlled = () => {
+  const [selected, setSelected] = useState<Key>("month");
+
+  return (
+    <Flex direction="column" gap="size-200" alignItems="start">
+      <SegmentedControl
+        aria-label="Time granularity"
+        selectedKey={selected}
+        onSelectionChange={setSelected}
+      >
+        <SegmentedControlItem id="day">Day</SegmentedControlItem>
+        <SegmentedControlItem id="week">Week</SegmentedControlItem>
+        <SegmentedControlItem id="month">Month</SegmentedControlItem>
+        <SegmentedControlItem id="year">Year</SegmentedControlItem>
+      </SegmentedControl>
+      <Text>Selected: {String(selected)}</Text>
+    </Flex>
+  );
+};

--- a/app/stories/SegmentedControl.stories.tsx
+++ b/app/stories/SegmentedControl.stories.tsx
@@ -101,10 +101,7 @@ export const IconOnly = () => (
   </SegmentedControl>
 );
 
-/**
- * Segments with very different label widths stress the thumb's slide-and-
- * stretch animation — the width delta is as large as the travel distance.
- */
+/** Stresses the thumb's stretch: the width delta rivals the travel distance. */
 export const MixedWidths = () => (
   <SegmentedControl aria-label="Span filter" defaultSelectedKey="all">
     <SegmentedControlItem id="all">All</SegmentedControlItem>

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -11,6 +11,12 @@ class ResizeObserverMock {
 }
 globalThis.ResizeObserver = ResizeObserverMock;
 
+// jsdom does not implement the Web Animations API, which react-aria's
+// SelectionIndicator uses to settle its slide transition
+if (typeof Element.prototype.getAnimations !== "function") {
+  Element.prototype.getAnimations = () => [];
+}
+
 // jsdom does not expose CSS.escape, which react-aria uses to build selectors
 // for virtually focused collection items
 if (typeof globalThis.CSS === "undefined") {


### PR DESCRIPTION
Adds a `SegmentedControl` to the core component library and moves four view switchers onto it.

## Why

Two of the four call sites were compact `Select`s — the LLM Input/Output card header and the markdown mode picker — where a dropdown hid which views existed behind a click, for a choice of two to four mutually exclusive views. The other two were `ToggleButtonGroup`s (playground template format, spans table root/all filter), which permit an empty selection that a view switcher can never represent; both had to guard against `selection.size === 0` at the call site.

## The component

Built on react-aria's `ToggleButtonGroup` with a `SelectionIndicator` thumb that slides and stretches into the newly selected segment.

- **Selection is always non-empty.** The group disallows empty selection and seeds itself with the first enabled segment when the caller names no default, so the public API takes a single `selectedKey` / `defaultSelectedKey` / `onSelectionChange(id)` instead of a key set. The multi-select toggle-group props are omitted from the type rather than passed through.
- **Composition.** A string child is wrapped in `Text` for you; otherwise compose an `Icon`, a `Text`, or both. Both the control and each item accept `css` and `className`, and the divider is keyed on the stable BEM class so a styled item keeps its hairlines. `isJustified` divides the container width equally; otherwise the track sizes to its segments and truncates rather than overflowing.
- **Accessibility.** `role="radiogroup"` / `role="radio"` with arrow-key navigation from react-aria, an inset focus ring, and reduced-motion overrides declared alongside each transition they cancel — a single ancestor rule would tie on specificity and lose on source order, leaving reduced-motion users with the full animation.
- **Tokens.** Styling goes through a `--global-segmented-control-*` set, so the control can be rethemed without touching component CSS. The track sits one clear step below the thumb in both themes, which needs an extra step down in light mode where the field surface is within ~3% of the thumb. Labels hold at 14px from S to M, matching `Button` and `Select` at those heights so the control reads as a peer in a toolbar.

## Testing

Storybook: **Core → Actions → Segmented Control** (sizes, icons, icon-only, mixed widths, justified, disabled, controlled) plus entries in the Gallery. Verified in light and dark; `pnpm typecheck`, `pnpm lint`, `pnpm fmt:check` clean and 2019 unit tests pass.

`vitest.setup.ts` gains a `getAnimations` stub — jsdom does not implement the Web Animations API that `SelectionIndicator` uses to settle its transition.