### PR TITLE
feat(playground): register Claude Opus 5

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1390,6 +1390,7 @@ class TogetherStreamingClient(OpenAIBaseStreamingClient):
     model_names=[
         PROVIDER_DEFAULT,
         "anthropic.claude-fable-5",
+        "anthropic.claude-opus-5",
         "anthropic.claude-opus-4-8",
         "anthropic.claude-opus-4-7",
         "anthropic.claude-sonnet-5",
@@ -2207,6 +2208,7 @@ def _anthropic_beta_headers_for_tools(
     model_names=[
         PROVIDER_DEFAULT,
         "claude-fable-5",
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-sonnet-5",


### PR DESCRIPTION
Registers **Claude Opus 5** in the playground so it can be selected as a model.

```python
# Anthropic                    # Bedrock
"claude-fable-5",              "anthropic.claude-fable-5",
"claude-opus-5",   # added     "anthropic.claude-opus-5",   # added
"claude-opus-4-8",             "anthropic.claude-opus-4-8",
```

## Verification

- `claude-opus-5` resolves to `AnthropicStreamingClient` — the adaptive-thinking client shared with Fable 5, Opus 4.8, Opus 4.7, and Sonnet 5 — not the legacy `AnthropicReasoningStreamingClient`. Confirmed against the registry directly.
- `anthropic.claude-opus-5` resolves to `BedrockStreamingClient`; this is the documented Bedrock ID for Opus 5.
- `model_cost_manifest.json` already carries a `claude-opus-5` entry at $5/$25, so cost tracking needs no change.
- No test enumerates these lists. Ruff clean.

## Known gap this PR does not address

Opus 5 removes `temperature`, `top_p`, `top_k`, and `thinking.budget_tokens` from the API — requests including them return 400 — and permits `thinking: disabled` only at effort `high` or below.

The playground currently gates `temperature`/`top_p` on **whether thinking is active**, not on model family (`anthropicAdapter.ts` → `isThinkingActive`). The default config is `thinking: adaptive`, so the default path is safe. But a user who switches thinking off gets those fields back, and the request 400s.

**This is pre-existing** — it already affects Fable 5, Opus 4.8, Opus 4.7, and Sonnet 5 today. Opus 5 inherits it and adds one new case (`disabled` + effort `xhigh`/`max`). Fixed in a follow-up stack; called out here so the exposure is on the record rather than discovered later.
