### PR TITLE
feat(cli): default pxi to Claude Opus 5

### DIFF
--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -86,7 +86,7 @@ pxi
 ```
 
 Pick the model with `--provider` and `--model` (defaults to Anthropic
-`claude-opus-4-8`):
+`claude-opus-5`):
 
 ```bash
 pxi --endpoint http://localhost:6006 --provider OPENAI --model gpt-5.4
@@ -106,7 +106,7 @@ opens.
 | `--api-key <key>` | Phoenix API key (overrides `PHOENIX_API_KEY`). |
 | `--profile <name>` | Use a saved Phoenix CLI profile. |
 | `--provider <provider>` | Built-in model provider (e.g. `ANTHROPIC`, `OPENAI`, `GOOGLE`). |
-| `--model <model>` | Model name (defaults to `claude-opus-4-8`). |
+| `--model <model>` | Model name (defaults to `claude-opus-5`). |
 | `--custom-provider-id <id>` | Use a custom provider configured under **Settings → Models** (requires `--model`). |
 | `--bypass-edits` | Apply edits without manual approval (see [You stay in control](#you-stay-in-control)). |
 | `--enable-web-access` | Allow PXI to consult the web for grounding. |
@@ -235,7 +235,7 @@ call. Models that are weak at tool use produce broken sessions even if they
 handle free-form chat well. Pick one of these validated models unless you have a
 specific reason not to:
 
-- **Anthropic** — `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`
+- **Anthropic** — `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`
 - **OpenAI** — `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`
 - **Google** — `gemini-3.1-pro-preview`, `gemini-3.5-flash`
 

--- a/js/.changeset/olive-donkeys-teach.md
+++ b/js/.changeset/olive-donkeys-teach.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Default the `pxi` terminal client to Anthropic `claude-opus-5` instead of `claude-opus-4-8`. Override with `--model` as before.

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -134,7 +134,7 @@ function PxiBanner() {
   );
 }
 
-/** Format the active model for the status line (e.g. `ANTHROPIC/claude-opus-4-8`). */
+/** Format the active model for the status line (e.g. `ANTHROPIC/claude-opus-5`). */
 function getModelLabel(options: PxiRuntimeOptions): string {
   if (options.modelSelection.providerType === "custom") {
     return `custom:${options.modelSelection.providerId}/${options.modelSelection.modelName}`;

--- a/js/packages/phoenix-cli/src/pxi/options.ts
+++ b/js/packages/phoenix-cli/src/pxi/options.ts
@@ -10,7 +10,7 @@ import type {
 } from "./types";
 
 export const DEFAULT_PXI_PROVIDER: BuiltInProvider = "ANTHROPIC";
-export const DEFAULT_PXI_MODEL = "claude-opus-4-8";
+export const DEFAULT_PXI_MODEL = "claude-opus-5";
 
 export const BUILT_IN_PROVIDERS = [
   "ANTHROPIC",
@@ -69,7 +69,7 @@ type RawPxiOptions = {
    * {@link DEFAULT_PXI_MODEL} for built-in providers; required when
    * `customProviderId` is set.
    *
-   * @example "claude-opus-4-8"
+   * @example "claude-opus-5"
    */
   model?: string;
   /**

--- a/js/packages/phoenix-cli/test/pxiOptions.test.ts
+++ b/js/packages/phoenix-cli/test/pxiOptions.test.ts
@@ -49,7 +49,7 @@ describe("PXI options", () => {
     expect(selection).toEqual({
       providerType: "builtin",
       provider: "ANTHROPIC",
-      modelName: "claude-opus-4-8",
+      modelName: "claude-opus-5",
     });
   });
 


### PR DESCRIPTION
Bumps the `pxi` terminal client default from `claude-opus-4-8` to **`claude-opus-5`**.

| File | Change |
|---|---|
| `pxi/options.ts` | `DEFAULT_PXI_MODEL`, JSDoc `@example` |
| `pxi/App.tsx` | status-line doc comment example |
| `test/pxiOptions.test.ts` | default-selection expectation |
| `docs/phoenix/pxi.mdx` | 3 references |
| `js/.changeset/` | minor bump for `@arizeai/phoenix-cli` |

`--model` still overrides the default, so invocations that pin a model are unaffected. Tests pass (8/8).

## Docs list is additive on purpose

The Anthropic line in `pxi.mdx` sits under *"Pick one of these **validated** models"* — it records models actually tested against PXI's tool-calling, not simply current models. So Opus 5 was **added** rather than swapped in, and the existing entries stay:

```
- **Anthropic** — `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`
```

## Reviewer note

Making Opus 5 the default implies it is validated for PXI's tool-calling, and this PR adds it to that list on that basis. **If nobody has driven a real PXI session on Opus 5 yet, that is worth doing before this merges** — it is the only change in this stack with user-facing blast radius.

Two behavioral shifts relevant to an agent loop: Opus 5 delegates to subagents more readily than Opus 4.8, and verifies its own work without being prompted. Both affect token spend per session.
