### PR TITLE
feat(agent): add Claude Opus 5 to the curated model list

### DIFF
--- a/app/src/components/agent/agentCuratedModels.ts
+++ b/app/src/components/agent/agentCuratedModels.ts
@@ -14,6 +14,7 @@ export type AgentPlaygroundModel = {
 export const AGENT_CURATED_BUILT_IN_MODELS: readonly AgentBuiltInModelSelection[] =
   [
     { provider: "ANTHROPIC", modelName: "claude-fable-5" },
+    { provider: "ANTHROPIC", modelName: "claude-opus-5" },
     { provider: "ANTHROPIC", modelName: "claude-opus-4-8" },
     { provider: "ANTHROPIC", modelName: "claude-opus-4-6" },
     { provider: "ANTHROPIC", modelName: "claude-sonnet-4-6" },


### PR DESCRIPTION
Adds **Claude Opus 5** to the agent's curated built-in model list, so it is selectable in the agent model picker alongside the playground registration in the PR below.

```ts
{ provider: "ANTHROPIC", modelName: "claude-fable-5" },
{ provider: "ANTHROPIC", modelName: "claude-opus-5" },   // added
{ provider: "ANTHROPIC", modelName: "claude-opus-4-8" },
```

`AGENT_CURATED_BUILT_IN_MODELS` is the only hardcoded Claude model list in the frontend — the playground's own picker is driven by the backend registry, so it needs no change.

## Scope

Purely additive. `claude-opus-4-6` and `claude-sonnet-4-6` are left in place: pruning older entries from a curated list is a product decision, not a consequence of adding Opus 5.

Prettier passes.
