### PR TITLE
chore(skills): sync agent skills with recent changes

### DIFF
--- a/.agents/skills/agent-browser/SKILL.md
+++ b/.agents/skills/agent-browser/SKILL.md
@@ -7,24 +7,20 @@ hidden: true
 
 # agent-browser
 
-Fast browser automation CLI for AI agents. Chrome/Chromium via CDP with
-accessibility-tree snapshots and compact `@eN` element refs.
+Fast browser automation CLI for AI agents. Chrome/Chromium via CDP with accessibility-tree snapshots and compact `@eN` element refs.
 
 Install: `npm i -g agent-browser && agent-browser install`
 
 ## Start here
 
-This file is a discovery stub, not the usage guide. Before running any
-`agent-browser` command, load the actual workflow content from the CLI:
+This file is a discovery stub, not the usage guide. Before running any `agent-browser` command, load the actual workflow content from the CLI:
 
 ```bash
 agent-browser skills get core             # start here — workflows, common patterns, troubleshooting
 agent-browser skills get core --full      # include full command reference and templates
 ```
 
-The CLI serves skill content that always matches the installed version,
-so instructions never go stale. The content in this stub cannot change
-between releases, which is why it just points at `skills get core`.
+The CLI serves skill content that always matches the installed version, so instructions never go stale. The content in this stub cannot change between releases, which is why it just points at `skills get core`.
 
 ## Specialized skills
 
@@ -34,12 +30,12 @@ Load a specialized skill when the task falls outside browser web pages:
 agent-browser skills get electron          # Electron desktop apps (VS Code, Slack, Discord, Figma, ...)
 agent-browser skills get slack             # Slack workspace automation
 agent-browser skills get dogfood           # Exploratory testing / QA / bug hunts
+agent-browser skills get derive-client     # Record a HAR, derive a standalone API client for a site
 agent-browser skills get vercel-sandbox    # agent-browser inside Vercel Sandbox microVMs
 agent-browser skills get agentcore         # AWS Bedrock AgentCore cloud browsers
 ```
 
-Run `agent-browser skills list` to see everything available on the
-installed version.
+Run `agent-browser skills list` to see everything available on the installed version.
 
 ## Why agent-browser
 

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -199,6 +199,7 @@ px auth status --profile prod
 
 ```bash
 px project list                                            # list all projects (table view)
+px project list --name-contains prod --format raw --no-progress | jq '.[].name'  # filter by name substring (case-insensitive)
 px project list --format raw --no-progress | jq '.[].name' # project names as JSON
 px project get my-project --format raw --no-progress       # single record by exact name
 px project get my-project --format raw --no-progress | jq -r '.id'  # extract project id

--- a/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
+++ b/.agents/skills/phoenix-evals/references/evaluators-pre-built.md
@@ -15,6 +15,21 @@ faithfulness_eval = FaithfulnessEvaluator(llm=llm)
 **Note**: `HallucinationEvaluator` is deprecated. Use `FaithfulnessEvaluator` instead.
 It uses "faithful"/"unfaithful" labels with score 1.0 = faithful.
 
+`ToxicityEvaluator` flags a single piece of text (a model output or a user input)
+as toxic — hateful, demeaning, abusive, or threatening. It takes an `LLM` and
+evaluates a `{"text": ...}` input, returning "toxic"/"non-toxic" with score
+1.0 = toxic (`direction="minimize"`):
+
+```python
+from phoenix.evals import LLM
+from phoenix.evals.metrics import ToxicityEvaluator
+
+llm = LLM(provider="openai", model="gpt-4o-mini")
+toxicity_eval = ToxicityEvaluator(llm=llm)
+
+scores = toxicity_eval.evaluate({"text": "You are a worthless idiot."})
+```
+
 ## TypeScript
 
 ```typescript
@@ -22,6 +37,15 @@ import { createHallucinationEvaluator } from "@arizeai/phoenix-evals";
 import { openai } from "@ai-sdk/openai";
 
 const hallucinationEval = createHallucinationEvaluator({ model: openai("gpt-4o") });
+```
+
+```typescript
+import { createToxicityEvaluator } from "@arizeai/phoenix-evals";
+import { openai } from "@ai-sdk/openai";
+
+const toxicityEval = createToxicityEvaluator({ model: openai("gpt-4o-mini") });
+const result = await toxicityEval.evaluate({ text: "You are a worthless idiot." });
+// result.label is "toxic" or "non-toxic"
 ```
 
 ## Available (2.0)
@@ -34,12 +58,13 @@ const hallucinationEval = createHallucinationEvaluator({ model: openai("gpt-4o")
 | `ToolSelectionEvaluator` | LLM | Did the agent select the right tool? |
 | `ToolInvocationEvaluator` | LLM | Did the agent invoke the tool correctly? |
 | `ToolResponseHandlingEvaluator` | LLM | Did the agent handle the tool response well? |
+| `ToxicityEvaluator` | LLM | Is the text toxic (hateful, abusive, threatening)? |
 | `MatchesRegex` | Code | Does output match a regex pattern? |
 | `PrecisionRecallFScore` | Code | Precision/recall/F-score metrics |
 | `exact_match` | Code | Exact string match |
 
-Legacy evaluators (`HallucinationEvaluator`, `QAEvaluator`, `RelevanceEvaluator`,
-`ToxicityEvaluator`, `SummarizationEvaluator`) are in `phoenix.evals.legacy` and deprecated.
+`HallucinationEvaluator` is exported from `phoenix.evals.metrics` as a deprecated
+alias — use `FaithfulnessEvaluator` instead.
 
 **TypeScript**: `PrecisionRecallFScore` is also available via `@arizeai/phoenix-evals/code`
 as `createPrecisionEvaluator`, `createRecallEvaluator`, `createF1Evaluator`,

--- a/.agents/skills/phoenix-evals/references/integrations-pytest.md
+++ b/.agents/skills/phoenix-evals/references/integrations-pytest.md
@@ -43,10 +43,26 @@ Stable `parametrize` `ids` give each case a fixed identity so runs accumulate as
 | Argument | Description |
 |---|---|
 | `dataset` | Dataset/experiment name. Defaults to the test file's path relative to project root. |
+| `dataset_description` | Description stored on the created/updated dataset. |
+| `experiment_description` | Description stored on the experiment. |
+| `experiment_metadata` | Free-form mapping (e.g. model, parameters) stored on the experiment. Must be a mapping or collection fails with a `UsageError`. |
 | `evaluators` | Evaluators run automatically against every case (hoisted). |
 | `repetitions` | Run each case N times to measure non-determinism (each is its own pytest item + experiment run). |
 
 Dataset-name precedence: `PHOENIX_TEST_DATASET` env > `phoenix_dataset` in `pytest.ini` > marker `dataset=` > file path.
+
+The current git commit is detected once per session and merged into
+`experiment_metadata` as `git_sha` (skipped if you already supply a `git_sha`;
+degrades silently outside a git checkout). `dataset_description`,
+`experiment_description`, and `experiment_metadata` are merged across all tests
+sharing a dataset name — conflicting values for the same dataset fail collection
+with a `UsageError`.
+
+Evaluator spans (including spans created inside evaluator bodies) are routed to a
+dedicated evaluators project rather than the experiment's task project, matching
+the TypeScript client's `runExperiment` behavior. Requires
+`arize-phoenix-client>=2.10.0`; the metadata kwargs and evaluator trace isolation
+were added later, so use a recent client build.
 
 ## Logging helpers
 

--- a/.agents/skills/phoenix-evals/references/setup-typescript.md
+++ b/.agents/skills/phoenix-evals/references/setup-typescript.md
@@ -14,12 +14,12 @@ pnpm add @arizeai/phoenix-client @arizeai/phoenix-evals @arizeai/phoenix-otel
 
 ## LLM Providers
 
-For LLM-as-judge evaluators, install Vercel AI SDK providers:
+`@arizeai/phoenix-evals` requires **Vercel AI SDK v7** (`ai@^7.0.0`) and **Node.js >= 22.12**. AI SDK v7 is ESM-only, and v4/v5/v6 will not work. Install a matching major version of `ai` and v7-compatible provider packages (`@ai-sdk/*` v4+):
 
 ```bash
-npm install ai @ai-sdk/openai      # Vercel AI SDK + OpenAI
-npm install @ai-sdk/anthropic      # Anthropic
-npm install @ai-sdk/google         # Google
+npm install "ai@^7" "@ai-sdk/openai@^4"      # Vercel AI SDK v7 + OpenAI
+npm install "@ai-sdk/anthropic@^4"           # Anthropic
+npm install "@ai-sdk/google@^4"              # Google
 ```
 
 Or use direct provider SDKs:

--- a/.agents/skills/phoenix-tracing/references/instrumentation-auto-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/instrumentation-auto-typescript.md
@@ -5,8 +5,11 @@ Automatically create spans for LLM calls without code changes.
 ## Supported Frameworks
 
 - **LLM SDKs:** OpenAI
-- **Frameworks:** LangChain
+- **Frameworks:** LangChain, Vercel AI SDK (v7+)
 - **Install:** `npm install @arizeai/openinference-instrumentation-{name}`
+
+The Vercel AI SDK is instrumented through its built-in telemetry (below), not
+through an `@arizeai/openinference-instrumentation-*` package.
 
 ## Setup
 
@@ -36,6 +39,53 @@ registerInstrumentations({ instrumentations: [instrumentation] });
 ```
 
 **Why:** ESM imports are hoisted before `register()` runs.
+
+## Vercel AI SDK (v7+)
+
+`register()` does **not** auto-register AI SDK telemetry — the v7 telemetry
+registry is process-global, so the application must configure it explicitly.
+Install `ai` and `@ai-sdk/otel`, then register the integration against the
+Phoenix provider's tracer:
+
+```bash
+npm install @arizeai/phoenix-otel ai @ai-sdk/otel
+```
+
+```typescript
+// instrumentation.ts
+import { OpenTelemetry } from "@ai-sdk/otel";
+import { registerTelemetry } from "ai";
+import { register } from "@arizeai/phoenix-otel";
+
+const provider = register({
+  projectName: "my-ai-app",
+});
+
+registerTelemetry(
+  new OpenTelemetry({
+    tracer: provider.getTracer("@arizeai/phoenix-otel/ai-sdk"),
+    // Disables LLM request-header span capture (headers can hold tokens);
+    // unrelated to Phoenix auth.
+    headers: false,
+  })
+);
+```
+
+```typescript
+// main.ts
+import "./instrumentation.ts";
+import { openai } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+const result = await generateText({
+  model: openai("gpt-4o-mini"),
+  prompt: "Write a short story about a cat.",
+});
+```
+
+**Version compatibility:** `@arizeai/phoenix-otel` 2.x emits correct spans for
+AI SDK **v7+**. AI SDK v6 and older emit a different span shape — use
+`@arizeai/phoenix-otel` 1.x for those.
 
 ## Limitations
 

--- a/.agents/skills/phoenix-tracing/references/setup-typescript.md
+++ b/.agents/skills/phoenix-tracing/references/setup-typescript.md
@@ -15,6 +15,8 @@ Setup Phoenix tracing in TypeScript/JavaScript with `@arizeai/phoenix-otel`.
 npm install @arizeai/phoenix-otel
 ```
 
+Requires Node.js 18 or newer. Both ESM and CommonJS entry points are provided.
+
 ```typescript
 import { register } from "@arizeai/phoenix-otel";
 register({ projectName: "my-app" });

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "vercel-labs/agent-browser",
       "sourceType": "github",
       "skillPath": "skills/agent-browser/SKILL.md",
-      "computedHash": "228f87d57035100d9dc6efcfc05aafd4b6e3962adacaa04b8217ab2fadb15dc8"
+      "computedHash": "a674b7d81066e3cc471a7512ddb4ae724418cbfefa75cbb050b0dc430e4d57a0"
     }
   }
 }


### PR DESCRIPTION
Two independent skill bumps, one commit each.

## 1. External skill refresh — `agent-browser`
`npx skills update --project` refreshed the lockfile-tracked `agent-browser` skill from `vercel-labs/agent-browser` (adds the `derive-client` specialized skill; re-pins `computedHash` in `skills-lock.json`). Same operation the weekly `weekly-skills-update.yml` job runs.

## 2. Audit sync — `phoenix-{cli,evals,tracing}`
Audit of the last week on `main` (through `8eeffd3ae`), correcting places where shipped code had diverged from the skill prose. Each change is grounded in source at that SHA:

- **phoenix-evals / evaluators-pre-built** — document the current built-in `ToxicityEvaluator` (`phoenix.evals.metrics`) and TS `createToxicityEvaluator`; drop the false "deprecated in `phoenix.evals.legacy`" note (that package no longer exists) and correctly mark `HallucinationEvaluator` as the deprecated alias. (#14636, #14677)
- **phoenix-evals / setup-typescript** — pin `ai@^7` and `@ai-sdk/*@^4` with Node `>=22.12`; `@arizeai/phoenix-evals` now requires Vercel AI SDK v7 (breaking). (#14006)
- **phoenix-tracing / setup + instrumentation-auto (TS)** — document Vercel AI SDK v7 support via `@arizeai/phoenix-otel` (openinference-vercel v3), the explicit `registerTelemetry` wiring, and Node 18+. (#14563)
- **phoenix-evals / integrations-pytest** — new `@pytest.mark.phoenix` kwargs (`dataset_description`, `experiment_description`, `experiment_metadata`), `git_sha` merge, cross-test metadata merge/conflict, and evaluator trace isolation. (#14613)
- **phoenix-cli** — add `px project list --name-contains`. (#14709)

## Notes
- Out of scope (server-only, no client/CLI surface): eval-metrics aggregation GraphQL APIs (#14445); the dataset-example `source` span is exposed on the Python client but not the TS client (#13814).
- No changes to internal skills (`phoenix-server`, `phoenix-frontend`, etc.).