### PR TITLE
fix: constrain experiment chart tooltip content

### DIFF
--- a/app/src/components/chart/AnnotationScoreLabelToggle.tsx
+++ b/app/src/components/chart/AnnotationScoreLabelToggle.tsx
@@ -1,4 +1,7 @@
-import { ToggleButton, ToggleButtonGroup } from "@phoenix/components/core";
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from "@phoenix/components/core";
 
 import type { AnnotationMetricsView } from "./annotationMetricsUtils";
 
@@ -16,19 +19,18 @@ export function AnnotationScoreLabelToggle({
   onChange: (view: AnnotationMetricsView) => void;
 }) {
   return (
-    <ToggleButtonGroup
+    <SegmentedControl
       aria-label="Evaluation metric view"
       size="S"
-      selectedKeys={[view]}
-      onSelectionChange={(selection) => {
-        const selectedView = selection.keys().next().value;
+      selectedKey={view}
+      onSelectionChange={(selectedView) => {
         if (isAnnotationMetricsView(selectedView)) {
           onChange(selectedView);
         }
       }}
     >
-      <ToggleButton id="labels">Labels</ToggleButton>
-      <ToggleButton id="scores">Scores</ToggleButton>
-    </ToggleButtonGroup>
+      <SegmentedControlItem id="labels">Labels</SegmentedControlItem>
+      <SegmentedControlItem id="scores">Scores</SegmentedControlItem>
+    </SegmentedControl>
   );
 }

--- a/app/src/components/chart/ChartTooltip.tsx
+++ b/app/src/components/chart/ChartTooltip.tsx
@@ -26,6 +26,7 @@ export function ChartTooltip(props: ChartTooltipProps) {
         flex-direction: column;
         gap: var(--global-dimension-size-50);
         min-width: 200px;
+        max-width: 300px;
         box-shadow: 0 8px 8px rgba(0, 0, 0, 0.1);
       `}
     >
@@ -69,14 +70,15 @@ export function ChartTooltipItem(props: ChartTooltipItemProps) {
           flex-direction: row;
           gap: var(--global-dimension-size-100);
           align-items: center;
+          min-width: 0;
         `}
       >
         <PreviewShape
           color={props.color ?? "transparent"}
           shape={props.shape ?? "line"}
         />
-        <Text title={props.name}>
-          <Truncate maxWidth="120px">{props.name}</Truncate>
+        <Text title={props.name} minWidth={0}>
+          <Truncate maxWidth="100%">{props.name}</Truncate>
         </Text>
       </div>
       <Text>{props.value}</Text>

--- a/app/src/components/chart/InteractiveLegend.tsx
+++ b/app/src/components/chart/InteractiveLegend.tsx
@@ -144,8 +144,8 @@ const legendStaticItemCSS = css`
 `;
 
 const legendTextCSS = css`
-  color: var(--chart-legend-text-color);
-  max-width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
 `;
 
 function getInteractiveDataKey(
@@ -421,14 +421,11 @@ function DefaultInteractiveLegendContent({
                   iconType={iconType}
                   inactiveColor={inactiveColor}
                 />
-                <Truncate maxWidth="100%">
-                  <span
-                    className="recharts-legend-item-text"
-                    css={legendTextCSS}
-                  >
+                <span className="recharts-legend-item-text" css={legendTextCSS}>
+                  <Truncate maxWidth="100%" title={label}>
                     {renderedLabel}
-                  </span>
-                </Truncate>
+                  </Truncate>
+                </span>
               </span>
             ) : (
               <button
@@ -459,7 +456,9 @@ function DefaultInteractiveLegendContent({
                   inactiveColor={inactiveColor}
                 />
                 <span className="recharts-legend-item-text" css={legendTextCSS}>
-                  <Truncate maxWidth="100%">{renderedLabel}</Truncate>
+                  <Truncate maxWidth="100%" title={label}>
+                    {renderedLabel}
+                  </Truncate>
                 </span>
               </button>
             )}

--- a/app/src/components/chart/InteractiveLegend.tsx
+++ b/app/src/components/chart/InteractiveLegend.tsx
@@ -10,6 +10,8 @@ import type {
 } from "recharts";
 import { Legend, Surface, Symbols } from "recharts";
 
+import { Truncate } from "@phoenix/components/core";
+
 /**
  * InteractiveLegend is intentionally larger than a thin `<Legend />` wrapper.
  *
@@ -97,6 +99,7 @@ const rightAlignedLegendCSS = css`
 const legendItemCSS = css`
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
 `;
 
 const legendButtonCSS = css`
@@ -108,6 +111,7 @@ const legendButtonCSS = css`
   display: inline-flex;
   align-items: center;
   gap: var(--global-dimension-size-50);
+  max-width: 100%;
   min-height: var(--global-dimension-size-200);
   padding: 0 var(--global-dimension-size-25);
   font: inherit;
@@ -133,9 +137,15 @@ const legendStaticItemCSS = css`
   display: inline-flex;
   align-items: center;
   gap: var(--global-dimension-size-50);
+  max-width: 100%;
   min-height: var(--global-dimension-size-200);
   padding: 0 var(--global-dimension-size-25);
   line-height: var(--global-line-height-xs);
+`;
+
+const legendTextCSS = css`
+  color: var(--chart-legend-text-color);
+  max-width: 100%;
 `;
 
 function getInteractiveDataKey(
@@ -281,6 +291,7 @@ function LegendIcon({
         height: LEGEND_ICON_VIEW_BOX_SIZE,
       }}
       width={iconSize}
+      css={{ flexShrink: 0 }}
     >
       {icon}
     </Surface>
@@ -410,9 +421,14 @@ function DefaultInteractiveLegendContent({
                   iconType={iconType}
                   inactiveColor={inactiveColor}
                 />
-                <span className="recharts-legend-item-text">
-                  {renderedLabel}
-                </span>
+                <Truncate maxWidth="100%">
+                  <span
+                    className="recharts-legend-item-text"
+                    css={legendTextCSS}
+                  >
+                    {renderedLabel}
+                  </span>
+                </Truncate>
               </span>
             ) : (
               <button
@@ -442,8 +458,8 @@ function DefaultInteractiveLegendContent({
                   iconType={iconType}
                   inactiveColor={inactiveColor}
                 />
-                <span className="recharts-legend-item-text">
-                  {renderedLabel}
+                <span className="recharts-legend-item-text" css={legendTextCSS}>
+                  <Truncate maxWidth="100%">{renderedLabel}</Truncate>
                 </span>
               </button>
             )}

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -142,16 +142,10 @@ export const defaultLegendProps: LegendProps = {
   wrapperStyle: {
     userSelect: "none",
   },
-  formatter: (value) => (
-    <span
-      style={{
-        color: "var(--chart-legend-text-color)",
-        userSelect: "none",
-      }}
-    >
-      {value}
-    </span>
-  ),
+  labelStyle: {
+    color: "var(--chart-legend-text-color)",
+    userSelect: "none",
+  },
 };
 
 /**

--- a/app/src/pages/dataset/metrics/ExperimentMetricsTooltipHeader.tsx
+++ b/app/src/pages/dataset/metrics/ExperimentMetricsTooltipHeader.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from "@phoenix/components";
+import { Flex, Text, Truncate } from "@phoenix/components";
 import { BaselineExperimentBadge } from "@phoenix/components/experiment";
 import { SequenceNumberToken } from "@phoenix/components/experiment/SequenceNumberToken";
 
@@ -16,11 +16,11 @@ export function ExperimentMetricsTooltipHeader({
   isBaseline?: boolean;
 }) {
   return (
-    <Flex direction="row" alignItems="center" gap="size-100">
+    <Flex direction="row" alignItems="center" gap="size-100" maxWidth="100%">
       <SequenceNumberToken sequenceNumber={sequenceNumber} />
       {name != null && (
-        <Text weight="heavy" size="S">
-          {name}
+        <Text weight="heavy" size="S" minWidth={0}>
+          <Truncate maxWidth="100%">{name}</Truncate>
         </Text>
       )}
       {isBaseline ? <BaselineExperimentBadge /> : null}

--- a/app/src/pages/dataset/metrics/ExperimentMetricsTooltipHeader.tsx
+++ b/app/src/pages/dataset/metrics/ExperimentMetricsTooltipHeader.tsx
@@ -20,7 +20,9 @@ export function ExperimentMetricsTooltipHeader({
       <SequenceNumberToken sequenceNumber={sequenceNumber} />
       {name != null && (
         <Text weight="heavy" size="S" minWidth={0}>
-          <Truncate maxWidth="100%">{name}</Truncate>
+          <Truncate maxWidth="100%" title={name}>
+            {name}
+          </Truncate>
         </Text>
       )}
       {isBaseline ? <BaselineExperimentBadge /> : null}

--- a/app/src/pages/project/metrics/ModelTokenDetailTooltipContent.tsx
+++ b/app/src/pages/project/metrics/ModelTokenDetailTooltipContent.tsx
@@ -1,6 +1,6 @@
 import type { TooltipContentProps } from "recharts";
 
-import { Text } from "@phoenix/components";
+import { Text, Truncate } from "@phoenix/components";
 import {
   ChartTooltip,
   ChartTooltipDivider,
@@ -34,8 +34,10 @@ export function ModelTokenDetailTooltipContent({
   return (
     <ChartTooltip>
       {label && (
-        <Text weight="heavy" size="S">
-          {String(label)}
+        <Text weight="heavy" size="S" minWidth={0}>
+          <Truncate maxWidth="100%" title={String(label)}>
+            {String(label)}
+          </Truncate>
         </Text>
       )}
       {payload.map((entry) => {

--- a/app/stories/AnnotationMetricsChart.stories.tsx
+++ b/app/stories/AnnotationMetricsChart.stories.tsx
@@ -1,0 +1,317 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { Text } from "@phoenix/components";
+import {
+  AnnotationMetricsChart,
+  type AnnotationMetricsChartPoint,
+  type AnnotationMetricsInputPoint,
+  type AnnotationMetricsSeries,
+  AnnotationScoreLabelToggle,
+  type AnnotationMetricsView,
+  ChartPanel,
+  compactCategoryXAxisProps,
+  compactYAxisProps,
+  getDefaultAnnotationMetricsView,
+  normalizeAnnotationMetrics,
+} from "@phoenix/components/chart";
+
+const ANNOTATION_NAME = "response quality";
+const LONG_ANNOTATION_NAME =
+  "policy_compliance_groundedness_citation_completeness_escalation_decision_and_response_quality";
+const LONG_LABEL_NAME =
+  "passes all production quality gates with complete citations and no unsupported claims";
+const LONG_UNBROKEN_LABEL_NAME =
+  "needs_human_review_due_to_policy_ambiguity_and_insufficient_source_attribution";
+
+type LabelFraction = {
+  label: string;
+  fraction: number;
+};
+
+/**
+ * Creates one normalized-series input point for a single annotation.
+ * @param params - Story fixture values.
+ * @param params.x - Category shown on the x axis.
+ * @param params.annotationName - Annotation represented by the point.
+ * @param params.meanScore - Optional numeric annotation score.
+ * @param params.labelFractions - Optional categorical distribution.
+ */
+function createAnnotationMetricsPoint({
+  x,
+  annotationName = ANNOTATION_NAME,
+  meanScore = null,
+  labelFractions = [],
+}: {
+  x: number;
+  annotationName?: string;
+  meanScore?: number | null;
+  labelFractions?: ReadonlyArray<LabelFraction>;
+}): AnnotationMetricsInputPoint {
+  return {
+    x,
+    metadata: { runName: `Run ${x}` },
+    summaries: [
+      {
+        name: annotationName,
+        meanScore,
+        labelFractions,
+      },
+    ],
+  };
+}
+
+/**
+ * Normalizes story inputs and requires the expected single annotation series.
+ * @param params - Story fixture values.
+ * @param params.points - Visible chart points.
+ * @param params.referencePoint - Optional comparison point.
+ */
+function createAnnotationMetricsSeries({
+  points,
+  referencePoint,
+}: {
+  points: ReadonlyArray<AnnotationMetricsInputPoint>;
+  referencePoint?: AnnotationMetricsInputPoint;
+}): AnnotationMetricsSeries {
+  const [series] = normalizeAnnotationMetrics({ points, referencePoint });
+  if (series == null) {
+    throw new Error(
+      "The annotation metrics story fixture must create a series"
+    );
+  }
+  return series;
+}
+
+const labelDistributionSeries = createAnnotationMetricsSeries({
+  points: [
+    createAnnotationMetricsPoint({
+      x: 1,
+      labelFractions: [
+        { label: "approved", fraction: 0.65 },
+        { label: "needs review", fraction: 0.25 },
+      ],
+    }),
+    createAnnotationMetricsPoint({
+      x: 2,
+      labelFractions: [
+        { label: "approved", fraction: 0.55 },
+        { label: "needs review", fraction: 0.3 },
+        { label: "rejected", fraction: 0.15 },
+      ],
+    }),
+    createAnnotationMetricsPoint({
+      x: 3,
+      labelFractions: [
+        { label: "approved", fraction: 0.72 },
+        { label: "needs review", fraction: 0.18 },
+        { label: "rejected", fraction: 0.1 },
+      ],
+    }),
+    createAnnotationMetricsPoint({
+      x: 4,
+      labelFractions: [
+        { label: "approved", fraction: 0.8 },
+        { label: "needs review", fraction: 0.12 },
+        { label: "rejected", fraction: 0.08 },
+      ],
+    }),
+  ],
+});
+
+const scoreSeries = createAnnotationMetricsSeries({
+  points: [
+    createAnnotationMetricsPoint({ x: 1, meanScore: 0.62 }),
+    createAnnotationMetricsPoint({ x: 2, meanScore: 0.71 }),
+    createAnnotationMetricsPoint({ x: 3, meanScore: 0.78 }),
+    createAnnotationMetricsPoint({ x: 4, meanScore: 0.86 }),
+  ],
+});
+
+const mixedSeries = createAnnotationMetricsSeries({
+  points: [
+    createAnnotationMetricsPoint({
+      x: 1,
+      meanScore: 0.58,
+      labelFractions: [
+        { label: "pass", fraction: 0.55 },
+        { label: "fail", fraction: 0.45 },
+      ],
+    }),
+    createAnnotationMetricsPoint({
+      x: 2,
+      meanScore: 0.7,
+      labelFractions: [
+        { label: "pass", fraction: 0.68 },
+        { label: "fail", fraction: 0.32 },
+      ],
+    }),
+    createAnnotationMetricsPoint({
+      x: 3,
+      meanScore: 0.82,
+      labelFractions: [
+        { label: "pass", fraction: 0.8 },
+        { label: "fail", fraction: 0.2 },
+      ],
+    }),
+    createAnnotationMetricsPoint({
+      x: 4,
+      meanScore: 0.9,
+      labelFractions: [
+        { label: "pass", fraction: 0.88 },
+        { label: "fail", fraction: 0.12 },
+      ],
+    }),
+  ],
+});
+
+const longNamesSeries = createAnnotationMetricsSeries({
+  points: [
+    createAnnotationMetricsPoint({
+      x: 1,
+      annotationName: LONG_ANNOTATION_NAME,
+      labelFractions: [
+        { label: LONG_LABEL_NAME, fraction: 0.6 },
+        { label: LONG_UNBROKEN_LABEL_NAME, fraction: 0.4 },
+      ],
+    }),
+    createAnnotationMetricsPoint({
+      x: 2,
+      annotationName: LONG_ANNOTATION_NAME,
+      labelFractions: [
+        { label: LONG_LABEL_NAME, fraction: 0.72 },
+        { label: LONG_UNBROKEN_LABEL_NAME, fraction: 0.28 },
+      ],
+    }),
+    createAnnotationMetricsPoint({
+      x: 3,
+      annotationName: LONG_ANNOTATION_NAME,
+      labelFractions: [
+        { label: LONG_LABEL_NAME, fraction: 0.8 },
+        { label: LONG_UNBROKEN_LABEL_NAME, fraction: 0.2 },
+      ],
+    }),
+  ],
+});
+
+const emptySeries: AnnotationMetricsSeries = {
+  name: ANNOTATION_NAME,
+  views: ["labels"],
+  labels: [],
+  data: [],
+};
+
+type AnnotationMetricsChartStoryProps = {
+  series: AnnotationMetricsSeries;
+  initialView?: AnnotationMetricsView;
+  width?: number;
+};
+
+function AnnotationMetricsChartStory({
+  series,
+  initialView,
+  width = 720,
+}: AnnotationMetricsChartStoryProps) {
+  const [view, setView] = useState(
+    () => initialView ?? getDefaultAnnotationMetricsView(series)
+  );
+  const activeView = series.views.includes(view)
+    ? view
+    : getDefaultAnnotationMetricsView(series);
+  const showViewToggle = series.views.length > 1;
+
+  return (
+    <div style={{ width }}>
+      <ChartPanel
+        title={series.name}
+        subtitle="Evaluation results across recent runs"
+        actions={
+          showViewToggle ? (
+            <AnnotationScoreLabelToggle view={activeView} onChange={setView} />
+          ) : undefined
+        }
+      >
+        <AnnotationMetricsChart
+          series={series}
+          view={activeView}
+          xAxisProps={{
+            ...compactCategoryXAxisProps,
+            dataKey: "x",
+            interval: 0,
+            tickFormatter: (value) => `#${String(value)}`,
+          }}
+          yAxisProps={compactYAxisProps}
+          syncId="annotation-metrics-story"
+          renderTooltipHeader={(point: AnnotationMetricsChartPoint) => (
+            <Text weight="heavy" size="S">
+              {String(point.metadata.runName ?? `Run ${point.x}`)}
+            </Text>
+          )}
+        />
+      </ChartPanel>
+    </div>
+  );
+}
+
+const meta: Meta<typeof AnnotationMetricsChartStory> = {
+  title: "Charting/Annotation Metrics Chart",
+  component: AnnotationMetricsChartStory,
+  parameters: {
+    layout: "padded",
+    controls: { disable: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AnnotationMetricsChartStory>;
+
+/**
+ * Categorical results render as a normalized stacked distribution. Run 1 also
+ * leaves a residual share so the generated "other" legend item is visible.
+ */
+export const LabelDistribution: Story = {
+  args: {
+    series: labelDistributionSeries,
+  },
+};
+
+/**
+ * Numeric-only annotations render as a line with the score domain and
+ * score-specific tooltip formatting.
+ */
+export const Scores: Story = {
+  args: {
+    series: scoreSeries,
+  },
+};
+
+/**
+ * Mixed annotations expose the production labels/scores view toggle.
+ */
+export const ScoresAndLabels: Story = {
+  args: {
+    series: mixedSeries,
+    initialView: "labels",
+  },
+};
+
+/**
+ * An empty series keeps the chart panel context while showing the shared
+ * annotation-metrics empty state.
+ */
+export const Empty: Story = {
+  args: {
+    series: emptySeries,
+  },
+};
+
+/**
+ * A narrow panel exercises long annotation titles and both wrapping and
+ * unbroken categorical legend labels.
+ */
+export const LongNames: Story = {
+  args: {
+    series: longNamesSeries,
+    width: 360,
+  },
+};

--- a/app/stories/ChartTooltip.stories.tsx
+++ b/app/stories/ChartTooltip.stories.tsx
@@ -1,0 +1,168 @@
+import { css } from "@emotion/react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Text } from "@phoenix/components";
+import type { ColorPreviewShape } from "@phoenix/components/chart";
+import {
+  ChartTooltip,
+  ChartTooltipDivider,
+  ChartTooltipItem,
+} from "@phoenix/components/chart";
+import { ExperimentMetricsTooltipHeader } from "@phoenix/pages/dataset/metrics/ExperimentMetricsTooltipHeader";
+
+type TooltipItem = {
+  color: string;
+  name: string;
+  shape: ColorPreviewShape;
+  value: string;
+};
+
+const DEFAULT_TOOLTIP_ITEMS: readonly TooltipItem[] = [
+  {
+    color: "var(--global-color-blue-700)",
+    name: "correctness",
+    shape: "line",
+    value: "0.91",
+  },
+  {
+    color: "var(--global-color-green-700)",
+    name: "groundedness",
+    shape: "line",
+    value: "0.86",
+  },
+];
+
+const LONG_EVALUATOR_TOOLTIP_ITEMS: readonly TooltipItem[] = [
+  {
+    color: "var(--global-color-blue-700)",
+    name: "policy compliance, semantic groundedness, citation completeness, and escalation decision quality for the customer support response",
+    shape: "line",
+    value: "0.91",
+  },
+  {
+    color: "var(--global-color-green-700)",
+    name: "groundedness_verification_with_retrieval_context_attribution_citation_coverage_policy_compliance_escalation_detection_and_response_quality_score",
+    shape: "line",
+    value: "0.76",
+  },
+  {
+    color: "var(--global-color-orange-700)",
+    name: "quality gate [production / multilingual / safety-sensitive] — verify answer, sources, uncertainty, policy, tone, and next-step guidance",
+    shape: "line",
+    value: "0.63",
+  },
+];
+
+const LONG_LABEL_TOOLTIP_ITEMS: readonly TooltipItem[] = [
+  {
+    color: "var(--global-color-blue-700)",
+    name: "passes all quality gates with complete citations and no unsupported claims, but still requires a human reviewer before production release",
+    shape: "square",
+    value: "40%",
+  },
+  {
+    color: "var(--global-color-green-700)",
+    name: "needs_human_review_due_to_policy_ambiguity_and_insufficient_source_attribution_before_this_response_can_be_released_to_the_customer",
+    shape: "square",
+    value: "40%",
+  },
+  {
+    color: "var(--global-color-orange-700)",
+    name: "conditionally acceptable — grounded and helpful; escalation owner, regional policy exception, and final approval are still unresolved",
+    shape: "square",
+    value: "20%",
+  },
+];
+
+const tooltipItemListCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-50);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+function TooltipItemList({ items }: { items: readonly TooltipItem[] }) {
+  return (
+    <ul css={tooltipItemListCSS}>
+      {items.map((item) => (
+        <li key={item.name}>
+          <ChartTooltipItem {...item} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ExperimentChartTooltip({
+  experimentName,
+  isBaseline = false,
+  items,
+}: {
+  experimentName: string;
+  isBaseline?: boolean;
+  items: readonly TooltipItem[];
+}) {
+  return (
+    <ChartTooltip>
+      <ExperimentMetricsTooltipHeader
+        sequenceNumber={8}
+        name={experimentName}
+        isBaseline={isBaseline}
+      />
+      <TooltipItemList items={items} />
+    </ChartTooltip>
+  );
+}
+
+const meta: Meta<typeof ChartTooltip> = {
+  title: "Charting/Chart Tooltip",
+  component: ChartTooltip,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ChartTooltip>;
+
+export const Default: Story = {
+  render: () => (
+    <ExperimentChartTooltip
+      experimentName="candidate 07"
+      items={DEFAULT_TOOLTIP_ITEMS}
+    />
+  ),
+};
+
+/**
+ * Multiple long evaluator names exercise tooltip item wrapping independently
+ * of the caller-provided tooltip header.
+ */
+export const LongEvaluatorNames: Story = {
+  render: () => (
+    <ExperimentChartTooltip
+      experimentName="candidate 07"
+      isBaseline
+      items={LONG_EVALUATOR_TOOLTIP_ITEMS}
+    />
+  ),
+};
+
+/**
+ * Categorical annotation summaries can contain user-defined labels that are
+ * much longer than their percentage values.
+ */
+export const LongLabelNames: Story = {
+  render: () => (
+    <ChartTooltip>
+      <Text weight="heavy" size="S">
+        categorical label breakdown
+      </Text>
+      <ChartTooltipDivider />
+      <TooltipItemList items={LONG_LABEL_TOOLTIP_ITEMS} />
+    </ChartTooltip>
+  ),
+};

--- a/app/stories/ExperimentMetricsCharts.stories.tsx
+++ b/app/stories/ExperimentMetricsCharts.stories.tsx
@@ -3,7 +3,6 @@ import { Suspense } from "react";
 import { RelayEnvironmentProvider } from "react-relay";
 import { Environment, Network, RecordSource, Store } from "relay-runtime";
 
-import { ChartPanel } from "@phoenix/components/chart";
 import type { ExperimentMetricChartKey } from "@phoenix/pages/dataset/constants";
 import {
   EXPERIMENT_METRIC_CHARTS,
@@ -195,12 +194,14 @@ function ExperimentMetricsChartsStory({
           }}
         >
           {chartKeys.map((chartKey) => {
-            const { name, description, Component } =
+            const { annotationName, Panel } =
               getExperimentMetricChart(chartKey);
             return (
-              <ChartPanel key={chartKey} title={name} subtitle={description}>
-                <Component datasetId={STORY_DATASET_ID} />
-              </ChartPanel>
+              <Panel
+                key={chartKey}
+                datasetId={STORY_DATASET_ID}
+                annotationName={annotationName}
+              />
             );
           })}
         </div>

--- a/app/stories/ExperimentMetricsCharts.stories.tsx
+++ b/app/stories/ExperimentMetricsCharts.stories.tsx
@@ -1,0 +1,291 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Suspense } from "react";
+import { RelayEnvironmentProvider } from "react-relay";
+import { Environment, Network, RecordSource, Store } from "relay-runtime";
+
+import { ChartPanel } from "@phoenix/components/chart";
+import type { ExperimentMetricChartKey } from "@phoenix/pages/dataset/constants";
+import {
+  EXPERIMENT_METRIC_CHARTS,
+  getExperimentMetricChart,
+} from "@phoenix/pages/dataset/metrics/chartCatalog";
+
+const STORY_DATASET_ID = "dataset:experiment-metrics-story";
+const LONG_EXPERIMENT_NAME =
+  "candidate 101 — deliberately long experiment name for testing tooltip max width, text overflow, flex shrinking, and CSS ellipsis behavior";
+const LONG_UNBROKEN_EXPERIMENT_NAME =
+  "candidate_101_deliberately_unbroken_experiment_name_for_issue_14695_testing_css_text_overflow_ellipsis_max_width_flex_shrink_behavior_with_a_single_continuous_identifier_that_has_no_whitespace_or_natural_break_points";
+
+type AnnotationSummaryFixture = {
+  annotationName: string;
+  meanScore: number | null;
+};
+
+type ExperimentFixture = {
+  id: string;
+  name: string;
+  sequenceNumber: number;
+  averageRunLatencyMs: number | null;
+  errorRate: number | null;
+  runCount: number;
+  annotationSummaries: AnnotationSummaryFixture[];
+  costSummary: {
+    prompt: {
+      tokens: number | null;
+      cost: number | null;
+    };
+    completion: {
+      tokens: number | null;
+      cost: number | null;
+    };
+    total: {
+      tokens: number | null;
+      cost: number | null;
+    };
+  };
+};
+
+const experiments: ExperimentFixture[] = [
+  {
+    id: "experiment:101",
+    name: "GPT-4.1 baseline",
+    sequenceNumber: 101,
+    averageRunLatencyMs: 1820,
+    errorRate: 0.08,
+    runCount: 50,
+    annotationSummaries: [
+      { annotationName: "correctness", meanScore: 0.72 },
+      { annotationName: "relevance", meanScore: 0.81 },
+      { annotationName: "helpfulness", meanScore: 0.76 },
+    ],
+    costSummary: {
+      prompt: { tokens: 64_200, cost: 0.1284 },
+      completion: { tokens: 18_400, cost: 0.1472 },
+      total: { tokens: 82_600, cost: 0.2756 },
+    },
+  },
+  {
+    id: "experiment:102",
+    name: "Shorter system prompt",
+    sequenceNumber: 102,
+    averageRunLatencyMs: 1490,
+    errorRate: 0.04,
+    runCount: 50,
+    annotationSummaries: [
+      { annotationName: "correctness", meanScore: 0.79 },
+      { annotationName: "relevance", meanScore: 0.84 },
+      { annotationName: "helpfulness", meanScore: 0.8 },
+    ],
+    costSummary: {
+      prompt: { tokens: 51_800, cost: 0.1036 },
+      completion: { tokens: 17_900, cost: 0.1432 },
+      total: { tokens: 69_700, cost: 0.2468 },
+    },
+  },
+  {
+    id: "experiment:103",
+    name: "Retrieval reranking",
+    sequenceNumber: 103,
+    averageRunLatencyMs: 2110,
+    errorRate: 0.02,
+    runCount: 50,
+    annotationSummaries: [
+      { annotationName: "correctness", meanScore: 0.86 },
+      { annotationName: "relevance", meanScore: 0.91 },
+      { annotationName: "helpfulness", meanScore: 0.88 },
+    ],
+    costSummary: {
+      prompt: { tokens: 70_100, cost: 0.1402 },
+      completion: { tokens: 19_600, cost: 0.1568 },
+      total: { tokens: 89_700, cost: 0.297 },
+    },
+  },
+  {
+    id: "experiment:104",
+    name: "Compact context window",
+    sequenceNumber: 104,
+    averageRunLatencyMs: 1320,
+    errorRate: 0.06,
+    runCount: 50,
+    annotationSummaries: [
+      { annotationName: "correctness", meanScore: 0.83 },
+      { annotationName: "relevance", meanScore: 0.87 },
+      { annotationName: "helpfulness", meanScore: 0.9 },
+    ],
+    costSummary: {
+      prompt: { tokens: 43_700, cost: 0.0874 },
+      completion: { tokens: 20_200, cost: 0.1616 },
+      total: { tokens: 63_900, cost: 0.249 },
+    },
+  },
+];
+
+type MetricsDataState = "populated" | "empty" | "longExperimentNames";
+
+function getExperimentsForDataState(
+  dataState: MetricsDataState
+): ExperimentFixture[] {
+  if (dataState === "empty") {
+    return [];
+  }
+  if (dataState === "longExperimentNames") {
+    return experiments.map((experiment, index) =>
+      index === 0
+        ? { ...experiment, name: LONG_EXPERIMENT_NAME }
+        : index === 1
+          ? { ...experiment, name: LONG_UNBROKEN_EXPERIMENT_NAME }
+          : experiment
+    );
+  }
+  return experiments;
+}
+
+function createMetricsResponse(dataState: MetricsDataState) {
+  const metricsExperiments = getExperimentsForDataState(dataState);
+  const baselineExperiment = metricsExperiments[0] ?? null;
+
+  return {
+    data: {
+      dataset: {
+        __typename: "Dataset",
+        id: STORY_DATASET_ID,
+        baselineExperiment,
+        metricsExperiments: {
+          edges: metricsExperiments.map((experiment) => ({ experiment })),
+        },
+      },
+    },
+  };
+}
+
+function createRelayEnvironment(dataState: MetricsDataState) {
+  return new Environment({
+    network: Network.create(async () => createMetricsResponse(dataState)),
+    store: new Store(new RecordSource()),
+  });
+}
+
+const relayEnvironments: Record<MetricsDataState, Environment> = {
+  populated: createRelayEnvironment("populated"),
+  empty: createRelayEnvironment("empty"),
+  longExperimentNames: createRelayEnvironment("longExperimentNames"),
+};
+
+type ExperimentMetricsChartsStoryProps = {
+  chartKeys: ExperimentMetricChartKey[];
+  dataState: MetricsDataState;
+};
+
+function ExperimentMetricsChartsStory({
+  chartKeys,
+  dataState,
+}: ExperimentMetricsChartsStoryProps) {
+  return (
+    <RelayEnvironmentProvider environment={relayEnvironments[dataState]}>
+      <Suspense fallback={<div>Loading experiment metrics…</div>}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns:
+              chartKeys.length === 1
+                ? "minmax(0, 720px)"
+                : "repeat(2, minmax(360px, 1fr))",
+            gap: "var(--global-dimension-size-200)",
+            width: "min(1100px, 100%)",
+          }}
+        >
+          {chartKeys.map((chartKey) => {
+            const { name, description, Component } =
+              getExperimentMetricChart(chartKey);
+            return (
+              <ChartPanel key={chartKey} title={name} subtitle={description}>
+                <Component datasetId={STORY_DATASET_ID} />
+              </ChartPanel>
+            );
+          })}
+        </div>
+      </Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+
+const allChartKeys = EXPERIMENT_METRIC_CHARTS.map(({ key }) => key);
+
+const meta: Meta<typeof ExperimentMetricsChartsStory> = {
+  title: "Charting/Experiment Metrics Charts",
+  component: ExperimentMetricsChartsStory,
+  parameters: {
+    layout: "padded",
+    controls: { disable: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExperimentMetricsChartsStory>;
+
+/**
+ * All five metric charts with representative experiment data, including a
+ * baseline reference and multiple annotation series.
+ */
+export const AllMetrics: Story = {
+  args: {
+    chartKeys: allChartKeys,
+    dataState: "populated",
+  },
+};
+
+export const AnnotationScores: Story = {
+  args: {
+    chartKeys: ["annotation_scores"],
+    dataState: "populated",
+  },
+};
+
+export const Latency: Story = {
+  args: {
+    chartKeys: ["latency"],
+    dataState: "populated",
+  },
+};
+
+export const Cost: Story = {
+  args: {
+    chartKeys: ["cost"],
+    dataState: "populated",
+  },
+};
+
+export const TokenUsage: Story = {
+  args: {
+    chartKeys: ["tokens"],
+    dataState: "populated",
+  },
+};
+
+export const ErrorRate: Story = {
+  args: {
+    chartKeys: ["error_rate"],
+    dataState: "populated",
+  },
+};
+
+/**
+ * The chart caller provides both naturally wrapping and continuous experiment
+ * names so the real tooltip-header overflow behavior can be inspected.
+ */
+export const LongExperimentNameTooltip: Story = {
+  args: {
+    chartKeys: ["latency"],
+    dataState: "longExperimentNames",
+  },
+};
+
+/**
+ * Exercises each chart's metric-specific no-data overlay.
+ */
+export const EmptyStates: Story = {
+  args: {
+    chartKeys: allChartKeys,
+    dataState: "empty",
+  },
+};

--- a/app/stories/StackedTimeSeriesBarChart.stories.tsx
+++ b/app/stories/StackedTimeSeriesBarChart.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import type { TooltipContentProps } from "recharts";
+import type { LegendPayload, TooltipContentProps } from "recharts";
 import {
   Bar,
   BarChart,
@@ -9,6 +9,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { expect, within } from "storybook/test";
 
 import { Card, Flex, Text, View } from "@phoenix/components";
 import type { SequentialChartColors } from "@phoenix/components/chart";
@@ -149,6 +150,13 @@ const highVolumeData = [
   },
 ];
 
+const LONG_ERROR_SERIES_NAME =
+  "errors_from_policy_validation_grounding_citation_completeness_and_escalation_checks";
+const LONG_OK_SERIES_NAME =
+  "successful traces that passed every production quality gate without requiring human review";
+const LONG_STATIC_SERIES_NAME =
+  "production_baseline_for_multilingual_safety_sensitive_customer_support_workflows";
+
 function TooltipContent({ active, payload, label }: TooltipContentProps) {
   const { fullTimeFormatter } = useTimeFormatters();
 
@@ -192,6 +200,9 @@ interface StackedBarChartProps {
   height?: number | string;
   firstColor?: keyof SequentialChartColors;
   secondColor?: keyof SequentialChartColors;
+  firstSeriesName?: string;
+  secondSeriesName?: string;
+  additionalLegendItems?: ReadonlyArray<LegendPayload>;
 }
 
 function StackedBarChart({
@@ -199,6 +210,9 @@ function StackedBarChart({
   height = 200,
   firstColor = "red300",
   secondColor = "default",
+  firstSeriesName = "error",
+  secondSeriesName = "ok",
+  additionalLegendItems,
 }: StackedBarChartProps) {
   const timeRange = {
     start: new Date("2021-01-01"),
@@ -248,17 +262,20 @@ function StackedBarChart({
             stackId="a"
             fill={colors[firstColor]}
             hide={isDataKeyHidden("error")}
+            name={firstSeriesName}
           />
           <Bar
             dataKey="ok"
             stackId="a"
             fill={colors[secondColor]}
             hide={isDataKeyHidden("ok")}
+            name={secondSeriesName}
             radius={[2, 2, 0, 0]}
           />
 
           <InteractiveLegend
             align="left"
+            additionalLegendItems={additionalLegendItems}
             hiddenDataKeys={hiddenDataKeys}
             iconType="circle"
             iconSize={8}
@@ -335,6 +352,78 @@ export const Tall: Story = {
   args: {
     data: chartData,
     height: 600,
+  },
+};
+
+/**
+ * Long interactive and supplemental legend labels remain inside their items,
+ * truncate with an ellipsis, and inherit the same neutral label color.
+ */
+export const LongLegendNames: Story = {
+  args: {
+    additionalLegendItems: [
+      {
+        color: "var(--global-color-purple-700)",
+        type: "plainline",
+        value: LONG_STATIC_SERIES_NAME,
+      },
+    ],
+    data: chartData,
+    firstSeriesName: LONG_ERROR_SERIES_NAME,
+    height: 400,
+    secondSeriesName: LONG_OK_SERIES_NAME,
+  },
+  render: (args) => (
+    <div style={{ width: "320px" }}>
+      <StackedBarChart {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    for (const label of [LONG_ERROR_SERIES_NAME, LONG_OK_SERIES_NAME]) {
+      const legendButton = canvas.getByRole("button", {
+        name: `Hide ${label}`,
+      });
+      const legendText = legendButton.querySelector<HTMLElement>(
+        ".recharts-legend-item-text"
+      );
+      const truncatedLabel = legendText?.firstElementChild;
+
+      if (!(truncatedLabel instanceof HTMLElement)) {
+        throw new Error(`Missing truncated legend label for ${label}`);
+      }
+
+      await expect(legendButton).toHaveAttribute("title", label);
+      await expect(truncatedLabel).toHaveAttribute("title", label);
+      await expect(truncatedLabel.scrollWidth).toBeGreaterThan(
+        truncatedLabel.clientWidth
+      );
+      await expect(
+        truncatedLabel.getBoundingClientRect().right
+      ).toBeLessThanOrEqual(legendButton.getBoundingClientRect().right + 1);
+      await expect(getComputedStyle(truncatedLabel).color).toBe(
+        getComputedStyle(legendButton).color
+      );
+    }
+
+    const staticTruncatedLabel = canvas.getByTitle(LONG_STATIC_SERIES_NAME);
+    const staticLegendText = staticTruncatedLabel.parentElement;
+    const staticLegendItem = staticLegendText?.parentElement;
+
+    if (!(staticLegendItem instanceof HTMLElement)) {
+      throw new Error("Missing static legend item");
+    }
+
+    await expect(staticTruncatedLabel.scrollWidth).toBeGreaterThan(
+      staticTruncatedLabel.clientWidth
+    );
+    await expect(
+      staticTruncatedLabel.getBoundingClientRect().right
+    ).toBeLessThanOrEqual(staticLegendItem.getBoundingClientRect().right + 1);
+    await expect(getComputedStyle(staticTruncatedLabel).color).toBe(
+      getComputedStyle(staticLegendItem).color
+    );
   },
 };
 

--- a/app/stories/StackedTimeSeriesBarChart.stories.tsx
+++ b/app/stories/StackedTimeSeriesBarChart.stories.tsx
@@ -382,7 +382,7 @@ export const LongLegendNames: Story = {
     const canvas = within(canvasElement);
 
     for (const label of [LONG_ERROR_SERIES_NAME, LONG_OK_SERIES_NAME]) {
-      const legendButton = canvas.getByRole("button", {
+      const legendButton = await canvas.findByRole("button", {
         name: `Hide ${label}`,
       });
       const legendText = legendButton.querySelector<HTMLElement>(
@@ -407,7 +407,9 @@ export const LongLegendNames: Story = {
       );
     }
 
-    const staticTruncatedLabel = canvas.getByTitle(LONG_STATIC_SERIES_NAME);
+    const staticTruncatedLabel = await canvas.findByTitle(
+      LONG_STATIC_SERIES_NAME
+    );
     const staticLegendText = staticTruncatedLabel.parentElement;
     const staticLegendItem = staticLegendText?.parentElement;
 


### PR DESCRIPTION
## Summary

- constrain chart tooltips and truncate long experiment and model names with full-name titles
- keep long interactive legend labels inside their items with consistent text and ellipsis colors
- add Storybook coverage for tooltip, experiment metric chart, annotation metric chart, empty, and long-legend states

## Screenshots

### Tooltip content

| Long evaluator names | Long categorical labels |
| --- | --- |
| ![Chart tooltip truncating long evaluator names](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14820-chart-tooltip-long-evaluator-names.png) | ![Chart tooltip truncating long categorical label names](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14820-chart-tooltip-long-label-names.png) |

### Experiment names in chart tooltips

| Long name with spaces | Long unbroken name |
| --- | --- |
| ![Experiment chart tooltip truncating a long spaced experiment name](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14820-experiment-long-name-tooltip.png) | ![Experiment chart tooltip truncating a long unbroken experiment name](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14820-experiment-unbroken-name-tooltip.png) |

### Long chart names and legends

| Stacked chart legend labels | Annotation metrics chart |
| --- | --- |
| ![Stacked chart keeping long legend labels within the chart width](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14820-long-legend-names.png) | ![Annotation metrics chart with long title and label names](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14820-annotation-metrics-long-names.png) |

## Verification

- targeted `oxfmt --check`
- targeted `oxlint`
- `make typecheck-frontend`
- `pnpm --dir app run build-storybook`
- `git diff --check origin/main...HEAD`
- browser-verified long spaced and unbroken experiment names, long tooltip values, and long legend labels

Resolves #14695