### PR TITLE
fix(server): fall back to text for invalid span mime types

### DIFF
--- a/src/phoenix/server/api/types/MimeType.py
+++ b/src/phoenix/server/api/types/MimeType.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 import strawberry
 
@@ -12,5 +12,6 @@ class MimeType(Enum):
     json = trace_schemas.MimeType.JSON.value
 
     @classmethod
-    def _missing_(cls, v: Any) -> Optional["MimeType"]:
-        return None if v else cls.text
+    def _missing_(cls, v: Any) -> "MimeType":
+        # Unrecognized or empty mime types fall back to text instead of raising.
+        return cls.text

--- a/src/phoenix/trace/schemas.py
+++ b/src/phoenix/trace/schemas.py
@@ -184,8 +184,9 @@ class MimeType(Enum):
     JSON = "application/json"
 
     @classmethod
-    def _missing_(cls, v: Any) -> Optional["MimeType"]:
-        return None if v else cls.TEXT
+    def _missing_(cls, v: Any) -> "MimeType":
+        # Unrecognized or empty mime types fall back to text instead of raising.
+        return cls.TEXT
 
 
 @dataclass(frozen=True)

--- a/tests/unit/server/api/types/test_Span.py
+++ b/tests/unit/server/api/types/test_Span.py
@@ -896,6 +896,76 @@ async def spans_with_annotations(
         session.add_all(hallucination_annotations + relevance_annotations)
 
 
+@pytest.fixture
+async def _span_with_invalid_mime_type(db: DbSessionFactory) -> int:
+    """A span whose stored input/output mime types are invalid ("plain/text")."""
+    async with db() as session:
+        project_rowid = await session.scalar(
+            insert(models.Project).values(name=token_hex(8)).returning(models.Project.id)
+        )
+        trace_rowid = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id=token_hex(16),
+                project_rowid=project_rowid,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
+        )
+        span_rowid = await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_rowid,
+                span_id=token_hex(8),
+                parent_id=None,
+                name="span-with-bad-mime-type",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={
+                    "input": {"value": "the-input-value", "mime_type": "plain/text"},
+                    "output": {"value": "the-output-value", "mime_type": "plain/text"},
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+    assert span_rowid is not None
+    return span_rowid
+
+
+async def test_span_with_invalid_mime_type_does_not_crash(
+    gql_client: AsyncGraphQLClient,
+    _span_with_invalid_mime_type: int,
+) -> None:
+    """Regression for #14762: an invalid stored mime type must not crash the resolver."""
+    query = """
+      query ($spanId: ID!) {
+        span: node(id: $spanId) {
+          ... on Span {
+            input { mimeType value }
+            output { mimeType value }
+          }
+        }
+      }
+    """
+    span_id = str(GlobalID(Span.__name__, str(_span_with_invalid_mime_type)))
+    response = await gql_client.execute(query=query, variables={"spanId": span_id})
+    assert not response.errors
+    assert (data := response.data) is not None
+    span = data["span"]
+    assert span["input"]["mimeType"] == "text"
+    assert span["input"]["value"] == "the-input-value"
+    assert span["output"]["mimeType"] == "text"
+    assert span["output"]["value"] == "the-output-value"
+
+
 async def test_as_example_revision_with_annotations(
     gql_client: AsyncGraphQLClient,
     spans_with_annotations: None,


### PR DESCRIPTION
## Problem

A mime type persisted in a span's `attributes` that is neither `text/plain` nor `application/json` — e.g. a typo'd `plain/text` — crashes the span's `input`/`output` GraphQL resolvers with `ValueError: 'plain/text' is not a valid MimeType`. Because the bad value stays in the database, every query touching that span keeps failing until the row is fixed by hand.

## Cause

`MimeType._missing_` (called by `Enum` for values that aren't defined members) only defaulted empty/falsy values to text and returned `None` for any other unrecognized string. Returning `None` from `_missing_` makes `Enum` raise `ValueError`, which propagates out of the resolver. The same pattern existed in both the GraphQL `MimeType` enum and the `phoenix.trace.schemas.MimeType` enum.

## Fix

Default any unrecognized mime type to text in both enums, so a malformed value stored in the DB degrades gracefully on the read path instead of raising. Valid values (`text/plain`, `application/json`) are unaffected — they never reach `_missing_`.

Added a regression test that persists a span with an invalid mime type and asserts the `input`/`output` resolvers return `text` instead of erroring.

## Scope

This addresses the read/display path only. Validating or normalizing mime types at ingestion time is a separate, larger change and is left as a follow-up.

Closes #14762
