### PR TITLE
feat(agents): PXI session event bus — detached turns, multi-client sync, multi-instance degradation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -40,7 +40,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ai-sdk/react": "^4.0.34",
+    "@ai-sdk/react": "4.0.34",
     "@apollo/client": "^4.2.7",
     "@arizeai/openinference-semantic-conventions": "^2.5.0",
     "@codemirror/autocomplete": "6.20.3",
@@ -72,7 +72,7 @@
     "@tanstack/react-virtual": "^3.14.6",
     "@uiw/codemirror-themes": "^4.25.11",
     "@uiw/react-codemirror": "^4.25.11",
-    "ai": "^7.0.31",
+    "ai": "7.0.31",
     "clsx": "^2.1.1",
     "codemirror-json-schema": "^0.8.1",
     "copy-to-clipboard": "^4.0.2",

--- a/app/playwright.multi-instance.config.ts
+++ b/app/playwright.multi-instance.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Config for the multi-instance PXI smoke test. Unlike the main config it
+ * starts no web server and performs no auth setup: the two Phoenix instances
+ * are provided externally (see scripts/pxi-multi-instance/run.sh), share one
+ * Postgres database, and run with auth disabled.
+ */
+export default defineConfig({
+  testDir: "./tests/pxi",
+  testMatch: "**/multi-instance.spec.ts",
+  // One long-running scenario with a real LLM turn in the middle.
+  timeout: 420_000,
+  expect: {
+    timeout: 30_000,
+  },
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: process.env.PXI_MI_BASE_URL_A ?? "http://localhost:16006",
+    trace: "retain-on-failure",
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
   .:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^4.0.34
+        specifier: 4.0.34
         version: 4.0.34(react@19.2.7)(zod@4.4.3)
       '@apollo/client':
         specifier: ^4.2.7
@@ -107,7 +107,7 @@ importers:
         specifier: ^4.25.11
         version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.6.0)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ai:
-        specifier: ^7.0.31
+        specifier: 7.0.31
         version: 7.0.31(zod@4.4.3)
       clsx:
         specifier: ^2.1.1

--- a/app/src/agent/chat/AgentSessionChatTransport.ts
+++ b/app/src/agent/chat/AgentSessionChatTransport.ts
@@ -1,0 +1,65 @@
+import {
+  DefaultChatTransport,
+  type ChatTransport,
+  type UIMessageChunk,
+} from "ai";
+
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+
+import type { SessionEventsBridge } from "./sessionEventsBridge";
+
+type SendMessagesOptions = Parameters<
+  ChatTransport<AgentUIMessage>["sendMessages"]
+>[0];
+
+/** POST transport whose reconnect path consumes replay windows from the bridge. */
+export class AgentSessionChatTransport extends DefaultChatTransport<AgentUIMessage> {
+  private readonly eventsBridge: SessionEventsBridge;
+
+  constructor({
+    eventsBridge,
+    ...options
+  }: ConstructorParameters<typeof DefaultChatTransport<AgentUIMessage>>[0] & {
+    eventsBridge: SessionEventsBridge;
+  }) {
+    super(options);
+    this.eventsBridge = eventsBridge;
+  }
+
+  override async sendMessages(
+    options: SendMessagesOptions
+  ): Promise<ReadableStream<UIMessageChunk>> {
+    const endLocalPost = this.eventsBridge.beginLocalPost();
+    try {
+      const responseStream = await super.sendMessages(options);
+      const reader = responseStream.getReader();
+      return new ReadableStream<UIMessageChunk>({
+        async pull(controller) {
+          try {
+            const result = await reader.read();
+            if (result.done) {
+              endLocalPost();
+              controller.close();
+              return;
+            }
+            controller.enqueue(result.value);
+          } catch (error) {
+            endLocalPost(true);
+            controller.error(error);
+          }
+        },
+        async cancel(reason) {
+          endLocalPost();
+          await reader.cancel(reason);
+        },
+      });
+    } catch (error) {
+      endLocalPost();
+      throw error;
+    }
+  }
+
+  override async reconnectToStream(): Promise<ReadableStream<UIMessageChunk> | null> {
+    return this.eventsBridge.getReconnectStream();
+  }
+}

--- a/app/src/agent/chat/AgentSessionChatTransport.ts
+++ b/app/src/agent/chat/AgentSessionChatTransport.ts
@@ -44,7 +44,11 @@ export class AgentSessionChatTransport extends DefaultChatTransport<AgentUIMessa
             }
             controller.enqueue(result.value);
           } catch (error) {
-            endLocalPost(true);
+            // A user abort must not re-attach to the turn it just stopped;
+            // only an unexpected mid-stream failure resumes through the bus.
+            const isAbortError =
+              error instanceof Error && error.name === "AbortError";
+            endLocalPost({ shouldResume: !isAbortError });
             controller.error(error);
           }
         },
@@ -54,7 +58,9 @@ export class AgentSessionChatTransport extends DefaultChatTransport<AgentUIMessa
         },
       });
     } catch (error) {
-      endLocalPost();
+      // The POST failed before a stream existed (e.g. 409 busy), so no turn
+      // was claimed by this client.
+      endLocalPost({ wasTurnClaimed: false });
       throw error;
     }
   }

--- a/app/src/agent/chat/buildAgentChatRequestBody.ts
+++ b/app/src/agent/chat/buildAgentChatRequestBody.ts
@@ -45,6 +45,8 @@ type BuildAgentChatRequestBodyOptions = {
   turnTraceContext?: TurnTraceContext | null;
   /** Browser execution timings added to completed client-tool parts. */
   toolTimings?: ClientToolTimingRecorder | null;
+  /** Stable identifier for the resident browser runtime that owns this turn. */
+  clientId?: string;
 };
 
 type BuildAgentChatRequestBodyResult = components["schemas"]["ChatRequest"];
@@ -117,6 +119,7 @@ export function buildAgentChatRequestBody({
   modelSelection,
   turnTraceContext = null,
   toolTimings = null,
+  clientId,
 }: BuildAgentChatRequestBodyOptions): BuildAgentChatRequestBodyResult {
   const traceRecording = getEffectiveTraceRecordingSettings({
     agentsConfig,
@@ -138,6 +141,7 @@ export function buildAgentChatRequestBody({
     contexts: requestContexts,
     model: modelSelection,
     turnTraceContext: turnTraceContext ?? undefined,
+    ...(clientId ? { clientId } : {}),
   };
   const [message] = toServerSafeUIMessages(
     enrichMessagesWithClientToolTimings({

--- a/app/src/agent/chat/sessionEventsBridge.ts
+++ b/app/src/agent/chat/sessionEventsBridge.ts
@@ -1,0 +1,498 @@
+import type { Chat } from "@ai-sdk/react";
+import {
+  parseJsonEventStream,
+  uiMessageChunkSchema,
+  type UIMessageChunk,
+} from "ai";
+
+import type { TranscriptPersistenceCoordinator } from "@phoenix/agent/chat/transcriptPersistence";
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+import type { components } from "@phoenix/api/__generated__/v1";
+import { authFetch } from "@phoenix/authFetch";
+import type {
+  AgentStore,
+  SessionBusConnection,
+  SessionBusState,
+} from "@phoenix/store/agentStore";
+
+type SessionStateData = components["schemas"]["SessionStateData"];
+type SessionTurnStartedData = components["schemas"]["SessionTurnStartedData"];
+
+type TurnWindow = {
+  turnId: string;
+  stream: ReadableStream<UIMessageChunk>;
+  controller: ReadableStreamDefaultController<UIMessageChunk>;
+  isClaimed: boolean;
+  isSuperseded: boolean;
+};
+
+type SessionEventsBridgeBinding = {
+  chat: Chat<AgentUIMessage>;
+  transcriptPersistence: TranscriptPersistenceCoordinator;
+  refetchTranscript: () => Promise<void>;
+};
+
+const INITIAL_RECONNECT_DELAY_MS = 500;
+const MAX_RECONNECT_DELAY_MS = 8_000;
+const DEGRADED_REFETCH_INTERVAL_MS = 4_000;
+
+/**
+ * Owns the authenticated session event subscription and exposes one replay
+ * window at a time to the AI SDK's reconnect transport.
+ */
+export class SessionEventsBridge {
+  private readonly sessionId: string;
+  private readonly eventsApiUrl: string;
+  private readonly clientId: string;
+  private readonly agentStore: AgentStore;
+  private abortController: AbortController | null = null;
+  private binding: SessionEventsBridgeBinding | null = null;
+  private currentTurnWindow: TurnWindow | null = null;
+  private currentTurnStarted: SessionTurnStartedData | null = null;
+  private currentSessionState: SessionStateData | null = null;
+  private localPostCount = 0;
+  private hasOriginatedActiveTurn = false;
+  private resumeQueue: Promise<void> = Promise.resolve();
+  private degradedRefetchTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor({
+    sessionId,
+    eventsApiUrl,
+    clientId,
+    agentStore,
+  }: {
+    sessionId: string;
+    eventsApiUrl: string;
+    clientId: string;
+    agentStore: AgentStore;
+  }) {
+    this.sessionId = sessionId;
+    this.eventsApiUrl = eventsApiUrl;
+    this.clientId = clientId;
+    this.agentStore = agentStore;
+  }
+
+  bind(binding: SessionEventsBridgeBinding): void {
+    this.binding = binding;
+  }
+
+  start(): void {
+    if (this.abortController != null) {
+      return;
+    }
+    const abortController = new AbortController();
+    this.abortController = abortController;
+    this.setConnection("connecting");
+    void this.runConnectionLoop(abortController.signal);
+  }
+
+  dispose(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+    this.stopDegradedRefetch();
+    this.failCurrentTurn(
+      new DOMException("Session event bridge closed", "AbortError")
+    );
+    this.binding = null;
+    this.agentStore.getState().setSessionResponsePending(this.sessionId, false);
+    this.agentStore.getState().clearSessionBusState(this.sessionId);
+  }
+
+  /** Marks a POST response as authoritative so its duplicate bus replay is ignored. */
+  beginLocalPost(): (shouldResume?: boolean) => void {
+    this.localPostCount += 1;
+    this.hasOriginatedActiveTurn = true;
+    let hasEnded = false;
+    return (shouldResume = false) => {
+      if (hasEnded) {
+        return;
+      }
+      hasEnded = true;
+      this.localPostCount = Math.max(0, this.localPostCount - 1);
+      if (
+        shouldResume &&
+        this.localPostCount === 0 &&
+        this.currentTurnStarted != null
+      ) {
+        this.openReplayWindow(this.currentTurnStarted);
+      }
+    };
+  }
+
+  /** Whether this resident runtime owns client-tool execution for the active turn. */
+  canExecuteClientTools(): boolean {
+    return (
+      this.localPostCount > 0 ||
+      this.hasOriginatedActiveTurn ||
+      this.currentSessionState?.originClientId === this.clientId
+    );
+  }
+
+  getReconnectStream(): ReadableStream<UIMessageChunk> | null {
+    if (this.localPostCount > 0) {
+      return null;
+    }
+    const turnWindow = this.currentTurnWindow;
+    if (turnWindow == null || turnWindow.isClaimed || turnWindow.isSuperseded) {
+      return null;
+    }
+    turnWindow.isClaimed = true;
+    return turnWindow.stream;
+  }
+
+  private async runConnectionLoop(signal: AbortSignal): Promise<void> {
+    let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+    while (!signal.aborted) {
+      try {
+        const response = await authFetch(this.eventsApiUrl, {
+          headers: { Accept: "text/event-stream" },
+          signal,
+        });
+        if (!response.ok) {
+          throw new Error(
+            `Session events failed with status ${response.status}`
+          );
+        }
+        if (response.body == null) {
+          throw new Error("Session events response body is empty");
+        }
+        reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+        this.setConnection("connected");
+        await this.consumeEventStream(response.body, signal);
+        if (!signal.aborted) {
+          throw new Error("Session events stream ended unexpectedly");
+        }
+      } catch (error) {
+        if (signal.aborted) {
+          break;
+        }
+        this.failCurrentTurn(
+          error instanceof Error
+            ? error
+            : new Error("Session events connection failed")
+        );
+        this.setConnection("reconnecting");
+        await waitForDelay({ delayMs: reconnectDelayMs, signal });
+        reconnectDelayMs = Math.min(
+          reconnectDelayMs * 2,
+          MAX_RECONNECT_DELAY_MS
+        );
+      }
+    }
+    if (this.abortController?.signal === signal) {
+      this.setConnection("disconnected");
+    }
+  }
+
+  private async consumeEventStream(
+    stream: ReadableStream<Uint8Array<ArrayBufferLike>>,
+    signal: AbortSignal
+  ): Promise<void> {
+    const reader = parseJsonEventStream({
+      stream,
+      schema: uiMessageChunkSchema,
+    }).getReader();
+    const abortReader = () => {
+      void reader.cancel(signal.reason);
+    };
+    signal.addEventListener("abort", abortReader, { once: true });
+    try {
+      while (!signal.aborted) {
+        const result = await reader.read();
+        if (result.done) {
+          return;
+        }
+        if (!result.value.success) {
+          throw result.value.error;
+        }
+        this.handleChunk(result.value.value);
+      }
+    } finally {
+      signal.removeEventListener("abort", abortReader);
+      reader.releaseLock();
+    }
+  }
+
+  private handleChunk(chunk: UIMessageChunk): void {
+    if (chunk.type === "data-session-state" && isSessionStateData(chunk.data)) {
+      this.handleSessionState(chunk.data);
+      return;
+    }
+    if (
+      chunk.type === "data-turn-started" &&
+      isSessionTurnStartedData(chunk.data)
+    ) {
+      this.handleTurnStarted(chunk.data);
+      return;
+    }
+    if (
+      chunk.type === "data-transcript-persisted" &&
+      isTranscriptPersistedData(chunk.data)
+    ) {
+      if (this.currentTurnWindow != null) {
+        this.binding?.transcriptPersistence.acknowledge(chunk.data);
+      }
+      return;
+    }
+    this.currentTurnWindow?.controller.enqueue(chunk);
+  }
+
+  private handleSessionState(data: SessionStateData): void {
+    const previousState = this.currentSessionState;
+    this.currentSessionState = data;
+    const degraded = !data.ownedByThisInstance || !data.streamAvailable;
+    const connection =
+      this.agentStore.getState().sessionBusStateBySessionId[this.sessionId]
+        ?.connection ?? "connected";
+    this.agentStore.getState().setSessionBusState(this.sessionId, {
+      state: data.state,
+      turnId: data.turnId ?? null,
+      assistantMessageId: data.assistantMessageId ?? null,
+      originClientId: data.originClientId ?? null,
+      degraded,
+      connection,
+    });
+
+    this.hasOriginatedActiveTurn =
+      data.state !== "idle" && data.originClientId === this.clientId;
+
+    const hasTurnEnded =
+      data.state === "idle" || data.state === "awaiting_client_tool";
+    if (hasTurnEnded) {
+      this.closeCurrentTurn();
+    }
+
+    const shouldPollTranscript = degraded && data.state !== "idle";
+    if (shouldPollTranscript) {
+      this.startDegradedRefetch();
+    } else {
+      this.stopDegradedRefetch();
+    }
+
+    if (data.state === "idle") {
+      this.currentTurnStarted = null;
+      this.agentStore
+        .getState()
+        .setSessionResponsePending(this.sessionId, false);
+      if (
+        previousState?.state !== "idle" ||
+        previousState?.streamAvailable === false
+      ) {
+        void this.refetchTranscript();
+      }
+    }
+  }
+
+  private handleTurnStarted(data: SessionTurnStartedData): void {
+    this.currentTurnStarted = data;
+    this.openReplayWindow(data);
+  }
+
+  private openReplayWindow(data: SessionTurnStartedData): void {
+    const sessionState = this.currentSessionState;
+    const isLocalPostActive = this.localPostCount > 0;
+    const isStreamAvailable = sessionState?.streamAvailable !== false;
+    const isTurnInFlight =
+      sessionState?.state === "streaming" ||
+      sessionState?.state === "persisting";
+    if (isLocalPostActive || !isStreamAvailable || !isTurnInFlight) {
+      return;
+    }
+
+    this.agentStore.getState().setSessionResponsePending(this.sessionId, true);
+    this.supersedeCurrentTurn();
+    let controller: ReadableStreamDefaultController<UIMessageChunk>;
+    const stream = new ReadableStream<UIMessageChunk>({
+      start(streamController) {
+        controller = streamController;
+      },
+    });
+    const turnWindow: TurnWindow = {
+      turnId: data.turnId,
+      stream,
+      controller: controller!,
+      isClaimed: false,
+      isSuperseded: false,
+    };
+    this.currentTurnWindow = turnWindow;
+    const submittedMessage = data.message as unknown as AgentUIMessage;
+    this.resumeQueue = this.resumeQueue
+      .catch(() => undefined)
+      .then(async () => {
+        if (turnWindow.isSuperseded || this.binding == null) {
+          return;
+        }
+        restoreSubmittedMessageBaseline({
+          chat: this.binding.chat,
+          submittedMessage,
+        });
+        await this.binding.chat.resumeStream();
+      });
+  }
+
+  private closeCurrentTurn(): void {
+    const turnWindow = this.currentTurnWindow;
+    if (turnWindow == null || turnWindow.isSuperseded) {
+      return;
+    }
+    turnWindow.controller.close();
+    this.currentTurnWindow = null;
+  }
+
+  private supersedeCurrentTurn(): void {
+    const turnWindow = this.currentTurnWindow;
+    if (turnWindow == null) {
+      return;
+    }
+    turnWindow.isSuperseded = true;
+    turnWindow.controller.error(
+      new TypeError(`Replaying session turn ${turnWindow.turnId}`)
+    );
+    this.currentTurnWindow = null;
+  }
+
+  private failCurrentTurn(error: Error): void {
+    const turnWindow = this.currentTurnWindow;
+    if (turnWindow == null) {
+      return;
+    }
+    turnWindow.isSuperseded = true;
+    turnWindow.controller.error(error);
+    this.currentTurnWindow = null;
+  }
+
+  private setConnection(connection: SessionBusConnection): void {
+    const current =
+      this.agentStore.getState().sessionBusStateBySessionId[this.sessionId];
+    const next: SessionBusState = {
+      state: current?.state ?? "idle",
+      turnId: current?.turnId ?? null,
+      assistantMessageId: current?.assistantMessageId ?? null,
+      originClientId: current?.originClientId ?? null,
+      degraded: current?.degraded ?? false,
+      connection,
+    };
+    this.agentStore.getState().setSessionBusState(this.sessionId, next);
+  }
+
+  private startDegradedRefetch(): void {
+    if (this.degradedRefetchTimer != null) {
+      return;
+    }
+    void this.refetchTranscript();
+    this.degradedRefetchTimer = setInterval(() => {
+      void this.refetchTranscript();
+    }, DEGRADED_REFETCH_INTERVAL_MS);
+  }
+
+  private stopDegradedRefetch(): void {
+    if (this.degradedRefetchTimer == null) {
+      return;
+    }
+    clearInterval(this.degradedRefetchTimer);
+    this.degradedRefetchTimer = null;
+  }
+
+  private async refetchTranscript(): Promise<void> {
+    try {
+      await this.binding?.refetchTranscript();
+    } catch {
+      // The event connection remains authoritative and the next poll retries.
+    }
+  }
+}
+
+/** Restore the server-submitted baseline before consuming a full turn replay. */
+function restoreSubmittedMessageBaseline({
+  chat,
+  submittedMessage,
+}: {
+  chat: Chat<AgentUIMessage>;
+  submittedMessage: AgentUIMessage;
+}): void {
+  const messages = chat.messages;
+  const submittedMessageIndex = messages.findIndex(
+    (message) => message.id === submittedMessage.id
+  );
+  if (submittedMessageIndex >= 0) {
+    chat.messages = [
+      ...messages.slice(0, submittedMessageIndex),
+      submittedMessage,
+    ];
+    return;
+  }
+
+  const hasTrailingPartialAssistant = messages.at(-1)?.role === "assistant";
+  const baseline = hasTrailingPartialAssistant
+    ? messages.slice(0, -1)
+    : messages;
+  chat.messages = [...baseline, submittedMessage];
+}
+
+function isSessionStateData(value: unknown): value is SessionStateData {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    isSessionRunState(value.state) &&
+    typeof value.ownedByThisInstance === "boolean" &&
+    typeof value.streamAvailable === "boolean"
+  );
+}
+
+function isSessionTurnStartedData(
+  value: unknown
+): value is SessionTurnStartedData {
+  return (
+    isRecord(value) &&
+    typeof value.turnId === "string" &&
+    isRecord(value.message) &&
+    typeof value.message.id === "string" &&
+    Array.isArray(value.message.parts)
+  );
+}
+
+function isTranscriptPersistedData(
+  value: unknown
+): value is components["schemas"]["TranscriptPersistedData"] {
+  return isRecord(value) && typeof value.messageId === "string";
+}
+
+function isSessionRunState(
+  value: unknown
+): value is components["schemas"]["SessionRunState"] {
+  return (
+    value === "idle" ||
+    value === "streaming" ||
+    value === "persisting" ||
+    value === "awaiting_client_tool" ||
+    value === "mutating"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function waitForDelay({
+  delayMs,
+  signal,
+}: {
+  delayMs: number;
+  signal: AbortSignal;
+}): Promise<void> {
+  if (signal.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const handleAbort = () => {
+      clearTimeout(timeoutId);
+      resolve();
+    };
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener("abort", handleAbort);
+      resolve();
+    }, delayMs);
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+}

--- a/app/src/agent/chat/sessionEventsBridge.ts
+++ b/app/src/agent/chat/sessionEventsBridge.ts
@@ -35,6 +35,8 @@ type SessionEventsBridgeBinding = {
 const INITIAL_RECONNECT_DELAY_MS = 500;
 const MAX_RECONNECT_DELAY_MS = 8_000;
 const DEGRADED_REFETCH_INTERVAL_MS = 4_000;
+/** After this much continuous downtime the advertised bus state is stale. */
+const STALE_DISCONNECT_THRESHOLD_MS = 30_000;
 
 /**
  * Owns the authenticated session event subscription and exposes one replay
@@ -54,6 +56,14 @@ export class SessionEventsBridge {
   private hasOriginatedActiveTurn = false;
   private resumeQueue: Promise<void> = Promise.resolve();
   private degradedRefetchTimer: ReturnType<typeof setInterval> | null = null;
+  /** The reader of the live event connection, cancellable to force a re-subscribe. */
+  private eventStreamReader: ReadableStreamDefaultReader<unknown> | null = null;
+  /** Set when a re-subscribe was requested to obtain a full turn replay. */
+  private isReplayReconnectRequested = false;
+  /** Set after a connection loss so the next idle state triggers a catch-up refetch. */
+  private shouldRefetchAfterReconnect = false;
+  /** The window the queued resume task handed to the transport. */
+  private pendingResumeWindow: TurnWindow | null = null;
 
   constructor({
     sessionId,
@@ -99,24 +109,51 @@ export class SessionEventsBridge {
   }
 
   /** Marks a POST response as authoritative so its duplicate bus replay is ignored. */
-  beginLocalPost(): (shouldResume?: boolean) => void {
+  beginLocalPost(): (options?: {
+    shouldResume?: boolean;
+    wasTurnClaimed?: boolean;
+  }) => void {
     this.localPostCount += 1;
     this.hasOriginatedActiveTurn = true;
     let hasEnded = false;
-    return (shouldResume = false) => {
+    return ({ shouldResume = false, wasTurnClaimed = true } = {}) => {
       if (hasEnded) {
         return;
       }
       hasEnded = true;
       this.localPostCount = Math.max(0, this.localPostCount - 1);
-      if (
-        shouldResume &&
-        this.localPostCount === 0 &&
-        this.currentTurnStarted != null
-      ) {
-        this.openReplayWindow(this.currentTurnStarted);
+      if (!wasTurnClaimed && this.localPostCount === 0) {
+        // The POST never claimed a turn (e.g. a 409-busy rejection), so fall
+        // back to what the server last advertised instead of keeping the
+        // optimistic originator flag set at POST start.
+        this.hasOriginatedActiveTurn =
+          this.currentSessionState != null &&
+          this.currentSessionState.state !== "idle" &&
+          this.currentSessionState.originClientId === this.clientId;
+      }
+      if (shouldResume && this.localPostCount === 0) {
+        // While the POST stream was live the bridge discarded bus chunks, so
+        // a window opened now would start mid-turn. Re-subscribe instead: the
+        // server replays the in-flight turn from its start and the replayed
+        // turn-started chunk opens a complete window to resume from.
+        this.requestReplayReconnect();
       }
     };
+  }
+
+  /**
+   * Cancels the live event connection so the loop re-subscribes immediately,
+   * making the server replay the active turn from its first chunk.
+   */
+  private requestReplayReconnect(): void {
+    const reader = this.eventStreamReader;
+    if (this.abortController == null || reader == null) {
+      // Not currently connected; the reconnect loop already replays in full
+      // on its next successful attempt.
+      return;
+    }
+    this.isReplayReconnectRequested = true;
+    void reader.cancel();
   }
 
   /** Whether this resident runtime owns client-tool execution for the active turn. */
@@ -129,11 +166,18 @@ export class SessionEventsBridge {
   }
 
   getReconnectStream(): ReadableStream<UIMessageChunk> | null {
-    if (this.localPostCount > 0) {
-      return null;
-    }
-    const turnWindow = this.currentTurnWindow;
-    if (turnWindow == null || turnWindow.isClaimed || turnWindow.isSuperseded) {
+    // Consume the window staged by the resume task that triggered this
+    // reconnect, not the bridge's current window: a fast turn may already
+    // have closed (and detached) its window, whose buffered replay must
+    // still be delivered rather than dropped.
+    const turnWindow = this.pendingResumeWindow;
+    this.pendingResumeWindow = null;
+    if (
+      turnWindow == null ||
+      turnWindow.isClaimed ||
+      turnWindow.isSuperseded ||
+      this.localPostCount > 0
+    ) {
       return null;
     }
     turnWindow.isClaimed = true;
@@ -142,6 +186,7 @@ export class SessionEventsBridge {
 
   private async runConnectionLoop(signal: AbortSignal): Promise<void> {
     let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+    let disconnectedSinceMs: number | null = null;
     while (!signal.aborted) {
       try {
         const response = await authFetch(this.eventsApiUrl, {
@@ -157,8 +202,15 @@ export class SessionEventsBridge {
           throw new Error("Session events response body is empty");
         }
         reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+        disconnectedSinceMs = null;
         this.setConnection("connected");
         await this.consumeEventStream(response.body, signal);
+        if (this.isReplayReconnectRequested) {
+          // An intentional re-subscribe for a full turn replay: reconnect
+          // immediately without failing the current window or backing off.
+          this.isReplayReconnectRequested = false;
+          continue;
+        }
         if (!signal.aborted) {
           throw new Error("Session events stream ended unexpectedly");
         }
@@ -166,12 +218,22 @@ export class SessionEventsBridge {
         if (signal.aborted) {
           break;
         }
+        // A requested replay reconnect that raced a real failure is moot: the
+        // failure path below reconnects (with full replay) anyway.
+        this.isReplayReconnectRequested = false;
+        // A turn may end while we are down; refetch at the next idle state.
+        this.shouldRefetchAfterReconnect = true;
         this.failCurrentTurn(
           error instanceof Error
             ? error
             : new Error("Session events connection failed")
         );
-        this.setConnection("reconnecting");
+        disconnectedSinceMs ??= Date.now();
+        const isBusStateStale =
+          Date.now() - disconnectedSinceMs >= STALE_DISCONNECT_THRESHOLD_MS;
+        // After prolonged downtime advertise "disconnected" (while still
+        // retrying) so busy gating stops trusting the stale bus state.
+        this.setConnection(isBusStateStale ? "disconnected" : "reconnecting");
         await waitForDelay({ delayMs: reconnectDelayMs, signal });
         reconnectDelayMs = Math.min(
           reconnectDelayMs * 2,
@@ -192,6 +254,7 @@ export class SessionEventsBridge {
       stream,
       schema: uiMessageChunkSchema,
     }).getReader();
+    this.eventStreamReader = reader;
     const abortReader = () => {
       void reader.cancel(signal.reason);
     };
@@ -210,6 +273,9 @@ export class SessionEventsBridge {
     } finally {
       signal.removeEventListener("abort", abortReader);
       reader.releaseLock();
+      if (this.eventStreamReader === reader) {
+        this.eventStreamReader = null;
+      }
     }
   }
 
@@ -274,10 +340,15 @@ export class SessionEventsBridge {
       this.agentStore
         .getState()
         .setSessionResponsePending(this.sessionId, false);
-      if (
-        previousState?.state !== "idle" ||
-        previousState?.streamAvailable === false
-      ) {
+      // Refetch only when a turn actually ended (or a connection loss may
+      // have hidden one) — never on the first state chunk of a fresh bridge,
+      // whose chat was just seeded from the same server transcript.
+      const hasLeftNonIdleState =
+        previousState != null &&
+        (previousState.state !== "idle" ||
+          previousState.streamAvailable === false);
+      if (hasLeftNonIdleState || this.shouldRefetchAfterReconnect) {
+        this.shouldRefetchAfterReconnect = false;
         void this.refetchTranscript();
       }
     }
@@ -319,14 +390,28 @@ export class SessionEventsBridge {
     this.resumeQueue = this.resumeQueue
       .catch(() => undefined)
       .then(async () => {
-        if (turnWindow.isSuperseded || this.binding == null) {
+        if (
+          turnWindow.isSuperseded ||
+          this.localPostCount > 0 ||
+          this.binding == null
+        ) {
           return;
         }
         restoreSubmittedMessageBaseline({
           chat: this.binding.chat,
           submittedMessage,
         });
-        await this.binding.chat.resumeStream();
+        // Stage this task's own window for the transport: even if the turn
+        // completed and the bridge already moved on, the closed window still
+        // delivers its buffered replay before finishing cleanly.
+        this.pendingResumeWindow = turnWindow;
+        try {
+          await this.binding.chat.resumeStream();
+        } finally {
+          if (this.pendingResumeWindow === turnWindow) {
+            this.pendingResumeWindow = null;
+          }
+        }
       });
   }
 
@@ -394,6 +479,11 @@ export class SessionEventsBridge {
   }
 
   private async refetchTranscript(): Promise<void> {
+    if (this.localPostCount > 0) {
+      // The live POST stream owns the transcript; a snapshot fetched now
+      // would clobber the in-flight messages when it lands.
+      return;
+    }
     try {
       await this.binding?.refetchTranscript();
     } catch {

--- a/app/src/agent/chat/transcriptPersistence.ts
+++ b/app/src/agent/chat/transcriptPersistence.ts
@@ -59,3 +59,7 @@ export function createTranscriptPersistenceCoordinator() {
     waitForMessage,
   };
 }
+
+export type TranscriptPersistenceCoordinator = ReturnType<
+  typeof createTranscriptPersistenceCoordinator
+>;

--- a/app/src/agent/chat/types.ts
+++ b/app/src/agent/chat/types.ts
@@ -13,6 +13,8 @@ type AgentMessageMetadata = NonNullable<
 
 /** Wire schema of the transient `data-session-summary` stream chunk. */
 type SessionSummaryChunk = components["schemas"]["SessionSummaryChunk"];
+type SessionStateChunk = components["schemas"]["SessionStateChunk"];
+type SessionTurnStartedChunk = components["schemas"]["SessionTurnStartedChunk"];
 type TranscriptPersistedChunk =
   components["schemas"]["TranscriptPersistedChunk"];
 
@@ -21,7 +23,9 @@ type TranscriptPersistedChunk =
  * alongside the message. Keys are the chunk type without the `data-` prefix.
  */
 type AgentUIDataTypes = {
+  "session-state": SessionStateChunk["data"];
   "session-summary": SessionSummaryChunk["data"];
+  "turn-started": SessionTurnStartedChunk["data"];
   "transcript-persisted": TranscriptPersistedChunk["data"];
 };
 

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1626,6 +1626,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/agents/{agent_id}/sessions/{session_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Subscribe To Session Events
+         * @description Follow current and future turns for an owned agent session.
+         */
+        get: operations["subscribeToAgentSessionEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{agent_id}/sessions/{session_id}/stop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stop Agent Session
+         * @description Request cancellation of the active turn for an owned agent session.
+         */
+        post: operations["stopAgentSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/agents/{agent_id}/sessions/{session_id}/chat": {
         parameters: {
             query?: never;
@@ -1710,6 +1750,22 @@ export interface components {
              * @description The session's GlobalID — the ``session_id`` the chat route expects.
              */
             id: string;
+        };
+        /** AgentSessionBusyErrorBody */
+        AgentSessionBusyErrorBody: {
+            /**
+             * Code
+             * @default agent_session_busy
+             * @constant
+             */
+            code?: "agent_session_busy";
+            state: components["schemas"]["SessionRunState"];
+            /** Turnid */
+            turnId: string;
+            /** Assistantmessageid */
+            assistantMessageId?: string | null;
+            /** Ownedbythisinstance */
+            ownedByThisInstance: boolean;
         };
         /** AgentSessionData */
         AgentSessionData: {
@@ -1919,6 +1975,8 @@ export interface components {
             trace?: components["schemas"]["AssistantMessageMetadataTraceIds"] | null;
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
             usage?: components["schemas"]["AssistantMessageMetadataUsage"] | null;
+            /** Interrupted */
+            interrupted?: ("stopped" | "errored") | null;
         } & {
             [key: string]: unknown;
         };
@@ -2055,6 +2113,8 @@ export interface components {
             requestedSkills?: string[];
             model: components["schemas"]["AgentModelSelection"];
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
+            /** Clientid */
+            clientId?: string | null;
             /**
              * Trigger
              * @default submit-message
@@ -4960,6 +5020,11 @@ export interface components {
              */
             identifier?: string;
         };
+        /**
+         * SessionRunState
+         * @enum {string}
+         */
+        SessionRunState: "idle" | "streaming" | "persisting" | "awaiting_client_tool" | "mutating";
         /** SessionTraceData */
         SessionTraceData: {
             /** Id */
@@ -5355,6 +5420,27 @@ export interface components {
              * @constant
              */
             type?: "step-start";
+        };
+        /** StopAgentSessionRequest */
+        StopAgentSessionRequest: {
+            /** Turnid */
+            turnId?: string | null;
+        };
+        /** StopAgentSessionResponse */
+        StopAgentSessionResponse: {
+            data: components["schemas"]["StopAgentSessionResponseData"];
+        };
+        /** StopAgentSessionResponseData */
+        StopAgentSessionResponseData: {
+            /** Turnid */
+            turnId?: string | null;
+            /** @default idle */
+            state?: components["schemas"]["SessionRunState"];
+            /**
+             * Remote
+             * @default false
+             */
+            remote?: boolean;
         };
         /**
          * SubagentsContext
@@ -6104,6 +6190,50 @@ export interface components {
             /** Enabled */
             enabled: boolean;
         };
+        /** SessionStateChunk */
+        SessionStateChunk: {
+            /**
+             * Type
+             * @default data-session-state
+             * @constant
+             */
+            type?: "data-session-state";
+            /**
+             * Id
+             * @default null
+             */
+            id?: string | null;
+            data: components["schemas"]["SessionStateData"];
+            /**
+             * Transient
+             * @default true
+             * @constant
+             */
+            transient?: true;
+        };
+        /** SessionStateData */
+        SessionStateData: {
+            state: components["schemas"]["SessionRunState"];
+            /**
+             * Turnid
+             * @default null
+             */
+            turnId?: string | null;
+            /**
+             * Assistantmessageid
+             * @default null
+             */
+            assistantMessageId?: string | null;
+            /**
+             * Originclientid
+             * @default null
+             */
+            originClientId?: string | null;
+            /** Ownedbythisinstance */
+            ownedByThisInstance: boolean;
+            /** Streamavailable */
+            streamAvailable: boolean;
+        };
         /**
          * SessionSummaryChunk
          * @description Transient ``data-session-summary`` stream chunk: the LLM-generated
@@ -6135,6 +6265,33 @@ export interface components {
              * @constant
              */
             transient?: true;
+        };
+        /** SessionTurnStartedChunk */
+        SessionTurnStartedChunk: {
+            /**
+             * Type
+             * @default data-turn-started
+             * @constant
+             */
+            type?: "data-turn-started";
+            /**
+             * Id
+             * @default null
+             */
+            id?: string | null;
+            data: components["schemas"]["SessionTurnStartedData"];
+            /**
+             * Transient
+             * @default true
+             * @constant
+             */
+            transient?: true;
+        };
+        /** SessionTurnStartedData */
+        SessionTurnStartedData: {
+            /** Turnid */
+            turnId: string;
+            message: components["schemas"]["PhoenixUIMessage"];
         };
         /**
          * ToolCallCallbackProviderMetadata
@@ -11275,6 +11432,90 @@ export interface operations {
                     "application/json": components["schemas"]["CompactAgentSessionResponse"];
                 };
             };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    subscribeToAgentSessionEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stopAgentSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StopAgentSessionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StopAgentSessionResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -11309,6 +11550,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
                 };
             };
             /** @description Validation Error */

--- a/app/src/components/agent/AgentChatInput.tsx
+++ b/app/src/components/agent/AgentChatInput.tsx
@@ -69,6 +69,7 @@ export type AgentChatInputProps = {
   onModelChange: (model: ModelMenuValue) => void;
   isInputDisabled?: boolean;
   isSubmitDisabled?: boolean;
+  placeholder?: string;
   onStop: () => void;
 };
 
@@ -96,6 +97,7 @@ export function AgentChatInput({
   onModelChange,
   isInputDisabled,
   isSubmitDisabled,
+  placeholder = "Send a message...",
   onStop,
 }: AgentChatInputProps) {
   const [slashMenuLayer, setSlashMenuLayer] = useState<HTMLDivElement | null>(
@@ -144,7 +146,7 @@ export function AgentChatInput({
           <AgentContextPills />
           <PromptInputBody>
             <SkillPromptInputBoundary
-              placeholder="Send a message..."
+              placeholder={placeholder}
               commands={PROMPT_COMMANDS}
               onSkillsChange={setAvailableSkills}
               textareaRef={textareaRef}

--- a/app/src/components/agent/AgentChatTopNavButton.tsx
+++ b/app/src/components/agent/AgentChatTopNavButton.tsx
@@ -4,6 +4,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { TooltipTrigger } from "@phoenix/components";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
+import { selectIsSessionBusy } from "@phoenix/store/agentStore";
 
 import { AgentChatWidgetTooltip, OPEN_AGENT_HOTKEY } from "./AgentChatWidget";
 import { PxiButton } from "./PxiButton";
@@ -37,7 +38,8 @@ export function AgentChatTopNavButton() {
   const [shouldFlashOnReturnHome, setShouldFlashOnReturnHome] = useState(false);
   const isResponsePending = useAgentContext((state) =>
     activeSessionId
-      ? (state.isResponsePendingBySessionId[activeSessionId] ?? false)
+      ? selectIsSessionBusy(activeSessionId)(state) ||
+        (state.isResponsePendingBySessionId[activeSessionId] ?? false)
       : false
   );
   useEffect(() => {
@@ -56,7 +58,8 @@ export function AgentChatTopNavButton() {
       // disarms here.
       const isActiveResponsePending =
         state.activeSessionId != null &&
-        (state.isResponsePendingBySessionId[state.activeSessionId] ?? false);
+        (selectIsSessionBusy(state.activeSessionId)(state) ||
+          (state.isResponsePendingBySessionId[state.activeSessionId] ?? false));
       const prefersReducedMotion =
         typeof window.matchMedia === "function" &&
         window.matchMedia("(prefers-reduced-motion: reduce)").matches;

--- a/app/src/components/agent/AgentChatWidget.tsx
+++ b/app/src/components/agent/AgentChatWidget.tsx
@@ -18,6 +18,7 @@ import { useTheme } from "@phoenix/contexts";
 import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { useActiveModalPortalContainerElement } from "@phoenix/hooks/useHasOpenModal";
 import { useModifierKey } from "@phoenix/hooks/useModifierKey";
+import { selectIsSessionBusy } from "@phoenix/store/agentStore";
 
 import { AgentFabPositioner } from "./AgentFabPositioner";
 import { FAB_RESTING_SIZE, FAB_STREAMING_SIZE } from "./agentFabPositioning";
@@ -375,7 +376,8 @@ export function AgentChatWidget({ boundaryRef }: AgentChatWidgetProps = {}) {
   const hasOpenModal = activeModalPortalContainer !== null;
   const isResponsePending = useAgentContext((state) =>
     activeSessionId
-      ? (state.isResponsePendingBySessionId[activeSessionId] ?? false)
+      ? selectIsSessionBusy(activeSessionId)(state) ||
+        (state.isResponsePendingBySessionId[activeSessionId] ?? false)
       : false
   );
 

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -23,8 +23,11 @@ import { ChatSessionUsage } from "@phoenix/components/agent/ChatSessionUsage";
 import { Loading } from "@phoenix/components/core";
 import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
-import type { AgentPosition } from "@phoenix/store/agentStore";
-import { DRAFT_SESSION_ID } from "@phoenix/store/agentStore";
+import {
+  DRAFT_SESSION_ID,
+  isSessionRunBusy,
+  type AgentPosition,
+} from "@phoenix/store/agentStore";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import type { agentSessionRelaySessionQuery } from "./__generated__/agentSessionRelaySessionQuery.graphql";
@@ -140,6 +143,9 @@ function AgentSessionsContent({
   const chatStatusBySessionId = useAgentContext(
     (state) => state.chatStatusBySessionId
   );
+  const sessionBusStateBySessionId = useAgentContext(
+    (state) => state.sessionBusStateBySessionId
+  );
   const setActiveSession = useAgentContext((state) => state.setActiveSession);
   const clearSessionEphemeralState = useAgentContext(
     (state) => state.clearSessionEphemeralState
@@ -170,7 +176,8 @@ function AgentSessionsContent({
       createdAt: Date.parse(node.createdAt as string),
       isDeleteDisabled:
         chatStatusBySessionId[node.id] === "submitted" ||
-        chatStatusBySessionId[node.id] === "streaming",
+        chatStatusBySessionId[node.id] === "streaming" ||
+        isSessionRunBusy(sessionBusStateBySessionId[node.id]?.state),
     })
   );
   const draftSession: AgentSessionListItem | null =
@@ -426,6 +433,9 @@ function AgentChatController({
     clearOperationError,
     rewindToMessage,
     forkFromMessage,
+    isSessionBusy,
+    isBusyFromElsewhere,
+    isDegraded,
   } = useAgentChat({
     sessionId,
     initialMessages,
@@ -450,6 +460,9 @@ function AgentChatController({
       clearOperationError={clearOperationError}
       rewindToMessage={rewindToMessage}
       forkFromMessage={forkFromMessage}
+      isSessionBusy={isSessionBusy}
+      isBusyFromElsewhere={isBusyFromElsewhere}
+      isDegraded={isDegraded}
       modelMenuValue={menuValue}
       onModelChange={handleModelChange}
       autoFocusInput

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -25,7 +25,7 @@ import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import {
   DRAFT_SESSION_ID,
-  isSessionRunBusy,
+  isSessionBusBusy,
   type AgentPosition,
 } from "@phoenix/store/agentStore";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
@@ -177,7 +177,7 @@ function AgentSessionsContent({
       isDeleteDisabled:
         chatStatusBySessionId[node.id] === "submitted" ||
         chatStatusBySessionId[node.id] === "streaming" ||
-        isSessionRunBusy(sessionBusStateBySessionId[node.id]?.state),
+        isSessionBusBusy(sessionBusStateBySessionId[node.id]),
     })
   );
   const draftSession: AgentSessionListItem | null =

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -302,6 +302,16 @@ const chatCSS = css`
     margin-bottom: var(--global-dimension-size-100);
   }
 
+  .chat__bus-alert {
+    margin-bottom: var(--global-dimension-size-100);
+  }
+
+  .chat__bus-status {
+    margin-bottom: var(--global-dimension-size-50);
+    color: var(--global-text-color-300);
+    font-size: var(--global-font-size-xs);
+  }
+
   /* Elicitation-style surfaces (consent gate, rewind confirmation, question
      carousel) can be taller than the panel; let the input region shrink and
      scroll internally instead of clipping at the panel edge. */
@@ -452,6 +462,9 @@ export function ChatView({
   clearOperationError,
   rewindToMessage,
   forkFromMessage,
+  isSessionBusy = false,
+  isBusyFromElsewhere = false,
+  isDegraded = false,
   modelMenuValue,
   onModelChange,
   children,
@@ -484,6 +497,12 @@ export function ChatView({
   rewindToMessage?: (messageId: string) => Promise<string | null>;
   /** Branches a new session from a message; absent hides the branch control. */
   forkFromMessage?: (messageId: string) => Promise<void>;
+  /** Whether local chat state or the server bus currently owns the session. */
+  isSessionBusy?: boolean;
+  /** Whether another browser/client owns the active turn. */
+  isBusyFromElsewhere?: boolean;
+  /** Whether live replay is unavailable because another server owns the turn. */
+  isDegraded?: boolean;
   modelMenuValue: ModelMenuValue;
   onModelChange: (model: ModelMenuValue) => void;
   emptyStateSubtext?: ReactNode;
@@ -546,7 +565,7 @@ export function ChatView({
   // the previous session) as soon as the view mounts. Consuming is atomic, so
   // re-runs and concurrent views are no-ops after the first send.
   useEffect(() => {
-    if (!sessionId) {
+    if (!sessionId || isSessionBusy) {
       return;
     }
     const pending = store.getState().consumePendingMessage(sessionId);
@@ -559,7 +578,7 @@ export function ChatView({
         ? { body: { requestedSkills: pending.requestedSkills } }
         : undefined
     );
-  }, [sessionId, sendMessage, store]);
+  }, [isSessionBusy, sessionId, sendMessage, store]);
 
   const showsEmptyState = messages.length === 0;
   const chatClassName = showsEmptyState ? "chat--empty" : "";
@@ -570,12 +589,22 @@ export function ChatView({
   const isSendDisabledForMissingCredentials =
     !isWaitingForAssistant && Boolean(missingCredentialsProvider);
   const isSubmitDisabled = isSendDisabledForMissingCredentials || isCompacting;
+  const inputStatus =
+    isBusyFromElsewhere && status !== "submitted" && status !== "streaming"
+      ? "submitted"
+      : status;
+  const composerPlaceholder = isDegraded
+    ? "Response is running on another server. Waiting for transcript…"
+    : isBusyFromElsewhere
+      ? "Responding in another window…"
+      : "Send a message...";
   const showThinkingIndicator = shouldShowThinkingIndicator({
     status,
     messages,
   });
   const latestMessage = messages.at(-1);
   const shouldShowInterruptedMessage =
+    !isSessionBusy &&
     status === "ready" &&
     !error &&
     latestMessage?.role === "user" &&
@@ -636,7 +665,8 @@ export function ChatView({
 
   // Rewind/branch changes finalized history, so these actions are only offered
   // once the chat has settled — never mid-request.
-  const hasChatSettled = status === "ready" || status === "error";
+  const hasChatSettled =
+    !isSessionBusy && (status === "ready" || status === "error");
 
   const onRewindRequest = useMemo<MessageRewindRequest | undefined>(() => {
     if (!hasChatSettled || !rewindToMessage) {
@@ -832,7 +862,7 @@ export function ChatView({
                     onRewind={onRewindRequest}
                   />
                 ) : null}
-                {error && (
+                {error && !isSessionBusy && (
                   <ChatErrorMessage
                     error={error}
                     latestUserMessageId={getLatestMessageId({
@@ -851,6 +881,19 @@ export function ChatView({
           </div>
         </ChatScrollContext.Provider>
         <div className="chat__input">
+          {isDegraded && isSessionBusy ? (
+            <div className="chat__bus-alert">
+              <Alert variant="info" title="Live updates unavailable">
+                This response is running on another server. The transcript will
+                refresh automatically when it finishes.
+              </Alert>
+            </div>
+          ) : null}
+          {isBusyFromElsewhere && !isDegraded ? (
+            <div className="chat__bus-status" role="status" aria-live="polite">
+              Responding in another window…
+            </div>
+          ) : null}
           {(operationError || (!rewindRequest && historyActionError)) && (
             <div className="chat__operation-error" role="alert">
               <Alert
@@ -866,11 +909,11 @@ export function ChatView({
               </Alert>
             </div>
           )}
-          {!hasAcknowledgedConsent ? (
+          {!hasAcknowledgedConsent && !isBusyFromElsewhere ? (
             <PromptInput status={status} isDisabled mode="elicitation">
               <AgentConsentGate />
             </PromptInput>
-          ) : rewindRequest ? (
+          ) : rewindRequest && !isBusyFromElsewhere ? (
             <PromptInput status={status} isDisabled mode="elicitation">
               <MessageRewindConfirmation
                 mode={rewindRequest.mode}
@@ -884,7 +927,7 @@ export function ChatView({
                 }}
               />
             </PromptInput>
-          ) : pendingElicitation ? (
+          ) : pendingElicitation && !isBusyFromElsewhere ? (
             <PromptInput status={status} isDisabled mode="elicitation">
               <ElicitationCarousel
                 key={pendingElicitation.toolCallId}
@@ -916,7 +959,7 @@ export function ChatView({
             </PromptInput>
           ) : (
             <AgentChatInput
-              status={status}
+              status={inputStatus}
               value={draftInput}
               onValueChange={setSessionDraftInput}
               onSubmit={({ text, requestedSkills, commandNames }) => {
@@ -950,8 +993,9 @@ export function ChatView({
               textareaRef={textareaRef}
               modelMenuValue={modelMenuValue}
               onModelChange={onModelChange}
-              isInputDisabled={isCompacting}
-              isSubmitDisabled={isSubmitDisabled}
+              isInputDisabled={isCompacting || isBusyFromElsewhere}
+              isSubmitDisabled={isBusyFromElsewhere ? false : isSubmitDisabled}
+              placeholder={composerPlaceholder}
               onStop={() => {
                 void stop();
               }}

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -865,20 +865,21 @@ export function ChatView({
                 {/* While the bus owns the session, hide transient replay
                     errors — but keep failed-send errors (trailing user
                     message) visible so a rejected send is never silent. */}
-                {error && (!isSessionBusy || latestMessage?.role === "user") && (
-                  <ChatErrorMessage
-                    error={error}
-                    latestUserMessageId={getLatestMessageId({
-                      messages,
-                      role: "user",
-                    })}
-                    canFork
-                    onRetry={
-                      rewindToMessage ? handleRetryFailedMessage : undefined
-                    }
-                    onRewind={onRewindRequest}
-                  />
-                )}
+                {error &&
+                  (!isSessionBusy || latestMessage?.role === "user") && (
+                    <ChatErrorMessage
+                      error={error}
+                      latestUserMessageId={getLatestMessageId({
+                        messages,
+                        role: "user",
+                      })}
+                      canFork
+                      onRetry={
+                        rewindToMessage ? handleRetryFailedMessage : undefined
+                      }
+                      onRewind={onRewindRequest}
+                    />
+                  )}
               </div>
             </div>
           </div>

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -862,7 +862,10 @@ export function ChatView({
                     onRewind={onRewindRequest}
                   />
                 ) : null}
-                {error && !isSessionBusy && (
+                {/* While the bus owns the session, hide transient replay
+                    errors — but keep failed-send errors (trailing user
+                    message) visible so a rejected send is never silent. */}
+                {error && (!isSessionBusy || latestMessage?.role === "user") && (
                   <ChatErrorMessage
                     error={error}
                     latestUserMessageId={getLatestMessageId({

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -1,7 +1,7 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
 import { getToolName, isTextUIPart, isToolUIPart } from "ai";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import {
   ConnectionHandler,
   commitLocalUpdate,
@@ -53,8 +53,9 @@ import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import {
   DRAFT_SESSION_ID,
-  isSessionRunBusy,
+  isSessionBusBusy,
   selectIsSessionBusy,
+  type AgentStore,
   type PendingAgentMessage,
 } from "@phoenix/store/agentStore";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
@@ -432,6 +433,25 @@ export function useAgentChat({
         onError: (error) => {
           transcriptPersistence.cancelPendingWaiters();
           turnCompletionGate.fail(error);
+          if (isAgentSessionBusyError(error)) {
+            // The server rejected the send because another client's turn is
+            // active. Return the text to the composer instead of leaving an
+            // unsent user message that the next transcript refresh would
+            // silently drop.
+            const didRestoreMessage = restoreBusyRejectedUserMessage({
+              chat,
+              sessionId: targetSessionId,
+              store,
+            });
+            setOperationError({
+              title: "Message could not be sent",
+              message: didRestoreMessage
+                ? "The assistant is already responding in another window. " +
+                  "Your message was returned to the composer."
+                : "The assistant is already responding in another window. " +
+                  "Wait for the current response to finish and try again.",
+            });
+          }
         },
         onFinish: ({ messages: finalMessages, message }) => {
           turnTraceContext.captureFromMetadata(
@@ -448,6 +468,12 @@ export function useAgentChat({
             environment: relayEnvironment,
             sessionId: targetSessionId,
           });
+          if (isRequestActive(chat.status)) {
+            // A request started while the snapshot was in flight; the live
+            // stream owns the transcript and a stale copy must not clobber
+            // the just-submitted message. The next idle refetch reconciles.
+            return;
+          }
           if (
             result?.agentSession.__typename === "AgentSession" &&
             Array.isArray(result.agentSession.messages)
@@ -467,6 +493,12 @@ export function useAgentChat({
   // runtime owns replacement semantics when the transport changes, while the
   // hook simply binds the current render surface to the selected instance.
   // Draft surfaces have no runtime until the first send creates a session.
+  // The reducer is a render trigger for the rare case where the registry
+  // disposed the runtime between render and the acquire effect.
+  const [, recreateDisposedRuntime] = useReducer(
+    (epoch: number) => epoch + 1,
+    0
+  );
   const persistedSessionId = isDraft ? null : sessionId;
   const chatApiUrl = persistedSessionId
     ? buildAgentChatApiUrl(persistedSessionId)
@@ -492,7 +524,14 @@ export function useAgentChat({
     if (!persistedSessionId || !sessionRuntime) {
       return;
     }
-    runtime.acquireSession(persistedSessionId);
+    const didAcquire = runtime.acquireSession(persistedSessionId);
+    if (!didAcquire) {
+      // The linger timer disposed this runtime between render and commit.
+      // Re-render so getOrCreateSessionRuntime builds a fresh instance; the
+      // new runtime's identity re-runs this effect and acquires it.
+      recreateDisposedRuntime();
+      return;
+    }
     return () => runtime.releaseSession(persistedSessionId);
   }, [persistedSessionId, runtime, sessionRuntime]);
 
@@ -598,6 +637,12 @@ export function useAgentChat({
           body: JSON.stringify({ turnId: turnId ?? undefined }),
         });
         if (response.status === 409) {
+          setOperationError({
+            title: "Response could not be stopped",
+            message:
+              "The response you tried to stop is no longer active. " +
+              "If a new response is running, try stopping it again.",
+          });
           return;
         }
         if (response.ok) {
@@ -697,6 +742,28 @@ export function useAgentChat({
         (persistedSessionId != null &&
           selectIsSessionBusy(persistedSessionId)(store.getState())))
     ) {
+      // Surface the rejection and give the user their message back to retry
+      // instead of silently dropping it.
+      const [blockedMessage] = args;
+      const blockedText =
+        blockedMessage != null &&
+        "text" in blockedMessage &&
+        typeof blockedMessage.text === "string"
+          ? blockedMessage.text
+          : "";
+      if (blockedText && sessionId) {
+        // Deferred: the composer clears itself right after its onSubmit
+        // returns, which would otherwise wipe the restored draft.
+        queueMicrotask(() => {
+          store.getState().setDraftInput(sessionId, blockedText);
+        });
+      }
+      setOperationError({
+        title: "Message could not be sent",
+        message:
+          "The assistant is still responding. " +
+          "Wait for the current response to finish and try again.",
+      });
       return;
     }
 
@@ -1027,7 +1094,7 @@ export function useAgentChat({
     sessionId != null && selectIsSessionBusy(sessionId)(store.getState());
   const isDegraded = sessionBusState?.degraded ?? false;
   const isBusyFromElsewhere =
-    isSessionRunBusy(sessionBusState?.state) &&
+    isSessionBusBusy(sessionBusState) &&
     (isDegraded ||
       sessionBusState?.originClientId !== sessionRuntime?.clientId);
 
@@ -1113,6 +1180,47 @@ export function getRemovedUserMessageText(
 
 function isRequestActive(status: ChatStatus): boolean {
   return status === "submitted" || status === "streaming";
+}
+
+/**
+ * The chat endpoint rejects sends with a 409 whose body carries this code
+ * while another client's turn holds the session. `DefaultChatTransport`
+ * surfaces non-ok responses as an `Error` whose message is the body text.
+ */
+const AGENT_SESSION_BUSY_ERROR_CODE = "agent_session_busy";
+
+function isAgentSessionBusyError(error: Error): boolean {
+  return error.message.includes(AGENT_SESSION_BUSY_ERROR_CODE);
+}
+
+/**
+ * Removes the trailing user message that a busy-rejected send left behind and
+ * restores its text to the session's composer draft. Returns whether a
+ * message was restored (busy-rejected continuations trail an assistant
+ * message and have nothing to restore).
+ */
+function restoreBusyRejectedUserMessage({
+  chat,
+  sessionId,
+  store,
+}: {
+  chat: Chat<AgentUIMessage>;
+  sessionId: string;
+  store: AgentStore;
+}): boolean {
+  const lastMessage = chat.messages.at(-1);
+  if (lastMessage?.role !== "user") {
+    return false;
+  }
+  const text = lastMessage.parts
+    .filter(isTextUIPart)
+    .map((part) => part.text)
+    .join("\n");
+  chat.messages = chat.messages.slice(0, -1);
+  if (text) {
+    store.getState().setDraftInput(sessionId, text);
+  }
+  return true;
 }
 
 function isResolvedToolCall({

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -1,12 +1,7 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
-import {
-  DefaultChatTransport,
-  getToolName,
-  isTextUIPart,
-  isToolUIPart,
-} from "ai";
-import { useCallback, useRef, useState } from "react";
+import { getToolName, isTextUIPart, isToolUIPart } from "ai";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ConnectionHandler,
   commitLocalUpdate,
@@ -15,6 +10,7 @@ import {
   useRelayEnvironment,
 } from "react-relay";
 
+import { AgentSessionChatTransport } from "@phoenix/agent/chat/AgentSessionChatTransport";
 import {
   buildAgentChatRequestBody,
   type AgentChatRequestBodyPatch,
@@ -22,6 +18,7 @@ import {
 import { createClientToolTimingRecorder } from "@phoenix/agent/chat/clientToolTimings";
 import { handleAgentToolCall } from "@phoenix/agent/chat/handleAgentToolCall";
 import { getUnresolvedToolCalls } from "@phoenix/agent/chat/interruptToolCalls";
+import type { SessionEventsBridge } from "@phoenix/agent/chat/sessionEventsBridge";
 import {
   SYSTEM_INTERRUPT_ERROR,
   USER_INTERRUPT_ERROR,
@@ -56,6 +53,8 @@ import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
 import {
   DRAFT_SESSION_ID,
+  isSessionRunBusy,
+  selectIsSessionBusy,
   type PendingAgentMessage,
 } from "@phoenix/store/agentStore";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
@@ -90,6 +89,10 @@ const CHAT_PATH_TEMPLATE =
   "/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof paths;
 const COMPACT_PATH_TEMPLATE =
   "/agents/{agent_id}/sessions/{session_id}/compact" satisfies keyof paths;
+const EVENTS_PATH_TEMPLATE =
+  "/agents/{agent_id}/sessions/{session_id}/events" satisfies keyof paths;
+const STOP_PATH_TEMPLATE =
+  "/agents/{agent_id}/sessions/{session_id}/stop" satisfies keyof paths;
 const ASSISTANT_AGENT_ID = "assistant";
 
 function buildAgentChatApiUrl(sessionId: string): string {
@@ -104,6 +107,24 @@ function buildAgentChatApiUrl(sessionId: string): string {
 function buildAgentCompactApiUrl(sessionId: string): string {
   return prependBasename(
     COMPACT_PATH_TEMPLATE.replace("{agent_id}", ASSISTANT_AGENT_ID).replace(
+      "{session_id}",
+      encodeURIComponent(sessionId)
+    )
+  );
+}
+
+function buildAgentEventsApiUrl(sessionId: string): string {
+  return prependBasename(
+    EVENTS_PATH_TEMPLATE.replace("{agent_id}", ASSISTANT_AGENT_ID).replace(
+      "{session_id}",
+      encodeURIComponent(sessionId)
+    )
+  );
+}
+
+function buildAgentStopApiUrl(sessionId: string): string {
+  return prependBasename(
+    STOP_PATH_TEMPLATE.replace("{agent_id}", ASSISTANT_AGENT_ID).replace(
       "{session_id}",
       encodeURIComponent(sessionId)
     )
@@ -236,6 +257,9 @@ export function useAgentChat({
   const pendingElicitation = useAgentContext((state) =>
     sessionId ? (state.pendingElicitationBySessionId[sessionId] ?? null) : null
   );
+  const sessionBusState = useAgentContext((state) =>
+    sessionId ? state.sessionBusStateBySessionId[sessionId] : undefined
+  );
 
   const [commitCreateAgentSession] =
     useMutation<useAgentChatCreateAgentSessionMutation>(
@@ -267,14 +291,22 @@ export function useAgentChat({
    * builds a chat after the create-session mutation returns one.
    */
   const createChatForSession = useCallback(
-    (
-      targetSessionId: string,
-      seedMessages: AgentUIMessage[]
-    ): Chat<AgentUIMessage> => {
+    ({
+      targetSessionId,
+      seedMessages,
+      clientId,
+      eventsBridge,
+    }: {
+      targetSessionId: string;
+      seedMessages: AgentUIMessage[];
+      clientId: string;
+      eventsBridge: SessionEventsBridge;
+    }): Chat<AgentUIMessage> => {
       const chatApiUrl = buildAgentChatApiUrl(targetSessionId);
       const turnTraceContext = createTurnTraceContextManager();
       const toolTimings = createClientToolTimingRecorder();
       const transcriptPersistence = createTranscriptPersistenceCoordinator();
+      const handledClientToolCallIds = new Set<string>();
       const turnCompletionGate = createTurnCompletionGate({
         endTurn: async () => {
           store.getState().setSessionResponsePending(targetSessionId, false);
@@ -295,7 +327,8 @@ export function useAgentChat({
         id: targetSessionId,
         messages: seedMessages,
         generateId: () => crypto.randomUUID(),
-        transport: new DefaultChatTransport({
+        transport: new AgentSessionChatTransport({
+          eventsBridge,
           api: chatApiUrl,
           fetch: authFetch,
           prepareSendMessagesRequest: ({ body, id, messages }) => {
@@ -319,6 +352,7 @@ export function useAgentChat({
                 modelSelection: selectAgentModel(store.getState()),
                 turnTraceContext: turnTraceContext.getActive(),
                 toolTimings,
+                clientId,
               }),
             };
           },
@@ -335,7 +369,19 @@ export function useAgentChat({
           const isServerExecuted =
             isRecord(phoenixMetadata) &&
             phoenixMetadata.toolExecutionEnvironment === "server";
+          if (
+            !isServerExecuted &&
+            (!eventsBridge.canExecuteClientTools() ||
+              handledClientToolCallIds.has(toolCall.toolCallId) ||
+              isResolvedToolCall({
+                messages: chat.messages,
+                toolCallId: toolCall.toolCallId,
+              }))
+          ) {
+            return;
+          }
           if (!isServerExecuted) {
+            handledClientToolCallIds.add(toolCall.toolCallId);
             toolTimings.recordStart(toolCall.toolCallId);
           }
           void handleAgentToolCall({
@@ -367,6 +413,9 @@ export function useAgentChat({
           }
         },
         sendAutomaticallyWhen: async ({ messages }) => {
+          if (!eventsBridge.canExecuteClientTools()) {
+            return false;
+          }
           const shouldSendAutomatically =
             await turnCompletionGate.handleSendAutomaticallyWhen({ messages });
           if (!shouldSendAutomatically) {
@@ -391,6 +440,23 @@ export function useAgentChat({
           turnCompletionGate.handleFinish({ finalMessages, message });
         },
       });
+      eventsBridge.bind({
+        chat,
+        transcriptPersistence,
+        refetchTranscript: async () => {
+          const result = await refetchAgentSession({
+            environment: relayEnvironment,
+            sessionId: targetSessionId,
+          });
+          if (
+            result?.agentSession.__typename === "AgentSession" &&
+            Array.isArray(result.agentSession.messages)
+          ) {
+            chat.messages = result.agentSession.messages as AgentUIMessage[];
+            chat.clearError();
+          }
+        },
+      });
       turnClientStateByChat.set(chat, { turnTraceContext, toolTimings });
       return chat;
     },
@@ -405,18 +471,30 @@ export function useAgentChat({
   const chatApiUrl = persistedSessionId
     ? buildAgentChatApiUrl(persistedSessionId)
     : null;
-  const chatInstance =
+  const sessionRuntime =
     chatApiUrl && persistedSessionId
-      ? runtime.getOrCreateChat({
+      ? runtime.getOrCreateSessionRuntime({
           sessionId: persistedSessionId,
           chatApiUrl,
-          createChat: (previousMessages) =>
-            createChatForSession(
-              persistedSessionId,
-              previousMessages ?? initialMessages ?? []
-            ),
+          eventsApiUrl: buildAgentEventsApiUrl(persistedSessionId),
+          createChat: ({ previousMessages, clientId, eventsBridge }) =>
+            createChatForSession({
+              targetSessionId: persistedSessionId,
+              seedMessages: previousMessages ?? initialMessages ?? [],
+              clientId,
+              eventsBridge,
+            }),
         })
       : null;
+  const chatInstance = sessionRuntime?.chat ?? null;
+
+  useEffect(() => {
+    if (!persistedSessionId || !sessionRuntime) {
+      return;
+    }
+    runtime.acquireSession(persistedSessionId);
+    return () => runtime.releaseSession(persistedSessionId);
+  }, [persistedSessionId, runtime, sessionRuntime]);
 
   // `useChat` subscribes the current React tree to the already-created runtime
   // instance. Draft surfaces expose an inert chat shape until the first send.
@@ -491,7 +569,7 @@ export function useAgentChat({
     );
   };
 
-  const handleStopWithToolCleanup = async () => {
+  const stopLocallyWithToolCleanup = async () => {
     await stop();
     if (sessionId) {
       store.getState().setSessionResponsePending(sessionId, false);
@@ -507,6 +585,39 @@ export function useAgentChat({
       turnClientState?.toolTimings.clear();
     }
     setMessages(removeInterruptedToolInputParts);
+  };
+
+  const handleStopWithToolCleanup = async () => {
+    if (!isDraft && sessionId) {
+      try {
+        const turnId =
+          store.getState().sessionBusStateBySessionId[sessionId]?.turnId;
+        const response = await authFetch(buildAgentStopApiUrl(sessionId), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ turnId: turnId ?? undefined }),
+        });
+        if (response.status === 409) {
+          return;
+        }
+        if (response.ok) {
+          const responseBody: unknown = await response.json().catch(() => null);
+          const stoppedTurnId =
+            isRecord(responseBody) && isRecord(responseBody.data)
+              ? responseBody.data.turnId
+              : null;
+          const didStopClaimedTurn = typeof stoppedTurnId === "string";
+          const isLocalRequestStillPreparing =
+            chatInstance != null && isRequestActive(chatInstance.status);
+          if (didStopClaimedTurn || !isLocalRequestStillPreparing) {
+            return;
+          }
+        }
+      } catch {
+        // Fall through to the legacy client-side abort and tool cleanup.
+      }
+    }
+    await stopLocallyWithToolCleanup();
   };
 
   /**
@@ -539,13 +650,19 @@ export function useAgentChat({
         isCreatingSessionRef.current = false;
         const newSessionId = response.createAgentSession.agentSession.id;
         const newChatApiUrl = buildAgentChatApiUrl(newSessionId);
-        const newChat = runtime.getOrCreateChat({
+        const newRuntime = runtime.getOrCreateSessionRuntime({
           sessionId: newSessionId,
           chatApiUrl: newChatApiUrl,
-          createChat: (previousMessages) =>
-            createChatForSession(newSessionId, previousMessages ?? []),
+          eventsApiUrl: buildAgentEventsApiUrl(newSessionId),
+          createChat: ({ previousMessages, clientId, eventsBridge }) =>
+            createChatForSession({
+              targetSessionId: newSessionId,
+              seedMessages: previousMessages ?? [],
+              clientId,
+              eventsBridge,
+            }),
         });
-        void newChat.sendMessage(
+        void newRuntime.chat.sendMessage(
           { text, metadata: buildUserMessageMetadata() },
           options
         );
@@ -574,7 +691,12 @@ export function useAgentChat({
       createSessionAndSendMessage(...args);
       return;
     }
-    if (chatInstance && isRequestActive(chatInstance.status)) {
+    if (
+      chatInstance &&
+      (isRequestActive(chatInstance.status) ||
+        (persistedSessionId != null &&
+          selectIsSessionBusy(persistedSessionId)(store.getState())))
+    ) {
       return;
     }
 
@@ -610,7 +732,10 @@ export function useAgentChat({
       });
       return;
     }
-    if (isRequestActive(chatInstance.status)) {
+    if (
+      isRequestActive(chatInstance.status) ||
+      selectIsSessionBusy(sessionId)(store.getState())
+    ) {
       restorePendingMessage();
       setOperationError({
         title: "Conversation could not be compacted",
@@ -778,7 +903,7 @@ export function useAgentChat({
         isDraft ||
         !sessionId ||
         !chatInstance ||
-        isRequestActive(chatInstance.status)
+        selectIsSessionBusy(sessionId)(store.getState())
       ) {
         return Promise.resolve(null);
       }
@@ -820,6 +945,7 @@ export function useAgentChat({
       isDraft,
       sessionId,
       setMessages,
+      store,
     ]
   );
 
@@ -829,7 +955,12 @@ export function useAgentChat({
   // runtime chat from the returned transcript and activates it.
   const forkFromMessage = useCallback(
     (messageId: string): Promise<void> => {
-      if (isDraft || !sessionId || !chatInstance) {
+      if (
+        isDraft ||
+        !sessionId ||
+        !chatInstance ||
+        selectIsSessionBusy(sessionId)(store.getState())
+      ) {
         return Promise.resolve();
       }
       clearError();
@@ -852,14 +983,17 @@ export function useAgentChat({
             const branchMessages = Array.isArray(payload.agentSession.messages)
               ? (payload.agentSession.messages as AgentUIMessage[])
               : [];
-            runtime.getOrCreateChat({
+            runtime.getOrCreateSessionRuntime({
               sessionId: branchSessionId,
               chatApiUrl: branchChatApiUrl,
-              createChat: (previousMessages) =>
-                createChatForSession(
-                  branchSessionId,
-                  previousMessages ?? branchMessages
-                ),
+              eventsApiUrl: buildAgentEventsApiUrl(branchSessionId),
+              createChat: ({ previousMessages, clientId, eventsBridge }) =>
+                createChatForSession({
+                  targetSessionId: branchSessionId,
+                  seedMessages: previousMessages ?? branchMessages,
+                  clientId,
+                  eventsBridge,
+                }),
             });
             const state = store.getState();
             if (restoredInput) {
@@ -889,6 +1023,14 @@ export function useAgentChat({
     ]
   );
 
+  const isSessionBusy =
+    sessionId != null && selectIsSessionBusy(sessionId)(store.getState());
+  const isDegraded = sessionBusState?.degraded ?? false;
+  const isBusyFromElsewhere =
+    isSessionRunBusy(sessionBusState?.state) &&
+    (isDegraded ||
+      sessionBusState?.originClientId !== sessionRuntime?.clientId);
+
   return {
     messages,
     sendMessage: handleSendMessage,
@@ -905,6 +1047,9 @@ export function useAgentChat({
     clearOperationError: () => setOperationError(null),
     rewindToMessage,
     forkFromMessage,
+    isSessionBusy,
+    isBusyFromElsewhere,
+    isDegraded,
   } as {
     messages: AgentUIMessage[];
     sendMessage: (
@@ -924,6 +1069,9 @@ export function useAgentChat({
     clearOperationError: () => void;
     rewindToMessage: (messageId: string) => Promise<string | null>;
     forkFromMessage: (messageId: string) => Promise<void>;
+    isSessionBusy: boolean;
+    isBusyFromElsewhere: boolean;
+    isDegraded: boolean;
   };
 }
 
@@ -965,6 +1113,25 @@ export function getRemovedUserMessageText(
 
 function isRequestActive(status: ChatStatus): boolean {
   return status === "submitted" || status === "streaming";
+}
+
+function isResolvedToolCall({
+  messages,
+  toolCallId,
+}: {
+  messages: AgentUIMessage[];
+  toolCallId: string;
+}): boolean {
+  return messages.some((message) =>
+    message.parts.some(
+      (part) =>
+        isToolUIPart(part) &&
+        part.toolCallId === toolCallId &&
+        (part.state === "output-available" ||
+          part.state === "output-error" ||
+          part.state === "output-denied")
+    )
+  );
 }
 
 async function getAgentCompactErrorMessage(

--- a/app/src/components/ai/prompt-input/PromptInputSubmit.tsx
+++ b/app/src/components/ai/prompt-input/PromptInputSubmit.tsx
@@ -12,6 +12,7 @@ import type { PromptInputSubmitProps } from "./types";
  * - **submitted / streaming** — stop icon; pressing stops generation.
  *
  * Automatically disables when `status` is `"ready"` and the textarea is empty.
+ * A disabled composer keeps the stop action available while generation is active.
  */
 export function PromptInputSubmit({
   ref,
@@ -46,7 +47,7 @@ export function PromptInputSubmit({
       ref={ref}
       css={promptInputSubmitCSS}
       className={className}
-      isDisabled={computedDisabled || context.isDisabled}
+      isDisabled={computedDisabled || (context.isDisabled && !isStreaming)}
       onPress={handlePress}
       aria-label={computedAriaLabel}
     >

--- a/app/src/components/ai/prompt-input/types.ts
+++ b/app/src/components/ai/prompt-input/types.ts
@@ -85,7 +85,8 @@ export interface PromptInputProps
    */
   status?: PromptInputStatus;
   /**
-   * When true, disables the textarea, submit button, and all tool buttons.
+   * When true, disables the textarea and tool buttons. The active stop action
+   * remains available for submitted/streaming inputs.
    * @default false
    */
   isDisabled?: boolean;

--- a/app/src/contexts/AgentChatRuntimeContext.tsx
+++ b/app/src/contexts/AgentChatRuntimeContext.tsx
@@ -1,9 +1,16 @@
 import type { Chat } from "@ai-sdk/react";
 import type { PropsWithChildren } from "react";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 
+import { SessionEventsBridge } from "@phoenix/agent/chat/sessionEventsBridge";
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { useAgentStore } from "@phoenix/contexts/AgentContext";
+
+export type AgentSessionChatRuntime = {
+  chat: Chat<AgentUIMessage>;
+  clientId: string;
+  eventsBridge: SessionEventsBridge;
+};
 
 type AgentChatRuntime = {
   /**
@@ -16,17 +23,25 @@ type AgentChatRuntime = {
    * variants alive; the replacement is seeded with the previous instance's
    * messages so the visible conversation carries over.
    */
-  getOrCreateChat: ({
+  getOrCreateSessionRuntime: ({
     sessionId,
     chatApiUrl,
+    eventsApiUrl,
     createChat,
   }: {
     sessionId: string;
     chatApiUrl: string;
-    createChat: (
-      previousMessages: AgentUIMessage[] | null
-    ) => Chat<AgentUIMessage>;
-  }) => Chat<AgentUIMessage>;
+    eventsApiUrl: string;
+    createChat: (options: {
+      previousMessages: AgentUIMessage[] | null;
+      clientId: string;
+      eventsBridge: SessionEventsBridge;
+    }) => Chat<AgentUIMessage>;
+  }) => AgentSessionChatRuntime;
+  /** Attaches a mounted session surface to its event bridge. */
+  acquireSession: (sessionId: string) => void;
+  /** Releases a mounted surface and starts the 30-second runtime linger. */
+  releaseSession: (sessionId: string) => void;
   /** Returns the resident chat for a session, if one exists. */
   getChat: (sessionId: string) => Chat<AgentUIMessage> | null;
   /**
@@ -34,6 +49,8 @@ type AgentChatRuntime = {
    * transcript's durable copy lives on the server.
    */
   evictChat: (sessionId: string) => void;
+  /** Disposes every runtime when the authenticated app root unmounts. */
+  dispose: () => void;
 };
 
 const AgentChatRuntimeContext = createContext<AgentChatRuntime | null>(null);
@@ -48,62 +65,144 @@ const AgentChatRuntimeContext = createContext<AgentChatRuntime | null>(null);
  *
  * A chat is created the first time a session's surface binds to it — seeded
  * from the Relay-fetched transcript — and stays resident until the session is
- * deleted, so requests continue while the visible surface moves between
- * layouts and unsent local state (e.g. an unsent branch) is not lost when the
- * user switches sessions.
+ * released. A short linger keeps requests and unsent state alive while the
+ * visible surface moves between layouts, after which the detached server turn
+ * remains recoverable through the session event stream.
  */
 export function AgentChatRuntimeProvider({ children }: PropsWithChildren) {
   const store = useAgentStore();
+  const disposeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [runtime] = useState<AgentChatRuntime>(() => {
     const chatRegistry = new Map<
       string,
       {
         chatApiUrl: string;
         chat: Chat<AgentUIMessage>;
+        clientId: string;
+        eventsBridge: SessionEventsBridge;
+        refCount: number;
+        lingerTimer: ReturnType<typeof setTimeout> | null;
         unsubscribe: () => void;
       }
     >();
 
+    const destroyEntry = (sessionId: string) => {
+      const entry = chatRegistry.get(sessionId);
+      if (!entry) {
+        return;
+      }
+      if (entry.lingerTimer != null) {
+        clearTimeout(entry.lingerTimer);
+      }
+      entry.unsubscribe();
+      entry.eventsBridge.dispose();
+      chatRegistry.delete(sessionId);
+      store.getState().setSessionChatStatus(sessionId, "ready");
+    };
+
     return {
-      getOrCreateChat: ({ sessionId, chatApiUrl, createChat }) => {
+      getOrCreateSessionRuntime: ({
+        sessionId,
+        chatApiUrl,
+        eventsApiUrl,
+        createChat,
+      }) => {
         const existingEntry = chatRegistry.get(sessionId);
         if (existingEntry && existingEntry.chatApiUrl === chatApiUrl) {
-          return existingEntry.chat;
+          return existingEntry;
         }
 
         // A model/transport swap replaces the runtime for this session. We do
         // not keep multiple chat variants per session alive; the replacement
         // inherits the previous instance's messages.
         if (existingEntry) {
-          existingEntry.unsubscribe();
+          destroyEntry(sessionId);
         }
 
-        const chat = createChat(existingEntry?.chat.messages ?? null);
+        const clientId = crypto.randomUUID();
+        const eventsBridge = new SessionEventsBridge({
+          sessionId,
+          eventsApiUrl,
+          clientId,
+          agentStore: store,
+        });
+        const chat = createChat({
+          previousMessages: existingEntry?.chat.messages ?? null,
+          clientId,
+          eventsBridge,
+        });
         // Mirror transient AI SDK status into the store so other surfaces
         // (session list, FAB) can react without holding a direct reference to
         // the runtime instance.
         const unsubscribe = chat["~registerStatusCallback"](() => {
           store.getState().setSessionChatStatus(sessionId, chat.status);
         });
-        chatRegistry.set(sessionId, { chatApiUrl, chat, unsubscribe });
+        const entry = {
+          chatApiUrl,
+          chat,
+          clientId,
+          eventsBridge,
+          refCount: 0,
+          lingerTimer: null,
+          unsubscribe,
+        };
+        chatRegistry.set(sessionId, entry);
         // Defer initial status sync to avoid updating state during render,
         // which triggers React warnings and can break component lifecycles.
         queueMicrotask(() => {
           store.getState().setSessionChatStatus(sessionId, chat.status);
         });
-        return chat;
+        return entry;
       },
-      getChat: (sessionId) => chatRegistry.get(sessionId)?.chat ?? null,
-      evictChat: (sessionId) => {
+      acquireSession: (sessionId) => {
         const entry = chatRegistry.get(sessionId);
         if (!entry) {
           return;
         }
-        entry.unsubscribe();
-        chatRegistry.delete(sessionId);
+        entry.refCount += 1;
+        if (entry.lingerTimer != null) {
+          clearTimeout(entry.lingerTimer);
+          entry.lingerTimer = null;
+        }
+        entry.eventsBridge.start();
+      },
+      releaseSession: (sessionId) => {
+        const entry = chatRegistry.get(sessionId);
+        if (!entry) {
+          return;
+        }
+        entry.refCount = Math.max(0, entry.refCount - 1);
+        if (entry.refCount > 0 || entry.lingerTimer != null) {
+          return;
+        }
+        entry.lingerTimer = setTimeout(() => {
+          const currentEntry = chatRegistry.get(sessionId);
+          if (currentEntry === entry && entry.refCount === 0) {
+            destroyEntry(sessionId);
+          }
+        }, 30_000);
+      },
+      getChat: (sessionId) => chatRegistry.get(sessionId)?.chat ?? null,
+      evictChat: (sessionId) => {
+        destroyEntry(sessionId);
+      },
+      dispose: () => {
+        for (const sessionId of chatRegistry.keys()) {
+          destroyEntry(sessionId);
+        }
       },
     };
   });
+
+  useEffect(() => {
+    if (disposeTimerRef.current != null) {
+      clearTimeout(disposeTimerRef.current);
+      disposeTimerRef.current = null;
+    }
+    return () => {
+      disposeTimerRef.current = setTimeout(() => runtime.dispose(), 0);
+    };
+  }, [runtime]);
 
   return (
     <AgentChatRuntimeContext.Provider value={runtime}>

--- a/app/src/contexts/AgentChatRuntimeContext.tsx
+++ b/app/src/contexts/AgentChatRuntimeContext.tsx
@@ -38,8 +38,13 @@ type AgentChatRuntime = {
       eventsBridge: SessionEventsBridge;
     }) => Chat<AgentUIMessage>;
   }) => AgentSessionChatRuntime;
-  /** Attaches a mounted session surface to its event bridge. */
-  acquireSession: (sessionId: string) => void;
+  /**
+   * Attaches a mounted session surface to its event bridge. Returns false
+   * when the runtime was already disposed (e.g. the linger timer fired
+   * between render and commit), in which case the surface must re-render to
+   * recreate a fresh runtime instead of staying bound to a dead one.
+   */
+  acquireSession: (sessionId: string) => boolean;
   /** Releases a mounted surface and starts the 30-second runtime linger. */
   releaseSession: (sessionId: string) => void;
   /** Returns the resident chat for a session, if one exists. */
@@ -157,7 +162,7 @@ export function AgentChatRuntimeProvider({ children }: PropsWithChildren) {
       acquireSession: (sessionId) => {
         const entry = chatRegistry.get(sessionId);
         if (!entry) {
-          return;
+          return false;
         }
         entry.refCount += 1;
         if (entry.lingerTimer != null) {
@@ -165,6 +170,7 @@ export function AgentChatRuntimeProvider({ children }: PropsWithChildren) {
           entry.lingerTimer = null;
         }
         entry.eventsBridge.start();
+        return true;
       },
       releaseSession: (sessionId) => {
         const entry = chatRegistry.get(sessionId);

--- a/app/src/pages/settings/SettingsAgentSessionActionMenu.tsx
+++ b/app/src/pages/settings/SettingsAgentSessionActionMenu.tsx
@@ -32,7 +32,10 @@ import {
 import { EditAgentSessionTitleDialog } from "@phoenix/components/agent/EditAgentSessionTitleDialog";
 import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
-import { DRAFT_SESSION_ID } from "@phoenix/store/agentStore";
+import {
+  DRAFT_SESSION_ID,
+  selectIsSessionBusy,
+} from "@phoenix/store/agentStore";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import type { SettingsAgentSessionActionMenuDeleteMutation } from "./__generated__/SettingsAgentSessionActionMenuDeleteMutation.graphql";
@@ -75,15 +78,12 @@ export function SettingsAgentSessionActionMenu({
   const store = useAgentStore();
   const runtime = useAgentChatRuntime();
   const activeSessionId = useAgentContext((state) => state.activeSessionId);
-  const chatStatus = useAgentContext(
-    (state) => state.chatStatusBySessionId[sessionId]
-  );
+  const isSessionBusy = useAgentContext(selectIsSessionBusy(sessionId));
   const setActiveSession = useAgentContext((state) => state.setActiveSession);
   const clearSessionEphemeralState = useAgentContext(
     (state) => state.clearSessionEphemeralState
   );
-  const isDeleteDisabled =
-    chatStatus === "submitted" || chatStatus === "streaming";
+  const isDeleteDisabled = isSessionBusy;
   const connectionIds = [
     ConnectionHandler.getConnectionID(
       "client:root",

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -1196,6 +1196,22 @@ export function isSessionRunBusy(
   return state != null && state !== "idle";
 }
 
+/**
+ * Whether the server-advertised bus state should gate local actions. After a
+ * prolonged connection loss the bridge marks the connection "disconnected"
+ * (while still retrying); a terminal idle/turn-end chunk may have been missed,
+ * so the stale busy state must not lock the composer indefinitely.
+ */
+export function isSessionBusBusy(
+  busState: SessionBusState | undefined
+): boolean {
+  return (
+    busState != null &&
+    busState.connection !== "disconnected" &&
+    isSessionRunBusy(busState.state)
+  );
+}
+
 /** Select whether local chat work or the server event bus owns the session. */
 export const selectIsSessionBusy =
   (sessionId: string) => (state: AgentState) => {
@@ -1203,14 +1219,18 @@ export const selectIsSessionBusy =
     return (
       chatStatus === "submitted" ||
       chatStatus === "streaming" ||
-      isSessionRunBusy(state.sessionBusStateBySessionId[sessionId]?.state)
+      isSessionBusBusy(state.sessionBusStateBySessionId[sessionId])
     );
   };
 
 /** Select whether a session still has a local or server-side response pending. */
 export const selectIsSessionResponsePending =
   (sessionId: string) => (state: AgentState) => {
-    const runState = state.sessionBusStateBySessionId[sessionId]?.state;
+    const busState = state.sessionBusStateBySessionId[sessionId];
+    const runState =
+      busState != null && busState.connection !== "disconnected"
+        ? busState.state
+        : undefined;
     return (
       (state.isResponsePendingBySessionId[sessionId] ?? false) ||
       runState === "streaming" ||

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -26,6 +26,7 @@ import type {
 } from "@phoenix/agent/tools/playgroundPrompt";
 import type { PendingPromptToolWrite } from "@phoenix/agent/tools/playgroundPromptTools";
 import type { PendingSavePrompt } from "@phoenix/agent/tools/playgroundSavePrompt";
+import type { components } from "@phoenix/api/__generated__/v1";
 import { getDefaultInvocationConfig } from "@phoenix/pages/playground/providerAdapters";
 
 import type { ModelConfig } from "./playground/types";
@@ -118,6 +119,22 @@ export type AgentPermissions = {
 export type PendingAgentMessage = {
   text: string;
   requestedSkills: string[];
+};
+
+export type SessionBusConnection =
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected";
+
+/** Latest server-advertised execution state for one agent session. */
+export type SessionBusState = {
+  state: components["schemas"]["SessionRunState"];
+  turnId: string | null;
+  assistantMessageId: string | null;
+  originClientId: string | null;
+  degraded: boolean;
+  connection: SessionBusConnection;
 };
 
 /**
@@ -319,6 +336,9 @@ export interface AgentState extends AgentProps {
   ) => void;
   chatStatusBySessionId: Record<string, ChatStatus>;
   setSessionChatStatus: (sessionId: string, status: ChatStatus) => void;
+  sessionBusStateBySessionId: Partial<Record<string, SessionBusState>>;
+  setSessionBusState: (sessionId: string, state: SessionBusState) => void;
+  clearSessionBusState: (sessionId: string) => void;
   /** Whether a logical PXI turn is still awaiting its terminal response. */
   isResponsePendingBySessionId: Partial<Record<string, boolean>>;
   setSessionResponsePending: (sessionId: string, isPending: boolean) => void;
@@ -655,6 +675,10 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
           delete newPendingElicitationBySessionId[sessionId];
           const newChatStatusBySessionId = { ...state.chatStatusBySessionId };
           delete newChatStatusBySessionId[sessionId];
+          const newSessionBusStateBySessionId = {
+            ...state.sessionBusStateBySessionId,
+          };
+          delete newSessionBusStateBySessionId[sessionId];
           const newIsResponsePendingBySessionId = {
             ...state.isResponsePendingBySessionId,
           };
@@ -677,6 +701,7 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
           return {
             pendingElicitationBySessionId: newPendingElicitationBySessionId,
             chatStatusBySessionId: newChatStatusBySessionId,
+            sessionBusStateBySessionId: newSessionBusStateBySessionId,
             isResponsePendingBySessionId: newIsResponsePendingBySessionId,
             isCompactionPendingBySessionId: newIsCompactionPendingBySessionId,
             draftInputBySessionId: newDraftInputBySessionId,
@@ -826,6 +851,33 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
         }),
         false,
         { type: "setSessionChatStatus" }
+      );
+    },
+    sessionBusStateBySessionId: {},
+    setSessionBusState: (sessionId, sessionBusState) => {
+      set(
+        (state) => ({
+          sessionBusStateBySessionId: {
+            ...state.sessionBusStateBySessionId,
+            [sessionId]: sessionBusState,
+          },
+        }),
+        false,
+        { type: "setSessionBusState" }
+      );
+    },
+    clearSessionBusState: (sessionId) => {
+      set(
+        (state) => {
+          if (!(sessionId in state.sessionBusStateBySessionId)) {
+            return state;
+          }
+          const next = { ...state.sessionBusStateBySessionId };
+          delete next[sessionId];
+          return { sessionBusStateBySessionId: next };
+        },
+        false,
+        { type: "clearSessionBusState" }
       );
     },
     isResponsePendingBySessionId: {},
@@ -1137,6 +1189,51 @@ export const createAgentStore = (initialProps?: Partial<AgentProps>) => {
 };
 
 export type AgentStore = ReturnType<typeof createAgentStore>;
+
+export function isSessionRunBusy(
+  state: components["schemas"]["SessionRunState"] | undefined
+): boolean {
+  return state != null && state !== "idle";
+}
+
+/** Select whether local chat work or the server event bus owns the session. */
+export const selectIsSessionBusy =
+  (sessionId: string) => (state: AgentState) => {
+    const chatStatus = state.chatStatusBySessionId[sessionId];
+    return (
+      chatStatus === "submitted" ||
+      chatStatus === "streaming" ||
+      isSessionRunBusy(state.sessionBusStateBySessionId[sessionId]?.state)
+    );
+  };
+
+/** Select whether a session still has a local or server-side response pending. */
+export const selectIsSessionResponsePending =
+  (sessionId: string) => (state: AgentState) => {
+    const runState = state.sessionBusStateBySessionId[sessionId]?.state;
+    return (
+      (state.isResponsePendingBySessionId[sessionId] ?? false) ||
+      runState === "streaming" ||
+      runState === "persisting" ||
+      runState === "awaiting_client_tool"
+    );
+  };
+
+/** Select whether any resident session is locally or remotely busy. */
+export const selectIsAnySessionBusy = (state: AgentState): boolean => {
+  const sessionIds = new Set([
+    ...Object.keys(state.chatStatusBySessionId),
+    ...Object.keys(state.sessionBusStateBySessionId),
+  ]);
+  return Array.from(sessionIds).some((sessionId) =>
+    selectIsSessionBusy(sessionId)(state)
+  );
+};
+
+/** Select whether a session is in read-only cross-instance degraded mode. */
+export const selectIsSessionDegraded =
+  (sessionId: string) => (state: AgentState) =>
+    state.sessionBusStateBySessionId[sessionId]?.degraded ?? false;
 
 export async function waitForRegisteredClientActions({
   agentStore,

--- a/app/tests/pxi/multi-instance.spec.ts
+++ b/app/tests/pxi/multi-instance.spec.ts
@@ -1,0 +1,241 @@
+import type { Browser, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import { waitForPersistedAssistantTurn } from "./fixtures";
+
+/**
+ * Multi-instance PXI smoke test.
+ *
+ * Requires two Phoenix instances sharing one Postgres database (see
+ * scripts/pxi-multi-instance/run.sh). Exercises the session event bus across
+ * deployment boundaries with a real LLM:
+ *
+ * - "A"  — the originating tab on instance A: sends the turns.
+ * - "A2" — a second tab on instance A: must follow the live turn through the
+ *          in-memory bus (same-instance replay + live tail).
+ * - "B"  — a tab on instance B (does NOT own the in-flight turn): must show
+ *          the degraded read-only state while the turn streams, then converge
+ *          on the persisted transcript.
+ */
+
+const BASE_URL_A = process.env.PXI_MI_BASE_URL_A;
+const BASE_URL_B = process.env.PXI_MI_BASE_URL_B;
+const ASSISTANT_PROVIDER = "OPENAI";
+const ASSISTANT_MODEL = process.env.PXI_E2E_ASSISTANT_MODEL ?? "gpt-5.4-mini";
+
+const FIRST_TURN_PROMPT =
+  "Reply with a single short sentence confirming you can hear me. " +
+  "Do not use any tools.";
+
+// Long enough that instance B's ~5s remote-lease poll and this spec's UI
+// assertions comfortably land while the turn is still streaming.
+const LONG_TURN_PROMPT =
+  "Without using any tools and without asking clarifying questions, write a " +
+  "detailed essay of roughly 1200 words on the history of software " +
+  "observability, from early logging through distributed tracing to modern " +
+  "LLM observability. Output quality does not matter; length does.";
+
+const DEGRADED_ALERT_TITLE = "Live updates unavailable";
+const DEGRADED_PLACEHOLDER =
+  "Response is running on another server. Waiting for transcript…";
+const BUSY_ELSEWHERE_TEXT = "Responding in another window…";
+const IDLE_PLACEHOLDER = "Send a message...";
+
+/** Mirrors the agent-store seed from tests/pxi/fixtures.ts, minus the consent gate. */
+async function seedAgentDefaults(page: Page) {
+  await page.addInitScript(
+    ({ provider, modelName }) => {
+      localStorage.clear();
+      localStorage.setItem(
+        "arize-phoenix-feature-flags",
+        JSON.stringify({ agents: true, tracing_ux: false })
+      );
+      localStorage.setItem(
+        "arize-phoenix-assistant",
+        JSON.stringify({
+          state: {
+            isOpen: false,
+            position: "pinned",
+            fabPlacement: "bottom-end",
+            defaultModelConfig: {
+              provider,
+              modelName,
+              invocationParameters: [],
+              supportedInvocationParameters: [],
+            },
+            capabilities: {
+              "graphql.mutations": false,
+              "web.access": false,
+            },
+          },
+          version: 0,
+        })
+      );
+    },
+    { provider: ASSISTANT_PROVIDER, modelName: ASSISTANT_MODEL }
+  );
+}
+
+async function openPxi(page: Page) {
+  await seedAgentDefaults(page);
+  await page.goto("/projects");
+  await page.getByRole("button", { name: "Ask PXI" }).click();
+  // A fresh browser context always sees the consent gate first.
+  const input = page.getByLabel("Message input");
+  const acknowledgeButton = page.getByRole("button", { name: "Acknowledge" });
+  await expect(input.or(acknowledgeButton).first()).toBeVisible();
+  if (await acknowledgeButton.isVisible().catch(() => false)) {
+    await acknowledgeButton.click();
+  }
+  await expect(input).toBeVisible();
+}
+
+/** Opens the sessions menu and selects the only session in the shared database. */
+async function openOnlySession(page: Page) {
+  await page.getByRole("button", { name: "Sessions" }).click();
+  const sessionItem = page
+    .getByRole("menuitemradio")
+    .or(page.getByRole("menuitem"))
+    .first();
+  await expect(sessionItem).toBeVisible();
+  await sessionItem.click();
+}
+
+async function newPxiPage(browser: Browser, baseURL: string): Promise<Page> {
+  const context = await browser.newContext({ baseURL });
+  return context.newPage();
+}
+
+function messageInput(page: Page) {
+  return page.getByLabel("Message input");
+}
+
+function stopButton(page: Page) {
+  return page.getByRole("button", { name: "Stop generation" });
+}
+
+async function sendMessage(page: Page, prompt: string) {
+  await messageInput(page).fill(prompt);
+  await page.getByRole("button", { name: "Send message" }).click();
+}
+
+test.describe("PXI multi-instance session event bus", () => {
+  test("degrades read-only on the non-owning instance and converges", async ({
+    browser,
+  }) => {
+    test.skip(
+      !BASE_URL_A || !BASE_URL_B,
+      "Set PXI_MI_BASE_URL_A and PXI_MI_BASE_URL_B (see scripts/pxi-multi-instance/run.sh)."
+    );
+
+    const pageA = await newPxiPage(browser, BASE_URL_A!);
+
+    await test.step("turn 1 on A creates and persists the session", async () => {
+      await openPxi(pageA);
+      await sendMessage(pageA, FIRST_TURN_PROMPT);
+      await stopButton(pageA)
+        .waitFor({ state: "visible", timeout: 30_000 })
+        .catch(() => {
+          // A very fast turn may already have completed.
+        });
+      await stopButton(pageA).waitFor({ state: "hidden", timeout: 180_000 });
+      const persisted = await waitForPersistedAssistantTurn({
+        request: pageA.request,
+        requireTraceId: false,
+      });
+      expect(persisted.assistantText.length).toBeGreaterThan(0);
+    });
+
+    const pageB = await newPxiPage(browser, BASE_URL_B!);
+    const pageA2 = await newPxiPage(browser, BASE_URL_A!);
+
+    await test.step("B (other instance) reads the persisted transcript while idle", async () => {
+      await openPxi(pageB);
+      await openOnlySession(pageB);
+      // The session row and transcript were written by instance A; reading
+      // them here proves cross-instance persistence.
+      await expect(
+        pageB.locator(".chat__messages").getByText(FIRST_TURN_PROMPT)
+      ).toBeVisible();
+      await expect(pageB.getByPlaceholder(IDLE_PLACEHOLDER)).toBeVisible();
+    });
+
+    await test.step("A2 (same instance) attaches to the session", async () => {
+      await openPxi(pageA2);
+      await openOnlySession(pageA2);
+      await expect(
+        pageA2.locator(".chat__messages").getByText(FIRST_TURN_PROMPT)
+      ).toBeVisible();
+    });
+
+    await test.step("turn 2 streams on A", async () => {
+      await sendMessage(pageA, LONG_TURN_PROMPT);
+      await expect(stopButton(pageA)).toBeVisible({ timeout: 30_000 });
+    });
+
+    await test.step("B degrades to read-only while the turn runs elsewhere", async () => {
+      // Instance B discovers the remote lease via its ~5s poll and must NOT
+      // receive live chunks — only the degraded state.
+      await expect(pageB.getByText(DEGRADED_ALERT_TITLE)).toBeVisible({
+        timeout: 60_000,
+      });
+      await expect(pageB.getByPlaceholder(DEGRADED_PLACEHOLDER)).toBeVisible();
+    });
+
+    await test.step("A2 follows the live turn through the in-memory bus", async () => {
+      await expect(pageA2.getByText(BUSY_ELSEWHERE_TEXT)).toBeVisible({
+        timeout: 60_000,
+      });
+      // The replayed turn-start carries the submitted user message.
+      await expect(
+        pageA2.locator(".chat__messages").getByText(LONG_TURN_PROMPT)
+      ).toBeVisible({ timeout: 60_000 });
+      // Same-instance followers get the live stream, never the degraded state.
+      await expect(pageA2.getByText(DEGRADED_ALERT_TITLE)).toHaveCount(0);
+    });
+
+    await test.step("turn 2 completes on A", async () => {
+      await stopButton(pageA).waitFor({ state: "hidden", timeout: 300_000 });
+      await waitForPersistedAssistantTurn({
+        request: pageA.request,
+        requireTraceId: false,
+      });
+    });
+
+    await test.step("all clients converge on the persisted transcript", async () => {
+      // B: degraded banner clears, transcript refreshes with turn 2.
+      await expect(pageB.getByText(DEGRADED_ALERT_TITLE)).toHaveCount(0, {
+        timeout: 60_000,
+      });
+      await expect(
+        pageB.locator(".chat__messages").getByText(LONG_TURN_PROMPT)
+      ).toBeVisible({ timeout: 60_000 });
+      await expect(pageB.getByPlaceholder(IDLE_PLACEHOLDER)).toBeVisible({
+        timeout: 60_000,
+      });
+
+      // A2: live turn settled into the same transcript.
+      await expect(pageA2.getByText(BUSY_ELSEWHERE_TEXT)).toHaveCount(0, {
+        timeout: 60_000,
+      });
+      await expect(
+        pageA2.locator(".chat__messages").getByText(LONG_TURN_PROMPT)
+      ).toBeVisible();
+
+      // The essay rendered everywhere: each surface holds a long assistant
+      // message beyond the two prompts (~350 chars of prompt text).
+      for (const page of [pageA, pageA2, pageB]) {
+        const transcriptLength = await page
+          .locator(".chat__messages")
+          .innerText()
+          .then((text) => text.length);
+        expect(transcriptLength).toBeGreaterThan(1_500);
+      }
+
+      // No surface shows an agent error.
+      for (const page of [pageA, pageA2, pageB]) {
+        await expect(page.locator(".chat__error")).toHaveCount(0);
+      }
+    });
+  });
+});

--- a/internal_docs/specs/pxi-chat-event-bus.md
+++ b/internal_docs/specs/pxi-chat-event-bus.md
@@ -1,0 +1,130 @@
+# PXI Chat Event Bus — Session Streaming, State Machine, Multi-Client Sync
+
+## Context
+
+Today a PXI chat turn runs **inline in the `POST .../chat` request coroutine** (`src/phoenix/server/api/routers/agents.py:2245`): whoever POSTs owns the stream, client disconnect cancels the turn, nothing is persisted until turn end, and there is no lock — two tabs can both start turns and the loser 409s after burning tokens. There is no way for a second tab, the CLI, or (future) another user to watch an in-flight turn.
+
+This spec introduces a per-session **in-memory event bus** with a lightweight **state machine**, a **detached turn runner**, a subscriber endpoint, and DB-visible session state for **graceful degradation** in multi-instance deployments.
+
+### Decisions
+
+| Decision | Choice |
+|---|---|
+| Turn execution | Detached background asyncio task; survives client disconnect; only explicit stop cancels |
+| Multi-instance | No cross-instance streaming. Non-owning instance = read-only degraded mode + polling. State visible via DB row + heartbeat (10s), auto-release after ~30s staleness |
+| Send while busy | Reject with structured 409; no queueing |
+| Client-side tools | Originating client only executes; others see pending state |
+| Transport | Hybrid: `POST /chat` still returns the SSE stream (bus-backed); new `GET .../events` SSE for other subscribers |
+| Late join | Full chunk replay from turn start, then live tail |
+| Abnormal end | Persist partial assistant message on **stop AND error** (server resolves dangling tool calls to `output-error`, closes text parts; `interrupted` marker in metadata). Resume = history-replay, same mechanism as existing client-tool continuations |
+| Stop | First-class endpoint; any client with session access; works cross-instance (best effort via DB flag, ≤1 heartbeat latency) |
+| Lock scope | State machine gates **all** transcript mutations: send, compact, truncate, branch, delete (title edits ungated) |
+| Scope | Both agents (`assistant` + `server`), legacy route back-compat, web UI + CLI consume |
+
+---
+
+## Architecture overview
+
+```
+POST /chat ──validate──▶ bus.begin_turn() ──▶ TurnRunner (detached asyncio task)
+   │                        │                    │ publishes chunks
+   └──── SSE response = subscribe(replay) ◀──── SessionChannel
+                                                  │  state machine + TurnLog (replay buffer)
+GET /events ──▶ subscribe(replay, +state chunks) ─┘  + subscriber queues
+POST /stop  ──▶ bus.stop() → runner.request_stop() → partial persist
+
+DB: agent_session_runs row (state, turn_id, instance_id, heartbeat_at, stop_requested_at)
+    = cross-instance visibility + lock; heartbeat daemon renews/sweeps
+```
+
+## Backend
+
+### New modules
+
+- `src/phoenix/server/agents/event_bus.py` — `AgentSessionEventBus` (registry + `DaemonTask` heartbeat loop, reuse `src/phoenix/server/types.py:84`), `SessionChannel` (state machine, `TurnLog` replay buffer capped ~100k chunks, subscriber `asyncio.Queue`s), `SessionRunState`, `SessionBusyError`, `SessionStateChunk` / `SessionTurnStartedChunk` (transient `data-*` chunks, registered like `SessionSummaryChunk` at `agents.py:227`), per-process `_INSTANCE_ID = uuid4().hex`.
+- `src/phoenix/server/agents/turn_runner.py` — `PreparedTurn`, `TurnRunner`, `resolve_dangling_chunks` (partial-persist cleanup).
+- `src/phoenix/server/agents/run_locks.py` — atomic claim/release/heartbeat SQL for both dialects (follow the `on_conflict_do_update` dialect-switch pattern of `_upsert_project_sessions`, `agents.py:1195-1229`).
+
+### State machine
+
+States: `idle` (no row) → `streaming` → `persisting` → `idle` | `awaiting_client_tool`; `mutating` for compact/truncate/branch/delete. Guards:
+
+- send while non-idle → 409 busy; continuation send allowed only in `awaiting_client_tool` with matching `assistant_message_id` (reuses semantics of `_merge_messages` `agents.py:1260` / `_update_trailing_assistant_message` `:1419`); idle continuation stays allowed (legacy/post-crash path, existing 409-on-mismatch protects it).
+- mutation begin allowed only from idle (or stale row takeover); held via `async with bus.hold_mutation(...)` context manager.
+- Claim = single atomic upsert with takeover predicate (`heartbeat_at < now() - 30s`, or awaiting + matching message id for continuations). No row returned ⇒ busy.
+
+### DB schema
+
+New `AgentSessionRun` model in `src/phoenix/db/models.py` (table `agent_session_runs`): `agent_session_id` (FK CASCADE, unique), `turn_id`, `state`, `assistant_message_id`, `origin_client_id`, `instance_id`, `stop_requested_at`, `started_at`, `heartbeat_at` (+ index). Alembic migration under `src/phoenix/db/migrations/versions/` (`down_revision = "e767d3c57f32"`). Rows are ephemeral lock records; downgrade just drops the table.
+
+### `chat` handler rework (`agents.py:1898-2400`)
+
+1. `_prepare_turn(...)` — all current validation/history-merge/model+agent construction (lines ~1905-2243) stays in the request coroutine so 404/409/422 surface before spawn. Capture `app.state`/`event_queue` into locals; runner must never touch `request`.
+2. Handler: `bus.begin_turn(...)` (409 on busy) → spawn `TurnRunner` (strong task ref on channel) → return `StreamingResponse(event_stream.encode_stream(channel.subscribe(replay=True)))` — wire format byte-identical.
+3. `TurnRunner.run()` uses an **inner/outer task split**: stop cancels the inner consume task; the outer task's `finally` runs `_finalize` (never skipped by cancellation). `_finalize`: partial persist (if needed) → publish closing chunks + `TranscriptPersistedChunk` → moved trace-finalize block (root span, `force_flush`, `_persist_db_traces_and_emit_event` — currently `agents.py:2365-2396`) → state transition/row release → wake subscribers → channel GC.
+4. Subscriber disconnect only removes its queue — never cancels the runner.
+5. **Contract requirement**: the `start` chunk carries the canonical `server_message_id` (`agents.py:2024`) so every client (POST stream and replay) converges on one assistant message id.
+
+### Partial persist (stop/error)
+
+Server-side mirror of the frontend's `addInterruptedToolOutputs` (`app/src/components/agent/useAgentChat.ts:439-492`), done as **synthetic chunks** (`ToolOutputErrorChunk`, `TextEnd`, `ReasoningEnd`) appended before `accumulate_ui_message_chunks_to_ui_messages` (`src/phoenix/server/agents/data_stream_protocol.py:83`) — reuses `_build_generated_assistant_message` (`agents.py:1515`) and `_persist_agent_session_turn` (`:1447`) unchanged. Add optional `interrupted: Literal["stopped","errored"]` to `AssistantMessageMetadata` (`src/phoenix/db/types/data_stream_protocol/phoenix_types.py`). Double-persist guarded by runner flag + single `_finalize` + existing `(session, position)` unique constraint.
+
+### New endpoints (same router/dependency stack, both agents; legacy route delegates unchanged)
+
+- `GET /agents/{agent_id}/sessions/{session_id}/events` — SSE. Local channel: initial `SessionStateChunk` (incl. `originClientId`), full replay, live tail across turns (`data-turn-started` opens each turn and carries the submitted user message), 15s keep-alive comments. Row owned elsewhere + fresh: degraded — state-only chunks (`ownedByThisInstance: false, streamAvailable: false`), poll row ~5s. Idle: state chunk, stay open for future turns. Uses a **non-refreshing** session loader (don't bump `expires_at`/`updated_at`).
+- `POST /agents/{agent_id}/sessions/{session_id}/stop` — body `{turnId?}`. Local streaming → `request_stop()` → 202; awaiting_client_tool → resolve dangling parts on persisted tail, release → 200; owned elsewhere → set `stop_requested_at` (owner honors ≤10s) → 202 remote; stale → delete row → 200; turn-id mismatch → 409.
+
+### Heartbeat + sweeper (bus `DaemonTask`, entered in `_lifespan` next to `agent_session_sweeper`, `app.py:680`)
+
+- 10s: batch heartbeat UPDATE for owned rows, RETURNING; missing row ⇒ lock lost ⇒ stop runner + dissolve channel; `stop_requested_at` set ⇒ honor stop.
+- 30s: sweep foreign rows with stale heartbeats (crashed instance's unpersisted tail is lost — accepted).
+- Shutdown: request_stop all channels, wait so partial persists land.
+
+### Mutation gating
+
+Bus on `app.state` + GraphQL `Context` (`src/phoenix/server/api/context.py`). Wrap `compact_agent_session` (`agents.py:1786`) and `truncate/branch/delete` in `src/phoenix/server/api/mutations/agent_session_mutations.py` in `hold_mutation`; `SessionBusyError` → 409 / GraphQL `Conflict`. Busy payload everywhere: `{code: "agent_session_busy", state, turnId, assistantMessageId, ownedByThisInstance}`.
+
+## Frontend (app/)
+
+Verified: `ai@7.0.22` + `@ai-sdk/react@4.0.23` support this natively — `chat.resumeStream()` → `transport.reconnectToStream()`; server `start` chunk messageId overwrites local id (convergence built in); replay into an existing partial message **duplicates parts**, so drop the partial trailing assistant message before resuming.
+
+- **`app/src/agent/chat/sessionEventsBridge.ts` (new)** — one fetch-SSE connection per attached session (`authFetch` + `parseJsonEventStream`/`uiMessageChunkSchema` from `ai`; EventSource can't do cookie-refresh auth). Demuxes: `data-session-state` → store; `data-transcript-persisted` → `transcriptPersistence` coordinator; turn chunks → per-turn `ReadableStream` windows. Triggers `chat.resumeStream()` when a turn is in flight and this client isn't the live originator; suppresses entirely when the local POST stream is active (no double-consume). Reconnect with backoff; replay-from-start makes blips self-heal.
+- **`app/src/agent/chat/AgentSessionChatTransport.ts` (new)** — extends `DefaultChatTransport`; `reconnectToStream()` returns the bridge's current turn window (or `null`). `sendMessages` config moves from `createChatForSession` (`useAgentChat.ts:294-325`) verbatim.
+- **`AgentChatRuntimeContext.tsx`** — registry entry gains `{eventsBridge, refCount, lingerTimer}`; acquire/release from `useAgentChat` effect; ~30s linger absorbs panel↔slideover moves and strict-mode double-mount.
+- **`app/src/store/agentStore.ts`** — new `sessionBusStateBySessionId` slice (`state, turnId, originClientId, degraded, connection`) + selectors (`selectIsSessionBusy` = local status OR bus state). Per-chat `clientId` (`crypto.randomUUID()`), sent in the POST body (`buildAgentChatRequestBody.ts`), echoed by server as `originClientId`.
+- **Composer/stop** (`Chat.tsx`): busy-from-elsewhere → disabled composer with "Responding in another window…", stop enabled. Stop (`handleStopWithToolCleanup`, `useAgentChat.ts:494`) now calls the stop endpoint; server does tool cleanup + persist; keep local abort + legacy cleanup as fallback (older server / endpoint error).
+- **Client tools**: `onToolCall` executes only when originator (or live local response); guard `sendAutomaticallyWhen` the same way; skip re-execution for toolCallIds already resolved (replay case). Non-originators render existing pending state + hint.
+- **Degraded mode**: banner + disabled composer; bridge polls `refetchAgentSession` (`agentSessionRelay.ts:52`) ~4s until idle, then refreshes transcript into the chat.
+- **Refresh mid-turn** falls out naturally: new clientId → foreign-turn resume path; busy state blocks re-send.
+
+## CLI (`js/packages/phoenix-cli/src/pxi/`)
+
+- `client.ts`: `subscribeToSessionEvents` (fetch-SSE + same `ai` parsers, per-turn windows into existing `streamAssistantMessage` `:358`), `stopSession`, typed `PxiBusyError` from the 409 payload, `clientId` in request body.
+- `App.tsx`: attach/follow on session restore or while idle (remote turn renders live, composer disabled with `remote-streaming` status); `interruptStream` (`:870`) calls stop endpoint first, local abort as fallback.
+- Regenerate `@arizeai/phoenix-client` OpenAPI types + `app/src/api/__generated__/v1.ts` (`pnpm generate:openapi`).
+
+## Testing
+
+- **Backend unit** (`tests/unit/server/agents/`): state machine transitions + busy payloads; replay/late-join ordering; claim/takeover/release SQL on both dialects; heartbeat lost-row + remote stop + sweeper; runner stop/error → partial persist with `interrupted` marker and resolved tool parts; success-path wire compatibility; no double persist. Router tests: send-while-busy 409, disconnect-mid-POST still persists, `/events` replay + degraded, `/stop` matrix, mutation gating.
+- **Frontend unit** (vitest): bridge demux/window/suppression matrix; transport resume vs POST-stream equivalence, no duplicate parts after drop-partial + re-resume (incl. multi-segment continuation turns); originator guards.
+- **Playwright e2e** (`app/tests/pxi/`, phoenix-pxi-playwright patterns): multi-tab sync, stop-from-other-tab, refresh-mid-turn (no duplicate assistant message), degraded mode via `/events` route interception.
+
+## Milestones (each independently shippable)
+
+1. **Schema + locks**: `AgentSessionRun` model, migration, `run_locks.py`, tests. No behavior change.
+2. **Bus + detached runner + stop** (core, backend): `event_bus.py`, `turn_runner.py`, chat handler rework, partial persist, `/stop`, heartbeat daemon, lifespan wiring. Env-var kill switch (e.g. `PHOENIX_AGENTS_DETACHED_TURNS`) for one release.
+3. **`GET /events`**: state/turn-started chunks, replay endpoint, degraded mode, keep-alive.
+4. **Mutation gating + busy-payload polish**, OpenAPI registration.
+5. **Web consumption**: types/clientId/store (no-op), then bridge + transport + guards, then busy/stop UX, then degraded UX.
+6. **CLI**: subscribe/attach, busy error, stop.
+7. **E2E hardening**: Playwright specs, strict-mode/soak of subscription lifecycle.
+
+## Key risks
+
+- **uvicorn multi-worker on one host**: each worker is its own instance ⇒ POST and `/events` can land on different workers → degraded mode without sticky routing. Document; Phoenix commonly runs single-worker.
+- **Cancellation vs `finally`-awaits**: the inner/outer task split in `TurnRunner` is load-bearing — don't collapse it.
+- **Canonical assistant messageId in `start` chunk** on both streams is required for client convergence — top coordination item between backend and frontend.
+- **Replay duplication** if the client doesn't drop its partial trailing message before resume (verified AI SDK behavior) — test hard.
+- **Replay buffer memory** on huge bash-agent turns — cap + `streamAvailable: false` degradation.
+- **Crashed owner loses the in-flight partial** (chunks are memory-only) — accepted; transcript ends at last persisted turn.
+- Pin `ai` minor versions in `app` and `phoenix-cli` (`resumeStream`/`reconnectToStream` are the contract surface).

--- a/js/packages/phoenix-cli/package.json
+++ b/js/packages/phoenix-cli/package.json
@@ -46,7 +46,7 @@
     "@arizeai/phoenix-client": "workspace:*",
     "@arizeai/phoenix-config": "workspace:*",
     "@clack/prompts": "^1.7.0",
-    "ai": "^7.0.0",
+    "ai": "7.0.31",
     "commander": "^15.0.0",
     "cross-spawn": "^7.0.6",
     "ignore": "^7.0.6",

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -6,6 +6,7 @@ import {
   createPxiChatClient,
   createPxiSessionClient,
   createUserMessage,
+  getPxiClientId,
 } from "./client";
 import {
   getSlashCommandName,
@@ -24,6 +25,7 @@ import {
   moveDraftCursorVertically,
   type DraftEditorState,
 } from "./draftEditor";
+import { PxiBusyError } from "./errors";
 import { Markdown } from "./inkMarkdown";
 import { fetchRecommendedPxiModels } from "./preflight";
 import { formatTokenUsageLine, getLatestAssistantUsage } from "./tokenUsage";
@@ -38,7 +40,9 @@ import type {
   PxiMessage,
   PxiRuntimeOptions,
   PxiSessionClient,
+  PxiSessionState,
   PxiSessionSummary,
+  PxiTurnStarted,
 } from "./types";
 
 /**
@@ -50,8 +54,20 @@ import type {
  * owns the conversation state and drives the {@link PxiChatClient}.
  */
 
-/** Whether the app is waiting on input (`idle`) or streaming a reply. */
-type PxiStatus = "idle" | "streaming";
+/** Whether the app is accepting input or following an active local/remote turn. */
+type PxiStatus = "idle" | "streaming" | "remote-streaming" | "degraded";
+
+function getSessionStatus({
+  sessionState,
+}: {
+  sessionState: PxiSessionState | null;
+}): Exclude<PxiStatus, "streaming"> {
+  if (!sessionState || sessionState.state === "idle") {
+    return "idle";
+  }
+  return sessionState.streamAvailable ? "remote-streaming" : "degraded";
+}
+
 type SessionPickerState = {
   status: "loading" | "ready" | "restoring" | "error";
   sessions: PxiSessionSummary[];
@@ -501,6 +517,13 @@ function InputPrompt({
   const showHints =
     cmdName !== null && !draftValue.includes(" ") && draftValue.length > 1;
   const hints = showHints ? matchingCommands(cmdName) : [];
+  const isComposerDisabled = status !== "idle";
+  const helperText =
+    status === "remote-streaming"
+      ? "following response from another client · esc stop · ctrl+c exit"
+      : status === "degraded"
+        ? "session busy on another Phoenix instance · live stream unavailable · esc stop"
+        : "↵ send · ⇧↵ newline · esc interrupt · /help · ctrl+c exit";
 
   return (
     <Box flexDirection="column" marginTop={1}>
@@ -517,7 +540,7 @@ function InputPrompt({
           <HighlightedDraft
             draft={draftValue}
             cursorIndex={draft.cursorIndex}
-            isCursorVisible={status !== "streaming"}
+            isCursorVisible={!isComposerDisabled}
           />
         </Text>
       </Box>
@@ -542,9 +565,7 @@ function InputPrompt({
             ))}
           </Box>
         ) : (
-          <Text dimColor>
-            ↵ send · ⇧↵ newline · esc interrupt · /help · ctrl+c exit
-          </Text>
+          <Text dimColor>{helperText}</Text>
         )}
         <Box flexShrink={0} marginLeft={2}>
           <Text>
@@ -796,6 +817,37 @@ function markMessageInterrupted({
   };
 }
 
+type RemoteTurnBaseline = {
+  turnId: string;
+  messages: PxiMessage[];
+};
+
+function buildRemoteTurnBaseline({
+  messages,
+  turn,
+  assistantMessageId,
+}: {
+  messages: PxiMessage[];
+  turn: PxiTurnStarted;
+  assistantMessageId?: string | null;
+}): PxiMessage[] {
+  const submittedMessageIndex = messages.findIndex(
+    (message) => message.id === turn.message.id
+  );
+  if (submittedMessageIndex >= 0) {
+    return [...messages.slice(0, submittedMessageIndex), turn.message];
+  }
+  const trailingMessage = messages.at(-1);
+  const hasReplayedAssistant =
+    trailingMessage?.role === "assistant" &&
+    Boolean(assistantMessageId) &&
+    trailingMessage.id === assistantMessageId;
+  const persistedBaseline = hasReplayedAssistant
+    ? messages.slice(0, -1)
+    : messages;
+  return [...persistedBaseline, turn.message];
+}
+
 /** Animated "PXI is thinking…" indicator shown while a reply is streaming. */
 export function ThinkingIndicator() {
   const [frameIndex, setFrameIndex] = useState(0);
@@ -855,22 +907,161 @@ export function PxiApp({
   );
   const abortControllerRef = useRef<AbortController | null>(null);
   const streamingAssistantMessageRef = useRef<PxiMessage | null>(null);
+  const statusRef = useRef<PxiStatus>(status);
+  const messagesRef = useRef<PxiMessage[]>(messages);
+  const sessionStateRef = useRef<PxiSessionState | null>(null);
+  const remoteTurnBaselineRef = useRef<RemoteTurnBaseline | null>(null);
+  const pendingLocalTurnBaselineRef = useRef<PxiMessage[] | null>(null);
+  const isStoppingRef = useRef(false);
   const modelRequestIdRef = useRef(0);
   const sessionRequestIdRef = useRef(0);
+  statusRef.current = status;
+  messagesRef.current = messages;
   const serverSessionClient = useMemo(
     () => sessionClient ?? createPxiSessionClient({ config: options.config }),
     [options.config, sessionClient]
   );
+
+  useEffect(() => {
+    const sessionId = activeSession?.id;
+    const subscribe = serverSessionClient.subscribeToSessionEvents;
+    sessionStateRef.current = null;
+    remoteTurnBaselineRef.current = null;
+    if (!sessionId || !subscribe) {
+      return;
+    }
+
+    const eventAbortController = new AbortController();
+    let isCurrentSession = true;
+    const refreshDegradedTranscript = () => {
+      void serverSessionClient
+        .getSession({ sessionId })
+        .then((session) => {
+          if (!isCurrentSession || sessionStateRef.current?.state !== "idle") {
+            return;
+          }
+          setActiveSession(session);
+          messagesRef.current = session.messages;
+          setMessages(session.messages);
+        })
+        .catch((sessionError: unknown) => {
+          if (!isCurrentSession) {
+            return;
+          }
+          setError(
+            sessionError instanceof Error
+              ? sessionError.message
+              : String(sessionError)
+          );
+        });
+    };
+
+    void subscribe({
+      sessionId,
+      abortSignal: eventAbortController.signal,
+      onSessionState: (sessionState) => {
+        sessionStateRef.current = sessionState;
+        const isSessionBusy = sessionState.state !== "idle";
+        const isActiveLocalTurn =
+          sessionState.originClientId === getPxiClientId() &&
+          statusRef.current === "streaming";
+        if (isSessionBusy && !isActiveLocalTurn) {
+          const nextStatus = getSessionStatus({ sessionState });
+          statusRef.current = nextStatus;
+          setStatus(nextStatus);
+          setModelPicker(null);
+          setSessionPicker(null);
+          return;
+        }
+        if (!isSessionBusy) {
+          const previousStatus = statusRef.current;
+          if (
+            previousStatus === "remote-streaming" ||
+            previousStatus === "degraded"
+          ) {
+            statusRef.current = "idle";
+            setStatus("idle");
+          }
+          remoteTurnBaselineRef.current = null;
+          if (previousStatus === "degraded") {
+            refreshDegradedTranscript();
+          }
+        }
+      },
+      onTurnStarted: (turn) => {
+        const sessionState = sessionStateRef.current;
+        const isActiveLocalTurn =
+          sessionState?.originClientId === getPxiClientId() &&
+          statusRef.current === "streaming";
+        const previousBaseline = remoteTurnBaselineRef.current;
+        const baseline =
+          previousBaseline && previousBaseline.turnId === turn.turnId
+            ? previousBaseline.messages
+            : buildRemoteTurnBaseline({
+                messages:
+                  pendingLocalTurnBaselineRef.current ?? messagesRef.current,
+                turn,
+                assistantMessageId: sessionState?.assistantMessageId,
+              });
+        remoteTurnBaselineRef.current = {
+          turnId: turn.turnId,
+          messages: baseline,
+        };
+        if (isActiveLocalTurn) {
+          return;
+        }
+        messagesRef.current = baseline;
+        setMessages(baseline);
+      },
+      onAssistantMessage: ({ turnId, message }) => {
+        const sessionState = sessionStateRef.current;
+        const isActiveLocalTurn =
+          sessionState?.originClientId === getPxiClientId() &&
+          statusRef.current === "streaming";
+        const baseline = remoteTurnBaselineRef.current;
+        if (isActiveLocalTurn || baseline?.turnId !== turnId) {
+          return;
+        }
+        const nextMessages = [...baseline.messages, message];
+        messagesRef.current = nextMessages;
+        setMessages(nextMessages);
+      },
+      onSessionTitle: (title) => {
+        setActiveSession((currentSession) =>
+          currentSession ? { ...currentSession, title } : currentSession
+        );
+      },
+      onError: (sessionError) => {
+        if (!eventAbortController.signal.aborted) {
+          setError(
+            sessionError instanceof Error
+              ? sessionError.message
+              : String(sessionError)
+          );
+        }
+      },
+    }).catch((sessionError: unknown) => {
+      if (!eventAbortController.signal.aborted) {
+        setError(
+          sessionError instanceof Error
+            ? sessionError.message
+            : String(sessionError)
+        );
+      }
+    });
+
+    return () => {
+      isCurrentSession = false;
+      eventAbortController.abort();
+    };
+  }, [activeSession?.id, serverSessionClient]);
 
   const handleExit = () => {
     abortControllerRef.current?.abort();
     exit();
   };
 
-  const interruptStream = () => {
-    if (status !== "streaming") {
-      return;
-    }
+  const interruptLocally = () => {
     abortControllerRef.current?.abort();
     const assistantMessage = streamingAssistantMessageRef.current;
     if (assistantMessage) {
@@ -880,13 +1071,50 @@ export function PxiApp({
       streamingAssistantMessageRef.current = interruptedMessage;
       setMessages((currentMessages) => {
         const lastMessage = currentMessages.at(-1);
-        if (lastMessage?.id === assistantMessage.id) {
-          return [...currentMessages.slice(0, -1), interruptedMessage];
-        }
-        return [...currentMessages, interruptedMessage];
+        const nextMessages =
+          lastMessage?.id === assistantMessage.id
+            ? [...currentMessages.slice(0, -1), interruptedMessage]
+            : [...currentMessages, interruptedMessage];
+        messagesRef.current = nextMessages;
+        return nextMessages;
       });
     }
-    setStatus("idle");
+    const nextStatus = getSessionStatus({
+      sessionState: sessionStateRef.current,
+    });
+    statusRef.current = nextStatus;
+    setStatus(nextStatus);
+  };
+
+  const interruptStream = () => {
+    if (statusRef.current === "idle" || isStoppingRef.current) {
+      return;
+    }
+    const sessionId = activeSession?.id;
+    const stop = serverSessionClient.stopSession;
+    if (!sessionId || !stop) {
+      if (statusRef.current === "streaming") {
+        interruptLocally();
+      }
+      return;
+    }
+    isStoppingRef.current = true;
+    const interruptedStatus = statusRef.current;
+    void stop({
+      sessionId,
+      turnId: sessionStateRef.current?.turnId ?? undefined,
+    })
+      .catch((stopError: unknown) => {
+        setError(
+          stopError instanceof Error ? stopError.message : String(stopError)
+        );
+        if (interruptedStatus === "streaming") {
+          interruptLocally();
+        }
+      })
+      .finally(() => {
+        isStoppingRef.current = false;
+      });
   };
 
   const startNewSession = ({ temporary }: { temporary: boolean }) => {
@@ -896,6 +1124,11 @@ export function PxiApp({
     setIsDraftTemporary(temporary);
     setModelPicker(null);
     setSessionPicker(null);
+    statusRef.current = "idle";
+    setStatus("idle");
+    sessionStateRef.current = null;
+    remoteTurnBaselineRef.current = null;
+    messagesRef.current = [];
     setMessages([]);
     setError(null);
     setDraft(EMPTY_DRAFT_EDITOR_STATE);
@@ -1027,6 +1260,7 @@ export function PxiApp({
         if (sessionRequestIdRef.current !== requestId) return;
         setActiveSession(session);
         setIsDraftTemporary(session.isTemporary);
+        messagesRef.current = session.messages;
         setMessages(session.messages);
         setError(null);
         setDraft(EMPTY_DRAFT_EDITOR_STATE);
@@ -1051,7 +1285,7 @@ export function PxiApp({
 
   const submitDraft = () => {
     const text = draft.value.trim();
-    if (!text || status === "streaming") {
+    if (!text || statusRef.current !== "idle") {
       return;
     }
 
@@ -1096,7 +1330,10 @@ export function PxiApp({
     streamingAssistantMessageRef.current = null;
     setDraft(EMPTY_DRAFT_EDITOR_STATE);
     setError(null);
+    pendingLocalTurnBaselineRef.current = messages;
+    statusRef.current = "streaming";
     setStatus("streaming");
+    messagesRef.current = nextMessages;
     setMessages(nextMessages);
     void (async () => {
       let resolvedClient = client;
@@ -1130,7 +1367,9 @@ export function PxiApp({
         abortSignal: abortController.signal,
         onAssistantMessage: (assistantMessage) => {
           streamingAssistantMessageRef.current = assistantMessage;
-          setMessages([...nextMessages, assistantMessage]);
+          const streamedMessages = [...nextMessages, assistantMessage];
+          messagesRef.current = streamedMessages;
+          setMessages(streamedMessages);
         },
         onSessionTitle: (title) => {
           setActiveSession((currentSession) =>
@@ -1144,12 +1383,29 @@ export function PxiApp({
           return;
         }
         if (assistantMessage) {
-          setMessages([...nextMessages, assistantMessage]);
+          const finalMessages = [...nextMessages, assistantMessage];
+          messagesRef.current = finalMessages;
+          setMessages(finalMessages);
         }
       })
       .catch((err: unknown) => {
         if (abortController.signal.aborted) {
           return;
+        }
+        if (err instanceof PxiBusyError) {
+          const observedSessionState = sessionStateRef.current;
+          const nextStatus =
+            observedSessionState?.turnId === err.turnId
+              ? getSessionStatus({ sessionState: observedSessionState })
+              : err.ownedByThisInstance
+                ? "remote-streaming"
+                : "degraded";
+          statusRef.current = nextStatus;
+          setStatus(nextStatus);
+          if (!remoteTurnBaselineRef.current) {
+            messagesRef.current = messages;
+            setMessages(messages);
+          }
         }
         setError(err instanceof Error ? err.message : String(err));
       })
@@ -1157,13 +1413,20 @@ export function PxiApp({
         if (abortControllerRef.current === abortController) {
           abortControllerRef.current = null;
         }
-        setStatus("idle");
+        pendingLocalTurnBaselineRef.current = null;
+        if (statusRef.current === "streaming") {
+          const nextStatus = getSessionStatus({
+            sessionState: sessionStateRef.current,
+          });
+          statusRef.current = nextStatus;
+          setStatus(nextStatus);
+        }
       });
   };
 
   const bracketedPasteMarkerCountRef = useRef(0);
   const handleRawInput = (input: string) => {
-    if (status === "streaming") {
+    if (status !== "idle") {
       return;
     }
     if (isBracketedPasteMarkerInput({ input })) {
@@ -1362,7 +1625,7 @@ export function PxiApp({
       interruptStream();
       return;
     }
-    if (status === "streaming") {
+    if (status !== "idle") {
       return;
     }
     if (isKeyboardProtocolResponseInput({ input })) {
@@ -1471,6 +1734,15 @@ export function PxiApp({
         </Box>
       ) : null}
       {status === "streaming" ? <ThinkingIndicator /> : null}
+      {status === "remote-streaming" ? (
+        <Text color="yellow">Following PXI response from another client…</Text>
+      ) : null}
+      {status === "degraded" ? (
+        <Text color="yellow">
+          PXI is responding on another Phoenix instance; live output is
+          unavailable.
+        </Text>
+      ) : null}
       {modelPicker ? (
         <ModelPicker state={modelPicker} />
       ) : sessionPicker ? (

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -55,7 +55,19 @@ import type {
  */
 
 /** Whether the app is accepting input or following an active local/remote turn. */
-type PxiStatus = "idle" | "streaming" | "remote-streaming" | "degraded";
+type PxiStatus =
+  | "idle"
+  | "streaming"
+  | "remote-streaming"
+  | "remote-awaiting-tool"
+  | "degraded";
+
+/** Statuses driven by another client's activity on the attached session. */
+const REMOTE_BUSY_STATUSES: ReadonlySet<PxiStatus> = new Set([
+  "remote-streaming",
+  "remote-awaiting-tool",
+  "degraded",
+]);
 
 function getSessionStatus({
   sessionState,
@@ -65,7 +77,67 @@ function getSessionStatus({
   if (!sessionState || sessionState.state === "idle") {
     return "idle";
   }
-  return sessionState.streamAvailable ? "remote-streaming" : "degraded";
+  if (sessionState.state === "awaiting_client_tool") {
+    return "remote-awaiting-tool";
+  }
+  // A session held by another Phoenix instance cannot stream to this process;
+  // a session on this instance can, even when its replay buffer overflowed.
+  return sessionState.ownedByThisInstance ? "remote-streaming" : "degraded";
+}
+
+/**
+ * The yellow status line under the transcript while another client owns the
+ * session, describing what is actually happening: streaming elsewhere, paused
+ * on a client tool, mutating (compaction/edit), replay overflow on this
+ * instance, or busy on a different Phoenix instance entirely.
+ */
+function getBusyStatusText({
+  status,
+  sessionState,
+}: {
+  status: PxiStatus;
+  sessionState: PxiSessionState | null;
+}): string | null {
+  switch (status) {
+    case "remote-awaiting-tool":
+      return "Waiting for a tool call to run in another client…";
+    case "degraded":
+      return "PXI is busy on another Phoenix instance; live output is unavailable.";
+    case "remote-streaming":
+      if (sessionState?.state === "mutating") {
+        return "The session is being updated in another client…";
+      }
+      if (sessionState?.streamAvailable === false) {
+        return "PXI is responding to another client; this turn is too long to replay, so output may be incomplete.";
+      }
+      return "Following PXI response from another client…";
+    default:
+      return null;
+  }
+}
+
+/** The composer footer hint for the current status. */
+function getHelperText({
+  status,
+  sessionState,
+}: {
+  status: PxiStatus;
+  sessionState: PxiSessionState | null;
+}): string {
+  switch (status) {
+    case "remote-awaiting-tool":
+      return "waiting for a tool in another client · esc stop · /new /sessions · ctrl+c exit";
+    case "degraded":
+      return "session busy on another Phoenix instance · esc stop · /new /sessions · ctrl+c exit";
+    case "remote-streaming":
+      // Stopping a mutation is not supported (the server rejects it), so
+      // don't advertise esc while the session is being updated elsewhere.
+      return sessionState?.state === "mutating"
+        ? "session updating in another client · /new /sessions · ctrl+c exit"
+        : "following another client · esc stop · /new /sessions · ctrl+c exit";
+    default:
+      return "↵ send · ⇧↵ newline · esc interrupt · /help · ctrl+c exit";
+  }
 }
 
 type SessionPickerState = {
@@ -502,11 +574,13 @@ function HighlightedDraft({
 function InputPrompt({
   draft,
   status,
+  sessionState,
   usageLine,
   modelLabel,
 }: {
   draft: DraftEditorState;
   status: PxiStatus;
+  sessionState: PxiSessionState | null;
   usageLine: string | null;
   modelLabel: string;
 }) {
@@ -517,13 +591,7 @@ function InputPrompt({
   const showHints =
     cmdName !== null && !draftValue.includes(" ") && draftValue.length > 1;
   const hints = showHints ? matchingCommands(cmdName) : [];
-  const isComposerDisabled = status !== "idle";
-  const helperText =
-    status === "remote-streaming"
-      ? "following response from another client · esc stop · ctrl+c exit"
-      : status === "degraded"
-        ? "session busy on another Phoenix instance · live stream unavailable · esc stop"
-        : "↵ send · ⇧↵ newline · esc interrupt · /help · ctrl+c exit";
+  const helperText = getHelperText({ status, sessionState });
 
   return (
     <Box flexDirection="column" marginTop={1}>
@@ -540,7 +608,10 @@ function InputPrompt({
           <HighlightedDraft
             draft={draftValue}
             cursorIndex={draft.cursorIndex}
-            isCursorVisible={!isComposerDisabled}
+            // The composer stays usable while another client owns the session
+            // (slash commands still work); only a local in-flight send hides
+            // the cursor.
+            isCursorVisible={status !== "streaming"}
           />
         </Text>
       </Box>
@@ -894,6 +965,10 @@ export function PxiApp({
     EMPTY_DRAFT_EDITOR_STATE
   );
   const [status, setStatus] = useState<PxiStatus>("idle");
+  // Render-facing mirror of `sessionStateRef` so busy-status copy re-renders
+  // on every server state chunk, not only when the coarse status changes.
+  const [remoteSessionState, setRemoteSessionState] =
+    useState<PxiSessionState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [activeSession, setActiveSession] = useState<PxiSessionSummary | null>(
     null
@@ -926,6 +1001,7 @@ export function PxiApp({
     const sessionId = activeSession?.id;
     const subscribe = serverSessionClient.subscribeToSessionEvents;
     sessionStateRef.current = null;
+    setRemoteSessionState(null);
     remoteTurnBaselineRef.current = null;
     if (!sessionId || !subscribe) {
       return;
@@ -960,7 +1036,9 @@ export function PxiApp({
       sessionId,
       abortSignal: eventAbortController.signal,
       onSessionState: (sessionState) => {
+        const previousSessionState = sessionStateRef.current;
         sessionStateRef.current = sessionState;
+        setRemoteSessionState(sessionState);
         const isSessionBusy = sessionState.state !== "idle";
         const isActiveLocalTurn =
           sessionState.originClientId === getPxiClientId() &&
@@ -969,21 +1047,23 @@ export function PxiApp({
           const nextStatus = getSessionStatus({ sessionState });
           statusRef.current = nextStatus;
           setStatus(nextStatus);
-          setModelPicker(null);
-          setSessionPicker(null);
           return;
         }
         if (!isSessionBusy) {
           const previousStatus = statusRef.current;
-          if (
-            previousStatus === "remote-streaming" ||
-            previousStatus === "degraded"
-          ) {
+          if (REMOTE_BUSY_STATUSES.has(previousStatus)) {
             statusRef.current = "idle";
             setStatus("idle");
           }
           remoteTurnBaselineRef.current = null;
-          if (previousStatus === "degraded") {
+          // Live output may have been missed when the session ran on another
+          // instance, or when this instance's replay buffer overflowed (a
+          // late subscriber gets no replay then); recover from the persisted
+          // transcript.
+          if (
+            previousStatus === "degraded" ||
+            previousSessionState?.streamAvailable === false
+          ) {
             refreshDegradedTranscript();
           }
         }
@@ -1127,6 +1207,7 @@ export function PxiApp({
     statusRef.current = "idle";
     setStatus("idle");
     sessionStateRef.current = null;
+    setRemoteSessionState(null);
     remoteTurnBaselineRef.current = null;
     messagesRef.current = [];
     setMessages([]);
@@ -1258,6 +1339,13 @@ export function PxiApp({
       .getSession({ sessionId: selectedSession.id })
       .then((session) => {
         if (sessionRequestIdRef.current !== requestId) return;
+        // Reset any remote-busy status carried over from the previous
+        // session; the new session's subscription re-derives it.
+        statusRef.current = "idle";
+        setStatus("idle");
+        sessionStateRef.current = null;
+        setRemoteSessionState(null);
+        remoteTurnBaselineRef.current = null;
         setActiveSession(session);
         setIsDraftTemporary(session.isTemporary);
         messagesRef.current = session.messages;
@@ -1285,11 +1373,13 @@ export function PxiApp({
 
   const submitDraft = () => {
     const text = draft.value.trim();
-    if (!text || statusRef.current !== "idle") {
+    if (!text || statusRef.current === "streaming") {
       return;
     }
 
-    // Intercept slash commands before sending to the server.
+    // Intercept slash commands before sending to the server. These stay
+    // available while another client owns the session, so a remote turn never
+    // locks the user out of /new, /sessions, etc.
     if (text.startsWith("/")) {
       setDraft(EMPTY_DRAFT_EDITOR_STATE);
       const result = runSlashCommand(text, {
@@ -1320,6 +1410,15 @@ export function PxiApp({
           `Unknown command: /${result.name}. Type /help to see available commands.`
         );
       }
+      return;
+    }
+
+    // Plain sends are rejected while the session is busy elsewhere; keep the
+    // draft so nothing typed is lost.
+    if (statusRef.current !== "idle") {
+      setError(
+        "The session is busy in another client. Press esc to stop it, or use /new or /sessions to switch."
+      );
       return;
     }
 
@@ -1406,6 +1505,13 @@ export function PxiApp({
             messagesRef.current = messages;
             setMessages(messages);
           }
+          // The send was rejected, so give the user their message back to
+          // retry once the session is free (unless they've typed since).
+          setDraft((currentDraft) =>
+            currentDraft.value
+              ? currentDraft
+              : { value: text, cursorIndex: text.length }
+          );
         }
         setError(err instanceof Error ? err.message : String(err));
       })
@@ -1426,7 +1532,9 @@ export function PxiApp({
 
   const bracketedPasteMarkerCountRef = useRef(0);
   const handleRawInput = (input: string) => {
-    if (status !== "idle") {
+    // Only a local in-flight send blocks the composer; while another client
+    // owns the session the user can still draft slash commands.
+    if (status === "streaming") {
       return;
     }
     if (isBracketedPasteMarkerInput({ input })) {
@@ -1625,7 +1733,9 @@ export function PxiApp({
       interruptStream();
       return;
     }
-    if (status !== "idle") {
+    // Only a local in-flight send blocks the composer; slash commands remain
+    // available while another client owns the session.
+    if (status === "streaming") {
       return;
     }
     if (isKeyboardProtocolResponseInput({ input })) {
@@ -1710,6 +1820,11 @@ export function PxiApp({
     }
   });
 
+  const busyStatusText = getBusyStatusText({
+    status,
+    sessionState: remoteSessionState,
+  });
+
   return (
     <Box flexDirection="column" paddingX={1}>
       <PxiBanner />
@@ -1734,15 +1849,7 @@ export function PxiApp({
         </Box>
       ) : null}
       {status === "streaming" ? <ThinkingIndicator /> : null}
-      {status === "remote-streaming" ? (
-        <Text color="yellow">Following PXI response from another client…</Text>
-      ) : null}
-      {status === "degraded" ? (
-        <Text color="yellow">
-          PXI is responding on another Phoenix instance; live output is
-          unavailable.
-        </Text>
-      ) : null}
+      {busyStatusText ? <Text color="yellow">{busyStatusText}</Text> : null}
       {modelPicker ? (
         <ModelPicker state={modelPicker} />
       ) : sessionPicker ? (
@@ -1751,6 +1858,7 @@ export function PxiApp({
         <InputPrompt
           draft={draft}
           status={status}
+          sessionState={remoteSessionState}
           usageLine={formatTokenUsageLine(getLatestAssistantUsage(messages))}
           modelLabel={activeModelSelection.modelName}
         />

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -5,13 +5,16 @@ import {
 } from "@arizeai/phoenix-client";
 import {
   DefaultChatTransport,
+  parseJsonEventStream,
   readUIMessageStream,
   type UIMessageChunk,
+  uiMessageChunkSchema,
 } from "ai";
 
 import { createOAuthFetch, hasOAuthCredentials } from "../authFetch";
 import { createPhoenixClient } from "../client";
 import type { PhoenixConfig } from "../config";
+import { parsePxiBusyError } from "./errors";
 import { formatPxiRuntimeError } from "./preflight";
 import type {
   PxiChatClient,
@@ -21,13 +24,24 @@ import type {
   PxiRuntimeOptions,
   PxiSession,
   PxiSessionClient,
+  PxiSessionEventHandlers,
+  PxiSessionState,
   PxiSessionSummary,
+  PxiStopSessionResult,
   PxiTransport,
+  PxiTurnStarted,
 } from "./types";
+
+export { PxiBusyError } from "./errors";
 
 const AGENT_SESSION_CHAT_PATH =
   "/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof pathsV1;
+const AGENT_SESSION_EVENTS_PATH =
+  "/agents/{agent_id}/sessions/{session_id}/events" satisfies keyof pathsV1;
+const AGENT_SESSION_STOP_PATH =
+  "/agents/{agent_id}/sessions/{session_id}/stop" satisfies keyof pathsV1;
 const SERVER_AGENT_ID = "server";
+const PXI_CLIENT_ID = crypto.randomUUID();
 
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
@@ -56,6 +70,21 @@ function toLocalISOWithOffset(date: Date): string {
   return `${localIso}${sign}${offsetHours}:${offsetRemainderMinutes}`;
 }
 
+function buildAgentSessionUrl({
+  endpoint,
+  agentSessionId,
+  path,
+}: {
+  endpoint: string;
+  agentSessionId: string;
+  path: string;
+}): string {
+  const resolvedPath = path
+    .replace("{agent_id}", SERVER_AGENT_ID)
+    .replace("{session_id}", encodeURIComponent(agentSessionId));
+  return `${trimTrailingSlash(endpoint)}${resolvedPath}`;
+}
+
 /** Build the agent-session chat URL. */
 export function buildAgentSessionChatUrl({
   endpoint,
@@ -64,11 +93,16 @@ export function buildAgentSessionChatUrl({
   endpoint: string;
   agentSessionId: string;
 }): string {
-  const path = AGENT_SESSION_CHAT_PATH.replace(
-    "{agent_id}",
-    SERVER_AGENT_ID
-  ).replace("{session_id}", encodeURIComponent(agentSessionId));
-  return `${trimTrailingSlash(endpoint)}${path}`;
+  return buildAgentSessionUrl({
+    endpoint,
+    agentSessionId,
+    path: AGENT_SESSION_CHAT_PATH,
+  });
+}
+
+/** Return the process-stable identity sent with every PXI turn. */
+export function getPxiClientId(): string {
+  return PXI_CLIENT_ID;
 }
 
 /** Pull a printable error message out of an error response body, if any. */
@@ -82,6 +116,320 @@ async function readErrorDetail({
   } catch {
     return null;
   }
+}
+
+function getPxiFetch({
+  config,
+  fetchImpl,
+}: {
+  config: PhoenixConfig;
+  fetchImpl?: typeof globalThis.fetch;
+}): typeof globalThis.fetch {
+  return (
+    fetchImpl ??
+    (hasOAuthCredentials(config)
+      ? createOAuthFetch({ config })
+      : (input, init) => globalThis.fetch(input, init))
+  );
+}
+
+function withBusyErrorParsing({
+  fetchImpl,
+}: {
+  fetchImpl: typeof globalThis.fetch;
+}): typeof globalThis.fetch {
+  return async (input, init) => {
+    const response = await fetchImpl(input, init);
+    const busyError = await parsePxiBusyError({ response });
+    if (busyError) {
+      throw busyError;
+    }
+    return response;
+  };
+}
+
+function isSessionStateChunk(chunk: UIMessageChunk): chunk is UIMessageChunk & {
+  type: "data-session-state";
+  data: PxiSessionState;
+} {
+  if (chunk.type !== "data-session-state") {
+    return false;
+  }
+  const data = chunk.data;
+  return (
+    data !== null &&
+    typeof data === "object" &&
+    "state" in data &&
+    typeof data.state === "string" &&
+    "ownedByThisInstance" in data &&
+    typeof data.ownedByThisInstance === "boolean" &&
+    "streamAvailable" in data &&
+    typeof data.streamAvailable === "boolean"
+  );
+}
+
+function isTurnStartedChunk(chunk: UIMessageChunk): chunk is UIMessageChunk & {
+  type: "data-turn-started";
+  data: PxiTurnStarted;
+} {
+  if (chunk.type !== "data-turn-started") {
+    return false;
+  }
+  const data = chunk.data;
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+  const message = "message" in data ? data.message : null;
+  return (
+    "turnId" in data &&
+    typeof data.turnId === "string" &&
+    message !== null &&
+    typeof message === "object" &&
+    "id" in message &&
+    typeof message.id === "string" &&
+    "role" in message &&
+    typeof message.role === "string" &&
+    "parts" in message &&
+    Array.isArray(message.parts)
+  );
+}
+
+type SubscribeToSessionEventsOptions = {
+  config: PhoenixConfig;
+  agentSessionId: string;
+  abortSignal?: AbortSignal;
+  fetchImpl?: typeof globalThis.fetch;
+} & PxiSessionEventHandlers;
+
+async function subscribeToSessionEventsOnce({
+  config,
+  agentSessionId,
+  abortSignal,
+  fetchImpl,
+  onSessionState,
+  onTurnStarted,
+  onAssistantMessage,
+  onSessionTitle,
+  onError,
+}: SubscribeToSessionEventsOptions): Promise<void> {
+  const endpoint = config.endpoint;
+  if (!endpoint) {
+    throw new Error("Phoenix endpoint not configured.");
+  }
+  const response = await getPxiFetch({ config, fetchImpl })(
+    buildAgentSessionUrl({
+      endpoint,
+      agentSessionId,
+      path: AGENT_SESSION_EVENTS_PATH,
+    }),
+    {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        ...buildPxiHeaders({ config }),
+      },
+      signal: abortSignal,
+    }
+  );
+  if (!response.ok) {
+    const detail = await readErrorDetail({ response });
+    throw new Error(
+      `Could not follow the PXI session: HTTP ${response.status} ${response.statusText}.${detail ? ` ${detail}` : ""}`
+    );
+  }
+  if (!response.body) {
+    throw new Error(
+      "Could not follow the PXI session because the response body is empty."
+    );
+  }
+
+  let currentSessionState: PxiSessionState | undefined;
+  let activeTurn:
+    | {
+        turnId: string;
+        writer: WritableStreamDefaultWriter<UIMessageChunk>;
+        completion: Promise<void>;
+      }
+    | undefined;
+
+  const closeActiveTurn = async () => {
+    const turn = activeTurn;
+    activeTurn = undefined;
+    if (!turn) {
+      return;
+    }
+    try {
+      await turn.writer.close();
+      await turn.completion;
+    } catch (error) {
+      if (!abortSignal?.aborted) {
+        onError?.(error);
+      }
+    }
+  };
+
+  try {
+    const parsedEvents = parseJsonEventStream({
+      stream: response.body,
+      schema: uiMessageChunkSchema,
+    });
+    for await (const parsedEvent of parsedEvents) {
+      if (!parsedEvent.success) {
+        throw parsedEvent.error;
+      }
+      const chunk = parsedEvent.value;
+      if (isSessionStateChunk(chunk)) {
+        currentSessionState = chunk.data;
+        if (
+          chunk.data.state === "idle" ||
+          chunk.data.state === "awaiting_client_tool"
+        ) {
+          await closeActiveTurn();
+        }
+        onSessionState(chunk.data);
+        continue;
+      }
+      if (isTurnStartedChunk(chunk)) {
+        await closeActiveTurn();
+        const isTurnInFlight =
+          currentSessionState?.state === "streaming" ||
+          currentSessionState?.state === "persisting";
+        if (!isTurnInFlight || currentSessionState?.streamAvailable === false) {
+          continue;
+        }
+        onTurnStarted(chunk.data);
+        const turnStream = new TransformStream<
+          UIMessageChunk,
+          UIMessageChunk
+        >();
+        const turnId = chunk.data.turnId;
+        const completion = streamAssistantMessage({
+          stream: turnStream.readable,
+          onAssistantMessage: (message) =>
+            onAssistantMessage({ turnId, message }),
+          onSessionTitle,
+        })
+          .then(() => undefined)
+          .catch((error: unknown) => {
+            if (!abortSignal?.aborted) {
+              onError?.(error);
+            }
+          });
+        activeTurn = {
+          turnId,
+          writer: turnStream.writable.getWriter(),
+          completion,
+        };
+        continue;
+      }
+      if (activeTurn) {
+        await activeTurn.writer.write(chunk);
+      }
+    }
+  } finally {
+    await closeActiveTurn();
+  }
+}
+
+/**
+ * Subscribe to current and future turns for a session. Session-control chunks
+ * are demultiplexed from the AI SDK protocol, while each turn's content is fed
+ * through the same assistant-message accumulator used by the POST response.
+ * Full-replay reconnects make transient connection failures self-healing.
+ */
+export async function subscribeToSessionEvents(
+  options: SubscribeToSessionEventsOptions
+): Promise<void> {
+  let reconnectDelayMs = 500;
+  while (!options.abortSignal?.aborted) {
+    try {
+      await subscribeToSessionEventsOnce(options);
+      if (options.abortSignal?.aborted) {
+        return;
+      }
+      throw new Error("PXI session event stream ended unexpectedly.");
+    } catch (error) {
+      if (options.abortSignal?.aborted) {
+        return;
+      }
+      options.onError?.(error);
+      await waitForAbortableDelay({
+        delayMs: reconnectDelayMs,
+        signal: options.abortSignal,
+      });
+      reconnectDelayMs = Math.min(reconnectDelayMs * 2, 8_000);
+    }
+  }
+}
+
+async function waitForAbortableDelay({
+  delayMs,
+  signal,
+}: {
+  delayMs: number;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (signal?.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const handleAbort = () => {
+      clearTimeout(timeoutId);
+      resolve();
+    };
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", handleAbort);
+      resolve();
+    }, delayMs);
+    signal?.addEventListener("abort", handleAbort, { once: true });
+  });
+}
+
+/** Request server-side interruption of a PXI session turn. */
+export async function stopSession({
+  config,
+  agentSessionId,
+  turnId,
+  fetchImpl,
+}: {
+  config: PhoenixConfig;
+  agentSessionId: string;
+  turnId?: string;
+  fetchImpl?: typeof globalThis.fetch;
+}): Promise<PxiStopSessionResult> {
+  const endpoint = config.endpoint;
+  if (!endpoint) {
+    throw new Error("Phoenix endpoint not configured.");
+  }
+  const response = await getPxiFetch({ config, fetchImpl })(
+    buildAgentSessionUrl({
+      endpoint,
+      agentSessionId,
+      path: AGENT_SESSION_STOP_PATH,
+    }),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...buildPxiHeaders({ config }),
+      },
+      body: JSON.stringify(turnId ? { turnId } : {}),
+    }
+  );
+  const busyError = await parsePxiBusyError({ response });
+  if (busyError) {
+    throw busyError;
+  }
+  if (!response.ok) {
+    const detail = await readErrorDetail({ response });
+    throw new Error(
+      `Could not stop the PXI session: HTTP ${response.status} ${response.statusText}.${detail ? ` ${detail}` : ""}`
+    );
+  }
+  const payload = (await response.json()) as {
+    data: PxiStopSessionResult;
+  };
+  return payload.data;
 }
 
 /** Create an `AgentSession`. */
@@ -133,11 +481,7 @@ export function createPxiSessionClient({
   config: PhoenixConfig;
   fetch?: typeof globalThis.fetch;
 }): PxiSessionClient {
-  const fetchImpl =
-    fetchOverride ??
-    (hasOAuthCredentials(config)
-      ? createOAuthFetch({ config })
-      : globalThis.fetch);
+  const fetchImpl = getPxiFetch({ config, fetchImpl: fetchOverride });
   return {
     createSession: ({ temporary }) =>
       createAgentSession({ config, temporary, fetchImpl }),
@@ -190,6 +534,20 @@ export function createPxiSessionClient({
         messages: session.messages as PxiMessage[],
       };
     },
+    subscribeToSessionEvents: ({ sessionId, ...handlers }) =>
+      subscribeToSessionEvents({
+        config,
+        agentSessionId: sessionId,
+        fetchImpl,
+        ...handlers,
+      }),
+    stopSession: ({ sessionId, turnId }) =>
+      stopSession({
+        config,
+        agentSessionId: sessionId,
+        turnId,
+        fetchImpl,
+      }),
   };
 }
 
@@ -268,6 +626,7 @@ function buildPxiRequestBase({ options }: { options: PxiRuntimeOptions }) {
       enableGraphqlMutations: options.enableGraphqlMutations,
     }),
     model: options.modelSelection,
+    clientId: PXI_CLIENT_ID,
   };
 }
 
@@ -304,11 +663,9 @@ export function createServerAgentTransport({
     throw new Error("Phoenix endpoint not configured.");
   }
 
-  const transportFetch =
-    fetch ??
-    (hasOAuthCredentials(options.config)
-      ? createOAuthFetch({ config: options.config })
-      : undefined);
+  const transportFetch = withBusyErrorParsing({
+    fetchImpl: getPxiFetch({ config: options.config, fetchImpl: fetch }),
+  });
 
   // The server session is created lazily on the first send and reused for the
   // rest of the chat. A failed creation clears the cached promise so the next

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -14,6 +14,7 @@ import {
 import { createOAuthFetch, hasOAuthCredentials } from "../authFetch";
 import { createPhoenixClient } from "../client";
 import type { PhoenixConfig } from "../config";
+import { AuthRequiredError } from "../exitCodes";
 import { parsePxiBusyError } from "./errors";
 import { formatPxiRuntimeError } from "./preflight";
 import type {
@@ -201,6 +202,41 @@ type SubscribeToSessionEventsOptions = {
   fetchImpl?: typeof globalThis.fetch;
 } & PxiSessionEventHandlers;
 
+const INITIAL_RECONNECT_DELAY_MS = 500;
+const MAX_RECONNECT_DELAY_MS = 8_000;
+/**
+ * HTTP statuses that will not get better by retrying: the endpoint does not
+ * exist on this server (pre-event-bus Phoenix), the session is gone, or the
+ * caller is not allowed to follow it.
+ */
+const FATAL_SUBSCRIBE_STATUSES: ReadonlySet<number> = new Set([401, 403, 404]);
+
+/** A non-OK response from the session-events endpoint. */
+class SessionEventsRequestError extends Error {
+  readonly status: number;
+
+  constructor({ message, status }: { message: string; status: number }) {
+    super(message);
+    this.name = "SessionEventsRequestError";
+    this.status = status;
+  }
+}
+
+/**
+ * Whether a subscription failure is permanent for this session (missing
+ * endpoint, deleted session, auth failure) rather than a transient network
+ * blip worth reconnecting through.
+ */
+function isFatalSubscribeError(error: unknown): boolean {
+  if (error instanceof AuthRequiredError) {
+    return true;
+  }
+  return (
+    error instanceof SessionEventsRequestError &&
+    FATAL_SUBSCRIBE_STATUSES.has(error.status)
+  );
+}
+
 async function subscribeToSessionEventsOnce({
   config,
   agentSessionId,
@@ -211,7 +247,10 @@ async function subscribeToSessionEventsOnce({
   onAssistantMessage,
   onSessionTitle,
   onError,
-}: SubscribeToSessionEventsOptions): Promise<void> {
+  onStreamEstablished,
+}: SubscribeToSessionEventsOptions & {
+  onStreamEstablished?: () => void;
+}): Promise<void> {
   const endpoint = config.endpoint;
   if (!endpoint) {
     throw new Error("Phoenix endpoint not configured.");
@@ -233,9 +272,10 @@ async function subscribeToSessionEventsOnce({
   );
   if (!response.ok) {
     const detail = await readErrorDetail({ response });
-    throw new Error(
-      `Could not follow the PXI session: HTTP ${response.status} ${response.statusText}.${detail ? ` ${detail}` : ""}`
-    );
+    throw new SessionEventsRequestError({
+      message: `Could not follow the PXI session: HTTP ${response.status} ${response.statusText}.${detail ? ` ${detail}` : ""}`,
+      status: response.status,
+    });
   }
   if (!response.body) {
     throw new Error(
@@ -268,6 +308,7 @@ async function subscribeToSessionEventsOnce({
     }
   };
 
+  let hasReceivedEvent = false;
   try {
     const parsedEvents = parseJsonEventStream({
       stream: response.body,
@@ -276,6 +317,10 @@ async function subscribeToSessionEventsOnce({
     for await (const parsedEvent of parsedEvents) {
       if (!parsedEvent.success) {
         throw parsedEvent.error;
+      }
+      if (!hasReceivedEvent) {
+        hasReceivedEvent = true;
+        onStreamEstablished?.();
       }
       const chunk = parsedEvent.value;
       if (isSessionStateChunk(chunk)) {
@@ -291,9 +336,13 @@ async function subscribeToSessionEventsOnce({
       }
       if (isTurnStartedChunk(chunk)) {
         await closeActiveTurn();
+        // `awaiting_client_tool` counts as in flight: attaching to a session
+        // paused on a client tool replays the partial turn so the pending
+        // tool call is visible.
         const isTurnInFlight =
           currentSessionState?.state === "streaming" ||
-          currentSessionState?.state === "persisting";
+          currentSessionState?.state === "persisting" ||
+          currentSessionState?.state === "awaiting_client_tool";
         if (!isTurnInFlight || currentSessionState?.streamAvailable === false) {
           continue;
         }
@@ -323,7 +372,16 @@ async function subscribeToSessionEventsOnce({
         continue;
       }
       if (activeTurn) {
-        await activeTurn.writer.write(chunk);
+        try {
+          await activeTurn.writer.write(chunk);
+        } catch {
+          // The per-turn consumer failed or was cancelled (its own error is
+          // reported through the turn's completion promise). Stop forwarding
+          // this turn's chunks but keep the events connection alive.
+          const failedTurn = activeTurn;
+          activeTurn = undefined;
+          void failedTurn.writer.abort().catch(() => undefined);
+        }
       }
     }
   } finally {
@@ -335,30 +393,46 @@ async function subscribeToSessionEventsOnce({
  * Subscribe to current and future turns for a session. Session-control chunks
  * are demultiplexed from the AI SDK protocol, while each turn's content is fed
  * through the same assistant-message accumulator used by the POST response.
- * Full-replay reconnects make transient connection failures self-healing.
+ *
+ * Transient failures (dropped connections, server restarts, proxy timeouts)
+ * reconnect silently with backoff — the server replays the in-flight turn from
+ * its start, so blips self-heal without surfacing to the UI. Permanent
+ * failures (endpoint missing on an older Phoenix server, deleted session, auth
+ * failure) are surfaced once through `onError` and end the subscription; the
+ * rest of the CLI keeps working without live following.
  */
 export async function subscribeToSessionEvents(
   options: SubscribeToSessionEventsOptions
 ): Promise<void> {
-  let reconnectDelayMs = 500;
+  let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
   while (!options.abortSignal?.aborted) {
     try {
-      await subscribeToSessionEventsOnce(options);
-      if (options.abortSignal?.aborted) {
-        return;
-      }
-      throw new Error("PXI session event stream ended unexpectedly.");
+      await subscribeToSessionEventsOnce({
+        ...options,
+        onStreamEstablished: () => {
+          reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+        },
+      });
+      // The server closed the stream; treat it like any transient drop and
+      // reconnect silently.
     } catch (error) {
       if (options.abortSignal?.aborted) {
         return;
       }
-      options.onError?.(error);
-      await waitForAbortableDelay({
-        delayMs: reconnectDelayMs,
-        signal: options.abortSignal,
-      });
-      reconnectDelayMs = Math.min(reconnectDelayMs * 2, 8_000);
+      if (isFatalSubscribeError(error)) {
+        options.onError?.(error);
+        return;
+      }
+      // Transient failure — reconnect silently.
     }
+    if (options.abortSignal?.aborted) {
+      return;
+    }
+    await waitForAbortableDelay({
+      delayMs: reconnectDelayMs,
+      signal: options.abortSignal,
+    });
+    reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
   }
 }
 

--- a/js/packages/phoenix-cli/src/pxi/errors.ts
+++ b/js/packages/phoenix-cli/src/pxi/errors.ts
@@ -1,0 +1,66 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+
+type BusyErrorData = componentsV1["schemas"]["AgentSessionBusyErrorBody"];
+type SessionRunState = componentsV1["schemas"]["SessionRunState"];
+
+const SESSION_RUN_STATES: ReadonlySet<SessionRunState> = new Set([
+  "idle",
+  "streaming",
+  "persisting",
+  "awaiting_client_tool",
+  "mutating",
+]);
+
+function isBusyErrorData(value: unknown): value is BusyErrorData {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<BusyErrorData>;
+  return (
+    candidate.code === "agent_session_busy" &&
+    typeof candidate.state === "string" &&
+    SESSION_RUN_STATES.has(candidate.state as SessionRunState) &&
+    typeof candidate.turnId === "string" &&
+    (candidate.assistantMessageId == null ||
+      typeof candidate.assistantMessageId === "string") &&
+    typeof candidate.ownedByThisInstance === "boolean"
+  );
+}
+
+/** Structured conflict returned when another turn or mutation owns a session. */
+export class PxiBusyError extends Error {
+  readonly code = "agent_session_busy" as const;
+  readonly state: SessionRunState;
+  readonly turnId: string;
+  readonly assistantMessageId: string | null;
+  readonly ownedByThisInstance: boolean;
+
+  constructor(data: BusyErrorData) {
+    const location = data.ownedByThisInstance
+      ? "this Phoenix server instance"
+      : "another Phoenix server instance";
+    super(`PXI session is busy (${data.state}) on ${location}.`);
+    this.name = "PxiBusyError";
+    this.state = data.state;
+    this.turnId = data.turnId;
+    this.assistantMessageId = data.assistantMessageId ?? null;
+    this.ownedByThisInstance = data.ownedByThisInstance;
+  }
+}
+
+/** Parse Phoenix's structured session-busy response without consuming it. */
+export async function parsePxiBusyError({
+  response,
+}: {
+  response: Response;
+}): Promise<PxiBusyError | null> {
+  if (response.status !== 409) {
+    return null;
+  }
+  try {
+    const data: unknown = await response.clone().json();
+    return isBusyErrorData(data) ? new PxiBusyError(data) : null;
+  } catch {
+    return null;
+  }
+}

--- a/js/packages/phoenix-cli/src/pxi/preflight.ts
+++ b/js/packages/phoenix-cli/src/pxi/preflight.ts
@@ -1,6 +1,7 @@
 import { buildGraphqlRequest } from "../commands/api";
 import type { PhoenixConfig } from "../config";
 import { InvalidArgumentError } from "../exitCodes";
+import { PxiBusyError } from "./errors";
 import type {
   BuiltInProvider,
   ModelSelection,
@@ -464,6 +465,9 @@ export function formatPxiRuntimeError({
   error: unknown;
   modelSelection: ModelSelection;
 }): Error {
+  if (error instanceof PxiBusyError) {
+    return error;
+  }
   const message = error instanceof Error ? error.message : String(error);
   const nextAction =
     modelSelection.providerType === "custom"

--- a/js/packages/phoenix-cli/src/pxi/types.ts
+++ b/js/packages/phoenix-cli/src/pxi/types.ts
@@ -25,12 +25,26 @@ export type AssistantMessageMetadata = SchemasV1["AssistantMessageMetadata"];
 
 /** Transient data chunks streamed alongside assistant message content. */
 type PxiDataTypes = {
+  "session-state": SchemasV1["SessionStateChunk"]["data"];
   "session-summary": SchemasV1["SessionSummaryChunk"]["data"];
   "transcript-persisted": SchemasV1["TranscriptPersistedChunk"]["data"];
+  "turn-started": SchemasV1["SessionTurnStartedChunk"]["data"];
 };
 
 /** A chat message (user or assistant) carrying PXI-specific metadata. */
 export type PxiMessage = UIMessage<AssistantMessageMetadata, PxiDataTypes>;
+
+/** Current server-side ownership and streaming state for an agent session. */
+export type PxiSessionState = SchemasV1["SessionStateData"];
+
+/** The submitted user message that establishes a remote turn's replay baseline. */
+export type PxiTurnStarted = Omit<PxiDataTypes["turn-started"], "message"> & {
+  message: PxiMessage;
+};
+
+/** Result returned after requesting that Phoenix stop an active session turn. */
+export type PxiStopSessionResult =
+  SchemasV1["StopAgentSessionResponse"]["data"];
 
 export type BuiltInProvider = SchemasV1["ModelProvider"];
 
@@ -113,10 +127,32 @@ export type PxiSession = PxiSessionSummary & {
 };
 
 /** Server-side session operations used by the chat UI. */
+export type PxiSessionEventHandlers = {
+  onSessionState: (state: PxiSessionState) => void;
+  onTurnStarted: (turn: PxiTurnStarted) => void;
+  onAssistantMessage: (options: {
+    turnId: string;
+    message: PxiMessage;
+  }) => void;
+  onSessionTitle?: (title: string) => void;
+  onError?: (error: unknown) => void;
+};
+
+/** Server-side session operations used by the chat UI. */
 export type PxiSessionClient = {
   createSession: (options: { temporary: boolean }) => Promise<PxiSession>;
   listSessions: () => Promise<PxiSessionSummary[]>;
   getSession: (options: { sessionId: string }) => Promise<PxiSession>;
+  subscribeToSessionEvents?: (
+    options: {
+      sessionId: string;
+      abortSignal?: AbortSignal;
+    } & PxiSessionEventHandlers
+  ) => Promise<void>;
+  stopSession?: (options: {
+    sessionId: string;
+    turnId?: string;
+  }) => Promise<PxiStopSessionResult>;
 };
 
 /**

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1626,6 +1626,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/agents/{agent_id}/sessions/{session_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Subscribe To Session Events
+         * @description Follow current and future turns for an owned agent session.
+         */
+        get: operations["subscribeToAgentSessionEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{agent_id}/sessions/{session_id}/stop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stop Agent Session
+         * @description Request cancellation of the active turn for an owned agent session.
+         */
+        post: operations["stopAgentSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/agents/{agent_id}/sessions/{session_id}/chat": {
         parameters: {
             query?: never;
@@ -1710,6 +1750,22 @@ export interface components {
              * @description The session's GlobalID — the ``session_id`` the chat route expects.
              */
             id: string;
+        };
+        /** AgentSessionBusyErrorBody */
+        AgentSessionBusyErrorBody: {
+            /**
+             * Code
+             * @default agent_session_busy
+             * @constant
+             */
+            code?: "agent_session_busy";
+            state: components["schemas"]["SessionRunState"];
+            /** Turnid */
+            turnId: string;
+            /** Assistantmessageid */
+            assistantMessageId?: string | null;
+            /** Ownedbythisinstance */
+            ownedByThisInstance: boolean;
         };
         /** AgentSessionData */
         AgentSessionData: {
@@ -1919,6 +1975,8 @@ export interface components {
             trace?: components["schemas"]["AssistantMessageMetadataTraceIds"] | null;
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
             usage?: components["schemas"]["AssistantMessageMetadataUsage"] | null;
+            /** Interrupted */
+            interrupted?: ("stopped" | "errored") | null;
         } & {
             [key: string]: unknown;
         };
@@ -2055,6 +2113,8 @@ export interface components {
             requestedSkills?: string[];
             model: components["schemas"]["AgentModelSelection"];
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
+            /** Clientid */
+            clientId?: string | null;
             /**
              * Trigger
              * @default submit-message
@@ -4960,6 +5020,11 @@ export interface components {
              */
             identifier?: string;
         };
+        /**
+         * SessionRunState
+         * @enum {string}
+         */
+        SessionRunState: "idle" | "streaming" | "persisting" | "awaiting_client_tool" | "mutating";
         /** SessionTraceData */
         SessionTraceData: {
             /** Id */
@@ -5355,6 +5420,27 @@ export interface components {
              * @constant
              */
             type?: "step-start";
+        };
+        /** StopAgentSessionRequest */
+        StopAgentSessionRequest: {
+            /** Turnid */
+            turnId?: string | null;
+        };
+        /** StopAgentSessionResponse */
+        StopAgentSessionResponse: {
+            data: components["schemas"]["StopAgentSessionResponseData"];
+        };
+        /** StopAgentSessionResponseData */
+        StopAgentSessionResponseData: {
+            /** Turnid */
+            turnId?: string | null;
+            /** @default idle */
+            state?: components["schemas"]["SessionRunState"];
+            /**
+             * Remote
+             * @default false
+             */
+            remote?: boolean;
         };
         /**
          * SubagentsContext
@@ -6104,6 +6190,50 @@ export interface components {
             /** Enabled */
             enabled: boolean;
         };
+        /** SessionStateChunk */
+        SessionStateChunk: {
+            /**
+             * Type
+             * @default data-session-state
+             * @constant
+             */
+            type?: "data-session-state";
+            /**
+             * Id
+             * @default null
+             */
+            id?: string | null;
+            data: components["schemas"]["SessionStateData"];
+            /**
+             * Transient
+             * @default true
+             * @constant
+             */
+            transient?: true;
+        };
+        /** SessionStateData */
+        SessionStateData: {
+            state: components["schemas"]["SessionRunState"];
+            /**
+             * Turnid
+             * @default null
+             */
+            turnId?: string | null;
+            /**
+             * Assistantmessageid
+             * @default null
+             */
+            assistantMessageId?: string | null;
+            /**
+             * Originclientid
+             * @default null
+             */
+            originClientId?: string | null;
+            /** Ownedbythisinstance */
+            ownedByThisInstance: boolean;
+            /** Streamavailable */
+            streamAvailable: boolean;
+        };
         /**
          * SessionSummaryChunk
          * @description Transient ``data-session-summary`` stream chunk: the LLM-generated
@@ -6135,6 +6265,33 @@ export interface components {
              * @constant
              */
             transient?: true;
+        };
+        /** SessionTurnStartedChunk */
+        SessionTurnStartedChunk: {
+            /**
+             * Type
+             * @default data-turn-started
+             * @constant
+             */
+            type?: "data-turn-started";
+            /**
+             * Id
+             * @default null
+             */
+            id?: string | null;
+            data: components["schemas"]["SessionTurnStartedData"];
+            /**
+             * Transient
+             * @default true
+             * @constant
+             */
+            transient?: true;
+        };
+        /** SessionTurnStartedData */
+        SessionTurnStartedData: {
+            /** Turnid */
+            turnId: string;
+            message: components["schemas"]["PhoenixUIMessage"];
         };
         /**
          * ToolCallCallbackProviderMetadata
@@ -11275,6 +11432,90 @@ export interface operations {
                     "application/json": components["schemas"]["CompactAgentSessionResponse"];
                 };
             };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    subscribeToAgentSessionEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stopAgentSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StopAgentSessionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StopAgentSessionResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -11309,6 +11550,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
                 };
             };
             /** @description Validation Error */

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1626,6 +1626,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/agents/{agent_id}/sessions/{session_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Subscribe To Session Events
+         * @description Follow current and future turns for an owned agent session.
+         */
+        get: operations["subscribeToAgentSessionEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{agent_id}/sessions/{session_id}/stop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stop Agent Session
+         * @description Request cancellation of the active turn for an owned agent session.
+         */
+        post: operations["stopAgentSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/agents/{agent_id}/sessions/{session_id}/chat": {
         parameters: {
             query?: never;
@@ -1710,6 +1750,22 @@ export interface components {
              * @description The session's GlobalID — the ``session_id`` the chat route expects.
              */
             id: string;
+        };
+        /** AgentSessionBusyErrorBody */
+        AgentSessionBusyErrorBody: {
+            /**
+             * Code
+             * @default agent_session_busy
+             * @constant
+             */
+            code?: "agent_session_busy";
+            state: components["schemas"]["SessionRunState"];
+            /** Turnid */
+            turnId: string;
+            /** Assistantmessageid */
+            assistantMessageId?: string | null;
+            /** Ownedbythisinstance */
+            ownedByThisInstance: boolean;
         };
         /** AgentSessionData */
         AgentSessionData: {
@@ -1919,6 +1975,8 @@ export interface components {
             trace?: components["schemas"]["AssistantMessageMetadataTraceIds"] | null;
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
             usage?: components["schemas"]["AssistantMessageMetadataUsage"] | null;
+            /** Interrupted */
+            interrupted?: ("stopped" | "errored") | null;
         } & {
             [key: string]: unknown;
         };
@@ -2055,6 +2113,8 @@ export interface components {
             requestedSkills?: string[];
             model: components["schemas"]["AgentModelSelection"];
             turnTraceContext?: components["schemas"]["TurnTraceContext"] | null;
+            /** Clientid */
+            clientId?: string | null;
             /**
              * Trigger
              * @default submit-message
@@ -4960,6 +5020,11 @@ export interface components {
              */
             identifier?: string;
         };
+        /**
+         * SessionRunState
+         * @enum {string}
+         */
+        SessionRunState: "idle" | "streaming" | "persisting" | "awaiting_client_tool" | "mutating";
         /** SessionTraceData */
         SessionTraceData: {
             /** Id */
@@ -5355,6 +5420,27 @@ export interface components {
              * @constant
              */
             type?: "step-start";
+        };
+        /** StopAgentSessionRequest */
+        StopAgentSessionRequest: {
+            /** Turnid */
+            turnId?: string | null;
+        };
+        /** StopAgentSessionResponse */
+        StopAgentSessionResponse: {
+            data: components["schemas"]["StopAgentSessionResponseData"];
+        };
+        /** StopAgentSessionResponseData */
+        StopAgentSessionResponseData: {
+            /** Turnid */
+            turnId?: string | null;
+            /** @default idle */
+            state?: components["schemas"]["SessionRunState"];
+            /**
+             * Remote
+             * @default false
+             */
+            remote?: boolean;
         };
         /**
          * SubagentsContext
@@ -6104,6 +6190,50 @@ export interface components {
             /** Enabled */
             enabled: boolean;
         };
+        /** SessionStateChunk */
+        SessionStateChunk: {
+            /**
+             * Type
+             * @default data-session-state
+             * @constant
+             */
+            type?: "data-session-state";
+            /**
+             * Id
+             * @default null
+             */
+            id?: string | null;
+            data: components["schemas"]["SessionStateData"];
+            /**
+             * Transient
+             * @default true
+             * @constant
+             */
+            transient?: true;
+        };
+        /** SessionStateData */
+        SessionStateData: {
+            state: components["schemas"]["SessionRunState"];
+            /**
+             * Turnid
+             * @default null
+             */
+            turnId?: string | null;
+            /**
+             * Assistantmessageid
+             * @default null
+             */
+            assistantMessageId?: string | null;
+            /**
+             * Originclientid
+             * @default null
+             */
+            originClientId?: string | null;
+            /** Ownedbythisinstance */
+            ownedByThisInstance: boolean;
+            /** Streamavailable */
+            streamAvailable: boolean;
+        };
         /**
          * SessionSummaryChunk
          * @description Transient ``data-session-summary`` stream chunk: the LLM-generated
@@ -6135,6 +6265,33 @@ export interface components {
              * @constant
              */
             transient?: true;
+        };
+        /** SessionTurnStartedChunk */
+        SessionTurnStartedChunk: {
+            /**
+             * Type
+             * @default data-turn-started
+             * @constant
+             */
+            type?: "data-turn-started";
+            /**
+             * Id
+             * @default null
+             */
+            id?: string | null;
+            data: components["schemas"]["SessionTurnStartedData"];
+            /**
+             * Transient
+             * @default true
+             * @constant
+             */
+            transient?: true;
+        };
+        /** SessionTurnStartedData */
+        SessionTurnStartedData: {
+            /** Turnid */
+            turnId: string;
+            message: components["schemas"]["PhoenixUIMessage"];
         };
         /**
          * ToolCallCallbackProviderMetadata
@@ -11275,6 +11432,90 @@ export interface operations {
                     "application/json": components["schemas"]["CompactAgentSessionResponse"];
                 };
             };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    subscribeToAgentSessionEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stopAgentSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StopAgentSessionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StopAgentSessionResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -11309,6 +11550,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSessionBusyErrorBody"];
                 };
             };
             /** @description Validation Error */

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -468,7 +468,7 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       ai:
-        specifier: ^7.0.0
+        specifier: 7.0.31
         version: 7.0.31(zod@4.4.3)
       commander:
         specifier: ^15.0.0

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -820,6 +820,18 @@ class StepStartUIPart(TypedDict):
     type: Literal["step-start"]
 
 
+class StopAgentSessionRequest(TypedDict):
+    turnId: NotRequired[str]
+
+
+class StopAgentSessionResponseData(TypedDict):
+    turnId: NotRequired[str]
+    state: NotRequired[
+        Literal["idle", "streaming", "persisting", "awaiting_client_tool", "mutating"]
+    ]
+    remote: NotRequired[bool]
+
+
 class SubagentsContext(TypedDict):
     type: Literal["subagents"]
     enabled: bool
@@ -1080,6 +1092,15 @@ class WebAccessContext(TypedDict):
     enabled: bool
 
 
+class SessionStateData(TypedDict):
+    state: Literal["idle", "streaming", "persisting", "awaiting_client_tool", "mutating"]
+    ownedByThisInstance: bool
+    streamAvailable: bool
+    turnId: NotRequired[str]
+    assistantMessageId: NotRequired[str]
+    originClientId: NotRequired[str]
+
+
 class SessionSummaryChunk(TypedDict):
     type: Literal["data-session-summary"]
     data: str
@@ -1105,6 +1126,14 @@ class TranscriptPersistedData(TypedDict):
 
 class AddDatasetLabelToDatasetResponseBody(TypedDict):
     data: DatasetLabel
+
+
+class AgentSessionBusyErrorBody(TypedDict):
+    state: Literal["idle", "streaming", "persisting", "awaiting_client_tool", "mutating"]
+    turnId: str
+    ownedByThisInstance: bool
+    code: NotRequired[str]
+    assistantMessageId: NotRequired[str]
 
 
 class AnnotateSessionsRequestBody(TypedDict):
@@ -1612,6 +1641,10 @@ class SpansResponseBody(TypedDict):
     next_cursor: Optional[str]
 
 
+class StopAgentSessionResponse(TypedDict):
+    data: StopAgentSessionResponseData
+
+
 class ToolApprovalRequestedPart(TypedDict):
     type: str
     toolCallId: str
@@ -1649,6 +1682,13 @@ class UpsertExperimentEvaluationResponseBody(TypedDict):
     data: UpsertExperimentEvaluationResponseBodyData
 
 
+class SessionStateChunk(TypedDict):
+    type: Literal["data-session-state"]
+    data: SessionStateData
+    id: NotRequired[str]
+    transient: NotRequired[bool]
+
+
 class TranscriptPersistedChunk(TypedDict):
     type: Literal["data-transcript-persisted"]
     data: TranscriptPersistedData
@@ -1666,6 +1706,7 @@ class AssistantMessageMetadata(TypedDict):
     trace: NotRequired[AssistantMessageMetadataTraceIds]
     turnTraceContext: NotRequired[TurnTraceContext]
     usage: NotRequired[AssistantMessageMetadataUsage]
+    interrupted: NotRequired[Literal["stopped", "errored"]]
 
 
 class CompactAgentSessionRequest(TypedDict):
@@ -1852,6 +1893,11 @@ class PromptMessage(TypedDict):
     ]
 
 
+class SessionTurnStartedData(TypedDict):
+    turnId: str
+    message: PhoenixUIMessage
+
+
 class AgentSessionData(TypedDict):
     id: str
     title: str
@@ -1891,6 +1937,7 @@ class ChatRequest(TypedDict):
     editPermission: NotRequired[Literal["manual", "bypass"]]
     requestedSkills: NotRequired[Sequence[str]]
     turnTraceContext: NotRequired[TurnTraceContext]
+    clientId: NotRequired[str]
     trigger: NotRequired[str]
 
 
@@ -1952,6 +1999,13 @@ class PromptVersionData(TypedDict):
 
 class PromptVersion(PromptVersionData):
     id: str
+
+
+class SessionTurnStartedChunk(TypedDict):
+    type: Literal["data-turn-started"]
+    data: SessionTurnStartedData
+    id: NotRequired[str]
+    transient: NotRequired[bool]
 
 
 class CompactAgentSessionResponse(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -8279,6 +8279,133 @@
               }
             }
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSessionBusyErrorBody"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{agent_id}/sessions/{session_id}/events": {
+      "get": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Subscribe To Session Events",
+        "description": "Follow current and future turns for an owned agent session.",
+        "operationId": "subscribeToAgentSessionEvents",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{agent_id}/sessions/{session_id}/stop": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Stop Agent Session",
+        "description": "Request cancellation of the active turn for an owned agent session.",
+        "operationId": "stopAgentSession",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StopAgentSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StopAgentSessionResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSessionBusyErrorBody"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -8337,6 +8464,16 @@
                 "schema": {}
               }
             }
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSessionBusyErrorBody"
+                }
+              }
+            },
+            "description": "Conflict"
           },
           "422": {
             "description": "Validation Error",
@@ -8444,6 +8581,45 @@
           "id"
         ],
         "title": "AgentSession"
+      },
+      "AgentSessionBusyErrorBody": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "const": "agent_session_busy",
+            "title": "Code",
+            "default": "agent_session_busy"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SessionRunState"
+          },
+          "turnId": {
+            "type": "string",
+            "title": "Turnid"
+          },
+          "assistantMessageId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assistantmessageid"
+          },
+          "ownedByThisInstance": {
+            "type": "boolean",
+            "title": "Ownedbythisinstance"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state",
+          "turnId",
+          "ownedByThisInstance"
+        ],
+        "title": "AgentSessionBusyErrorBody"
       },
       "AgentSessionData": {
         "properties": {
@@ -8969,6 +9145,21 @@
                 "type": "null"
               }
             ]
+          },
+          "interrupted": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "stopped",
+                  "errored"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interrupted"
           }
         },
         "additionalProperties": true,
@@ -9331,6 +9522,17 @@
                 "type": "null"
               }
             ]
+          },
+          "clientId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clientid"
           },
           "trigger": {
             "type": "string",
@@ -16534,6 +16736,17 @@
         ],
         "title": "SessionNoteData"
       },
+      "SessionRunState": {
+        "type": "string",
+        "enum": [
+          "idle",
+          "streaming",
+          "persisting",
+          "awaiting_client_tool",
+          "mutating"
+        ],
+        "title": "SessionRunState"
+      },
       "SessionTraceData": {
         "properties": {
           "id": {
@@ -17255,6 +17468,61 @@
         "type": "object",
         "title": "StepStartUIPart",
         "description": "A step boundary part of a message."
+      },
+      "StopAgentSessionRequest": {
+        "properties": {
+          "turnId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turnid"
+          }
+        },
+        "type": "object",
+        "title": "StopAgentSessionRequest"
+      },
+      "StopAgentSessionResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/StopAgentSessionResponseData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "StopAgentSessionResponse"
+      },
+      "StopAgentSessionResponseData": {
+        "properties": {
+          "turnId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turnid"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SessionRunState",
+            "default": "idle"
+          },
+          "remote": {
+            "type": "boolean",
+            "title": "Remote",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "StopAgentSessionResponseData"
       },
       "SubagentsContext": {
         "properties": {
@@ -19060,6 +19328,101 @@
         "title": "WebAccessContext",
         "description": "User's per-turn request to expose web search / fetch tools."
       },
+      "SessionStateChunk": {
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "const": "data-session-state",
+            "default": "data-session-state",
+            "title": "Type",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Id"
+          },
+          "data": {
+            "$ref": "#/components/schemas/SessionStateData"
+          },
+          "transient": {
+            "const": true,
+            "default": true,
+            "title": "Transient",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "SessionStateChunk",
+        "type": "object"
+      },
+      "SessionStateData": {
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/SessionRunState"
+          },
+          "turnId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Turnid"
+          },
+          "assistantMessageId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Assistantmessageid"
+          },
+          "originClientId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Originclientid"
+          },
+          "ownedByThisInstance": {
+            "title": "Ownedbythisinstance",
+            "type": "boolean"
+          },
+          "streamAvailable": {
+            "title": "Streamavailable",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "state",
+          "ownedByThisInstance",
+          "streamAvailable"
+        ],
+        "title": "SessionStateData",
+        "type": "object"
+      },
       "SessionSummaryChunk": {
         "additionalProperties": false,
         "description": "Transient ``data-session-summary`` stream chunk: the LLM-generated\nsession title, emitted on any turn that starts with the session still\nuntitled. Being transient, it reaches the client's ``onData`` callback\nbut is never appended to the message parts.\n\nSee the Vercel AI SDK data stream protocol:\n    - Data parts: https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol#data-parts\n    - Transient parts: https://ai-sdk.dev/docs/ai-sdk-ui/streaming-data#transient-data-parts-ephemeral",
@@ -19097,6 +19460,60 @@
           "data"
         ],
         "title": "SessionSummaryChunk",
+        "type": "object"
+      },
+      "SessionTurnStartedChunk": {
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "const": "data-turn-started",
+            "default": "data-turn-started",
+            "title": "Type",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Id"
+          },
+          "data": {
+            "$ref": "#/components/schemas/SessionTurnStartedData"
+          },
+          "transient": {
+            "const": true,
+            "default": true,
+            "title": "Transient",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "SessionTurnStartedChunk",
+        "type": "object"
+      },
+      "SessionTurnStartedData": {
+        "properties": {
+          "turnId": {
+            "title": "Turnid",
+            "type": "string"
+          },
+          "message": {
+            "$ref": "#/components/schemas/PhoenixUIMessage"
+          }
+        },
+        "required": [
+          "turnId",
+          "message"
+        ],
+        "title": "SessionTurnStartedData",
         "type": "object"
       },
       "ToolCallCallbackProviderMetadata": {

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -462,6 +462,29 @@ CREATE INDEX ix_agent_sessions_user_id_updated_at ON public.agent_sessions
     USING btree (user_id, updated_at DESC);
 
 
+-- Table: agent_session_runs
+-- -------------------------
+CREATE TABLE public.agent_session_runs (
+    agent_session_id BIGINT NOT NULL,
+    turn_id VARCHAR NOT NULL,
+    state VARCHAR NOT NULL,
+    assistant_message_id VARCHAR,
+    origin_client_id VARCHAR,
+    instance_id VARCHAR NOT NULL,
+    stop_requested_at TIMESTAMP WITH TIME ZONE,
+    started_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    heartbeat_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT pk_agent_session_runs PRIMARY KEY (agent_session_id),
+    CONSTRAINT fk_agent_session_runs_agent_session_id_agent_sessions
+        FOREIGN KEY (agent_session_id)
+        REFERENCES public.agent_sessions (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_session_runs_heartbeat_at ON public.agent_session_runs
+    USING btree (heartbeat_at);
+
+
 -- Table: agent_session_messages
 -- -----------------------------
 CREATE TABLE public.agent_session_messages (

--- a/scripts/pxi-multi-instance/docker-compose.yml
+++ b/scripts/pxi-multi-instance/docker-compose.yml
@@ -1,0 +1,51 @@
+name: pxi-multi-instance
+
+# Two Phoenix instances sharing one Postgres database, on non-default host
+# ports so the stack never collides with a local dev instance (6006/5432).
+# Used by run.sh to smoke-test PXI's multi-instance session event bus:
+# a turn streamed on instance A must surface as a degraded read-only session
+# on instance B, and both must converge on the persisted transcript.
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "15432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    # No volume on purpose: every run starts from a clean database so the
+    # Playwright spec can assume exactly one agent session exists.
+
+  phoenix-a:
+    image: phoenix-pxi-multi-instance:local
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      args:
+        BASE_IMAGE: ${PHOENIX_MI_BASE_IMAGE:-gcr.io/distroless/python3-debian13:nonroot}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "16006:6006"
+    environment: &phoenix-env
+      PHOENIX_SQL_DATABASE_URL: postgresql://postgres:postgres@db:5432/postgres
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?OPENAI_API_KEY is required for the PXI assistant}
+
+  # Started by run.sh only after phoenix-a is healthy, so database migrations
+  # never run concurrently on both instances.
+  phoenix-b:
+    image: phoenix-pxi-multi-instance:local
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "16007:6006"
+    environment: *phoenix-env

--- a/scripts/pxi-multi-instance/run.sh
+++ b/scripts/pxi-multi-instance/run.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Multi-instance PXI smoke test.
+#
+# Builds the Phoenix docker image from the current working tree, starts two
+# Phoenix containers sharing one Postgres database (ports 16006/16007/15432 so
+# nothing collides with a local dev instance), then runs the Playwright spec
+# app/tests/pxi/multi-instance.spec.ts against both instances with a real LLM.
+#
+# Requirements:
+#   - docker (with compose v2)
+#   - OPENAI_API_KEY, read from app/.env (or already exported)
+#
+# Usage:
+#   scripts/pxi-multi-instance/run.sh            # build, test, tear down
+#   KEEP_STACK=1 scripts/pxi-multi-instance/run.sh  # leave the stack running
+#   SKIP_BUILD=1 scripts/pxi-multi-instance/run.sh  # reuse the existing image
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+
+BASE_URL_A="http://localhost:16006"
+BASE_URL_B="http://localhost:16007"
+ASSISTANT_MODEL="${PXI_E2E_ASSISTANT_MODEL:-gpt-5.4-mini}"
+
+log() { printf '\n[pxi-multi-instance] %s\n' "$*"; }
+
+# --- Credentials -------------------------------------------------------------
+if [[ -z "${OPENAI_API_KEY:-}" && -f "${REPO_ROOT}/app/.env" ]]; then
+  # app/.env is a list of `export KEY=value` lines; source it in a subshell and
+  # extract only the key we need so dev-instance settings don't leak in.
+  OPENAI_API_KEY="$(
+    # shellcheck disable=SC1091
+    source "${REPO_ROOT}/app/.env" >/dev/null 2>&1
+    printf '%s' "${OPENAI_API_KEY:-}"
+  )"
+fi
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "OPENAI_API_KEY not set and not found in app/.env" >&2
+  exit 1
+fi
+export OPENAI_API_KEY
+
+# --- Build -------------------------------------------------------------------
+if [[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]]; then
+  export PHOENIX_MI_BASE_IMAGE="gcr.io/distroless/python3-debian13:nonroot-arm64"
+fi
+
+if [[ -z "${SKIP_BUILD:-}" ]]; then
+  log "Building the Phoenix image from the working tree (this can take a while)…"
+  "${COMPOSE[@]}" build phoenix-a
+fi
+
+# --- Startup -----------------------------------------------------------------
+teardown() {
+  if [[ -n "${KEEP_STACK:-}" ]]; then
+    log "KEEP_STACK set; leaving the stack running:"
+    log "  A: ${BASE_URL_A}  B: ${BASE_URL_B}  postgres: localhost:15432"
+    return
+  fi
+  log "Tearing down the stack…"
+  "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap teardown EXIT
+
+wait_for_healthz() {
+  local url="$1" name="$2" deadline=$((SECONDS + 180))
+  until curl -fsS "${url}/healthz" >/dev/null 2>&1; do
+    if ((SECONDS > deadline)); then
+      log "${name} did not become healthy; recent logs:"
+      "${COMPOSE[@]}" logs --tail 50 "${name}" || true
+      exit 1
+    fi
+    sleep 2
+  done
+  log "${name} is healthy at ${url}"
+}
+
+log "Starting postgres + phoenix-a…"
+"${COMPOSE[@]}" up -d db phoenix-a
+wait_for_healthz "${BASE_URL_A}" phoenix-a
+
+# phoenix-a has finished migrations by the time it serves /healthz, so
+# phoenix-b can start without racing them.
+log "Starting phoenix-b…"
+"${COMPOSE[@]}" up -d phoenix-b
+wait_for_healthz "${BASE_URL_B}" phoenix-b
+
+# --- Test --------------------------------------------------------------------
+log "Running the multi-instance Playwright spec (assistant model: ${ASSISTANT_MODEL})…"
+cd "${REPO_ROOT}/app"
+PXI_MI_BASE_URL_A="${BASE_URL_A}" \
+PXI_MI_BASE_URL_B="${BASE_URL_B}" \
+PXI_E2E_ASSISTANT_MODEL="${ASSISTANT_MODEL}" \
+pnpm exec playwright test --config=playwright.multi-instance.config.ts "$@"
+
+log "Multi-instance PXI smoke test passed."

--- a/src/phoenix/db/migrations/versions/2961f19cccd8_create_agent_session_runs.py
+++ b/src/phoenix/db/migrations/versions/2961f19cccd8_create_agent_session_runs.py
@@ -1,0 +1,48 @@
+"""create agent session runs
+
+Revision ID: 2961f19cccd8
+Revises: e767d3c57f32
+Create Date: 2026-07-27 12:04:55.895420
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2961f19cccd8"
+down_revision: Union[str, None] = "e767d3c57f32"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    agent_session_id_type = sa.Integer().with_variant(sa.BigInteger(), "postgresql")
+    op.create_table(
+        "agent_session_runs",
+        sa.Column(
+            "agent_session_id",
+            agent_session_id_type,
+            sa.ForeignKey("agent_sessions.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("turn_id", sa.String(), nullable=False),
+        sa.Column("state", sa.String(), nullable=False),
+        sa.Column("assistant_message_id", sa.String(), nullable=True),
+        sa.Column("origin_client_id", sa.String(), nullable=True),
+        sa.Column("instance_id", sa.String(), nullable=False),
+        sa.Column("stop_requested_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("heartbeat_at", sa.TIMESTAMP(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_agent_session_runs_heartbeat_at",
+        "agent_session_runs",
+        ["heartbeat_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("agent_session_runs")

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3303,6 +3303,25 @@ class AgentSession(HasId):
     )
 
 
+class AgentSessionRun(Base):
+    """Ephemeral ownership and state for an in-flight agent session operation."""
+
+    __tablename__ = "agent_session_runs"
+    agent_session_id: Mapped[int] = mapped_column(
+        ForeignKey("agent_sessions.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    turn_id: Mapped[str] = mapped_column(String, nullable=False)
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    assistant_message_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    origin_client_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    instance_id: Mapped[str] = mapped_column(String, nullable=False)
+    stop_requested_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(UtcTimeStamp, nullable=False)
+    heartbeat_at: Mapped[datetime] = mapped_column(UtcTimeStamp, nullable=False)
+    __table_args__ = (Index("ix_agent_session_runs_heartbeat_at", "heartbeat_at"),)
+
+
 class AgentSessionMessage(HasId):
     __tablename__ = "agent_session_messages"
     agent_session_id: Mapped[int] = mapped_column(

--- a/src/phoenix/db/types/data_stream_protocol/phoenix_types.py
+++ b/src/phoenix/db/types/data_stream_protocol/phoenix_types.py
@@ -50,6 +50,7 @@ class AssistantMessageMetadata(CamelBaseModel):
     trace: AssistantMessageMetadataTraceIds | None = None
     turn_trace_context: TurnTraceContext | None = None
     usage: AssistantMessageMetadataUsage | None = None
+    interrupted: Literal["stopped", "errored"] | None = None
 
 
 class UserMessageMetadata(CamelBaseModel):

--- a/src/phoenix/server/agents/event_bus.py
+++ b/src/phoenix/server/agents/event_bus.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import aclosing, asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -31,9 +32,12 @@ if TYPE_CHECKING:
     from phoenix.server.agents.turn_runner import TurnRunner
 
 
+logger = logging.getLogger(__name__)
+
 _INSTANCE_ID = uuid4().hex
 _MAX_REPLAY_CHUNKS = 100_000
 _HEARTBEAT_INTERVAL_SECONDS = 10
+_STALE_AFTER_SECONDS = 30
 _REMOTE_STATE_POLL_INTERVAL_SECONDS = 5
 _KEEP_ALIVE_INTERVAL_SECONDS = 15
 
@@ -180,7 +184,11 @@ class SessionChannel:
         self.state = state
         self._broadcast(self.state_chunk())
 
-    async def publish(self, chunk: BaseChunk) -> None:
+    def publish(self, chunk: BaseChunk) -> None:
+        # Deliberately synchronous: the turn runner's consume loop must have no
+        # suspension points other than the stream's __anext__, so that a stop
+        # cancellation is always delivered *inside* the stream generator (whose
+        # except/finally blocks perform the partial persist and trace flush).
         if self.stream_available:
             if len(self.turn_log) < _MAX_REPLAY_CHUNKS:
                 self.turn_log.append(chunk)
@@ -351,22 +359,31 @@ class AgentSessionEventBus(DaemonTask):
         next_state = (
             SessionRunState.AWAITING_CLIENT_TOOL if awaiting_client_tool else SessionRunState.IDLE
         )
-        async with self._db() as session:
-            if awaiting_client_tool:
-                await transition_run(
-                    session,
-                    agent_session_id=agent_session_id,
-                    instance_id=self.instance_id,
-                    turn_id=turn_id,
-                    state=next_state.value,
-                )
-            else:
-                await release_run(
-                    session,
-                    agent_session_id=agent_session_id,
-                    instance_id=self.instance_id,
-                    turn_id=turn_id,
-                )
+        try:
+            async with self._db() as session:
+                if awaiting_client_tool:
+                    await transition_run(
+                        session,
+                        agent_session_id=agent_session_id,
+                        instance_id=self.instance_id,
+                        turn_id=turn_id,
+                        state=next_state.value,
+                    )
+                else:
+                    await release_run(
+                        session,
+                        agent_session_id=agent_session_id,
+                        instance_id=self.instance_id,
+                        turn_id=turn_id,
+                    )
+        except Exception:
+            # Always finish the channel locally so the session can't get stuck
+            # busy in memory; the heartbeat reconciles the orphaned DB lease.
+            logger.exception(
+                "Failed to update the agent session lease at turn completion; "
+                "the heartbeat will reconcile it"
+            )
+            next_state = SessionRunState.IDLE
         if channel := self._channels.get(agent_session_id):
             channel.finish_turn(state=next_state)
             self._discard_idle_channel(channel)
@@ -400,18 +417,26 @@ class AgentSessionEventBus(DaemonTask):
         try:
             yield
         finally:
-            async with self._db() as session:
-                await release_run(
-                    session,
-                    agent_session_id=agent_session_id,
-                    instance_id=self.instance_id,
-                    turn_id=turn_id,
+            try:
+                async with self._db() as session:
+                    await release_run(
+                        session,
+                        agent_session_id=agent_session_id,
+                        instance_id=self.instance_id,
+                        turn_id=turn_id,
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to release the agent session mutation lease; "
+                    "the heartbeat will reconcile it"
                 )
             channel.finish_turn(state=SessionRunState.IDLE)
             self._discard_idle_channel(channel)
 
     async def get_run(self, *, agent_session_id: int) -> SessionRun | None:
-        async with self._db.read() as session:
+        # Lease reads must hit the primary: stop/busy decisions acting on a
+        # lagging read replica could miss or resurrect a lease.
+        async with self._db() as session:
             return await get_run(session, agent_session_id=agent_session_id)
 
     async def request_stop(
@@ -451,10 +476,30 @@ class AgentSessionEventBus(DaemonTask):
             channel.finish_turn(state=SessionRunState.IDLE)
             self._discard_idle_channel(channel)
 
+    def _get_fresh_remote_run(self, run: SessionRun | None) -> SessionRun | None:
+        """Return the run if it is live on another instance, else None."""
+        if run is None or run.instance_id == self.instance_id:
+            return None
+        is_stale = run.heartbeat_at < datetime.now(timezone.utc) - timedelta(
+            seconds=_STALE_AFTER_SECONDS
+        )
+        return None if is_stale else run
+
     async def session_events(self, *, agent_session_id: int) -> AsyncIterator[BaseChunk | None]:
         last_remote_state: SessionStateData | None = None
         while True:
-            if channel := self._channels.get(agent_session_id):
+            remote_run = self._get_fresh_remote_run(
+                await self.get_run(agent_session_id=agent_session_id)
+            )
+            if remote_run is None:
+                # This instance owns the session (or nobody does): subscribe to
+                # the local channel, creating an idle one if needed so future
+                # local turns surface. While idle, re-poll the lease so a turn
+                # started on another instance still surfaces as a remote state
+                # change.
+                channel = self._channels.setdefault(
+                    agent_session_id, SessionChannel(agent_session_id=agent_session_id)
+                )
                 keep_alive_elapsed_seconds = 0
                 async with aclosing(channel.subscribe_session()) as subscription:
                     async for event in subscription:
@@ -464,7 +509,7 @@ class AgentSessionEventBus(DaemonTask):
                             continue
                         if channel.state is SessionRunState.IDLE:
                             run = await self.get_run(agent_session_id=agent_session_id)
-                            if run is not None and run.instance_id != self.instance_id:
+                            if self._get_fresh_remote_run(run) is not None:
                                 break
                         keep_alive_elapsed_seconds += _REMOTE_STATE_POLL_INTERVAL_SECONDS
                         if keep_alive_elapsed_seconds >= _KEEP_ALIVE_INTERVAL_SECONDS:
@@ -472,30 +517,20 @@ class AgentSessionEventBus(DaemonTask):
                             yield None
                     else:
                         return
-                if channel.state is SessionRunState.IDLE:
-                    self._channels.pop(agent_session_id, None)
+                self._discard_idle_channel(channel)
                 continue
-            run = await self.get_run(agent_session_id=agent_session_id)
-            if run is None:
-                channel = self._channels.setdefault(
-                    agent_session_id, SessionChannel(agent_session_id=agent_session_id)
-                )
-                async for event in channel.subscribe_session():
-                    yield event
-                return
-            is_stale = run.heartbeat_at < datetime.now(timezone.utc) - timedelta(seconds=30)
             remote_state = SessionStateData(
-                state=SessionRunState.IDLE if is_stale else SessionRunState(run.state),
-                turn_id=None if is_stale else run.turn_id,
-                assistant_message_id=None if is_stale else run.assistant_message_id,
-                origin_client_id=None if is_stale else run.origin_client_id,
+                state=SessionRunState(remote_run.state),
+                turn_id=remote_run.turn_id,
+                assistant_message_id=remote_run.assistant_message_id,
+                origin_client_id=remote_run.origin_client_id,
                 owned_by_this_instance=False,
                 stream_available=False,
             )
             if remote_state != last_remote_state:
                 yield SessionStateChunk(data=remote_state)
                 last_remote_state = remote_state
-            await asyncio.sleep(5)
+            await asyncio.sleep(_REMOTE_STATE_POLL_INTERVAL_SECONDS)
 
     async def _run(self) -> None:
         while self._running:
@@ -505,9 +540,7 @@ class AgentSessionEventBus(DaemonTask):
             except asyncio.CancelledError:
                 raise
             except Exception:
-                import logging
-
-                logging.getLogger(__name__).exception("Agent session event-bus heartbeat failed")
+                logger.exception("Agent session event-bus heartbeat failed")
 
     async def _heartbeat_and_sweep(self) -> None:
         async with self._db() as session:
@@ -520,12 +553,47 @@ class AgentSessionEventBus(DaemonTask):
                 continue
             run = owned_by_session_id.get(agent_session_id)
             if run is None:
-                channel.request_stop()
-                channel.finish_turn(state=SessionRunState.IDLE)
-                self._discard_idle_channel(channel)
-                continue
+                # The lease may have been claimed after the heartbeat UPDATE
+                # snapshot (a turn that started mid-heartbeat); re-check before
+                # declaring the lock lost, or a fresh turn gets killed.
+                run = await self.get_run(agent_session_id=agent_session_id)
+                if run is None or run.instance_id != self.instance_id:
+                    channel.request_stop()
+                    channel.finish_turn(state=SessionRunState.IDLE)
+                    self._discard_idle_channel(channel)
+                    continue
             if run.stop_requested_at is not None:
                 channel.request_stop()
+        # Release zombie leases: rows we own whose channel is gone or idle
+        # (e.g. a turn whose completion-time DB update failed). Without this,
+        # the heartbeat renews the row forever and the session stays locked.
+        reconcile_before = datetime.now(timezone.utc) - timedelta(
+            seconds=_HEARTBEAT_INTERVAL_SECONDS
+        )
+        for agent_session_id, run in owned_by_session_id.items():
+            owned_channel = self._channels.get(agent_session_id)
+            if owned_channel is not None and owned_channel.state is not SessionRunState.IDLE:
+                continue
+            if run.started_at > reconcile_before:
+                # A lease claimed moments ago may not have its channel set up
+                # yet (begin_turn suspends between the DB claim and the channel
+                # transition); give it a full interval before reconciling.
+                continue
+            logger.warning(
+                "Releasing orphaned agent session lease for session %d (state=%s)",
+                agent_session_id,
+                run.state,
+            )
+            try:
+                async with self._db() as session:
+                    await release_run(
+                        session,
+                        agent_session_id=agent_session_id,
+                        instance_id=self.instance_id,
+                        turn_id=run.turn_id,
+                    )
+            except Exception:
+                logger.exception("Failed to release orphaned agent session lease")
 
     def _discard_idle_channel(self, channel: SessionChannel) -> None:
         if channel.state is SessionRunState.IDLE and not channel.subscribers:

--- a/src/phoenix/server/agents/event_bus.py
+++ b/src/phoenix/server/agents/event_bus.py
@@ -1,0 +1,547 @@
+"""Per-process fan-out and database-visible state for agent-session turns."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import aclosing, asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import TYPE_CHECKING, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict
+from pydantic_ai.ui.vercel_ai.response_types import BaseChunk, DataChunk
+
+from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
+from phoenix.server.agents.run_locks import (
+    SessionRun,
+    claim_run,
+    delete_stale_runs,
+    get_run,
+    heartbeat_runs,
+    release_run,
+    request_stop,
+    transition_run,
+)
+from phoenix.server.api.openapi.registry import register_openapi_schema
+from phoenix.server.types import DaemonTask, DbSessionFactory
+
+if TYPE_CHECKING:
+    from phoenix.server.agents.turn_runner import TurnRunner
+
+
+_INSTANCE_ID = uuid4().hex
+_MAX_REPLAY_CHUNKS = 100_000
+_HEARTBEAT_INTERVAL_SECONDS = 10
+_REMOTE_STATE_POLL_INTERVAL_SECONDS = 5
+_KEEP_ALIVE_INTERVAL_SECONDS = 15
+
+
+class SessionRunState(str, Enum):
+    IDLE = "idle"
+    STREAMING = "streaming"
+    PERSISTING = "persisting"
+    AWAITING_CLIENT_TOOL = "awaiting_client_tool"
+    MUTATING = "mutating"
+
+
+class _CamelDataModel(BaseModel):
+    model_config = ConfigDict(alias_generator=lambda name: _to_camel(name), populate_by_name=True)
+
+
+def _to_camel(name: str) -> str:
+    first, *rest = name.split("_")
+    return first + "".join(word.capitalize() for word in rest)
+
+
+class SessionStateData(_CamelDataModel):
+    state: SessionRunState
+    turn_id: str | None = None
+    assistant_message_id: str | None = None
+    origin_client_id: str | None = None
+    owned_by_this_instance: bool
+    stream_available: bool
+
+
+@register_openapi_schema
+class SessionStateChunk(DataChunk):
+    type: Literal["data-session-state"] = "data-session-state"
+    data: SessionStateData
+    transient: Literal[True] = True
+
+
+class SessionTurnStartedData(_CamelDataModel):
+    turn_id: str
+    message: PhoenixUIMessage
+
+
+@register_openapi_schema
+class SessionTurnStartedChunk(DataChunk):
+    type: Literal["data-turn-started"] = "data-turn-started"
+    data: SessionTurnStartedData
+    transient: Literal[True] = True
+
+
+class BusyErrorData(_CamelDataModel):
+    code: Literal["agent_session_busy"] = "agent_session_busy"
+    state: SessionRunState
+    turn_id: str
+    assistant_message_id: str | None = None
+    owned_by_this_instance: bool
+
+
+@register_openapi_schema
+class AgentSessionBusyErrorBody(BusyErrorData):
+    pass
+
+
+class SessionBusyError(Exception):
+    def __init__(self, run: SessionRun, *, owned_by_this_instance: bool) -> None:
+        super().__init__(f"Agent session is busy ({run.state})")
+        self.run = run
+        self.owned_by_this_instance = owned_by_this_instance
+
+    @property
+    def body(self) -> AgentSessionBusyErrorBody:
+        return AgentSessionBusyErrorBody(
+            state=SessionRunState(self.run.state),
+            turn_id=self.run.turn_id,
+            assistant_message_id=self.run.assistant_message_id,
+            owned_by_this_instance=self.owned_by_this_instance,
+        )
+
+
+class TurnIdMismatchError(Exception):
+    def __init__(self, run: SessionRun) -> None:
+        super().__init__("The requested turn is no longer active")
+        self.run = run
+
+
+class _TurnEnded:
+    def __init__(self, turn_id: str) -> None:
+        self.turn_id = turn_id
+
+
+_ChannelEvent = BaseChunk | _TurnEnded
+
+
+class SessionChannel:
+    def __init__(self, *, agent_session_id: int) -> None:
+        self.agent_session_id = agent_session_id
+        self.state = SessionRunState.IDLE
+        self.turn_id: str | None = None
+        self.assistant_message_id: str | None = None
+        self.origin_client_id: str | None = None
+        self.submitted_message: PhoenixUIMessage | None = None
+        self.stream_available = True
+        self.turn_log: list[BaseChunk] = []
+        self.last_ended_turn_id: str | None = None
+        self.subscribers: set[asyncio.Queue[_ChannelEvent]] = set()
+        self.runner: TurnRunner | None = None
+        self.runner_task: asyncio.Task[None] | None = None
+
+    def state_chunk(self) -> SessionStateChunk:
+        return SessionStateChunk(
+            data=SessionStateData(
+                state=self.state,
+                turn_id=self.turn_id,
+                assistant_message_id=self.assistant_message_id,
+                origin_client_id=self.origin_client_id,
+                owned_by_this_instance=True,
+                stream_available=self.stream_available,
+            )
+        )
+
+    def begin_turn(
+        self,
+        *,
+        turn_id: str,
+        assistant_message_id: str,
+        origin_client_id: str | None,
+        submitted_message: PhoenixUIMessage,
+    ) -> None:
+        self.state = SessionRunState.STREAMING
+        self.turn_id = turn_id
+        self.assistant_message_id = assistant_message_id
+        self.origin_client_id = origin_client_id
+        self.submitted_message = submitted_message
+        self.stream_available = True
+        self.turn_log = []
+        self.last_ended_turn_id = None
+        self._broadcast(self.state_chunk())
+        self._broadcast(
+            SessionTurnStartedChunk(
+                data=SessionTurnStartedData(turn_id=turn_id, message=submitted_message)
+            )
+        )
+
+    def set_state(self, state: SessionRunState) -> None:
+        self.state = state
+        self._broadcast(self.state_chunk())
+
+    async def publish(self, chunk: BaseChunk) -> None:
+        if self.stream_available:
+            if len(self.turn_log) < _MAX_REPLAY_CHUNKS:
+                self.turn_log.append(chunk)
+            else:
+                self.turn_log.clear()
+                self.stream_available = False
+                self._broadcast(self.state_chunk())
+        self._broadcast(chunk)
+
+    def finish_turn(self, *, state: SessionRunState) -> None:
+        ended_turn_id = self.turn_id
+        self.set_state(state)
+        if ended_turn_id is not None:
+            self.last_ended_turn_id = ended_turn_id
+            self._broadcast(_TurnEnded(ended_turn_id))
+        self.runner = None
+        self.runner_task = None
+        if state is SessionRunState.IDLE:
+            self.turn_id = None
+            self.assistant_message_id = None
+            self.origin_client_id = None
+            self.submitted_message = None
+            self.stream_available = True
+
+    def request_stop(self) -> bool:
+        if self.runner is None:
+            return False
+        self.runner.request_stop()
+        return True
+
+    def _broadcast(self, event: _ChannelEvent) -> None:
+        for subscriber in tuple(self.subscribers):
+            subscriber.put_nowait(event)
+
+    async def subscribe_turn(self, *, turn_id: str) -> AsyncIterator[BaseChunk]:
+        queue: asyncio.Queue[_ChannelEvent] = asyncio.Queue()
+        self.subscribers.add(queue)
+        replay = list(self.turn_log) if self.turn_id == turn_id and self.stream_available else []
+        if self.last_ended_turn_id == turn_id and self.stream_available:
+            replay = list(self.turn_log)
+        try:
+            for chunk in replay:
+                yield chunk
+            if self.last_ended_turn_id == turn_id:
+                return
+            while True:
+                event = await queue.get()
+                if isinstance(event, _TurnEnded) and event.turn_id == turn_id:
+                    return
+                if isinstance(event, (SessionStateChunk, SessionTurnStartedChunk, _TurnEnded)):
+                    continue
+                yield event
+        finally:
+            self.subscribers.discard(queue)
+
+    async def subscribe_session(self) -> AsyncGenerator[BaseChunk | None, None]:
+        queue: asyncio.Queue[_ChannelEvent] = asyncio.Queue()
+        self.subscribers.add(queue)
+        initial_events: list[BaseChunk] = [self.state_chunk()]
+        if (
+            self.turn_id is not None
+            and self.submitted_message is not None
+            and self.stream_available
+        ):
+            initial_events.append(
+                SessionTurnStartedChunk(
+                    data=SessionTurnStartedData(
+                        turn_id=self.turn_id,
+                        message=self.submitted_message,
+                    )
+                )
+            )
+            initial_events.extend(self.turn_log)
+        try:
+            for initial_event in initial_events:
+                yield initial_event
+            while True:
+                try:
+                    queued_event = await asyncio.wait_for(
+                        queue.get(), timeout=_REMOTE_STATE_POLL_INTERVAL_SECONDS
+                    )
+                except asyncio.TimeoutError:
+                    yield None
+                    continue
+                if isinstance(queued_event, _TurnEnded):
+                    continue
+                yield queued_event
+        finally:
+            self.subscribers.discard(queue)
+
+
+class AgentSessionEventBus(DaemonTask):
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__()
+        self._db = db
+        self._channels: dict[int, SessionChannel] = {}
+
+    @property
+    def instance_id(self) -> str:
+        return _INSTANCE_ID
+
+    async def begin_turn(
+        self,
+        *,
+        agent_session_id: int,
+        turn_id: str,
+        assistant_message_id: str,
+        origin_client_id: str | None,
+        submitted_message: PhoenixUIMessage,
+        is_continuation: bool,
+    ) -> SessionChannel:
+        async with self._db() as session:
+            claimed = await claim_run(
+                session,
+                agent_session_id=agent_session_id,
+                turn_id=turn_id,
+                state=SessionRunState.STREAMING.value,
+                assistant_message_id=assistant_message_id,
+                origin_client_id=origin_client_id,
+                instance_id=self.instance_id,
+                allow_awaiting_continuation=is_continuation,
+            )
+            if claimed is None:
+                existing = await get_run(session, agent_session_id=agent_session_id)
+                if existing is None:
+                    raise RuntimeError("Agent session lease disappeared during claim")
+                raise SessionBusyError(
+                    existing,
+                    owned_by_this_instance=existing.instance_id == self.instance_id,
+                )
+        channel = self._channels.setdefault(
+            agent_session_id, SessionChannel(agent_session_id=agent_session_id)
+        )
+        channel.begin_turn(
+            turn_id=turn_id,
+            assistant_message_id=assistant_message_id,
+            origin_client_id=origin_client_id,
+            submitted_message=submitted_message,
+        )
+        return channel
+
+    def start_runner(self, channel: SessionChannel, runner: TurnRunner) -> None:
+        channel.runner = runner
+        task = asyncio.create_task(runner.run())
+        channel.runner_task = task
+
+    async def mark_persisting(self, *, agent_session_id: int, turn_id: str) -> None:
+        async with self._db() as session:
+            transitioned = await transition_run(
+                session,
+                agent_session_id=agent_session_id,
+                instance_id=self.instance_id,
+                turn_id=turn_id,
+                state=SessionRunState.PERSISTING.value,
+            )
+        if transitioned is None:
+            raise RuntimeError("Agent session lease was lost before persistence")
+        if channel := self._channels.get(agent_session_id):
+            channel.set_state(SessionRunState.PERSISTING)
+
+    async def complete_turn(
+        self,
+        *,
+        agent_session_id: int,
+        turn_id: str,
+        awaiting_client_tool: bool,
+    ) -> None:
+        next_state = (
+            SessionRunState.AWAITING_CLIENT_TOOL if awaiting_client_tool else SessionRunState.IDLE
+        )
+        async with self._db() as session:
+            if awaiting_client_tool:
+                await transition_run(
+                    session,
+                    agent_session_id=agent_session_id,
+                    instance_id=self.instance_id,
+                    turn_id=turn_id,
+                    state=next_state.value,
+                )
+            else:
+                await release_run(
+                    session,
+                    agent_session_id=agent_session_id,
+                    instance_id=self.instance_id,
+                    turn_id=turn_id,
+                )
+        if channel := self._channels.get(agent_session_id):
+            channel.finish_turn(state=next_state)
+            self._discard_idle_channel(channel)
+
+    @asynccontextmanager
+    async def hold_mutation(self, *, agent_session_id: int) -> AsyncIterator[None]:
+        turn_id = uuid4().hex
+        async with self._db() as session:
+            claimed = await claim_run(
+                session,
+                agent_session_id=agent_session_id,
+                turn_id=turn_id,
+                state=SessionRunState.MUTATING.value,
+                assistant_message_id=None,
+                origin_client_id=None,
+                instance_id=self.instance_id,
+            )
+            if claimed is None:
+                existing = await get_run(session, agent_session_id=agent_session_id)
+                if existing is None:
+                    raise RuntimeError("Agent session lease disappeared during claim")
+                raise SessionBusyError(
+                    existing,
+                    owned_by_this_instance=existing.instance_id == self.instance_id,
+                )
+        channel = self._channels.setdefault(
+            agent_session_id, SessionChannel(agent_session_id=agent_session_id)
+        )
+        channel.turn_id = turn_id
+        channel.set_state(SessionRunState.MUTATING)
+        try:
+            yield
+        finally:
+            async with self._db() as session:
+                await release_run(
+                    session,
+                    agent_session_id=agent_session_id,
+                    instance_id=self.instance_id,
+                    turn_id=turn_id,
+                )
+            channel.finish_turn(state=SessionRunState.IDLE)
+            self._discard_idle_channel(channel)
+
+    async def get_run(self, *, agent_session_id: int) -> SessionRun | None:
+        async with self._db.read() as session:
+            return await get_run(session, agent_session_id=agent_session_id)
+
+    async def request_stop(
+        self,
+        *,
+        agent_session_id: int,
+        turn_id: str | None,
+    ) -> tuple[SessionRun | None, bool]:
+        run = await self.get_run(agent_session_id=agent_session_id)
+        if run is None:
+            return None, False
+        if turn_id is not None and run.turn_id != turn_id:
+            raise TurnIdMismatchError(run)
+        is_local = run.instance_id == self.instance_id
+        if is_local:
+            channel = self._channels.get(agent_session_id)
+            if channel is not None and channel.request_stop():
+                return run, True
+        async with self._db() as session:
+            updated = await request_stop(
+                session,
+                agent_session_id=agent_session_id,
+                turn_id=run.turn_id,
+            )
+        return updated, is_local
+
+    async def release_awaiting_turn(self, *, run: SessionRun) -> None:
+        async with self._db() as session:
+            await release_run(
+                session,
+                agent_session_id=run.agent_session_id,
+                instance_id=run.instance_id,
+                turn_id=run.turn_id,
+            )
+        if channel := self._channels.get(run.agent_session_id):
+            channel.request_stop()
+            channel.finish_turn(state=SessionRunState.IDLE)
+            self._discard_idle_channel(channel)
+
+    async def session_events(self, *, agent_session_id: int) -> AsyncIterator[BaseChunk | None]:
+        last_remote_state: SessionStateData | None = None
+        while True:
+            if channel := self._channels.get(agent_session_id):
+                keep_alive_elapsed_seconds = 0
+                async with aclosing(channel.subscribe_session()) as subscription:
+                    async for event in subscription:
+                        if event is not None:
+                            keep_alive_elapsed_seconds = 0
+                            yield event
+                            continue
+                        if channel.state is SessionRunState.IDLE:
+                            run = await self.get_run(agent_session_id=agent_session_id)
+                            if run is not None and run.instance_id != self.instance_id:
+                                break
+                        keep_alive_elapsed_seconds += _REMOTE_STATE_POLL_INTERVAL_SECONDS
+                        if keep_alive_elapsed_seconds >= _KEEP_ALIVE_INTERVAL_SECONDS:
+                            keep_alive_elapsed_seconds = 0
+                            yield None
+                    else:
+                        return
+                if channel.state is SessionRunState.IDLE:
+                    self._channels.pop(agent_session_id, None)
+                continue
+            run = await self.get_run(agent_session_id=agent_session_id)
+            if run is None:
+                channel = self._channels.setdefault(
+                    agent_session_id, SessionChannel(agent_session_id=agent_session_id)
+                )
+                async for event in channel.subscribe_session():
+                    yield event
+                return
+            is_stale = run.heartbeat_at < datetime.now(timezone.utc) - timedelta(seconds=30)
+            remote_state = SessionStateData(
+                state=SessionRunState.IDLE if is_stale else SessionRunState(run.state),
+                turn_id=None if is_stale else run.turn_id,
+                assistant_message_id=None if is_stale else run.assistant_message_id,
+                origin_client_id=None if is_stale else run.origin_client_id,
+                owned_by_this_instance=False,
+                stream_available=False,
+            )
+            if remote_state != last_remote_state:
+                yield SessionStateChunk(data=remote_state)
+                last_remote_state = remote_state
+            await asyncio.sleep(5)
+
+    async def _run(self) -> None:
+        while self._running:
+            await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
+            try:
+                await self._heartbeat_and_sweep()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                import logging
+
+                logging.getLogger(__name__).exception("Agent session event-bus heartbeat failed")
+
+    async def _heartbeat_and_sweep(self) -> None:
+        async with self._db() as session:
+            owned_runs = await heartbeat_runs(session, instance_id=self.instance_id)
+            await delete_stale_runs(session, instance_id=self.instance_id)
+        owned_by_session_id = {run.agent_session_id: run for run in owned_runs}
+        for agent_session_id, channel in tuple(self._channels.items()):
+            if channel.state is SessionRunState.IDLE:
+                self._discard_idle_channel(channel)
+                continue
+            run = owned_by_session_id.get(agent_session_id)
+            if run is None:
+                channel.request_stop()
+                channel.finish_turn(state=SessionRunState.IDLE)
+                self._discard_idle_channel(channel)
+                continue
+            if run.stop_requested_at is not None:
+                channel.request_stop()
+
+    def _discard_idle_channel(self, channel: SessionChannel) -> None:
+        if channel.state is SessionRunState.IDLE and not channel.subscribers:
+            self._channels.pop(channel.agent_session_id, None)
+
+    async def stop(self) -> None:
+        await super().stop()
+        tasks: list[asyncio.Task[None]] = []
+        for channel in tuple(self._channels.values()):
+            channel.request_stop()
+            if channel.runner_task is not None:
+                tasks.append(channel.runner_task)
+        if tasks:
+            try:
+                await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=30)
+            except asyncio.TimeoutError:
+                for task in tasks:
+                    task.cancel()
+        self._channels.clear()

--- a/src/phoenix/server/agents/run_locks.py
+++ b/src/phoenix/server/agents/run_locks.py
@@ -1,0 +1,198 @@
+"""Database leases for agent-session turns and transcript mutations."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.dialects.postgresql import insert as insert_postgresql
+from sqlalchemy.dialects.sqlite import insert as insert_sqlite
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
+
+
+@dataclass(frozen=True)
+class SessionRun:
+    agent_session_id: int
+    turn_id: str
+    state: str
+    assistant_message_id: str | None
+    origin_client_id: str | None
+    instance_id: str
+    stop_requested_at: datetime | None
+    started_at: datetime
+    heartbeat_at: datetime
+
+
+def _to_session_run(row: models.AgentSessionRun) -> SessionRun:
+    return SessionRun(
+        agent_session_id=row.agent_session_id,
+        turn_id=row.turn_id,
+        state=row.state,
+        assistant_message_id=row.assistant_message_id,
+        origin_client_id=row.origin_client_id,
+        instance_id=row.instance_id,
+        stop_requested_at=row.stop_requested_at,
+        started_at=row.started_at,
+        heartbeat_at=row.heartbeat_at,
+    )
+
+
+async def claim_run(
+    session: AsyncSession,
+    *,
+    agent_session_id: int,
+    turn_id: str,
+    state: str,
+    assistant_message_id: str | None,
+    origin_client_id: str | None,
+    instance_id: str,
+    allow_awaiting_continuation: bool = False,
+    now: datetime | None = None,
+    stale_after: timedelta = timedelta(seconds=30),
+) -> SessionRun | None:
+    """Atomically create a lease or replace a stale/continuable lease."""
+    claimed_at = now or datetime.now(timezone.utc)
+    values = {
+        "agent_session_id": agent_session_id,
+        "turn_id": turn_id,
+        "state": state,
+        "assistant_message_id": assistant_message_id,
+        "origin_client_id": origin_client_id,
+        "instance_id": instance_id,
+        "stop_requested_at": None,
+        "started_at": claimed_at,
+        "heartbeat_at": claimed_at,
+    }
+    dialect = SupportedSQLDialect(session.bind.dialect.name)
+    statement: Any
+    if dialect is SupportedSQLDialect.POSTGRESQL:
+        statement = insert_postgresql(models.AgentSessionRun).values(**values)
+    else:
+        statement = insert_sqlite(models.AgentSessionRun).values(**values)
+    can_take_over = models.AgentSessionRun.heartbeat_at < claimed_at - stale_after
+    if allow_awaiting_continuation and assistant_message_id is not None:
+        can_take_over |= (models.AgentSessionRun.state == "awaiting_client_tool") & (
+            models.AgentSessionRun.assistant_message_id == assistant_message_id
+        )
+    statement = statement.on_conflict_do_update(
+        index_elements=(models.AgentSessionRun.agent_session_id,),
+        set_={key: getattr(statement.excluded, key) for key in values if key != "agent_session_id"},
+        where=can_take_over,
+    ).returning(models.AgentSessionRun)
+    row = await session.scalar(statement)
+    return _to_session_run(row) if row is not None else None
+
+
+async def get_run(session: AsyncSession, *, agent_session_id: int) -> SessionRun | None:
+    row = await session.scalar(
+        select(models.AgentSessionRun).where(
+            models.AgentSessionRun.agent_session_id == agent_session_id
+        )
+    )
+    return _to_session_run(row) if row is not None else None
+
+
+async def transition_run(
+    session: AsyncSession,
+    *,
+    agent_session_id: int,
+    instance_id: str,
+    turn_id: str,
+    state: str,
+    assistant_message_id: str | None = None,
+    now: datetime | None = None,
+) -> SessionRun | None:
+    values: dict[str, object] = {
+        "state": state,
+        "heartbeat_at": now or datetime.now(timezone.utc),
+    }
+    if assistant_message_id is not None:
+        values["assistant_message_id"] = assistant_message_id
+    row = await session.scalar(
+        update(models.AgentSessionRun)
+        .where(
+            models.AgentSessionRun.agent_session_id == agent_session_id,
+            models.AgentSessionRun.instance_id == instance_id,
+            models.AgentSessionRun.turn_id == turn_id,
+        )
+        .values(**values)
+        .returning(models.AgentSessionRun)
+    )
+    return _to_session_run(row) if row is not None else None
+
+
+async def release_run(
+    session: AsyncSession,
+    *,
+    agent_session_id: int,
+    instance_id: str,
+    turn_id: str,
+) -> bool:
+    released_id = await session.scalar(
+        delete(models.AgentSessionRun)
+        .where(
+            models.AgentSessionRun.agent_session_id == agent_session_id,
+            models.AgentSessionRun.instance_id == instance_id,
+            models.AgentSessionRun.turn_id == turn_id,
+        )
+        .returning(models.AgentSessionRun.agent_session_id)
+    )
+    return released_id is not None
+
+
+async def heartbeat_runs(
+    session: AsyncSession,
+    *,
+    instance_id: str,
+    now: datetime | None = None,
+) -> list[SessionRun]:
+    rows = await session.scalars(
+        update(models.AgentSessionRun)
+        .where(models.AgentSessionRun.instance_id == instance_id)
+        .values(heartbeat_at=now or datetime.now(timezone.utc))
+        .returning(models.AgentSessionRun)
+    )
+    return [_to_session_run(row) for row in rows]
+
+
+async def request_stop(
+    session: AsyncSession,
+    *,
+    agent_session_id: int,
+    turn_id: str | None,
+    now: datetime | None = None,
+) -> SessionRun | None:
+    statement = update(models.AgentSessionRun).where(
+        models.AgentSessionRun.agent_session_id == agent_session_id
+    )
+    if turn_id is not None:
+        statement = statement.where(models.AgentSessionRun.turn_id == turn_id)
+    row = await session.scalar(
+        statement.values(stop_requested_at=now or datetime.now(timezone.utc)).returning(
+            models.AgentSessionRun
+        )
+    )
+    return _to_session_run(row) if row is not None else None
+
+
+async def delete_stale_runs(
+    session: AsyncSession,
+    *,
+    instance_id: str,
+    now: datetime | None = None,
+    stale_after: timedelta = timedelta(seconds=30),
+) -> list[int]:
+    stale_before = (now or datetime.now(timezone.utc)) - stale_after
+    return list(
+        await session.scalars(
+            delete(models.AgentSessionRun)
+            .where(
+                models.AgentSessionRun.instance_id != instance_id,
+                models.AgentSessionRun.heartbeat_at < stale_before,
+            )
+            .returning(models.AgentSessionRun.agent_session_id)
+        )
+    )

--- a/src/phoenix/server/agents/turn_runner.py
+++ b/src/phoenix/server/agents/turn_runner.py
@@ -137,8 +137,13 @@ class TurnRunner:
         stream_failed = False
 
         async def consume() -> None:
+            # INVARIANT: the only suspension points in this loop must be the
+            # stream's __anext__ awaits. That guarantees a stop cancellation is
+            # thrown *inside* the stream generator, whose except/finally blocks
+            # perform the partial persist and trace flush. Publishing is
+            # synchronous on purpose — do not add awaits here.
             async for chunk in self._prepared_turn.stream():
-                await self._channel.publish(chunk)
+                self._channel.publish(chunk)
 
         self._consume_task = asyncio.create_task(consume())
         try:
@@ -151,12 +156,15 @@ class TurnRunner:
             stream_failed = True
             logger.exception("Agent-session turn failed")
         finally:
-            await self._bus.complete_turn(
-                agent_session_id=self._prepared_turn.agent_session_id,
-                turn_id=self._prepared_turn.turn_id,
-                awaiting_client_tool=(
-                    not self._stop_requested
-                    and not stream_failed
-                    and self._prepared_turn.is_awaiting_client_tool()
-                ),
-            )
+            try:
+                await self._bus.complete_turn(
+                    agent_session_id=self._prepared_turn.agent_session_id,
+                    turn_id=self._prepared_turn.turn_id,
+                    awaiting_client_tool=(
+                        not self._stop_requested
+                        and not stream_failed
+                        and self._prepared_turn.is_awaiting_client_tool()
+                    ),
+                )
+            except Exception:
+                logger.exception("Failed to complete agent-session turn bookkeeping")

--- a/src/phoenix/server/agents/turn_runner.py
+++ b/src/phoenix/server/agents/turn_runner.py
@@ -1,0 +1,162 @@
+"""Detached execution for prepared agent-session turns."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic_ai.ui.vercel_ai.response_types import (
+    BaseChunk,
+    ReasoningEndChunk,
+    ReasoningStartChunk,
+    TextEndChunk,
+    TextStartChunk,
+    ToolInputAvailableChunk,
+    ToolInputStartChunk,
+    ToolOutputAvailableChunk,
+    ToolOutputDeniedChunk,
+    ToolOutputErrorChunk,
+)
+
+from phoenix.db.types.data_stream_protocol import (
+    AssistantMessageMetadata,
+    PhoenixUIMessage,
+    ReasoningUIPart,
+    TextUIPart,
+)
+from phoenix.server.agents.event_bus import AgentSessionEventBus, SessionChannel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PreparedTurn:
+    agent_session_id: int
+    turn_id: str
+    stream: Callable[[], AsyncIterator[BaseChunk]]
+    is_awaiting_client_tool: Callable[[], bool]
+    mark_stopped: Callable[[], None]
+
+
+def resolve_dangling_chunks(
+    chunks: Sequence[BaseChunk],
+    *,
+    error_text: str,
+) -> list[BaseChunk]:
+    """Close partial text/reasoning parts and fail unresolved tool calls."""
+    open_text_ids: set[str] = set()
+    open_reasoning_ids: set[str] = set()
+    pending_tool_call_ids: set[str] = set()
+    for chunk in chunks:
+        if isinstance(chunk, TextStartChunk):
+            open_text_ids.add(chunk.id)
+        elif isinstance(chunk, TextEndChunk):
+            open_text_ids.discard(chunk.id)
+        elif isinstance(chunk, ReasoningStartChunk):
+            open_reasoning_ids.add(chunk.id)
+        elif isinstance(chunk, ReasoningEndChunk):
+            open_reasoning_ids.discard(chunk.id)
+        elif isinstance(chunk, (ToolInputStartChunk, ToolInputAvailableChunk)):
+            pending_tool_call_ids.add(chunk.tool_call_id)
+        elif isinstance(
+            chunk,
+            (ToolOutputAvailableChunk, ToolOutputErrorChunk, ToolOutputDeniedChunk),
+        ):
+            pending_tool_call_ids.discard(chunk.tool_call_id)
+    resolved: list[BaseChunk] = [
+        ToolOutputErrorChunk(tool_call_id=tool_call_id, error_text=error_text)
+        for tool_call_id in pending_tool_call_ids
+    ]
+    resolved.extend(TextEndChunk(id=text_id) for text_id in open_text_ids)
+    resolved.extend(ReasoningEndChunk(id=reasoning_id) for reasoning_id in open_reasoning_ids)
+    return resolved
+
+
+def resolve_dangling_message(
+    message: PhoenixUIMessage,
+    *,
+    interrupted: Literal["stopped", "errored"],
+    error_text: str,
+) -> PhoenixUIMessage:
+    """Resolve incomplete parts on an already-persisted assistant message."""
+    part_payloads: list[dict[str, object]] = []
+    terminal_tool_states = {"output-available", "output-error", "output-denied"}
+    for part in message.parts:
+        payload = part.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if isinstance(part, (TextUIPart, ReasoningUIPart)) and part.state == "streaming":
+            payload["state"] = "done"
+        state = getattr(part, "state", None)
+        tool_call_id = getattr(part, "tool_call_id", None)
+        if tool_call_id is not None and state not in terminal_tool_states:
+            payload["state"] = "output-error"
+            payload["errorText"] = error_text
+            payload.pop("approval", None)
+            payload.pop("output", None)
+            payload.pop("preliminary", None)
+        part_payloads.append(payload)
+    metadata = message.metadata
+    if isinstance(metadata, AssistantMessageMetadata):
+        metadata = metadata.model_copy(update={"interrupted": interrupted})
+    return PhoenixUIMessage.model_validate(
+        {
+            **message.model_dump(mode="json", by_alias=True, exclude={"parts"}),
+            "metadata": (
+                metadata.model_dump(mode="json", by_alias=True, exclude_none=True)
+                if metadata is not None
+                else None
+            ),
+            "parts": part_payloads,
+        }
+    )
+
+
+class TurnRunner:
+    def __init__(
+        self,
+        *,
+        bus: AgentSessionEventBus,
+        channel: SessionChannel,
+        prepared_turn: PreparedTurn,
+    ) -> None:
+        self._bus = bus
+        self._channel = channel
+        self._prepared_turn = prepared_turn
+        self._consume_task: asyncio.Task[None] | None = None
+        self._stop_requested = False
+
+    def request_stop(self) -> None:
+        self._stop_requested = True
+        self._prepared_turn.mark_stopped()
+        if self._consume_task is not None and not self._consume_task.done():
+            self._consume_task.cancel()
+
+    async def run(self) -> None:
+        stream_failed = False
+
+        async def consume() -> None:
+            async for chunk in self._prepared_turn.stream():
+                await self._channel.publish(chunk)
+
+        self._consume_task = asyncio.create_task(consume())
+        try:
+            await self._consume_task
+        except asyncio.CancelledError:
+            if not self._stop_requested:
+                stream_failed = True
+                logger.exception("Agent-session turn was unexpectedly cancelled")
+        except BaseException:
+            stream_failed = True
+            logger.exception("Agent-session turn failed")
+        finally:
+            await self._bus.complete_turn(
+                agent_session_id=self._prepared_turn.agent_session_id,
+                turn_id=self._prepared_turn.turn_id,
+                awaiting_client_tool=(
+                    not self._stop_requested
+                    and not stream_failed
+                    and self._prepared_turn.is_awaiting_client_tool()
+                ),
+            )

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -17,6 +17,7 @@ from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.types import UserId
 
 if TYPE_CHECKING:
+    from phoenix.server.agents.event_bus import AgentSessionEventBus
     from phoenix.server.daemons.experiment_runner import ExperimentRunner
     from phoenix.server.daemons.span_cost_calculator import SpanCostCalculator
     from phoenix.server.daemons.system_settings import SystemSettings
@@ -45,6 +46,7 @@ class Context(BaseContext):
     span_cost_calculator: SpanCostCalculator
     experiment_runner: ExperimentRunner
     sandbox_session_manager: SandboxSessionManager
+    agent_session_event_bus: AgentSessionEventBus
     encrypt: Callable[[bytes], bytes]
     decrypt: Callable[[bytes], bytes]
     last_updated_at: CanGetLastUpdatedAt = _NoOp()
@@ -121,6 +123,7 @@ def build_context(
     span_cost_calculator: SpanCostCalculator,
     experiment_runner: ExperimentRunner,
     sandbox_session_manager: SandboxSessionManager,
+    agent_session_event_bus: AgentSessionEventBus,
     encrypt: Callable[[bytes], bytes],
     decrypt: Callable[[bytes], bytes],
     cache_for_dataloaders: Optional[CacheForDataLoaders] = None,
@@ -144,6 +147,7 @@ def build_context(
         span_cost_calculator=span_cost_calculator,
         experiment_runner=experiment_runner,
         sandbox_session_manager=sandbox_session_manager,
+        agent_session_event_bus=agent_session_event_bus,
         encrypt=encrypt,
         decrypt=decrypt,
         last_updated_at=last_updated_at,

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -1,5 +1,8 @@
 """Mutations for persisted assistant chat sessions."""
 
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
@@ -16,6 +19,7 @@ from phoenix.config import (
 )
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
+from phoenix.server.agents.event_bus import SessionBusyError
 from phoenix.server.agents.session_titles import (
     truncate_agent_session_title,
     validate_agent_session_title,
@@ -23,7 +27,7 @@ from phoenix.server.agents.session_titles import (
 from phoenix.server.api.agent_helpers import get_agent_session_owner_filter
 from phoenix.server.api.auth import IsAgentAssistantEnabled, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import BadRequest, NotFound
+from phoenix.server.api.exceptions import BadRequest, Conflict, NotFound
 from phoenix.server.api.queries import Query
 from phoenix.server.api.types.AgentSession import AgentSession, to_gql_agent_session
 from phoenix.server.api.types.node import from_global_id_with_expected_type
@@ -156,7 +160,13 @@ class AgentSessionMutationMixin:
             )
         except ValueError as exc:
             raise BadRequest(str(exc)) from exc
-        async with info.context.db() as session:
+        async with info.context.db.read() as session:
+            await _load_owned_agent_session(
+                session,
+                info=info,
+                agent_session_rowid=agent_session_rowid,
+            )
+        async with _hold_session_mutation(info, agent_session_rowid), info.context.db() as session:
             agent_session = await _load_owned_agent_session(
                 session,
                 info=info,
@@ -209,7 +219,13 @@ class AgentSessionMutationMixin:
             )
         except ValueError as exc:
             raise BadRequest(str(exc)) from exc
-        async with info.context.db() as session:
+        async with info.context.db.read() as session:
+            await _load_owned_agent_session(
+                session,
+                info=info,
+                agent_session_rowid=agent_session_rowid,
+            )
+        async with _hold_session_mutation(info, agent_session_rowid), info.context.db() as session:
             source_session = await _load_owned_agent_session(
                 session,
                 info=info,
@@ -308,14 +324,14 @@ class AgentSessionMutationMixin:
         )
         if (owner_filter := get_agent_session_owner_filter(info.context)) is not None:
             lookup_stmt = lookup_stmt.where(owner_filter)
-        async with info.context.db() as session:
+        async with info.context.db.read() as session:
             agent_session_id = await session.scalar(lookup_stmt)
-            if agent_session_id is not None:
-                await session.execute(
-                    delete(models.AgentSession).where(models.AgentSession.id == agent_session_id)
-                )
         if agent_session_id is None:
             raise NotFound(f"No agent session found for ID '{input.id}'")
+        async with _hold_session_mutation(info, agent_session_rowid), info.context.db() as session:
+            await session.execute(
+                delete(models.AgentSession).where(models.AgentSession.id == agent_session_id)
+            )
         return DeleteAgentSessionMutationPayload(
             deleted_agent_session_id=GlobalID(AgentSession.__name__, str(agent_session_id)),
             query=Query(),
@@ -345,6 +361,20 @@ async def _load_owned_agent_session(
     ):
         raise NotFound(f"No agent session found for row ID '{agent_session_rowid}'")
     return agent_session
+
+
+@asynccontextmanager
+async def _hold_session_mutation(
+    info: Info[Context, None],
+    agent_session_rowid: int,
+) -> AsyncIterator[None]:
+    try:
+        async with info.context.agent_session_event_bus.hold_mutation(
+            agent_session_id=agent_session_rowid
+        ):
+            yield
+    except SessionBusyError as exc:
+        raise Conflict(json.dumps(exc.body.model_dump(mode="json", by_alias=True))) from exc
 
 
 async def _load_session_message_prefix(

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -57,6 +57,7 @@ from pydantic_ai.ui.vercel_ai.request_types import (
 from pydantic_ai.ui.vercel_ai.response_types import (
     BaseChunk,
     DataChunk,
+    ErrorChunk,
     FinishChunk,
     MessageMetadataChunk,
     StartChunk,
@@ -70,7 +71,7 @@ from sqlalchemy.dialects.sqlite import insert as insert_sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response, StreamingResponse
 from strawberry.relay import GlobalID
 from typing_extensions import TypeIs, assert_never
 
@@ -116,6 +117,13 @@ from phoenix.server.agents.context import (
 from phoenix.server.agents.data_stream_protocol import (
     accumulate_ui_message_chunks_to_ui_messages,
 )
+from phoenix.server.agents.event_bus import (
+    AgentSessionBusyErrorBody,
+    AgentSessionEventBus,
+    SessionBusyError,
+    SessionRunState,
+    TurnIdMismatchError,
+)
 from phoenix.server.agents.exceptions import AgentError, CompactionError
 from phoenix.server.agents.model_factory import build_model
 from phoenix.server.agents.model_selection import AgentModelSelection
@@ -135,6 +143,12 @@ from phoenix.server.agents.skills import get_skills_for_contexts
 from phoenix.server.agents.summarization import (
     summarize_messages,
     summarize_messages_for_compaction,
+)
+from phoenix.server.agents.turn_runner import (
+    PreparedTurn,
+    TurnRunner,
+    resolve_dangling_chunks,
+    resolve_dangling_message,
 )
 from phoenix.server.agents.types import (
     AgentDependencies,
@@ -303,6 +317,7 @@ class _ChatRequestMixin(_ObservabilityMixin):
     )
     model: AgentModelSelection
     turn_trace_context: TurnTraceContext | None = None
+    client_id: str | None = None
 
 
 class ChatSubmitMessage(_ChatRequestMixin):
@@ -381,6 +396,20 @@ class CompactAgentSessionResponseData(V1RoutesBaseModel):
 
 
 class CompactAgentSessionResponse(ResponseBody[CompactAgentSessionResponseData]):
+    pass
+
+
+class StopAgentSessionRequest(_CamelBaseModel):
+    turn_id: str | None = None
+
+
+class StopAgentSessionResponseData(_CamelBaseModel):
+    turn_id: str | None = None
+    state: SessionRunState = SessionRunState.IDLE
+    remote: bool = False
+
+
+class StopAgentSessionResponse(ResponseBody[StopAgentSessionResponseData]):
     pass
 
 
@@ -1347,6 +1376,40 @@ async def _refresh_and_load_agent_session(
     return refreshed_agent_session
 
 
+async def _load_agent_session_without_refresh(
+    session: AsyncSession,
+    *,
+    agent_session_id: str,
+    user_id: int | None,
+) -> models.AgentSession:
+    """Load an owner-qualified session without extending its activity window."""
+    try:
+        agent_session_rowid = from_global_id_with_expected_type(
+            GlobalID.from_id(agent_session_id),
+            models.AgentSession.__name__,
+        )
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Session not found") from None
+    owner_filter = (
+        models.AgentSession.user_id.is_(None)
+        if user_id is None
+        else models.AgentSession.user_id == user_id
+    )
+    agent_session = await session.scalar(
+        select(models.AgentSession).where(
+            models.AgentSession.id == agent_session_rowid,
+            owner_filter,
+            or_(
+                models.AgentSession.expires_at.is_(None),
+                models.AgentSession.expires_at > datetime.now(timezone.utc),
+            ),
+        )
+    )
+    if agent_session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return agent_session
+
+
 async def _update_agent_session(
     session: AsyncSession,
     *,
@@ -1596,6 +1659,22 @@ def _get_request_user_id(request: Request) -> int | None:
     return int(user.identity)
 
 
+async def _hold_agent_session_mutation(
+    session_id: str,
+    request: Request,
+) -> AsyncIterator[None]:
+    async with request.app.state.db.read() as session:
+        agent_session = await _load_agent_session_without_refresh(
+            session,
+            agent_session_id=session_id,
+            user_id=_get_request_user_id(request),
+        )
+        agent_session_rowid = agent_session.id
+    bus: AgentSessionEventBus = request.app.state.agent_session_event_bus
+    async with bus.hold_mutation(agent_session_id=agent_session_rowid):
+        yield
+
+
 def _parse_agent_session_cursor(cursor: str) -> Cursor:
     try:
         parsed_cursor = Cursor.from_string(cursor)
@@ -1782,6 +1861,8 @@ def create_agents_router(
         "/agents/{agent_id}/sessions/{session_id}/compact",
         response_model=CompactAgentSessionResponse,
         response_model_exclude_none=True,
+        dependencies=[Depends(_hold_agent_session_mutation)],
+        responses={409: {"model": AgentSessionBusyErrorBody}},
     )
     async def compact_agent_session(
         agent_id: str,
@@ -1895,7 +1976,159 @@ def create_agents_router(
             ),
         )
 
-    @router.post("/agents/{agent_id}/sessions/{session_id}/chat")
+    @router.get(
+        "/agents/{agent_id}/sessions/{session_id}/events",
+        operation_id="subscribeToAgentSessionEvents",
+        response_class=StreamingResponse,
+    )
+    async def subscribe_to_session_events(
+        agent_id: str,
+        session_id: str,
+        request: Request,
+    ) -> StreamingResponse:
+        """Follow current and future turns for an owned agent session."""
+        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
+            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
+        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
+            raise HTTPException(status_code=403, detail="Server agent is disabled")
+        async with request.app.state.db.read() as session:
+            agent_session = await _load_agent_session_without_refresh(
+                session,
+                agent_session_id=session_id,
+                user_id=_get_request_user_id(request),
+            )
+            agent_session_rowid = agent_session.id
+        bus: AgentSessionEventBus = request.app.state.agent_session_event_bus
+
+        async def encoded_events() -> AsyncIterator[bytes]:
+            async for chunk in bus.session_events(agent_session_id=agent_session_rowid):
+                if chunk is None:
+                    yield b": keep-alive\n\n"
+                else:
+                    yield f"data: {chunk.encode(7)}\n\n".encode()
+
+        return StreamingResponse(
+            encoded_events(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "x-vercel-ai-ui-message-stream": "v1",
+            },
+        )
+
+    @router.post(
+        "/agents/{agent_id}/sessions/{session_id}/stop",
+        operation_id="stopAgentSession",
+        response_model=StopAgentSessionResponse,
+        responses={409: {"model": AgentSessionBusyErrorBody}},
+    )
+    async def stop_agent_session(
+        agent_id: str,
+        session_id: str,
+        request: Request,
+        request_body: StopAgentSessionRequest,
+    ) -> Response:
+        """Request cancellation of the active turn for an owned agent session."""
+        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
+            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
+        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
+            raise HTTPException(status_code=403, detail="Server agent is disabled")
+        async with request.app.state.db.read() as session:
+            agent_session = await _load_agent_session_without_refresh(
+                session,
+                agent_session_id=session_id,
+                user_id=_get_request_user_id(request),
+            )
+            agent_session_rowid = agent_session.id
+        bus: AgentSessionEventBus = request.app.state.agent_session_event_bus
+        run = await bus.get_run(agent_session_id=agent_session_rowid)
+        if run is None:
+            return JSONResponse(
+                StopAgentSessionResponse(data=StopAgentSessionResponseData()).model_dump(
+                    mode="json", by_alias=True
+                ),
+                status_code=200,
+            )
+        if request_body.turn_id is not None and request_body.turn_id != run.turn_id:
+            return JSONResponse(
+                AgentSessionBusyErrorBody(
+                    state=SessionRunState(run.state),
+                    turn_id=run.turn_id,
+                    assistant_message_id=run.assistant_message_id,
+                    owned_by_this_instance=run.instance_id == bus.instance_id,
+                ).model_dump(mode="json", by_alias=True),
+                status_code=409,
+            )
+        if run.heartbeat_at < datetime.now(timezone.utc) - timedelta(seconds=30):
+            await bus.release_awaiting_turn(run=run)
+            return JSONResponse(
+                StopAgentSessionResponse(
+                    data=StopAgentSessionResponseData(turn_id=run.turn_id)
+                ).model_dump(mode="json", by_alias=True),
+                status_code=200,
+            )
+        if run.state == SessionRunState.AWAITING_CLIENT_TOOL.value:
+            async with request.app.state.db() as session:
+                trailing_message = await session.scalar(
+                    select(models.AgentSessionMessage)
+                    .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
+                    .order_by(models.AgentSessionMessage.position.desc())
+                    .limit(1)
+                )
+                if trailing_message is not None and trailing_message.message.role == "assistant":
+                    trailing_message.message = resolve_dangling_message(
+                        trailing_message.message,
+                        interrupted="stopped",
+                        error_text="Tool execution was interrupted by the user.",
+                    )
+            await bus.release_awaiting_turn(run=run)
+            return JSONResponse(
+                StopAgentSessionResponse(
+                    data=StopAgentSessionResponseData(turn_id=run.turn_id)
+                ).model_dump(mode="json", by_alias=True),
+                status_code=200,
+            )
+        if run.state == SessionRunState.MUTATING.value:
+            return JSONResponse(
+                AgentSessionBusyErrorBody(
+                    state=SessionRunState.MUTATING,
+                    turn_id=run.turn_id,
+                    assistant_message_id=run.assistant_message_id,
+                    owned_by_this_instance=run.instance_id == bus.instance_id,
+                ).model_dump(mode="json", by_alias=True),
+                status_code=409,
+            )
+        try:
+            _, is_local = await bus.request_stop(
+                agent_session_id=agent_session_rowid,
+                turn_id=request_body.turn_id,
+            )
+        except TurnIdMismatchError as exc:
+            return JSONResponse(
+                AgentSessionBusyErrorBody(
+                    state=SessionRunState(exc.run.state),
+                    turn_id=exc.run.turn_id,
+                    assistant_message_id=exc.run.assistant_message_id,
+                    owned_by_this_instance=exc.run.instance_id == bus.instance_id,
+                ).model_dump(mode="json", by_alias=True),
+                status_code=409,
+            )
+        return JSONResponse(
+            StopAgentSessionResponse(
+                data=StopAgentSessionResponseData(
+                    turn_id=run.turn_id,
+                    state=SessionRunState(run.state),
+                    remote=not is_local,
+                )
+            ).model_dump(mode="json", by_alias=True),
+            status_code=202,
+        )
+
+    @router.post(
+        "/agents/{agent_id}/sessions/{session_id}/chat",
+        responses={409: {"model": AgentSessionBusyErrorBody}},
+    )
     async def chat(
         agent_id: str,
         session_id: str,
@@ -1906,10 +2139,13 @@ def create_agents_router(
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
         if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
             raise HTTPException(status_code=403, detail="Server agent is disabled")
+        app_state = request.app.state
+        event_queue = request.state.event_queue
+        accept_header = request.headers.get("accept")
         body = request_body
         request_received_at = datetime.now(timezone.utc)
         attach_user_id = _resolve_attach_user_id(body.attach_user_id)
-        recording = request.app.state.system_settings.agent_trace_recording
+        recording = app_state.system_settings.agent_trace_recording
         ingest_traces, export_remote_traces = _resolve_trace_recording(
             ingest_traces=body.ingest_traces,
             export_remote_traces=body.export_remote_traces,
@@ -1928,7 +2164,7 @@ def create_agents_router(
         phoenix_user_email: str | None = None
         initial_bash_snapshot: bytes | None = None
         try:
-            async with request.app.state.db() as session:
+            async with app_state.db() as session:
                 agent_session = await _refresh_and_load_agent_session(
                     session,
                     agent_session_id=session_id,
@@ -1945,7 +2181,7 @@ def create_agents_router(
                 project_name = agent_session.project_name
                 tracer = (
                     Tracer(
-                        span_cost_calculator=request.app.state.span_cost_calculator,
+                        span_cost_calculator=app_state.span_cost_calculator,
                         enable_remote_export=export_remote_traces,
                         project_name=project_name,
                     )
@@ -1960,7 +2196,7 @@ def create_agents_router(
                 model = await build_model(
                     body.model,
                     session=session,
-                    decrypt=request.app.state.decrypt,
+                    decrypt=app_state.decrypt,
                     tracer_provider=tracer_provider,
                 )
                 sandbox_availability = SandboxAvailability()
@@ -1970,7 +2206,7 @@ def create_agents_router(
                     if _contexts_need_sandbox_availability(resolved_contexts):
                         available_backend_types = await _load_available_sandbox_backend_types(
                             session=session,
-                            decrypt=request.app.state.decrypt,
+                            decrypt=app_state.decrypt,
                         )
                         sandbox_availability = await _load_sandbox_availability(
                             session,
@@ -2033,16 +2269,16 @@ def create_agents_router(
         if agent_id == _SERVER_AGENT_ID:
             server_agent = build_server_agent(
                 model=model,
-                schema=request.app.state.graphql_schema,
-                build_graphql_context=lambda: request.app.state.build_graphql_context(phoenix_user),
-                db=request.app.state.db,
-                event_queue=request.state.event_queue,
+                schema=app_state.graphql_schema,
+                build_graphql_context=lambda: app_state.build_graphql_context(phoenix_user),
+                db=app_state.db,
+                event_queue=event_queue,
                 prompts=ServerAgentPrompts(base=agent_prompts.base),
-                docs_mcp_server=request.app.state.docs_mcp_server,
+                docs_mcp_server=app_state.docs_mcp_server,
                 enable_web_access=web_access_enabled,
                 allow_mutations=graphql_mutations_enabled,
-                read_only=request.app.state.read_only,
-                auth_enabled=request.app.state.authentication_enabled,
+                read_only=app_state.read_only,
+                auth_enabled=app_state.authentication_enabled,
                 user_id=request_user_id,
                 is_viewer=is_viewer,
                 tracer_provider=tracer_provider,
@@ -2053,7 +2289,7 @@ def create_agents_router(
             server_agent_adapter: VercelAIAdapter[None, str] = VercelAIAdapter(
                 agent=server_agent,
                 run_input=_to_pydantic_ai_request_data(body, messages=model_transcript_messages),
-                accept=request.headers.get("accept"),
+                accept=accept_header,
                 server_message_id=server_message_id,
             )
 
@@ -2072,17 +2308,15 @@ def create_agents_router(
             subagent = (
                 build_server_agent(
                     model=model,
-                    schema=request.app.state.graphql_schema,
-                    build_graphql_context=lambda: request.app.state.build_graphql_context(
-                        phoenix_user
-                    ),
-                    db=request.app.state.db,
-                    event_queue=request.state.event_queue,
-                    docs_mcp_server=request.app.state.docs_mcp_server,
+                    schema=app_state.graphql_schema,
+                    build_graphql_context=lambda: app_state.build_graphql_context(phoenix_user),
+                    db=app_state.db,
+                    event_queue=event_queue,
+                    docs_mcp_server=app_state.docs_mcp_server,
                     enable_web_access=web_access_enabled,
                     allow_mutations=graphql_mutations_enabled,
-                    read_only=request.app.state.read_only,
-                    auth_enabled=request.app.state.authentication_enabled,
+                    read_only=app_state.read_only,
+                    auth_enabled=app_state.authentication_enabled,
                     user_id=request_user_id,
                     is_viewer=is_viewer,
                     tracer_provider=tracer_provider,
@@ -2115,21 +2349,21 @@ def create_agents_router(
 
             agent = build_agent(
                 model=model,
-                docs_mcp_server=request.app.state.docs_mcp_server,
+                docs_mcp_server=app_state.docs_mcp_server,
                 enable_web_access=web_access_enabled,
                 tracer_provider=tracer_provider,
                 server_agent=subagent,
                 publish_subagent_message_chunk=publish_subagent_message_chunk,
                 set_subagent_final_tool_output=set_subagent_final_tool_output,
-                db=request.app.state.db,
-                event_queue=request.state.event_queue,
-                read_only=request.app.state.read_only,
-                auth_enabled=request.app.state.authentication_enabled,
+                db=app_state.db,
+                event_queue=event_queue,
+                read_only=app_state.read_only,
+                auth_enabled=app_state.authentication_enabled,
                 user_id=request_user_id,
                 is_viewer=is_viewer,
-                schema=request.app.state.graphql_schema if bash_enabled else None,
+                schema=app_state.graphql_schema if bash_enabled else None,
                 build_graphql_context=(
-                    (lambda: request.app.state.build_graphql_context(phoenix_user))
+                    (lambda: app_state.build_graphql_context(phoenix_user))
                     if bash_enabled
                     else None
                 ),
@@ -2155,7 +2389,7 @@ def create_agents_router(
             assistant_adapter: VercelAIAdapter[AgentDependencies, AgentOutput] = VercelAIAdapter(
                 agent=agent,
                 run_input=_to_pydantic_ai_request_data(body, messages=model_transcript_messages),
-                accept=request.headers.get("accept"),
+                accept=accept_header,
                 server_message_id=server_message_id,
             )
             deps = AgentDependencies(
@@ -2210,7 +2444,7 @@ def create_agents_router(
                 return None
             if summary is not None:
                 await _persist_agent_session_title(
-                    request.app.state.db,
+                    app_state.db,
                     agent_session_rowid=agent_session_rowid,
                     user_id=request_user_id,
                     title=summary,
@@ -2219,6 +2453,14 @@ def create_agents_router(
 
         turn_final_output_text: str | None = None
         turn_is_terminal = False
+        turn_interrupted: Literal["stopped", "errored"] | None = None
+        stop_was_requested = False
+        bus: AgentSessionEventBus = app_state.agent_session_event_bus
+        turn_id = uuid4().hex
+
+        def _mark_stopped() -> None:
+            nonlocal stop_was_requested
+            stop_was_requested = True
 
         async def _on_complete(result: AgentRunResult[Any]) -> AsyncIterator[BaseChunk]:
             nonlocal turn_final_output_text, turn_is_terminal
@@ -2243,11 +2485,19 @@ def create_agents_router(
             )
 
         async def _stream_with_session() -> AsyncIterator[BaseChunk]:
+            nonlocal turn_interrupted
             stream_error: BaseException | None = None
             summary_task: asyncio.Task[str | None] | None = None
             emitted_message_chunks: list[BaseChunk] = []
+            persistence_started = False
 
             async def _persist_turn() -> TranscriptPersistedChunk:
+                nonlocal persistence_started
+                persistence_started = True
+                await bus.mark_persisting(
+                    agent_session_id=agent_session_rowid,
+                    turn_id=turn_id,
+                )
                 session_title = (
                     summary_task.result()
                     if summary_task is not None
@@ -2269,7 +2519,7 @@ def create_agents_router(
                     # Persist the submitted user message and its generated response.
                     turn_messages = [body.message, generated_assistant_message]
                 await _persist_agent_session_turn(
-                    request.app.state.db,
+                    app_state.db,
                     agent_session_rowid=agent_session_rowid,
                     user_id=request_user_id,
                     new_messages=turn_messages,
@@ -2279,6 +2529,33 @@ def create_agents_router(
                 return TranscriptPersistedChunk(
                     data=TranscriptPersistedData(message_id=turn_messages[-1].id)
                 )
+
+            def _resolve_interrupted_stream(
+                interrupted: Literal["stopped", "errored"],
+            ) -> list[BaseChunk]:
+                error_text = (
+                    "Tool execution was interrupted by the user."
+                    if interrupted == "stopped"
+                    else "Tool execution was interrupted because the response failed."
+                )
+                resolved_chunks: list[BaseChunk] = []
+                if not any(isinstance(chunk, StartChunk) for chunk in emitted_message_chunks):
+                    resolved_chunks.append(StartChunk(message_id=server_message_id))
+                resolved_chunks.extend(
+                    resolve_dangling_chunks(
+                        emitted_message_chunks,
+                        error_text=error_text,
+                    )
+                )
+                resolved_chunks.append(
+                    MessageMetadataChunk(
+                        message_metadata=AssistantMessageMetadata(
+                            session_id=otel_session_id,
+                            interrupted=interrupted,
+                        )
+                    )
+                )
+                return resolved_chunks
 
             try:
                 if tracer is not None and body.turn_trace_context is not None:
@@ -2358,9 +2635,26 @@ def create_agents_router(
                     async for message_chunk in message_chunk_stream:
                         emitted_message_chunks.append(message_chunk)
                         yield message_chunk
+                    if any(isinstance(chunk, ErrorChunk) for chunk in emitted_message_chunks):
+                        turn_interrupted = "errored"
+                        for resolved_chunk in _resolve_interrupted_stream(turn_interrupted):
+                            emitted_message_chunks.append(resolved_chunk)
+                            yield resolved_chunk
                     yield await _persist_turn()
             except BaseException as exc:
                 stream_error = exc
+                if not persistence_started:
+                    turn_interrupted = "stopped" if stop_was_requested else "errored"
+                    try:
+                        for resolved_chunk in _resolve_interrupted_stream(turn_interrupted):
+                            emitted_message_chunks.append(resolved_chunk)
+                            yield resolved_chunk
+                        yield await _persist_turn()
+                    except BaseException:
+                        logger.exception(
+                            "Failed to persist interrupted agent turn for session %r",
+                            session_id,
+                        )
                 raise
             finally:
                 if summary_task is not None:
@@ -2384,17 +2678,43 @@ def create_agents_router(
                         )
                     tracer.tracer_provider.force_flush()
                     if ingest_traces:
-                        project_id = await _ensure_project_exists(
-                            request.app.state.db, project_name
-                        )
+                        project_id = await _ensure_project_exists(app_state.db, project_name)
                         db_traces = tracer.get_db_traces(project_id=project_id)
                         await _persist_db_traces_and_emit_event(
-                            db=request.app.state.db,
-                            event_queue=request.state.event_queue,
+                            db=app_state.db,
+                            event_queue=event_queue,
                             db_traces=db_traces,
                         )
                     tracer.tracer_provider.shutdown()
 
-        return adapter.streaming_response(_stream_with_session())
+        try:
+            channel = await bus.begin_turn(
+                agent_session_id=agent_session_rowid,
+                turn_id=turn_id,
+                assistant_message_id=server_message_id,
+                origin_client_id=body.client_id,
+                submitted_message=body.message,
+                is_continuation=body.message.role == "assistant",
+            )
+        except SessionBusyError as exc:
+            if tracer is not None:
+                tracer.tracer_provider.shutdown()
+            return JSONResponse(
+                exc.body.model_dump(mode="json", by_alias=True),
+                status_code=409,
+            )
+        runner = TurnRunner(
+            bus=bus,
+            channel=channel,
+            prepared_turn=PreparedTurn(
+                agent_session_id=agent_session_rowid,
+                turn_id=turn_id,
+                stream=_stream_with_session,
+                is_awaiting_client_tool=lambda: not turn_is_terminal and turn_interrupted is None,
+                mark_stopped=_mark_stopped,
+            ),
+        )
+        bus.start_runner(channel, runner)
+        return adapter.streaming_response(channel.subscribe_turn(turn_id=turn_id))
 
     return router, chat

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -2005,7 +2005,10 @@ def create_agents_router(
                 if chunk is None:
                     yield b": keep-alive\n\n"
                 else:
-                    yield f"data: {chunk.encode(7)}\n\n".encode()
+                    # sdk_version 5 matches the POST /chat stream's encoding
+                    # (the VercelAIAdapter default) so both streams are
+                    # byte-identical for the same chunk.
+                    yield f"data: {chunk.encode(5)}\n\n".encode()
 
         return StreamingResponse(
             encoded_events(),
@@ -2455,6 +2458,7 @@ def create_agents_router(
         turn_is_terminal = False
         turn_interrupted: Literal["stopped", "errored"] | None = None
         stop_was_requested = False
+        run_completed = False
         bus: AgentSessionEventBus = app_state.agent_session_event_bus
         turn_id = uuid4().hex
 
@@ -2463,7 +2467,8 @@ def create_agents_router(
             stop_was_requested = True
 
         async def _on_complete(result: AgentRunResult[Any]) -> AsyncIterator[BaseChunk]:
-            nonlocal turn_final_output_text, turn_is_terminal
+            nonlocal turn_final_output_text, turn_is_terminal, run_completed
+            run_completed = True
             if isinstance(result.output, str):
                 turn_is_terminal = True
                 turn_final_output_text = result.output.strip() or None
@@ -2635,7 +2640,12 @@ def create_agents_router(
                     async for message_chunk in message_chunk_stream:
                         emitted_message_chunks.append(message_chunk)
                         yield message_chunk
-                    if any(isinstance(chunk, ErrorChunk) for chunk in emitted_message_chunks):
+                    # An ErrorChunk marks the turn as errored only when the
+                    # main run never completed: interleaved subagent chunks can
+                    # surface an ErrorChunk even though the turn succeeded.
+                    if not run_completed and any(
+                        isinstance(chunk, ErrorChunk) for chunk in emitted_message_chunks
+                    ):
                         turn_interrupted = "errored"
                         for resolved_chunk in _resolve_interrupted_stream(turn_interrupted):
                             emitted_message_chunks.append(resolved_chunk)

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -90,6 +90,7 @@ from phoenix.db.facilitator import Facilitator
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.types import AnnotationPrecursor
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
+from phoenix.server.agents.event_bus import AgentSessionEventBus, SessionBusyError
 from phoenix.server.api.auth_messages import AUTH_ERROR_MESSAGES, AuthErrorCode
 from phoenix.server.api.context import Context, build_context
 from phoenix.server.api.dataloaders import CacheForDataLoaders
@@ -623,6 +624,7 @@ def _lifespan(
     dml_event_handler: DmlEventHandler,
     trace_data_sweeper: Optional[TraceDataSweeper],
     agent_session_sweeper: AgentSessionSweeper,
+    agent_session_event_bus: AgentSessionEventBus,
     experiment_sweeper: ExperimentSweeper,
     span_cost_calculator: SpanCostCalculator,
     generative_model_store: GenerativeModelStore,
@@ -678,6 +680,7 @@ def _lifespan(
             if trace_data_sweeper:
                 await stack.enter_async_context(trace_data_sweeper)
             await stack.enter_async_context(agent_session_sweeper)
+            await stack.enter_async_context(agent_session_event_bus)
             await stack.enter_async_context(experiment_sweeper)
             await stack.enter_async_context(span_cost_calculator)
             await stack.enter_async_context(generative_model_store)
@@ -757,6 +760,7 @@ def create_graphql_router(
     span_cost_calculator: SpanCostCalculator,
     experiment_runner: ExperimentRunner,
     sandbox_session_manager: SandboxSessionManager,
+    agent_session_event_bus: AgentSessionEventBus,
     encrypt: Callable[[bytes], bytes],
     decrypt: Callable[[bytes], bytes],
     cache_for_dataloaders: Optional[CacheForDataLoaders] = None,
@@ -794,6 +798,7 @@ def create_graphql_router(
             span_cost_calculator=span_cost_calculator,
             experiment_runner=experiment_runner,
             sandbox_session_manager=sandbox_session_manager,
+            agent_session_event_bus=agent_session_event_bus,
             encrypt=encrypt,
             decrypt=decrypt,
             cache_for_dataloaders=cache_for_dataloaders,
@@ -853,6 +858,13 @@ async def plain_text_http_exception_handler(request: Request, exc: HTTPException
     if not is_body_allowed_for_status_code(exc.status_code):
         return Response(status_code=exc.status_code, headers=headers)
     return PlainTextResponse(str(exc.detail), status_code=exc.status_code, headers=headers)
+
+
+async def agent_session_busy_exception_handler(request: Request, exc: SessionBusyError) -> Response:
+    return JSONResponse(
+        exc.body.model_dump(mode="json", by_alias=True),
+        status_code=409,
+    )
 
 
 class _HasDbStatus(Protocol):
@@ -989,6 +1001,7 @@ def create_app(
     )
     system_settings = SystemSettings(db=db, registry=SETTINGS_REGISTRY)
     agent_session_sweeper = AgentSessionSweeper(db, settings=system_settings)
+    agent_session_event_bus = AgentSessionEventBus(db)
     experiment_sweeper = ExperimentSweeper(db)
     generative_model_store = GenerativeModelStore(db)
     span_cost_calculator = SpanCostCalculator(db, generative_model_store)
@@ -1049,6 +1062,7 @@ def create_app(
         span_cost_calculator=span_cost_calculator,
         experiment_runner=experiment_runner,
         sandbox_session_manager=sandbox_session_manager,
+        agent_session_event_bus=agent_session_event_bus,
         encrypt=encryption_service.encrypt,
         decrypt=encryption_service.decrypt,
     )
@@ -1075,6 +1089,7 @@ def create_app(
             dml_event_handler=dml_event_handler,
             trace_data_sweeper=trace_data_sweeper,
             agent_session_sweeper=agent_session_sweeper,
+            agent_session_event_bus=agent_session_event_bus,
             experiment_sweeper=experiment_sweeper,
             span_cost_calculator=span_cost_calculator,
             generative_model_store=generative_model_store,
@@ -1095,6 +1110,7 @@ def create_app(
         middleware=middlewares,
         exception_handlers={
             HTTPException: plain_text_http_exception_handler,
+            SessionBusyError: agent_session_busy_exception_handler,
         },
         debug=debug,
         swagger_ui_parameters={
@@ -1283,6 +1299,7 @@ def create_app(
     app.state.span_queue_is_full = lambda: bulk_inserter.is_full
     app.state.docs_mcp_server = docs_mcp_server
     app.state.sandbox_session_manager = sandbox_session_manager
+    app.state.agent_session_event_bus = agent_session_event_bus
     app.state.graphql_schema = graphql_schema
     app.state.build_graphql_context = _get_build_graphql_context_function(
         db=db,
@@ -1290,6 +1307,7 @@ def create_app(
         span_cost_calculator=span_cost_calculator,
         experiment_runner=experiment_runner,
         sandbox_session_manager=sandbox_session_manager,
+        agent_session_event_bus=agent_session_event_bus,
         encrypt=encryption_service.encrypt,
         decrypt=encryption_service.decrypt,
         cache_for_dataloaders=cache_for_dataloaders,
@@ -1392,6 +1410,7 @@ def _get_build_graphql_context_function(
     span_cost_calculator: SpanCostCalculator,
     experiment_runner: ExperimentRunner,
     sandbox_session_manager: SandboxSessionManager,
+    agent_session_event_bus: AgentSessionEventBus,
     encrypt: Callable[[bytes], bytes],
     decrypt: Callable[[bytes], bytes],
     cache_for_dataloaders: Optional[CacheForDataLoaders],
@@ -1419,6 +1438,7 @@ def _get_build_graphql_context_function(
             span_cost_calculator=span_cost_calculator,
             experiment_runner=experiment_runner,
             sandbox_session_manager=sandbox_session_manager,
+            agent_session_event_bus=agent_session_event_bus,
             encrypt=encrypt,
             decrypt=decrypt,
             cache_for_dataloaders=cache_for_dataloaders,

--- a/src/phoenix/server/daemons/agent_session_sweeper.py
+++ b/src/phoenix/server/daemons/agent_session_sweeper.py
@@ -18,6 +18,14 @@ _JITTER_SECONDS = 60
 _DELETE_BATCH_SIZE = 100
 
 
+def _has_active_run() -> sa.ColumnElement[bool]:
+    return sa.exists(
+        sa.select(models.AgentSessionRun.agent_session_id).where(
+            models.AgentSessionRun.agent_session_id == models.AgentSession.id
+        )
+    )
+
+
 class AgentSessionSweeper(DaemonTask):
     """Periodically delete expired agent sessions."""
 
@@ -47,6 +55,7 @@ class AgentSessionSweeper(DaemonTask):
             sa.delete(models.AgentSession)
             .where(models.AgentSession.expires_at.is_not(None))
             .where(models.AgentSession.expires_at < datetime.now(timezone.utc))
+            .where(~_has_active_run())
             .returning(models.AgentSession.id)
         )
         async with self._db() as session:
@@ -71,6 +80,7 @@ class AgentSessionSweeper(DaemonTask):
                 sa.delete(models.AgentSession)
                 .where(models.AgentSession.expires_at.is_(None))
                 .where(models.AgentSession.updated_at < cutoff)
+                .where(~_has_active_run())
                 .where(models.AgentSession.id.in_(batch))
             )
             async with self._db() as session:
@@ -104,11 +114,12 @@ class AgentSessionSweeper(DaemonTask):
         # row recheck fail for a session whose updated_at moved after the
         # ranking snapshot.
         stmt = sa.delete(models.AgentSession).where(
+            ~_has_active_run(),
             sa.tuple_(models.AgentSession.id, models.AgentSession.updated_at).in_(
                 sa.select(ranked.c.id, ranked.c.updated_at).where(
                     ranked.c.rank > max_count_per_user
                 )
-            )
+            ),
         )
         async with self._db() as session:
             result = await session.execute(stmt)

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -21,7 +21,6 @@ from opentelemetry.sdk.trace import TracerProvider
 from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart, ToolReturnPart
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.ui.vercel_ai import VercelAIAdapter
 from pydantic_ai.ui.vercel_ai.response_types import (
     BaseChunk,
     DataChunk,
@@ -646,51 +645,6 @@ async def test_chat_turn_persists_session_transcript(
     assert user_message_ids == ["msg-user-1", "msg-user-2"]
     assert len(second_turn_messages) > len(messages)
     assert second_turn_message_rowids[: len(message_rowids)] == message_rowids
-
-
-async def test_failed_chat_turn_does_not_persist_partial_transcript(
-    db: DbSessionFactory,
-    httpx_client: httpx.AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def failing_run_stream(
-        _adapter: VercelAIAdapter[Any, Any],
-        **_kwargs: Any,
-    ) -> AsyncIterator[BaseChunk]:
-        yield StartChunk(message_id="partial-assistant")
-        yield TextStartChunk(id="text")
-        yield TextDeltaChunk(id="text", delta="partial response")
-        raise RuntimeError("model stream failed")
-
-    monkeypatch.setattr(VercelAIAdapter, "run_stream", failing_run_stream)
-
-    async def _fake_build_model(*args: object, **kwargs: object) -> TestModel:
-        return TestModel(call_tools=[])
-
-    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
-    session_id = "46464646-4646-4464-8464-464646464646"
-    persisted_messages = [_user_message("earlier message")]
-    agent_session_id = await _create_agent_session_row(
-        db,
-        project_session_id=session_id,
-        title="Already titled",
-        messages=persisted_messages,
-    )
-
-    with pytest.raises(RuntimeError, match="model stream failed"):
-        await httpx_client.post(
-            _chat_url(agent_session_id),
-            json=_chat_body(
-                session_id,
-                _user_message("new message", message_id="msg-user-2"),
-            ),
-        )
-
-    async with db() as session:
-        agent_session_rowid = await session.scalar(select(models.AgentSession.id))
-        assert agent_session_rowid is not None
-        stored_messages = await _load_session_messages(session, agent_session_rowid)
-    assert stored_messages == persisted_messages
 
 
 async def test_client_tool_continuation_extends_the_persisted_assistant_message(


### PR DESCRIPTION


https://github.com/user-attachments/assets/40453f05-bb03-4a7b-aa2f-6dbdf2aa39d3



## What

A per-session **event bus** for PXI chat, decoupling agent turns from HTTP request lifetimes so multiple clients (browser tabs, the CLI, and eventually multiple users) can share one live chat session.

Four commits:

1. **`docs(internal)`** — design spec at `internal_docs/specs/pxi-chat-event-bus.md` (decision table, architecture, risks).
2. **`feat(agents)`** — the implementation:
   - **Detached turn runner**: `POST /chat` claims a DB lease, spawns the turn as a server-owned task publishing to an in-memory `SessionChannel`, and streams back a bus subscription — wire format unchanged. Turns survive client disconnects; only an explicit stop cancels.
   - **State machine + DB leases** (`agent_session_runs` table): gates sends *and* transcript mutations (compact/truncate/branch/delete) with structured 409s; 10s heartbeat with ~30s stale takeover.
   - **`GET .../events`**: SSE endpoint with full-turn replay for late joiners, live tail across turns, and session-state chunks (busy/idle/origin client).
   - **`POST .../stop`**: first-class stop from any client, cross-instance via a DB flag; partial turns are now **persisted** on stop/error (dangling tool calls resolved server-side, `interrupted` marker in metadata) and resumable via the existing history-replay path.
   - **Multi-instance degradation**: a client routed to a non-owning instance gets a read-only "running on another server" state and transcript refresh on completion — no cross-instance streaming, no new infra.
   - **Web**: session events bridge + custom `ChatTransport` riding the AI SDK's native `resumeStream()`/`reconnectToStream()`; multi-tab live sync, busy composer states, originator-only client tools. **CLI**: attach/follow of live sessions, busy handling, stop endpoint.
3. **`fix(agents)`** — hardening from an adversarial review pass (12 files): idle `/events` connections now detect remote turns, zombie-lease reconciliation, abort-vs-resume and replay-duplication fixes in the web bridge, fatal-error classification and TUI unlock in the CLI, and more.
4. **`test(agents)`** — a docker-compose multi-instance smoke harness (`scripts/pxi-multi-instance/run.sh`): two Phoenix containers sharing Postgres + a three-client Playwright spec with a real LLM. **Passing**: cross-instance reads, degraded read-only mid-turn, same-instance live follow, convergence.

## Why

Today the agent loop runs inline in the `POST /chat` coroutine: whoever sends owns the stream, a closed tab kills the turn and discards its output, nothing prevents two tabs from racing turns (the loser 409s after burning tokens), and a second client has no way to see an in-flight response. This blocks multi-tab UX, CLI/web session sharing, and future multi-user sessions — and multi-Phoenix deployments had no session-level coordination at all.

## Alternatives considered

| Decision | Chosen | Alternatives (why not) |
|---|---|---|
| Turn execution | Detached background task | *In-request producer + bus tee*: smaller change, but sender disconnect still kills the turn — fails the core goal. *Cancel-on-last-subscriber*: saves compute but makes turn survival dependent on connection stability. |
| Multi-instance | Read-only degradation + DB lease/heartbeat | *Redis pub/sub*: full cross-instance streaming, but adds an optional infra dependency and a second code path. *DB-relayed chunk streaming*: works on plain Postgres but writes every chunk to the DB (load, latency). *Instance-to-instance proxying*: no new infra but adds intra-cluster networking and failure modes. |
| Concurrent sends | Reject with structured 409 | *Queueing*: seamless but needs queue visibility/ordering UX. *Stop-and-replace*: destructive when another client owns the turn. |
| Late join | Full chunk replay from turn start | *Snapshot + live tail*: less replay traffic but needs a new snapshot chunk type and mid-stream part seeding; replay reuses the exact client pipeline as live streaming. |
| Client transport | POST keeps its SSE body + separate `GET /events` | *Uniform 202 + subscribe-only*: cleaner model but breaks the AI SDK transport contract and adds ack/subscribe races. *WebSocket channel*: most bus-native but replaces the entire AI SDK HTTP story and complicates auth/proxies. |
| Partial turns | Persist on stop and error | *Discard (status quo)*: simpler, but viewers watching a long turn see it vanish; persistence reuses the client-tool continuation machinery, so resume comes for free. |

## Known limitations

- One bus per process: uvicorn multi-worker on one host degrades like multi-instance (documented; Phoenix commonly runs single-worker).
- A crashed owner loses the in-flight partial (chunks are memory-only); transcript ends at the last persisted turn, lease auto-releases in ~30s.
- Replay buffer capped (~100k chunks); overflow degrades late-join replay rather than OOMing.
- Unit/E2E coverage for the new machinery is deliberately deferred (manually validated + multi-instance smoke harness); test plan is in the spec doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
