### PR TITLE
feat(trace): expand or collapse all span info sections at once

### DIFF
--- a/app/src/components/core/card/Card.tsx
+++ b/app/src/components/core/card/Card.tsx
@@ -19,16 +19,19 @@ function Card({
   interactiveTitle = false,
   collapseButtonLabel,
   defaultOpen = true,
+  isOpen,
   scrollBody = false,
   extra,
   onCollapseChange,
+  onOpenChange,
   testId,
   ...otherProps
 }: CardProps & { ref?: Ref<HTMLElement> }) {
   const { styleProps } = useStyleProps(otherProps, viewStyleProps);
-  const [isCollapsed, setIsCollapsed] = useState(
+  const [uncontrolledIsCollapsed, setUncontrolledIsCollapsed] = useState(
     collapsible ? !defaultOpen : false
   );
+  const isCollapsed = isOpen == null ? uncontrolledIsCollapsed : !isOpen;
 
   const headerId = useId();
   const collapseButtonId = useId();
@@ -60,8 +63,11 @@ function Card({
     </div>
   );
 
+  // The local state is kept in step even while `isOpen` controls the card, so a
+  // card that later drops back to uncontrolled resumes where the reader left it.
   const toggleCollapsed = () => {
-    setIsCollapsed(!isCollapsed);
+    setUncontrolledIsCollapsed(!isCollapsed);
+    onOpenChange?.(isCollapsed);
   };
 
   // With `interactiveTitle` the toggle itself is only the arrow, so the rest of

--- a/app/src/components/core/card/types.ts
+++ b/app/src/components/core/card/types.ts
@@ -41,6 +41,18 @@ export interface CardProps extends PropsWithChildren<ViewStyleProps> {
    */
   defaultOpen?: boolean;
   /**
+   * Whether the card body is open, when the caller owns that state. Leave unset
+   * to let the card track it from `defaultOpen`. Pair with `onOpenChange`, which
+   * is the only way a controlled card learns the reader toggled it. Only
+   * applicable if `collapsible` is `true`.
+   */
+  isOpen?: boolean;
+  /**
+   * Callback fired when the reader toggles the card, with the open state they
+   * asked for. Unlike `onCollapseChange`, this fires only on their action.
+   */
+  onOpenChange?: (isOpen: boolean) => void;
+  /**
    * Set when the title contains interactive elements (selects, buttons, etc.).
    * The collapse toggle then renders as a standalone arrow button beside the
    * title instead of wrapping it, so interactive controls are not nested

--- a/app/src/components/core/tabs/Tabs.tsx
+++ b/app/src/components/core/tabs/Tabs.tsx
@@ -218,14 +218,56 @@ const tabListCSS = css`
   }
 `;
 
+const tabListRowCSS = css`
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+
+  .react-aria-TabList {
+    // the tabs take the row and the extra content keeps its own width, so the
+    // tab list is what scrolls once there are more tabs than space
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .tab-list-row__extra {
+    // the margin, not the tab list's growth, is what holds this at the end —
+    // page level styles are free to pin the tab list's flex, and several do
+    margin-inline-start: auto;
+    flex: none;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--global-dimension-size-100);
+    // the end inset matches the page gutter, so these controls line up with the
+    // actions in the header above rather than hugging the edge
+    padding-inline-start: var(--global-dimension-size-100);
+    padding-inline-end: var(--global-dimension-size-200);
+  }
+
+  // the tab list draws its bottom border only under the tabs themselves, so the
+  // row carries the rest of the edge across to the end
+  &:has(> [data-orientation="horizontal"]) {
+    box-shadow: inset 0 -1px 0 0 var(--tab-border-color);
+  }
+`;
+
 export function TabList<T extends object>({
   children,
+  extra,
   css: _css,
   className,
   ...props
-}: AriaTabListProps<T> & StylableProps) {
+}: AriaTabListProps<T> &
+  StylableProps & {
+    /**
+     * Content aligned to the end of the tab bar, level with the tabs. For
+     * horizontal tab lists — controls that act on the selected tab's panel.
+     */
+    extra?: React.ReactNode;
+  }) {
   const { ref, hasOverflowAtStart, hasOverflowAtEnd } = useHorizontalOverflow();
-  return (
+  const tabList = (
     <AriaTabList
       ref={ref}
       css={css(tabListCSS, _css)}
@@ -236,6 +278,15 @@ export function TabList<T extends object>({
     >
       {children}
     </AriaTabList>
+  );
+  if (extra == null) {
+    return tabList;
+  }
+  return (
+    <div className="tab-list-row" css={tabListRowCSS}>
+      {tabList}
+      <div className="tab-list-row__extra">{extra}</div>
+    </div>
   );
 }
 

--- a/app/src/pages/trace/SessionDetailsTracesView.tsx
+++ b/app/src/pages/trace/SessionDetailsTracesView.tsx
@@ -59,6 +59,7 @@ import { SESSION_DETAILS_PAGE_SIZE } from "@phoenix/pages/trace/constants";
 
 import { ConnectedTraceTree } from "./ConnectedTraceTree";
 import { SpanDetails } from "./SpanDetails";
+import { SpanInfoCardsProvider } from "./SpanInfoCardsContext";
 
 const INITIAL_SELECTED_TRACE_MAX_PAGES = 3;
 
@@ -290,7 +291,11 @@ export function SessionDetailsTracesView({
       </Panel>
       <Separator css={compactResizeHandleCSS} />
       <Panel id="session-traces-span-details">
-        <SpanDetailsPanel selectedSpanNodeId={selectedSpanNodeId} />
+        {/* above the panel, which remounts per span, so a collapse the reader
+            asked for survives moving between spans in the session */}
+        <SpanInfoCardsProvider>
+          <SpanDetailsPanel selectedSpanNodeId={selectedSpanNodeId} />
+        </SpanInfoCardsProvider>
       </Panel>
     </Group>
   );

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import type { PropsWithChildren } from "react";
-import { Suspense, useEffect, useRef } from "react";
+import { Suspense, useContext, useEffect, useRef } from "react";
+import { TabListStateContext } from "react-aria-components";
 import { useHotkeys } from "react-hotkeys-hook";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import {
@@ -44,6 +45,7 @@ import { SpanAside } from "./SpanAside";
 import { SpanAsideProvider, useOpenSpanAside } from "./SpanAsideContext";
 import { SpanDownloadMenu } from "./SpanDownloadMenu";
 import { SpanEventsList } from "./SpanEventsList";
+import { SpanInfoCardsToggle } from "./SpanInfoCardsToggle";
 import { NOTE_HOTKEY } from "./SpanNotesEditor";
 import { SpanToDatasetExampleDialog } from "./SpanToDatasetExampleDialog";
 
@@ -238,7 +240,7 @@ function SpanDetailsContent({ spanNodeId }: { spanNodeId: string }) {
             />
           </View>
           <Tabs>
-            <TabList>
+            <TabList extra={<SpanDetailsTabActions />}>
               <Tab id="info">Info</Tab>
               <Tab id="attributes">Attributes</Tab>
               <Tab id="events">
@@ -300,6 +302,16 @@ function SpanDetailsContent({ spanNodeId }: { spanNodeId: string }) {
       </Panel>
     </Group>
   );
+}
+
+/**
+ * Controls that sit level with the tabs and act on the selected panel. Only the
+ * info tab has any, so the slot is empty on the others rather than offering a
+ * control with nothing to act on.
+ */
+function SpanDetailsTabActions() {
+  const selectedTab = useContext(TabListStateContext)?.selectedKey;
+  return selectedTab === "info" ? <SpanInfoCardsToggle /> : null;
 }
 
 const spanInfoWrapCSS = css`

--- a/app/src/pages/trace/SpanInfoCardsContext.tsx
+++ b/app/src/pages/trace/SpanInfoCardsContext.tsx
@@ -1,0 +1,130 @@
+import type { PropsWithChildren } from "react";
+import { createContext, startTransition, useContext, useState } from "react";
+
+import type { CardProps } from "@phoenix/components";
+
+/**
+ * The cards the info tab's expand/collapse control acts on.
+ *
+ * Every span kind renders its input and output cards differently, but each of
+ * those renders under one of these keys, so the control reaches them all
+ * without knowing which kind is on screen. Cards nested inside these — a
+ * prompt template, a tool schema — are left to the reader.
+ */
+export const SPAN_INFO_CARD_KEYS = [
+  "annotations",
+  "input",
+  "output",
+  "metadata",
+  "attributes",
+  "notes",
+] as const;
+
+export type SpanInfoCardKey = (typeof SPAN_INFO_CARD_KEYS)[number];
+
+type SpanInfoCardsContextType = {
+  /**
+   * The open state chosen for each card. A card missing from this map has not
+   * been touched and still decides for itself, which is how cards keep the
+   * defaults that suit their content.
+   */
+  openStateByCard: Partial<Record<SpanInfoCardKey, boolean>>;
+
+  /** Records the open state the reader asked for on a single card. */
+  setCardOpen: (cardKey: SpanInfoCardKey, isOpen: boolean) => void;
+
+  /** Whether every card is currently collapsed. Drives the toolbar toggle. */
+  areAllCardsCollapsed: boolean;
+
+  /**
+   * Opens or collapses every card at once, overriding whatever the reader had
+   * set on the individual cards.
+   */
+  setAllCardsOpen: (isOpen: boolean) => void;
+};
+
+const SpanInfoCardsContext = createContext<SpanInfoCardsContextType | null>(
+  null
+);
+
+/**
+ * Shares the info tab's card open state between the cards and the control that
+ * expands or collapses them all.
+ *
+ * Mount above the span details view rather than inside it: the reader picks
+ * spans from the trace tree while the drawer stays open, and a collapse they
+ * asked for should hold across that.
+ */
+export function SpanInfoCardsProvider({ children }: PropsWithChildren) {
+  const [openStateByCard, setOpenStateByCard] = useState<
+    Partial<Record<SpanInfoCardKey, boolean>>
+  >({});
+
+  const setCardOpen = (cardKey: SpanInfoCardKey, isOpen: boolean) => {
+    setOpenStateByCard((prev) => ({ ...prev, [cardKey]: isOpen }));
+  };
+
+  /**
+   * Applies a global expand/collapse as a non-urgent update — opening every
+   * card can mount an entire attributes table and both message lists at once.
+   */
+  const setAllCardsOpen = (isOpen: boolean) => {
+    startTransition(() => {
+      setOpenStateByCard(
+        Object.fromEntries(SPAN_INFO_CARD_KEYS.map((key) => [key, isOpen]))
+      );
+    });
+  };
+
+  const areAllCardsCollapsed = SPAN_INFO_CARD_KEYS.every(
+    (cardKey) => openStateByCard[cardKey] === false
+  );
+
+  return (
+    <SpanInfoCardsContext.Provider
+      value={{
+        openStateByCard,
+        setCardOpen,
+        areAllCardsCollapsed,
+        setAllCardsOpen,
+      }}
+    >
+      {children}
+    </SpanInfoCardsContext.Provider>
+  );
+}
+
+/**
+ * Returns the info tab's card open state and actions.
+ *
+ * @throws Error when called outside of a `SpanInfoCardsProvider`.
+ */
+export function useSpanInfoCards() {
+  const context = useContext(SpanInfoCardsContext);
+  if (context === null) {
+    throw new Error(
+      "useSpanInfoCards must be used within a SpanInfoCardsProvider"
+    );
+  }
+  return context;
+}
+
+/**
+ * `Card` props that put one of the info tab's main cards under the tab's
+ * expand/collapse control. Spread these alongside `defaultCardProps`.
+ *
+ * `isOpen` stays undefined until something sets the card's state, so a card
+ * nobody has touched still honors its own `defaultOpen`.
+ */
+export function useSpanInfoCardProps(
+  cardKey: SpanInfoCardKey
+): SpanInfoCardProps {
+  const { openStateByCard, setCardOpen } = useSpanInfoCards();
+  return {
+    isOpen: openStateByCard[cardKey],
+    onOpenChange: (isOpen) => setCardOpen(cardKey, isOpen),
+  };
+}
+
+/** The `Card` props {@link useSpanInfoCardProps} supplies. */
+export type SpanInfoCardProps = Pick<CardProps, "isOpen" | "onOpenChange">;

--- a/app/src/pages/trace/SpanInfoCardsToggle.tsx
+++ b/app/src/pages/trace/SpanInfoCardsToggle.tsx
@@ -1,0 +1,41 @@
+import {
+  Icon,
+  IconButton,
+  Icons,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
+
+import { useSpanInfoCards } from "./SpanInfoCardsContext";
+
+/**
+ * Expands or collapses every main card in the span info tab at once, so a
+ * reader can take in the shape of a span without scrolling through it. The
+ * label says "sections" — that is what the cards read as to someone looking at
+ * the tab, whatever they are built from.
+ *
+ * Individual cards stay free afterwards — expanding one back out flips this
+ * control to offer the collapse again.
+ */
+export function SpanInfoCardsToggle() {
+  const { areAllCardsCollapsed, setAllCardsOpen } = useSpanInfoCards();
+  const label = areAllCardsCollapsed
+    ? "Expand all sections"
+    : "Collapse all sections";
+  return (
+    <TooltipTrigger>
+      <IconButton
+        size="S"
+        aria-label={label}
+        onPress={() => setAllCardsOpen(areAllCardsCollapsed)}
+      >
+        <Icon
+          svg={
+            areAllCardsCollapsed ? <Icons.RowExpand /> : <Icons.RowCollapse />
+          }
+        />
+      </IconButton>
+      <Tooltip offset={-5}>{label}</Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -41,6 +41,7 @@ import type {
 } from "./__generated__/TraceDetailsQuery.graphql";
 import { ConnectedTraceTree } from "./ConnectedTraceTree";
 import { SpanDetails } from "./SpanDetails";
+import { SpanInfoCardsProvider } from "./SpanInfoCardsContext";
 import { TraceHeaderTraceAnnotations } from "./TraceHeaderTraceAnnotations";
 
 type RootSpan = NonNullable<
@@ -173,13 +174,17 @@ export function TraceDetails(props: TraceDetailsProps) {
         </Panel>
         <Separator css={compactResizeHandleCSS} />
         <Panel id="span-details">
-          <ScrollingTabsWrapper>
-            {selectedSpanNodeId ? (
-              <Suspense fallback={<Loading />}>
-                <SpanDetails spanNodeId={selectedSpanNodeId} />
-              </Suspense>
-            ) : null}
-          </ScrollingTabsWrapper>
+          {/* above the span details, so a collapse the reader asked for holds
+              as they move between spans in the tree */}
+          <SpanInfoCardsProvider>
+            <ScrollingTabsWrapper>
+              {selectedSpanNodeId ? (
+                <Suspense fallback={<Loading />}>
+                  <SpanDetails spanNodeId={selectedSpanNodeId} />
+                </Suspense>
+              ) : null}
+            </ScrollingTabsWrapper>
+          </SpanInfoCardsProvider>
         </Panel>
       </Group>
     </main>

--- a/app/src/pages/trace/span/EmbeddingInput.tsx
+++ b/app/src/pages/trace/span/EmbeddingInput.tsx
@@ -8,6 +8,7 @@ import {
 } from "@phoenix/components/markdown";
 import type { AttributeEmbeddingEmbedding } from "@phoenix/openInference/tracing/types";
 
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 
 /**
@@ -19,11 +20,13 @@ export function EmbeddingInput({
   embeddings: AttributeEmbeddingEmbedding[];
 }) {
   const numTexts = embeddings.length;
+  const cardProps = useSpanInfoCardProps("input");
   return (
     <Card
       title="Input"
       subTitle={`${numTexts} ${numTexts === 1 ? "text" : "texts"}`}
       {...defaultCardProps}
+      {...cardProps}
     >
       {
         <ul

--- a/app/src/pages/trace/span/LLMInput.tsx
+++ b/app/src/pages/trace/span/LLMInput.tsx
@@ -13,6 +13,7 @@ import type {
 import { isModelProvider } from "@phoenix/utils/generativeUtils";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 import { LLMInvocationParams } from "./LLMInvocationParams";
 import type { LLMIOView } from "./LLMIOViewSelect";
@@ -105,11 +106,13 @@ export function LLMInput({
   ].filter(Boolean);
 
   const isRawView = view === "input" && hasInput;
+  const cardProps = useSpanInfoCardProps("input");
 
   return (
     <MarkdownDisplayProvider>
       <Card
-        collapsible
+        {...defaultCardProps}
+        {...cardProps}
         title="Input"
         subTitle={modelNameEl}
         extra={

--- a/app/src/pages/trace/span/LLMOutput.tsx
+++ b/app/src/pages/trace/span/LLMOutput.tsx
@@ -5,6 +5,7 @@ import {
 } from "@phoenix/components/markdown";
 import type { AttributeMessage } from "@phoenix/openInference/tracing/types";
 
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 import type { LLMIOView } from "./LLMIOViewSelect";
 import { LLMIOViewSelect, useLLMIOView } from "./LLMIOViewSelect";
@@ -33,6 +34,7 @@ export function LLMOutput({
     views.push({ id: "output-messages", label: "Messages" });
   if (hasOutput) views.push({ id: "output", label: "Raw" });
   const { view, setView } = useLLMIOView(views);
+  const cardProps = useSpanInfoCardProps("output");
 
   if (!hasOutput && !hasOutputMessages) {
     return null;
@@ -44,6 +46,7 @@ export function LLMOutput({
     <MarkdownDisplayProvider>
       <Card
         {...defaultCardProps}
+        {...cardProps}
         title="Output"
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">

--- a/app/src/pages/trace/span/RerankerInput.tsx
+++ b/app/src/pages/trace/span/RerankerInput.tsx
@@ -13,6 +13,7 @@ import {
 import type { AttributeDocument } from "@phoenix/openInference/tracing/types";
 
 import { DocumentItem } from "../DocumentItem";
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps, documentsListCSS } from "./constants";
 
 /**
@@ -28,11 +29,15 @@ export function RerankerInput({
   inputDocuments: AttributeDocument[];
 }) {
   const numInputDocuments = inputDocuments.length;
+  const cardProps = useSpanInfoCardProps("input");
   return (
     <Card
       title="Input"
-      subTitle={`${numInputDocuments} ${numInputDocuments === 1 ? "document" : "documents"}`}
+      subTitle={`${numInputDocuments} ${
+        numInputDocuments === 1 ? "document" : "documents"
+      }`}
       {...defaultCardProps}
+      {...cardProps}
     >
       <MarkdownDisplayProvider>
         <DisclosureGroup defaultExpandedKeys={["query"]}>

--- a/app/src/pages/trace/span/RerankerOutput.tsx
+++ b/app/src/pages/trace/span/RerankerOutput.tsx
@@ -2,6 +2,7 @@ import { Card } from "@phoenix/components";
 import type { AttributeDocument } from "@phoenix/openInference/tracing/types";
 
 import { DocumentItem } from "../DocumentItem";
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps, documentsListCSS } from "./constants";
 
 /**
@@ -13,11 +14,15 @@ export function RerankerOutput({
   outputDocuments: AttributeDocument[];
 }) {
   const numOutputDocuments = outputDocuments.length;
+  const cardProps = useSpanInfoCardProps("output");
   return (
     <Card
       title={"Output"}
-      subTitle={`${numOutputDocuments} ${numOutputDocuments === 1 ? "document" : "documents"}`}
+      subTitle={`${numOutputDocuments} ${
+        numOutputDocuments === 1 ? "document" : "documents"
+      }`}
       {...defaultCardProps}
+      {...cardProps}
     >
       <ul css={documentsListCSS}>
         {outputDocuments.map((document, idx) => (

--- a/app/src/pages/trace/span/RetrieverInput.tsx
+++ b/app/src/pages/trace/span/RetrieverInput.tsx
@@ -4,6 +4,7 @@ import {
   MarkdownDisplayProvider,
 } from "@phoenix/components/markdown";
 
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 import { MimeTypeCodeBlock } from "./MimeTypeCodeBlock";
 import type { SpanIOValue } from "./types";
@@ -13,11 +14,13 @@ import type { SpanIOValue } from "./types";
  */
 export function RetrieverInput({ value, mimeType }: SpanIOValue) {
   const isText = mimeType === "text";
+  const cardProps = useSpanInfoCardProps("input");
   return (
     <MarkdownDisplayProvider>
       <Card
         title="Input"
         {...defaultCardProps}
+        {...cardProps}
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isText ? (

--- a/app/src/pages/trace/span/RetrieverOutput.tsx
+++ b/app/src/pages/trace/span/RetrieverOutput.tsx
@@ -10,6 +10,7 @@ import type { AttributeDocument } from "@phoenix/openInference/tracing/types";
 
 import { RetrievalEvaluationLabel } from "../../project/RetrievalEvaluationLabel";
 import { DocumentItem } from "../DocumentItem";
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 import type { DocumentEvaluation, RetrievalMetric } from "./types";
 
@@ -31,12 +32,14 @@ export function RetrieverOutput({
   spanNodeId: string;
 }) {
   const hasDocumentRetrievalMetrics = retrievalMetrics.length > 0;
+  const cardProps = useSpanInfoCardProps("output");
   return (
     <MarkdownDisplayProvider>
       <Card
         title="Output"
         subTitle="Documents"
         {...defaultCardProps}
+        {...cardProps}
         extra={<ConnectedMarkdownModeSelect />}
       >
         {hasDocumentRetrievalMetrics && (

--- a/app/src/pages/trace/span/SpanAnnotationsCard.tsx
+++ b/app/src/pages/trace/span/SpanAnnotationsCard.tsx
@@ -26,6 +26,7 @@ import { usePreferencesContext } from "@phoenix/contexts";
 
 import { SpanAnnotationsTable } from "../SpanAnnotationsTable";
 import { useOpenSpanAside } from "../SpanAsideContext";
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import type { SpanAnnotationsCardSummaryQuery } from "./__generated__/SpanAnnotationsCardSummaryQuery.graphql";
 import { defaultCardProps } from "./constants";
 import { useSpanAnnotationCounts } from "./useSpanAnnotationCounts";
@@ -101,6 +102,7 @@ function SpanAnnotationsCardContents({ spanNodeId }: { spanNodeId: string }) {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [areRowsExpanded, setAreRowsExpanded] = useState(false);
   const [view, setView] = useState<SpanAnnotationsView>("list");
+  const cardProps = useSpanInfoCardProps("annotations");
   const hasAnnotations = annotationCount > 0;
   const emptyState = (
     <CompactEmptyState
@@ -111,6 +113,7 @@ function SpanAnnotationsCardContents({ spanNodeId }: { spanNodeId: string }) {
   return (
     <Card
       {...defaultCardProps}
+      {...cardProps}
       title="Annotations"
       titleExtra={<Counter variant="quiet">{annotationCount}</Counter>}
       // the summary tokens are clickable, so the collapse toggle is a

--- a/app/src/pages/trace/span/SpanAttributesCard.tsx
+++ b/app/src/pages/trace/span/SpanAttributesCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import type { CardProps } from "@phoenix/components";
 import {
   Card,
   ContextualHelp,
@@ -39,7 +40,10 @@ const attributesContextualHelp = (
  * The card body and header, inside the provider so both can read the same
  * view state — the header needs the attribute count, the body the entries.
  */
-function AttributesCardContents({ defaultOpen }: { defaultOpen: boolean }) {
+function AttributesCardContents({
+  defaultOpen,
+  ...collapseProps
+}: { defaultOpen: boolean } & SpanAttributesCardCollapseProps) {
   // Every flattened key, not the rows currently listed: the count describes
   // the span, so it should not drop as the user narrows the search
   const { entries, isViewable } = useJSONView();
@@ -47,6 +51,7 @@ function AttributesCardContents({ defaultOpen }: { defaultOpen: boolean }) {
   return (
     <Card
       {...defaultCardProps}
+      {...collapseProps}
       title="Attributes"
       defaultOpen={defaultOpen}
       titleExtra={
@@ -81,6 +86,16 @@ function AttributesCardContents({ defaultOpen }: { defaultOpen: boolean }) {
 }
 
 /**
+ * The card's open state, when the caller owns it. The info tab passes these so
+ * its expand/collapse control reaches the card; the attributes tab, where the
+ * card is the whole view, leaves them unset.
+ */
+type SpanAttributesCardCollapseProps = Pick<
+  CardProps,
+  "isOpen" | "onOpenChange"
+>;
+
+/**
  * A card that displays all the attributes of a span, either as a searchable
  * table of the flattened attribute keys or as the JSON document itself.
  *
@@ -90,6 +105,7 @@ function AttributesCardContents({ defaultOpen }: { defaultOpen: boolean }) {
 export function SpanAttributesCard({
   attributes,
   defaultOpen = true,
+  ...collapseProps
 }: {
   attributes: string;
   /**
@@ -99,7 +115,7 @@ export function SpanAttributesCard({
    * @default true
    */
   defaultOpen?: boolean;
-}) {
+} & SpanAttributesCardCollapseProps) {
   return (
     // OpenTelemetry addresses list items with a dotted index
     // (`llm.input_messages.0.message.content`), so the keys read exactly as
@@ -109,7 +125,7 @@ export function SpanAttributesCard({
       defaultMode="table"
       indexNotation="dot"
     >
-      <AttributesCardContents defaultOpen={defaultOpen} />
+      <AttributesCardContents defaultOpen={defaultOpen} {...collapseProps} />
     </JSONViewProvider>
   );
 }

--- a/app/src/pages/trace/span/SpanInfo.tsx
+++ b/app/src/pages/trace/span/SpanInfo.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { Alert, Flex, View } from "@phoenix/components";
 
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { EmbeddingSpanInfo } from "./EmbeddingSpanInfo";
 import { LLMSpanInfo } from "./LLMSpanInfo";
 import { RerankerSpanInfo } from "./RerankerSpanInfo";
@@ -24,6 +25,10 @@ export function SpanInfo({ span }: { span: SpanInfoData }) {
   // Parse the attributes once
   const { json: attributesObject, parseError } =
     parseSpanAttributes(attributes);
+  // The other cards reach the tab's expand/collapse control from inside their
+  // own components; this one also renders in the attributes tab, where it is
+  // the whole view and has nothing to collapse alongside.
+  const attributesCardProps = useSpanInfoCardProps("attributes");
 
   const statusDescription = span.statusMessage ? (
     <Alert variant="danger">{span.statusMessage}</Alert>
@@ -44,7 +49,10 @@ export function SpanInfo({ span }: { span: SpanInfoData }) {
           </Alert>
           {/* open here, unlike below: with nothing parsed to render above it,
               the raw attributes are all there is to look at */}
-          <SpanAttributesCard attributes={attributes} />
+          <SpanAttributesCard
+            attributes={attributes}
+            {...attributesCardProps}
+          />
           {notesCard}
         </Flex>
       </View>
@@ -105,6 +113,7 @@ export function SpanInfo({ span }: { span: SpanInfoData }) {
         <SpanAttributesCard
           attributes={attributes}
           defaultOpen={!hasContentAboveAttributes && !hasMetadata}
+          {...attributesCardProps}
         />
         {notesCard}
       </Flex>

--- a/app/src/pages/trace/span/SpanInput.tsx
+++ b/app/src/pages/trace/span/SpanInput.tsx
@@ -4,6 +4,7 @@ import {
   MarkdownDisplayProvider,
 } from "@phoenix/components/markdown";
 
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 import { MimeTypeCodeBlock } from "./MimeTypeCodeBlock";
 import type { SpanIOValue } from "./types";
@@ -13,11 +14,13 @@ import type { SpanIOValue } from "./types";
  */
 export function SpanInput({ value, mimeType }: SpanIOValue) {
   const isText = mimeType === "text";
+  const cardProps = useSpanInfoCardProps("input");
   return (
     <MarkdownDisplayProvider>
       <Card
         title="Input"
         {...defaultCardProps}
+        {...cardProps}
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isText ? <ConnectedMarkdownModeSelect /> : null}

--- a/app/src/pages/trace/span/SpanMetadata.tsx
+++ b/app/src/pages/trace/span/SpanMetadata.tsx
@@ -1,14 +1,16 @@
 import { Card } from "@phoenix/components";
 
 import { ReadonlyJSONBlock } from "../ReadonlyJSONBlock";
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 
 /**
  * A card that displays the metadata attribute of a span as JSON.
  */
 export function SpanMetadata({ metadata }: { metadata: unknown }) {
+  const cardProps = useSpanInfoCardProps("metadata");
   return (
-    <Card {...defaultCardProps} title="Metadata">
+    <Card {...defaultCardProps} {...cardProps} title="Metadata">
       <ReadonlyJSONBlock>{JSON.stringify(metadata)}</ReadonlyJSONBlock>
     </Card>
   );

--- a/app/src/pages/trace/span/SpanNotesCard.tsx
+++ b/app/src/pages/trace/span/SpanNotesCard.tsx
@@ -16,6 +16,7 @@ import { CompactEmptyState } from "@phoenix/components/core/empty";
 import { RowExpandToggleButton } from "@phoenix/components/table";
 
 import { useOpenSpanAside } from "../SpanAsideContext";
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { NOTE_HOTKEY } from "../SpanNotesEditor";
 import { SpanNotesTable } from "../SpanNotesTable";
 import { defaultCardProps } from "./constants";
@@ -40,9 +41,11 @@ function SpanNotesCardContents({ spanNodeId }: { spanNodeId: string }) {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [areRowsExpanded, setAreRowsExpanded] = useState(false);
   const openSpanAside = useOpenSpanAside();
+  const cardProps = useSpanInfoCardProps("notes");
   return (
     <Card
       {...defaultCardProps}
+      {...cardProps}
       title="Notes"
       titleExtra={<Counter variant="quiet">{noteCount}</Counter>}
       defaultOpen={false}

--- a/app/src/pages/trace/span/SpanOutput.tsx
+++ b/app/src/pages/trace/span/SpanOutput.tsx
@@ -4,6 +4,7 @@ import {
   MarkdownDisplayProvider,
 } from "@phoenix/components/markdown";
 
+import { useSpanInfoCardProps } from "../SpanInfoCardsContext";
 import { defaultCardProps } from "./constants";
 import { MimeTypeCodeBlock } from "./MimeTypeCodeBlock";
 import type { SpanIOValue } from "./types";
@@ -13,11 +14,13 @@ import type { SpanIOValue } from "./types";
  */
 export function SpanOutput({ value, mimeType }: SpanIOValue) {
   const isText = mimeType === "text";
+  const cardProps = useSpanInfoCardProps("output");
   return (
     <MarkdownDisplayProvider>
       <Card
         title="Output"
         {...defaultCardProps}
+        {...cardProps}
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isText ? <ConnectedMarkdownModeSelect /> : null}

--- a/app/stories/Tabs.stories.tsx
+++ b/app/stories/Tabs.stories.tsx
@@ -2,6 +2,9 @@ import type { Meta, StoryFn } from "@storybook/react";
 
 import {
   Card,
+  Icon,
+  IconButton,
+  Icons,
   LazyTabPanel,
   Tab,
   TabList,
@@ -179,5 +182,39 @@ const OrientationTemplate: StoryFn = (args) => (
 
 export const VerticalOrientation = {
   render: OrientationTemplate,
+  args: {},
+};
+
+const ExtraTemplate: StoryFn = (args) => (
+  <Card title="Tabs with an Extra Slot">
+    <View width="600px" padding="size-200">
+      <Tabs {...args}>
+        <TabList
+          extra={
+            <IconButton size="S" aria-label="Collapse all">
+              <Icon svg={<Icons.RowCollapse />} />
+            </IconButton>
+          }
+        >
+          <Tab id="tab1">Tab 1</Tab>
+          <Tab id="tab2">Tab 2</Tab>
+          <Tab id="tab3">Tab 3</Tab>
+        </TabList>
+        <TabPanel padded id="tab1">
+          Content for Tab 1
+        </TabPanel>
+        <TabPanel padded id="tab2">
+          Content for Tab 2
+        </TabPanel>
+        <TabPanel padded id="tab3">
+          Content for Tab 3
+        </TabPanel>
+      </Tabs>
+    </View>
+  </Card>
+);
+
+export const WithExtra = {
+  render: ExtraTemplate,
   args: {},
 };


### PR DESCRIPTION
Closes #14768

<img width="1728" height="931" alt="Screenshot 2026-07-27 at 5 47 19 PM" src="https://github.com/user-attachments/assets/23c574a8-dc20-41fd-abf1-75da1f38e330" />


The span info tab stacks six cards — annotations, input, output, metadata, attributes, and notes — and a reader taking in the shape of an unfamiliar span had to collapse each one by hand. This adds a quiet toggle at the end of the tab bar that opens or collapses all six together.

### Behavior

- The toggle appears only on the **Info** tab, aligned with the header actions above it.
- Cards keep their own defaults until something sets them, so the initial view is unchanged.
- Toggling a single card still works; doing so flips the control back to offering the collapse.
- The state lives in a context mounted above the span details view, so a collapse holds while moving between spans with the drawer open (both the trace view and the session traces view).
- Nested cards — prompt template, invocation params, per-document cards — are left to the reader.
- The Attributes tab's own attributes card is unaffected, so collapsing everything on Info never leaves that tab empty.

### Supporting changes

- `Card` gains controlled `isOpen` / `onOpenChange` props. Uncontrolled behavior is unchanged.
- `TabList` gains an `extra` slot for controls level with the tabs, plus a Storybook story. The slot is held at the end with `margin-inline-start: auto` rather than by growing the tab list, since page-level styles (`ProjectPage`) pin `div[role="tablist"] { flex: none }` and that cascades into the drawer.

