### PR TITLE
feat(charts): reorder selected charts by dragging in the chart menu

### DIFF
--- a/app/src/components/chart/MetricsChartSelector.tsx
+++ b/app/src/components/chart/MetricsChartSelector.tsx
@@ -1,4 +1,7 @@
+import { RestrictToVerticalAxis } from "@dnd-kit/abstract/modifiers";
+import { useSortable } from "@dnd-kit/react/sortable";
 import { css } from "@emotion/react";
+import type { ReactNode, Ref } from "react";
 import { useState } from "react";
 import type { Key, Selection } from "react-aria-components";
 import { MenuSection } from "react-aria-components";
@@ -21,6 +24,11 @@ import {
 } from "@phoenix/components";
 import { CompactEmptyState } from "@phoenix/components/core/empty";
 import { SearchIcon } from "@phoenix/components/core/field";
+import {
+  dndDragFeedbackCSS,
+  dndRowHandleCSS,
+  ReorderProvider,
+} from "@phoenix/components/dnd";
 
 import type { ChartTypeIconType } from "./ChartTypeIcon";
 import { ChartTypeIcon } from "./ChartTypeIcon";
@@ -55,15 +63,38 @@ const chartMenuItemIconCSS = css`
     var(--global-dimension-size-100);
 `;
 
+const chartMenuItemCSS = css`
+  ${dndDragFeedbackCSS}
+  /* Doubled to out-specify the menu item's own hover background, which the
+     dragged copy keeps while the pointer is over it */
+  &&[data-dnd-dragging] {
+    background-color: var(--global-menu-background-color);
+  }
+  .chart-menu-item__handle {
+    ${dndRowHandleCSS}
+  }
+  &[data-hovered] .chart-menu-item__handle,
+  &[data-focused] .chart-menu-item__handle {
+    opacity: 1;
+  }
+`;
+
 function ChartMenuItem<K extends Key>({
   option,
+  ref,
+  trailingContent,
 }: {
   option: ChartSelectorOption<K>;
+  ref?: Ref<HTMLDivElement>;
+  /** Rendered at the end of the row, e.g. a drag handle. */
+  trailingContent?: ReactNode;
 }) {
   return (
     <MenuItem
       id={option.key}
+      ref={ref}
       textValue={`${option.name} ${option.description}`}
+      css={chartMenuItemCSS}
       leadingContent={
         <ChartTypeIcon
           type={option.chartType}
@@ -71,6 +102,7 @@ function ChartMenuItem<K extends Key>({
           css={chartMenuItemIconCSS}
         />
       }
+      trailingContent={trailingContent}
     >
       <div css={chartMenuItemContentCSS}>
         <Text>{option.name}</Text>
@@ -82,9 +114,57 @@ function ChartMenuItem<K extends Key>({
   );
 }
 
+/** Shared so every sortable row passes the same array identity to dnd-kit. */
+const SORTABLE_MODIFIERS = [RestrictToVerticalAxis];
+
 /**
- * A searchable menu to select which charts from a catalog are shown. Allows up
- * to `maxSelected` charts to be selected at once.
+ * A chart row in the "Selected" section, draggable by its handle to change the
+ * order the charts are displayed in.
+ *
+ * The handle is deliberately not focusable: a menu owns its own keyboard
+ * navigation, so nothing inside a menu item can be tabbed to. Reordering is
+ * therefore pointer-only here.
+ */
+function SortableChartMenuItem<K extends Key>({
+  option,
+  index,
+  isReorderingDisabled,
+}: {
+  option: ChartSelectorOption<K>;
+  index: number;
+  isReorderingDisabled: boolean;
+}) {
+  const { ref, handleRef } = useSortable({
+    id: option.key,
+    index,
+    disabled: isReorderingDisabled,
+    modifiers: SORTABLE_MODIFIERS,
+  });
+  return (
+    <ChartMenuItem
+      option={option}
+      ref={ref}
+      trailingContent={
+        isReorderingDisabled ? null : (
+          <span
+            ref={handleRef}
+            className="chart-menu-item__handle"
+            aria-hidden="true"
+            // Keep a press on the handle from also toggling the chart. dnd-kit
+            // listens on the handle itself, so it still sees the event.
+            onPointerDown={(event) => event.stopPropagation()}
+          >
+            <Icon svg={<Icons.DragHandle />} />
+          </span>
+        )
+      }
+    />
+  );
+}
+
+/**
+ * A searchable menu to select which charts from a catalog are shown, and in
+ * what order. Allows up to `maxSelected` charts to be selected at once.
  *
  * Rows do NOT jump between the "Selected" and "Available" sections as they are
  * toggled: the partition is snapshotted when the menu opens (this component
@@ -92,9 +172,14 @@ function ChartMenuItem<K extends Key>({
  * checkmark in place. The next time the menu opens, the sections re-snapshot to
  * reflect the current selection. This mirrors GitHub's label picker.
  *
- * The component is store-agnostic: it renders the `options` it is given, in the
- * order they are given, and reports selection changes up. Wrap it with a
- * connected component to bind it to a particular catalog and selection store.
+ * Charts in the "Selected" section can be dragged by their handle to reorder
+ * them; a chart turned on from "Available" is appended to the end of the
+ * selection. Reordering is disabled while the list is filtered, where the
+ * visible rows are only part of the order.
+ *
+ * The component is store-agnostic: it renders the `options` it is given and
+ * reports selection changes up. Wrap it with a connected component to bind it
+ * to a particular catalog and selection store.
  */
 export function MetricsChartSelector<K extends Key>({
   options,
@@ -102,8 +187,12 @@ export function MetricsChartSelector<K extends Key>({
   onSelectionChange,
   maxSelected = 3,
 }: {
-  /** The charts to choose from, in display order. */
+  /** The charts to choose from, in catalog order. */
   options: readonly ChartSelectorOption<K>[];
+  /**
+   * The selected charts, in the order they are displayed in. Reordering and
+   * newly selected charts are reported back through `onSelectionChange`.
+   */
   selectedKeys: readonly K[];
   onSelectionChange: (keys: K[]) => void;
   /**
@@ -113,18 +202,29 @@ export function MetricsChartSelector<K extends Key>({
   maxSelected?: number;
 }) {
   const { contains } = useFilter({ sensitivity: "base" });
+  // Reordering a filtered list is ambiguous, so it is only enabled while the
+  // full list is shown
+  const [isFiltered, setIsFiltered] = useState(false);
 
   // Freeze which section each chart belongs to at open time so rows stay put
   // while the menu is open. This component remounts on every open (the popover
   // unmounts its content on close), so the snapshot is fresh each time.
-  const [sectionSnapshot] = useState<Set<Key>>(() => new Set(selectedKeys));
+  // Dragging reorders this list; a chart unchecked while the menu is open keeps
+  // its slot in it until the menu is reopened.
+  const [sectionOrder, setSectionOrder] = useState<K[]>(() => {
+    // Drop keys with no option so every row has an index matching this order
+    const optionKeys = new Set<Key>(options.map((option) => option.key));
+    return selectedKeys.filter((key) => optionKeys.has(key));
+  });
+  const sectionKeySet = new Set<Key>(sectionOrder);
 
   const selectedKeySet = new Set<Key>(selectedKeys);
-  const selectedSectionCharts = options.filter((option) =>
-    sectionSnapshot.has(option.key)
-  );
+  const optionsByKey = new Map(options.map((option) => [option.key, option]));
+  const selectedSectionCharts = sectionOrder
+    .map((key) => optionsByKey.get(key))
+    .filter((option) => option != null);
   const availableSectionCharts = options.filter(
-    (option) => !sectionSnapshot.has(option.key)
+    (option) => !sectionKeySet.has(option.key)
   );
 
   const isAtMax = selectedKeys.length >= maxSelected;
@@ -137,59 +237,104 @@ export function MetricsChartSelector<K extends Key>({
         .map((option) => option.key)
     : [];
 
+  /**
+   * The keys to report up for a given selection: the "Selected" section keeps
+   * its own (drag-reorderable) order, charts turned on from "Available" follow
+   * it in the order they were added, and anything newly checked goes last.
+   */
+  const toDisplayOrder = (order: readonly K[], keys: Set<Key>) =>
+    [
+      ...order,
+      ...selectedKeys.filter((key) => !sectionKeySet.has(key)),
+      ...options
+        .map((option) => option.key)
+        .filter((key) => !sectionKeySet.has(key) && !selectedKeySet.has(key)),
+    ]
+      .filter((key) => keys.has(key))
+      .slice(0, maxSelected);
+
   const handleSelectionChange = (selection: Selection) => {
-    // Normalize to catalog order so the charts display in a stable order, and
-    // cap at the selection limit.
-    const orderedKeys = options.map((option) => option.key);
     const nextKeys =
       selection === "all"
-        ? orderedKeys
-        : orderedKeys.filter((key) => selection.has(key));
-    onSelectionChange(nextKeys.slice(0, maxSelected));
+        ? new Set<Key>(options.map((option) => option.key))
+        : selection;
+    onSelectionChange(toDisplayOrder(sectionOrder, nextKeys));
+  };
+
+  const handleOrderCommit = (nextSectionOrder: K[]) => {
+    const nextKeys = toDisplayOrder(nextSectionOrder, selectedKeySet);
+    // A canceled or round-trip drag ends on the order it started with; skip the
+    // update so the selection is not re-persisted for an unchanged order.
+    if (nextKeys.some((key, index) => selectedKeys[index] !== key)) {
+      onSelectionChange(nextKeys);
+    }
   };
 
   const hasSelectedSection = selectedSectionCharts.length > 0;
+  // A single row has no order to change, and a filtered list only shows part
+  // of the order
+  const isReorderingDisabled = selectedSectionCharts.length < 2 || isFiltered;
 
   return (
     <>
-      <Autocomplete filter={contains}>
+      <Autocomplete
+        filter={contains}
+        onInputChange={(value) => setIsFiltered(value.trim() !== "")}
+      >
         <MenuHeader>
           <SearchField aria-label="Search charts" variant="quiet" autoFocus>
             <SearchIcon />
             <Input placeholder="Filter charts" />
           </SearchField>
         </MenuHeader>
-        <Menu
-          aria-label="Metric charts"
-          selectionMode="multiple"
-          selectedKeys={selectedKeySet}
-          disabledKeys={disabledKeys}
-          onSelectionChange={handleSelectionChange}
-          renderEmptyState={() => (
-            <CompactEmptyState
-              icon={<Icon svg={<Icons.BarChart />} />}
-              description="No charts found"
-            />
-          )}
+        {/* The rows preview the new order as the drag goes; the selection is
+            only reported up at drag end so the charts behind the menu are not
+            re-rendered (and re-persisted) on every drag-over step. */}
+        <ReorderProvider
+          order={sectionOrder}
+          onOrderChange={setSectionOrder}
+          onOrderCommit={handleOrderCommit}
         >
-          {hasSelectedSection && (
-            <>
-              <MenuSection>
-                <MenuSectionTitle title="Selected" />
-                {selectedSectionCharts.map((option) => (
-                  <ChartMenuItem key={option.key} option={option} />
-                ))}
-              </MenuSection>
-              <Separator />
-            </>
-          )}
-          <MenuSection>
-            {hasSelectedSection && <MenuSectionTitle title="Available" />}
-            {availableSectionCharts.map((option) => (
-              <ChartMenuItem key={option.key} option={option} />
-            ))}
-          </MenuSection>
-        </Menu>
+          <Menu
+            aria-label="Metric charts"
+            selectionMode="multiple"
+            // The selection is a persisted setting, so Escape should close the
+            // menu rather than clear every chart
+            escapeKeyBehavior="none"
+            selectedKeys={selectedKeySet}
+            disabledKeys={disabledKeys}
+            onSelectionChange={handleSelectionChange}
+            renderEmptyState={() => (
+              <CompactEmptyState
+                icon={<Icon svg={<Icons.BarChart />} />}
+                description="No charts found"
+              />
+            )}
+          >
+            {hasSelectedSection && (
+              <>
+                <MenuSection>
+                  <MenuSectionTitle title="Selected" />
+                  {selectedSectionCharts.map((option, index) => (
+                    <SortableChartMenuItem
+                      key={option.key}
+                      option={option}
+                      index={index}
+                      isReorderingDisabled={isReorderingDisabled}
+                    />
+                  ))}
+                </MenuSection>
+                <Separator />
+              </>
+            )}
+            <MenuSection>
+              {hasSelectedSection && <MenuSectionTitle title="Available" />}
+              {availableSectionCharts.map((option) => (
+                <ChartMenuItem key={option.key} option={option} />
+              ))}
+            </MenuSection>
+          </Menu>
+        </ReorderProvider>
       </Autocomplete>
       <MenuFooter>
         <Flex

--- a/app/src/components/core/menu/Menu.tsx
+++ b/app/src/components/core/menu/Menu.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import type { KeyboardEvent, PropsWithChildren, ReactNode } from "react";
+import type { KeyboardEvent, PropsWithChildren, ReactNode, Ref } from "react";
 import type { PopoverProps } from "react-aria-components";
 import {
   Header,
@@ -9,6 +9,7 @@ import {
   type MenuProps as AriaMenuProps,
   MenuTrigger as AriaMenuTrigger,
 } from "react-aria-components";
+import type { AriaMenuOptions } from "react-aria/useMenu";
 
 import { classNames } from "@phoenix/utils/classNames";
 
@@ -80,11 +81,26 @@ type MenuKeyboardProps = {
   onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void;
 };
 
+/**
+ * Options React Aria Components forwards to `useMenu` but leaves out of its own
+ * prop types. Sourced from `useMenu` so a rename or removal upstream is a build
+ * error here rather than a silent behavior change.
+ */
+type MenuAriaPassthroughProps = {
+  /**
+   * Whether pressing Escape clears the menu's selection. Set to "none" for a
+   * menu whose selection is a persisted setting rather than a transient
+   * filter, so Escape closes the menu instead of wiping the setting.
+   * @default "clearSelection"
+   */
+  escapeKeyBehavior?: AriaMenuOptions<never>["escapeKeyBehavior"];
+};
+
 export const Menu = <T extends object>({
   className,
   onKeyDown,
   ...props
-}: AriaMenuProps<T> & MenuKeyboardProps) => {
+}: AriaMenuProps<T> & MenuKeyboardProps & MenuAriaPassthroughProps) => {
   return (
     <AriaMenu
       className={classNames("react-aria-Menu", className)}
@@ -154,16 +170,20 @@ export const MenuItem = <T extends object>({
   className,
   trailingContent,
   leadingContent,
+  ref,
   ...props
 }: AriaMenuItemProps<T> & {
   trailingContent?: ReactNode;
   leadingContent?: ReactNode;
+  /** The rendered item element, e.g. to make the item a drag-and-drop sortable. */
+  ref?: Ref<HTMLDivElement>;
 }) => {
   const textValue =
     props.textValue ||
     (typeof props.children === "string" ? props.children : undefined);
   return (
     <AriaMenuItem
+      ref={ref}
       {...props}
       css={menuItemCss}
       className={classNames("react-aria-MenuItem", className)}

--- a/app/src/components/dnd/ReorderProvider.tsx
+++ b/app/src/components/dnd/ReorderProvider.tsx
@@ -1,0 +1,80 @@
+import { move } from "@dnd-kit/helpers";
+import { DragDropProvider } from "@dnd-kit/react";
+import type { ComponentProps, ReactNode } from "react";
+import { useRef } from "react";
+
+type Sensors = ComponentProps<typeof DragDropProvider>["sensors"];
+
+export interface ReorderProviderProps<T extends string | number> {
+  /** Ids of the sortable items in current display order. Every sortable inside must appear here with a matching index. */
+  order: T[];
+  /** Called with the new order as it changes during a drag and when a canceled drag restores the original order. */
+  onOrderChange: (order: T[]) => void;
+  /**
+   * Called once with the final order when a drag ends (the restored original
+   * order if the drag was canceled). The committed value is read from the
+   * `order` prop, so intermediate `onOrderChange` updates must be applied back
+   * into it synchronously. Wire expensive consumers here and keep
+   * `onOrderChange` cheap when reorders should not be applied live on every
+   * drag-over step.
+   */
+  onOrderCommit?: (order: T[]) => void;
+  /**
+   * Overrides dnd-kit's default sensors, which start a drag from the sortable's
+   * handle only.
+   */
+  sensors?: Sensors;
+  children: ReactNode;
+}
+
+/**
+ * Drag-and-drop boundary for a list of reorderable items. Pair with any
+ * `useSortable`-based child that takes its index from `order`.
+ */
+export function ReorderProvider<T extends string | number>({
+  order,
+  onOrderChange,
+  onOrderCommit,
+  sensors,
+  children,
+}: ReorderProviderProps<T>) {
+  // The order when the current drag started, restored if the drag is canceled
+  const initialOrderRef = useRef<T[] | null>(null);
+  return (
+    <DragDropProvider
+      sensors={sensors}
+      onDragStart={() => {
+        initialOrderRef.current = order;
+      }}
+      onDragOver={(event) => {
+        // Commit each reorder as the drag previews it so the rest of the UI
+        // moves with the dragged item. Committing state here also makes
+        // dnd-kit's optimistic-sorting plugin defer to React: without a state
+        // update it reorders the elements directly in the DOM, and a drag
+        // released outside every sortable then left the list permanently out of
+        // sync with the state behind it (#14609).
+        const newOrder = move(order, event);
+        if (newOrder === order) {
+          return;
+        }
+        onOrderChange(newOrder);
+      }}
+      onDragEnd={(event) => {
+        const initialOrder = initialOrderRef.current;
+        initialOrderRef.current = null;
+        // The order the user saw was already committed during the drag, so a
+        // completed drag needs no change here (re-applying move() would shift
+        // the item a second time); a canceled drag restores the order from
+        // when the drag started.
+        const finalOrder =
+          event.canceled && initialOrder != null ? initialOrder : order;
+        if (finalOrder !== order) {
+          onOrderChange(finalOrder);
+        }
+        onOrderCommit?.(finalOrder);
+      }}
+    >
+      {children}
+    </DragDropProvider>
+  );
+}

--- a/app/src/components/dnd/index.ts
+++ b/app/src/components/dnd/index.ts
@@ -1,2 +1,3 @@
 export * from "./DragHandle";
+export * from "./ReorderProvider";
 export * from "./styles";

--- a/app/src/components/dnd/styles.ts
+++ b/app/src/components/dnd/styles.ts
@@ -24,7 +24,8 @@ export const dndDragFeedbackCSS = css`
  * Appearance for a hover-revealed drag handle button: hidden until the
  * containing row/header is hovered (via a sibling `&:hover .{className}`
  * rule each consumer adds) or the handle itself is focused. Compose into a
- * handle's own layout CSS (size, position).
+ * handle's own layout CSS (size, position); for a plain list row prefer
+ * {@link dndRowHandleCSS}, which already applies this.
  */
 export const dndHandleAppearanceCSS = css`
   ${revealOnHoverCSS}
@@ -48,4 +49,21 @@ export const dndHandleAppearanceCSS = css`
     outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
     outline-offset: calc(-1 * var(--focus-ring-thickness));
   }
+`;
+
+/**
+ * A hover-revealed drag handle sized to sit at the end of a list row:
+ * {@link dndHandleAppearanceCSS} in a centered square box. Compose into the
+ * handle's own rule, and pair with a `&:hover .{className} { opacity: 1 }`
+ * rule on the row so hovering the row reveals it.
+ */
+export const dndRowHandleCSS = css`
+  ${dndHandleAppearanceCSS}
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: var(--global-dimension-size-225);
+  height: var(--global-dimension-size-225);
+  font-size: var(--global-font-size-m);
 `;

--- a/app/src/components/table/columnOrdering/ColumnOrderingProvider.tsx
+++ b/app/src/components/table/columnOrdering/ColumnOrderingProvider.tsx
@@ -1,11 +1,7 @@
-import { move } from "@dnd-kit/helpers";
-import {
-  DragDropProvider,
-  KeyboardSensor,
-  PointerSensor,
-} from "@dnd-kit/react";
-import { useRef } from "react";
+import { KeyboardSensor, PointerSensor } from "@dnd-kit/react";
 import type { ReactNode } from "react";
+
+import { ReorderProvider } from "@phoenix/components/dnd";
 
 /**
  * Elements inside a sortable header that own their own pointer interactions
@@ -45,19 +41,16 @@ const sensors = [
   KeyboardSensor,
 ];
 
+/**
+ * The column-flavored names for `ReorderProviderProps` (in
+ * `components/dnd/ReorderProvider`), which documents what each one does.
+ */
 export interface ColumnOrderingProviderProps {
-  /** Ids of sortable columns in current display order. Every sortable inside must appear here with a matching index. */
+  /** Maps to `order`. */
   columnOrder: string[];
-  /** Called with the new order as it changes during a drag and when a canceled drag restores the original order. */
+  /** Maps to `onOrderChange`. */
   onColumnOrderChange: (columnOrder: string[]) => void;
-  /**
-   * Called once with the final order when a drag ends (the restored original
-   * order if the drag was canceled). The committed value is read from the
-   * `columnOrder` prop, so intermediate `onColumnOrderChange` updates must be
-   * applied back into it synchronously. Wire expensive consumers (e.g. a
-   * table re-render) here and keep `onColumnOrderChange` cheap when reorders
-   * should not be applied live on every drag-over step.
-   */
+  /** Maps to `onOrderCommit`. */
   onColumnOrderCommit?: (columnOrder: string[]) => void;
   children: ReactNode;
 }
@@ -72,45 +65,14 @@ export function ColumnOrderingProvider({
   onColumnOrderCommit,
   children,
 }: ColumnOrderingProviderProps) {
-  // The order when the current drag started, restored if the drag is canceled
-  const initialColumnOrderRef = useRef<string[] | null>(null);
   return (
-    <DragDropProvider
+    <ReorderProvider
+      order={columnOrder}
+      onOrderChange={onColumnOrderChange}
+      onOrderCommit={onColumnOrderCommit}
       sensors={sensors}
-      onDragStart={() => {
-        initialColumnOrderRef.current = columnOrder;
-      }}
-      onDragOver={(event) => {
-        // Commit each reorder as the drag previews it so the column bodies
-        // move with the headers. Committing state here also makes dnd-kit's
-        // optimistic-sorting plugin defer to React: without a state update it
-        // reorders the header cells directly in the DOM, and a drag released
-        // outside every header (e.g. past the far left of the table) then
-        // left the headers permanently out of sync with the cells (#14609).
-        const newColumnOrder = move(columnOrder, event);
-        if (newColumnOrder === columnOrder) {
-          return;
-        }
-        onColumnOrderChange(newColumnOrder);
-      }}
-      onDragEnd={(event) => {
-        const initialColumnOrder = initialColumnOrderRef.current;
-        initialColumnOrderRef.current = null;
-        // The order the user saw was already committed during the drag, so a
-        // completed drag needs no change here (re-applying move() would shift
-        // the column a second time); a canceled drag restores the order from
-        // when the drag started.
-        const finalColumnOrder =
-          event.canceled && initialColumnOrder != null
-            ? initialColumnOrder
-            : columnOrder;
-        if (finalColumnOrder !== columnOrder) {
-          onColumnOrderChange(finalColumnOrder);
-        }
-        onColumnOrderCommit?.(finalColumnOrder);
-      }}
     >
       {children}
-    </DragDropProvider>
+    </ReorderProvider>
   );
 }

--- a/app/src/components/table/columnSelector/ColumnSelector.tsx
+++ b/app/src/components/table/columnSelector/ColumnSelector.tsx
@@ -14,10 +14,7 @@ import {
   MenuHeader,
   Popover,
 } from "@phoenix/components";
-import {
-  dndDragFeedbackCSS,
-  dndHandleAppearanceCSS,
-} from "@phoenix/components/dnd";
+import { dndDragFeedbackCSS, dndRowHandleCSS } from "@phoenix/components/dnd";
 
 import { ColumnOrderingProvider, orderColumns } from "../columnOrdering";
 
@@ -90,14 +87,7 @@ export const columnRowCSS = css`
     min-width: 0;
   }
   .column-selector-row__handle {
-    ${dndHandleAppearanceCSS}
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex: none;
-    width: var(--global-dimension-size-225);
-    height: var(--global-dimension-size-225);
-    font-size: var(--global-font-size-m);
+    ${dndRowHandleCSS}
   }
   &:hover {
     background-color: var(--global-color-gray-200);

--- a/app/stories/MetricsChartSelector.stories.tsx
+++ b/app/stories/MetricsChartSelector.stories.tsx
@@ -26,6 +26,10 @@ import { PROJECT_METRIC_CHARTS } from "@phoenix/pages/project/metrics/chartCatal
  * menu opens and only re-snapshots the next time it is opened — GitHub's label
  * picker behavior. Each row carries a small preview glyph of the chart's shape
  * (vertical bars, a ranked horizontal chart, or a line).
+ *
+ * Rows in the "Selected" section can be dragged by the handle that appears on
+ * hover to change the order the charts are displayed in. Charts turned on from
+ * "Available" are appended to the end of that order.
  */
 const meta: Meta<typeof MetricsChartSelector> = {
   title: "Chart/MetricsChartSelector",
@@ -74,7 +78,9 @@ function InteractiveSelector({
 /**
  * Opens with a couple of charts already selected. Note the frozen "Selected"
  * section — unchecking a selected chart keeps it in place rather than dropping
- * it to "Available".
+ * it to "Available". With more than one chart selected, the rows can be
+ * dragged by their handles to reorder them; the order is reported up as the
+ * drag previews it.
  */
 export const Default: Story = {
   render: () => <InteractiveSelector initialKeys={["traces", "latency"]} />,


### PR DESCRIPTION
resolves #14793

Charts in the **Selected** section of the chart picker can now be dragged by a handle to set the order they appear in above the table.

### Behavior

- Rows in **Selected** get a hover-revealed drag handle; dragging previews the new order in the menu and commits it once on drop, so the chart strip isn't re-rendered and re-persisted on every drag-over step.
- A chart turned on from **Available** is appended to the end of the order (previously the selection was always re-normalized to catalog order, so order wasn't expressible at all).
- Reordering is disabled while the list is filtered — the visible rows are only part of the order — and when only one chart is selected.
- The experiments chart selector shares the component, so it picks this up too.

### Implementation

- `components/dnd/ReorderProvider.tsx` (new) — the drag lifecycle previously inside `ColumnOrderingProvider` (commit on drag over per #14609, restore on cancel, optional `onOrderCommit`) extracted generic, with an optional `sensors` override. `ColumnOrderingProvider` is now a thin wrapper supplying the table-header sensors, so there's one implementation of the tricky part.
- `dndRowHandleCSS` moved into `components/dnd/styles.ts` — the chart menu and `ColumnSelector` compose it instead of each repeating the handle box.
- `MenuItem` accepts a `ref` so a sortable can attach to it.

### Escape no longer clears the selection

React Aria's default `escapeKeyBehavior` treats a menu selection as a transient filter, so pressing Escape wiped the persisted chart selection instead of closing the menu. Confirmed pre-existing on `main`, but it now destroys the order too, so this sets `escapeKeyBehavior="none"` on this menu. Happy to split it out if you'd rather.

### Known gap

Reordering is pointer-only. Nothing inside a `role="menuitem"` is tabbable, so a `<button>` handle would add an ARIA violation without buying keyboard reordering; the handle is a non-focusable span.

The issue also asks to rearrange from the top strip directly — not included here.

### Testing

Verified against a running server: drag reorders the strip and persists across reload; repeated drags in one session, after Escape-close, and after outside-click dismiss all work; toggling rows and clicking the handle don't interfere; filtering hides the handles. Table column drag and the Columns popover (the refactored provider's other consumers) still reorder correctly. Typecheck, lint, and the full unit suite pass.
