### PR TITLE
fix(playground): reject Anthropic parameter combinations that 400

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -71,6 +71,7 @@ from phoenix.db.types.model_provider import (
 )
 from phoenix.db.types.prompts import (
     PromptAnthropicInvocationParameters,
+    PromptAnthropicInvocationParametersContent,
     PromptAnthropicOutputConfig,
     PromptAnthropicThinkingConfigAdaptive,
     PromptAnthropicThinkingConfigDisabled,
@@ -2231,6 +2232,58 @@ ANTHROPIC_EXTENDED_THINKING_MODELS = [
     "claude-3-7-sonnet-latest",
 ]
 
+# Claude Opus 5 accepts `thinking: {"type": "disabled"}` only at effort `high`
+# or below; pairing it with `xhigh` or `max` returns a 400. Opus 4.8 accepts
+# that combination, so this is keyed by model rather than by family.
+ANTHROPIC_DISABLED_THINKING_EFFORT_CEILING_MODELS = frozenset({"claude-opus-5"})
+
+_ANTHROPIC_EFFORTS_ABOVE_HIGH = frozenset({"xhigh", "max"})
+
+
+def _validate_anthropic_invocation_parameters(
+    model_name: str,
+    params: PromptAnthropicInvocationParametersContent,
+) -> None:
+    """Reject invocation parameters that Anthropic rejects with a 400.
+
+    Invocation parameters are forwarded to Anthropic verbatim, and the GraphQL
+    API is callable without the UI, so these combinations are caught here rather
+    than relying on the playground to hide the fields. Raising `BadRequest`
+    surfaces an actionable message instead of a raw provider error.
+    """
+    if model_name in ANTHROPIC_ADAPTIVE_THINKING_MODELS:
+        unsupported = [
+            name
+            for name, value in (
+                ("temperature", params.temperature),
+                ("top_p", params.top_p),
+            )
+            if isinstance(value, float)
+        ]
+        if unsupported:
+            raise BadRequest(
+                f"{model_name} does not support {' or '.join(unsupported)}. "
+                "Anthropic removed the sampling parameters on this model; "
+                "use the effort level to steer its output instead."
+            )
+        if isinstance(params.thinking, PromptAnthropicThinkingConfigEnabled):
+            raise BadRequest(
+                f"{model_name} does not support a thinking budget. "
+                "Anthropic replaced extended thinking with adaptive thinking on "
+                "this model; select adaptive thinking and set an effort level."
+            )
+    if (
+        model_name in ANTHROPIC_DISABLED_THINKING_EFFORT_CEILING_MODELS
+        and isinstance(params.thinking, PromptAnthropicThinkingConfigDisabled)
+        and isinstance(params.output_config, PromptAnthropicOutputConfig)
+        and params.output_config.effort in _ANTHROPIC_EFFORTS_ABOVE_HIGH
+    ):
+        raise BadRequest(
+            f"{model_name} only allows thinking to be disabled at effort 'high' "
+            f"or below, but the effort level is '{params.output_config.effort}'. "
+            "Lower the effort level, or use adaptive thinking."
+        )
+
 
 @register_llm_client(
     provider_key=GenerativeProviderKey.ANTHROPIC,
@@ -2367,6 +2420,7 @@ class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):
         extra_body: dict[str, Any] | None = None
         if invocation_parameters:
             anthropic_params = invocation_parameters.anthropic
+            _validate_anthropic_invocation_parameters(self.model_name, anthropic_params)
             if isinstance(anthropic_params.temperature, float):
                 params["temperature"] = anthropic_params.temperature
             if isinstance(anthropic_params.stop_sequences, list):

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -25,6 +25,10 @@ from phoenix.db.types.model_provider import LLMClientFactory, ModelProvider
 from phoenix.db.types.prompts import (
     PromptAnthropicInvocationParameters,
     PromptAnthropicInvocationParametersContent,
+    PromptAnthropicOutputConfig,
+    PromptAnthropicThinkingConfigAdaptive,
+    PromptAnthropicThinkingConfigDisabled,
+    PromptAnthropicThinkingConfigEnabled,
     PromptOpenAIInvocationParameters,
     PromptOpenAIInvocationParametersContent,
     PromptToolChoiceSpecificFunctionTool,
@@ -47,6 +51,7 @@ from phoenix.server.api.helpers.playground_clients import (
     OpenAIStreamingClient,
     _get_builtin_provider_client,
     _resolve_provider_api_key,
+    _validate_anthropic_invocation_parameters,
     get_openai_client_class,
 )
 from phoenix.server.api.input_types.GenerativeCredentialInput import GenerativeCredentialInput
@@ -919,3 +924,93 @@ class TestResolveProviderApiKey:
                 credentials,
             )
         assert isinstance(client, OpenAIStreamingClient)
+
+
+class TestValidateAnthropicInvocationParameters:
+    """Anthropic rejects some parameter combinations with a 400.
+
+    These are caught server-side because invocation parameters are forwarded
+    verbatim and the GraphQL API is reachable without the playground UI.
+    """
+
+    ADAPTIVE_MODEL = "claude-opus-4-8"
+    LEGACY_MODEL = "claude-opus-4-6"
+    EFFORT_CEILING_MODEL = "claude-opus-5"
+
+    @staticmethod
+    def _content(**kwargs: Any) -> PromptAnthropicInvocationParametersContent:
+        return PromptAnthropicInvocationParametersContent(max_tokens=8192, **kwargs)
+
+    @pytest.mark.parametrize("field,value", [("temperature", 0.7), ("top_p", 0.9)])
+    def test_sampling_params_rejected_on_adaptive_thinking_models(
+        self, field: str, value: float
+    ) -> None:
+        with pytest.raises(BadRequest, match=field):
+            _validate_anthropic_invocation_parameters(
+                self.ADAPTIVE_MODEL, self._content(**{field: value})
+            )
+
+    def test_thinking_budget_rejected_on_adaptive_thinking_models(self) -> None:
+        with pytest.raises(BadRequest, match="thinking budget"):
+            _validate_anthropic_invocation_parameters(
+                self.ADAPTIVE_MODEL,
+                self._content(
+                    thinking=PromptAnthropicThinkingConfigEnabled(
+                        type="enabled", budget_tokens=2048
+                    )
+                ),
+            )
+
+    def test_adaptive_thinking_accepted(self) -> None:
+        _validate_anthropic_invocation_parameters(
+            self.ADAPTIVE_MODEL,
+            self._content(thinking=PromptAnthropicThinkingConfigAdaptive(type="adaptive")),
+        )
+
+    def test_no_parameters_accepted(self) -> None:
+        _validate_anthropic_invocation_parameters(self.ADAPTIVE_MODEL, self._content())
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    def test_disabled_thinking_rejected_above_high_effort(self, effort: str) -> None:
+        with pytest.raises(BadRequest, match="effort"):
+            _validate_anthropic_invocation_parameters(
+                self.EFFORT_CEILING_MODEL,
+                self._content(
+                    thinking=PromptAnthropicThinkingConfigDisabled(type="disabled"),
+                    output_config=PromptAnthropicOutputConfig(effort=effort),
+                ),
+            )
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    def test_disabled_thinking_accepted_at_or_below_high_effort(self, effort: str) -> None:
+        _validate_anthropic_invocation_parameters(
+            self.EFFORT_CEILING_MODEL,
+            self._content(
+                thinking=PromptAnthropicThinkingConfigDisabled(type="disabled"),
+                output_config=PromptAnthropicOutputConfig(effort=effort),
+            ),
+        )
+
+    def test_effort_ceiling_does_not_apply_to_other_models(self) -> None:
+        """Opus 4.8 accepts disabled thinking at any effort; only Opus 5 has the ceiling."""
+        _validate_anthropic_invocation_parameters(
+            self.ADAPTIVE_MODEL,
+            self._content(
+                thinking=PromptAnthropicThinkingConfigDisabled(type="disabled"),
+                output_config=PromptAnthropicOutputConfig(effort="xhigh"),
+            ),
+        )
+
+    @pytest.mark.parametrize("field,value", [("temperature", 0.7), ("top_p", 0.9)])
+    def test_legacy_models_still_accept_sampling_params(self, field: str, value: float) -> None:
+        _validate_anthropic_invocation_parameters(
+            self.LEGACY_MODEL, self._content(**{field: value})
+        )
+
+    def test_legacy_models_still_accept_thinking_budget(self) -> None:
+        _validate_anthropic_invocation_parameters(
+            self.LEGACY_MODEL,
+            self._content(
+                thinking=PromptAnthropicThinkingConfigEnabled(type="enabled", budget_tokens=2048)
+            ),
+        )


### PR DESCRIPTION
Invocation parameters are forwarded to Anthropic verbatim, so combinations the API rejects surfaced as raw provider 400s. The GraphQL API is reachable without the playground UI and saved prompts can persist these combinations, so the check belongs server-side rather than only in the frontend.

## Rejected combinations

| Condition | Models | Why |
|---|---|---|
| `temperature` / `top_p` | adaptive-thinking family | Anthropic removed the sampling parameters on these models |
| `thinking.budget_tokens` | adaptive-thinking family | extended thinking was replaced by adaptive thinking |
| thinking disabled + effort `xhigh`/`max` | **Claude Opus 5 only** | Opus 5 allows disabling thinking only at effort `high` or below |

The third rule is keyed by model rather than by family on purpose: Opus 4.8 accepts that pairing, so it is not a property of the adaptive-thinking generation.

Each raises `BadRequest` with an actionable message naming the model and the alternative, instead of a provider error the user can't act on.

## Not affected

Legacy models (Opus 4.6 and older) still accept both the sampling parameters and a thinking budget — covered by explicit tests so a future change can't silently widen the rule.

## Tests

14 new cases in `TestValidateAnthropicInvocationParameters`, parametrized across both sampling params, all five effort levels, and all three thinking modes. Full file: 39 passed, 7 skipped (Postgres-only).

Notably `test_effort_ceiling_does_not_apply_to_other_models` pins the Opus-5-only behavior, and the legacy-model cases pin the negative side of the family rule.

## Scope

This is the server-side half. The playground currently gates `temperature`/`top_p` on **whether thinking is active** rather than on model family (`anthropicAdapter.ts` → `isThinkingActive`), so a user who switches thinking off still sees fields this PR now rejects. The frontend gating follows in the PR above; until then the failure is a clean Phoenix error rather than a raw Anthropic 400, which is already an improvement.
