### PR TITLE
feat(cli): add /compact to the pxi chat with busy-session rejection

### DIFF
--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -765,6 +765,15 @@ export function useAgentChat({
       });
       return;
     }
+    if (store.getState().isBusyElsewhereBySessionId[sessionId]) {
+      restorePendingMessage();
+      setOperationError({
+        title: "Conversation could not be compacted",
+        message:
+          "Session is being used elsewhere. Try again when the other turn completes.",
+      });
+      return;
+    }
 
     store.getState().setSessionCompactionPending(sessionId, true);
     void (async () => {
@@ -777,7 +786,22 @@ export function useAgentChat({
           }),
         });
         if (!response.ok) {
-          throw new Error(await getAgentCompactErrorMessage(response));
+          const errorBody: unknown = await response.json().catch(() => null);
+          if (
+            response.status === 409 &&
+            isRecord(errorBody) &&
+            errorBody.code === SESSION_BUSY_ERROR_CODE
+          ) {
+            // Another client's turn holds the session lock: enter
+            // busy-elsewhere mode (the poll swaps in the fresh transcript
+            // when the turn completes) instead of raising a red error.
+            restorePendingMessage();
+            store.getState().setSessionBusyElsewhere(sessionId, true);
+            return;
+          }
+          throw new Error(
+            getAgentCompactErrorMessage(errorBody, response.status)
+          );
         }
         const result: unknown = await response.json();
         const data =
@@ -1106,18 +1130,11 @@ function isRequestActive(status: ChatStatus): boolean {
   return status === "submitted" || status === "streaming";
 }
 
-async function getAgentCompactErrorMessage(
-  response: Response
-): Promise<string> {
-  try {
-    const body: unknown = await response.json();
-    if (isRecord(body) && typeof body.detail === "string") {
-      return body.detail;
-    }
-  } catch {
-    // Fall back to the HTTP status when the response is not JSON.
+function getAgentCompactErrorMessage(body: unknown, status: number): string {
+  if (isRecord(body) && typeof body.detail === "string") {
+    return body.detail;
   }
-  return `Compaction failed with status ${response.status}.`;
+  return `Compaction failed with status ${status}.`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/docs/phoenix/pxi.mdx
+++ b/docs/phoenix/pxi.mdx
@@ -130,8 +130,19 @@ client and never sent to the model.
 | Command | Effect |
 | --- | --- |
 | `/help` | List the available slash commands. |
-| `/clear` | Clear the conversation history and start a fresh session. |
+| `/clear` | Clear the conversation history and start a fresh session (alias for `/new`). |
+| `/new` | Start a new persisted session. |
+| `/temporary` | Start a new temporary session. |
+| `/sessions` | Browse and restore persisted sessions. |
+| `/model` | Switch models for this session. |
+| `/compact` | Compact older conversation context into a checkpoint summary. Text after the command (e.g. `/compact keep going`) is sent as a follow-up message once compaction finishes. |
 | `/exit` | Exit the terminal client. |
+
+`/compact` asks the model to summarize every completed turn into a durable
+checkpoint; later turns load history from the checkpoint onward, freeing
+context for long-running sessions. Compaction is rejected while the session is
+in use elsewhere (for example, a turn streaming in the browser) — the chat
+shows the busy indicator and refreshes when the other turn completes.
 
 ## Status line
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -127,7 +127,8 @@ pxi --endpoint http://localhost:6006 --provider OPENAI --model gpt-5.4
 npx -y @arizeai/phoenix-cli pxi                              # run without installing
 ```
 
-Inside the chat, `/help`, `/clear`, and `/exit` are handled locally. See the
+Inside the chat, slash commands (`/help`, `/clear`, `/new`, `/temporary`,
+`/sessions`, `/model`, `/compact`, `/exit`) are handled locally. See the
 [PXI documentation](https://arize.com/docs/phoenix/pxi) for the full flag and
 slash-command reference, model setup, and privacy controls.
 

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -15,6 +15,7 @@ import {
   runSlashCommand,
   SLASH_COMMANDS,
 } from "./commands";
+import { getCompactionSummary, isCompactionMessage } from "./compaction";
 import {
   deleteDraftTextAtCursor,
   deleteDraftTextBeforeCursor,
@@ -118,6 +119,14 @@ const SESSION_BUSY_STATUS_TEXT =
   "Session is being used elsewhere, the chat will refresh when complete";
 const SESSION_STALE_STATUS_TEXT =
   "Session was updated elsewhere, the chat has been refreshed";
+const COMPACTING_STATUS_TEXT = "Compacting conversation";
+const ALREADY_COMPACT_STATUS_TEXT =
+  "Conversation is already compact. There are no older complete turns to compact.";
+const COMPACT_WHILE_BUSY_ERROR_TEXT =
+  "Session is being used elsewhere. Try again when the other turn completes.";
+const COMPACT_DRAFT_SESSION_ERROR_TEXT =
+  "There is no persisted conversation to compact.";
+const COMPACTION_DIVIDER_TEXT = "── Conversation compacted ──";
 
 export type PxiAppProps = {
   options: PxiRuntimeOptions;
@@ -358,6 +367,18 @@ function Transcript({
   return (
     <Box flexDirection="column">
       {messages.map((message) => {
+        if (isCompactionMessage({ message })) {
+          // A compaction checkpoint is a persisted summary, not something the
+          // user typed: render it as a labeled divider with the summary dimmed.
+          return (
+            <Box key={message.id} flexDirection="column" marginBottom={1}>
+              <Text color="yellow" bold>
+                {COMPACTION_DIVIDER_TEXT}
+              </Text>
+              <Text dimColor>{getCompactionSummary({ message })}</Text>
+            </Box>
+          );
+        }
         const label = message.role === "user" ? "You" : "PXI";
         const color = message.role === "user" ? "cyan" : "green";
         return (
@@ -819,10 +840,10 @@ export function ThinkingIndicator() {
 }
 
 /**
- * Spinner and status line shown while another client's turn holds the
- * session's server-side lock.
+ * Spinner and status line for long-running session states — another client's
+ * turn holding the server-side lock, or an in-flight compaction.
  */
-function SessionBusyIndicator() {
+function StatusSpinnerLine({ text }: { text: string }) {
   const [frameIndex, setFrameIndex] = useState(0);
 
   useEffect(() => {
@@ -834,7 +855,7 @@ function SessionBusyIndicator() {
 
   return (
     <Text color="yellow">
-      {TOOL_SPINNER_FRAMES[frameIndex]} {SESSION_BUSY_STATUS_TEXT}
+      {TOOL_SPINNER_FRAMES[frameIndex]} {text}
     </Text>
   );
 }
@@ -878,6 +899,10 @@ export function PxiApp({
   // A send was rejected as stale (another client appended to the session) and
   // the transcript was refreshed in place; shown until the next send.
   const [showStaleRefreshNotice, setShowStaleRefreshNotice] = useState(false);
+  // A compaction request is in flight; plain sends are blocked while set.
+  const [isCompacting, setIsCompacting] = useState(false);
+  // One-shot notice after a no-op compaction; shown until the next send.
+  const [compactionNotice, setCompactionNotice] = useState<string | null>(null);
   const [activeSession, setActiveSession] = useState<PxiSessionSummary | null>(
     null
   );
@@ -965,6 +990,7 @@ export function PxiApp({
     setIsDraftTemporary(temporary);
     setIsSessionBusy(false);
     setShowStaleRefreshNotice(false);
+    setCompactionNotice(null);
     setModelPicker(null);
     setSessionPicker(null);
     setMessages([]);
@@ -1103,6 +1129,7 @@ export function PxiApp({
         // completes.
         setIsSessionBusy(session.isActive === true);
         setShowStaleRefreshNotice(false);
+        setCompactionNotice(null);
         setMessages(session.messages);
         setError(null);
         setDraft(EMPTY_DRAFT_EDITOR_STATE);
@@ -1125,6 +1152,85 @@ export function PxiApp({
       });
   };
 
+  /**
+   * Compact the persisted conversation into a checkpoint summary. Mirrors the
+   * web UI's `/compact`: rejected while the session is busy elsewhere, shows a
+   * one-shot notice when there is nothing to compact, and sends `pendingText`
+   * as a follow-up message once the compaction lands.
+   */
+  const compactSession = (pendingText?: string) => {
+    setCompactionNotice(null);
+    const restorePendingText = () => {
+      if (pendingText) {
+        setDraft((currentDraft) =>
+          currentDraft.value
+            ? currentDraft
+            : { value: pendingText, cursorIndex: pendingText.length }
+        );
+      }
+    };
+    if (!activeSession) {
+      restorePendingText();
+      setError(COMPACT_DRAFT_SESSION_ERROR_TEXT);
+      return;
+    }
+    if (isCompacting) {
+      restorePendingText();
+      return;
+    }
+    if (isSessionBusy) {
+      restorePendingText();
+      setError(COMPACT_WHILE_BUSY_ERROR_TEXT);
+      return;
+    }
+    const compactionSessionId = activeSession.id;
+    // A session switch (/new, restore) mid-compaction supersedes this request.
+    const requestId = sessionRequestIdRef.current;
+    const baseMessages = messages;
+    setError(null);
+    setIsCompacting(true);
+    void serverSessionClient
+      .compactSession({
+        sessionId: compactionSessionId,
+        model: activeModelSelection,
+      })
+      .then((result) => {
+        if (sessionRequestIdRef.current !== requestId) return;
+        const checkpoint = result.compactionMessage;
+        const nextMessages =
+          checkpoint &&
+          !baseMessages.some((message) => message.id === checkpoint.id)
+            ? [...baseMessages, checkpoint]
+            : baseMessages;
+        setMessages(nextMessages);
+        if (!result.compacted) {
+          setCompactionNotice(ALREADY_COMPACT_STATUS_TEXT);
+        }
+        if (pendingText) {
+          sendUserText({ text: pendingText, baseMessages: nextMessages });
+        }
+      })
+      .catch((compactError: unknown) => {
+        if (sessionRequestIdRef.current !== requestId) return;
+        restorePendingText();
+        if (isSessionBusyError({ error: compactError })) {
+          // Another client's turn holds the session lock (HTTP 409): enter
+          // the busy state; the poll refreshes the transcript once the other
+          // turn completes.
+          setIsSessionBusy(true);
+          return;
+        }
+        setError(
+          compactError instanceof Error
+            ? compactError.message
+            : String(compactError)
+        );
+      })
+      .finally(() => {
+        setIsCompacting(false);
+      });
+  };
+
   const submitDraft = () => {
     const text = draft.value.trim();
     if (!text || status === "streaming") {
@@ -1138,6 +1244,7 @@ export function PxiApp({
         startNewSession,
         openModelPicker,
         openSessionPicker,
+        compactSession,
         exit: handleExit,
       });
       if (result.type === "help") {
@@ -1166,19 +1273,32 @@ export function PxiApp({
     }
 
     // Plain sends are blocked while another client's turn holds the session
-    // lock; keep the draft editable so nothing typed is lost.
-    if (isSessionBusy) {
+    // lock or a compaction is in flight; keep the draft editable so nothing
+    // typed is lost.
+    if (isSessionBusy || isCompacting) {
       return;
     }
 
+    setDraft(EMPTY_DRAFT_EDITOR_STATE);
+    sendUserText({ text, baseMessages: messages });
+  };
+
+  /** Append a user message to `baseMessages` and stream the reply. */
+  const sendUserText = ({
+    text,
+    baseMessages,
+  }: {
+    text: string;
+    baseMessages: PxiMessage[];
+  }) => {
     const userMessage = createUserMessage({ text });
-    const nextMessages = [...messages, userMessage];
+    const nextMessages = [...baseMessages, userMessage];
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
     streamingAssistantMessageRef.current = null;
-    setDraft(EMPTY_DRAFT_EDITOR_STATE);
     setError(null);
     setShowStaleRefreshNotice(false);
+    setCompactionNotice(null);
     setStatus("streaming");
     setMessages(nextMessages);
     void (async () => {
@@ -1608,8 +1728,12 @@ export function PxiApp({
       ) : null}
       {status === "streaming" ? (
         <ThinkingIndicator />
+      ) : isCompacting ? (
+        <StatusSpinnerLine text={COMPACTING_STATUS_TEXT} />
       ) : isSessionBusy ? (
-        <SessionBusyIndicator />
+        <StatusSpinnerLine text={SESSION_BUSY_STATUS_TEXT} />
+      ) : compactionNotice ? (
+        <Text color="yellow">{compactionNotice}</Text>
       ) : showStaleRefreshNotice ? (
         <Text color="yellow">{SESSION_STALE_STATUS_TEXT}</Text>
       ) : null}

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -220,7 +220,68 @@ export function createPxiSessionClient({
         messages: session.messages as PxiMessage[],
       };
     },
+    async compactSession({ sessionId, model }) {
+      const client = createPhoenixClient({ config, fetch: fetchImpl });
+      try {
+        const { data: payload } = await client.POST(
+          "/agents/{agent_id}/sessions/{session_id}/compact",
+          {
+            params: {
+              path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
+            },
+            body: { model },
+          }
+        );
+        if (!payload) {
+          throw new Error(
+            "Could not compact the PXI session because Phoenix returned no data."
+          );
+        }
+        return {
+          compacted: payload.data.compacted,
+          compactionMessage: (payload.data.compaction_message ??
+            null) as PxiMessage | null,
+        };
+      } catch (error) {
+        if (error instanceof HttpError) {
+          throw await buildCompactionHttpError({ error });
+        }
+        throw error;
+      }
+    },
   };
+}
+
+/**
+ * Translate a compaction HTTP failure into a printable error. A 409 whose body
+ * carries the session-busy code is rethrown with that code in the message so
+ * {@link isSessionBusyError} recognizes it and the UI can enter its busy state.
+ */
+async function buildCompactionHttpError({
+  error,
+}: {
+  error: HttpError;
+}): Promise<Error> {
+  let code: string | null = null;
+  let detail: string | null = null;
+  try {
+    const body: unknown = await error.response.clone().json();
+    if (body !== null && typeof body === "object") {
+      const record = body as { code?: unknown };
+      if (typeof record.code === "string") {
+        code = record.code;
+      }
+    }
+    detail = formatApiError(body);
+  } catch {
+    // Not JSON: fall through to the status-line message.
+  }
+  if (code === SESSION_BUSY_ERROR_CODE) {
+    return new Error(SESSION_BUSY_ERROR_CODE);
+  }
+  return new Error(
+    `Could not compact the conversation: HTTP ${error.status} ${error.statusText}.${detail ? ` ${detail}` : ""}`
+  );
 }
 
 /**

--- a/js/packages/phoenix-cli/src/pxi/commands.ts
+++ b/js/packages/phoenix-cli/src/pxi/commands.ts
@@ -9,6 +9,11 @@ export type CommandContext = {
   startNewSession: (options: { temporary: boolean }) => void;
   openModelPicker: () => void;
   openSessionPicker: () => void;
+  /**
+   * Compact older conversation context into a checkpoint summary. Any text
+   * after the command is sent as a follow-up message once compaction finishes.
+   */
+  compactSession: (pendingText?: string) => void;
   exit: () => void;
 };
 
@@ -24,6 +29,11 @@ export const SLASH_COMMANDS: PxiCommand[] = [
     name: "clear",
     description: "Start a new persisted session (alias for /new)",
     handler: (_args, ctx) => ctx.startNewSession({ temporary: false }),
+  },
+  {
+    name: "compact",
+    description: "Compact older conversation context",
+    handler: (args, ctx) => ctx.compactSession(args || undefined),
   },
   {
     name: "model",

--- a/js/packages/phoenix-cli/src/pxi/compaction.ts
+++ b/js/packages/phoenix-cli/src/pxi/compaction.ts
@@ -1,0 +1,37 @@
+import type { PxiMessage } from "./types";
+
+/**
+ * Compaction checkpoints in the PXI transcript.
+ *
+ * Compacting a session persists a checkpoint message that summarizes every
+ * prior turn; the server then loads model history from the latest checkpoint
+ * onward. On the wire a checkpoint is an ordinary user-role message flagged by
+ * `metadata.isCompactionMessage`, so the transcript renders it distinctly
+ * rather than as something the user typed.
+ */
+
+/** Whether a transcript message is a compaction checkpoint. */
+export function isCompactionMessage({
+  message,
+}: {
+  message: PxiMessage;
+}): boolean {
+  // Read defensively: PxiMessage types metadata for assistant messages, so a
+  // user-role checkpoint's metadata arrives untyped.
+  const metadata = message.metadata as
+    | { isCompactionMessage?: unknown }
+    | undefined;
+  return message.role === "user" && metadata?.isCompactionMessage === true;
+}
+
+/** The checkpoint's summary text — the concatenated text parts. */
+export function getCompactionSummary({
+  message,
+}: {
+  message: PxiMessage;
+}): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}

--- a/js/packages/phoenix-cli/src/pxi/types.ts
+++ b/js/packages/phoenix-cli/src/pxi/types.ts
@@ -117,11 +117,25 @@ export type PxiSession = PxiSessionSummary & {
   isActive?: boolean;
 };
 
+/**
+ * The outcome of a compaction request. `compacted` is false when the
+ * conversation had no older complete turns to compact; `compactionMessage` is
+ * the persisted checkpoint (the fresh one, or the existing one for a no-op).
+ */
+export type PxiCompactionResult = {
+  compacted: boolean;
+  compactionMessage: PxiMessage | null;
+};
+
 /** Server-side session operations used by the chat UI. */
 export type PxiSessionClient = {
   createSession: (options: { temporary: boolean }) => Promise<PxiSession>;
   listSessions: () => Promise<PxiSessionSummary[]>;
   getSession: (options: { sessionId: string }) => Promise<PxiSession>;
+  compactSession: (options: {
+    sessionId: string;
+    model: ModelSelection;
+  }) => Promise<PxiCompactionResult>;
 };
 
 /**

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -1091,6 +1091,9 @@ describe("PXI app", () => {
       getSession: async () => {
         throw new Error("not used");
       },
+      compactSession: async () => {
+        throw new Error("not used");
+      },
     };
     const client: PxiChatClient = { sendMessage: async () => null };
     const { lastFrame, stdin, unmount } = render(
@@ -1124,6 +1127,9 @@ describe("PXI app", () => {
       }),
       listSessions: async () => [],
       getSession: async () => {
+        throw new Error("not used");
+      },
+      compactSession: async () => {
         throw new Error("not used");
       },
     };
@@ -1182,6 +1188,9 @@ describe("PXI app", () => {
         },
       ],
       getSession,
+      compactSession: async () => {
+        throw new Error("not used");
+      },
     };
     const client: PxiChatClient = { sendMessage: async () => null };
     const { lastFrame, stdin, unmount } = render(
@@ -1224,6 +1233,9 @@ describe("PXI app", () => {
       }),
       listSessions: async () => [],
       getSession: async () => {
+        throw new Error("not used");
+      },
+      compactSession: async () => {
         throw new Error("not used");
       },
     };
@@ -1398,6 +1410,246 @@ describe("PXI app", () => {
     expect(frame).toContain("data retention");
     expect(frame).toContain("https://example.com/phoenix/settings/data");
     expect(frame).not.toContain("](/settings/data)");
+    unmount();
+  });
+});
+
+describe("PXI /compact command", () => {
+  const persistedTranscript: PxiMessage[] = [
+    {
+      id: "user-1",
+      role: "user",
+      parts: [{ type: "text", text: "first question" }],
+    },
+    {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "first answer" }],
+    },
+  ];
+  const checkpointMessage: PxiMessage = {
+    id: "checkpoint-1",
+    role: "user",
+    metadata: {
+      isCompactionMessage: true,
+    } as unknown as PxiMessage["metadata"],
+    parts: [{ type: "text", text: "Summary of the conversation so far." }],
+  };
+
+  function createSessionClientWithPersistedSession({
+    compactSession,
+    isTurnActive = false,
+  }: {
+    compactSession: PxiSessionClient["compactSession"];
+    isTurnActive?: boolean;
+  }): PxiSessionClient {
+    return {
+      createSession: async () => {
+        throw new Error("not used");
+      },
+      listSessions: async () => [
+        {
+          id: "session-1",
+          title: "First session",
+          updatedAt: "2026-07-24T12:00:00Z",
+          isTemporary: false,
+        },
+      ],
+      getSession: async ({ sessionId }: { sessionId: string }) => ({
+        id: sessionId,
+        title: "First session",
+        updatedAt: "2026-07-24T12:00:00Z",
+        isTemporary: false,
+        isTurnActive,
+        messages: persistedTranscript,
+      }),
+      compactSession,
+    };
+  }
+
+  /** Activate the persisted session through the session picker. */
+  async function restoreFirstSession({
+    stdin,
+  }: {
+    stdin: { write: (input: string) => unknown };
+  }) {
+    await writeInput({ stdin, input: "/sessions" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+  }
+
+  it("compacts the session and renders the checkpoint divider", async () => {
+    const compactSession = vi.fn(async () => ({
+      compacted: true,
+      compactionMessage: checkpointMessage,
+    }));
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        sessionClient={createSessionClientWithPersistedSession({
+          compactSession,
+        })}
+      />
+    );
+    await restoreFirstSession({ stdin });
+
+    await writeInput({ stdin, input: "/compact" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+
+    expect(compactSession).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      model: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-5.4",
+      },
+    });
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain("Conversation compacted");
+    expect(frame).toContain("Summary of the conversation so far.");
+    unmount();
+  });
+
+  it("shows a notice when there is nothing to compact", async () => {
+    const compactSession = vi.fn(async () => ({
+      compacted: false,
+      compactionMessage: null,
+    }));
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        sessionClient={createSessionClientWithPersistedSession({
+          compactSession,
+        })}
+      />
+    );
+    await restoreFirstSession({ stdin });
+
+    await writeInput({ stdin, input: "/compact" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+
+    expect(stripAnsi(lastFrame() ?? "")).toContain(
+      "Conversation is already compact"
+    );
+    unmount();
+  });
+
+  it("rejects /compact before any conversation is persisted", async () => {
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp options={createOptions()} client={client} />
+    );
+
+    await writeInput({ stdin, input: "/compact" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(stripAnsi(lastFrame() ?? "")).toContain(
+      "There is no persisted conversation to compact."
+    );
+    unmount();
+  });
+
+  it("enters the busy state when the server rejects compaction as busy", async () => {
+    const compactSession = vi.fn(async () => {
+      throw new Error("agent_session_busy");
+    });
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        sessionClient={createSessionClientWithPersistedSession({
+          compactSession,
+        })}
+      />
+    );
+    await restoreFirstSession({ stdin });
+
+    await writeInput({ stdin, input: "/compact" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+
+    const frame = stripAnsi(lastFrame() ?? "");
+    expect(frame).toContain(
+      "Session is being used elsewhere, the chat will refresh when complete"
+    );
+    expect(frame).not.toContain("Error:");
+    unmount();
+  });
+
+  it("rejects /compact while the session is busy elsewhere", async () => {
+    const compactSession = vi.fn(async () => {
+      throw new Error("not used");
+    });
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        sessionClient={createSessionClientWithPersistedSession({
+          compactSession,
+          isTurnActive: true,
+        })}
+      />
+    );
+    await restoreFirstSession({ stdin });
+
+    await writeInput({ stdin, input: "/compact" });
+    await writeInput({ stdin, input: "\r" });
+
+    expect(compactSession).not.toHaveBeenCalled();
+    expect(stripAnsi(lastFrame() ?? "")).toContain(
+      "Try again when the other turn completes."
+    );
+    unmount();
+  });
+
+  it("sends trailing /compact text as a follow-up after the checkpoint", async () => {
+    const compactSession = vi.fn(async () => ({
+      compacted: true,
+      compactionMessage: checkpointMessage,
+    }));
+    let capturedMessages: PxiMessage[] = [];
+    const client: PxiChatClient = {
+      sendMessage: async ({ messages }) => {
+        capturedMessages = messages;
+        return null;
+      },
+    };
+    const { stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        sessionClient={createSessionClientWithPersistedSession({
+          compactSession,
+        })}
+      />
+    );
+    await restoreFirstSession({ stdin });
+
+    await writeInput({ stdin, input: "/compact continue from here" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    await act(async () => Promise.resolve());
+
+    expect(capturedMessages.map((message) => message.id).slice(0, 3)).toEqual([
+      "user-1",
+      "assistant-1",
+      "checkpoint-1",
+    ]);
+    const followUp = capturedMessages.at(-1);
+    expect(followUp?.role).toBe("user");
+    expect(followUp?.parts.find((part) => part.type === "text")?.text).toBe(
+      "continue from here"
+    );
     unmount();
   });
 });

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -1438,10 +1438,10 @@ describe("PXI /compact command", () => {
 
   function createSessionClientWithPersistedSession({
     compactSession,
-    isTurnActive = false,
+    isActive = false,
   }: {
     compactSession: PxiSessionClient["compactSession"];
-    isTurnActive?: boolean;
+    isActive?: boolean;
   }): PxiSessionClient {
     return {
       createSession: async () => {
@@ -1460,7 +1460,7 @@ describe("PXI /compact command", () => {
         title: "First session",
         updatedAt: "2026-07-24T12:00:00Z",
         isTemporary: false,
-        isTurnActive,
+        isActive,
         messages: persistedTranscript,
       }),
       compactSession,
@@ -1596,7 +1596,7 @@ describe("PXI /compact command", () => {
         client={client}
         sessionClient={createSessionClientWithPersistedSession({
           compactSession,
-          isTurnActive: true,
+          isActive: true,
         })}
       />
     );

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -7,6 +7,7 @@ import {
   buildPxiHeaders,
   createPxiChatClient,
   createPxiSessionClient,
+  isSessionBusyError,
 } from "../src/pxi/client";
 import { resolvePxiRuntimeOptions } from "../src/pxi/options";
 import type { PxiMessage, PxiTransport } from "../src/pxi/types";
@@ -282,6 +283,108 @@ describe("PXI client", () => {
         parts: [{ type: "text", text: "What failed?" }],
       },
     ]);
+  });
+
+  it("compacts a session on the server-agent compact route", async () => {
+    const checkpoint = {
+      id: "checkpoint-1",
+      role: "user",
+      metadata: { type: "user", isCompactionMessage: true },
+      parts: [{ type: "text", text: "Summary of the conversation so far." }],
+    };
+    const fetchImpl = vi.fn(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        const request =
+          _input instanceof Request ? _input : new Request(_input, init);
+        expect(request.url).toBe(
+          "http://localhost:6006/agents/server/sessions/session-1/compact"
+        );
+        expect(request.method).toBe("POST");
+        expect(await request.json()).toEqual({
+          model: {
+            providerType: "builtin",
+            provider: "OPENAI",
+            modelName: "gpt-5.4",
+          },
+        });
+        return new Response(
+          JSON.stringify({
+            data: { compacted: true, compaction_message: checkpoint },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+    ) as typeof fetch;
+    const sessionClient = createPxiSessionClient({
+      config: { endpoint: "http://localhost:6006" },
+      fetch: fetchImpl,
+    });
+
+    const result = await sessionClient.compactSession({
+      sessionId: "session-1",
+      model: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-5.4",
+      },
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.compactionMessage).toEqual(checkpoint);
+  });
+
+  it("surfaces a compaction 409 busy rejection as a session-busy error", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ code: "agent_session_busy" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      })
+    ) as typeof fetch;
+    const sessionClient = createPxiSessionClient({
+      config: { endpoint: "http://localhost:6006" },
+      fetch: fetchImpl,
+    });
+
+    const compaction = sessionClient.compactSession({
+      sessionId: "session-1",
+      model: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-5.4",
+      },
+    });
+
+    await expect(compaction).rejects.toSatisfy((error: unknown) =>
+      isSessionBusyError({ error })
+    );
+  });
+
+  it("surfaces compaction failures with the server's detail message", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ detail: "Conversation compaction failed: boom" }),
+          { status: 502, headers: { "Content-Type": "application/json" } }
+        )
+      ) as typeof fetch;
+    const sessionClient = createPxiSessionClient({
+      config: { endpoint: "http://localhost:6006" },
+      fetch: fetchImpl,
+    });
+
+    const compaction = sessionClient.compactSession({
+      sessionId: "session-1",
+      model: {
+        providerType: "builtin",
+        provider: "OPENAI",
+        modelName: "gpt-5.4",
+      },
+    });
+
+    await expect(compaction).rejects.toThrowError(
+      /Conversation compaction failed: boom/
+    );
   });
 
   it("streams assistant text updates", async () => {

--- a/js/packages/phoenix-cli/test/pxiCommands.test.ts
+++ b/js/packages/phoenix-cli/test/pxiCommands.test.ts
@@ -11,6 +11,7 @@ describe("SLASH_COMMANDS", () => {
   it("includes session lifecycle commands", () => {
     const names = SLASH_COMMANDS.map((c) => c.name);
     expect(names).toContain("clear");
+    expect(names).toContain("compact");
     expect(names).toContain("model");
     expect(names).toContain("new");
     expect(names).toContain("sessions");
@@ -26,6 +27,7 @@ describe("runSlashCommand", () => {
       startNewSession: vi.fn(),
       openModelPicker: vi.fn(),
       openSessionPicker: vi.fn(),
+      compactSession: vi.fn(),
       exit: vi.fn(),
     };
   }
@@ -59,6 +61,19 @@ describe("runSlashCommand", () => {
     const context = createContext();
     runSlashCommand("/model", context);
     expect(context.openModelPicker).toHaveBeenCalledOnce();
+  });
+
+  it("compacts the session for /compact", () => {
+    const context = createContext();
+    const result = runSlashCommand("/compact", context);
+    expect(context.compactSession).toHaveBeenCalledWith(undefined);
+    expect(result).toEqual({ type: "handled" });
+  });
+
+  it("passes trailing text to /compact as a pending message", () => {
+    const context = createContext();
+    runSlashCommand("/compact and then continue", context);
+    expect(context.compactSession).toHaveBeenCalledWith("and then continue");
   });
 
   it("calls exit for /exit", () => {

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1890,112 +1890,145 @@ def create_agents_router(
         session_id: str,
         request: Request,
         request_body: CompactAgentSessionRequest,
-    ) -> CompactAgentSessionResponse:
-        if agent_id != _ASSISTANT_AGENT_ID:
+    ) -> CompactAgentSessionResponse | JSONResponse:
+        if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
+        if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
+            raise HTTPException(status_code=403, detail="Server agent is disabled")
         user = request.user if "user" in request.scope else None
         phoenix_user = user if isinstance(user, PhoenixUser) else None
         request_user_id = int(phoenix_user.identity) if phoenix_user is not None else None
+        db_session_factory: DbSessionFactory = request.app.state.db
 
-        try:
-            async with request.app.state.db() as session:
-                agent_session = await _refresh_and_load_agent_session(
-                    session,
-                    agent_session_id=session_id,
-                    user_id=request_user_id,
-                )
-                message_rows = await _load_agent_session_history(
-                    session,
-                    agent_session_rowid=agent_session.id,
-                )
-                first_row = message_rows[0] if message_rows else None
-                latest_compaction = (
-                    first_row if first_row is not None and first_row.is_compaction_point else None
-                )
-                latest_row = message_rows[-1] if message_rows else None
-                if latest_row is None or latest_row.message.role != "assistant":
-                    return CompactAgentSessionResponse(
-                        data=CompactAgentSessionResponseData(
-                            compacted=False,
-                            compaction_message=(
-                                latest_compaction.message if latest_compaction is not None else None
-                            ),
-                        ),
-                    )
-                boundary_row = latest_row
-                messages_to_summarize = [row.message for row in message_rows]
-                model = await build_model(
-                    request_body.model,
-                    session=session,
-                    decrypt=request.app.state.decrypt,
-                )
-                agent_session_rowid = agent_session.id
-        except AgentError as exc:
-            raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
-
-        summary_messages = _to_pydantic_ai_messages(messages_to_summarize)
-        try:
-            summary = await summarize_messages_for_compaction(
-                messages=summary_messages,
-                model=model,
-            )
-        except CompactionError as exc:
-            raise HTTPException(
-                status_code=502, detail=f"Conversation compaction failed: {exc}"
-            ) from exc
-
-        async with request.app.state.db() as session:
-            await _refresh_and_load_agent_session(
+        async with db_session_factory() as session:
+            agent_session = await _refresh_and_load_agent_session(
                 session,
                 agent_session_id=session_id,
                 user_id=request_user_id,
-                for_update=True,
             )
-            current_history = await _load_agent_session_history(
+            agent_session_rowid = agent_session.id
+            # Claim the turn lock before reading history: an in-flight turn
+            # persists its messages only when it completes, so without the
+            # lock the tail would look stable and the checkpoint would land
+            # mid-turn, summarizing a transcript that omits it.
+            if not await _claim_agent_session_turn_lock(
                 session,
                 agent_session_rowid=agent_session_rowid,
-            )
-            current_first_row = current_history[0] if current_history else None
-            current_compaction = (
-                current_first_row
-                if current_first_row is not None and current_first_row.is_compaction_point
-                else None
-            )
-            if current_compaction is not None and (
-                latest_compaction is None or current_compaction.id != latest_compaction.id
             ):
-                return CompactAgentSessionResponse(
-                    data=CompactAgentSessionResponseData(
-                        compacted=False,
-                        compaction_message=current_compaction.message,
-                    ),
-                )
-            current_latest_row = current_history[-1] if current_history else None
-            if (
-                current_latest_row is None
-                or current_latest_row.id != boundary_row.id
-                or current_latest_row.message != boundary_row.message
-            ):
-                raise HTTPException(
-                    status_code=409,
-                    detail="The conversation changed while it was being compacted; try again",
-                )
-            compaction_message = _build_compaction_message(
-                message_id=str(uuid4()),
-                summary=summary,
+                return JSONResponse({"code": "agent_session_busy"}, status_code=409)
+
+        # The lock is held from here on; keep its heartbeat fresh while the
+        # summarization call runs so concurrent turns stay rejected.
+        heartbeat_task = asyncio.create_task(
+            _heartbeat_agent_session_turn_lock(
+                db_session_factory,
+                agent_session_rowid=agent_session_rowid,
             )
-            compaction_message_row = models.AgentSessionMessage(
-                agent_session_id=agent_session_rowid,
-                position=boundary_row.position + 1,
-                message=compaction_message,
-            )
-            session.add(compaction_message_row)
-        return CompactAgentSessionResponse(
-            data=CompactAgentSessionResponseData(
-                compacted=True,
-                compaction_message=compaction_message,
-            ),
         )
+        try:
+            try:
+                async with db_session_factory() as session:
+                    message_rows = await _load_agent_session_history(
+                        session,
+                        agent_session_rowid=agent_session_rowid,
+                    )
+                    first_row = message_rows[0] if message_rows else None
+                    latest_compaction = (
+                        first_row
+                        if first_row is not None and first_row.is_compaction_point
+                        else None
+                    )
+                    latest_row = message_rows[-1] if message_rows else None
+                    if latest_row is None or latest_row.message.role != "assistant":
+                        return CompactAgentSessionResponse(
+                            data=CompactAgentSessionResponseData(
+                                compacted=False,
+                                compaction_message=(
+                                    latest_compaction.message
+                                    if latest_compaction is not None
+                                    else None
+                                ),
+                            ),
+                        )
+                    boundary_row = latest_row
+                    messages_to_summarize = [row.message for row in message_rows]
+                    model = await build_model(
+                        request_body.model,
+                        session=session,
+                        decrypt=request.app.state.decrypt,
+                    )
+            except AgentError as exc:
+                raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+            summary_messages = _to_pydantic_ai_messages(messages_to_summarize)
+            try:
+                summary = await summarize_messages_for_compaction(
+                    messages=summary_messages,
+                    model=model,
+                )
+            except CompactionError as exc:
+                raise HTTPException(
+                    status_code=502, detail=f"Conversation compaction failed: {exc}"
+                ) from exc
+
+            async with db_session_factory() as session:
+                await _refresh_and_load_agent_session(
+                    session,
+                    agent_session_id=session_id,
+                    user_id=request_user_id,
+                    for_update=True,
+                )
+                current_history = await _load_agent_session_history(
+                    session,
+                    agent_session_rowid=agent_session_rowid,
+                )
+                current_first_row = current_history[0] if current_history else None
+                current_compaction = (
+                    current_first_row
+                    if current_first_row is not None and current_first_row.is_compaction_point
+                    else None
+                )
+                if current_compaction is not None and (
+                    latest_compaction is None or current_compaction.id != latest_compaction.id
+                ):
+                    return CompactAgentSessionResponse(
+                        data=CompactAgentSessionResponseData(
+                            compacted=False,
+                            compaction_message=current_compaction.message,
+                        ),
+                    )
+                current_latest_row = current_history[-1] if current_history else None
+                if (
+                    current_latest_row is None
+                    or current_latest_row.id != boundary_row.id
+                    or current_latest_row.message != boundary_row.message
+                ):
+                    raise HTTPException(
+                        status_code=409,
+                        detail="The conversation changed while it was being compacted; try again",
+                    )
+                compaction_message = _build_compaction_message(
+                    message_id=str(uuid4()),
+                    summary=summary,
+                )
+                compaction_message_row = models.AgentSessionMessage(
+                    agent_session_id=agent_session_rowid,
+                    position=boundary_row.position + 1,
+                    message=compaction_message,
+                )
+                session.add(compaction_message_row)
+            return CompactAgentSessionResponse(
+                data=CompactAgentSessionResponseData(
+                    compacted=True,
+                    compaction_message=compaction_message,
+                ),
+            )
+        finally:
+            heartbeat_task.cancel()
+            await _release_agent_session_turn_lock(
+                db_session_factory,
+                agent_session_rowid=agent_session_rowid,
+            )
 
     @router.post("/agents/{agent_id}/sessions/{session_id}/chat")
     async def chat(

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1907,18 +1907,12 @@ def create_agents_router(
                 user_id=request_user_id,
             )
             agent_session_rowid = agent_session.id
-            # Claim the turn lock before reading history: an in-flight turn
-            # persists its messages only when it completes, so without the
-            # lock the tail would look stable and the checkpoint would land
-            # mid-turn, summarizing a transcript that omits it.
             if not await _claim_agent_session_turn_lock(
                 session,
                 agent_session_rowid=agent_session_rowid,
             ):
                 return JSONResponse({"code": "agent_session_busy"}, status_code=409)
 
-        # The lock is held from here on; keep its heartbeat fresh while the
-        # summarization call runs so concurrent turns stay rejected.
         heartbeat_task = asyncio.create_task(
             _heartbeat_agent_session_turn_lock(
                 db_session_factory,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -402,6 +402,21 @@ class CompactAgentSessionResponse(ResponseBody[CompactAgentSessionResponseData])
     pass
 
 
+def _compact_agent_session_response(
+    *,
+    compacted: bool,
+    compaction_message: PhoenixUIMessage | None,
+) -> JSONResponse:
+    """Serialize a compaction result the way the route's response model would."""
+    response = CompactAgentSessionResponse(
+        data=CompactAgentSessionResponseData(
+            compacted=compacted,
+            compaction_message=compaction_message,
+        ),
+    )
+    return JSONResponse(response.model_dump(mode="json", by_alias=True, exclude_none=True))
+
+
 _PydanticAIRequestDataAdapter: TypeAdapter[PydanticAIRequestData] = TypeAdapter(
     PydanticAIRequestData
 )
@@ -1890,7 +1905,7 @@ def create_agents_router(
         session_id: str,
         request: Request,
         request_body: CompactAgentSessionRequest,
-    ) -> CompactAgentSessionResponse | JSONResponse:
+    ) -> JSONResponse:
         if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
         if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
@@ -1931,12 +1946,10 @@ def create_agents_router(
                 )
                 latest_row = message_rows[-1] if message_rows else None
                 if latest_row is None or latest_row.message.role != "assistant":
-                    return CompactAgentSessionResponse(
-                        data=CompactAgentSessionResponseData(
-                            compacted=False,
-                            compaction_message=(
-                                latest_compaction.message if latest_compaction is not None else None
-                            ),
+                    return _compact_agent_session_response(
+                        compacted=False,
+                        compaction_message=(
+                            latest_compaction.message if latest_compaction is not None else None
                         ),
                     )
                 boundary_row = latest_row
@@ -1973,11 +1986,9 @@ def create_agents_router(
                 if current_compaction is not None and (
                     latest_compaction is None or current_compaction.id != latest_compaction.id
                 ):
-                    return CompactAgentSessionResponse(
-                        data=CompactAgentSessionResponseData(
-                            compacted=False,
-                            compaction_message=current_compaction.message,
-                        ),
+                    return _compact_agent_session_response(
+                        compacted=False,
+                        compaction_message=current_compaction.message,
                     )
                 current_latest_row = current_history[-1] if current_history else None
                 if (
@@ -1999,11 +2010,9 @@ def create_agents_router(
                     message=compaction_message,
                 )
                 session.add(compaction_message_row)
-            return CompactAgentSessionResponse(
-                data=CompactAgentSessionResponseData(
-                    compacted=True,
-                    compaction_message=compaction_message,
-                ),
+            return _compact_agent_session_response(
+                compacted=True,
+                compaction_message=compaction_message,
             )
         except AgentError as exc:
             raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1926,50 +1926,38 @@ def create_agents_router(
             )
         )
         try:
-            try:
-                async with db_session_factory() as session:
-                    message_rows = await _load_agent_session_history(
-                        session,
-                        agent_session_rowid=agent_session_rowid,
-                    )
-                    first_row = message_rows[0] if message_rows else None
-                    latest_compaction = (
-                        first_row
-                        if first_row is not None and first_row.is_compaction_point
-                        else None
-                    )
-                    latest_row = message_rows[-1] if message_rows else None
-                    if latest_row is None or latest_row.message.role != "assistant":
-                        return CompactAgentSessionResponse(
-                            data=CompactAgentSessionResponseData(
-                                compacted=False,
-                                compaction_message=(
-                                    latest_compaction.message
-                                    if latest_compaction is not None
-                                    else None
-                                ),
+            async with db_session_factory() as session:
+                message_rows = await _load_agent_session_history(
+                    session,
+                    agent_session_rowid=agent_session_rowid,
+                )
+                first_row = message_rows[0] if message_rows else None
+                latest_compaction = (
+                    first_row if first_row is not None and first_row.is_compaction_point else None
+                )
+                latest_row = message_rows[-1] if message_rows else None
+                if latest_row is None or latest_row.message.role != "assistant":
+                    return CompactAgentSessionResponse(
+                        data=CompactAgentSessionResponseData(
+                            compacted=False,
+                            compaction_message=(
+                                latest_compaction.message if latest_compaction is not None else None
                             ),
-                        )
-                    boundary_row = latest_row
-                    messages_to_summarize = [row.message for row in message_rows]
-                    model = await build_model(
-                        request_body.model,
-                        session=session,
-                        decrypt=request.app.state.decrypt,
+                        ),
                     )
-            except AgentError as exc:
-                raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+                boundary_row = latest_row
+                messages_to_summarize = [row.message for row in message_rows]
+                model = await build_model(
+                    request_body.model,
+                    session=session,
+                    decrypt=request.app.state.decrypt,
+                )
 
             summary_messages = _to_pydantic_ai_messages(messages_to_summarize)
-            try:
-                summary = await summarize_messages_for_compaction(
-                    messages=summary_messages,
-                    model=model,
-                )
-            except CompactionError as exc:
-                raise HTTPException(
-                    status_code=502, detail=f"Conversation compaction failed: {exc}"
-                ) from exc
+            summary = await summarize_messages_for_compaction(
+                messages=summary_messages,
+                model=model,
+            )
 
             async with db_session_factory() as session:
                 await _refresh_and_load_agent_session(
@@ -2023,6 +2011,12 @@ def create_agents_router(
                     compaction_message=compaction_message,
                 ),
             )
+        except AgentError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+        except CompactionError as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Conversation compaction failed: {exc}"
+            ) from exc
         finally:
             heartbeat_task.cancel()
             await _release_agent_session_turn_lock(

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -573,9 +573,7 @@ async def test_compact_is_rejected_while_a_turn_holds_the_session_lock(
     )
     live_heartbeat = datetime.now(timezone.utc)
     async with db() as session:
-        await session.execute(
-            update(models.AgentSession).values(turn_lock_heartbeat_at=live_heartbeat)
-        )
+        await session.execute(update(models.AgentSession).values(heartbeat_at=live_heartbeat))
 
     response = await httpx_client.post(_compact_url(agent_session_id), json=_compact_body())
 
@@ -584,7 +582,7 @@ async def test_compact_is_rejected_while_a_turn_holds_the_session_lock(
     async with db() as session:
         stored = await session.scalar(select(models.AgentSession))
         assert stored is not None
-        assert stored.turn_lock_heartbeat_at is not None
+        assert stored.heartbeat_at is not None
         compaction_message_count = await session.scalar(
             select(func.count())
             .select_from(models.AgentSessionMessage)
@@ -632,9 +630,7 @@ async def test_compact_takes_over_a_stale_session_lock(
     )
     stale_heartbeat = datetime.now(timezone.utc) - TURN_LOCK_STALENESS * 2
     async with db() as session:
-        await session.execute(
-            update(models.AgentSession).values(turn_lock_heartbeat_at=stale_heartbeat)
-        )
+        await session.execute(update(models.AgentSession).values(heartbeat_at=stale_heartbeat))
 
     response = await httpx_client.post(_compact_url(agent_session_id), json=_compact_body())
 
@@ -643,7 +639,7 @@ async def test_compact_takes_over_a_stale_session_lock(
     async with db() as session:
         stored = await session.scalar(select(models.AgentSession))
         assert stored is not None
-        assert stored.turn_lock_heartbeat_at is None
+        assert stored.heartbeat_at is None
 
 
 async def test_chat_send_during_compaction_is_rejected_as_busy(
@@ -708,7 +704,7 @@ async def test_chat_send_during_compaction_is_rejected_as_busy(
     async with db() as session:
         stored = await session.scalar(select(models.AgentSession))
         assert stored is not None
-        assert stored.turn_lock_heartbeat_at is None
+        assert stored.heartbeat_at is None
 
 
 async def test_server_agent_compact_route_matches_chat_route_gating(

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -35,7 +35,7 @@ from pydantic_ai.ui.vercel_ai.response_types import (
     TextStartChunk,
 )
 from pydantic_ai.usage import RequestUsage
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.exc import SAWarning
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
@@ -54,6 +54,7 @@ from phoenix.server.agents.data_stream_protocol import (
 )
 from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
+from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS
 from phoenix.server.api.routers.agents import (
     _build_message_metadata_chunk,
     _emit_turn_root_span,
@@ -92,6 +93,10 @@ def _server_agent_chat_url(agent_session_id: str) -> str:
 
 def _compact_url(agent_session_id: str) -> str:
     return f"/agents/assistant/sessions/{agent_session_id}/compact"
+
+
+def _server_agent_compact_url(agent_session_id: str) -> str:
+    return f"/agents/server/sessions/{agent_session_id}/compact"
 
 
 def _compact_body() -> dict[str, Any]:
@@ -538,6 +543,233 @@ async def test_compact_agent_session_without_a_completed_turn_is_a_noop(
     assert response.json() == {"data": {"compacted": False}}
     async with db() as session:
         assert await session.scalar(select(models.AgentSessionSnapshot)) is None
+
+
+async def test_compact_is_rejected_while_a_turn_holds_the_session_lock(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compaction contends for the same turn lock as a chat send: a live
+    heartbeat means another turn is streaming, so compaction is rejected as
+    busy before any model work — and must not release the other turn's lock."""
+
+    async def _unexpected_build_model(*args: object, **kwargs: object) -> FunctionModel:
+        raise AssertionError("a rejected compaction must not build a model")
+
+    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _unexpected_build_model)
+    agent_session_id = await _create_agent_session_row(
+        db,
+        project_session_id="93939393-9393-4393-8393-939393939393",
+        title="Busy session",
+        messages=[
+            _user_message("Hello", message_id="user-1"),
+            {
+                "id": "assistant-1",
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "Hi there."}],
+            },
+        ],
+    )
+    live_heartbeat = datetime.now(timezone.utc)
+    async with db() as session:
+        await session.execute(
+            update(models.AgentSession).values(turn_lock_heartbeat_at=live_heartbeat)
+        )
+
+    response = await httpx_client.post(_compact_url(agent_session_id), json=_compact_body())
+
+    assert response.status_code == 409
+    assert response.json() == {"code": "agent_session_busy"}
+    async with db() as session:
+        stored = await session.scalar(select(models.AgentSession))
+        assert stored is not None
+        assert stored.turn_lock_heartbeat_at is not None
+        compaction_message_count = await session.scalar(
+            select(func.count())
+            .select_from(models.AgentSessionMessage)
+            .where(models.AgentSessionMessage.is_compaction_message)
+        )
+    assert compaction_message_count == 0
+
+
+async def test_compact_takes_over_a_stale_session_lock(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A heartbeat older than the staleness window belongs to an abandoned
+    turn: compaction claims the lock, compacts, and releases it."""
+    checkpoint = {
+        "objectives": ["Recover the session"],
+        "constraints_and_preferences": [],
+        "decisions": [],
+        "completed_work": [],
+        "active_work": [],
+        "blockers": [],
+        "next_steps": [],
+        "important_details": [],
+    }
+
+    def compact_function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="conversation_checkpoint", args=checkpoint)]
+        )
+
+    _mock_turn_models(monkeypatch, FunctionModel(function=compact_function))
+    agent_session_id = await _create_agent_session_row(
+        db,
+        project_session_id="94949494-9494-4494-8494-949494949494",
+        title="Abandoned turn",
+        messages=[
+            _user_message("Hello", message_id="user-1"),
+            {
+                "id": "assistant-1",
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "Hi there."}],
+            },
+        ],
+    )
+    stale_heartbeat = datetime.now(timezone.utc) - TURN_LOCK_STALENESS * 2
+    async with db() as session:
+        await session.execute(
+            update(models.AgentSession).values(turn_lock_heartbeat_at=stale_heartbeat)
+        )
+
+    response = await httpx_client.post(_compact_url(agent_session_id), json=_compact_body())
+
+    assert response.status_code == 200
+    assert response.json()["data"]["compacted"] is True
+    async with db() as session:
+        stored = await session.scalar(select(models.AgentSession))
+        assert stored is not None
+        assert stored.turn_lock_heartbeat_at is None
+
+
+async def test_chat_send_during_compaction_is_rejected_as_busy(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compaction holds the session's turn lock while summarizing, so a
+    concurrent chat send is rejected as busy; the lock is released once the
+    compaction completes."""
+    session_id = "95959595-9595-4595-8595-959595959595"
+    checkpoint = {
+        "objectives": ["Summarize while locked"],
+        "constraints_and_preferences": [],
+        "decisions": [],
+        "completed_work": [],
+        "active_work": [],
+        "blockers": [],
+        "next_steps": [],
+        "important_details": [],
+    }
+    concurrent_sends: list[tuple[int, dict[str, Any]]] = []
+    agent_session_id = await _create_agent_session_row(
+        db,
+        project_session_id=session_id,
+        title="Compacting session",
+        messages=[
+            _user_message("Hello", message_id="user-1"),
+            {
+                "id": "assistant-1",
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "Hi there."}],
+            },
+        ],
+    )
+
+    async def compact_function(
+        messages: list[ModelMessage], agent_info: AgentInfo
+    ) -> ModelResponse:
+        # The summarization call is in flight: a follow-up send right now
+        # must bounce off the turn lock the compaction is holding.
+        chat_response = await httpx_client.post(
+            _chat_url(agent_session_id),
+            json=_chat_body(
+                session_id,
+                _user_message("follow-up", message_id="user-2"),
+                lastMessageId="assistant-1",
+            ),
+        )
+        concurrent_sends.append((chat_response.status_code, chat_response.json()))
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="conversation_checkpoint", args=checkpoint)]
+        )
+
+    _mock_turn_models(monkeypatch, FunctionModel(function=compact_function))
+
+    compact_response = await httpx_client.post(_compact_url(agent_session_id), json=_compact_body())
+
+    assert compact_response.status_code == 200
+    assert compact_response.json()["data"]["compacted"] is True
+    assert concurrent_sends == [(409, {"code": "agent_session_busy"})]
+    async with db() as session:
+        stored = await session.scalar(select(models.AgentSession))
+        assert stored is not None
+        assert stored.turn_lock_heartbeat_at is None
+
+
+async def test_server_agent_compact_route_matches_chat_route_gating(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The compact route serves the same agents as chat: the server agent can
+    compact its sessions, unknown agents are 404, and disabling bash turns the
+    route off for the server agent only."""
+    checkpoint = {
+        "objectives": ["Compact a server session"],
+        "constraints_and_preferences": [],
+        "decisions": [],
+        "completed_work": [],
+        "active_work": [],
+        "blockers": [],
+        "next_steps": [],
+        "important_details": [],
+    }
+
+    def compact_function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name="conversation_checkpoint", args=checkpoint)]
+        )
+
+    _mock_turn_models(monkeypatch, FunctionModel(function=compact_function))
+    agent_session_id = await _create_agent_session_row(
+        db,
+        project_session_id="96969696-9696-4696-8696-969696969696",
+        title="Server session",
+        messages=[
+            _user_message("Hello", message_id="user-1"),
+            {
+                "id": "assistant-1",
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "Hi there."}],
+            },
+        ],
+    )
+
+    unknown_agent_response = await httpx_client.post(
+        f"/agents/nonexistent/sessions/{agent_session_id}/compact",
+        json=_compact_body(),
+    )
+    assert unknown_agent_response.status_code == 404
+
+    server_response = await httpx_client.post(
+        _server_agent_compact_url(agent_session_id),
+        json=_compact_body(),
+    )
+    assert server_response.status_code == 200
+    assert server_response.json()["data"]["compacted"] is True
+
+    monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_BASH", "true")
+    disabled_response = await httpx_client.post(
+        _server_agent_compact_url(agent_session_id),
+        json=_compact_body(),
+    )
+    assert disabled_response.status_code == 403
+    assert "Server agent is disabled" in disabled_response.text
 
 
 async def test_chat_turn_persists_session_transcript(


### PR DESCRIPTION
Stacked on #14809.
resolves #14673

Adds `/compact` to the PXI CLI, mirroring the web UI's compaction flow, and closes the busy-session gap in the compaction endpoint so compaction contends for the session turn lock exactly like a chat send.

## Server

- `POST /agents/{agent_id}/sessions/{session_id}/compact` now claims the session turn lock before reading history and returns `409 {"code": "agent_session_busy"}` when another turn holds it. Previously an in-flight turn (whose messages persist only at turn end) could be compacted out from under it, landing the checkpoint mid-turn.
- The lock heartbeat stays fresh for the duration of the summarization call, so concurrent chat sends are rejected as busy while a compaction runs; the lock is released when compaction finishes (including error paths).
- The compact route now serves the `server` agent with the same gating as the other session routes (404 for unknown agents, 403 when `PHOENIX_AGENTS_DISABLE_BASH` is set) — required for the CLI, which chats through the server agent.

## Web UI

- `/compact` is refused up front while the session is busy elsewhere, and a busy 409 from the endpoint now enters the existing busy-poll state (restoring any pending follow-up text) instead of rendering a generic red error.

## CLI

- New `/compact` slash command: posts to the compact endpoint with the active model selection, shows a compacting spinner, and blocks plain sends while in flight.
- The persisted checkpoint renders as a labeled `── Conversation compacted ──` divider with the summary dimmed, instead of a plain "You" turn.
- `compacted: false` responses show the web UI's "already compact" notice; trailing text (`/compact keep going`) is sent as a follow-up message once the checkpoint lands, matching the web command.
- A busy 409 enters the CLI's existing busy-poll state, and `/compact` is refused with an explanatory error while the session is already busy elsewhere.
- Docs: slash-command table in `docs/phoenix/pxi.mdx` updated to the full current registry (it listed only `/help`, `/clear`, `/exit`), plus the package README.

## Tests

- Server: compact-while-locked → 409 busy (no model work, lock left intact); stale-lock takeover; chat send during an in-flight compaction → 409 busy with lock released after; server-agent compact route gating.
- CLI: command registry/dispatch (incl. trailing-text args), full TUI flows (success divider render, already-compact notice, busy 409 → busy indicator, busy guard, follow-up send after checkpoint), and wire-level session-client tests (request shape, busy 409 recognition, error detail propagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)