### PR TITLE
ci: add MoraVigoMalusardi to the external-issue triage allowlist

### DIFF
--- a/.github/workflows/auto-label-external-issues.yaml
+++ b/.github/workflows/auto-label-external-issues.yaml
@@ -53,6 +53,7 @@ jobs:
               "ehutt",
               "jimbobbennett",
               "mikeldking",
+              "MoraVigoMalusardi",
               "Nancy-Chauhan",
               "PatriciaArnedo",
               "rickarize",


### PR DESCRIPTION
Adds my GitHub username to the internal-contributor allowlist so my own issues and PRs are not auto-labeled `triage`.