### PR TITLE
fix(ui): let the attributes table's columns be resized again

### DIFF
--- a/app/src/components/table/TableColumnHeader.tsx
+++ b/app/src/components/table/TableColumnHeader.tsx
@@ -32,6 +32,12 @@ export function TableColumnHeader<Data, Value>({
 }: {
   header: Header<Data, Value>;
 }) {
+  // TanStack hands back the same header object on every render — a resize or a
+  // sort mutates it in place rather than rebuilding it — so a memoized version
+  // of this component would go on reporting the width and sort direction the
+  // column was first rendered with, and a drag of the resizer would move
+  // nothing.
+  "use no memo";
   const { column } = header;
   const sorted = column.getIsSorted();
   const canSort = column.getCanSort();

--- a/app/src/components/table/__tests__/TableColumnHeader.test.tsx
+++ b/app/src/components/table/__tests__/TableColumnHeader.test.tsx
@@ -1,0 +1,118 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { TableColumnHeader } from "../TableColumnHeader";
+
+type Row = { key: string };
+
+const columns: ColumnDef<Row>[] = [
+  { id: "key", header: "Key", accessorKey: "key", size: 320 },
+  { id: "value", header: "Value", accessorKey: "key", enableResizing: false },
+];
+
+/**
+ * The header row on its own: no `style` prop, which is the arrangement a table
+ * without pinned columns renders.
+ */
+function HeaderRow() {
+  "use no memo";
+  // eslint-disable-next-line react-hooks-js/incompatible-library
+  const table = useReactTable<Row>({
+    columns,
+    data: [{ key: "llm.model_name" }],
+    columnResizeMode: "onChange",
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+  return (
+    <table>
+      <thead>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <TableColumnHeader key={header.id} header={header} />
+            ))}
+          </tr>
+        ))}
+      </thead>
+    </table>
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function query(selector: string): Element {
+  const element = container.querySelector(selector);
+  if (element === null) {
+    throw new Error(`no element matched ${selector}`);
+  }
+  return element;
+}
+
+/** The first header cell, as the element whose inline width is read below. */
+function queryHeader(): HTMLTableCellElement {
+  const element = query("th");
+  if (!(element instanceof HTMLTableCellElement)) {
+    throw new Error("the header cell is not a <th>");
+  }
+  return element;
+}
+
+describe("TableColumnHeader", () => {
+  it("takes the width a drag of its resizer leaves the column at", () => {
+    act(() => {
+      root.render(<HeaderRow />);
+    });
+    const header = queryHeader();
+    expect(header.style.width).toBe("320px");
+
+    // TanStack hands the same header object back on every render, so a
+    // memoized header would keep reporting the width the column started at
+    act(() => {
+      query("div.resizer").dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, clientX: 320 })
+      );
+    });
+    act(() => {
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { bubbles: true, clientX: 420 })
+      );
+    });
+    expect(header.style.width).toBe("420px");
+
+    act(() => {
+      document.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, clientX: 420 })
+      );
+    });
+    expect(header.style.width).toBe("420px");
+  });
+
+  it("gives a column that cannot be resized no resizer", () => {
+    act(() => {
+      root.render(<HeaderRow />);
+    });
+    expect(container.querySelectorAll("div.resizer")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
The key column of the span attributes table could not be dragged wider or narrower.

## Cause

The React Compiler memoizes `TableColumnHeader`, and TanStack hands back the *same* `header` object on every render — a resize mutates it in place rather than rebuilding it. With no prop identity changing, the memoized header kept rendering the width its column started at. The drag did update `columnSizing` and the table did re-render; the header simply never reflected it. The stale sort caret and `isResizing` class came along for the ride.

Every other table component in the app carries `"use no memo"` for this reason. `TableColumnHeader`, extracted as a shared component in #14746, did not. `ResizableTable` escaped the bug by accident — it passes a freshly built `getCommonPinningStyles(column)` object each render, so a prop identity changes and forces the re-render. The span attributes table passes no `style`, so its header stayed frozen.

## Change

`"use no memo"` on `TableColumnHeader`, plus a regression test that drags the resizer and asserts the header takes the new width. The test fails without the directive (`expected '320px' to be '420px'`) and passes with it.

## Test plan

- [x] `pnpm vitest run` — 2012 passing
- [x] `pnpm typecheck`, `pnpm lint` — no new findings
- [x] Open a span's Attributes card and drag the boundary between Key and Value