### PR TITLE
feat(experiments): collapse experiment table rows to a single line

### DIFF
--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -191,7 +191,7 @@ export const expandableRowsTableCSS = css`
 
 /**
  * Selectable rows plus the row-height states the toolbar toggle drives, composed
- * once so the three tracing tables cannot answer the same question differently.
+ * once so the tables that offer it cannot answer the same question differently.
  */
 export const expandableSelectableTableCSS = css(
   selectableTableCSS,

--- a/app/src/components/table/useTableRowsExpanded.ts
+++ b/app/src/components/table/useTableRowsExpanded.ts
@@ -1,8 +1,8 @@
 import { usePreferencesContext } from "@phoenix/contexts";
 
 /**
- * The row-height preference the tracing tables share, with the attribute that
- * drives `expandableRowsTableCSS`.
+ * The row-height preference the tracing and experiments tables share, with the
+ * attribute that drives `expandableRowsTableCSS`.
  */
 export function useTableRowsExpanded() {
   const isExpanded = usePreferencesContext(

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -24,6 +24,7 @@ import {
   Icons,
   Link,
   LinkButton,
+  OverflowRow,
   ProgressBar,
   RichTooltip,
   Text,
@@ -58,7 +59,9 @@ import {
   createRowSelectionColumn,
   IntCell,
   LoadMoreRow,
+  RowExpandToggleButton,
   useColumnOrder,
+  useTableRowsExpanded,
 } from "@phoenix/components/table";
 import { CellWithControlsWrap } from "@phoenix/components/table/CellWithControlsWrap";
 import {
@@ -66,8 +69,9 @@ import {
   CHECKBOX_COLUMN_PINNING,
 } from "@phoenix/components/table/constants";
 import {
+  expandableSelectableTableCSS,
   getCommonPinningStyles,
-  selectableTableCSS,
+  TABLE_DATA_CELL_CLASS,
 } from "@phoenix/components/table/styles";
 import { TextCell } from "@phoenix/components/table/TextCell";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
@@ -140,6 +144,7 @@ const TableBody = <T extends { id: string }>({
               return (
                 <td
                   key={cell.id}
+                  className={TABLE_DATA_CELL_CLASS}
                   style={{
                     ...getCommonPinningStyles(cell.column),
                     width: `calc(var(${colSizeVar}) * 1px)`,
@@ -182,6 +187,11 @@ export function ExperimentsTable({
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [rowSelection, setRowSelection] = useState({});
   const [, setSearchText] = useState("");
+  const {
+    isExpanded: areRowsExpanded,
+    setIsExpanded: setAreRowsExpanded,
+    tableProps: rowsExpandedTableProps,
+  } = useTableRowsExpanded();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<ExperimentsTableQuery, ExperimentsTableFragment$key>(
       graphql`
@@ -419,13 +429,13 @@ export function ExperimentsTable({
           return <>all examples</>;
         }
         return (
-          <Flex direction="row" gap="size-100" alignItems="center" wrap="wrap">
+          <OverflowRow isExpanded={areRowsExpanded}>
             {datasetSplits.edges.map((edge) => (
               <Token key={edge.node.id} color={edge.node.color}>
                 {edge.node.name}
               </Token>
             ))}
-          </Flex>
+          </OverflowRow>
         );
       },
     },
@@ -527,7 +537,7 @@ export function ExperimentsTable({
         if (value === null || typeof value !== "number") {
           return "--";
         }
-        return <LatencyText latencyMs={value} />;
+        return <LatencyText latencyMs={value} size="S" />;
       },
     },
     {
@@ -730,6 +740,10 @@ export function ExperimentsTable({
             columnOrder={storedColumnOrder}
             onColumnOrderChange={setStoredColumnOrder}
           />
+          <RowExpandToggleButton
+            isExpanded={areRowsExpanded}
+            onChange={setAreRowsExpanded}
+          />
         </Flex>
       </View>
       <div
@@ -745,7 +759,8 @@ export function ExperimentsTable({
           onColumnOrderChange={onVisibleColumnOrderChange}
         >
           <table
-            css={selectableTableCSS}
+            css={expandableSelectableTableCSS}
+            {...rowsExpandedTableProps}
             style={{
               ...columnSizeVars,
               width: table.getTotalSize(),

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -97,8 +97,9 @@ export interface PreferencesProps {
    */
   showMetricsInTraceTree: boolean;
   /**
-   * Whether tracing tables' rows wrap their content or clip it to a single
-   * line. A reading preference, so it spans projects and tabs.
+   * Whether the tracing and experiments tables' rows wrap their content or
+   * clip it to a single line. A reading preference, so it spans datasets,
+   * projects and tabs.
    * @default false
    */
   areTableRowsExpanded: boolean;


### PR DESCRIPTION
The experiments table now offers the same row expand/collapse the tracing tables do, and starts collapsed: every cell clips to one ellipsized line so the rows scan down an even grid, and the toolbar toggle wraps them when a value needs reading where it sits.

### Details

- **Shares the preference.** It reads `areTableRowsExpanded` through `useTableRowsExpanded()` rather than keeping its own — the toggle is a reading preference, so it should mean one thing across datasets, projects and tabs. It already defaults to collapsed.
- **Shares the styles.** `expandableSelectableTableCSS` + the `data-rows` attribute on the `<table>`, with `TABLE_DATA_CELL_CLASS` on each data cell so the collapsed rules can reach them. `<pre>` is handled too, so metadata JSON stays inline.
- **The splits cell** wrapped its tokens onto as many lines as they needed, which was the one cell that grew a row past a single line. It now uses `OverflowRow`, so collapsed it keeps what fits and puts the rest behind a "+N" popover.
- **`RowExpandToggleButton`** sits after the column selector, the same position it takes in `SpansTable`.

Also passes `size="S"` to the avg latency cell's `LatencyText`, which was rendering a size larger than the rest of the table.

### Follow-up left out

The `description` column still uses `TextCell`, which hard-truncates at 100 characters, so expanding a row won't reveal more of it. Changing that would touch every table using `TextCell`.

### Testing

- `tsc --noEmit` clean; oxlint reports only the file's pre-existing warnings; oxfmt clean.
- `vitest run src/pages/experiments` passes.
- Not verified visually against a running server beyond the latency-size fix.