### PR TITLE
fix(cost): carry LiteLLM above_NNNk tier rates into the manifest

### DIFF
--- a/.github/.scripts/sync_models.py
+++ b/.github/.scripts/sync_models.py
@@ -13,6 +13,60 @@ class TokenPrice(BaseModel):
     base_rate: float
     is_prompt: bool
     token_type: str
+    customization: dict[str, Any] | None = None
+
+
+# LiteLLM publishes whole-prompt tier rates alongside the flat rates, e.g.
+# `input_cost_per_token_above_200k_tokens`. Once the prompt strictly exceeds the
+# threshold the tier rate replaces the base rate outright, so a model priced at
+# 1.25e-6 below 200K and 2.5e-6 above it is under-billed 2x on long prompts if the
+# tier is ignored.
+ABOVE_TIER_PATTERN = re.compile(r"^(?P<base>.+)_above_(?P<thousands>\d+)k_tokens$")
+
+# Tier thresholds are measured against the prompt length, not the token type being
+# priced, so output and cache rates key off the prompt count too.
+PROMPT_TOKEN_COUNT_KEY = "llm.token_count.prompt"
+
+
+def extract_threshold_customization(
+    model_info: dict[str, Any],
+    base_field: str,
+) -> dict[str, Any] | None:
+    """Build a threshold_based customization from LiteLLM's `_above_NNNk_tokens` fields.
+
+    Returns None when the model publishes no tier rate for `base_field`. When more than
+    one tier is published, the lowest threshold wins: `ThresholdBasedTokenPriceCustomization`
+    holds a single breakpoint, and the lowest one is the point at which billing first
+    diverges from the base rate.
+    """
+    tiers: list[tuple[int, float]] = []
+    for key, value in model_info.items():
+        match = ABOVE_TIER_PATTERN.match(key)
+        if not match or match.group("base") != base_field:
+            continue
+        try:
+            new_rate = float(value)
+        except (TypeError, ValueError):
+            continue
+        if not new_rate:
+            continue
+        tiers.append((int(match.group("thousands")) * 1000, new_rate))
+
+    if not tiers:
+        return None
+    tiers.sort()
+    if len(tiers) > 1:
+        print(
+            f"  ! {base_field}: {len(tiers)} tiers published "
+            f"({', '.join(str(t) for t, _ in tiers)}); using {tiers[0][0]}"
+        )
+    threshold, new_rate = tiers[0]
+    return {
+        "type": "threshold_based",
+        "key": PROMPT_TOKEN_COUNT_KEY,
+        "threshold": threshold,
+        "new_rate": new_rate,
+    }
 
 
 def validate_regular_expression(value: str) -> str:
@@ -163,6 +217,9 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="input",
                     base_rate=input_cost,
                     is_prompt=True,
+                    customization=extract_threshold_customization(
+                        model_info, "input_cost_per_token"
+                    ),
                 )
             )
 
@@ -172,6 +229,9 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="output",
                     base_rate=output_cost,
                     is_prompt=False,
+                    customization=extract_threshold_customization(
+                        model_info, "output_cost_per_token"
+                    ),
                 )
             )
 
@@ -181,6 +241,9 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="cache_read",
                     base_rate=cache_read_cost,
                     is_prompt=True,
+                    customization=extract_threshold_customization(
+                        model_info, "cache_read_input_token_cost"
+                    ),
                 )
             )
 
@@ -190,6 +253,9 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="cache_write",
                     base_rate=cache_creation_cost,
                     is_prompt=True,
+                    customization=extract_threshold_customization(
+                        model_info, "cache_creation_input_token_cost"
+                    ),
                 )
             )
 
@@ -199,6 +265,9 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="audio",
                     base_rate=input_audio_cost,
                     is_prompt=True,
+                    customization=extract_threshold_customization(
+                        model_info, "input_cost_per_audio_token"
+                    ),
                 )
             )
 
@@ -208,6 +277,9 @@ def extract_litellm_entries(data: dict[str, Any]) -> list[LiteLLMPricingEntry]:
                     token_type="audio",
                     base_rate=output_audio_cost,
                     is_prompt=False,
+                    customization=extract_threshold_customization(
+                        model_info, "output_cost_per_audio_token"
+                    ),
                 )
             )
 

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -133,22 +133,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -504,6 +528,33 @@
       ]
     },
     {
+      "name": "claude-opus-5",
+      "name_pattern": "claude-opus-5",
+      "source": "litellm",
+      "token_prices": [
+        {
+          "base_rate": 5e-6,
+          "is_prompt": true,
+          "token_type": "input"
+        },
+        {
+          "base_rate": 0.000025,
+          "is_prompt": false,
+          "token_type": "output"
+        },
+        {
+          "base_rate": 5e-7,
+          "is_prompt": true,
+          "token_type": "cache_read"
+        },
+        {
+          "base_rate": 6.25e-6,
+          "is_prompt": true,
+          "token_type": "cache_write"
+        }
+      ]
+    },
+    {
       "name": "claude-sonnet-4-20250514",
       "name_pattern": "claude-sonnet-4-20250514|anthropic\\.claude-sonnet-4-20250514-v1:0|claude-sonnet-4@20250514",
       "source": "litellm",
@@ -511,22 +562,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -538,22 +613,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -565,22 +664,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -592,22 +715,46 @@
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 3e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 6e-7
+          }
         },
         {
           "base_rate": 3.75e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 7.5e-6
+          }
         }
       ]
     },
@@ -781,12 +928,24 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.000015
+          }
         }
       ]
     },
@@ -1043,17 +1202,35 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.000015
+          }
         },
         {
           "base_rate": 1.25e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 2.5e-7
+          }
         }
       ]
     },
@@ -1065,17 +1242,35 @@
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 2.5e-6
+          }
         },
         {
           "base_rate": 0.00001,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.000015
+          }
         },
         {
           "base_rate": 1.25e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 2.5e-7
+          }
         },
         {
           "base_rate": 7e-7,
@@ -1153,17 +1348,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -1290,17 +1503,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -1312,17 +1543,35 @@
         {
           "base_rate": 2e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 4e-6
+          }
         },
         {
           "base_rate": 0.000012,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 0.000018
+          }
         },
         {
           "base_rate": 2e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 200000,
+            "new_rate": 4e-7
+          }
         }
       ]
     },
@@ -3192,17 +3441,35 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 5e-7
+          }
         }
       ]
     },
@@ -3214,17 +3481,35 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 5e-7
+          }
         }
       ]
     },
@@ -3324,17 +3609,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3346,17 +3649,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3368,17 +3689,35 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 1e-6
+          }
         }
       ]
     },
@@ -3390,17 +3729,35 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 1e-6
+          }
         }
       ]
     },
@@ -3412,17 +3769,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3434,17 +3809,35 @@
         {
           "base_rate": 0.00003,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00006
+          }
         },
         {
           "base_rate": 0.00018,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00027
+          }
         },
         {
           "base_rate": 3e-6,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 6e-6
+          }
         }
       ]
     },
@@ -3456,22 +3849,46 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 1e-6
+          }
         },
         {
           "base_rate": 6.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.0000125
+          }
         }
       ]
     },
@@ -3483,22 +3900,46 @@
         {
           "base_rate": 1e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 2e-6
+          }
         },
         {
           "base_rate": 6e-6,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 9e-6
+          }
         },
         {
           "base_rate": 1e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 2e-7
+          }
         },
         {
           "base_rate": 1.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 2.5e-6
+          }
         }
       ]
     },
@@ -3510,22 +3951,46 @@
         {
           "base_rate": 5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.00001
+          }
         },
         {
           "base_rate": 0.00003,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.000045
+          }
         },
         {
           "base_rate": 5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 1e-6
+          }
         },
         {
           "base_rate": 6.25e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.0000125
+          }
         }
       ]
     },
@@ -3537,22 +4002,46 @@
         {
           "base_rate": 2.5e-6,
           "is_prompt": true,
-          "token_type": "input"
+          "token_type": "input",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 5e-6
+          }
         },
         {
           "base_rate": 0.000015,
           "is_prompt": false,
-          "token_type": "output"
+          "token_type": "output",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 0.0000225
+          }
         },
         {
           "base_rate": 2.5e-7,
           "is_prompt": true,
-          "token_type": "cache_read"
+          "token_type": "cache_read",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 5e-7
+          }
         },
         {
           "base_rate": 3.125e-6,
           "is_prompt": true,
-          "token_type": "cache_write"
+          "token_type": "cache_write",
+          "customization": {
+            "type": "threshold_based",
+            "key": "llm.token_count.prompt",
+            "threshold": 272000,
+            "new_rate": 6.25e-6
+          }
         }
       ]
     },

--- a/tests/unit/server/cost_tracking/test_sync_models_tier_rates.py
+++ b/tests/unit/server/cost_tracking/test_sync_models_tier_rates.py
@@ -1,0 +1,162 @@
+"""Tests for tier-rate extraction in the LiteLLM sync script.
+
+`.github/.scripts/sync_models.py` is a standalone script rather than a package
+module, so it is loaded by path.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[4]
+SYNC_SCRIPT = REPO_ROOT / ".github" / ".scripts" / "sync_models.py"
+
+
+def _load_sync_models() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("sync_models", SYNC_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sync_models"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sync_models = _load_sync_models()
+extract_threshold_customization = sync_models.extract_threshold_customization
+PROMPT_TOKEN_COUNT_KEY = sync_models.PROMPT_TOKEN_COUNT_KEY
+
+
+class TestExtractThresholdCustomization:
+    def test_returns_none_when_no_tier_published(self) -> None:
+        model_info = {"input_cost_per_token": 1.25e-6, "output_cost_per_token": 1e-5}
+        assert extract_threshold_customization(model_info, "input_cost_per_token") is None
+
+    @pytest.mark.parametrize(
+        "field,tier_field,threshold",
+        [
+            ("input_cost_per_token", "input_cost_per_token_above_200k_tokens", 200_000),
+            ("output_cost_per_token", "output_cost_per_token_above_272k_tokens", 272_000),
+            ("input_cost_per_token", "input_cost_per_token_above_128k_tokens", 128_000),
+            (
+                "cache_read_input_token_cost",
+                "cache_read_input_token_cost_above_200k_tokens",
+                200_000,
+            ),
+            (
+                "cache_creation_input_token_cost",
+                "cache_creation_input_token_cost_above_200k_tokens",
+                200_000,
+            ),
+        ],
+    )
+    def test_extracts_tier_for_each_priced_field(
+        self, field: str, tier_field: str, threshold: int
+    ) -> None:
+        model_info = {field: 1.25e-6, tier_field: 2.5e-6}
+        customization = extract_threshold_customization(model_info, field)
+        assert customization == {
+            "type": "threshold_based",
+            "key": PROMPT_TOKEN_COUNT_KEY,
+            "threshold": threshold,
+            "new_rate": 2.5e-6,
+        }
+
+    def test_thresholds_key_off_prompt_length_not_the_priced_token(self) -> None:
+        """Tier breakpoints are a function of prompt size even for output rates."""
+        model_info = {
+            "output_cost_per_token": 1e-5,
+            "output_cost_per_token_above_200k_tokens": 1.5e-5,
+        }
+        customization = extract_threshold_customization(model_info, "output_cost_per_token")
+        assert customization is not None
+        assert customization["key"] == PROMPT_TOKEN_COUNT_KEY
+
+    def test_does_not_leak_across_fields(self) -> None:
+        """An input tier must not be picked up when extracting the output rate."""
+        model_info = {
+            "input_cost_per_token": 1.25e-6,
+            "input_cost_per_token_above_200k_tokens": 2.5e-6,
+            "output_cost_per_token": 1e-5,
+        }
+        assert extract_threshold_customization(model_info, "output_cost_per_token") is None
+
+    def test_audio_field_is_not_matched_by_the_plain_input_field(self) -> None:
+        model_info = {
+            "input_cost_per_audio_token": 1e-6,
+            "input_cost_per_audio_token_above_200k_tokens": 2e-6,
+        }
+        assert extract_threshold_customization(model_info, "input_cost_per_token") is None
+        assert extract_threshold_customization(model_info, "input_cost_per_audio_token") == {
+            "type": "threshold_based",
+            "key": PROMPT_TOKEN_COUNT_KEY,
+            "threshold": 200_000,
+            "new_rate": 2e-6,
+        }
+
+    def test_lowest_threshold_wins_when_several_tiers_published(self) -> None:
+        """The lowest breakpoint is where billing first diverges from the base rate."""
+        model_info = {
+            "input_cost_per_token": 1e-6,
+            "input_cost_per_token_above_272k_tokens": 4e-6,
+            "input_cost_per_token_above_128k_tokens": 2e-6,
+        }
+        customization = extract_threshold_customization(model_info, "input_cost_per_token")
+        assert customization is not None
+        assert customization["threshold"] == 128_000
+        assert customization["new_rate"] == 2e-6
+
+    @pytest.mark.parametrize("value", [0, 0.0, None, "", "not-a-number"])
+    def test_unusable_tier_values_are_ignored(self, value: object) -> None:
+        model_info = {
+            "input_cost_per_token": 1.25e-6,
+            "input_cost_per_token_above_200k_tokens": value,
+        }
+        assert extract_threshold_customization(model_info, "input_cost_per_token") is None
+
+
+class TestManifestReflectsTierRates:
+    """Guards the regenerated manifest against silently losing tier rates again."""
+
+    def test_flagship_models_carry_tier_customizations(self) -> None:
+        import json
+
+        manifest_path = (
+            REPO_ROOT / "src" / "phoenix" / "server" / "cost_tracking" / "model_cost_manifest.json"
+        )
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        customized = {
+            model["name"]
+            for model in manifest["models"]
+            for price in model["token_prices"]
+            if price.get("customization")
+        }
+        # Before this fix the manifest carried zero threshold_based customizations
+        # across every model, so any regression here drops back to an empty set.
+        assert customized, "manifest has no tier rates at all"
+        assert "gemini-2.5-pro" in customized
+        assert "claude-sonnet-4-5" in customized
+
+    def test_customizations_are_well_formed(self) -> None:
+        import json
+
+        from phoenix.db.types.token_price_customization import TokenPriceCustomizationParser
+
+        manifest_path = (
+            REPO_ROOT / "src" / "phoenix" / "server" / "cost_tracking" / "model_cost_manifest.json"
+        )
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        seen = 0
+        for model in manifest["models"]:
+            for price in model["token_prices"]:
+                if not (raw := price.get("customization")):
+                    continue
+                seen += 1
+                parsed = TokenPriceCustomizationParser.parse(raw)
+                assert parsed is not None
+                assert parsed.type == "threshold_based"  # type: ignore[union-attr]
+                assert parsed.threshold > 0  # type: ignore[union-attr]
+                assert parsed.new_rate > 0  # type: ignore[union-attr]
+        assert seen > 0


### PR DESCRIPTION
Closes #14314.

### The problem

`sync_models.py` only reads LiteLLM's flat rate fields, so every `*_above_NNNk_tokens` tier is dropped on the way into `model_cost_manifest.json`. Before this change the manifest carried **zero** `threshold_based` customizations across 267 models, and Phoenix under-bills any trace whose prompt exceeds a tier threshold.

| Model | Base input | Above threshold | Under-bill |
|---|---|---|---|
| `gemini-2.5-pro` | `1.25e-6` | `2.5e-6` (200K) | 2x |
| `claude-sonnet-4-5` | `3e-6` | `6e-6` (200K) | 2x |
| `gpt-5.4` | `2.5e-6` | `5e-6` (272K) | 2x |
| `gpt-5.5` | `5e-6` | `1e-5` (272K) | 2x |

Output rates are affected too: `gpt-5.4` goes `1.5e-5` to `2.25e-5` above 272K.

### The change

Nothing downstream needed touching. `ThresholdBasedTokenPriceCustomization` and `ThresholdBasedTokenCostCalculator` already do the right thing; the sync script was simply never emitting the customization.

`extract_threshold_customization()` matches `<field>_above_<N>k_tokens` for each of the six priced fields and emits a `threshold_based` customization keyed on `llm.token_count.prompt`. The key is deliberate: LiteLLM's breakpoints are a function of **prompt** length, so output and cache rates key off the prompt count too, not their own token type.

Where a model publishes more than one tier the lowest threshold wins, that's where billing first diverges from the base rate, and the script prints the tiers it didn't use rather than dropping them silently.

### Result

Regenerating the manifest produces **77 customizations across 23 models**, up from zero. Spot-checked against the issue's table:

```
gemini-2.5-pro input 1.25e-06 -> above 200000: 2.5e-06
 output 1e-05 -> above 200000: 1.5e-05
claude-sonnet-4-5 input 3e-06 -> above 200000: 6e-06
gpt-5.4 input 2.5e-06 -> above 272000: 5e-06
gpt-5.5 input 5e-06 -> above 272000: 1e-05
```

### Tests

New `tests/unit/server/cost_tracking/test_sync_models_tier_rates.py`. The script isn't a package module so it's loaded by path.

Covers each priced field, that output tiers key off the prompt count, that an input tier doesn't leak into the output rate, that `input_cost_per_audio_token_above_200k_tokens` isn't matched when extracting `input_cost_per_token` (the pattern is anchored for exactly this reason), lowest-tier-wins, and that unusable values (`0`, `None`, `""`, non-numeric) yield no customization. Two further tests assert the regenerated manifest still contains tier rates and that every emitted customization round-trips through `TokenPriceCustomizationParser`, so this can't silently regress to an empty set again.

### One thing to flag

Re-running the sync also picked up **`claude-opus-5`**, which LiteLLM has added since the manifest was last regenerated. It's unrelated to tier rates and I've left it in because it's what the script now produces, happy to strip it if you'd rather keep the diff to this fix alone.

> **Correction, added 12 August 2026.**
>
> This line originally read: *"I've shipped the same tier-rate fix at comet-ml/opik (#7023, #7347) if it's useful for comparison."*
>
> That is not true and I am striking it rather than quietly deleting it. Those two pull requests are Anuj7411's work, not mine. I have no contributions to comet-ml/opik. I should not have claimed them and I am sorry for the error.
>
> For the same reason, credit for the fix in this repository belongs with #14329, which Anuj7411 had open for two weeks before I opened this one and which correctly closed #14314.



