### PR TITLE
refactor(ui): migrate single-choice toggles to segmented controls

### DIFF
--- a/app/src/components/code/CodeLanguageRadioGroup.tsx
+++ b/app/src/components/code/CodeLanguageRadioGroup.tsx
@@ -1,4 +1,4 @@
-import { ToggleButton, ToggleButtonGroup } from "@phoenix/components";
+import { SegmentedControl, SegmentedControlItem } from "@phoenix/components";
 import type { SizingProps } from "@phoenix/components/core/types";
 import type { ProgrammingLanguage } from "@phoenix/types/code";
 import { isProgrammingLanguage } from "@phoenix/types/code";
@@ -12,28 +12,24 @@ export function CodeLanguageRadioGroup({
   onChange: (language: ProgrammingLanguage) => void;
 } & SizingProps) {
   return (
-    <ToggleButtonGroup
+    <SegmentedControl
       size={size}
-      selectedKeys={[language]}
+      selectedKey={language}
       aria-label="Code Language"
-      onSelectionChange={(v) => {
-        if (v.size === 0) {
-          return;
-        }
-        const language = v.keys().next().value;
-        if (isProgrammingLanguage(language)) {
-          onChange(language);
+      onSelectionChange={(selectedLanguage) => {
+        if (isProgrammingLanguage(selectedLanguage)) {
+          onChange(selectedLanguage);
         } else {
-          throw new Error(`Unknown language: ${language}`);
+          throw new Error(`Unknown language: ${selectedLanguage}`);
         }
       }}
     >
-      <ToggleButton aria-label="Python" id="Python">
+      <SegmentedControlItem aria-label="Python" id="Python">
         Python
-      </ToggleButton>
-      <ToggleButton aria-label="TypeScript" id="TypeScript">
+      </SegmentedControlItem>
+      <SegmentedControlItem aria-label="TypeScript" id="TypeScript">
         TypeScript
-      </ToggleButton>
-    </ToggleButtonGroup>
+      </SegmentedControlItem>
+    </SegmentedControl>
   );
 }

--- a/app/src/components/code/PackageManagerCommandBlock.tsx
+++ b/app/src/components/code/PackageManagerCommandBlock.tsx
@@ -1,10 +1,9 @@
 import { css } from "@emotion/react";
-import type { Key } from "react";
 
 import {
   CopyToClipboardButton,
-  ToggleButton,
-  ToggleButtonGroup,
+  SegmentedControl,
+  SegmentedControlItem,
 } from "@phoenix/components";
 import { usePreferencesContext } from "@phoenix/contexts";
 import { packageManagersByLanguage } from "@phoenix/store/preferencesStore";
@@ -55,29 +54,6 @@ const packageManagerCommandBlockCSS = css`
   .package-manager-command__code {
     background-color: transparent;
   }
-
-  .package-manager-command__toggle-group {
-    gap: var(--global-dimension-size-50);
-  }
-
-  .package-manager-command__toggle {
-    border: none;
-    border-radius: var(--global-rounding-small) !important;
-    background: transparent;
-    color: var(--global-color-gray-500);
-    height: var(--global-dimension-size-325);
-  }
-
-  .package-manager-command__toggle[data-selected="true"] {
-    background: var(--global-color-gray-300);
-    color: var(--global-color-gray-800);
-    // fix layout shift caused by margin-left: -1px in ToggleButtonGroup
-    margin: 0 !important;
-    &:hover {
-      background: var(--global-color-gray-400);
-      color: var(--global-color-gray-900);
-    }
-  }
 `;
 
 type PackageManagerCommandBlockProps = {
@@ -85,13 +61,6 @@ type PackageManagerCommandBlockProps = {
   packages: readonly string[];
   className?: string;
 };
-
-function getSelectedKey(selection: Set<Key> | "all"): string | null {
-  if (selection === "all" || selection.size === 0) {
-    return null;
-  }
-  return String(selection.keys().next().value);
-}
 
 export function PackageManagerCommandBlock({
   language,
@@ -114,33 +83,26 @@ export function PackageManagerCommandBlock({
       css={packageManagerCommandBlockCSS}
     >
       <div className="package-manager-command__header">
-        <ToggleButtonGroup
+        <SegmentedControl
           aria-label="Package manager"
-          selectedKeys={[selectedPackageManager]}
-          disallowEmptySelection
+          selectedKey={selectedPackageManager}
           size="S"
-          className="package-manager-command__toggle-group"
-          onSelectionChange={(selection) => {
-            const nextKey = getSelectedKey(selection);
-            if (nextKey == null) {
-              return;
-            }
+          onSelectionChange={(nextKey) => {
             if (isPackageManager(nextKey)) {
               setPackageManager(language, nextKey);
             }
           }}
         >
           {packageManagerOptions.map((packageManager) => (
-            <ToggleButton
+            <SegmentedControlItem
               key={packageManager}
               id={packageManager}
               aria-label={packageManager}
-              className="package-manager-command__toggle"
             >
               {packageManager}
-            </ToggleButton>
+            </SegmentedControlItem>
           ))}
-        </ToggleButtonGroup>
+        </SegmentedControl>
         <CopyToClipboardButton text={selectedCommand} />
       </div>
       <div className="package-manager-command__code" css={codeBlockWithCopyCSS}>

--- a/app/src/components/core/toggleButtonGroup/ToggleButtonGroup.tsx
+++ b/app/src/components/core/toggleButtonGroup/ToggleButtonGroup.tsx
@@ -46,6 +46,12 @@ const baseToggleButtonGroupCSS = css(`
 
 export type ToggleButtonGroupProps = AriaToggleButtonGroupProps;
 
+/**
+ * Groups buttons that can be toggled independently or arranged in a
+ * non-segmented layout, such as a wrapping choice grid. For a compact,
+ * mutually exclusive choice that always has a selection, use
+ * `SegmentedControl` instead.
+ */
 export const ToggleButtonGroup = ({
   size = "M",
   css: cssProp,

--- a/app/src/components/experiment/ExperimentCompareViewModeToggle.tsx
+++ b/app/src/components/experiment/ExperimentCompareViewModeToggle.tsx
@@ -1,8 +1,9 @@
 import {
   Icon,
   Icons,
-  ToggleButton,
-  ToggleButtonGroup,
+  SegmentedControl,
+  SegmentedControlItem,
+  Text,
 } from "@phoenix/components";
 
 export type ExperimentCompareViewMode = "grid" | "list" | "metrics";
@@ -34,14 +35,10 @@ export function ExperimentCompareViewModeToggle({
   onViewModeChange: (newViewMode: ExperimentCompareViewMode) => void;
 }) {
   return (
-    <ToggleButtonGroup
-      selectedKeys={[viewMode]}
-      selectionMode="single"
-      onSelectionChange={(selection) => {
-        if (selection.size === 0) {
-          return;
-        }
-        const selectedKey = selection.keys().next().value;
+    <SegmentedControl
+      aria-label="Experiment comparison view"
+      selectedKey={viewMode}
+      onSelectionChange={(selectedKey) => {
         if (isExperimentCompareViewMode(selectedKey)) {
           onViewModeChange(selectedKey);
         } else {
@@ -50,21 +47,18 @@ export function ExperimentCompareViewModeToggle({
       }}
       size="S"
     >
-      <ToggleButton
-        id="grid"
-        leadingVisual={<Icon svg={<Icons.GridFilled />} />}
-      >
-        Grid
-      </ToggleButton>
-      <ToggleButton id="list" leadingVisual={<Icon svg={<Icons.List />} />}>
-        List
-      </ToggleButton>
-      <ToggleButton
-        id="metrics"
-        leadingVisual={<Icon svg={<Icons.BarChart />} />}
-      >
-        Metrics
-      </ToggleButton>
-    </ToggleButtonGroup>
+      <SegmentedControlItem id="grid">
+        <Icon svg={<Icons.GridFilled />} />
+        <Text>Grid</Text>
+      </SegmentedControlItem>
+      <SegmentedControlItem id="list">
+        <Icon svg={<Icons.List />} />
+        <Text>List</Text>
+      </SegmentedControlItem>
+      <SegmentedControlItem id="metrics">
+        <Icon svg={<Icons.BarChart />} />
+        <Text>Metrics</Text>
+      </SegmentedControlItem>
+    </SegmentedControl>
   );
 }

--- a/app/src/components/nav/ThemeToggle.tsx
+++ b/app/src/components/nav/ThemeToggle.tsx
@@ -1,20 +1,11 @@
-import { css } from "@emotion/react";
-
 import {
   Icon,
   Icons,
-  ToggleButton,
-  ToggleButtonGroup,
+  SegmentedControl,
+  SegmentedControlItem,
+  Text,
 } from "@phoenix/components";
 import { isProviderThemeMode, useTheme } from "@phoenix/contexts";
-
-const themeToggleCSS = css`
-  width: 100%;
-  & > .toggle-button {
-    flex: 1 1 0;
-    justify-content: center;
-  }
-`;
 
 /**
  * A compact segmented control for picking the theme mode: light, dark, or
@@ -23,14 +14,12 @@ const themeToggleCSS = css`
 export function ThemeToggle() {
   const { themeMode, setThemeMode } = useTheme();
   return (
-    <ToggleButtonGroup
+    <SegmentedControl
       size="S"
       aria-label="Theme"
-      selectionMode="single"
-      disallowEmptySelection
-      selectedKeys={[themeMode]}
-      onSelectionChange={(keys) => {
-        const selectedKey = Array.from(keys)[0];
+      isJustified
+      selectedKey={themeMode}
+      onSelectionChange={(selectedKey) => {
         if (
           typeof selectedKey === "string" &&
           isProviderThemeMode(selectedKey)
@@ -38,21 +27,20 @@ export function ThemeToggle() {
           setThemeMode(selectedKey);
         }
       }}
-      css={themeToggleCSS}
       className="theme-toggle"
     >
-      <ToggleButton id="light" leadingVisual={<Icon svg={<Icons.Sun />} />}>
-        Light
-      </ToggleButton>
-      <ToggleButton id="dark" leadingVisual={<Icon svg={<Icons.Moon />} />}>
-        Dark
-      </ToggleButton>
-      <ToggleButton
-        id="system"
-        leadingVisual={<Icon svg={<Icons.HalfMoonHalfSun />} />}
-      >
-        System
-      </ToggleButton>
-    </ToggleButtonGroup>
+      <SegmentedControlItem id="light">
+        <Icon svg={<Icons.Sun />} />
+        <Text>Light</Text>
+      </SegmentedControlItem>
+      <SegmentedControlItem id="dark">
+        <Icon svg={<Icons.Moon />} />
+        <Text>Dark</Text>
+      </SegmentedControlItem>
+      <SegmentedControlItem id="system">
+        <Icon svg={<Icons.HalfMoonHalfSun />} />
+        <Text>System</Text>
+      </SegmentedControlItem>
+    </SegmentedControl>
   );
 }

--- a/app/src/components/trace/SpanDownloadDialog.tsx
+++ b/app/src/components/trace/SpanDownloadDialog.tsx
@@ -18,10 +18,10 @@ import {
   Icons,
   Input,
   Label,
+  SegmentedControl,
+  SegmentedControlItem,
   Text,
   TextField,
-  ToggleButton,
-  ToggleButtonGroup,
   View,
 } from "@phoenix/components";
 
@@ -153,12 +153,10 @@ export function SpanDownloadDialog({
                       </Text>
                     </ContextualHelp>
                   </Flex>
-                  <ToggleButtonGroup
-                    selectedKeys={[scope]}
-                    disallowEmptySelection
+                  <SegmentedControl
+                    selectedKey={scope}
                     aria-label="Data"
-                    onSelectionChange={(keys) => {
-                      const key = keys.keys().next().value;
+                    onSelectionChange={(key) => {
                       if (key !== "spans" && key !== "traces") {
                         return;
                       }
@@ -168,9 +166,13 @@ export function SpanDownloadDialog({
                       }
                     }}
                   >
-                    <ToggleButton id="spans">Spans</ToggleButton>
-                    <ToggleButton id="traces">Traces</ToggleButton>
-                  </ToggleButtonGroup>
+                    <SegmentedControlItem id="spans">
+                      Spans
+                    </SegmentedControlItem>
+                    <SegmentedControlItem id="traces">
+                      Traces
+                    </SegmentedControlItem>
+                  </SegmentedControl>
                 </div>
                 <div css={labeledGroupCSS}>
                   <Flex direction="row" alignItems="center" gap="size-50">
@@ -185,20 +187,22 @@ export function SpanDownloadDialog({
                       </Text>
                     </ContextualHelp>
                   </Flex>
-                  <ToggleButtonGroup
-                    selectedKeys={[format]}
-                    disallowEmptySelection
+                  <SegmentedControl
+                    selectedKey={format}
                     aria-label="Format"
-                    onSelectionChange={(keys) => {
-                      const key = keys.keys().next().value;
+                    onSelectionChange={(key) => {
                       if (key === "jsonl" || key === "otlp-json") {
                         setFormat(key);
                       }
                     }}
                   >
-                    <ToggleButton id="jsonl">JSONL</ToggleButton>
-                    <ToggleButton id="otlp-json">OTLP JSON</ToggleButton>
-                  </ToggleButtonGroup>
+                    <SegmentedControlItem id="jsonl">
+                      JSONL
+                    </SegmentedControlItem>
+                    <SegmentedControlItem id="otlp-json">
+                      OTLP JSON
+                    </SegmentedControlItem>
+                  </SegmentedControl>
                 </div>
               </Flex>
               <TextField

--- a/app/src/pages/playground/MessageContentRadioGroup.tsx
+++ b/app/src/pages/playground/MessageContentRadioGroup.tsx
@@ -1,8 +1,8 @@
 import {
   Icon,
   Icons,
-  ToggleButton,
-  ToggleButtonGroup,
+  SegmentedControl,
+  SegmentedControlItem,
   Tooltip,
   TooltipArrow,
   TooltipTrigger,
@@ -23,38 +23,34 @@ export function AIMessageContentRadioGroup({
   onChange: (messageMode: AIMessageMode) => void;
 }) {
   return (
-    <ToggleButtonGroup
-      selectedKeys={[messageMode]}
+    <SegmentedControl
+      selectedKey={messageMode}
       size="S"
       aria-label="Message Mode"
-      onSelectionChange={(v) => {
-        if (v.size === 0) {
-          return;
-        }
-        const mode = v.keys().next().value;
+      onSelectionChange={(mode) => {
         if (typeof mode === "string" && isAIMessageMode(mode)) {
           onChange(mode);
         }
       }}
     >
       <TooltipTrigger delay={0}>
-        <ToggleButton aria-label="text input" id={"text"}>
+        <SegmentedControlItem aria-label="text input" id="text">
           <Icon svg={<Icons.MessageSquare />} />
-        </ToggleButton>
+        </SegmentedControlItem>
         <Tooltip placement="top">
           <TooltipArrow />
           Text input
         </Tooltip>
       </TooltipTrigger>
       <TooltipTrigger delay={0}>
-        <ToggleButton aria-label="tool calling" id={"toolCalls"}>
+        <SegmentedControlItem aria-label="tool calling" id="toolCalls">
           <Icon svg={<Icons.Code />} />
-        </ToggleButton>
+        </SegmentedControlItem>
         <Tooltip placement="top">
           <TooltipArrow />
           Tool calling
         </Tooltip>
       </TooltipTrigger>
-    </ToggleButtonGroup>
+    </SegmentedControl>
   );
 }

--- a/app/src/pages/playground/PlaygroundCredentialsDropdown.tsx
+++ b/app/src/pages/playground/PlaygroundCredentialsDropdown.tsx
@@ -16,10 +16,10 @@ import {
   Icons,
   Label,
   Popover,
+  SegmentedControl,
+  SegmentedControlItem,
   Skeleton,
   Text,
-  ToggleButton,
-  ToggleButtonGroup,
   View,
 } from "@phoenix/components";
 import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
@@ -81,27 +81,23 @@ export function PlaygroundCredentialsDropdown() {
                     <Heading level={2} weight="heavy">
                       API Keys
                     </Heading>
-                    <ToggleButtonGroup
-                      selectedKeys={[credentialView]}
+                    <SegmentedControl
+                      selectedKey={credentialView}
                       size="S"
                       aria-label="Credential Source"
-                      onSelectionChange={(v) => {
-                        if (v.size === 0) {
-                          return;
-                        }
-                        const view = v.keys().next().value;
+                      onSelectionChange={(view) => {
                         if (view === "local" || view === "server") {
                           setCredentialView(view);
                         }
                       }}
                     >
-                      <ToggleButton aria-label="Local" id="local">
+                      <SegmentedControlItem aria-label="Local" id="local">
                         Local
-                      </ToggleButton>
-                      <ToggleButton aria-label="Server" id="server">
+                      </SegmentedControlItem>
+                      <SegmentedControlItem aria-label="Server" id="server">
                         Server
-                      </ToggleButton>
-                    </ToggleButtonGroup>
+                      </SegmentedControlItem>
+                    </SegmentedControl>
                   </Flex>
                   {credentialView === "local" ? (
                     <LocalCredentialsView providers={currentProviders} />

--- a/app/src/pages/playground/PlaygroundOperationTypeRadioGroup.tsx
+++ b/app/src/pages/playground/PlaygroundOperationTypeRadioGroup.tsx
@@ -1,4 +1,4 @@
-import { ToggleButton, ToggleButtonGroup } from "@phoenix/components";
+import { SegmentedControl, SegmentedControlItem } from "@phoenix/components";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import type { GenAIOperationType } from "@phoenix/store";
 
@@ -12,25 +12,21 @@ export function PlaygroundOperationTypeRadioGroup() {
     (state) => state.setOperationType
   );
   return (
-    <ToggleButtonGroup
-      defaultSelectedKeys={[operationType]}
+    <SegmentedControl
+      selectedKey={operationType}
       aria-label="Operation Type"
-      onSelectionChange={(v) => {
-        if (v.size === 0) {
-          return;
-        }
-        const type = v.keys().next().value;
+      onSelectionChange={(type) => {
         if (typeof type === "string" && isGenAIOperationType(type)) {
           setOperationType(type);
         }
       }}
     >
-      <ToggleButton aria-label="Chat" id={"chat"}>
+      <SegmentedControlItem aria-label="Chat" id="chat">
         Chat
-      </ToggleButton>
-      <ToggleButton aria-label="Completion" id={"text_completion"}>
+      </SegmentedControlItem>
+      <SegmentedControlItem aria-label="Completion" id="text_completion">
         Completion
-      </ToggleButton>
-    </ToggleButtonGroup>
+      </SegmentedControlItem>
+    </SegmentedControl>
   );
 }

--- a/app/src/pages/projects/ProjectViewModeToggle.tsx
+++ b/app/src/pages/projects/ProjectViewModeToggle.tsx
@@ -1,15 +1,12 @@
-import { css } from "@emotion/react";
-
 import {
   Icon,
   Icons,
-  ToggleButton,
-  ToggleButtonGroup,
+  SegmentedControl,
+  SegmentedControlItem,
   Tooltip,
   TooltipTrigger,
 } from "@phoenix/components";
 import { usePreferencesContext } from "@phoenix/contexts";
-import type { ProjectViewMode } from "@phoenix/store/preferencesStore";
 
 export const ProjectViewModeToggle = () => {
   const { projectViewMode, setProjectViewMode } = usePreferencesContext(
@@ -20,36 +17,28 @@ export const ProjectViewModeToggle = () => {
   );
 
   return (
-    <ToggleButtonGroup
-      css={css`
-        flex-basis: fit-content;
-      `}
-      selectedKeys={[projectViewMode]}
-      selectionMode="single"
+    <SegmentedControl
+      aria-label="Project view"
+      selectedKey={projectViewMode}
       onSelectionChange={(value) => {
-        const selectedKey = value.values().next().value;
-        if (typeof selectedKey === "string") {
-          setProjectViewMode(selectedKey as ProjectViewMode);
+        if (value === "grid" || value === "table") {
+          setProjectViewMode(value);
         }
       }}
       size="M"
     >
       <TooltipTrigger delay={100}>
-        <ToggleButton
-          id="grid"
-          aria-label="Grid view"
-          leadingVisual={<Icon svg={<Icons.GridFilled />} />}
-        />
+        <SegmentedControlItem id="grid" aria-label="Grid view">
+          <Icon svg={<Icons.GridFilled />} />
+        </SegmentedControlItem>
         <Tooltip>View projects in a grid</Tooltip>
       </TooltipTrigger>
       <TooltipTrigger delay={100}>
-        <ToggleButton
-          id="table"
-          aria-label="Table view"
-          leadingVisual={<Icon svg={<Icons.List />} />}
-        />
+        <SegmentedControlItem id="table" aria-label="Table view">
+          <Icon svg={<Icons.List />} />
+        </SegmentedControlItem>
         <Tooltip>View projects in a table</Tooltip>
       </TooltipTrigger>
-    </ToggleButtonGroup>
+    </SegmentedControl>
   );
 };

--- a/app/stories/Gallery.stories.tsx
+++ b/app/stories/Gallery.stories.tsx
@@ -92,7 +92,7 @@ const Template: StoryFn = () => {
           >
             {`Toggle Direction: ${direction}`}
           </Button>
-          <ToggleButtonGroup size="S">
+          <ToggleButtonGroup size="S" selectionMode="multiple">
             <ToggleButton>Option 1</ToggleButton>
             <ToggleButton>Option 2</ToggleButton>
             <ToggleButton>Option 3</ToggleButton>

--- a/app/stories/ToggleButtonGroup.stories.tsx
+++ b/app/stories/ToggleButtonGroup.stories.tsx
@@ -43,8 +43,8 @@ export const Default: Meta<typeof ToggleButtonGroup> = {
   args: {
     size: "M",
     isDisabled: false,
-    defaultSelectedKeys: ["1"],
-    selectionMode: "single",
+    defaultSelectedKeys: ["1", "3"],
+    selectionMode: "multiple",
   },
   argTypes: {
     size: {
@@ -79,8 +79,8 @@ export const AsIcon: Meta<typeof ToggleButtonGroup> = {
   args: {
     size: "M",
     isDisabled: false,
-    defaultSelectedKeys: ["1"],
-    selectionMode: "single",
+    defaultSelectedKeys: ["1", "3"],
+    selectionMode: "multiple",
   },
   argTypes: {
     size: {


### PR DESCRIPTION
Consistently applies the new segmented control. 

Project grid mode toggle and theme select. 
<img width="1600" height="1000" alt="01-project-theme__dark" src="https://github.com/user-attachments/assets/f99063ec-ae8d-4507-baa2-2548f31f5f26" />


Experiment comparison view mode 
<img width="1440" height="1000" alt="02-experiment-compare__dark" src="https://github.com/user-attachments/assets/bc3d68c3-9a2d-40f2-a3f3-daa4279d9cd3" />

Experiment language and pkg mgr select
<img width="1440" height="1000" alt="03-code-package__dark" src="https://github.com/user-attachments/assets/92add801-25eb-4083-a041-6404d5c9e6d4" />

Download dialog
<img width="1600" height="1000" alt="04-span-download__dark" src="https://github.com/user-attachments/assets/072eefaf-aab5-4bf9-8abd-fcde5cdedd4b" />

Message type (toggle on far side of AI card header)
<img width="1440" height="1000" alt="05-playground-message__dark" src="https://github.com/user-attachments/assets/8101c947-d548-41bc-a994-e142ee85f2a9" />

API key location select
<img width="1440" height="1000" alt="06-playground-credentials__dark" src="https://github.com/user-attachments/assets/a63d2c9c-265d-43e2-97c5-5acf683569f0" />
