### PR TITLE
refactor(playground): name Anthropic model families, drop inert subclass

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2203,15 +2203,41 @@ def _anthropic_beta_headers_for_tools(
     return {"anthropic-beta": ",".join(betas)}
 
 
+# Anthropic models that use adaptive thinking (`thinking: {"type": "adaptive"}`).
+# These models removed `temperature`, `top_p`, `top_k`, and extended thinking
+# (`thinking: {"type": "enabled", "budget_tokens": N}`) from their request
+# surface; sending any of them returns a 400.
+ANTHROPIC_ADAPTIVE_THINKING_MODELS = [
+    "claude-fable-5",
+    "claude-opus-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-5",
+]
+
+# Older Anthropic models that still accept extended thinking
+# (`thinking: {"type": "enabled", "budget_tokens": N}`) alongside the sampling
+# parameters. Kept as a distinct group because the request surface differs, not
+# because they use a different client.
+ANTHROPIC_EXTENDED_THINKING_MODELS = [
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-opus-4-5",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    "claude-opus-4-1",
+    "claude-sonnet-4-0",
+    "claude-opus-4-0",
+    "claude-3-7-sonnet-latest",
+]
+
+
 @register_llm_client(
     provider_key=GenerativeProviderKey.ANTHROPIC,
     model_names=[
         PROVIDER_DEFAULT,
-        "claude-fable-5",
-        "claude-opus-5",
-        "claude-opus-4-8",
-        "claude-opus-4-7",
-        "claude-sonnet-5",
+        *ANTHROPIC_ADAPTIVE_THINKING_MODELS,
+        *ANTHROPIC_EXTENDED_THINKING_MODELS,
     ],
 )
 class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):
@@ -2640,27 +2666,6 @@ class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):
             return tool_use_content
 
         return content
-
-
-ANTHROPIC_REASONING_MODELS = [
-    "claude-opus-4-6",
-    "claude-sonnet-4-6",
-    "claude-opus-4-5",
-    "claude-sonnet-4-5",
-    "claude-haiku-4-5",
-    "claude-opus-4-1",
-    "claude-sonnet-4-0",
-    "claude-opus-4-0",
-    "claude-3-7-sonnet-latest",
-]
-
-
-@register_llm_client(
-    provider_key=GenerativeProviderKey.ANTHROPIC,
-    model_names=ANTHROPIC_REASONING_MODELS,
-)
-class AnthropicReasoningStreamingClient(AnthropicStreamingClient):
-    pass
 
 
 @register_llm_client(
@@ -3524,12 +3529,6 @@ async def _get_builtin_provider_client(
         anthropic_client_factory: ClientFactory["AsyncAnthropic"] = LLMClientFactory(
             create_anthropic_client, anthropic_rate_limit_key(api_key, None)
         )
-        if model_name in ANTHROPIC_REASONING_MODELS:
-            return AnthropicReasoningStreamingClient(
-                client_factory=anthropic_client_factory,
-                model_name=model_name,
-                provider=provider,
-            )
         return AnthropicStreamingClient(
             client_factory=anthropic_client_factory,
             model_name=model_name,
@@ -4068,12 +4067,6 @@ async def _get_custom_provider_client(
             anthropic_client_factory = cfg.get_client_factory(extra_headers=headers)
         except Exception as e:
             raise BadRequest(f"Failed to create {cfg.type} client factory: {e}")
-        if model_name in ANTHROPIC_REASONING_MODELS:
-            return AnthropicReasoningStreamingClient(
-                client_factory=anthropic_client_factory,
-                model_name=model_name,
-                provider=provider,
-            )
         return AnthropicStreamingClient(
             client_factory=anthropic_client_factory,
             model_name=model_name,


### PR DESCRIPTION
Pure refactor of Anthropic model grouping in `playground_clients.py`. **No behavior change.**

## The name was backwards

`ANTHROPIC_REASONING_MODELS` listed Opus 4.6 and older — the *legacy* models. The models it excluded (Fable 5, Opus 5, Opus 4.8, Opus 4.7, Sonnet 5) are the ones that actually reason adaptively. It read as the opposite of what it meant: "legacy models that accept `budget_tokens`."

Replaced with two constants named for the request surface each group accepts:

| Constant | Accepts |
|---|---|
| `ANTHROPIC_ADAPTIVE_THINKING_MODELS` | adaptive thinking; `temperature`, `top_p`, `top_k`, `budget_tokens` all removed from the API |
| `ANTHROPIC_EXTENDED_THINKING_MODELS` | extended thinking with `budget_tokens`, sampling params still valid |

## The subclass was inert

`AnthropicReasoningStreamingClient` was added in `8edd11857` to override `supported_invocation_parameters()` and append a "Thinking Budget" field. That mechanism was later removed from this module entirely — `grep supported_invocation_parameters` returns nothing repo-wide — leaving the class body as `pass`.

So both dispatch sites were choosing between two behaviorally identical classes:

```python
if model_name in ANTHROPIC_REASONING_MODELS:
    return AnthropicReasoningStreamingClient(...)   # identical args
return AnthropicStreamingClient(...)                # identical behavior
```

Deleted the subclass and both dead branches; every Anthropic model now registers on `AnthropicStreamingClient` directly.

## Verification

- All **14** Anthropic model names still resolve to `AnthropicStreamingClient` — asserted against the live registry, not by inspection.
- The class name was referenced nowhere outside those three Python sites (no frontend, config, or test references).
- `provider` is set in `__init__`, not derived from the class, so telemetry is unaffected.
- Ruff clean; existing tests pass.

Lands before the behavior change above it so a reviewer never has to separate moved code from changed logic.
