### PR TITLE
docs(otel): document arize-phoenix-otel/server version independence

### DIFF
--- a/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel.mdx
+++ b/docs/phoenix/sdk-api-reference/python/arize-phoenix-otel.mdx
@@ -17,6 +17,10 @@ pip install "arize-phoenix-otel>=0.16.0"
 Starting in **0.16.0**, `phoenix.otel` re-exports the OpenInference context managers and semantic conventions, so manual instrumentation no longer requires separately installing `openinference-instrumentation` or `openinference-semantic-conventions`. On older versions, import them from `openinference.instrumentation` and `openinference.semconv.trace` instead.
 </Note>
 
+<Note>
+`arize-phoenix-otel` is versioned independently of the Phoenix server; the two are not coupled. Any recent SDK version works with any Phoenix server version — there is no version pairing to track. See [Version compatibility](/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers#version-compatibility).
+</Note>
+
 ## Quick Start
 
 ```python

--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers.mdx
@@ -57,6 +57,17 @@ The convenience function handles four things for you. Each one has additional ca
 | **Span Exporter** | Auto-detects gRPC or HTTP from the endpoint URL and configures the matching OTLP exporter. If `api_key` is set, it adds the `Authorization: Bearer <key>` header for you. |
 | **Resource** | Sets the project name automatically from your `project_name` argument (or the `PHOENIX_PROJECT` environment variable, with `PHOENIX_PROJECT_NAME` accepted as an alias). |
 
+# Version Compatibility
+
+`arize-phoenix-otel` is versioned independently of the Phoenix server, and the two are **not coupled** — any recent SDK version works with any server version. You do not need to upgrade the server when you upgrade the SDK, or match version numbers between them.
+
+This works because `register()` never calls a version-gated server endpoint. Everything it wires up rests on two backward-compatible contracts:
+
+- **OTLP transport** — the exporter sends spans over the OpenTelemetry Protocol, which every Phoenix server version accepts.
+- **[OpenInference semantic conventions](/docs/phoenix/tracing/concepts-tracing/otel-openinference)** — the attribute names both sides agree on, tracked in the `openinference-semantic-conventions` package and evolved additively.
+
+Because compatibility rests on these stable layers rather than matched version pairs, there is no `arize-phoenix-otel` × Phoenix server version table to consult. (Individual *features* — not the SDK as a whole — may carry a minimum server version; those are noted on the relevant feature pages.)
+
 # Auto-instrumentation
 
 `register()` has an `auto_instrument=True` option that automatically calls `.instrument()` on every OpenInference auto-instrumentor installed in your environment.

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -65,6 +65,10 @@ The Phoenix OTEL SDK provides a lightweight wrapper around OpenTelemetry with se
   </Tab>
 </Tabs>
 
+<Note>
+**Do I need to match the SDK version to my Phoenix server version?** No. `arize-phoenix-otel` (and `@arizeai/phoenix-otel`) are versioned independently of the Phoenix server. Any recent SDK version works with any Phoenix server version — you don't need to upgrade the server when you upgrade the SDK, or vice versa. The SDK sends traces over OTLP using [OpenInference semantic conventions](/docs/phoenix/tracing/concepts-tracing/otel-openinference), both of which are backward compatible, so there is no version pairing to track. See [The phoenix.otel helpers](/docs/phoenix/tracing/concepts-tracing/otel-openinference/phoenix-otel-helpers#version-compatibility) for why.
+</Note>
+
 ## Configure
 
 Set environment variables to connect to your Phoenix instance:

--- a/packages/phoenix-otel/README.md
+++ b/packages/phoenix-otel/README.md
@@ -40,6 +40,7 @@ Provides a lightweight wrapper around OpenTelemetry primitives with Phoenix-awar
 - **Production Ready**: Built-in batching and authentication
 - **Phoenix Integration**: Seamless integration with Phoenix Cloud and self-hosted instances
 - **OpenTelemetry Compatible**: Works with existing OpenTelemetry infrastructure
+- **Server Version Independent**: Versioned separately from the Phoenix server — any recent `arize-phoenix-otel` works with any Phoenix server version, with no version pairing to track (traces are sent over OTLP using OpenInference semantic conventions, both backward compatible)
 
 These defaults are aware of environment variables you may have set to configure Phoenix:
 


### PR DESCRIPTION
## Summary

Closes the docs gap behind #10497. A user asked for an `arize-phoenix-otel` × Phoenix server version-compatibility table. Digging into it, there's no coupling to document: `arize-phoenix-otel` declares no dependency on `arize-phoenix`/the server (its deps are OpenTelemetry + OpenInference only), and `register()` sets up an OTLP exporter rather than calling any version-gated server endpoint. @mikeldking confirmed in-thread that the packages are intentionally decoupled.

So rather than a version-skew table (which would imply constraints that don't exist), this documents the **compatibility model** — "any recent `arize-phoenix-otel` works with any Phoenix server version" — in the places users look when installing or upgrading.

## Changes

- **`setup-using-phoenix-otel.mdx`** — `<Note>` after the Install tabs directly answering "Do I need to match the SDK version to my server version? No."
- **`phoenix-otel-helpers.mdx`** — new **Version Compatibility** section explaining *why* (OTLP transport + OpenInference semantic conventions, both backward compatible). Anchor target the other pages link to.
- **`arize-phoenix-otel.mdx`** (Python API reference) — `<Note>` linking to the above.
- **`packages/phoenix-otel/README.md`** — new **Server Version Independent** bullet in Key Benefits (PyPI landing page).

## Not in this PR

The root of the user's confusion was the **in-app banner** that recommends an `arize-phoenix` version but says nothing about `arize-phoenix-otel`. That's a frontend change, not a docs one — flagged as a suggested follow-up on the issue.

## Verification note

Anchor link `#version-compatibility` is derived from the `# Version Compatibility` heading via Mintlify's default slugging; worth a quick click-through in the docs preview.