### PR TITLE
docs: add encryption guide to self-hosting advanced section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1204,6 +1204,11 @@
             ]
           },
           {
+            "group": "Advanced",
+            "icon": "gears",
+            "pages": ["docs/phoenix/self-hosting/advanced/encryption"]
+          },
+          {
             "group": "Misc",
             "icon": "boxes-stacked",
             "pages": [

--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -692,10 +692,10 @@
 
 - [Migrations](https://arize.com/docs/phoenix/self-hosting/upgrade/migrations): Database migration guide
 - [Privacy](https://arize.com/docs/phoenix/self-hosting/security/privacy): Privacy and data protection
+- [Network Security](https://arize.com/docs/phoenix/self-hosting/security/network-security): Restrict outbound requests, configure network policies, and enable CSRF protection
+- [Encryption](https://arize.com/docs/phoenix/self-hosting/advanced/encryption): Configure TLS/HTTPS, encryption at rest, and application-level encryption of secrets
 - [Self-Hosting FAQs](https://arize.com/docs/phoenix/self-hosting/misc/frequently-asked-questions): Troubleshoot common self-hosting issues
 
-
-- [Network Security](https://arize.com/docs/phoenix/self-hosting/security/network-security): Understanding outbound network requests and how to secure your self-hosted Phoenix deployment
 ## Cookbooks
 
 - [Cookbook Index](https://arize.com/docs/phoenix/cookbook): All examples — agents, evaluation, tracing, prompt engineering, datasets

--- a/docs/phoenix/self-hosting/advanced/encryption.mdx
+++ b/docs/phoenix/self-hosting/advanced/encryption.mdx
@@ -1,0 +1,156 @@
+---
+title: "Encryption"
+description: Encryption in transit (TLS/HTTPS), at rest (database and storage), and application-level encryption for self-hosted Phoenix deployments
+---
+
+## Overview
+
+Phoenix is designed to be self-hosted securely. This guide covers the three layers of encryption relevant to a production deployment:
+
+1. **[Encryption in transit](#encryption-in-transit-tls-https)** — TLS/HTTPS between clients and Phoenix, and between Phoenix and its database
+2. **[Encryption at rest](#encryption-at-rest)** — encrypting the database and storage volumes that hold your data
+3. **[Application-level encryption](#application-level-encryption)** — how Phoenix hashes and encrypts sensitive values (passwords, API keys, stored provider credentials) before they reach the database
+
+It is assumed you are familiar with the [Phoenix architecture](/docs/phoenix/self-hosting/architecture): a single server container backed by a PostgreSQL (or SQLite) database.
+
+## Encryption in Transit (TLS / HTTPS)
+
+Phoenix serves its UI, REST/GraphQL APIs, and OTLP trace collection over HTTP (port `6006`) and optionally OTLP over gRPC (port `4317`). In production, this traffic should always be encrypted. There are three common approaches.
+
+### Option 1: Load Balancer / Ingress Termination
+
+TLS is terminated at a load balancer or ingress controller (e.g., AWS ALB, GCP Load Balancer, NGINX Ingress), which forwards decrypted traffic to the Phoenix container over HTTP.
+
+- **Pros:** Certificate management is typically fully managed by the cloud provider; offloads TLS overhead from the application; the most common and straightforward setup.
+- **Cons:** Traffic between the load balancer and the Phoenix container is unencrypted (though usually confined to a private network).
+
+<Note>
+If you terminate TLS for gRPC traffic at a load balancer, make sure it supports HTTP/2 end-to-end — OTLP over gRPC requires it.
+</Note>
+
+### Option 2: Native TLS on the Phoenix Server
+
+Unlike many web applications, Phoenix can terminate TLS itself — no reverse proxy required. This encrypts traffic all the way to the container, which is useful for simple deployments or environments where a load balancer is not available.
+
+```bash
+# Enable TLS for both HTTP and gRPC
+export PHOENIX_TLS_ENABLED=true
+export PHOENIX_TLS_CERT_FILE=/etc/ssl/certs/phoenix.crt
+export PHOENIX_TLS_KEY_FILE=/etc/ssl/private/phoenix.key
+
+# Optional: password for an encrypted private key
+export PHOENIX_TLS_KEY_FILE_PASSWORD=your-key-password
+```
+
+TLS can also be enabled selectively per protocol:
+
+| Environment Variable            | Description                                                          |
+| :------------------------------ | :------------------------------------------------------------------- |
+| `PHOENIX_TLS_ENABLED`           | Enable TLS for both the HTTP and gRPC servers                        |
+| `PHOENIX_TLS_ENABLED_FOR_HTTP`  | Enable TLS for the HTTP server only (overrides `PHOENIX_TLS_ENABLED`) |
+| `PHOENIX_TLS_ENABLED_FOR_GRPC`  | Enable TLS for the gRPC server only (overrides `PHOENIX_TLS_ENABLED`) |
+| `PHOENIX_TLS_CERT_FILE`         | Path to the TLS certificate file (PEM)                               |
+| `PHOENIX_TLS_KEY_FILE`          | Path to the TLS private key file (PEM)                               |
+| `PHOENIX_TLS_KEY_FILE_PASSWORD` | Password for the private key file, if encrypted                      |
+| `PHOENIX_TLS_CA_FILE`           | Path to the CA certificate used to verify client certificates        |
+| `PHOENIX_TLS_VERIFY_CLIENT`     | Require and verify client certificates (mutual TLS)                  |
+
+For mutual TLS (mTLS), where Phoenix also verifies the certificates of connecting clients:
+
+```bash
+export PHOENIX_TLS_VERIFY_CLIENT=true
+export PHOENIX_TLS_CA_FILE=/etc/ssl/certs/ca.crt
+```
+
+Remember to point clients at `https://` (and configure them with the CA certificate if you use a private CA).
+
+### Option 3: Service Mesh Sidecar
+
+In Kubernetes environments, a service mesh (e.g., Istio, Linkerd, Cilium mTLS) can transparently encrypt all pod-to-pod traffic with mutual TLS via sidecar or node-level proxies.
+
+- **Pros:** End-to-end encryption inside the cluster without application configuration; adds traffic management and observability.
+- **Cons:** Adds operational complexity; requires familiarity with service mesh concepts.
+
+### Encrypting the Database Connection
+
+Traffic between Phoenix and PostgreSQL should also be encrypted, especially when the database runs outside the Phoenix host or cluster. Phoenix supports standard PostgreSQL SSL parameters in the connection string:
+
+```bash
+# Require an encrypted connection and verify the server certificate
+export PHOENIX_SQL_DATABASE_URL="postgresql://user:password@db.example.com:5432/phoenix?sslmode=verify-full&sslrootcert=/etc/ssl/certs/rds-ca.pem"
+```
+
+Supported parameters include `sslmode`, `sslrootcert`, `sslcert`, `sslkey`, and `sslpassword` (for client-certificate authentication).
+
+<Note>
+When using [AWS RDS IAM authentication](/docs/phoenix/self-hosting/configuration/using-amazon-aurora) or [Azure Managed Identity](/docs/phoenix/self-hosting/configuration/using-azure-managed-identity), SSL is enforced automatically and cannot be disabled.
+</Note>
+
+### Other Encrypted Connections
+
+- **LDAP:** When using LDAP authentication, always use `PHOENIX_LDAP_TLS_MODE=starttls` or `ldaps` in production. See [Authentication](/docs/phoenix/self-hosting/features/authentication) for the full set of LDAP TLS options, including custom CAs and client certificates.
+- **SMTP:** Phoenix connects to your mail server with STARTTLS and validates certificates by default (`PHOENIX_SMTP_VALIDATE_CERTS=true`). See [Email](/docs/phoenix/self-hosting/features/email).
+- **Outbound LLM provider calls:** Requests from the Playground and evaluations to AI provider APIs use HTTPS. To control which endpoints Phoenix can reach, see [Network Security](/docs/phoenix/self-hosting/security/network-security).
+
+## Encryption at Rest
+
+All Phoenix application data — traces, datasets, experiments, prompts, annotations, users, and settings — lives in your database. Encrypting that storage is strongly recommended for production deployments.
+
+### PostgreSQL
+
+For production deployments we recommend a managed PostgreSQL service (e.g., Amazon RDS/Aurora, Google Cloud SQL, Azure Database for PostgreSQL), all of which offer built-in encryption at rest (typically AES-256), often enabled by default or with a single setting. Verify that:
+
+- Storage encryption is enabled on the instance
+- Automated backups and snapshots are encrypted (this usually follows from instance encryption)
+- Encryption keys are managed appropriately for your compliance needs (e.g., customer-managed keys via KMS)
+
+For self-managed PostgreSQL, use full-disk or volume-level encryption (e.g., LUKS, encrypted EBS volumes, encrypted Kubernetes persistent volumes) on the data directory, and refer to the PostgreSQL documentation for options such as `pgcrypto` if you need finer-grained control.
+
+### SQLite
+
+When Phoenix runs without PostgreSQL, data is stored as SQLite files in the Phoenix working directory (`PHOENIX_WORKING_DIR`). Place the working directory on an encrypted volume or filesystem. SQLite-backed deployments are best suited for development and small teams; use PostgreSQL for production.
+
+### Backups and Exports
+
+Anything derived from the database inherits its sensitivity: database dumps, snapshots, and exported datasets should be stored on encrypted media and transferred over encrypted channels.
+
+## Application-Level Encryption
+
+Beyond transport and storage encryption, Phoenix hashes or encrypts sensitive values at the application layer before persisting them, so they are not readable in plaintext even with direct database access.
+
+| Data                                                | Protection                                                                                             |
+| :-------------------------------------------------- | :----------------------------------------------------------------------------------------------------- |
+| User passwords                                      | Salted and hashed with PBKDF2-HMAC-SHA256 (per-user salt); never stored or recoverable in plaintext     |
+| API keys and session tokens                         | Issued as JWTs signed with a key derived from `PHOENIX_SECRET`; only the token identifier is stored     |
+| AI provider credentials (custom providers, secrets) | Encrypted with Fernet (AES-128-CBC + HMAC-SHA256) using a key derived from `PHOENIX_SECRET` via PBKDF2  |
+
+The `PHOENIX_SECRET` environment variable is the root of trust for application-level protection:
+
+```bash
+export PHOENIX_ENABLE_AUTH=true
+export PHOENIX_SECRET=a-secret-of-at-least-32-characters-with-digits-1
+```
+
+<Warning>
+Treat `PHOENIX_SECRET` like a master key:
+
+- Use a long, random value (at least 32 characters, including digits and lowercase letters) generated by a secrets manager — never a dictionary word or a value reused from another system.
+- Store it in a secrets manager (e.g., Kubernetes Secrets, AWS Secrets Manager, HashiCorp Vault), not in plaintext configuration or images.
+- Changing `PHOENIX_SECRET` invalidates existing sessions and makes previously encrypted credentials (e.g., stored AI provider API keys) undecryptable — they must be re-entered after rotation.
+</Warning>
+
+<Note>
+Application-level encryption protects against exposure of database backups and dumps. It does not protect against an attacker who obtains both the database **and** `PHOENIX_SECRET` — keep the secret separate from database backups.
+</Note>
+
+## Summary
+
+| Layer                | Recommendation                                                                                          |
+| :------------------- | :------------------------------------------------------------------------------------------------------ |
+| Client ↔ Phoenix     | Terminate TLS at a load balancer, enable native TLS (`PHOENIX_TLS_*`), or use a service mesh             |
+| Phoenix ↔ PostgreSQL | Set `sslmode=verify-full` (or at least `require`) with a trusted root certificate                         |
+| Data at rest         | Use a managed database with encryption at rest, or encrypted volumes for self-managed databases/SQLite   |
+| Secrets in the app   | Set a strong `PHOENIX_SECRET`; passwords are hashed and stored credentials are encrypted with it          |
+| Backups              | Store dumps, snapshots, and exports on encrypted media, separately from `PHOENIX_SECRET`                 |
+
+For related hardening guidance, see [Network Security](/docs/phoenix/self-hosting/security/network-security), [Authentication](/docs/phoenix/self-hosting/features/authentication), and [Access Control (RBAC)](/docs/phoenix/settings/access-control-rbac).

--- a/docs/phoenix/self-hosting/advanced/encryption.mdx
+++ b/docs/phoenix/self-hosting/advanced/encryption.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Encryption"
-description: Encryption in transit (TLS/HTTPS), at rest (database and storage), and application-level encryption for self-hosted Phoenix deployments
+description: Encryption in transit (TLS/HTTPS), at rest, and application-level encryption for self-hosted Phoenix deployments
 ---
 
 ## Overview
 
-Phoenix is designed to be self-hosted securely. This guide covers the three layers of encryption relevant to a production deployment:
+This guide covers the three layers of encryption relevant to a production Phoenix deployment:
 
 1. **[Encryption in transit](#encryption-in-transit-tls-https)** — TLS/HTTPS between clients and Phoenix, and between Phoenix and its database
-2. **[Encryption at rest](#encryption-at-rest)** — encrypting the database and storage volumes that hold your data
-3. **[Application-level encryption](#application-level-encryption)** — how Phoenix hashes and encrypts sensitive values (passwords, API keys, stored provider credentials) before they reach the database
+2. **[Encryption at rest](#encryption-at-rest)** — encrypting the database and storage that hold your data
+3. **[Application-level encryption](#application-level-encryption)** — how Phoenix hashes and encrypts sensitive values before they reach the database
 
-It is assumed you are familiar with the [Phoenix architecture](/docs/phoenix/self-hosting/architecture): a single server container backed by a PostgreSQL (or SQLite) database.
+It is assumed you are familiar with the [Phoenix architecture](/docs/phoenix/self-hosting/architecture): a single server container backed by a PostgreSQL database.
 
 ## Encryption in Transit (TLS / HTTPS)
 
@@ -19,30 +19,20 @@ Phoenix serves its UI, REST/GraphQL APIs, and OTLP trace collection over HTTP (p
 
 ### Option 1: Load Balancer / Ingress Termination
 
-TLS is terminated at a load balancer or ingress controller (e.g., AWS ALB, GCP Load Balancer, NGINX Ingress), which forwards decrypted traffic to the Phoenix container over HTTP.
+TLS is terminated at a load balancer or ingress controller (e.g., AWS ALB, NGINX Ingress), which forwards decrypted traffic to the Phoenix container over HTTP.
 
-- **Pros:** Certificate management is typically fully managed by the cloud provider; offloads TLS overhead from the application; the most common and straightforward setup.
+- **Pros:** Certificate management is typically handled by the cloud provider; the most common and straightforward setup.
 - **Cons:** Traffic between the load balancer and the Phoenix container is unencrypted (though usually confined to a private network).
-
-<Note>
-If you terminate TLS for gRPC traffic at a load balancer, make sure it supports HTTP/2 end-to-end — OTLP over gRPC requires it.
-</Note>
 
 ### Option 2: Native TLS on the Phoenix Server
 
-Unlike many web applications, Phoenix can terminate TLS itself — no reverse proxy required. This encrypts traffic all the way to the container, which is useful for simple deployments or environments where a load balancer is not available.
+Phoenix can terminate TLS itself — no reverse proxy required:
 
 ```bash
-# Enable TLS for both HTTP and gRPC
 export PHOENIX_TLS_ENABLED=true
 export PHOENIX_TLS_CERT_FILE=/etc/ssl/certs/phoenix.crt
 export PHOENIX_TLS_KEY_FILE=/etc/ssl/private/phoenix.key
-
-# Optional: password for an encrypted private key
-export PHOENIX_TLS_KEY_FILE_PASSWORD=your-key-password
 ```
-
-TLS can also be enabled selectively per protocol:
 
 | Environment Variable            | Description                                                          |
 | :------------------------------ | :------------------------------------------------------------------- |
@@ -55,32 +45,22 @@ TLS can also be enabled selectively per protocol:
 | `PHOENIX_TLS_CA_FILE`           | Path to the CA certificate used to verify client certificates        |
 | `PHOENIX_TLS_VERIFY_CLIENT`     | Require and verify client certificates (mutual TLS)                  |
 
-For mutual TLS (mTLS), where Phoenix also verifies the certificates of connecting clients:
-
-```bash
-export PHOENIX_TLS_VERIFY_CLIENT=true
-export PHOENIX_TLS_CA_FILE=/etc/ssl/certs/ca.crt
-```
-
 Remember to point clients at `https://` (and configure them with the CA certificate if you use a private CA).
 
 ### Option 3: Service Mesh Sidecar
 
-In Kubernetes environments, a service mesh (e.g., Istio, Linkerd, Cilium mTLS) can transparently encrypt all pod-to-pod traffic with mutual TLS via sidecar or node-level proxies.
+In Kubernetes environments, a service mesh (e.g., Istio, Linkerd) can transparently encrypt all pod-to-pod traffic with mutual TLS.
 
-- **Pros:** End-to-end encryption inside the cluster without application configuration; adds traffic management and observability.
+- **Pros:** End-to-end encryption inside the cluster without application configuration.
 - **Cons:** Adds operational complexity; requires familiarity with service mesh concepts.
 
 ### Encrypting the Database Connection
 
-Traffic between Phoenix and PostgreSQL should also be encrypted, especially when the database runs outside the Phoenix host or cluster. Phoenix supports standard PostgreSQL SSL parameters in the connection string:
+Traffic between Phoenix and PostgreSQL should also be encrypted when the database runs outside the Phoenix host or cluster. Phoenix supports standard PostgreSQL SSL parameters (`sslmode`, `sslrootcert`, `sslcert`, `sslkey`, `sslpassword`) in the connection string:
 
 ```bash
-# Require an encrypted connection and verify the server certificate
-export PHOENIX_SQL_DATABASE_URL="postgresql://user:password@db.example.com:5432/phoenix?sslmode=verify-full&sslrootcert=/etc/ssl/certs/rds-ca.pem"
+export PHOENIX_SQL_DATABASE_URL="postgresql://user:password@db.example.com:5432/phoenix?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.pem"
 ```
-
-Supported parameters include `sslmode`, `sslrootcert`, `sslcert`, `sslkey`, and `sslpassword` (for client-certificate authentication).
 
 <Note>
 When using [AWS RDS IAM authentication](/docs/phoenix/self-hosting/configuration/using-amazon-aurora) or [Azure Managed Identity](/docs/phoenix/self-hosting/configuration/using-azure-managed-identity), SSL is enforced automatically and cannot be disabled.
@@ -88,43 +68,29 @@ When using [AWS RDS IAM authentication](/docs/phoenix/self-hosting/configuration
 
 ### Other Encrypted Connections
 
-- **LDAP:** When using LDAP authentication, always use `PHOENIX_LDAP_TLS_MODE=starttls` or `ldaps` in production. See [Authentication](/docs/phoenix/self-hosting/features/authentication) for the full set of LDAP TLS options, including custom CAs and client certificates.
-- **SMTP:** Phoenix connects to your mail server with STARTTLS and validates certificates by default (`PHOENIX_SMTP_VALIDATE_CERTS=true`). See [Email](/docs/phoenix/self-hosting/features/email).
-- **Outbound LLM provider calls:** Requests from the Playground and evaluations to AI provider APIs use HTTPS. To control which endpoints Phoenix can reach, see [Network Security](/docs/phoenix/self-hosting/security/network-security).
+- **LDAP:** Use `PHOENIX_LDAP_TLS_MODE=starttls` (default) or `ldaps` in production. See [Authentication](/docs/phoenix/self-hosting/features/authentication).
+- **SMTP:** Server certificates are validated by default (`PHOENIX_SMTP_VALIDATE_CERTS=true`). See [Email](/docs/phoenix/self-hosting/features/email).
+- **Outbound LLM provider calls** use HTTPS. To control which endpoints Phoenix can reach, see [Network Security](/docs/phoenix/self-hosting/security/network-security).
 
 ## Encryption at Rest
 
-All Phoenix application data — traces, datasets, experiments, prompts, annotations, users, and settings — lives in your database. Encrypting that storage is strongly recommended for production deployments.
+All Phoenix application data — traces, datasets, experiments, prompts, annotations, users, and settings — lives in your database, so encrypting that storage is the main concern.
 
-### PostgreSQL
+For production deployments we recommend a managed PostgreSQL service (e.g., Amazon RDS/Aurora, Google Cloud SQL, Azure Database for PostgreSQL), which offer built-in encryption at rest — verify that storage encryption is enabled on the instance and that backups and snapshots are encrypted. For self-managed PostgreSQL, use disk or volume-level encryption (e.g., LUKS, encrypted EBS volumes, encrypted Kubernetes persistent volumes) on the data directory.
 
-For production deployments we recommend a managed PostgreSQL service (e.g., Amazon RDS/Aurora, Google Cloud SQL, Azure Database for PostgreSQL), all of which offer built-in encryption at rest (typically AES-256), often enabled by default or with a single setting. Verify that:
-
-- Storage encryption is enabled on the instance
-- Automated backups and snapshots are encrypted (this usually follows from instance encryption)
-- Encryption keys are managed appropriately for your compliance needs (e.g., customer-managed keys via KMS)
-
-For self-managed PostgreSQL, use full-disk or volume-level encryption (e.g., LUKS, encrypted EBS volumes, encrypted Kubernetes persistent volumes) on the data directory, and refer to the PostgreSQL documentation for options such as `pgcrypto` if you need finer-grained control.
-
-### SQLite
-
-When Phoenix runs without PostgreSQL, data is stored as SQLite files in the Phoenix working directory (`PHOENIX_WORKING_DIR`). Place the working directory on an encrypted volume or filesystem. SQLite-backed deployments are best suited for development and small teams; use PostgreSQL for production.
-
-### Backups and Exports
-
-Anything derived from the database inherits its sensitivity: database dumps, snapshots, and exported datasets should be stored on encrypted media and transferred over encrypted channels.
+Database dumps, snapshots, and exported data inherit the same sensitivity and should be stored on encrypted media.
 
 ## Application-Level Encryption
 
 Beyond transport and storage encryption, Phoenix hashes or encrypts sensitive values at the application layer before persisting them, so they are not readable in plaintext even with direct database access.
 
-| Data                                                | Protection                                                                                             |
-| :-------------------------------------------------- | :----------------------------------------------------------------------------------------------------- |
-| User passwords                                      | Salted and hashed with PBKDF2-HMAC-SHA256 (per-user salt); never stored or recoverable in plaintext     |
-| API keys and session tokens                         | Issued as JWTs signed with a key derived from `PHOENIX_SECRET`; only the token identifier is stored     |
-| AI provider credentials (custom providers, secrets) | Encrypted with Fernet (AES-128-CBC + HMAC-SHA256) using a key derived from `PHOENIX_SECRET` via PBKDF2  |
+| Data                                                | Protection                                                                                            |
+| :-------------------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| User passwords                                      | Salted and hashed with PBKDF2-HMAC-SHA256 (per-user salt); never stored in plaintext                   |
+| API keys and session tokens                         | Issued as JWTs signed with `PHOENIX_SECRET`; the token itself is never stored in the database          |
+| AI provider credentials (custom providers, secrets) | Encrypted with Fernet (AES-128-CBC + HMAC-SHA256) using a key derived from `PHOENIX_SECRET` via PBKDF2 |
 
-The `PHOENIX_SECRET` environment variable is the root of trust for application-level protection:
+The `PHOENIX_SECRET` environment variable is the root of trust for these protections. It must be at least 32 characters and include at least one digit and one lowercase letter:
 
 ```bash
 export PHOENIX_ENABLE_AUTH=true
@@ -134,23 +100,12 @@ export PHOENIX_SECRET=a-secret-of-at-least-32-characters-with-digits-1
 <Warning>
 Treat `PHOENIX_SECRET` like a master key:
 
-- Use a long, random value (at least 32 characters, including digits and lowercase letters) generated by a secrets manager — never a dictionary word or a value reused from another system.
-- Store it in a secrets manager (e.g., Kubernetes Secrets, AWS Secrets Manager, HashiCorp Vault), not in plaintext configuration or images.
-- Changing `PHOENIX_SECRET` invalidates existing sessions and makes previously encrypted credentials (e.g., stored AI provider API keys) undecryptable — they must be re-entered after rotation.
+- Use a long, random value and store it in a secrets manager (e.g., Kubernetes Secrets, AWS Secrets Manager, HashiCorp Vault) — never in plaintext configuration or images, and never alongside database backups.
+- Changing `PHOENIX_SECRET` invalidates existing sessions and API keys, and makes previously encrypted credentials (e.g., stored AI provider API keys) undecryptable — they must be re-entered after rotation.
 </Warning>
 
 <Note>
-Application-level encryption protects against exposure of database backups and dumps. It does not protect against an attacker who obtains both the database **and** `PHOENIX_SECRET` — keep the secret separate from database backups.
+Application-level encryption protects against exposure of database backups and dumps. It does not protect against an attacker who obtains both the database **and** `PHOENIX_SECRET`.
 </Note>
-
-## Summary
-
-| Layer                | Recommendation                                                                                          |
-| :------------------- | :------------------------------------------------------------------------------------------------------ |
-| Client ↔ Phoenix     | Terminate TLS at a load balancer, enable native TLS (`PHOENIX_TLS_*`), or use a service mesh             |
-| Phoenix ↔ PostgreSQL | Set `sslmode=verify-full` (or at least `require`) with a trusted root certificate                         |
-| Data at rest         | Use a managed database with encryption at rest, or encrypted volumes for self-managed databases/SQLite   |
-| Secrets in the app   | Set a strong `PHOENIX_SECRET`; passwords are hashed and stored credentials are encrypted with it          |
-| Backups              | Store dumps, snapshots, and exports on encrypted media, separately from `PHOENIX_SECRET`                 |
 
 For related hardening guidance, see [Network Security](/docs/phoenix/self-hosting/security/network-security), [Authentication](/docs/phoenix/self-hosting/features/authentication), and [Access Control (RBAC)](/docs/phoenix/settings/access-control-rbac).

--- a/docs/phoenix/self-hosting/advanced/encryption.mdx
+++ b/docs/phoenix/self-hosting/advanced/encryption.mdx
@@ -7,11 +7,11 @@ description: Encryption in transit (TLS/HTTPS), at rest, and application-level e
 
 This guide covers the three layers of encryption relevant to a production Phoenix deployment:
 
-1. **[Encryption in transit](#encryption-in-transit-tls-https)** — TLS/HTTPS between clients and Phoenix, and between Phoenix and its database
-2. **[Encryption at rest](#encryption-at-rest)** — encrypting the database and storage that hold your data
-3. **[Application-level encryption](#application-level-encryption)** — how Phoenix hashes and encrypts sensitive values before they reach the database
+1. **[Encryption in transit](#encryption-in-transit-tls-https)**: TLS/HTTPS between clients and Phoenix, and between Phoenix and its database
+2. **[Encryption at rest](#encryption-at-rest)**: encrypting the database and storage that hold your data
+3. **[Application-level encryption](#application-level-encryption)**: how Phoenix hashes and encrypts sensitive values before they reach the database
 
-It is assumed you are familiar with the [Phoenix architecture](/docs/phoenix/self-hosting/architecture): a single server container backed by a PostgreSQL database.
+If you haven't already, take a look at the [Phoenix architecture](/docs/phoenix/self-hosting/architecture): a single server container backed by a PostgreSQL database.
 
 ## Encryption in Transit (TLS / HTTPS)
 
@@ -21,12 +21,12 @@ Phoenix serves its UI, REST/GraphQL APIs, and OTLP trace collection over HTTP (p
 
 TLS is terminated at a load balancer or ingress controller (e.g., AWS ALB, NGINX Ingress), which forwards decrypted traffic to the Phoenix container over HTTP.
 
-- **Pros:** Certificate management is typically handled by the cloud provider; the most common and straightforward setup.
+- **Pros:** Certificate management is typically handled by the cloud provider. This is the most common and straightforward setup.
 - **Cons:** Traffic between the load balancer and the Phoenix container is unencrypted (though usually confined to a private network).
 
 ### Option 2: Native TLS on the Phoenix Server
 
-Phoenix can terminate TLS itself — no reverse proxy required:
+Phoenix can terminate TLS itself, with no reverse proxy required:
 
 ```bash
 export PHOENIX_TLS_ENABLED=true
@@ -52,7 +52,7 @@ Remember to point clients at `https://` (and configure them with the CA certific
 In Kubernetes environments, a service mesh (e.g., Istio, Linkerd) can transparently encrypt all pod-to-pod traffic with mutual TLS.
 
 - **Pros:** End-to-end encryption inside the cluster without application configuration.
-- **Cons:** Adds operational complexity; requires familiarity with service mesh concepts.
+- **Cons:** Adds operational complexity and requires familiarity with service mesh concepts.
 
 ### Encrypting the Database Connection
 
@@ -74,11 +74,11 @@ When using [AWS RDS IAM authentication](/docs/phoenix/self-hosting/configuration
 
 ## Encryption at Rest
 
-All Phoenix application data — traces, datasets, experiments, prompts, annotations, users, and settings — lives in your database, so encrypting that storage is the main concern.
+All Phoenix application data (traces, datasets, experiments, prompts, annotations, users, and settings) lives in your database, so encrypting that storage is the main concern.
 
-For production deployments we recommend a managed PostgreSQL service (e.g., Amazon RDS/Aurora, Google Cloud SQL, Azure Database for PostgreSQL), which offer built-in encryption at rest — verify that storage encryption is enabled on the instance and that backups and snapshots are encrypted. For self-managed PostgreSQL, use disk or volume-level encryption (e.g., LUKS, encrypted EBS volumes, encrypted Kubernetes persistent volumes) on the data directory.
+For production deployments we recommend a managed PostgreSQL service such as Amazon RDS/Aurora, Google Cloud SQL, or Azure Database for PostgreSQL. These offer built-in encryption at rest; verify that storage encryption is enabled on the instance and that backups and snapshots are encrypted. For self-managed PostgreSQL, use disk or volume-level encryption (e.g., LUKS, encrypted EBS volumes, encrypted Kubernetes persistent volumes) on the data directory.
 
-Database dumps, snapshots, and exported data inherit the same sensitivity and should be stored on encrypted media.
+Database dumps, snapshots, and exported data are just as sensitive as the database itself and should be stored on encrypted media.
 
 ## Application-Level Encryption
 
@@ -90,7 +90,7 @@ Beyond transport and storage encryption, Phoenix hashes or encrypts sensitive va
 | API keys and session tokens                         | Issued as JWTs signed with `PHOENIX_SECRET`; the token itself is never stored in the database          |
 | AI provider credentials (custom providers, secrets) | Encrypted with Fernet (AES-128-CBC + HMAC-SHA256) using a key derived from `PHOENIX_SECRET` via PBKDF2 |
 
-The `PHOENIX_SECRET` environment variable is the root of trust for these protections. It must be at least 32 characters and include at least one digit and one lowercase letter:
+All of these protections are anchored by the `PHOENIX_SECRET` environment variable. It must be at least 32 characters and include at least one digit and one lowercase letter:
 
 ```bash
 export PHOENIX_ENABLE_AUTH=true
@@ -100,8 +100,8 @@ export PHOENIX_SECRET=a-secret-of-at-least-32-characters-with-digits-1
 <Warning>
 Treat `PHOENIX_SECRET` like a master key:
 
-- Use a long, random value and store it in a secrets manager (e.g., Kubernetes Secrets, AWS Secrets Manager, HashiCorp Vault) — never in plaintext configuration or images, and never alongside database backups.
-- Changing `PHOENIX_SECRET` invalidates existing sessions and API keys, and makes previously encrypted credentials (e.g., stored AI provider API keys) undecryptable — they must be re-entered after rotation.
+- Use a long, random value and store it in a secrets manager (e.g., Kubernetes Secrets, AWS Secrets Manager, HashiCorp Vault). Never keep it in plaintext configuration or images, and never alongside database backups.
+- Changing `PHOENIX_SECRET` invalidates existing sessions and API keys, and makes previously encrypted credentials (e.g., stored AI provider API keys) undecryptable. They must be re-entered after rotation.
 </Warning>
 
 <Note>


### PR DESCRIPTION
Adds a new **Advanced** section under Self-Hosting docs with an **Encryption** page (`docs/phoenix/self-hosting/advanced/encryption.mdx`) covering:

- **Encryption in transit** — TLS termination at a load balancer/ingress, Phoenix's native TLS support (`PHOENIX_TLS_*` env vars including mTLS), service mesh sidecars, PostgreSQL connection encryption (`sslmode`, `sslrootcert`, etc.), and pointers to LDAP/SMTP TLS settings
- **Encryption at rest** — managed database encryption, encrypted volumes for self-managed PostgreSQL and SQLite working directories, and encrypted backups/exports
- **Application-level encryption** — how Phoenix protects sensitive values in the database: PBKDF2-HMAC-SHA256 salted password hashing, HS256-signed JWTs for API keys/sessions, and Fernet encryption of stored AI provider credentials keyed from `PHOENIX_SECRET` (with rotation and threat-model caveats)

Also:
- Registers the page in `docs.json` navigation under a new "Advanced" group in the Self-Hosting tab
- Adds an llms.txt entry and folds a stray Network Security entry back into its section
- Verified `docs.json` parses and the phoenix-cli llms.txt parser tests pass (25/25)
