### PR TITLE
fix(ui): collapse span header actions at a wider breakpoint

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -54,7 +54,10 @@ const spanHasException = (span: Span) => {
   return span.events.some((event) => event.name === "exception");
 };
 
-const CONDENSED_VIEW_CONTAINER_WIDTH_THRESHOLD = 950;
+// Below this container width the header actions collapse to icon-only buttons.
+// The identity row also holds the span kind, name, and status badge, so the
+// actions have to give up their labels well before the container gets narrow.
+const CONDENSED_VIEW_CONTAINER_WIDTH_THRESHOLD = 1200;
 // The side panel sizes in pixels
 const ASIDE_PANEL_DEFAULT_SIZE_PIXELS = 400;
 const ASIDE_PANEL_MIN_SIZE_PIXELS = 300;


### PR DESCRIPTION
## Problem

The span details header grew: the identity row now carries the span kind token, span name, and a full-label status badge, and a **Download** action was added alongside Playground / Add to Dataset / Annotate. At the old 950px threshold the labeled buttons crowded the row and squeezed the span name down to a few characters before collapsing.

## Change

Raise `CONDENSED_VIEW_CONTAINER_WIDTH_THRESHOLD` from 950 → 1200 in `SpanDetails.tsx` so the action buttons drop to icon-only earlier. The measured element is the span details panel itself, so opening the annotation aside also triggers the condensed view sooner.

No other behavior changes — the threshold is the single knob driving label visibility and the Annotate hotkey chip.