### PR TITLE
fix(ui): anchor IO tooltips beside the cell in tracing tables

### DIFF
--- a/app/src/components/table/columnOrdering/ColumnOrderingProvider.tsx
+++ b/app/src/components/table/columnOrdering/ColumnOrderingProvider.tsx
@@ -52,9 +52,11 @@ export interface ColumnOrderingProviderProps {
   onColumnOrderChange: (columnOrder: string[]) => void;
   /**
    * Called once with the final order when a drag ends (the restored original
-   * order if the drag was canceled). Wire expensive consumers (e.g. a table
-   * re-render) here and keep `onColumnOrderChange` cheap when reorders should
-   * not be applied live on every drag-over step.
+   * order if the drag was canceled). The committed value is read from the
+   * `columnOrder` prop, so intermediate `onColumnOrderChange` updates must be
+   * applied back into it synchronously. Wire expensive consumers (e.g. a
+   * table re-render) here and keep `onColumnOrderChange` cheap when reorders
+   * should not be applied live on every drag-over step.
    */
   onColumnOrderCommit?: (columnOrder: string[]) => void;
   children: ReactNode;
@@ -94,16 +96,18 @@ export function ColumnOrderingProvider({
       onDragEnd={(event) => {
         const initialColumnOrder = initialColumnOrderRef.current;
         initialColumnOrderRef.current = null;
-        // The order the user saw was already committed during the drag;
-        // re-applying move() here would shift the column a second time.
-        if (!event.canceled) {
-          onColumnOrderCommit?.(columnOrder);
-          return;
+        // The order the user saw was already committed during the drag, so a
+        // completed drag needs no change here (re-applying move() would shift
+        // the column a second time); a canceled drag restores the order from
+        // when the drag started.
+        const finalColumnOrder =
+          event.canceled && initialColumnOrder != null
+            ? initialColumnOrder
+            : columnOrder;
+        if (finalColumnOrder !== columnOrder) {
+          onColumnOrderChange(finalColumnOrder);
         }
-        if (initialColumnOrder != null) {
-          onColumnOrderChange(initialColumnOrder);
-          onColumnOrderCommit?.(initialColumnOrder);
-        }
+        onColumnOrderCommit?.(finalColumnOrder);
       }}
     >
       {children}

--- a/app/src/components/table/columnOrdering/ColumnOrderingProvider.tsx
+++ b/app/src/components/table/columnOrdering/ColumnOrderingProvider.tsx
@@ -50,6 +50,13 @@ export interface ColumnOrderingProviderProps {
   columnOrder: string[];
   /** Called with the new order as it changes during a drag and when a canceled drag restores the original order. */
   onColumnOrderChange: (columnOrder: string[]) => void;
+  /**
+   * Called once with the final order when a drag ends (the restored original
+   * order if the drag was canceled). Wire expensive consumers (e.g. a table
+   * re-render) here and keep `onColumnOrderChange` cheap when reorders should
+   * not be applied live on every drag-over step.
+   */
+  onColumnOrderCommit?: (columnOrder: string[]) => void;
   children: ReactNode;
 }
 
@@ -60,6 +67,7 @@ export interface ColumnOrderingProviderProps {
 export function ColumnOrderingProvider({
   columnOrder,
   onColumnOrderChange,
+  onColumnOrderCommit,
   children,
 }: ColumnOrderingProviderProps) {
   // The order when the current drag started, restored if the drag is canceled
@@ -89,10 +97,12 @@ export function ColumnOrderingProvider({
         // The order the user saw was already committed during the drag;
         // re-applying move() here would shift the column a second time.
         if (!event.canceled) {
+          onColumnOrderCommit?.(columnOrder);
           return;
         }
         if (initialColumnOrder != null) {
           onColumnOrderChange(initialColumnOrder);
+          onColumnOrderCommit?.(initialColumnOrder);
         }
       }}
     >

--- a/app/src/components/table/columnSelector/ColumnSelector.tsx
+++ b/app/src/components/table/columnSelector/ColumnSelector.tsx
@@ -19,7 +19,7 @@ import {
   dndHandleAppearanceCSS,
 } from "@phoenix/components/dnd";
 
-import { ColumnOrderingProvider } from "../columnOrdering";
+import { ColumnOrderingProvider, orderColumns } from "../columnOrdering";
 
 export interface ColumnSelectorColumn {
   id: string;
@@ -181,15 +181,13 @@ export function ColumnSelectorMenu({
   const [draftColumnOrder, setDraftColumnOrder] = useState<string[] | null>(
     null
   );
-  const orderedColumns = useMemo(() => {
-    if (draftColumnOrder == null) {
-      return columns;
-    }
-    const columnsById = new Map(columns.map((column) => [column.id, column]));
-    return draftColumnOrder
-      .map((columnId) => columnsById.get(columnId))
-      .filter((column) => column != null);
-  }, [columns, draftColumnOrder]);
+  const orderedColumns = useMemo(
+    () =>
+      draftColumnOrder == null
+        ? columns
+        : orderColumns({ columns, columnOrder: draftColumnOrder }),
+    [columns, draftColumnOrder]
+  );
   const filteredColumns = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
     if (!query) {
@@ -222,7 +220,15 @@ export function ColumnSelectorMenu({
           onColumnOrderChange={setDraftColumnOrder}
           onColumnOrderCommit={(columnOrder) => {
             setDraftColumnOrder(null);
-            onColumnOrderChange?.(columnOrder);
+            // A canceled or round-trip drag commits the order it started
+            // with; skip the parent update so consumers don't persist and
+            // re-render for an unchanged order.
+            const hasOrderChanged = columnOrder.some(
+              (columnId, index) => columns[index]?.id !== columnId
+            );
+            if (hasOrderChanged) {
+              onColumnOrderChange?.(columnOrder);
+            }
           }}
         >
           <ul css={columnListCSS}>

--- a/app/src/components/table/columnSelector/ColumnSelector.tsx
+++ b/app/src/components/table/columnSelector/ColumnSelector.tsx
@@ -175,15 +175,30 @@ export function ColumnSelectorMenu({
   children,
 }: ColumnSelectorMenuProps) {
   const [searchQuery, setSearchQuery] = useState("");
+  // Order previewed while a drag is in flight. Reorders are applied to this
+  // local draft on every drag-over step so only the popover list re-renders;
+  // the (expensive) table column order is committed once when the drag ends.
+  const [draftColumnOrder, setDraftColumnOrder] = useState<string[] | null>(
+    null
+  );
+  const orderedColumns = useMemo(() => {
+    if (draftColumnOrder == null) {
+      return columns;
+    }
+    const columnsById = new Map(columns.map((column) => [column.id, column]));
+    return draftColumnOrder
+      .map((columnId) => columnsById.get(columnId))
+      .filter((column) => column != null);
+  }, [columns, draftColumnOrder]);
   const filteredColumns = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
     if (!query) {
-      return columns;
+      return orderedColumns;
     }
-    return columns.filter((column) =>
+    return orderedColumns.filter((column) =>
       column.label.toLowerCase().includes(query)
     );
-  }, [columns, searchQuery]);
+  }, [orderedColumns, searchQuery]);
 
   // Reordering a filtered list is ambiguous, so it is only enabled when the
   // full list is shown
@@ -203,10 +218,12 @@ export function ColumnSelectorMenu({
       </MenuHeader>
       <div css={columnSelectorBodyCSS}>
         <ColumnOrderingProvider
-          columnOrder={columns.map((column) => column.id)}
-          onColumnOrderChange={(columnOrder) =>
-            onColumnOrderChange?.(columnOrder)
-          }
+          columnOrder={orderedColumns.map((column) => column.id)}
+          onColumnOrderChange={setDraftColumnOrder}
+          onColumnOrderCommit={(columnOrder) => {
+            setDraftColumnOrder(null);
+            onColumnOrderChange?.(columnOrder);
+          }}
         >
           <ul css={columnListCSS}>
             {filteredColumns.map((column, index) => (

--- a/app/src/pages/project/IOValueTooltipCell.tsx
+++ b/app/src/pages/project/IOValueTooltipCell.tsx
@@ -239,7 +239,10 @@ function IOValueTooltipCell({
       >
         <span>{previewText}</span>
       </TriggerWrap>
-      <RichTooltip placement="bottom start" width="auto" css={tooltipCSS}>
+      {/* Side placement keeps the tooltip out of the column's vertical mouse
+          path so users can scan values by moving down the column; react-aria
+          flips it to the other side when there is no room. */}
+      <RichTooltip placement="end top" offset={4} width="auto" css={tooltipCSS}>
         <div css={tooltipContentCSS}>
           <div css={[scrollFadeCSS, scrollFadeTopCSS]} aria-hidden />
           <ErrorBoundary fallback={TextErrorBoundaryFallback}>

--- a/app/src/pages/project/IOValueTooltipCell.tsx
+++ b/app/src/pages/project/IOValueTooltipCell.tsx
@@ -242,7 +242,7 @@ function IOValueTooltipCell({
       {/* Side placement keeps the tooltip out of the column's vertical mouse
           path so users can scan values by moving down the column; react-aria
           flips it to the other side when there is no room. */}
-      <RichTooltip placement="end top" offset={4} width="auto" css={tooltipCSS}>
+      <RichTooltip placement="end top" offset={3} width="auto" css={tooltipCSS}>
         <div css={tooltipContentCSS}>
           <div css={[scrollFadeCSS, scrollFadeTopCSS]} aria-hidden />
           <ErrorBoundary fallback={TextErrorBoundaryFallback}>


### PR DESCRIPTION
## Problem

Two usability issues with the tracing tables (spans / traces / sessions):

1. The IO value tooltips open below the cell (`bottom start`), directly in the mouse path. Moving down the column runs the cursor into the tooltip, which keeps it open (react-aria hoverable tooltips) and blocks scanning values row by row.
2. Dragging a column in the column selector committed the new column order to the table on **every drag-over step**, re-rendering the whole table repeatedly during the drag and causing jank.

## Changes

### Tooltip placement (`IOValueTooltipCell`)

Anchor the tooltip to the side of the cell instead (`end top`, 4px offset):

- Tooltip opens just past the right edge of the cell, top-aligned with the hovered row, leaving the column's vertical mouse path clear — you can run the cursor straight down the input/output column and read each value as it appears beside the row.
- react-aria flips it to the left automatically when there's no room on the right.
- Scanning stays fast: only the first tooltip waits the 700ms delay; subsequent rows show immediately via react-aria's warmup.

No changes to the lazy full-value fetch, scroll fades, or height cap.

### Column selector drag performance (`ColumnSelector`, `ColumnOrderingProvider`)

Defer the table update until the drag ends:

- `ColumnOrderingProvider` gains an optional `onColumnOrderCommit` callback fired once with the final order when a drag ends (the restored original order on cancel).
- `ColumnSelectorMenu` now previews reorders in local draft state — only the popover list re-renders during the drag — and commits the order to the table once on drop.
- Header-drag reordering in the tables is untouched: those call sites don't pass `onColumnOrderCommit`, so columns still move live under the header, which is the point of that interaction.