### PR TITLE
feat(ui): collapse/expand rows in the tracing tables

### DIFF
--- a/app/src/components/annotation/AnnotationLabel.tsx
+++ b/app/src/components/annotation/AnnotationLabel.tsx
@@ -2,27 +2,22 @@ import { css } from "@emotion/react";
 import type { PropsWithChildren } from "react";
 
 import { AnnotationNameAndValue } from "@phoenix/components/annotation/AnnotationNameAndValue";
+import { outlinedPillCSS } from "@phoenix/components/core/styles";
 
 import type { Annotation, AnnotationDisplayPreference } from "./types";
 
-export const baseAnnotationLabelCSS = css`
-  border-radius: var(--global-dimension-size-50);
-  border: 1px solid var(--global-border-color-default);
-  padding: var(--global-dimension-size-50) var(--global-dimension-size-100);
-  transition: background-color 0.2s;
-  display: flex;
-  flex-direction: row;
-  gap: var(--global-dimension-size-50);
-  &[data-clickable="true"] {
-    cursor: pointer;
-    &:hover {
-      background-color: var(--global-color-gray-300);
+export const baseAnnotationLabelCSS = css(
+  outlinedPillCSS,
+  css`
+    padding: var(--global-dimension-size-50) var(--global-dimension-size-100);
+    display: flex;
+    flex-direction: row;
+    gap: var(--global-dimension-size-50);
+    .icon-wrap {
+      font-size: 12px;
     }
-  }
-  .icon-wrap {
-    font-size: 12px;
-  }
-`;
+  `
+);
 
 export function AnnotationLabel({
   annotation,

--- a/app/src/components/annotation/AnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/AnnotationSummaryGroup.tsx
@@ -1,17 +1,13 @@
-import { css } from "@emotion/react";
 import React, { useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 
 import { Flex } from "@phoenix/components";
 import type { AnnotationSummaryGroup$key } from "@phoenix/components/annotation/__generated__/AnnotationSummaryGroup.graphql";
-import { AnnotationLabel } from "@phoenix/components/annotation/AnnotationLabel";
-import { AnnotationSummaryPopover } from "@phoenix/components/annotation/AnnotationSummaryPopover";
+import { AnnotationSummaryTokens } from "@phoenix/components/annotation/AnnotationSummaryTokens";
 import { Divider } from "@phoenix/components/core/layout";
 import {
   Summary,
   SummaryValue,
-  SummaryValueLabelPreview,
-  SummaryValuePreview,
 } from "@phoenix/pages/project/AnnotationSummary";
 import type { AnnotationConfigCategorical } from "@phoenix/pages/settings/types";
 
@@ -128,13 +124,6 @@ type AnnotationSummaryGroupProps = {
   renderEmptyState?: () => React.ReactNode;
 };
 
-const annotationLabelCSS = css`
-  min-height: 20px;
-  align-items: center;
-  justify-content: center;
-  display: flex;
-`;
-
 /**
  * Lays out a row of annotation summary stacks as peer columns alongside the
  * other header metrics (status, cost, latency). An optional leading divider
@@ -172,47 +161,12 @@ export const AnnotationSummaryGroupTokens = ({
   }
 
   return (
-    <Flex direction="row" gap="size-50" wrap="wrap">
-      {sortedSummariesByName.map((summary) => {
-        const latestAnnotation = annotationsByName[summary.name]?.[0];
-        const meanScore = summary?.meanScore;
-        if (!latestAnnotation) {
-          return null;
-        }
-        return (
-          <AnnotationSummaryPopover
-            key={latestAnnotation.id}
-            annotations={annotationsByName[summary.name]}
-            width="500px"
-            meanScore={meanScore}
-            showFilterActions={showFilterActions}
-          >
-            <AnnotationLabel
-              annotation={latestAnnotation}
-              annotationDisplayPreference="none"
-              css={annotationLabelCSS}
-              clickable
-            >
-              {meanScore != null ? (
-                <SummaryValuePreview
-                  name={latestAnnotation.name}
-                  meanScore={meanScore}
-                  size="S"
-                  disableAnimation
-                  annotationConfig={
-                    categoricalAnnotationConfigsByName[latestAnnotation.name]
-                  }
-                />
-              ) : (
-                <SummaryValueLabelPreview
-                  labelFractions={summary.labelFractions}
-                />
-              )}
-            </AnnotationLabel>
-          </AnnotationSummaryPopover>
-        );
-      })}
-    </Flex>
+    <AnnotationSummaryTokens
+      summaries={sortedSummariesByName}
+      annotationsByName={annotationsByName}
+      categoricalAnnotationConfigsByName={categoricalAnnotationConfigsByName}
+      showFilterActions={showFilterActions}
+    />
   );
 };
 

--- a/app/src/components/annotation/AnnotationSummaryTokens.tsx
+++ b/app/src/components/annotation/AnnotationSummaryTokens.tsx
@@ -17,7 +17,6 @@ const annotationLabelCSS = css`
   display: flex;
 `;
 
-/** The per-name summary a token renders: its latest value, or its label mix */
 type AnnotationSummary = {
   name: string;
   meanScore?: number | null;
@@ -26,9 +25,8 @@ type AnnotationSummary = {
 
 /**
  * A bare run of annotation tokens — the caller owns the layout (wrap, or
- * `OverflowRow`). Spans, traces and sessions each read their annotations from
- * their own Relay fragment but render them identically, so they share this and
- * keep only their fragment hook of their own.
+ * `OverflowRow`). Spans, traces and sessions read their annotations from
+ * different Relay fragments but render them identically, so they share this.
  */
 export function AnnotationSummaryTokens({
   summaries,
@@ -36,7 +34,6 @@ export function AnnotationSummaryTokens({
   categoricalAnnotationConfigsByName,
   showFilterActions = false,
 }: {
-  /** The summaries to render, in the order they should appear */
   summaries: readonly AnnotationSummary[];
   /** Every annotation behind a summary, newest first, keyed by summary name */
   annotationsByName: Record<string, readonly Annotation[] | undefined>;

--- a/app/src/components/annotation/AnnotationSummaryTokens.tsx
+++ b/app/src/components/annotation/AnnotationSummaryTokens.tsx
@@ -1,0 +1,92 @@
+import { css } from "@emotion/react";
+
+import { AnnotationLabel } from "@phoenix/components/annotation/AnnotationLabel";
+import { AnnotationSummaryPopover } from "@phoenix/components/annotation/AnnotationSummaryPopover";
+import {
+  SummaryValueLabelPreview,
+  SummaryValuePreview,
+} from "@phoenix/pages/project/AnnotationSummary";
+import type { AnnotationConfigCategorical } from "@phoenix/pages/settings/types";
+
+import type { Annotation } from "./types";
+
+const annotationLabelCSS = css`
+  min-height: 20px;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+`;
+
+/** The per-name summary a token renders: its latest value, or its label mix */
+type AnnotationSummary = {
+  name: string;
+  meanScore?: number | null;
+  labelFractions: readonly { label: string; fraction: number }[];
+};
+
+/**
+ * A bare run of annotation tokens — the caller owns the layout (wrap, or
+ * `OverflowRow`). Spans, traces and sessions each read their annotations from
+ * their own Relay fragment but render them identically, so they share this and
+ * keep only their fragment hook of their own.
+ */
+export function AnnotationSummaryTokens({
+  summaries,
+  annotationsByName,
+  categoricalAnnotationConfigsByName,
+  showFilterActions = false,
+}: {
+  /** The summaries to render, in the order they should appear */
+  summaries: readonly AnnotationSummary[];
+  /** Every annotation behind a summary, newest first, keyed by summary name */
+  annotationsByName: Record<string, readonly Annotation[] | undefined>;
+  categoricalAnnotationConfigsByName: Record<
+    string,
+    AnnotationConfigCategorical | undefined
+  >;
+  showFilterActions?: boolean;
+}) {
+  return (
+    <>
+      {summaries.map((summary) => {
+        const latestAnnotation = annotationsByName[summary.name]?.[0];
+        const meanScore = summary?.meanScore;
+        if (!latestAnnotation) {
+          return null;
+        }
+        return (
+          <AnnotationSummaryPopover
+            key={latestAnnotation.id}
+            annotations={annotationsByName[summary.name] ?? []}
+            width="500px"
+            meanScore={meanScore}
+            showFilterActions={showFilterActions}
+          >
+            <AnnotationLabel
+              annotation={latestAnnotation}
+              annotationDisplayPreference="none"
+              css={annotationLabelCSS}
+              clickable
+            >
+              {meanScore != null ? (
+                <SummaryValuePreview
+                  name={latestAnnotation.name}
+                  meanScore={meanScore}
+                  size="S"
+                  disableAnimation
+                  annotationConfig={
+                    categoricalAnnotationConfigsByName[latestAnnotation.name]
+                  }
+                />
+              ) : (
+                <SummaryValueLabelPreview
+                  labelFractions={summary.labelFractions}
+                />
+              )}
+            </AnnotationLabel>
+          </AnnotationSummaryPopover>
+        );
+      })}
+    </>
+  );
+}

--- a/app/src/components/annotation/SessionAnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/SessionAnnotationSummaryGroup.tsx
@@ -1,17 +1,12 @@
-import { css } from "@emotion/react";
 import React, { useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 
-import { Flex } from "@phoenix/components";
 import type { SessionAnnotationSummaryGroup$key } from "@phoenix/components/annotation/__generated__/SessionAnnotationSummaryGroup.graphql";
-import { AnnotationLabel } from "@phoenix/components/annotation/AnnotationLabel";
 import { AnnotationSummaryGroupStacksRow } from "@phoenix/components/annotation/AnnotationSummaryGroup";
-import { AnnotationSummaryPopover } from "@phoenix/components/annotation/AnnotationSummaryPopover";
+import { AnnotationSummaryTokens } from "@phoenix/components/annotation/AnnotationSummaryTokens";
 import {
   Summary,
   SummaryValue,
-  SummaryValueLabelPreview,
-  SummaryValuePreview,
 } from "@phoenix/pages/project/AnnotationSummary";
 import type { AnnotationConfigCategorical } from "@phoenix/pages/settings/types";
 
@@ -122,13 +117,6 @@ type SessionAnnotationSummaryGroupProps = {
   renderEmptyState?: () => React.ReactNode;
 };
 
-const annotationLabelCSS = css`
-  min-height: 20px;
-  align-items: center;
-  justify-content: center;
-  display: flex;
-`;
-
 export const SessionAnnotationSummaryGroupTokens = ({
   session,
   showFilterActions = false,
@@ -145,47 +133,12 @@ export const SessionAnnotationSummaryGroupTokens = ({
   }
 
   return (
-    <Flex direction="row" gap="size-50" wrap="wrap">
-      {sortedSummariesByName.map((summary) => {
-        const latestAnnotation = annotationsByName[summary.name]?.[0];
-        const meanScore = summary?.meanScore;
-        if (!latestAnnotation) {
-          return null;
-        }
-        return (
-          <AnnotationSummaryPopover
-            key={latestAnnotation.id}
-            annotations={annotationsByName[summary.name]}
-            width="500px"
-            meanScore={meanScore}
-            showFilterActions={showFilterActions}
-          >
-            <AnnotationLabel
-              annotation={latestAnnotation}
-              annotationDisplayPreference="none"
-              css={annotationLabelCSS}
-              clickable
-            >
-              {meanScore != null ? (
-                <SummaryValuePreview
-                  name={latestAnnotation.name}
-                  meanScore={meanScore}
-                  size="S"
-                  disableAnimation
-                  annotationConfig={
-                    categoricalAnnotationConfigsByName[latestAnnotation.name]
-                  }
-                />
-              ) : (
-                <SummaryValueLabelPreview
-                  labelFractions={summary.labelFractions}
-                />
-              )}
-            </AnnotationLabel>
-          </AnnotationSummaryPopover>
-        );
-      })}
-    </Flex>
+    <AnnotationSummaryTokens
+      summaries={sortedSummariesByName}
+      annotationsByName={annotationsByName}
+      categoricalAnnotationConfigsByName={categoricalAnnotationConfigsByName}
+      showFilterActions={showFilterActions}
+    />
   );
 };
 

--- a/app/src/components/annotation/TraceAnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/TraceAnnotationSummaryGroup.tsx
@@ -1,17 +1,12 @@
-import { css } from "@emotion/react";
 import React, { useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 
-import { Flex } from "@phoenix/components";
 import type { TraceAnnotationSummaryGroup$key } from "@phoenix/components/annotation/__generated__/TraceAnnotationSummaryGroup.graphql";
-import { AnnotationLabel } from "@phoenix/components/annotation/AnnotationLabel";
 import { AnnotationSummaryGroupStacksRow } from "@phoenix/components/annotation/AnnotationSummaryGroup";
-import { AnnotationSummaryPopover } from "@phoenix/components/annotation/AnnotationSummaryPopover";
+import { AnnotationSummaryTokens } from "@phoenix/components/annotation/AnnotationSummaryTokens";
 import {
   Summary,
   SummaryValue,
-  SummaryValueLabelPreview,
-  SummaryValuePreview,
 } from "@phoenix/pages/project/AnnotationSummary";
 import type { AnnotationConfigCategorical } from "@phoenix/pages/settings/types";
 
@@ -130,13 +125,6 @@ type TraceAnnotationSummaryGroupProps = {
   renderEmptyState?: () => React.ReactNode;
 };
 
-const annotationLabelCSS = css`
-  min-height: 20px;
-  align-items: center;
-  justify-content: center;
-  display: flex;
-`;
-
 export const TraceAnnotationSummaryGroupTokens = ({
   trace,
   showFilterActions = false,
@@ -153,47 +141,12 @@ export const TraceAnnotationSummaryGroupTokens = ({
   }
 
   return (
-    <Flex direction="row" gap="size-50" wrap="wrap">
-      {sortedSummariesByName.map((summary) => {
-        const latestAnnotation = annotationsByName[summary.name]?.[0];
-        const meanScore = summary?.meanScore;
-        if (!latestAnnotation) {
-          return null;
-        }
-        return (
-          <AnnotationSummaryPopover
-            key={latestAnnotation.id}
-            annotations={annotationsByName[summary.name]}
-            width="500px"
-            meanScore={meanScore}
-            showFilterActions={showFilterActions}
-          >
-            <AnnotationLabel
-              annotation={latestAnnotation}
-              annotationDisplayPreference="none"
-              css={annotationLabelCSS}
-              clickable
-            >
-              {meanScore != null ? (
-                <SummaryValuePreview
-                  name={latestAnnotation.name}
-                  meanScore={meanScore}
-                  size="S"
-                  disableAnimation
-                  annotationConfig={
-                    categoricalAnnotationConfigsByName[latestAnnotation.name]
-                  }
-                />
-              ) : (
-                <SummaryValueLabelPreview
-                  labelFractions={summary.labelFractions}
-                />
-              )}
-            </AnnotationLabel>
-          </AnnotationSummaryPopover>
-        );
-      })}
-    </Flex>
+    <AnnotationSummaryTokens
+      summaries={sortedSummariesByName}
+      annotationsByName={annotationsByName}
+      categoricalAnnotationConfigsByName={categoricalAnnotationConfigsByName}
+      showFilterActions={showFilterActions}
+    />
   );
 };
 

--- a/app/src/components/code/jsonView/JSONViewRowExpandButton.tsx
+++ b/app/src/components/code/jsonView/JSONViewRowExpandButton.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  Icon,
-  Icons,
-  Tooltip,
-  TooltipTrigger,
-} from "@phoenix/components";
+import { RowExpandToggleButton } from "@phoenix/components/table";
 
 import { useJSONView } from "./JSONViewContext";
 
@@ -21,26 +15,11 @@ export function JSONViewRowExpandButton() {
   if (!isViewable || mode !== "table") {
     return null;
   }
-  const label = areRowsExpanded ? "Collapse rows" : "Expand rows";
   return (
-    <TooltipTrigger>
-      <Button
-        size="S"
-        variant="default"
-        aria-label={label}
-        aria-pressed={areRowsExpanded}
-        leadingVisual={
-          <Icon
-            svg={areRowsExpanded ? <Icons.RowCollapse /> : <Icons.RowExpand />}
-          />
-        }
-        onPress={() => setAreRowsExpanded(!areRowsExpanded)}
-      />
-      <Tooltip offset={1}>
-        {areRowsExpanded
-          ? "Clip each row to a single line"
-          : "Wrap each row over as many lines as it needs"}
-      </Tooltip>
-    </TooltipTrigger>
+    <RowExpandToggleButton
+      size="S"
+      isExpanded={areRowsExpanded}
+      onChange={setAreRowsExpanded}
+    />
   );
 }

--- a/app/src/components/core/index.tsx
+++ b/app/src/components/core/index.tsx
@@ -46,6 +46,7 @@ export * from "./switch";
 export * from "./menu";
 export * from "./dropzone";
 export * from "./utility/LineClamp";
+export * from "./utility/OverflowRow";
 export * from "./utility/Truncate";
 export * from "./datetime/Calendar";
 export * from "./datetime/CalendarContent";

--- a/app/src/components/core/styles.ts
+++ b/app/src/components/core/styles.ts
@@ -1,6 +1,24 @@
 import { css } from "@emotion/react";
 
 /**
+ * The outlined pill worn by annotation labels and the controls that stand in
+ * for them (e.g. an overflow row's "+N" badge): square-ish corners, a hairline
+ * border, and — when marked clickable — a washed hover invitation. One owner
+ * so the pills and their stand-ins cannot drift apart.
+ */
+export const outlinedPillCSS = css`
+  border-radius: var(--global-dimension-size-50);
+  border: 1px solid var(--global-border-color-default);
+  transition: background-color 0.2s;
+  &[data-clickable="true"] {
+    cursor: pointer;
+    &:hover {
+      background-color: var(--global-color-gray-300);
+    }
+  }
+`;
+
+/**
  * Hover invitation for quiet interactive text (click-to-copy IDs, values that
  * reveal a tooltip): a subtle background wash that appears on hover without
  * shifting the text's position. Matches the quiet Button hover treatment.

--- a/app/src/components/core/styles.ts
+++ b/app/src/components/core/styles.ts
@@ -1,10 +1,8 @@
 import { css } from "@emotion/react";
 
 /**
- * The outlined pill worn by annotation labels and the controls that stand in
- * for them (e.g. an overflow row's "+N" badge): square-ish corners, a hairline
- * border, and — when marked clickable — a washed hover invitation. One owner
- * so the pills and their stand-ins cannot drift apart.
+ * The outlined pill worn by annotation labels and the controls that stand in for
+ * them (an overflow row's "+N" badge), so the two cannot drift apart.
  */
 export const outlinedPillCSS = css`
   border-radius: var(--global-dimension-size-50);

--- a/app/src/components/core/utility/OverflowRow.tsx
+++ b/app/src/components/core/utility/OverflowRow.tsx
@@ -1,0 +1,452 @@
+import { css } from "@emotion/react";
+import type { CSSProperties, PropsWithChildren } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { Button as AriaButton, DialogTrigger } from "react-aria-components";
+
+import { StopPropagation } from "@phoenix/components/StopPropagation";
+import { classNames } from "@phoenix/utils/classNames";
+
+import { Dialog } from "../dialog";
+import { Flex } from "../layout";
+import { Popover, PopoverArrow } from "../overlay";
+import { outlinedPillCSS } from "../styles";
+import { View } from "../view";
+
+type FirstLine = {
+  /** How many items share the first line and are shown by the row itself */
+  visibleCount: number;
+  /** The right edge of the last visible item, where the badge is placed */
+  badgeLeft: number;
+  /** The measured height of the first line, which the row clamps to */
+  lineHeight: number;
+};
+
+/** What the row renders from, once the hidden items are counted */
+type OverflowState = FirstLine & {
+  /** How many items wrapped past the first line and are hidden */
+  hiddenCount: number;
+};
+
+const overflowRowCSS = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--global-dimension-size-50);
+  min-width: 0;
+  max-width: 100%;
+
+  &.overflow-row--collapsed {
+    position: relative;
+    // Items that don't fit wrap to lines below the measured clamp and are cut
+    // off whole. They are also made inert, so nothing that the row is cutting
+    // off can take focus or reach the accessibility tree — the "+N" badge
+    // stands in for them.
+    align-content: flex-start;
+    overflow: clip;
+  }
+  &.overflow-row--overflowing {
+    // The clamp is the first line's measured height rather than a fixed
+    // dimension, so the items decide how tall the row is and are never
+    // cropped mid-pill.
+    height: var(--overflow-row-line-height);
+    // room for the badge, which sits out of flow at the end of the first line
+    padding-right: var(--global-dimension-size-600);
+  }
+
+  // The badge and its popover are the row's own output rather than items, so
+  // they are kept in a boxless slot: the measurement skips them for free, and
+  // the content observer can tell the row's own changes from its children's.
+  .overflow-row__badge-slot {
+    display: contents;
+  }
+
+  // The badge stands in for the pills it hides, so it wears the shared pill
+  // shell. It is an unstyled react-aria button, so the rest of its dress is
+  // declared here.
+  .overflow-row__badge {
+    ${outlinedPillCSS};
+    position: absolute;
+    left: var(--overflow-row-badge-left);
+    top: 50%;
+    transform: translateY(-50%);
+    box-sizing: border-box;
+    height: var(--overflow-row-line-height);
+    padding: 0 var(--global-dimension-size-100);
+    background-color: transparent;
+    color: var(--global-text-color-700);
+    font-family: inherit;
+    font-size: var(--global-font-size-s);
+    line-height: normal;
+    &:hover {
+      color: var(--global-text-color-900);
+    }
+    &:focus-visible {
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+    }
+  }
+`;
+
+/** What {@link measureOverflow} reads off the DOM */
+type OverflowMeasurement = FirstLine & {
+  /** The child elements that render a box, in document order */
+  items: HTMLElement[];
+};
+
+/** Whether an element renders a box, and so counts as an item */
+function hasBox(element: HTMLElement): boolean {
+  return element.offsetWidth > 0 || element.offsetHeight > 0;
+}
+
+/**
+ * Collects the container's items. Only elements that render a box are items —
+ * boxless wrappers (display: contents event guards and badge slot, closed
+ * popovers) are skipped.
+ */
+function getItems(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.children).filter(
+    (element): element is HTMLElement =>
+      element instanceof HTMLElement && hasBox(element)
+  );
+}
+
+/**
+ * Measures which of the container's items fit on its first line.
+ */
+function measureOverflow(container: HTMLElement): OverflowMeasurement {
+  const items = getItems(container);
+  let visibleCount = 0;
+  let badgeLeft = 0;
+  let lineHeight = 0;
+  // `align-items: center` cross-centers the items, so items sharing a line do
+  // not share an offsetTop. Flex lines never overlap vertically though, so
+  // line membership is an overlap test against the band the first line has
+  // covered so far rather than a comparison of top edges.
+  let lineTop = Number.POSITIVE_INFINITY;
+  let lineBottom = Number.NEGATIVE_INFINITY;
+  for (const item of items) {
+    const top = item.offsetTop;
+    const bottom = top + item.offsetHeight;
+    if (visibleCount > 0 && (top >= lineBottom || bottom <= lineTop)) {
+      // Items lay out in document order, so everything after the first wrap
+      // is on a later line too.
+      break;
+    }
+    visibleCount += 1;
+    lineTop = Math.min(lineTop, top);
+    lineBottom = Math.max(lineBottom, bottom);
+    badgeLeft = Math.max(badgeLeft, item.offsetLeft + item.offsetWidth);
+    lineHeight = Math.max(lineHeight, item.offsetHeight);
+  }
+  return { items, visibleCount, badgeLeft, lineHeight };
+}
+
+/**
+ * The attributes that hide a clipped item, each recorded on the element under
+ * its own flag so that only the ones this row actually added are ever removed.
+ */
+const CLIPPED_ITEM_ATTRIBUTES = [
+  { name: "inert", value: "", flag: "overflowRowInert" },
+  { name: "aria-hidden", value: "true", flag: "overflowRowAriaHidden" },
+] as const;
+
+/**
+ * Takes the clipped items out of the tab order and the accessibility tree.
+ * They are still rendered — only cut off — so without this a keyboard user
+ * would focus a pill that `overflow: clip` forbids the browser from scrolling
+ * into view, and a screen reader would read items the row does not show. The
+ * badge's popover is the one place they are exposed.
+ */
+function setClippedItems({
+  items,
+  visibleCount,
+}: {
+  items: HTMLElement[];
+  visibleCount: number;
+}) {
+  items.forEach((item, index) => {
+    if (index < visibleCount) {
+      restoreClippedItem(item);
+      return;
+    }
+    for (const { name, value, flag } of CLIPPED_ITEM_ATTRIBUTES) {
+      // A child that already hides itself keeps ownership of the attribute, so
+      // restoring cannot delete state React would not put back. This is also
+      // what makes a second pass over an already-clipped item a no-op.
+      if (!item.hasAttribute(name)) {
+        item.dataset[flag] = "true";
+        item.setAttribute(name, value);
+      }
+    }
+  });
+}
+
+/** Undoes only what {@link setClippedItems} applied, never a child's own state */
+function restoreClippedItem(element: HTMLElement) {
+  for (const { name, flag } of CLIPPED_ITEM_ATTRIBUTES) {
+    if (element.dataset[flag]) {
+      delete element.dataset[flag];
+      element.removeAttribute(name);
+    }
+  }
+}
+
+function restoreClippedItems(container: HTMLElement) {
+  for (const element of Array.from(container.children)) {
+    if (element instanceof HTMLElement) {
+      restoreClippedItem(element);
+    }
+  }
+}
+
+/** How the row watches its items for changes it cannot see as a resize */
+const CONTENT_OBSERVER_OPTIONS = {
+  childList: true,
+  characterData: true,
+  subtree: true,
+} as const satisfies MutationObserverInit;
+
+/**
+ * Whether a mutation is the row's own "+N" badge appearing, leaving or
+ * recounting. The badge is an output of the measurement, so re-measuring for
+ * it would only ever arrive back at the same answer.
+ */
+function isBadgeMutation(record: MutationRecord): boolean {
+  const isInBadgeSlot = (node: Node) => {
+    const element = node instanceof Element ? node : node.parentElement;
+    return element?.closest(".overflow-row__badge-slot") != null;
+  };
+  if (record.type === "childList") {
+    return [...record.addedNodes, ...record.removedNodes].every(isInBadgeSlot);
+  }
+  return isInBadgeSlot(record.target);
+}
+
+function isSameOverflow(a: OverflowState | null, b: OverflowState | null) {
+  if (a === null || b === null) {
+    return a === b;
+  }
+  return (
+    a.hiddenCount === b.hiddenCount &&
+    a.visibleCount === b.visibleCount &&
+    a.badgeLeft === b.badgeLeft &&
+    a.lineHeight === b.lineHeight
+  );
+}
+
+/**
+ * The body of the "+N" popover: the same children the row renders, minus the
+ * ones already visible in the row. The children compose through component
+ * boundaries (fragments, connected components), so they cannot be sliced as a
+ * React array — instead the full set renders again and the leading elements
+ * that the row already shows are switched off by DOM position, using the
+ * row's own first-line count. `display: none` keeps them out of the
+ * accessibility tree, so together with the row's inert clipped items every
+ * item is exposed exactly once.
+ */
+function OverflowRowPopoverItems({
+  visibleCount,
+  children,
+}: PropsWithChildren<{ visibleCount: number }>) {
+  const ref = useRef<HTMLElement>(null);
+  useLayoutEffect(() => {
+    const container = ref.current;
+    if (!container) {
+      return undefined;
+    }
+    const hideRowVisibleItems = () => {
+      const all = Array.from(container.children).filter(
+        (element): element is HTMLElement => element instanceof HTMLElement
+      );
+      // Undo only the hiding this effect applied before deciding which elements
+      // are items. Clearing every child's inline display would be simpler, but
+      // some children own theirs (the display: contents event guards), and
+      // React would not restore what we wipe.
+      for (const element of all) {
+        if (element.dataset.overflowRowHidden) {
+          element.style.display = "";
+          delete element.dataset.overflowRowHidden;
+        }
+      }
+      // Only elements that render a box are items; the children also produce
+      // boxless wrappers (display: contents event guards, closed popovers) that
+      // must not throw off the position count.
+      const items = all.filter(hasBox);
+      items.slice(0, visibleCount).forEach((element) => {
+        element.style.display = "none";
+        element.dataset.overflowRowHidden = "true";
+      });
+    };
+    hideRowVisibleItems();
+    // The items can change under an open popover (a streaming refetch). Watching
+    // for that is push-based, so a parent render that changed nothing costs no
+    // reflow — and the inline display written above is an attribute, which the
+    // observer does not watch and so cannot feed back into it.
+    const observer = new MutationObserver(hideRowVisibleItems);
+    observer.observe(container, CONTENT_OBSERVER_OPTIONS);
+    return () => observer.disconnect();
+  }, [visibleCount]);
+  return (
+    <Flex
+      ref={ref}
+      direction="row"
+      wrap="wrap"
+      gap="size-50"
+      maxWidth="size-5000"
+    >
+      {children}
+    </Flex>
+  );
+}
+
+/**
+ * A single-line row of items (annotation labels, tags) that hides whatever
+ * doesn't fit behind a "+N" badge, which opens the hidden items in a popover.
+ * When `isExpanded`, the row simply wraps instead.
+ *
+ * The items are measured where they render: the row lets flex wrapping push
+ * items that don't fit onto clipped lines, then counts the items that left the
+ * first line. Nothing is ever cut mid-item, and the measurement never has to
+ * know what the items are — any composed children that render a flat run of
+ * elements (fragments included) work.
+ */
+export function OverflowRow({
+  children,
+  isExpanded = false,
+}: PropsWithChildren<{
+  /** Whether the row wraps all of its items rather than clipping to one line */
+  isExpanded?: boolean;
+}>) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const remeasureRef = useRef<(() => void) | null>(null);
+  const [overflow, setOverflow] = useState<OverflowState | null>(null);
+
+  // The observer lives for as long as the row is collapsed — it is not torn
+  // down when the items re-render, only when the row changes shape.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (isExpanded || !container) {
+      setOverflow(null);
+      return undefined;
+    }
+    // The row's own border-box width as of the last measurement. Seeded by the
+    // measurement itself so the observer's mandatory initial delivery, which
+    // reports the width we already measured at, costs nothing.
+    let lastInlineSize: number | null = null;
+    const remeasure = () => {
+      lastInlineSize = container.getBoundingClientRect().width;
+      const { items, visibleCount, badgeLeft, lineHeight } =
+        measureOverflow(container);
+      setClippedItems({ items, visibleCount });
+      const hiddenCount = items.length - visibleCount;
+      const next =
+        hiddenCount === 0
+          ? null
+          : { hiddenCount, visibleCount, badgeLeft, lineHeight };
+      setOverflow((prev) => (isSameOverflow(prev, next) ? prev : next));
+    };
+    // measure synchronously so the first paint is already clamped
+    remeasure();
+    remeasureRef.current = remeasure;
+    // A web font swapping in re-lays the items out without changing the row's
+    // width or any of its text, so nothing else would catch it. Rows that mount
+    // once the fonts have settled — every row after the first paint — have
+    // nothing to wait for.
+    let isUnmounted = false;
+    if (document.fonts?.status === "loading") {
+      void document.fonts.ready.then(() => {
+        if (!isUnmounted) {
+          remeasure();
+        }
+      });
+    }
+    // Only a change in the row's inline size can re-wrap the items. Ignoring
+    // the block size stops the clamp this callback applies from feeding back
+    // into the observer that watches the very element it clamps, which
+    // browsers report as a ResizeObserver loop.
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      const inlineSize = entry?.borderBoxSize?.[0]?.inlineSize ?? null;
+      if (inlineSize !== null && inlineSize === lastInlineSize) {
+        return;
+      }
+      lastInlineSize = inlineSize;
+      remeasure();
+    });
+    resizeObserver.observe(container);
+    // The resize observer only sees the row's own width; items swapped for a
+    // same-size set (e.g. a streaming refetch) change its contents instead.
+    // Watching for that is push-based, so a render that changed nothing costs
+    // no reflow.
+    const contentObserver = new MutationObserver((records) => {
+      if (records.every(isBadgeMutation)) {
+        return;
+      }
+      remeasure();
+    });
+    contentObserver.observe(container, CONTENT_OBSERVER_OPTIONS);
+    return () => {
+      isUnmounted = true;
+      resizeObserver.disconnect();
+      contentObserver.disconnect();
+      remeasureRef.current = null;
+      restoreClippedItems(container);
+    };
+  }, [isExpanded]);
+
+  // Clamping reserves room for the badge, which narrows the content box and
+  // can push one more item onto a clipped line. Measure once more against the
+  // clamped geometry; the count only ever grows, so this settles immediately.
+  useLayoutEffect(() => {
+    if (overflow !== null) {
+      remeasureRef.current?.();
+    }
+  }, [overflow]);
+
+  return (
+    <div
+      ref={containerRef}
+      css={overflowRowCSS}
+      className={classNames("overflow-row", {
+        "overflow-row--collapsed": !isExpanded,
+        "overflow-row--overflowing": !isExpanded && overflow !== null,
+      })}
+      style={
+        overflow !== null
+          ? ({
+              "--overflow-row-badge-left": `calc(${overflow.badgeLeft}px + var(--global-dimension-size-50))`,
+              "--overflow-row-line-height": `${overflow.lineHeight}px`,
+            } as CSSProperties)
+          : undefined
+      }
+    >
+      {children}
+      {!isExpanded && overflow !== null ? (
+        <div className="overflow-row__badge-slot">
+          <DialogTrigger>
+            <AriaButton
+              className="overflow-row__badge"
+              data-clickable="true"
+              aria-label={`Show ${overflow.hiddenCount} more`}
+            >
+              +{overflow.hiddenCount}
+            </AriaButton>
+            <StopPropagation>
+              <Popover placement="bottom end">
+                <PopoverArrow />
+                <Dialog>
+                  <View padding="size-150">
+                    <OverflowRowPopoverItems
+                      visibleCount={overflow.visibleCount}
+                    >
+                      {children}
+                    </OverflowRowPopoverItems>
+                  </View>
+                </Dialog>
+              </Popover>
+            </StopPropagation>
+          </DialogTrigger>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/components/core/utility/OverflowRow.tsx
+++ b/app/src/components/core/utility/OverflowRow.tsx
@@ -13,17 +13,13 @@ import { outlinedPillCSS } from "../styles";
 import { View } from "../view";
 
 type FirstLine = {
-  /** How many items share the first line and are shown by the row itself */
   visibleCount: number;
   /** The right edge of the last visible item, where the badge is placed */
   badgeLeft: number;
-  /** The measured height of the first line, which the row clamps to */
   lineHeight: number;
 };
 
-/** What the row renders from, once the hidden items are counted */
 type OverflowState = FirstLine & {
-  /** How many items wrapped past the first line and are hidden */
   hiddenCount: number;
 };
 
@@ -38,32 +34,22 @@ const overflowRowCSS = css`
 
   &.overflow-row--collapsed {
     position: relative;
-    // Items that don't fit wrap to lines below the measured clamp and are cut
-    // off whole. They are also made inert, so nothing that the row is cutting
-    // off can take focus or reach the accessibility tree — the "+N" badge
-    // stands in for them.
+    // items that don't fit wrap to lines below the clamp and are cut off whole
     align-content: flex-start;
     overflow: clip;
   }
   &.overflow-row--overflowing {
-    // The clamp is the first line's measured height rather than a fixed
-    // dimension, so the items decide how tall the row is and are never
-    // cropped mid-pill.
     height: var(--overflow-row-line-height);
     // room for the badge, which sits out of flow at the end of the first line
     padding-right: var(--global-dimension-size-600);
   }
 
-  // The badge and its popover are the row's own output rather than items, so
-  // they are kept in a boxless slot: the measurement skips them for free, and
-  // the content observer can tell the row's own changes from its children's.
+  // Boxless, so the measurement skips the badge and the content observer can
+  // tell the row's own output from its children's.
   .overflow-row__badge-slot {
     display: contents;
   }
 
-  // The badge stands in for the pills it hides, so it wears the shared pill
-  // shell. It is an unstyled react-aria button, so the rest of its dress is
-  // declared here.
   .overflow-row__badge {
     ${outlinedPillCSS};
     position: absolute;
@@ -87,21 +73,18 @@ const overflowRowCSS = css`
   }
 `;
 
-/** What {@link measureOverflow} reads off the DOM */
 type OverflowMeasurement = FirstLine & {
   /** The child elements that render a box, in document order */
   items: HTMLElement[];
 };
 
-/** Whether an element renders a box, and so counts as an item */
 function hasBox(element: HTMLElement): boolean {
   return element.offsetWidth > 0 || element.offsetHeight > 0;
 }
 
 /**
- * Collects the container's items. Only elements that render a box are items —
- * boxless wrappers (display: contents event guards and badge slot, closed
- * popovers) are skipped.
+ * Only elements that render a box are items — boxless wrappers (the badge slot,
+ * display: contents event guards, closed popovers) are skipped.
  */
 function getItems(container: HTMLElement): HTMLElement[] {
   return Array.from(container.children).filter(
@@ -110,26 +93,22 @@ function getItems(container: HTMLElement): HTMLElement[] {
   );
 }
 
-/**
- * Measures which of the container's items fit on its first line.
- */
+/** Measures which of the container's items fit on its first line. */
 function measureOverflow(container: HTMLElement): OverflowMeasurement {
   const items = getItems(container);
   let visibleCount = 0;
   let badgeLeft = 0;
   let lineHeight = 0;
-  // `align-items: center` cross-centers the items, so items sharing a line do
-  // not share an offsetTop. Flex lines never overlap vertically though, so
-  // line membership is an overlap test against the band the first line has
-  // covered so far rather than a comparison of top edges.
+  // `align-items: center` means items on one line don't share an offsetTop, so
+  // line membership is a vertical overlap test against the band covered so far
+  // rather than a comparison of top edges.
   let lineTop = Number.POSITIVE_INFINITY;
   let lineBottom = Number.NEGATIVE_INFINITY;
   for (const item of items) {
     const top = item.offsetTop;
     const bottom = top + item.offsetHeight;
     if (visibleCount > 0 && (top >= lineBottom || bottom <= lineTop)) {
-      // Items lay out in document order, so everything after the first wrap
-      // is on a later line too.
+      // document order, so everything past the first wrap is on a later line
       break;
     }
     visibleCount += 1;
@@ -141,21 +120,16 @@ function measureOverflow(container: HTMLElement): OverflowMeasurement {
   return { items, visibleCount, badgeLeft, lineHeight };
 }
 
-/**
- * The attributes that hide a clipped item, each recorded on the element under
- * its own flag so that only the ones this row actually added are ever removed.
- */
+/** Each recorded under its own flag, so only what this row added is removed */
 const CLIPPED_ITEM_ATTRIBUTES = [
   { name: "inert", value: "", flag: "overflowRowInert" },
   { name: "aria-hidden", value: "true", flag: "overflowRowAriaHidden" },
 ] as const;
 
 /**
- * Takes the clipped items out of the tab order and the accessibility tree.
- * They are still rendered — only cut off — so without this a keyboard user
- * would focus a pill that `overflow: clip` forbids the browser from scrolling
- * into view, and a screen reader would read items the row does not show. The
- * badge's popover is the one place they are exposed.
+ * Takes the clipped items out of the tab order and the accessibility tree. They
+ * are still rendered, only cut off, so without this a keyboard user would focus
+ * a pill that `overflow: clip` forbids the browser from scrolling into view.
  */
 function setClippedItems({
   items,
@@ -171,8 +145,7 @@ function setClippedItems({
     }
     for (const { name, value, flag } of CLIPPED_ITEM_ATTRIBUTES) {
       // A child that already hides itself keeps ownership of the attribute, so
-      // restoring cannot delete state React would not put back. This is also
-      // what makes a second pass over an already-clipped item a no-op.
+      // restoring cannot delete state React would not put back.
       if (!item.hasAttribute(name)) {
         item.dataset[flag] = "true";
         item.setAttribute(name, value);
@@ -199,7 +172,6 @@ function restoreClippedItems(container: HTMLElement) {
   }
 }
 
-/** How the row watches its items for changes it cannot see as a resize */
 const CONTENT_OBSERVER_OPTIONS = {
   childList: true,
   characterData: true,
@@ -207,9 +179,8 @@ const CONTENT_OBSERVER_OPTIONS = {
 } as const satisfies MutationObserverInit;
 
 /**
- * Whether a mutation is the row's own "+N" badge appearing, leaving or
- * recounting. The badge is an output of the measurement, so re-measuring for
- * it would only ever arrive back at the same answer.
+ * The badge is an output of the measurement, so re-measuring for it would only
+ * ever arrive back at the same answer.
  */
 function isBadgeMutation(record: MutationRecord): boolean {
   const isInBadgeSlot = (node: Node) => {
@@ -235,14 +206,11 @@ function isSameOverflow(a: OverflowState | null, b: OverflowState | null) {
 }
 
 /**
- * The body of the "+N" popover: the same children the row renders, minus the
- * ones already visible in the row. The children compose through component
- * boundaries (fragments, connected components), so they cannot be sliced as a
- * React array — instead the full set renders again and the leading elements
- * that the row already shows are switched off by DOM position, using the
- * row's own first-line count. `display: none` keeps them out of the
- * accessibility tree, so together with the row's inert clipped items every
- * item is exposed exactly once.
+ * The body of the "+N" popover: the children the row is hiding. They compose
+ * through component boundaries (fragments, connected components) and so cannot
+ * be sliced as a React array — instead the full set renders again and the
+ * prefix the row already shows is switched off by DOM position. Paired with the
+ * row's inert clipped items, that exposes every item to assistive tech once.
  */
 function OverflowRowPopoverItems({
   visibleCount,
@@ -258,19 +226,14 @@ function OverflowRowPopoverItems({
       const all = Array.from(container.children).filter(
         (element): element is HTMLElement => element instanceof HTMLElement
       );
-      // Undo only the hiding this effect applied before deciding which elements
-      // are items. Clearing every child's inline display would be simpler, but
-      // some children own theirs (the display: contents event guards), and
-      // React would not restore what we wipe.
+      // Undo only this effect's own hiding: some children own their inline
+      // display (the event guards), and React would not restore what we wipe.
       for (const element of all) {
         if (element.dataset.overflowRowHidden) {
           element.style.display = "";
           delete element.dataset.overflowRowHidden;
         }
       }
-      // Only elements that render a box are items; the children also produce
-      // boxless wrappers (display: contents event guards, closed popovers) that
-      // must not throw off the position count.
       const items = all.filter(hasBox);
       items.slice(0, visibleCount).forEach((element) => {
         element.style.display = "none";
@@ -278,10 +241,9 @@ function OverflowRowPopoverItems({
       });
     };
     hideRowVisibleItems();
-    // The items can change under an open popover (a streaming refetch). Watching
-    // for that is push-based, so a parent render that changed nothing costs no
-    // reflow — and the inline display written above is an attribute, which the
-    // observer does not watch and so cannot feed back into it.
+    // The items can change under an open popover (a streaming refetch). The
+    // inline display written above is an attribute, which this does not watch
+    // and so cannot feed back into.
     const observer = new MutationObserver(hideRowVisibleItems);
     observer.observe(container, CONTENT_OBSERVER_OPTIONS);
     return () => observer.disconnect();
@@ -304,11 +266,9 @@ function OverflowRowPopoverItems({
  * doesn't fit behind a "+N" badge, which opens the hidden items in a popover.
  * When `isExpanded`, the row simply wraps instead.
  *
- * The items are measured where they render: the row lets flex wrapping push
- * items that don't fit onto clipped lines, then counts the items that left the
- * first line. Nothing is ever cut mid-item, and the measurement never has to
- * know what the items are — any composed children that render a flat run of
- * elements (fragments included) work.
+ * Items are measured where they render: flex wrapping pushes what doesn't fit
+ * onto clipped lines, and the row counts what left the first line. So nothing
+ * is cut mid-item, and the row never has to know what its children are.
  */
 export function OverflowRow({
   children,
@@ -321,17 +281,14 @@ export function OverflowRow({
   const remeasureRef = useRef<(() => void) | null>(null);
   const [overflow, setOverflow] = useState<OverflowState | null>(null);
 
-  // The observer lives for as long as the row is collapsed — it is not torn
-  // down when the items re-render, only when the row changes shape.
   useLayoutEffect(() => {
     const container = containerRef.current;
     if (isExpanded || !container) {
       setOverflow(null);
       return undefined;
     }
-    // The row's own border-box width as of the last measurement. Seeded by the
-    // measurement itself so the observer's mandatory initial delivery, which
-    // reports the width we already measured at, costs nothing.
+    // Seeded by the measurement itself, so the resize observer's mandatory
+    // initial delivery reports a width already measured at and costs nothing.
     let lastInlineSize: number | null = null;
     const remeasure = () => {
       lastInlineSize = container.getBoundingClientRect().width;
@@ -348,10 +305,8 @@ export function OverflowRow({
     // measure synchronously so the first paint is already clamped
     remeasure();
     remeasureRef.current = remeasure;
-    // A web font swapping in re-lays the items out without changing the row's
-    // width or any of its text, so nothing else would catch it. Rows that mount
-    // once the fonts have settled — every row after the first paint — have
-    // nothing to wait for.
+    // A font swapping in re-lays the items out without changing the row's width
+    // or its text, so neither observer below would catch it.
     let isUnmounted = false;
     if (document.fonts?.status === "loading") {
       void document.fonts.ready.then(() => {
@@ -360,10 +315,9 @@ export function OverflowRow({
         }
       });
     }
-    // Only a change in the row's inline size can re-wrap the items. Ignoring
-    // the block size stops the clamp this callback applies from feeding back
-    // into the observer that watches the very element it clamps, which
-    // browsers report as a ResizeObserver loop.
+    // Only a change in inline size can re-wrap the items. Ignoring block size
+    // stops the clamp this callback applies from feeding back into the observer
+    // watching the very element it clamps, which browsers report as a loop.
     const resizeObserver = new ResizeObserver(([entry]) => {
       const inlineSize = entry?.borderBoxSize?.[0]?.inlineSize ?? null;
       if (inlineSize !== null && inlineSize === lastInlineSize) {
@@ -373,10 +327,8 @@ export function OverflowRow({
       remeasure();
     });
     resizeObserver.observe(container);
-    // The resize observer only sees the row's own width; items swapped for a
-    // same-size set (e.g. a streaming refetch) change its contents instead.
-    // Watching for that is push-based, so a render that changed nothing costs
-    // no reflow.
+    // The resize observer only sees the row's width; items swapped for a
+    // same-size set (a streaming refetch) change its contents instead.
     const contentObserver = new MutationObserver((records) => {
       if (records.every(isBadgeMutation)) {
         return;

--- a/app/src/components/core/utility/Truncate.tsx
+++ b/app/src/components/core/utility/Truncate.tsx
@@ -2,7 +2,8 @@ import { css } from "@emotion/react";
 import type { CSSProperties } from "react";
 import React from "react";
 
-const truncateSingleCSS = css`
+/** Clips text to one line with an ellipsis. The single-line half of {@link Truncate}, exported so the same clip can be composed into a cell or table rule. */
+export const truncateSingleCSS = css`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;

--- a/app/src/components/core/utility/Truncate.tsx
+++ b/app/src/components/core/utility/Truncate.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import type { CSSProperties } from "react";
 import React from "react";
 
-/** Clips text to one line with an ellipsis. The single-line half of {@link Truncate}, exported so the same clip can be composed into a cell or table rule. */
+/** The single-line half of {@link Truncate}, for composing into a cell or table rule */
 export const truncateSingleCSS = css`
   text-overflow: ellipsis;
   overflow: hidden;

--- a/app/src/components/table/CellWithControlsWrap.tsx
+++ b/app/src/components/table/CellWithControlsWrap.tsx
@@ -20,7 +20,11 @@ const cellWithControlsWrapCSS = css`
     display: flex;
     align-items: center;
   }
-  &[data-align="top"] > :not(.controls) {
+  // Top alignment applies when asked for (data-align="top") and inside a
+  // table whose rows are expanded (data-rows="expanded"), where every cell's
+  // content reads from the top.
+  &[data-align="top"] > :not(.controls),
+  [data-rows="expanded"] & > :not(.controls) {
     align-items: flex-start;
   }
   .controls {
@@ -54,8 +58,10 @@ const cellControlsCSS = css`
   gap: var(--global-table-cell-controls-gap);
 
   // Content that starts at the top of a taller row keeps its control beside
-  // the first line rather than letting it drift down the empty space below
-  [data-align="top"] > & {
+  // the first line rather than letting it drift down the empty space below —
+  // whether the cell asked for top alignment or sits in an expanded-rows table
+  [data-align="top"] > &,
+  [data-rows="expanded"] & {
     top: calc(
       var(--global-table-cell-padding-y) +
         (var(--global-line-height-s) - var(--embedded-copy-button-size)) / 2

--- a/app/src/components/table/CellWithControlsWrap.tsx
+++ b/app/src/components/table/CellWithControlsWrap.tsx
@@ -20,9 +20,7 @@ const cellWithControlsWrapCSS = css`
     display: flex;
     align-items: center;
   }
-  // Top alignment applies when asked for (data-align="top") and inside a
-  // table whose rows are expanded (data-rows="expanded"), where every cell's
-  // content reads from the top.
+  // Top-aligned when asked for, and inside a table whose rows are expanded.
   &[data-align="top"] > :not(.controls),
   [data-rows="expanded"] & > :not(.controls) {
     align-items: flex-start;
@@ -57,9 +55,8 @@ const cellControlsCSS = css`
   flex-direction: row;
   gap: var(--global-table-cell-controls-gap);
 
-  // Content that starts at the top of a taller row keeps its control beside
-  // the first line rather than letting it drift down the empty space below —
-  // whether the cell asked for top alignment or sits in an expanded-rows table
+  // Content starting at the top of a taller row keeps its control beside the
+  // first line rather than letting it drift down the space below.
   [data-align="top"] > &,
   [data-rows="expanded"] & {
     top: calc(

--- a/app/src/components/table/CopyableTextCell.tsx
+++ b/app/src/components/table/CopyableTextCell.tsx
@@ -1,7 +1,27 @@
+import { css } from "@emotion/react";
+
 import { CopyToClipboardButton, Text } from "@phoenix/components";
-import { Truncate } from "@phoenix/components/core/utility/Truncate";
+import { truncateSingleCSS } from "@phoenix/components/core/utility/Truncate";
 
 import { CellWithControlsWrap } from "./CellWithControlsWrap";
+
+const copyableTextCellCSS = css`
+  // The cell wrap lays its children out as a flex row, so the value is made a
+  // block box for the ellipsis to act on, and is let out of its content width
+  // so there is something for it to clip
+  .copyable-text-cell__value {
+    display: block;
+    min-width: 0;
+    ${truncateSingleCSS};
+  }
+  // Expanded rows are the state in which a value is read rather than scanned,
+  // so the whole of it is shown. Ids carry no break opportunities of their own,
+  // so they may break anywhere rather than widen the column.
+  [data-rows="expanded"] & .copyable-text-cell__value {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+`;
 
 export interface CopyableTextCellProps {
   /** The text to display. Renders "--" when null or empty. */
@@ -9,8 +29,9 @@ export interface CopyableTextCellProps {
 }
 
 /**
- * A table cell displaying truncated text with a copy-to-clipboard control,
- * e.g. for identifiers such as span, trace, and session ids.
+ * A table cell displaying text with a copy-to-clipboard control, e.g. for
+ * identifiers such as span, trace, and session ids. The value is truncated to
+ * a single line, or wrapped in full when the table's rows are expanded.
  */
 export function CopyableTextCell({ value }: CopyableTextCellProps) {
   if (!value) {
@@ -18,9 +39,11 @@ export function CopyableTextCell({ value }: CopyableTextCellProps) {
   }
   return (
     <CellWithControlsWrap controls={<CopyToClipboardButton text={value} />}>
-      <Truncate>
-        <Text>{value}</Text>
-      </Truncate>
+      <div css={copyableTextCellCSS}>
+        <Text fontFamily="mono" className="copyable-text-cell__value">
+          {value}
+        </Text>
+      </div>
     </CellWithControlsWrap>
   );
 }

--- a/app/src/components/table/CopyableTextCell.tsx
+++ b/app/src/components/table/CopyableTextCell.tsx
@@ -6,17 +6,16 @@ import { truncateSingleCSS } from "@phoenix/components/core/utility/Truncate";
 import { CellWithControlsWrap } from "./CellWithControlsWrap";
 
 const copyableTextCellCSS = css`
-  // The cell wrap lays its children out as a flex row, so the value is made a
-  // block box for the ellipsis to act on, and is let out of its content width
-  // so there is something for it to clip
+  // The cell wrap lays its children out as a flex row, so the value needs to be
+  // a block box for the ellipsis to act on, and out of its content width so
+  // there is something to clip.
   .copyable-text-cell__value {
     display: block;
     min-width: 0;
     ${truncateSingleCSS};
   }
-  // Expanded rows are the state in which a value is read rather than scanned,
-  // so the whole of it is shown. Ids carry no break opportunities of their own,
-  // so they may break anywhere rather than widen the column.
+  // Ids carry no break opportunities of their own, so they may break anywhere
+  // rather than widen the column.
   [data-rows="expanded"] & .copyable-text-cell__value {
     white-space: normal;
     overflow-wrap: anywhere;

--- a/app/src/components/table/RowExpandToggleButton.tsx
+++ b/app/src/components/table/RowExpandToggleButton.tsx
@@ -21,9 +21,8 @@ export function RowExpandToggleButton({
   onChange: (isExpanded: boolean) => void;
   size?: ButtonProps["size"];
 }) {
-  // Phrased as what it does to each row rather than as "expand rows", which a
-  // table that also expands a row into its descendants (TracesTable's span
-  // tree) already spends on that unrelated control.
+  // Phrased as what it does to each row rather than as "expand rows", which
+  // TracesTable already spends on its unrelated span-tree control.
   const label = isExpanded
     ? "Clip each row to a single line"
     : "Wrap each row over as many lines as it needs";

--- a/app/src/components/table/RowExpandToggleButton.tsx
+++ b/app/src/components/table/RowExpandToggleButton.tsx
@@ -1,0 +1,47 @@
+import {
+  Button,
+  type ButtonProps,
+  Icon,
+  Icons,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
+
+/**
+ * Toggles how much of a row a table shows: a single clipped line each, so the
+ * rows can be scanned down an even grid, or the wrapped content, so a value
+ * can be read where it sits.
+ */
+export function RowExpandToggleButton({
+  isExpanded,
+  onChange,
+  size = "M",
+}: {
+  isExpanded: boolean;
+  onChange: (isExpanded: boolean) => void;
+  size?: ButtonProps["size"];
+}) {
+  // Phrased as what it does to each row rather than as "expand rows", which a
+  // table that also expands a row into its descendants (TracesTable's span
+  // tree) already spends on that unrelated control.
+  const label = isExpanded
+    ? "Clip each row to a single line"
+    : "Wrap each row over as many lines as it needs";
+  return (
+    <TooltipTrigger>
+      <Button
+        size={size}
+        variant="default"
+        aria-label={label}
+        aria-pressed={isExpanded}
+        leadingVisual={
+          <Icon
+            svg={isExpanded ? <Icons.RowCollapse /> : <Icons.RowExpand />}
+          />
+        }
+        onPress={() => onChange(!isExpanded)}
+      />
+      <Tooltip offset={1}>{label}</Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/app/src/components/table/index.tsx
+++ b/app/src/components/table/index.tsx
@@ -14,6 +14,8 @@ export * from "./CellTop";
 export * from "./LargeTextWrap";
 export * from "./JSONCell";
 export * from "./PaddedCell";
+export * from "./RowExpandToggleButton";
+export * from "./useTableRowsExpanded";
 export * from "./IndeterminateCheckboxCell";
 export * from "./UserCell";
 

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -2,6 +2,16 @@ import { css } from "@emotion/react";
 import type { Column } from "@tanstack/react-table";
 import type { CSSProperties } from "react";
 
+import { truncateSingleCSS } from "@phoenix/components/core/utility/Truncate";
+
+/**
+ * Marks a `<td>` that holds one column's value, as opposed to the cells that
+ * stand in for a whole row (empty state, load more). Table bodies put it on
+ * every cell they render from a column definition, so rules about row height
+ * can name the cells they mean rather than inferring them.
+ */
+export const TABLE_DATA_CELL_CLASS = "table__cell";
+
 export const tableCSS = css`
   // fixes table row sizing issues with full height cell children
   // this enables features like hovering anywhere on a cell to display controls
@@ -75,6 +85,24 @@ export const tableCSS = css`
       }
     }
   }
+  // Right-aligned columns (numbers) — driven by the column's
+  // meta.textAlign rendered as the cell's align attribute. The attribute
+  // handles inline content; the flex-row cell components (latency, token
+  // counts, costs) don't respond to text-align, so the row itself is pushed
+  // to the cell's end to keep digits on a shared right edge.
+  th[align="right"] {
+    text-align: right;
+    .sort {
+      justify-content: flex-end;
+    }
+  }
+  td[align="right"] {
+    // justify-content is inert on non-flex children, so this reaches the
+    // flex-row cell components without naming them
+    > * {
+      justify-content: flex-end;
+    }
+  }
   tbody:not(.is-empty) {
     tr {
       // when paired with table.height:fit-content, allows table cells and their children to fill entire row height
@@ -128,6 +156,46 @@ export const selectableTableCSS = css(
       }
     }
   `
+);
+
+/**
+ * Row-height states for tables with an expand/collapse rows toggle, applied
+ * via a `data-rows="collapsed" | "expanded"` attribute on the `<table>`.
+ * Collapsed clips every cell to a single ellipsized line so rows keep an even
+ * height and the table scans as a grid; expanded lets cells wrap and grow,
+ * top-aligned so a row's cells all start on the same line.
+ */
+export const expandableRowsTableCSS = css`
+  // Only cells that hold a column's value take a row height, so a row's height
+  // is decided by the cells a body renders from the column definitions. The
+  // cells that stand in for a whole row (empty state, load more) are not data
+  // cells and lay themselves out.
+  &[data-rows="collapsed"] {
+    td.${TABLE_DATA_CELL_CLASS} {
+      ${truncateSingleCSS};
+    }
+  }
+  // Full-height cells (e.g. copyable id cells) top-align themselves under
+  // data-rows="expanded" — see CellWithControlsWrap, which owns that rule.
+  &[data-rows="expanded"] {
+    td.${TABLE_DATA_CELL_CLASS} {
+      vertical-align: top;
+      overflow: hidden;
+      // long unbroken values (ids, serialized JSON) wrap within the cell
+      // rather than widening the column
+      overflow-wrap: anywhere;
+    }
+  }
+`;
+
+/**
+ * The dress every tracing table wears: selectable rows plus the row-height
+ * states its toolbar toggle drives. Composed once so the three tables cannot
+ * end up with different answers to the same question.
+ */
+export const expandableSelectableTableCSS = css(
+  selectableTableCSS,
+  expandableRowsTableCSS
 );
 
 export const paginationCSS = css`

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -7,8 +7,7 @@ import { truncateSingleCSS } from "@phoenix/components/core/utility/Truncate";
 /**
  * Marks a `<td>` that holds one column's value, as opposed to the cells that
  * stand in for a whole row (empty state, load more). Table bodies put it on
- * every cell they render from a column definition, so rules about row height
- * can name the cells they mean rather than inferring them.
+ * every cell they render from a column definition.
  */
 export const TABLE_DATA_CELL_CLASS = "table__cell";
 
@@ -85,11 +84,10 @@ export const tableCSS = css`
       }
     }
   }
-  // Right-aligned columns (numbers) — driven by the column's
-  // meta.textAlign rendered as the cell's align attribute. The attribute
-  // handles inline content; the flex-row cell components (latency, token
-  // counts, costs) don't respond to text-align, so the row itself is pushed
-  // to the cell's end to keep digits on a shared right edge.
+  // Right-aligned columns (numbers), driven by the column's meta.textAlign.
+  // text-align handles inline content, but the flex-row cell components
+  // (latency, token counts, costs) don't respond to it, so the row itself is
+  // pushed to the cell's end to keep digits on a shared right edge.
   th[align="right"] {
     text-align: right;
     .sort {
@@ -166,17 +164,13 @@ export const selectableTableCSS = css(
  * top-aligned so a row's cells all start on the same line.
  */
 export const expandableRowsTableCSS = css`
-  // Only cells that hold a column's value take a row height, so a row's height
-  // is decided by the cells a body renders from the column definitions. The
-  // cells that stand in for a whole row (empty state, load more) are not data
-  // cells and lay themselves out.
+  // Only data cells take a row height; the cells that stand in for a whole row
+  // (empty state, load more) lay themselves out.
   &[data-rows="collapsed"] {
     td.${TABLE_DATA_CELL_CLASS} {
       ${truncateSingleCSS};
     }
   }
-  // Full-height cells (e.g. copyable id cells) top-align themselves under
-  // data-rows="expanded" — see CellWithControlsWrap, which owns that rule.
   &[data-rows="expanded"] {
     td.${TABLE_DATA_CELL_CLASS} {
       vertical-align: top;
@@ -189,9 +183,8 @@ export const expandableRowsTableCSS = css`
 `;
 
 /**
- * The dress every tracing table wears: selectable rows plus the row-height
- * states its toolbar toggle drives. Composed once so the three tables cannot
- * end up with different answers to the same question.
+ * Selectable rows plus the row-height states the toolbar toggle drives, composed
+ * once so the three tracing tables cannot answer the same question differently.
  */
 export const expandableSelectableTableCSS = css(
   selectableTableCSS,

--- a/app/src/components/table/useTableRowsExpanded.ts
+++ b/app/src/components/table/useTableRowsExpanded.ts
@@ -1,9 +1,8 @@
 import { usePreferencesContext } from "@phoenix/contexts";
 
 /**
- * The row-height preference the tracing tables share, together with the
- * attribute that drives {@link expandableRowsTableCSS}. Reading it through one
- * hook keeps the three tables from answering the same question differently.
+ * The row-height preference the tracing tables share, with the attribute that
+ * drives `expandableRowsTableCSS`.
  */
 export function useTableRowsExpanded() {
   const isExpanded = usePreferencesContext(
@@ -15,7 +14,6 @@ export function useTableRowsExpanded() {
   return {
     isExpanded,
     setIsExpanded,
-    /** Spread onto the `<table>` that wears `expandableRowsTableCSS` */
     tableProps: { "data-rows": isExpanded ? "expanded" : "collapsed" },
   } as const;
 }

--- a/app/src/components/table/useTableRowsExpanded.ts
+++ b/app/src/components/table/useTableRowsExpanded.ts
@@ -1,0 +1,21 @@
+import { usePreferencesContext } from "@phoenix/contexts";
+
+/**
+ * The row-height preference the tracing tables share, together with the
+ * attribute that drives {@link expandableRowsTableCSS}. Reading it through one
+ * hook keeps the three tables from answering the same question differently.
+ */
+export function useTableRowsExpanded() {
+  const isExpanded = usePreferencesContext(
+    (state) => state.areTableRowsExpanded
+  );
+  const setIsExpanded = usePreferencesContext(
+    (state) => state.setAreTableRowsExpanded
+  );
+  return {
+    isExpanded,
+    setIsExpanded,
+    /** Spread onto the `<table>` that wears `expandableRowsTableCSS` */
+    tableProps: { "data-rows": isExpanded ? "expanded" : "collapsed" },
+  } as const;
+}

--- a/app/src/components/trace/LatencyText.tsx
+++ b/app/src/components/trace/LatencyText.tsx
@@ -62,10 +62,11 @@ export function LatencyText({
   const latencyText = useMemo(() => latencyMsFormatter(latencyMs), [latencyMs]);
 
   return (
+    // No justify-content: an inline value would override the right-alignment
+    // a numeric table cell applies to its flex children.
     <Flex
       direction="row"
       alignItems="center"
-      justifyContent="start"
       gap="size-50"
       className="latency-text"
     >

--- a/app/src/components/trace/LatencyText.tsx
+++ b/app/src/components/trace/LatencyText.tsx
@@ -62,8 +62,8 @@ export function LatencyText({
   const latencyText = useMemo(() => latencyMsFormatter(latencyMs), [latencyMs]);
 
   return (
-    // No justify-content: an inline value would override the right-alignment
-    // a numeric table cell applies to its flex children.
+    // No justify-content: it would override the right-alignment a numeric
+    // table cell applies to its flex children.
     <Flex
       direction="row"
       alignItems="center"

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -29,6 +29,7 @@ import {
   Heading,
   Icon,
   Icons,
+  OverflowRow,
   Text,
   View,
 } from "@phoenix/components";
@@ -36,7 +37,10 @@ import { MeanScore } from "@phoenix/components/annotation/MeanScore";
 import { SessionAnnotationSummaryGroupTokens } from "@phoenix/components/annotation/SessionAnnotationSummaryGroup";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { useTimeRange } from "@phoenix/components/datetime";
-import { selectableTableCSS } from "@phoenix/components/table/styles";
+import {
+  expandableSelectableTableCSS,
+  TABLE_DATA_CELL_CLASS,
+} from "@phoenix/components/table/styles";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SessionTokenCosts } from "@phoenix/components/trace/SessionTokenCosts";
@@ -52,6 +56,8 @@ import {
   ColumnOrderingProvider,
   CopyableTextCell,
   IntCell,
+  RowExpandToggleButton,
+  useTableRowsExpanded,
   useColumnOrder,
 } from "../../components/table";
 import type { SessionsTable_sessions$key } from "./__generated__/SessionsTable_sessions.graphql";
@@ -71,6 +77,7 @@ import { TableAsidePanel, TableAsideToggleButton } from "./TableAside";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
 import {
+  ANNOTATION_COLUMN_SIZING,
   DEFAULT_SESSION_SORT,
   getGqlSessionSort,
   makeAnnotationColumnId,
@@ -115,14 +122,12 @@ const TableBody = <T extends { id: string }>({
               return (
                 <td
                   key={cell.id}
+                  className={TABLE_DATA_CELL_CLASS}
                   style={{
                     width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     maxWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,
-                    // prevent all wrapping, just show an ellipsis and let users expand if necessary
-                    textWrap: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
+                    // wrapping vs. single-line ellipsis is decided by the
+                    // table's data-rows state — see expandableRowsTableCSS
                   }}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -153,6 +158,11 @@ export function SessionsTable(props: SessionsTableProps) {
   // search/filter still applied. The parent query is intentionally not reloaded
   // on window slides — see the load effect in `ProjectPage` and issue #14216.
   const { timeRangeISOStrings } = useTimeRange();
+  const {
+    isExpanded: areRowsExpanded,
+    setIsExpanded: setAreRowsExpanded,
+    tableProps: rowsExpandedTableProps,
+  } = useTableRowsExpanded();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<SessionsTableQuery, SessionsTable_sessions$key>(
       graphql`
@@ -342,8 +352,13 @@ export function SessionsTable(props: SessionsTableProps) {
       id: "annotations",
       accessorKey: "sessionAnnotations",
       enableSorting: false,
+      ...ANNOTATION_COLUMN_SIZING,
       cell: ({ row }) => {
-        return <SessionAnnotationSummaryGroupTokens session={row.original} />;
+        return (
+          <OverflowRow isExpanded={areRowsExpanded}>
+            <SessionAnnotationSummaryGroupTokens session={row.original} />
+          </OverflowRow>
+        );
       },
     },
     ...dynamicAnnotationColumns,
@@ -592,6 +607,10 @@ export function SessionsTable(props: SessionsTableProps) {
               columns={table.getAllColumns()}
               query={data}
             />
+            <RowExpandToggleButton
+              isExpanded={areRowsExpanded}
+              onChange={setAreRowsExpanded}
+            />
             <TableAsideToggleButton />
           </Flex>
         </View>
@@ -619,7 +638,8 @@ export function SessionsTable(props: SessionsTableProps) {
                 onColumnOrderChange={onVisibleColumnOrderChange}
               >
                 <table
-                  css={selectableTableCSS}
+                  css={expandableSelectableTableCSS}
+                  {...rowsExpandedTableProps}
                   style={{
                     ...columnSizeVars,
                     width: table.getTotalSize(),

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -418,24 +418,26 @@ export function SessionsTable(props: SessionsTableProps) {
       header: "p50 latency",
       accessorKey: "traceLatencyMsP50",
       enableSorting: false,
+      meta: { textAlign: "right" },
       cell: ({ getValue }) => {
         const value = getValue();
         if (value === null || typeof value !== "number") {
           return null;
         }
-        return <LatencyText latencyMs={value} />;
+        return <LatencyText latencyMs={value} size="S" />;
       },
     },
     {
       header: "p99 latency",
       accessorKey: "traceLatencyMsP99",
       enableSorting: false,
+      meta: { textAlign: "right" },
       cell: ({ getValue }) => {
         const value = getValue();
         if (value === null || typeof value !== "number") {
           return null;
         }
-        return <LatencyText latencyMs={value} />;
+        return <LatencyText latencyMs={value} size="S" />;
       },
     },
     {
@@ -443,6 +445,7 @@ export function SessionsTable(props: SessionsTableProps) {
       accessorKey: "tokenCountTotal",
       enableSorting: true,
       minSize: 80,
+      meta: { textAlign: "right" },
       cell: ({ getValue, row }) => {
         const value = getValue();
         if (value == null || typeof value !== "number") {
@@ -464,13 +467,16 @@ export function SessionsTable(props: SessionsTableProps) {
       id: "costTotal",
       enableSorting: true,
       minSize: 80,
+      meta: { textAlign: "right" },
       cell: ({ row, getValue }) => {
         const value = getValue();
         if (value === null || typeof value !== "number") {
           return "--";
         }
         const session = row.original;
-        return <SessionTokenCosts totalCost={value} nodeId={session.id} />;
+        return (
+          <SessionTokenCosts totalCost={value} nodeId={session.id} size="S" />
+        );
       },
     },
     {

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -126,8 +126,6 @@ const TableBody = <T extends { id: string }>({
                   style={{
                     width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     maxWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,
-                    // wrapping vs. single-line ellipsis is decided by the
-                    // table's data-rows state — see expandableRowsTableCSS
                   }}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -170,8 +170,6 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
                     ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,
                     maxWidth: `calc(var(${colSizeVar}) * 1px)`,
-                    // wrapping vs. single-line ellipsis is decided by the
-                    // table's data-rows state — see expandableRowsTableCSS
                     userSelect:
                       cell.column.id === CHECKBOX_COLUMN_ID
                         ? "none"

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -26,6 +26,7 @@ import {
   Icon,
   Icons,
   Link,
+  OverflowRow,
   SegmentedControl,
   SegmentedControlItem,
   Text,
@@ -43,6 +44,8 @@ import {
   CopyableTextCell,
   createRowSelectionColumn,
   LoadMoreRow,
+  RowExpandToggleButton,
+  useTableRowsExpanded,
   useColumnOrder,
 } from "@phoenix/components/table";
 import {
@@ -50,8 +53,9 @@ import {
   CHECKBOX_COLUMN_PINNING,
 } from "@phoenix/components/table/constants";
 import {
+  expandableSelectableTableCSS,
+  TABLE_DATA_CELL_CLASS,
   getCommonPinningStyles,
-  selectableTableCSS,
 } from "@phoenix/components/table/styles";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useShiftClickRowSelection } from "@phoenix/components/table/useShiftClickRowSelection";
@@ -95,6 +99,7 @@ import { TableAsidePanel, TableAsideToggleButton } from "./TableAside";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
 import {
+  ANNOTATION_COLUMN_SIZING,
   DEFAULT_SORT,
   getGqlSort,
   makeAnnotationColumnId,
@@ -159,15 +164,14 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
               return (
                 <td
                   key={cell.id}
+                  className={TABLE_DATA_CELL_CLASS}
+                  align={cell.column.columnDef.meta?.textAlign}
                   style={{
                     ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,
                     maxWidth: `calc(var(${colSizeVar}) * 1px)`,
-                    // prevent all wrapping, just show an ellipsis and let users expand if necessary
-                    textWrap: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
+                    // wrapping vs. single-line ellipsis is decided by the
+                    // table's data-rows state — see expandableRowsTableCSS
                     userSelect:
                       cell.column.id === CHECKBOX_COLUMN_ID
                         ? "none"
@@ -230,6 +234,11 @@ export function SpansTable(props: SpansTableProps) {
   useAdvertiseAgentContext(advertisedRootSpansOnlyContext);
 
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
+  const {
+    isExpanded: areRowsExpanded,
+    setIsExpanded: setAreRowsExpanded,
+    tableProps: rowsExpandedTableProps,
+  } = useTableRowsExpanded();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<SpansTableSpansQuery, SpansTable_spans$key>(
       graphql`
@@ -481,10 +490,10 @@ export function SpansTable(props: SpansTableProps) {
       id: "annotations",
       accessorKey: "spanAnnotations",
       enableSorting: false,
-
+      ...ANNOTATION_COLUMN_SIZING,
       cell: ({ row }) => {
         return (
-          <Flex direction="row" gap="size-50" wrap="wrap">
+          <OverflowRow isExpanded={areRowsExpanded}>
             <AnnotationSummaryGroupTokens
               span={row.original}
               showFilterActions
@@ -513,7 +522,7 @@ export function SpansTable(props: SpansTableProps) {
                 </>
               );
             })}
-          </Flex>
+          </OverflowRow>
         );
       },
     },
@@ -531,11 +540,12 @@ export function SpansTable(props: SpansTableProps) {
       ),
       id: TRACE_ANNOTATIONS_COLUMN_ID,
       enableSorting: false,
+      ...ANNOTATION_COLUMN_SIZING,
       cell: ({ row }) => {
         return (
-          <Flex direction="row" gap="size-50" wrap="wrap">
+          <OverflowRow isExpanded={areRowsExpanded}>
             <TraceAnnotationSummaryGroupTokens trace={row.original.trace} />
-          </Flex>
+          </OverflowRow>
         );
       },
     },
@@ -712,13 +722,13 @@ export function SpansTable(props: SpansTableProps) {
     {
       header: "latency",
       accessorKey: "latencyMs",
-
+      meta: { textAlign: "right" },
       cell: ({ getValue }) => {
         const value = getValue();
         if (value === null || typeof value !== "number") {
           return null;
         }
-        return <LatencyText latencyMs={value} />;
+        return <LatencyText latencyMs={value} size="S" />;
       },
     },
     {
@@ -726,6 +736,7 @@ export function SpansTable(props: SpansTableProps) {
       accessorKey: rootSpansOnly
         ? "cumulativeTokenCountTotal"
         : "tokenCountTotal",
+      meta: { textAlign: "right" },
       cell: ({ row, getValue }) => {
         const value = getValue();
         if (value === null) {
@@ -741,6 +752,7 @@ export function SpansTable(props: SpansTableProps) {
             <SpanCumulativeTokenCount
               tokenCountTotal={tokenCountTotal || 0}
               nodeId={span.id}
+              size="S"
             />
           );
         }
@@ -749,6 +761,7 @@ export function SpansTable(props: SpansTableProps) {
           <SpanTokenCount
             tokenCountTotal={tokenCountTotal || 0}
             nodeId={span.id}
+            size="S"
           />
         );
       },
@@ -759,6 +772,7 @@ export function SpansTable(props: SpansTableProps) {
         ? "trace.costSummary.total.cost"
         : "costSummary.total.cost",
       id: rootSpansOnly ? "cumulativeTokenCostTotal" : "tokenCostTotal",
+      meta: { textAlign: "right" },
       cell: ({ row, getValue }) => {
         const value = getValue();
         if (value === null || typeof value !== "number") {
@@ -939,6 +953,10 @@ export function SpansTable(props: SpansTableProps) {
             </SegmentedControl>
             <TableMetricsChartSelector view="spans" />
             <SpanColumnSelector columns={table.getAllColumns()} query={data} />
+            <RowExpandToggleButton
+              isExpanded={areRowsExpanded}
+              onChange={setAreRowsExpanded}
+            />
             <ProjectFilterConfigButton />
             <TableAsideToggleButton />
           </Flex>
@@ -967,7 +985,8 @@ export function SpansTable(props: SpansTableProps) {
                 onColumnOrderChange={onVisibleColumnOrderChange}
               >
                 <table
-                  css={selectableTableCSS}
+                  css={expandableSelectableTableCSS}
+                  {...rowsExpandedTableProps}
                   style={{
                     ...columnSizeVars,
                     width: table.getTotalSize(),
@@ -1036,6 +1055,7 @@ export function SpansTable(props: SpansTableProps) {
                             return (
                               <ColumnHeaderCell
                                 key={header.id}
+                                align={header.column.columnDef.meta?.textAlign}
                                 columnId={header.column.id}
                                 // Only the top header group is reorderable;
                                 // sub-headers of a group column move with it

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -33,6 +33,7 @@ import {
   Icon,
   Icons,
   Link,
+  OverflowRow,
   Text,
   View,
 } from "@phoenix/components";
@@ -47,6 +48,8 @@ import {
   ColumnOrderingProvider,
   CopyableTextCell,
   createRowSelectionColumn,
+  RowExpandToggleButton,
+  useTableRowsExpanded,
   useColumnOrder,
 } from "@phoenix/components/table";
 import {
@@ -54,8 +57,9 @@ import {
   CHECKBOX_COLUMN_PINNING,
 } from "@phoenix/components/table/constants";
 import {
+  expandableSelectableTableCSS,
+  TABLE_DATA_CELL_CLASS,
   getCommonPinningStyles,
-  selectableTableCSS,
 } from "@phoenix/components/table/styles";
 import { TableExpandButton } from "@phoenix/components/table/TableExpandButton";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
@@ -95,6 +99,7 @@ import { spansTableCSS } from "./styles";
 import { TableMetricsChartsPanelGroup } from "./TableMetricsCharts";
 import { TableMetricsChartSelector } from "./TableMetricsChartSelector";
 import {
+  ANNOTATION_COLUMN_SIZING,
   DEFAULT_SORT,
   getGqlSort,
   makeAnnotationColumnId,
@@ -163,15 +168,13 @@ const TableBody = <
               return (
                 <td
                   key={cell.id}
+                  className={TABLE_DATA_CELL_CLASS}
                   style={{
                     ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,
                     maxWidth: `calc(var(${colSizeVar}) * 1px)`,
-                    // prevent all wrapping, just show an ellipsis and let users expand if necessary
-                    textWrap: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
+                    // wrapping vs. single-line ellipsis is decided by the
+                    // table's data-rows state — see expandableRowsTableCSS
                     userSelect:
                       cell.column.id === CHECKBOX_COLUMN_ID
                         ? "none"
@@ -245,6 +248,11 @@ export function TracesTable(props: TracesTableProps) {
   // still applied. The parent query is intentionally not reloaded on window
   // slides — see the load effect in `ProjectPage` and issue #14216.
   const { timeRangeISOStrings } = useTimeRange();
+  const {
+    isExpanded: areRowsExpanded,
+    setIsExpanded: setAreRowsExpanded,
+    tableProps: rowsExpandedTableProps,
+  } = useTableRowsExpanded();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<TracesTableQuery, TracesTable_spans$key>(
       graphql`
@@ -571,6 +579,7 @@ export function TracesTable(props: TracesTableProps) {
         id: "annotations",
         accessorKey: "spanAnnotations",
         enableSorting: false,
+        ...ANNOTATION_COLUMN_SIZING,
         cell: ({ row }) => {
           if (row.original.__additionalRow) {
             return null;
@@ -579,7 +588,7 @@ export function TracesTable(props: TracesTableProps) {
             row.original.spanAnnotations.length === 0 &&
             row.original.documentRetrievalMetrics.length === 0;
           return (
-            <Flex direction="row" gap="size-50" wrap="wrap">
+            <OverflowRow isExpanded={areRowsExpanded}>
               <AnnotationSummaryGroupTokens
                 span={row.original}
                 showFilterActions
@@ -609,7 +618,7 @@ export function TracesTable(props: TracesTableProps) {
                 );
               })}
               {hasNoFeedback ? "--" : null}
-            </Flex>
+            </OverflowRow>
           );
         },
       },
@@ -629,12 +638,13 @@ export function TracesTable(props: TracesTableProps) {
         ),
         id: TRACE_ANNOTATIONS_COLUMN_ID,
         enableSorting: false,
+        ...ANNOTATION_COLUMN_SIZING,
         cell: ({ row }) => {
           if (row.depth !== 0 || row.original.__additionalRow) {
             return null;
           }
           return (
-            <Flex direction="row" gap="size-50" wrap="wrap">
+            <OverflowRow isExpanded={areRowsExpanded}>
               <TraceAnnotationSummaryGroupTokens
                 trace={
                   row.original.trace as Parameters<
@@ -642,14 +652,14 @@ export function TracesTable(props: TracesTableProps) {
                   >[0]["trace"]
                 }
               />
-            </Flex>
+            </OverflowRow>
           );
         },
       },
       ...dynamicAnnotationColumns,
       ...dynamicTraceAnnotationColumns,
     ],
-    [dynamicAnnotationColumns, dynamicTraceAnnotationColumns]
+    [areRowsExpanded, dynamicAnnotationColumns, dynamicTraceAnnotationColumns]
   );
 
   const columns: ColumnDef<TableRow>[] = useMemo(
@@ -1071,6 +1081,10 @@ export function TracesTable(props: TracesTableProps) {
             <SpanFilterConditionField onValidCondition={setFilterCondition} />
             <TableMetricsChartSelector view="traces" />
             <SpanColumnSelector columns={table.getAllColumns()} query={data} />
+            <RowExpandToggleButton
+              isExpanded={areRowsExpanded}
+              onChange={setAreRowsExpanded}
+            />
           </Flex>
         </View>
         <div
@@ -1086,7 +1100,8 @@ export function TracesTable(props: TracesTableProps) {
             onColumnOrderChange={onVisibleColumnOrderChange}
           >
             <table
-              css={selectableTableCSS}
+              css={expandableSelectableTableCSS}
+              {...rowsExpandedTableProps}
               style={{
                 ...columnSizeVars,
                 width: table.getTotalSize(),

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -860,6 +860,7 @@ export function TracesTable(props: TracesTableProps) {
       {
         header: "latency",
         accessorKey: "latencyMs",
+        meta: { textAlign: "right" },
         cell: ({ getValue, row }) => {
           const value = getValue();
           if (
@@ -869,13 +870,14 @@ export function TracesTable(props: TracesTableProps) {
           ) {
             return null;
           }
-          return <LatencyText latencyMs={value} />;
+          return <LatencyText latencyMs={value} size="S" />;
         },
       },
       {
         header: "total tokens",
         minSize: 80,
         accessorKey: "cumulativeTokenCountTotal",
+        meta: { textAlign: "right" },
         cell: ({ row, getValue }) => {
           if (row.original.__additionalRow) {
             return null;
@@ -888,6 +890,7 @@ export function TracesTable(props: TracesTableProps) {
             <TraceTokenCount
               tokenCountTotal={value as number}
               nodeId={row.original.trace.id}
+              size="S"
             />
           );
         },
@@ -897,6 +900,7 @@ export function TracesTable(props: TracesTableProps) {
         minSize: 80,
         accessorKey: "trace.costSummary.total.cost",
         id: "cumulativeTokenCostTotal",
+        meta: { textAlign: "right" },
         cell: ({ row, getValue }) => {
           const value = getValue();
           if (value === null || typeof value !== "number") {

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -173,8 +173,6 @@ const TableBody = <
                     ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,
                     maxWidth: `calc(var(${colSizeVar}) * 1px)`,
-                    // wrapping vs. single-line ellipsis is decided by the
-                    // table's data-rows state — see expandableRowsTableCSS
                     userSelect:
                       cell.column.id === CHECKBOX_COLUMN_ID
                         ? "none"

--- a/app/src/pages/project/tableUtils.ts
+++ b/app/src/pages/project/tableUtils.ts
@@ -14,10 +14,7 @@ export const TRACE_ANNOTATIONS_COLUMN_PREFIX = "trace-annotations";
 export const ANNOTATIONS_KEY_SEPARATOR = "-";
 export const TRACE_ANNOTATIONS_COLUMN_ID = "traceAnnotations";
 export const TRACE_ANNOTATIONS_COLUMN_LABEL = "trace annotations";
-/**
- * Sizing for the annotation columns of the tracing tables. Wide enough to leave
- * room for a full annotation pill beside `OverflowRow`'s "+N" badge.
- */
+/** Wide enough for a full annotation pill beside `OverflowRow`'s "+N" badge */
 export const ANNOTATION_COLUMN_SIZING = {
   size: 250,
   minSize: 150,

--- a/app/src/pages/project/tableUtils.ts
+++ b/app/src/pages/project/tableUtils.ts
@@ -1,4 +1,4 @@
-import type { ColumnSort } from "@tanstack/react-table";
+import type { ColumnDef, ColumnSort } from "@tanstack/react-table";
 
 import type {
   ProjectSessionSort,
@@ -14,6 +14,14 @@ export const TRACE_ANNOTATIONS_COLUMN_PREFIX = "trace-annotations";
 export const ANNOTATIONS_KEY_SEPARATOR = "-";
 export const TRACE_ANNOTATIONS_COLUMN_ID = "traceAnnotations";
 export const TRACE_ANNOTATIONS_COLUMN_LABEL = "trace annotations";
+/**
+ * Sizing for the annotation columns of the tracing tables. Wide enough to leave
+ * room for a full annotation pill beside `OverflowRow`'s "+N" badge.
+ */
+export const ANNOTATION_COLUMN_SIZING = {
+  size: 250,
+  minSize: 150,
+} satisfies Partial<ColumnDef<unknown>>;
 export const DEFAULT_SORT: SpanSort = {
   col: "startTime",
   dir: "desc",

--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -207,7 +207,9 @@ function SpanAsideAnnotationList(props: {
           overflow="auto"
           maxHeight="100%"
         >
-          <AnnotationSummaryGroupTokens span={data} />
+          <Flex direction="row" gap="size-50" wrap="wrap">
+            <AnnotationSummaryGroupTokens span={data} />
+          </Flex>
         </View>
       </FocusScope>
     </TitledPanel>

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -194,9 +194,7 @@ export interface PreferencesState extends PreferencesProps {
    * @param showMetricsInTraceTree
    */
   setShowMetricsInTraceTree: (showMetricsInTraceTree: boolean) => void;
-  /**
-   * Setter for whether tracing tables' rows are expanded
-   */
+  /** Setter for whether tracing tables' rows are expanded */
   setAreTableRowsExpanded: (areTableRowsExpanded: boolean) => void;
   /**
    * Setter for the model configs by provider
@@ -304,8 +302,7 @@ export const createPreferencesStore = (
         type: "setShowMetricsInTraceTree",
       });
     },
-    // Clipped to start: rows of an even height are what make a table
-    // scannable as a grid. Expanding is the deliberate second step.
+    // Clipped to start: an even row height is what makes a table scan as a grid
     areTableRowsExpanded: false,
     setAreTableRowsExpanded: (areTableRowsExpanded) => {
       set({ areTableRowsExpanded }, false, {

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -97,6 +97,12 @@ export interface PreferencesProps {
    */
   showMetricsInTraceTree: boolean;
   /**
+   * Whether tracing tables' rows wrap their content or clip it to a single
+   * line. A reading preference, so it spans projects and tabs.
+   * @default false
+   */
+  areTableRowsExpanded: boolean;
+  /**
    * {@link ModelConfig|ModelConfigs} for llm providers will be used as the default parameters for the provider
    */
   modelConfigByProvider: ModelConfigByProvider;
@@ -188,6 +194,10 @@ export interface PreferencesState extends PreferencesProps {
    * @param showMetricsInTraceTree
    */
   setShowMetricsInTraceTree: (showMetricsInTraceTree: boolean) => void;
+  /**
+   * Setter for whether tracing tables' rows are expanded
+   */
+  setAreTableRowsExpanded: (areTableRowsExpanded: boolean) => void;
   /**
    * Setter for the model configs by provider
    */
@@ -292,6 +302,14 @@ export const createPreferencesStore = (
     setShowMetricsInTraceTree: (showMetricsInTraceTree) => {
       set({ showMetricsInTraceTree }, false, {
         type: "setShowMetricsInTraceTree",
+      });
+    },
+    // Clipped to start: rows of an even height are what make a table
+    // scannable as a grid. Expanding is the deliberate second step.
+    areTableRowsExpanded: false,
+    setAreTableRowsExpanded: (areTableRowsExpanded) => {
+      set({ areTableRowsExpanded }, false, {
+        type: "setAreTableRowsExpanded",
       });
     },
     modelConfigByProvider: {},

--- a/app/stories/CopyableTextCell.stories.tsx
+++ b/app/stories/CopyableTextCell.stories.tsx
@@ -1,6 +1,11 @@
+import { css } from "@emotion/react";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { CopyableTextCell } from "@phoenix/components/table/CopyableTextCell";
+import {
+  expandableRowsTableCSS,
+  tableCSS,
+} from "@phoenix/components/table/styles";
 
 const meta: Meta<typeof CopyableTextCell> = {
   title: "Table/CopyableTextCell",
@@ -21,6 +26,42 @@ export const Default: Story = {
 export const LongValue: Story = {
   args: {
     value: "user-3f7b2ee5d0f48ba2-very-long-identifier-that-truncates",
+  },
+};
+
+const narrowTableCSS = css(tableCSS, expandableRowsTableCSS, {
+  width: 240,
+  tableLayout: "fixed",
+});
+
+/**
+ * The cell takes its row height from the table it sits in: collapsed clips the
+ * value to one ellipsized line, expanded wraps the whole of it. Both tables are
+ * the same width, so the only difference is the `data-rows` state.
+ */
+export const InTable: StoryObj = {
+  render: () => {
+    const value = "user-3f7b2ee5d0f48ba2-very-long-identifier-that-truncates";
+    return (
+      <>
+        {(["collapsed", "expanded"] as const).map((rows) => (
+          <table key={rows} css={narrowTableCSS} data-rows={rows}>
+            <thead>
+              <tr>
+                <th>{rows}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <CopyableTextCell value={value} />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        ))}
+      </>
+    );
   },
 };
 

--- a/app/stories/CopyableTextCell.stories.tsx
+++ b/app/stories/CopyableTextCell.stories.tsx
@@ -35,8 +35,7 @@ const narrowTableCSS = css(tableCSS, expandableRowsTableCSS, {
 });
 
 /**
- * The cell takes its row height from the table it sits in: collapsed clips the
- * value to one ellipsized line, expanded wraps the whole of it. Both tables are
+ * The cell takes its row height from the table it sits in. Both tables here are
  * the same width, so the only difference is the `data-rows` state.
  */
 export const InTable: StoryObj = {

--- a/app/stories/OverflowRow.stories.tsx
+++ b/app/stories/OverflowRow.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useState } from "react";
+
+import { Flex, OverflowRow, Switch, Token, View } from "@phoenix/components";
+
+const meta: Meta = {
+  title: "Core/Utility/OverflowRow",
+  component: OverflowRow,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+const LABELS = [
+  "correctness",
+  "hallucination",
+  "toxicity",
+  "relevance",
+  "conciseness",
+  "helpfulness",
+  "coherence",
+  "groundedness",
+];
+
+const COLORS = [
+  "var(--global-color-celery-600)",
+  "var(--global-color-fuchsia-600)",
+  "var(--global-color-indigo-600)",
+  "var(--global-color-magenta-600)",
+  "var(--global-color-seafoam-600)",
+  "var(--global-color-yellow-600)",
+  "var(--global-color-purple-600)",
+  "var(--global-color-chartreuse-600)",
+];
+
+const Tokens = () => (
+  <>
+    {LABELS.map((label, index) => (
+      <Token key={label} color={COLORS[index % COLORS.length]} size="M">
+        {label}
+      </Token>
+    ))}
+  </>
+);
+
+const Template = ({ width }: { width: number }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <Flex direction="column" gap="size-200">
+      <Switch isSelected={isExpanded} onChange={setIsExpanded}>
+        Expanded
+      </Switch>
+      <View
+        borderWidth="thin"
+        borderColor="default"
+        borderRadius="medium"
+        padding="size-100"
+        width={`${width}px`}
+      >
+        <OverflowRow isExpanded={isExpanded}>
+          <Tokens />
+        </OverflowRow>
+      </View>
+    </Flex>
+  );
+};
+
+export const Default: StoryFn = () => <Template width={320} />;
+
+export const Narrow: StoryFn = () => <Template width={160} />;
+
+export const FitsWithoutOverflow: StoryFn = () => <Template width={900} />;


### PR DESCRIPTION
Adds a row-height toggle to the spans, traces, and sessions tables.

**Collapsed** (the default) clips every cell to a single ellipsized line, so rows keep an even height and the table scans as a grid. **Expanded** lets cells wrap and grow, top-aligned so a row's cells all start on the same line. It's a reading preference, so it persists across projects and tabs.

### What's here

- `RowExpandToggleButton` in each table's toolbar, backed by one `areTableRowsExpanded` preference and a shared `useTableRowsExpanded()` hook.
- `expandableRowsTableCSS` owns both row states on the `<table>` via a `data-rows` attribute, replacing the per-`<td>` inline clipping the three tables each carried their own copy of. Data cells are marked with `TABLE_DATA_CELL_CLASS` so the full-width empty-state and load-more cells lay themselves out.
- `OverflowRow` for annotation cells: clips a run of pills to one line and stands in for the rest with a `+N` badge that opens them in a popover. Clipped pills are made `inert`, so keyboard focus and screen readers only reach what the row actually shows.
- `CopyableTextCell` renders ids in mono and wraps them in full when rows are expanded.
- The three `*AnnotationSummaryGroupTokens` components now share one `AnnotationSummaryTokens` renderer and keep only their own Relay fragment hook.

### Testing

`tsc --noEmit`, `oxlint`, `oxfmt`, and `vitest` (2010 passed / 12 skipped) all pass.

**Not yet verified in a browser.** Badge placement, the collapsed one-line height, and the expanded wrapping have no visual confirmation — `app/stories/OverflowRow.stories.tsx` and the new `InTable` story on `CopyableTextCell` are the cheap check.

### Known trade-off

The `+N` badge's 48px gutter is reserved only while the row is overflowing, so at a width where the pills fit bare but not with the gutter, the row settles at "no badge" if that width is reached by widening and at "+1" if reached by narrowing. It converges and doesn't oscillate. Reserving the gutter unconditionally would make it width-deterministic at the cost of a `+1` on rows whose last pill fits in that 48px — happy to switch if that reads better.
