### PR TITLE
feat(charts): keep chart panels readable at narrow widths

### DIFF
--- a/app/src/components/chart/ChartPanel.tsx
+++ b/app/src/components/chart/ChartPanel.tsx
@@ -25,6 +25,9 @@ const COMPACT_HEIGHT_BREAKPOINT = "200px";
 const chartPanelCSS = css`
   display: flex;
   flex-direction: column;
+  /* Keep the border inside the size the layout gives the panel, so a scrolling
+     parent has nothing to clip and side-by-side panels add no stray overflow */
+  box-sizing: border-box;
   height: 100%;
   width: 100%;
   min-width: ${CHART_MIN_WIDTH}px;

--- a/app/src/components/chart/ChartPanel.tsx
+++ b/app/src/components/chart/ChartPanel.tsx
@@ -8,6 +8,15 @@ import { ErrorBoundary } from "@phoenix/components/exception";
 const DEFAULT_CHART_HEIGHT = 190;
 
 /**
+ * The narrowest a chart panel gets. Below this the x axis thins out to a tick
+ * or two, the legend crowds the plot, and the title is mostly ellipsis — the
+ * chart stops carrying any reading. Layouts that place charts side by side
+ * scroll horizontally at this width instead of shrinking them further, so a
+ * chart is the same usable size at every window width.
+ */
+export const CHART_MIN_WIDTH = 320;
+
+/**
  * Below this panel height the subtitle is dropped so the chart keeps the
  * space; the title alone still identifies the chart.
  */
@@ -18,7 +27,7 @@ const chartPanelCSS = css`
   flex-direction: column;
   height: 100%;
   width: 100%;
-  min-width: 0;
+  min-width: ${CHART_MIN_WIDTH}px;
   border: var(--global-border-size-thin) solid var(--chart-panel-border-color);
   border-radius: var(--global-rounding-medium);
   background-color: var(--chart-panel-background-color);

--- a/app/src/components/chart/ChartPanelStrip.tsx
+++ b/app/src/components/chart/ChartPanelStrip.tsx
@@ -1,0 +1,75 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
+
+import { View } from "@phoenix/components";
+
+import { CHART_MIN_WIDTH } from "./ChartPanel";
+
+/** The gap between panels, in sync with `--global-dimension-size-100` */
+const CHART_GAP = 8;
+
+/** The width the strip needs to show every panel at its minimum width */
+function getRequiredWidth(chartCount: number): number {
+  return chartCount * CHART_MIN_WIDTH + (chartCount - 1) * CHART_GAP;
+}
+
+const chartPanelStripCSS = (chartCount: number) => css`
+  height: 100%;
+  /* Sized so the grid below can ask whether the panels still fit */
+  container-type: inline-size;
+
+  .chart-panel-strip__grid {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(${CHART_MIN_WIDTH}px, 1fr);
+    gap: ${CHART_GAP}px;
+    height: 100%;
+    /* Let hover UI (e.g. tall chart tooltips) escape the short strip instead
+       of being clipped at its bottom edge */
+    overflow: visible;
+  }
+
+  /* Past the point where the panels no longer fit side by side, the strip
+     scrolls rather than squeezing them below a readable width. Scrolling
+     needs a clipping box, which costs tooltips their room to escape — a
+     trade only made at widths where the charts would be unreadable anyway. */
+  @container (width < ${getRequiredWidth(chartCount)}px) {
+    .chart-panel-strip__grid {
+      overflow-x: auto;
+      /* Clipped either way once scrolling; keeps a tall tooltip from also
+         adding a vertical scrollbar */
+      overflow-y: hidden;
+    }
+  }
+`;
+
+/**
+ * The horizontal strip of chart panels shown above a table (project spans,
+ * traces and sessions, or dataset experiments). Panels share the available
+ * width evenly down to {@link CHART_MIN_WIDTH}, after which the strip scrolls
+ * horizontally so every chart stays readable.
+ */
+export function ChartPanelStrip({
+  chartCount,
+  children,
+}: {
+  /** How many chart panels `children` renders */
+  chartCount: number;
+  children: ReactNode;
+}) {
+  return (
+    <View
+      paddingStart="size-200"
+      paddingEnd="size-200"
+      paddingTop="size-100"
+      height="100%"
+      overflow="visible"
+      position="relative"
+      zIndex={2}
+    >
+      <div css={chartPanelStripCSS(chartCount)}>
+        <div className="chart-panel-strip__grid">{children}</div>
+      </div>
+    </View>
+  );
+}

--- a/app/src/components/chart/ChartPanelStrip.tsx
+++ b/app/src/components/chart/ChartPanelStrip.tsx
@@ -1,4 +1,4 @@
-import { css } from "@emotion/react";
+import { css, keyframes } from "@emotion/react";
 import type { ReactNode } from "react";
 
 import { View } from "@phoenix/components";
@@ -8,25 +8,87 @@ import { CHART_MIN_WIDTH } from "./ChartPanel";
 /** The gap between panels, in sync with `--global-dimension-size-100` */
 const CHART_GAP = 8;
 
+/** The width of the edge fades, in sync with `--global-dimension-size-300` */
+const FADE_WIDTH = "var(--global-dimension-size-300)";
+
 /** The width the strip needs to show every panel at its minimum width */
 function getRequiredWidth(chartCount: number): number {
   return chartCount * CHART_MIN_WIDTH + (chartCount - 1) * CHART_GAP;
 }
 
+const fadeInKeyframes = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const fadeOutKeyframes = keyframes`
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+`;
+
 const chartPanelStripCSS = (chartCount: number) => css`
   height: 100%;
-  /* Sized so the grid below can ask whether the panels still fit */
+  /* Sized so the scroller below can ask whether the panels still fit */
   container-type: inline-size;
 
+  .chart-panel-strip__scroller {
+    display: flex;
+    height: 100%;
+    /* Let hover UI (e.g. tall chart tooltips) escape the short strip instead
+       of being clipped at its bottom edge */
+    overflow: visible;
+  }
+
   .chart-panel-strip__grid {
+    /* Fills the strip when the panels fit and holds its minimum width — the
+       width the scroller then scrolls — when they do not */
+    flex: 1 0 auto;
     display: grid;
     grid-auto-flow: column;
     grid-auto-columns: minmax(${CHART_MIN_WIDTH}px, 1fr);
     gap: ${CHART_GAP}px;
     height: 100%;
-    /* Let hover UI (e.g. tall chart tooltips) escape the short strip instead
-       of being clipped at its bottom edge */
-    overflow: visible;
+  }
+
+  /* Fades pinned to the scroller's edges, marking the panels scrolled out of
+     view on that side. They take no layout width of their own (negative
+     margins) and never intercept a scroll or a hover. Hidden until the strip
+     both scrolls and has content past that edge — see the container query. */
+  .chart-panel-strip__fade {
+    position: sticky;
+    flex: none;
+    width: ${FADE_WIDTH};
+    opacity: 0;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .chart-panel-strip__fade--start {
+    left: 0;
+    margin-right: calc(-1 * ${FADE_WIDTH});
+    background: linear-gradient(
+      to right,
+      var(--global-background-color-default),
+      transparent
+    );
+  }
+
+  .chart-panel-strip__fade--end {
+    right: 0;
+    margin-left: calc(-1 * ${FADE_WIDTH});
+    background: linear-gradient(
+      to left,
+      var(--global-background-color-default),
+      transparent
+    );
   }
 
   /* Past the point where the panels no longer fit side by side, the strip
@@ -34,11 +96,28 @@ const chartPanelStripCSS = (chartCount: number) => css`
      needs a clipping box, which costs tooltips their room to escape — a
      trade only made at widths where the charts would be unreadable anyway. */
   @container (width < ${getRequiredWidth(chartCount)}px) {
-    .chart-panel-strip__grid {
+    .chart-panel-strip__scroller {
       overflow-x: auto;
       /* Clipped either way once scrolling; keeps a tall tooltip from also
          adding a vertical scrollbar */
       overflow-y: hidden;
+    }
+
+    /* Tie each fade's opacity to the scroll position, so a side shows one only
+       while it has panels scrolled past it. Chrome-only CSS, guarded by
+       @supports so unsupported browsers simply fall back to no fade. */
+    @supports (animation-timeline: scroll()) {
+      .chart-panel-strip__fade--start {
+        animation: ${fadeInKeyframes} linear both;
+        animation-timeline: scroll(nearest inline);
+        animation-range: 0 ${FADE_WIDTH};
+      }
+
+      .chart-panel-strip__fade--end {
+        animation: ${fadeOutKeyframes} linear both;
+        animation-timeline: scroll(nearest inline);
+        animation-range: calc(100% - ${FADE_WIDTH}) 100%;
+      }
     }
   }
 `;
@@ -47,7 +126,8 @@ const chartPanelStripCSS = (chartCount: number) => css`
  * The horizontal strip of chart panels shown above a table (project spans,
  * traces and sessions, or dataset experiments). Panels share the available
  * width evenly down to {@link CHART_MIN_WIDTH}, after which the strip scrolls
- * horizontally so every chart stays readable.
+ * horizontally so every chart stays readable, fading its edges to mark the
+ * panels scrolled out of view.
  */
 export function ChartPanelStrip({
   chartCount,
@@ -68,7 +148,17 @@ export function ChartPanelStrip({
       zIndex={2}
     >
       <div css={chartPanelStripCSS(chartCount)}>
-        <div className="chart-panel-strip__grid">{children}</div>
+        <div className="chart-panel-strip__scroller">
+          <div
+            className="chart-panel-strip__fade chart-panel-strip__fade--start"
+            aria-hidden
+          />
+          <div className="chart-panel-strip__grid">{children}</div>
+          <div
+            className="chart-panel-strip__fade chart-panel-strip__fade--end"
+            aria-hidden
+          />
+        </div>
       </div>
     </View>
   );

--- a/app/src/components/chart/index.tsx
+++ b/app/src/components/chart/index.tsx
@@ -1,5 +1,6 @@
 export * from "./ChartEmptyStateOverlay";
 export * from "./ChartPanel";
+export * from "./ChartPanelStrip";
 export * from "./ChartTypeIcon";
 export * from "./MetricsChartSelector";
 export * from "./ChartTooltip";

--- a/app/src/pages/dataset/metrics/DatasetMetricsPage.tsx
+++ b/app/src/pages/dataset/metrics/DatasetMetricsPage.tsx
@@ -40,7 +40,9 @@ export function DatasetMetricsPage() {
         width: 100%;
         height: 100%;
         box-sizing: border-box;
-        overflow-y: auto;
+        /* Scrolls in both directions: the rows hold their charts at a
+           readable width rather than shrinking to fit a narrow window */
+        overflow: auto;
       `}
     >
       <div
@@ -49,6 +51,9 @@ export function DatasetMetricsPage() {
           flex-direction: column;
           gap: var(--global-dimension-size-200);
           padding: var(--global-dimension-size-200);
+          /* The widest row's charts at their minimum width. Every row stretches
+             to it, so a scrolled page keeps its charts aligned in a column. */
+          min-width: min-content;
         `}
       >
         {METRIC_PAGE_ROWS.map((row) => (

--- a/app/src/pages/experiments/ExperimentsMetricsCharts.tsx
+++ b/app/src/pages/experiments/ExperimentsMetricsCharts.tsx
@@ -7,8 +7,7 @@ import {
   useDefaultLayout,
 } from "react-resizable-panels";
 
-import { View } from "@phoenix/components";
-import { ChartPanel } from "@phoenix/components/chart";
+import { ChartPanel, ChartPanelStrip } from "@phoenix/components/chart";
 import { transparentResizeHandleCSS } from "@phoenix/components/resize";
 import { useDatasetContext } from "@phoenix/contexts/DatasetContext";
 import { getExperimentMetricCharts } from "@phoenix/pages/dataset/metrics/chartCatalog";
@@ -32,14 +31,6 @@ const chartsResizeHandleCSS = css`
   z-index: 1;
 `;
 
-const chartsGridCSS = css`
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(0, 1fr);
-  gap: var(--global-dimension-size-100);
-  height: 100%;
-`;
-
 /**
  * A strip of user-selected metric charts shown above the experiments table.
  * Any chart in the experiment metric chart catalog can be added. The
@@ -52,23 +43,13 @@ function ExperimentsMetricsCharts() {
   );
   const charts = getExperimentMetricCharts(selectedChartKeys);
   return (
-    <View
-      paddingStart="size-200"
-      paddingEnd="size-200"
-      paddingTop="size-100"
-      height="100%"
-      overflow="visible"
-      position="relative"
-      zIndex={2}
-    >
-      <div css={chartsGridCSS}>
-        {charts.map(({ key, name, description, Component }) => (
-          <ChartPanel key={key} title={name} subtitle={description} fillHeight>
-            <Component datasetId={datasetId} />
-          </ChartPanel>
-        ))}
-      </div>
-    </View>
+    <ChartPanelStrip chartCount={charts.length}>
+      {charts.map(({ key, name, description, Component }) => (
+        <ChartPanel key={key} title={name} subtitle={description} fillHeight>
+          <Component datasetId={datasetId} />
+        </ChartPanel>
+      ))}
+    </ChartPanelStrip>
   );
 }
 

--- a/app/src/pages/project/TableMetricsCharts.tsx
+++ b/app/src/pages/project/TableMetricsCharts.tsx
@@ -7,8 +7,8 @@ import {
   useDefaultLayout,
 } from "react-resizable-panels";
 
-import { useTimeRange, View } from "@phoenix/components";
-import { ChartPanel } from "@phoenix/components/chart";
+import { useTimeRange } from "@phoenix/components";
+import { ChartPanel, ChartPanelStrip } from "@phoenix/components/chart";
 import { transparentResizeHandleCSS } from "@phoenix/components/resize";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
@@ -38,14 +38,6 @@ const chartsResizeHandleCSS = css`
   z-index: 1;
 `;
 
-const chartsGridCSS = css`
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(0, 1fr);
-  gap: var(--global-dimension-size-100);
-  height: 100%;
-`;
-
 /**
  * A strip of user-selected metric charts shown above a project table (spans,
  * traces, or sessions) for troubleshooting. Any chart in the chart catalog
@@ -69,35 +61,20 @@ const TableMetricsCharts = memo(function TableMetricsCharts({
   const timeRange = useClosedTimeRange({ refreshKey: fetchKey });
   const charts = getProjectMetricCharts(selectedChartKeys);
   return (
-    <View
-      paddingStart="size-200"
-      paddingEnd="size-200"
-      paddingTop="size-100"
-      height="100%"
-      overflow="visible"
-      position="relative"
-      zIndex={2}
-    >
-      <div css={chartsGridCSS}>
-        {/* Re-fetch the charts on each stream refresh so they stay live */}
-        <MetricFetchKeyProvider value={fetchKey}>
-          {charts.map(({ key, name, description, Component }) => (
-            <ChartPanel
-              key={key}
-              title={name}
-              subtitle={description}
-              fillHeight
-            >
-              <Component
-                projectId={projectId}
-                timeRange={timeRange}
-                onTimeRangeSelected={setCustomTimeRange}
-              />
-            </ChartPanel>
-          ))}
-        </MetricFetchKeyProvider>
-      </div>
-    </View>
+    <ChartPanelStrip chartCount={charts.length}>
+      {/* Re-fetch the charts on each stream refresh so they stay live */}
+      <MetricFetchKeyProvider value={fetchKey}>
+        {charts.map(({ key, name, description, Component }) => (
+          <ChartPanel key={key} title={name} subtitle={description} fillHeight>
+            <Component
+              projectId={projectId}
+              timeRange={timeRange}
+              onTimeRangeSelected={setCustomTimeRange}
+            />
+          </ChartPanel>
+        ))}
+      </MetricFetchKeyProvider>
+    </ChartPanelStrip>
   );
 });
 

--- a/app/src/pages/project/metrics/ProjectMetricsPage.tsx
+++ b/app/src/pages/project/metrics/ProjectMetricsPage.tsx
@@ -40,7 +40,9 @@ export function ProjectMetricsPage() {
         width: 100%;
         height: 100%;
         box-sizing: border-box;
-        overflow-y: auto;
+        /* Scrolls in both directions: the rows hold their charts at a
+           readable width rather than shrinking to fit a narrow window */
+        overflow: auto;
       `}
     >
       <MetricPanels
@@ -67,6 +69,9 @@ const MetricPanels = memo(function MetricPanels({
         flex-direction: column;
         gap: var(--global-dimension-size-200);
         padding: var(--global-dimension-size-200);
+        /* The widest row's charts at their minimum width. Every row stretches
+           to it, so a scrolled page keeps its charts aligned in a column. */
+        min-width: min-content;
       `}
     >
       {METRIC_PAGE_ROWS.map((row) => (


### PR DESCRIPTION
Closes #14794

## Problem

Charts kept shrinking with the window until they stopped saying anything — axis ticks thinned out to one or two labels, the legend crowded the plot, and titles were mostly ellipsis.

## Change

Chart panels now hold a uniform **320px minimum width**, exported as `CHART_MIN_WIDTH` from `ChartPanel`. The layouts that place panels side by side scroll horizontally once the panels no longer fit, instead of squeezing them further.

**Project & dataset metrics pages** — the row stack is sized to `min-content` (the widest row's charts at their minimum width) and the page scrolls in both directions. Every row stretches to that width, so a scrolled page keeps its charts aligned in a column.

**Chart strips above the tables** (project spans/traces/sessions, dataset experiments) — both duplicated the same grid, so they now share a new `ChartPanelStrip`. The strip switches to horizontal scrolling through a container query, and only once the panels stop fitting. That matters because scrolling needs a clipping box, which costs tall chart tooltips the room they currently have to escape the short strip — this way that trade is only made at widths where the charts would be unreadable anyway.

**Panels size their border box** — `height: 100%` sized the *content* box, so each panel's 1px border sat 2px outside the grid cell the layout gave it. The overhang painted fine while the strip was `overflow: visible`, but once the strip narrowed enough to scroll, `overflow-y: hidden` clipped the panels' bottom border. Sizing the border box also drops the ~6px of phantom horizontal overflow the borders added, so the strip no longer offers a scrollbar at widths where the charts fit.

**Scrolled-away panels are marked by edge fades** — the strip's grid now sits in a scroller with a sticky fade on each side. The fades take no layout width, never intercept a scroll or hover, and tie their opacity to the scroll position, so a side shows one only while it has panels past it. Same scroll-timeline treatment as the IO value tooltip's fades, `@supports`-guarded so non-Chromium browsers simply get no fade.

## Verification

`tsc --noEmit`, `oxlint`, and `oxfmt` clean; frontend suite passes.

Checked in a running browser (project spans, 3 charts):

| strip width | overflow | panel widths | fades (start / end) |
| --- | --- | --- | --- |
| 1200px (panels fit) | `visible` — tooltips still escape | 395px each, `scrollWidth == clientWidth` | 0 / 0 |
| 700px (scrolling) | `overflow-x: auto` | 320px each, nothing clipped | 0 → 1 as it scrolls, 1 → 0 at the end |

Bottom borders and rounded corners render fully in the scrolling state.
