### PR TITLE
docs: fix broken pricing link in Phoenix vs Arize FAQ

### DIFF
--- a/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize.mdx
@@ -3,4 +3,4 @@ title: "What is the difference between Phoenix and Arize?"
 description: "Arize is the company that makes Phoenix. Phoenix is an open source LLM observability tool offered by Arize. It can be access in its Cloud form online, or self-hosted and run on your own machine or server."
 ---
 
-"Arize" can also refer to Arize's enterprise platform, often called Arize AX, available on arize.com. Arize AX is the enterprise SaaS version of Phoenix that comes with additional features like Copilot, ML and CV support, HIPAA compliance, Security Reviews, a customer success team, and more. See [here for a breakdown](https://phoenix.arize.com/pricing/) of the two tools.
+"Arize" can also refer to Arize's enterprise platform, often called Arize AX, available on arize.com. Arize AX is the enterprise SaaS version of Phoenix that comes with additional features like Copilot, ML and CV support, HIPAA compliance, Security Reviews, a customer success team, and more. See [here for a breakdown](https://arize.com/pricing/) of the two tools.


### PR DESCRIPTION
Fixes the broken "See here for a breakdown" link in the Phoenix vs Arize FAQ page
