### PR TITLE
feat: show cost and token breakdown bars in tooltips

### DIFF
--- a/app/src/components/RichTokenBreakdown.tsx
+++ b/app/src/components/RichTokenBreakdown.tsx
@@ -6,8 +6,17 @@ import {
 import { Text } from "@phoenix/components/core/content";
 import { Flex } from "@phoenix/components/core/layout";
 
-type RichTokenCostBreakdownProps = {
+type RichTokenBreakdownProps = {
+  /**
+   * The noun for the value being broken down, e.g. "cost" or "tokens".
+   */
   valueLabel: string;
+  /**
+   * Qualifies the total, e.g. "Total" or "Average". Rendered ahead of the
+   * value label, so `Prompt` and `cost` read as "Prompt cost".
+   * @default "Total"
+   */
+  totalLabel?: string;
   totalValue: number;
   formatter: (value: number) => string;
   segments: {
@@ -19,30 +28,39 @@ type RichTokenCostBreakdownProps = {
 
 export function RichTokenBreakdown({
   valueLabel,
+  totalLabel = "Total",
   totalValue,
   formatter,
   segments,
-}: RichTokenCostBreakdownProps) {
+}: RichTokenBreakdownProps) {
   const colors = useSequentialChartColors();
   const segmentsWithColor = segments.map((segment, index) => ({
     ...segment,
     color: segment.color || getChartColor(index, colors),
   }));
+  // An all-zero breakdown has nothing to draw, and an empty bar reads as a
+  // rendering failure rather than as an empty total.
+  const hasChartedSegments = segmentsWithColor.some(
+    (segment) => segment.value > 0
+  );
   return (
     <Flex direction="column" gap="size-150">
       {/* Totals */}
       <Flex direction="row" gap="size-200" justifyContent="space-between">
-        <Text weight="heavy">Total {valueLabel}</Text>
+        <Text weight="heavy">{`${totalLabel} ${valueLabel}`}</Text>
         <Flex direction="row" gap="size-400">
           <Text weight="heavy">{formatter(totalValue)}</Text>
         </Flex>
       </Flex>
       {/* Segment graph */}
-      <SegmentChart
-        height={6}
-        totalValue={totalValue}
-        segments={segmentsWithColor}
-      />
+      {hasChartedSegments && (
+        <SegmentChart
+          height={6}
+          minimumSegmentPercentage={1}
+          totalValue={totalValue}
+          segments={segmentsWithColor}
+        />
+      )}
       {/* Segment table */}
       <Flex direction="column" gap="size-100">
         {segmentsWithColor.map((segment) => {

--- a/app/src/components/RichTokenBreakdown.tsx
+++ b/app/src/components/RichTokenBreakdown.tsx
@@ -38,11 +38,6 @@ export function RichTokenBreakdown({
     ...segment,
     color: segment.color || getChartColor(index, colors),
   }));
-  // An all-zero breakdown has nothing to draw, and an empty bar reads as a
-  // rendering failure rather than as an empty total.
-  const hasChartedSegments = segmentsWithColor.some(
-    (segment) => segment.value > 0
-  );
   return (
     <Flex direction="column" gap="size-150">
       {/* Totals */}
@@ -53,14 +48,12 @@ export function RichTokenBreakdown({
         </Flex>
       </Flex>
       {/* Segment graph */}
-      {hasChartedSegments && (
-        <SegmentChart
-          height={6}
-          minimumSegmentPercentage={1}
-          totalValue={totalValue}
-          segments={segmentsWithColor}
-        />
-      )}
+      <SegmentChart
+        height={6}
+        minimumSegmentPercentage={1}
+        totalValue={totalValue}
+        segments={segmentsWithColor}
+      />
       {/* Segment table */}
       <Flex direction="column" gap="size-100">
         {segmentsWithColor.map((segment) => {

--- a/app/src/components/agent/ChatTokenUsage.tsx
+++ b/app/src/components/agent/ChatTokenUsage.tsx
@@ -279,21 +279,17 @@ export function ChatTokenUsageDetails({
     {
       name: "Uncached",
       value: uncachedPrompt,
-      color: getTokenDetailColor({ colors, index: 0, tokenType: "input" }),
+      color: getTokenDetailColor({ colors, tokenType: "input" }),
     },
     {
       name: "Cache read",
       value: cacheRead,
-      color: getTokenDetailColor({ colors, index: 1, tokenType: "cache_read" }),
+      color: getTokenDetailColor({ colors, tokenType: "cache_read" }),
     },
     {
       name: "Cache write",
       value: cacheWrite,
-      color: getTokenDetailColor({
-        colors,
-        index: 2,
-        tokenType: "cache_write",
-      }),
+      color: getTokenDetailColor({ colors, tokenType: "cache_write" }),
     },
   ].filter((segment) => segment.value > 0);
 

--- a/app/src/components/agent/ChatTokenUsage.tsx
+++ b/app/src/components/agent/ChatTokenUsage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@phoenix/components/chart";
 import { TokenCount } from "@phoenix/components/trace";
 import { formatInt, formatIntShort } from "@phoenix/utils/numberFormatUtils";
+import { getTokenDetailColor } from "@phoenix/utils/tokenDetailUtils";
 
 const chatTokenUsageCSS = css`
   display: contents;
@@ -272,10 +273,28 @@ export function ChatTokenUsageDetails({
     { name: "Prompt", value: prompt, color: colors.category1 },
     { name: "Completion", value: completion, color: colors.category2 },
   ];
+  // Colored by token type, so the cache reads here match the cache reads in
+  // the metrics charts and the cost tooltips.
   const promptSegments: TokenSegment[] = [
-    { name: "Uncached", value: uncachedPrompt, color: colors.category1 },
-    { name: "Cache read", value: cacheRead, color: colors.category5 },
-    { name: "Cache write", value: cacheWrite, color: colors.category4 },
+    {
+      name: "Uncached",
+      value: uncachedPrompt,
+      color: getTokenDetailColor({ colors, index: 0, tokenType: "input" }),
+    },
+    {
+      name: "Cache read",
+      value: cacheRead,
+      color: getTokenDetailColor({ colors, index: 1, tokenType: "cache_read" }),
+    },
+    {
+      name: "Cache write",
+      value: cacheWrite,
+      color: getTokenDetailColor({
+        colors,
+        index: 2,
+        tokenType: "cache_write",
+      }),
+    },
   ].filter((segment) => segment.value > 0);
 
   return (

--- a/app/src/components/chart/SegmentChart.tsx
+++ b/app/src/components/chart/SegmentChart.tsx
@@ -63,6 +63,11 @@ export const SegmentChart = ({
     minimumSegmentPercentage > 0
       ? segments.filter((segment) => segment.value > 0)
       : segments;
+  // An all-zero breakdown has nothing to draw, and a bar of pure background
+  // reads as a rendering failure rather than as an empty total.
+  if (!visibleSegments.some((segment) => segment.value > 0)) {
+    return null;
+  }
 
   return (
     <div style={{ height: `${height}px` }} css={chartContainerCSS}>

--- a/app/src/components/trace/SpanTokenCountDetails.tsx
+++ b/app/src/components/trace/SpanTokenCountDetails.tsx
@@ -31,17 +31,17 @@ export function SpanTokenCountDetails(props: { spanNodeId: string }) {
       const prompt = data.node.tokenCountPrompt ?? 0;
       const completion = data.node.tokenCountCompletion ?? 0;
       const total = data.node.tokenCountTotal ?? 0;
+      // Keyed by the token types the API reports elsewhere, so a token type
+      // keeps the label, order, and color it carries in the metrics charts.
       const promptDetails: Record<string, number> = {};
-
-      // Add available prompt details
       if (data.node.tokenPromptDetails?.audio) {
         promptDetails.audio = data.node.tokenPromptDetails.audio;
       }
       if (data.node.tokenPromptDetails?.cacheRead) {
-        promptDetails["cache read"] = data.node.tokenPromptDetails.cacheRead;
+        promptDetails.cache_read = data.node.tokenPromptDetails.cacheRead;
       }
       if (data.node.tokenPromptDetails?.cacheWrite) {
-        promptDetails["cache write"] = data.node.tokenPromptDetails.cacheWrite;
+        promptDetails.cache_write = data.node.tokenPromptDetails.cacheWrite;
       }
 
       return {

--- a/app/src/components/trace/TokenCostsDetails.tsx
+++ b/app/src/components/trace/TokenCostsDetails.tsx
@@ -1,18 +1,17 @@
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
 
+import type { TokenDetailsBreakdownProps } from "./TokenDetailsBreakdown";
 import { TokenDetailsBreakdown } from "./TokenDetailsBreakdown";
 
-export interface TokenCostsDetailsProps {
-  total?: number | null;
-  prompt?: number | null;
-  completion?: number | null;
-  promptDetails?: Record<string, number | null> | null;
-  completionDetails?: Record<string, number | null> | null;
+export type TokenCostsDetailsProps = Omit<
+  TokenDetailsBreakdownProps,
+  "valueLabel" | "totalLabel" | "formatter"
+> & {
   /**
    * The label for the cost details. Defaults to "Total".
    */
   label?: string;
-}
+};
 
 export function TokenCostsDetails({
   total,

--- a/app/src/components/trace/TokenCostsDetails.tsx
+++ b/app/src/components/trace/TokenCostsDetails.tsx
@@ -1,80 +1,6 @@
-import { css } from "@emotion/react";
-
-import { Text } from "@phoenix/components";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
 
-const tokenCostsDetailsCSS = css`
-  display: flex;
-  flex-direction: column;
-  gap: var(--global-dimension-size-100);
-  min-width: 200px;
-`;
-
-const tokenCostRowCSS = css`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--global-dimension-size-200);
-
-  &[data-is-total="true"] {
-    font-weight: var(--global-font-weight-heavy);
-  }
-
-  &[data-is-sub-item="true"] {
-    margin-left: var(--global-dimension-size-200);
-    color: var(--global-text-color-500);
-    font-size: var(--global-font-size-xs);
-  }
-`;
-
-const sectionHeaderCSS = css`
-  font-weight: var(--global-font-weight-heavy);
-  font-size: var(--global-font-size-xs);
-  color: var(--global-text-color-700);
-  margin-top: var(--global-dimension-size-100);
-`;
-
-interface TokenCostRowProps {
-  label: string;
-  cost: number;
-  isTotal?: boolean;
-  isSubItem?: boolean;
-}
-
-function TokenCostRow({ label, cost, isTotal, isSubItem }: TokenCostRowProps) {
-  return (
-    <div
-      css={tokenCostRowCSS}
-      data-is-total={isTotal}
-      data-is-sub-item={isSubItem}
-    >
-      <Text
-        size={isSubItem ? "XS" : "S"}
-        weight={isTotal ? "heavy" : "normal"}
-        color={isSubItem ? "text-500" : isTotal ? "text-900" : "text-700"}
-      >
-        {label}
-      </Text>
-      <Text
-        size={isSubItem ? "XS" : "S"}
-        color={isSubItem ? "text-500" : "text-700"}
-      >
-        {costFormatter(cost)}
-      </Text>
-    </div>
-  );
-}
-
-function SectionHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <div css={sectionHeaderCSS}>
-      <Text size="XS" weight="heavy" color="text-700">
-        {children}
-      </Text>
-    </div>
-  );
-}
+import { TokenDetailsBreakdown } from "./TokenDetailsBreakdown";
 
 export interface TokenCostsDetailsProps {
   total?: number | null;
@@ -96,70 +22,16 @@ export function TokenCostsDetails({
   completionDetails,
   label = "Total",
 }: TokenCostsDetailsProps) {
-  const hasPromptDetails =
-    promptDetails &&
-    Object.entries(promptDetails).some(
-      ([, value]) => value != null && value > 0
-    );
-  const hasCompletionDetails =
-    completionDetails &&
-    Object.entries(completionDetails).some(
-      ([, value]) => value != null && value > 0
-    );
   return (
-    <div css={tokenCostsDetailsCSS}>
-      {/* Main three rows */}
-      {total != null && (
-        <TokenCostRow label={label} cost={total} isTotal={true} />
-      )}
-
-      {prompt != null && <TokenCostRow label="Prompt" cost={prompt} />}
-
-      {completion != null && (
-        <TokenCostRow label="Completion" cost={completion} />
-      )}
-
-      {/* Prompt details sub-section */}
-      {hasPromptDetails && (
-        <>
-          <SectionHeader>Prompt Details</SectionHeader>
-          {promptDetails &&
-            Object.entries(promptDetails).map(([key, value]) => {
-              if (value != null && value > 0) {
-                return (
-                  <TokenCostRow
-                    key={`prompt-${key}`}
-                    label={key.charAt(0).toUpperCase() + key.slice(1)}
-                    cost={value}
-                    isSubItem={true}
-                  />
-                );
-              }
-              return null;
-            })}
-        </>
-      )}
-
-      {/* Completion details sub-section */}
-      {hasCompletionDetails && (
-        <>
-          <SectionHeader>Completion Details</SectionHeader>
-          {completionDetails &&
-            Object.entries(completionDetails).map(([key, value]) => {
-              if (value != null && value > 0) {
-                return (
-                  <TokenCostRow
-                    key={`completion-${key}`}
-                    label={key.charAt(0).toUpperCase() + key.slice(1)}
-                    cost={value}
-                    isSubItem={true}
-                  />
-                );
-              }
-              return null;
-            })}
-        </>
-      )}
-    </div>
+    <TokenDetailsBreakdown
+      valueLabel="cost"
+      totalLabel={label}
+      formatter={costFormatter}
+      total={total}
+      prompt={prompt}
+      completion={completion}
+      promptDetails={promptDetails}
+      completionDetails={completionDetails}
+    />
   );
 }

--- a/app/src/components/trace/TokenCountDetails.tsx
+++ b/app/src/components/trace/TokenCountDetails.tsx
@@ -1,33 +1,17 @@
 import { numberFormatter } from "@phoenix/utils/numberFormatUtils";
 
+import type { TokenDetailsBreakdownProps } from "./TokenDetailsBreakdown";
 import { TokenDetailsBreakdown } from "./TokenDetailsBreakdown";
 
-export interface TokenCountDetailsProps {
-  /**
-   * Total token count
-   */
-  total?: number | null;
-  /**
-   * Prompt token count
-   */
-  prompt?: number | null;
-  /**
-   * Completion token count
-   */
-  completion?: number | null;
-  /**
-   * Additional prompt token details as key-value pairs
-   */
-  promptDetails?: Record<string, number | null | undefined>;
-  /**
-   * Additional completion token details as key-value pairs
-   */
-  completionDetails?: Record<string, number | null | undefined>;
+export type TokenCountDetailsProps = Omit<
+  TokenDetailsBreakdownProps,
+  "valueLabel" | "totalLabel" | "formatter"
+> & {
   /**
    * The label for the count details. Defaults to "Total".
    */
   label?: string;
-}
+};
 
 export function TokenCountDetails({
   total,

--- a/app/src/components/trace/TokenCountDetails.tsx
+++ b/app/src/components/trace/TokenCountDetails.tsx
@@ -1,74 +1,6 @@
-import { css } from "@emotion/react";
+import { numberFormatter } from "@phoenix/utils/numberFormatUtils";
 
-import { Text } from "@phoenix/components";
-import { formatNumber } from "@phoenix/utils/numberFormatUtils";
-
-const tokenCountDetailsCSS = css`
-  display: flex;
-  flex-direction: column;
-  gap: var(--global-dimension-size-50);
-`;
-
-const tokenCountRowCSS = css`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--global-dimension-size-100);
-`;
-
-const tokenCountValueCSS = css`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--global-dimension-size-25);
-`;
-
-const sectionHeaderCSS = css`
-  margin-top: var(--global-dimension-size-100);
-  margin-bottom: var(--global-dimension-size-25);
-`;
-
-interface TokenCountRowProps {
-  label: string;
-  count: number | null | undefined;
-  isTotal?: boolean;
-  isSubItem?: boolean;
-}
-
-function TokenCountRow({
-  label,
-  count,
-  isTotal = false,
-  isSubItem = false,
-}: TokenCountRowProps) {
-  const displayCount = typeof count === "number" ? formatNumber(count) : "--";
-
-  return (
-    <div css={tokenCountRowCSS}>
-      <Text
-        size={isSubItem ? "XS" : "S"}
-        color={isSubItem ? "text-500" : isTotal ? "text-900" : "text-700"}
-        weight={isTotal ? "heavy" : "normal"}
-      >
-        {label}
-      </Text>
-      <div css={tokenCountValueCSS}>
-        <Text size={isSubItem ? "XS" : "S"} color="text-700">
-          {displayCount}t
-        </Text>
-      </div>
-    </div>
-  );
-}
-
-function SectionHeader({ children }: { children: string }) {
-  return (
-    <Text size="XS" color="text-700" weight="heavy" css={sectionHeaderCSS}>
-      {children}
-    </Text>
-  );
-}
+import { TokenDetailsBreakdown } from "./TokenDetailsBreakdown";
 
 export interface TokenCountDetailsProps {
   /**
@@ -105,71 +37,16 @@ export function TokenCountDetails({
   completionDetails,
   label = "Total",
 }: TokenCountDetailsProps) {
-  const hasPromptDetails =
-    promptDetails &&
-    Object.entries(promptDetails).some(
-      ([, value]) => value != null && value > 0
-    );
-  const hasCompletionDetails =
-    completionDetails &&
-    Object.entries(completionDetails).some(
-      ([, value]) => value != null && value > 0
-    );
-
   return (
-    <div css={tokenCountDetailsCSS}>
-      {/* Main three rows */}
-      {total != null && (
-        <TokenCountRow label={label} count={total} isTotal={true} />
-      )}
-
-      {prompt != null && <TokenCountRow label="Prompt" count={prompt} />}
-
-      {completion != null && (
-        <TokenCountRow label="Completion" count={completion} />
-      )}
-
-      {/* Prompt details sub-section */}
-      {hasPromptDetails && (
-        <>
-          <SectionHeader>Prompt Details</SectionHeader>
-          {promptDetails &&
-            Object.entries(promptDetails).map(([key, value]) => {
-              if (value != null && value > 0) {
-                return (
-                  <TokenCountRow
-                    key={`prompt-${key}`}
-                    label={key.charAt(0).toUpperCase() + key.slice(1)}
-                    count={value}
-                    isSubItem={true}
-                  />
-                );
-              }
-              return null;
-            })}
-        </>
-      )}
-
-      {/* Completion details sub-section */}
-      {hasCompletionDetails && (
-        <>
-          <SectionHeader>Completion Details</SectionHeader>
-          {completionDetails &&
-            Object.entries(completionDetails).map(([key, value]) => {
-              if (value != null && value > 0) {
-                return (
-                  <TokenCountRow
-                    key={`completion-${key}`}
-                    label={key.charAt(0).toUpperCase() + key.slice(1)}
-                    count={value}
-                    isSubItem={true}
-                  />
-                );
-              }
-              return null;
-            })}
-        </>
-      )}
-    </div>
+    <TokenDetailsBreakdown
+      valueLabel="tokens"
+      totalLabel={label}
+      formatter={numberFormatter}
+      total={total}
+      prompt={prompt}
+      completion={completion}
+      promptDetails={promptDetails}
+      completionDetails={completionDetails}
+    />
   );
 }

--- a/app/src/components/trace/TokenDetailsBreakdown.tsx
+++ b/app/src/components/trace/TokenDetailsBreakdown.tsx
@@ -1,23 +1,13 @@
-import { css } from "@emotion/react";
-
 import { Flex } from "@phoenix/components";
 import { useCategoryChartColors } from "@phoenix/components/chart";
 import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
 import {
   compareTokenTypes,
+  getRemainderTokenType,
   getTokenDetailColor,
   getTokenDetailLabel,
+  TOKEN_DETAIL_EPSILON,
 } from "@phoenix/utils/tokenDetailUtils";
-
-/**
- * Costs and token counts are summed from floating point values, so a detail
- * breakdown that fully accounts for its group can still leave a sliver behind.
- */
-const REMAINDER_EPSILON = 1e-9;
-
-const tokenDetailsBreakdownCSS = css`
-  min-width: var(--global-dimension-size-3000);
-`;
 
 type TokenDetailValues = Record<string, number | null | undefined>;
 
@@ -75,64 +65,61 @@ export function TokenDetailsBreakdown({
     return null;
   }
 
-  const promptValue = prompt ?? 0;
-  const completionValue = completion ?? 0;
-  const totalValue = total ?? promptValue + completionValue;
-  const segments = [
-    ...(prompt != null
-      ? [{ name: "Prompt", value: promptValue, color: colors.category1 }]
-      : []),
-    ...(completion != null
-      ? [
-          {
-            name: "Completion",
-            value: completionValue,
-            color: colors.category2,
-          },
-        ]
-      : []),
-  ];
-  const promptSegments = buildDetailSegments({
-    colors,
-    details: promptDetails,
-    groupTotal: promptValue,
-    remainderTokenType: "input",
-  });
-  const completionSegments = buildDetailSegments({
-    colors,
-    details: completionDetails,
-    groupTotal: completionValue,
-    remainderTokenType: "output",
-  });
+  const groups = [
+    {
+      label: "Prompt",
+      isPrompt: true,
+      value: prompt,
+      details: promptDetails,
+      color: colors.category1,
+    },
+    {
+      label: "Completion",
+      isPrompt: false,
+      value: completion,
+      details: completionDetails,
+      color: colors.category2,
+    },
+  ].map((group) => ({
+    ...group,
+    // An absent group is left out of the split entirely; a zero one still
+    // belongs in the legend.
+    value: group.value ?? 0,
+    isPresent: group.value != null,
+    segments: buildDetailSegments({
+      colors,
+      details: group.details,
+      groupTotal: group.value ?? 0,
+      isPrompt: group.isPrompt,
+    }),
+  }));
 
   return (
-    <Flex direction="column" gap="size-200" css={tokenDetailsBreakdownCSS}>
+    <Flex direction="column" gap="size-200" minWidth="size-3000">
       <RichTokenBreakdown
         valueLabel={valueLabel}
         totalLabel={totalLabel}
-        totalValue={totalValue}
+        totalValue={
+          total ?? groups.reduce((acc, group) => acc + group.value, 0)
+        }
         formatter={formatter}
-        segments={segments}
+        segments={groups
+          .filter((group) => group.isPresent)
+          .map(({ label, value, color }) => ({ name: label, value, color }))}
       />
       {/* A lone segment restates the group total, so it is left to the legend above */}
-      {promptSegments.length > 1 && (
-        <RichTokenBreakdown
-          valueLabel={valueLabel}
-          totalLabel="Prompt"
-          totalValue={promptValue}
-          formatter={formatter}
-          segments={promptSegments}
-        />
-      )}
-      {completionSegments.length > 1 && (
-        <RichTokenBreakdown
-          valueLabel={valueLabel}
-          totalLabel="Completion"
-          totalValue={completionValue}
-          formatter={formatter}
-          segments={completionSegments}
-        />
-      )}
+      {groups
+        .filter((group) => group.segments.length > 1)
+        .map((group) => (
+          <RichTokenBreakdown
+            key={group.label}
+            valueLabel={valueLabel}
+            totalLabel={group.label}
+            totalValue={group.value}
+            formatter={formatter}
+            segments={group.segments}
+          />
+        ))}
     </Flex>
   );
 }
@@ -140,55 +127,46 @@ export function TokenDetailsBreakdown({
 /**
  * Turns one group's token-type values into labeled, colored segments.
  *
- * Details refine the authoritative prompt and completion totals but may be
- * incomplete for spans recorded before a token type was tracked. Any positive
- * remainder is attributed to the group's plain token type, so the bar always
- * accounts for the total it is drawn against.
+ * Any value the details do not account for is attributed to the group's plain
+ * token type, so the bar always adds up to the total it is drawn against.
  *
  * @param params - Segment building context.
  * @param params.colors - Theme-aware categorical chart colors.
  * @param params.details - Values keyed by token type.
  * @param params.groupTotal - The prompt or completion total the details refine.
- * @param params.remainderTokenType - Token type that absorbs the unaccounted remainder.
+ * @param params.isPrompt - Whether the group holds prompt rather than completion usage.
  * @returns Segments in canonical token-type order.
  */
 function buildDetailSegments({
   colors,
   details,
   groupTotal,
-  remainderTokenType,
+  isPrompt,
 }: {
   colors: ReturnType<typeof useCategoryChartColors>;
   details: TokenDetailValues | null | undefined;
   groupTotal: number;
-  remainderTokenType: string;
+  isPrompt: boolean;
 }): DetailSegment[] {
-  const valueByTokenType = new Map<string, number>();
+  const values: Record<string, number> = {};
+  let detailTotal = 0;
   Object.entries(details ?? {}).forEach(([tokenType, value]) => {
     if (value != null && value > 0) {
-      valueByTokenType.set(
-        tokenType,
-        (valueByTokenType.get(tokenType) ?? 0) + value
-      );
+      values[tokenType] = value;
+      detailTotal += value;
     }
   });
-  if (valueByTokenType.size === 0) {
+  if (detailTotal === 0) {
     return [];
   }
 
-  const detailTotal = Array.from(valueByTokenType.values()).reduce(
-    (acc, value) => acc + value,
-    0
-  );
   const remainder = groupTotal - detailTotal;
-  if (remainder > REMAINDER_EPSILON) {
-    valueByTokenType.set(
-      remainderTokenType,
-      (valueByTokenType.get(remainderTokenType) ?? 0) + remainder
-    );
+  if (remainder > TOKEN_DETAIL_EPSILON) {
+    const tokenType = getRemainderTokenType(isPrompt);
+    values[tokenType] = (values[tokenType] ?? 0) + remainder;
   }
 
-  return Array.from(valueByTokenType.entries())
+  return Object.entries(values)
     .sort(([leftType], [rightType]) => compareTokenTypes(leftType, rightType))
     .map(([tokenType, value], index) => ({
       name: getTokenDetailLabel(tokenType),

--- a/app/src/components/trace/TokenDetailsBreakdown.tsx
+++ b/app/src/components/trace/TokenDetailsBreakdown.tsx
@@ -1,0 +1,198 @@
+import { css } from "@emotion/react";
+
+import { Flex } from "@phoenix/components";
+import { useCategoryChartColors } from "@phoenix/components/chart";
+import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
+import {
+  compareTokenTypes,
+  getTokenDetailColor,
+  getTokenDetailLabel,
+} from "@phoenix/utils/tokenDetailUtils";
+
+/**
+ * Costs and token counts are summed from floating point values, so a detail
+ * breakdown that fully accounts for its group can still leave a sliver behind.
+ */
+const REMAINDER_EPSILON = 1e-9;
+
+const tokenDetailsBreakdownCSS = css`
+  min-width: var(--global-dimension-size-3000);
+`;
+
+type TokenDetailValues = Record<string, number | null | undefined>;
+
+type DetailSegment = {
+  name: string;
+  value: number;
+  color: string;
+};
+
+export interface TokenDetailsBreakdownProps {
+  /**
+   * The noun for the value being broken down, e.g. "cost" or "tokens".
+   */
+  valueLabel: string;
+  /**
+   * Qualifies the total, e.g. "Total" or "Average".
+   * @default "Total"
+   */
+  totalLabel?: string;
+  /**
+   * Renders a value in the unit being broken down.
+   */
+  formatter: (value: number) => string;
+  total?: number | null;
+  prompt?: number | null;
+  completion?: number | null;
+  /**
+   * Prompt values keyed by token type, e.g. `{ input: 12, cache_read: 4 }`.
+   */
+  promptDetails?: TokenDetailValues | null;
+  /**
+   * Completion values keyed by token type.
+   */
+  completionDetails?: TokenDetailValues | null;
+}
+
+/**
+ * A total split into prompt and completion, each drawn as a proportional bar
+ * with a color-keyed legend. Prompt and completion get a bar of their own when
+ * they break down further by token type, e.g. into cache reads and writes.
+ */
+export function TokenDetailsBreakdown({
+  valueLabel,
+  totalLabel = "Total",
+  formatter,
+  total,
+  prompt,
+  completion,
+  promptDetails,
+  completionDetails,
+}: TokenDetailsBreakdownProps) {
+  const colors = useCategoryChartColors();
+
+  if (total == null && prompt == null && completion == null) {
+    return null;
+  }
+
+  const promptValue = prompt ?? 0;
+  const completionValue = completion ?? 0;
+  const totalValue = total ?? promptValue + completionValue;
+  const segments = [
+    ...(prompt != null
+      ? [{ name: "Prompt", value: promptValue, color: colors.category1 }]
+      : []),
+    ...(completion != null
+      ? [
+          {
+            name: "Completion",
+            value: completionValue,
+            color: colors.category2,
+          },
+        ]
+      : []),
+  ];
+  const promptSegments = buildDetailSegments({
+    colors,
+    details: promptDetails,
+    groupTotal: promptValue,
+    remainderTokenType: "input",
+  });
+  const completionSegments = buildDetailSegments({
+    colors,
+    details: completionDetails,
+    groupTotal: completionValue,
+    remainderTokenType: "output",
+  });
+
+  return (
+    <Flex direction="column" gap="size-200" css={tokenDetailsBreakdownCSS}>
+      <RichTokenBreakdown
+        valueLabel={valueLabel}
+        totalLabel={totalLabel}
+        totalValue={totalValue}
+        formatter={formatter}
+        segments={segments}
+      />
+      {/* A lone segment restates the group total, so it is left to the legend above */}
+      {promptSegments.length > 1 && (
+        <RichTokenBreakdown
+          valueLabel={valueLabel}
+          totalLabel="Prompt"
+          totalValue={promptValue}
+          formatter={formatter}
+          segments={promptSegments}
+        />
+      )}
+      {completionSegments.length > 1 && (
+        <RichTokenBreakdown
+          valueLabel={valueLabel}
+          totalLabel="Completion"
+          totalValue={completionValue}
+          formatter={formatter}
+          segments={completionSegments}
+        />
+      )}
+    </Flex>
+  );
+}
+
+/**
+ * Turns one group's token-type values into labeled, colored segments.
+ *
+ * Details refine the authoritative prompt and completion totals but may be
+ * incomplete for spans recorded before a token type was tracked. Any positive
+ * remainder is attributed to the group's plain token type, so the bar always
+ * accounts for the total it is drawn against.
+ *
+ * @param params - Segment building context.
+ * @param params.colors - Theme-aware categorical chart colors.
+ * @param params.details - Values keyed by token type.
+ * @param params.groupTotal - The prompt or completion total the details refine.
+ * @param params.remainderTokenType - Token type that absorbs the unaccounted remainder.
+ * @returns Segments in canonical token-type order.
+ */
+function buildDetailSegments({
+  colors,
+  details,
+  groupTotal,
+  remainderTokenType,
+}: {
+  colors: ReturnType<typeof useCategoryChartColors>;
+  details: TokenDetailValues | null | undefined;
+  groupTotal: number;
+  remainderTokenType: string;
+}): DetailSegment[] {
+  const valueByTokenType = new Map<string, number>();
+  Object.entries(details ?? {}).forEach(([tokenType, value]) => {
+    if (value != null && value > 0) {
+      valueByTokenType.set(
+        tokenType,
+        (valueByTokenType.get(tokenType) ?? 0) + value
+      );
+    }
+  });
+  if (valueByTokenType.size === 0) {
+    return [];
+  }
+
+  const detailTotal = Array.from(valueByTokenType.values()).reduce(
+    (acc, value) => acc + value,
+    0
+  );
+  const remainder = groupTotal - detailTotal;
+  if (remainder > REMAINDER_EPSILON) {
+    valueByTokenType.set(
+      remainderTokenType,
+      (valueByTokenType.get(remainderTokenType) ?? 0) + remainder
+    );
+  }
+
+  return Array.from(valueByTokenType.entries())
+    .sort(([leftType], [rightType]) => compareTokenTypes(leftType, rightType))
+    .map(([tokenType, value], index) => ({
+      name: getTokenDetailLabel(tokenType),
+      value,
+      color: getTokenDetailColor({ colors, index, tokenType }),
+    }));
+}

--- a/app/src/components/trace/index.tsx
+++ b/app/src/components/trace/index.tsx
@@ -10,6 +10,7 @@ export * from "./SpanCumulativeTokenCount";
 export * from "./SpanCumulativeTokenCountDetails";
 export * from "./TokenCount";
 export * from "./TokenCountDetails";
+export * from "./TokenDetailsBreakdown";
 export * from "./TokenCosts";
 export * from "./TokenCostsDetails";
 export * from "./SpanTokenCosts";

--- a/app/src/pages/project/ProjectStats.tsx
+++ b/app/src/pages/project/ProjectStats.tsx
@@ -12,9 +12,8 @@ import {
   TooltipTrigger,
   View,
 } from "@phoenix/components";
-import { useCategoryChartColors } from "@phoenix/components/chart";
-import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { TokenCostsDetails } from "@phoenix/components/trace/TokenCostsDetails";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
 
@@ -77,7 +76,6 @@ export function ProjectStats(props: { project: ProjectStats_project$key }) {
     data?.spanAnnotationNames ?? []
   );
   const documentEvaluationNames = data?.documentEvaluationNames;
-  const colors = useCategoryChartColors();
 
   return (
     <Flex direction="row" gap="size-400" alignItems="center">
@@ -102,22 +100,10 @@ export function ProjectStats(props: { project: ProjectStats_project$key }) {
           <RichTooltip placement="bottom">
             <TooltipArrow />
             <View width="size-3600">
-              <RichTokenBreakdown
-                valueLabel="cost"
-                totalValue={data?.costSummary?.total?.cost ?? 0}
-                formatter={costFormatter}
-                segments={[
-                  {
-                    name: "Prompt",
-                    value: data?.costSummary?.prompt?.cost ?? 0,
-                    color: colors.category1,
-                  },
-                  {
-                    name: "Completion",
-                    value: data?.costSummary?.completion?.cost ?? 0,
-                    color: colors.category2,
-                  },
-                ]}
+              <TokenCostsDetails
+                total={data?.costSummary?.total?.cost ?? 0}
+                prompt={data?.costSummary?.prompt?.cost ?? 0}
+                completion={data?.costSummary?.completion?.cost ?? 0}
               />
             </View>
           </RichTooltip>

--- a/app/src/pages/project/ProjectStats.tsx
+++ b/app/src/pages/project/ProjectStats.tsx
@@ -13,7 +13,7 @@ import {
   View,
 } from "@phoenix/components";
 import { useCategoryChartColors } from "@phoenix/components/chart";
-import { RichTokenBreakdown } from "@phoenix/components/RichTokenCostBreakdown";
+import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";

--- a/app/src/pages/project/SpansTableAside.tsx
+++ b/app/src/pages/project/SpansTableAside.tsx
@@ -12,10 +12,9 @@ import {
   TooltipTrigger,
   View,
 } from "@phoenix/components";
-import { useCategoryChartColors } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/components/datetime";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
-import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
+import { TokenCostsDetails } from "@phoenix/components/trace/TokenCostsDetails";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
@@ -99,7 +98,6 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
     project?.traceAnnotationsNames ?? []
   );
   const documentEvaluationNames = project?.documentEvaluationNames ?? [];
-  const colors = useCategoryChartColors();
 
   return (
     <Group orientation="vertical">
@@ -127,22 +125,10 @@ export function SpansTableAside(props: { filterCondition?: string | null }) {
                   <RichTooltip placement="bottom">
                     <TooltipArrow />
                     <View width="size-3600">
-                      <RichTokenBreakdown
-                        valueLabel="cost"
-                        totalValue={project?.costSummary?.total?.cost ?? 0}
-                        formatter={costFormatter}
-                        segments={[
-                          {
-                            name: "Prompt",
-                            value: project?.costSummary?.prompt?.cost ?? 0,
-                            color: colors.category1,
-                          },
-                          {
-                            name: "Completion",
-                            value: project?.costSummary?.completion?.cost ?? 0,
-                            color: colors.category2,
-                          },
-                        ]}
+                      <TokenCostsDetails
+                        total={project?.costSummary?.total?.cost ?? 0}
+                        prompt={project?.costSummary?.prompt?.cost ?? 0}
+                        completion={project?.costSummary?.completion?.cost ?? 0}
                       />
                     </View>
                   </RichTooltip>

--- a/app/src/pages/project/SpansTableAside.tsx
+++ b/app/src/pages/project/SpansTableAside.tsx
@@ -15,7 +15,7 @@ import {
 import { useCategoryChartColors } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/components/datetime";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
-import { RichTokenBreakdown } from "@phoenix/components/RichTokenCostBreakdown";
+import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";

--- a/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceTokenCountTimeSeries.tsx
@@ -40,14 +40,14 @@ import {
   intShortFormatter,
   percentFormatter,
 } from "@phoenix/utils/numberFormatUtils";
-
-import type { TraceTokenCountTimeSeriesQuery } from "./__generated__/TraceTokenCountTimeSeriesQuery.graphql";
 import {
   compareTokenTypes,
   getTokenDetailColor,
-  getTokenDetailDataKey,
   getTokenDetailLabel,
-} from "./tokenDetails";
+} from "@phoenix/utils/tokenDetailUtils";
+
+import type { TraceTokenCountTimeSeriesQuery } from "./__generated__/TraceTokenCountTimeSeriesQuery.graphql";
+import { getTokenDetailDataKey } from "./tokenDetails";
 
 type TokenCountTimeSeriesDatum = NonNullable<
   NonNullable<

--- a/app/src/pages/project/metrics/tokenDetails.ts
+++ b/app/src/pages/project/metrics/tokenDetails.ts
@@ -6,13 +6,14 @@
 import type { useCategoryChartColors } from "@phoenix/components/chart";
 import {
   compareTokenTypes,
+  getRemainderTokenType,
   getTokenDetailColor,
   getTokenDetailFallbackColors,
   getTokenDetailLabel,
+  TOKEN_DETAIL_EPSILON,
 } from "@phoenix/utils/tokenDetailUtils";
 
 const TOKEN_DETAIL_DATA_KEY_PREFIX = "tokenDetail:";
-const TOKEN_DETAIL_EPSILON = 1e-9;
 const TOKEN_DETAIL_BAR_RADIUS = 2;
 
 /** Numeric field projected from each token-detail cost breakdown. */
@@ -331,24 +332,16 @@ export function buildModelTokenDetailChartData({
       });
     });
 
-    const missingInputValue =
-      (model.costSummary.prompt[metric] ?? 0) - detailTotals.prompt;
-    recordTokenDetailValue({
-      chartDatum,
-      isPrompt: true,
-      seriesByDataKey,
-      tokenType: "input",
-      value: missingInputValue,
-    });
-
-    const missingOutputValue =
-      (model.costSummary.completion[metric] ?? 0) - detailTotals.completion;
-    recordTokenDetailValue({
-      chartDatum,
-      isPrompt: false,
-      seriesByDataKey,
-      tokenType: "output",
-      value: missingOutputValue,
+    ([true, false] as const).forEach((isPrompt) => {
+      const tokenKind = isPrompt ? "prompt" : "completion";
+      recordTokenDetailValue({
+        chartDatum,
+        isPrompt,
+        seriesByDataKey,
+        tokenType: getRemainderTokenType(isPrompt),
+        value:
+          (model.costSummary[tokenKind][metric] ?? 0) - detailTotals[tokenKind],
+      });
     });
 
     return chartDatum;

--- a/app/src/pages/project/metrics/tokenDetails.ts
+++ b/app/src/pages/project/metrics/tokenDetails.ts
@@ -4,18 +4,16 @@
  */
 
 import type { useCategoryChartColors } from "@phoenix/components/chart";
+import {
+  compareTokenTypes,
+  getTokenDetailColor,
+  getTokenDetailFallbackColors,
+  getTokenDetailLabel,
+} from "@phoenix/utils/tokenDetailUtils";
 
 const TOKEN_DETAIL_DATA_KEY_PREFIX = "tokenDetail:";
 const TOKEN_DETAIL_EPSILON = 1e-9;
 const TOKEN_DETAIL_BAR_RADIUS = 2;
-const TOKEN_DETAIL_SORT_ORDER: Partial<Record<string, number>> = {
-  input: 0,
-  output: 0,
-  cache_read: 1,
-  cache_write: 2,
-  reasoning: 3,
-  audio: 4,
-};
 
 /** Numeric field projected from each token-detail cost breakdown. */
 export type TokenDetailMetric = "tokens" | "cost";
@@ -101,20 +99,6 @@ export function getModelTokenDetailDataKey({
 }
 
 /**
- * Converts a snake-case token type into a user-facing chart label.
- *
- * Sentence case rather than title case, so that a label reads the same whether
- * or not `getModelTokenDetailLabel` prefixes it with its prompt/completion kind.
- *
- * @param tokenType - Raw token type received from the API.
- * @returns A sentence-cased label with underscores replaced by spaces.
- */
-export function getTokenDetailLabel(tokenType: string) {
-  const words = tokenType.split("_").join(" ");
-  return words.charAt(0).toUpperCase() + words.slice(1);
-}
-
-/**
  * Returns an unambiguous label for a model token-detail series. The prompt or
  * completion prefix is added only when the same token type exists in both.
  *
@@ -140,83 +124,6 @@ export function getModelTokenDetailLabel({
     return label;
   }
   return `${series.isPrompt ? "Prompt" : "Completion"} ${label.toLowerCase()}`;
-}
-
-/**
- * Compares token types using the canonical chart order, then alphabetically
- * for provider-specific types that are not in the known order.
- *
- * @param left - First token type.
- * @param right - Second token type.
- * @returns A standard array-sort comparison value.
- */
-export function compareTokenTypes(left: string, right: string) {
-  const leftOrder = TOKEN_DETAIL_SORT_ORDER[left] ?? 100;
-  const rightOrder = TOKEN_DETAIL_SORT_ORDER[right] ?? 100;
-  if (leftOrder !== rightOrder) {
-    return leftOrder - rightOrder;
-  }
-  return left.localeCompare(right);
-}
-
-/**
- * Selects a stable color for a token type. Known semantic types retain the
- * same color across charts; provider-specific types cycle through fallbacks.
- *
- * @param params - Color selection context.
- * @param params.colors - Theme-aware categorical chart colors.
- * @param params.index - Position of the series in display order.
- * @param params.tokenType - Raw token type received from the API.
- * @returns A theme-aware CSS color value.
- */
-export function getTokenDetailColor({
-  colors,
-  index,
-  tokenType,
-}: {
-  colors: ReturnType<typeof useCategoryChartColors>;
-  index: number;
-  tokenType: string;
-}) {
-  if (tokenType === "input") {
-    return colors.category1;
-  }
-  if (tokenType === "output") {
-    return colors.category2;
-  }
-  if (tokenType === "cache_read") {
-    return colors.category9;
-  }
-  if (tokenType === "cache_write") {
-    return colors.category7;
-  }
-  if (tokenType === "reasoning") {
-    return colors.category4;
-  }
-  if (tokenType === "audio") {
-    return colors.category3;
-  }
-  const fallbackColors = getTokenDetailFallbackColors(colors);
-  return fallbackColors[index % fallbackColors.length];
-}
-
-/**
- * The colors used for token types with no semantic color of their own.
- *
- * @param colors - Theme-aware categorical chart colors.
- * @returns Fallback colors in assignment order.
- */
-function getTokenDetailFallbackColors(
-  colors: ReturnType<typeof useCategoryChartColors>
-) {
-  return [
-    colors.category5,
-    colors.category6,
-    colors.category8,
-    colors.category10,
-    colors.category11,
-    colors.category12,
-  ];
 }
 
 /**

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -25,6 +25,7 @@ import {
   View,
 } from "@phoenix/components";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
+import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanStatusBadge } from "@phoenix/components/trace/SpanStatusBadge";
 import { TraceTreeProvider } from "@phoenix/components/trace/TraceTree";
@@ -34,7 +35,6 @@ import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
 import { clearSelectionScopedParams } from "@phoenix/utils/urlUtils";
 
-import { RichTokenBreakdown } from "../../components/RichTokenCostBreakdown";
 import type {
   TraceDetailsQuery,
   TraceDetailsQuery$data,

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -25,9 +25,9 @@ import {
   View,
 } from "@phoenix/components";
 import { compactResizeHandleCSS } from "@phoenix/components/resize";
-import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanStatusBadge } from "@phoenix/components/trace/SpanStatusBadge";
+import { TokenCostsDetails } from "@phoenix/components/trace/TokenCostsDetails";
 import { TraceTreeProvider } from "@phoenix/components/trace/TraceTree";
 import { TraceTreeToolbar } from "@phoenix/components/trace/TraceTreeToolbar";
 import type { SpanStatusCodeType } from "@phoenix/components/trace/types";
@@ -258,22 +258,10 @@ function TraceHeader({
             <RichTooltip placement="bottom">
               <TooltipArrow />
               <View width="size-3600">
-                <RichTokenBreakdown
-                  valueLabel="cost"
-                  totalValue={costSummary?.total?.cost ?? 0}
-                  formatter={costFormatter}
-                  segments={[
-                    {
-                      name: "Prompt",
-                      value: costSummary?.prompt?.cost ?? 0,
-                      color: "rgba(254, 119, 99, 1)",
-                    },
-                    {
-                      name: "Completion",
-                      value: costSummary?.completion?.cost ?? 0,
-                      color: "rgba(98, 104, 239, 1)",
-                    },
-                  ]}
+                <TokenCostsDetails
+                  total={costSummary?.total?.cost ?? 0}
+                  prompt={costSummary?.prompt?.cost ?? 0}
+                  completion={costSummary?.completion?.cost ?? 0}
                 />
               </View>
             </RichTooltip>

--- a/app/src/utils/tokenDetailUtils.ts
+++ b/app/src/utils/tokenDetailUtils.ts
@@ -6,6 +6,14 @@
 
 import type { useCategoryChartColors } from "@phoenix/components/chart";
 
+type CategoryChartColors = ReturnType<typeof useCategoryChartColors>;
+
+/**
+ * Costs and token counts are summed from floating point values, so a value
+ * this small is noise left over from the arithmetic rather than real usage.
+ */
+export const TOKEN_DETAIL_EPSILON = 1e-9;
+
 const TOKEN_DETAIL_SORT_ORDER: Partial<Record<string, number>> = {
   input: 0,
   output: 0,
@@ -14,6 +22,26 @@ const TOKEN_DETAIL_SORT_ORDER: Partial<Record<string, number>> = {
   reasoning: 3,
   audio: 4,
 };
+
+const TOKEN_DETAIL_COLORS: Partial<Record<string, keyof CategoryChartColors>> =
+  {
+    input: "category1",
+    output: "category2",
+    cache_read: "category9",
+    cache_write: "category7",
+    reasoning: "category4",
+    audio: "category3",
+  };
+
+/** The colors used for token types with no semantic color of their own. */
+const TOKEN_DETAIL_FALLBACK_COLORS = [
+  "category5",
+  "category6",
+  "category8",
+  "category10",
+  "category11",
+  "category12",
+] as const satisfies readonly (keyof CategoryChartColors)[];
 
 /**
  * Converts a snake-case token type into a user-facing label.
@@ -27,6 +55,20 @@ const TOKEN_DETAIL_SORT_ORDER: Partial<Record<string, number>> = {
 export function getTokenDetailLabel(tokenType: string) {
   const words = tokenType.split("_").join(" ");
   return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * The token type that absorbs value a group's details do not account for.
+ *
+ * Details refine the authoritative prompt and completion totals but may be
+ * incomplete for spans recorded before a token type was tracked; the leftover
+ * is plain input or output usage.
+ *
+ * @param isPrompt - Whether the group holds prompt rather than completion usage.
+ * @returns The token type to attribute the remainder to.
+ */
+export function getRemainderTokenType(isPrompt: boolean) {
+  return isPrompt ? "input" : "output";
 }
 
 /**
@@ -52,39 +94,27 @@ export function compareTokenTypes(left: string, right: string) {
  *
  * @param params - Color selection context.
  * @param params.colors - Theme-aware categorical chart colors.
- * @param params.index - Position of the series in display order.
  * @param params.tokenType - Raw token type received from the API.
+ * @param params.index - Position of the series in display order. Only
+ *   disambiguates token types that have no semantic color of their own.
  * @returns A theme-aware CSS color value.
  */
 export function getTokenDetailColor({
   colors,
-  index,
+  index = 0,
   tokenType,
 }: {
-  colors: ReturnType<typeof useCategoryChartColors>;
-  index: number;
+  colors: CategoryChartColors;
+  index?: number;
   tokenType: string;
 }) {
-  if (tokenType === "input") {
-    return colors.category1;
+  const semanticColor = TOKEN_DETAIL_COLORS[tokenType];
+  if (semanticColor) {
+    return colors[semanticColor];
   }
-  if (tokenType === "output") {
-    return colors.category2;
-  }
-  if (tokenType === "cache_read") {
-    return colors.category9;
-  }
-  if (tokenType === "cache_write") {
-    return colors.category7;
-  }
-  if (tokenType === "reasoning") {
-    return colors.category4;
-  }
-  if (tokenType === "audio") {
-    return colors.category3;
-  }
-  const fallbackColors = getTokenDetailFallbackColors(colors);
-  return fallbackColors[index % fallbackColors.length];
+  return colors[
+    TOKEN_DETAIL_FALLBACK_COLORS[index % TOKEN_DETAIL_FALLBACK_COLORS.length]
+  ];
 }
 
 /**
@@ -93,15 +123,6 @@ export function getTokenDetailColor({
  * @param colors - Theme-aware categorical chart colors.
  * @returns Fallback colors in assignment order.
  */
-export function getTokenDetailFallbackColors(
-  colors: ReturnType<typeof useCategoryChartColors>
-) {
-  return [
-    colors.category5,
-    colors.category6,
-    colors.category8,
-    colors.category10,
-    colors.category11,
-    colors.category12,
-  ];
+export function getTokenDetailFallbackColors(colors: CategoryChartColors) {
+  return TOKEN_DETAIL_FALLBACK_COLORS.map((color) => colors[color]);
 }

--- a/app/src/utils/tokenDetailUtils.ts
+++ b/app/src/utils/tokenDetailUtils.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared presentation rules for token types (`input`, `cache_read`, ...), so a
+ * token type reads and looks the same wherever it is broken out — the model
+ * charts, the time series, and the cost/token tooltips.
+ */
+
+import type { useCategoryChartColors } from "@phoenix/components/chart";
+
+const TOKEN_DETAIL_SORT_ORDER: Partial<Record<string, number>> = {
+  input: 0,
+  output: 0,
+  cache_read: 1,
+  cache_write: 2,
+  reasoning: 3,
+  audio: 4,
+};
+
+/**
+ * Converts a snake-case token type into a user-facing label.
+ *
+ * Sentence case rather than title case, so that a label reads the same whether
+ * or not it is prefixed with its prompt/completion kind.
+ *
+ * @param tokenType - Raw token type received from the API.
+ * @returns A sentence-cased label with underscores replaced by spaces.
+ */
+export function getTokenDetailLabel(tokenType: string) {
+  const words = tokenType.split("_").join(" ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Compares token types using the canonical display order, then alphabetically
+ * for provider-specific types that are not in the known order.
+ *
+ * @param left - First token type.
+ * @param right - Second token type.
+ * @returns A standard array-sort comparison value.
+ */
+export function compareTokenTypes(left: string, right: string) {
+  const leftOrder = TOKEN_DETAIL_SORT_ORDER[left] ?? 100;
+  const rightOrder = TOKEN_DETAIL_SORT_ORDER[right] ?? 100;
+  if (leftOrder !== rightOrder) {
+    return leftOrder - rightOrder;
+  }
+  return left.localeCompare(right);
+}
+
+/**
+ * Selects a stable color for a token type. Known semantic types retain the
+ * same color across charts; provider-specific types cycle through fallbacks.
+ *
+ * @param params - Color selection context.
+ * @param params.colors - Theme-aware categorical chart colors.
+ * @param params.index - Position of the series in display order.
+ * @param params.tokenType - Raw token type received from the API.
+ * @returns A theme-aware CSS color value.
+ */
+export function getTokenDetailColor({
+  colors,
+  index,
+  tokenType,
+}: {
+  colors: ReturnType<typeof useCategoryChartColors>;
+  index: number;
+  tokenType: string;
+}) {
+  if (tokenType === "input") {
+    return colors.category1;
+  }
+  if (tokenType === "output") {
+    return colors.category2;
+  }
+  if (tokenType === "cache_read") {
+    return colors.category9;
+  }
+  if (tokenType === "cache_write") {
+    return colors.category7;
+  }
+  if (tokenType === "reasoning") {
+    return colors.category4;
+  }
+  if (tokenType === "audio") {
+    return colors.category3;
+  }
+  const fallbackColors = getTokenDetailFallbackColors(colors);
+  return fallbackColors[index % fallbackColors.length];
+}
+
+/**
+ * The colors used for token types with no semantic color of their own.
+ *
+ * @param colors - Theme-aware categorical chart colors.
+ * @returns Fallback colors in assignment order.
+ */
+export function getTokenDetailFallbackColors(
+  colors: ReturnType<typeof useCategoryChartColors>
+) {
+  return [
+    colors.category5,
+    colors.category6,
+    colors.category8,
+    colors.category10,
+    colors.category11,
+    colors.category12,
+  ];
+}

--- a/app/stories/RichTokenBreakdown.stories.tsx
+++ b/app/stories/RichTokenBreakdown.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Flex, View } from "@phoenix/components";
-import { RichTokenBreakdown } from "@phoenix/components/RichTokenCostBreakdown";
+import { RichTokenBreakdown } from "@phoenix/components/RichTokenBreakdown";
 import { formatCost, formatInt } from "@phoenix/utils/numberFormatUtils";
 
 const meta = {
@@ -21,6 +21,11 @@ const meta = {
     formatter: {
       control: false,
       description: "Formats the total and segment values.",
+    },
+    totalLabel: {
+      control: "text",
+      description:
+        'Qualifies the total, e.g. "Total", "Average", or the name of the group being broken down.',
     },
   },
   render: (args) => (
@@ -63,7 +68,8 @@ export const CachedConversation: Story = {
       <Flex direction="column" gap="size-300">
         <RichTokenBreakdown {...args} />
         <RichTokenBreakdown
-          valueLabel="prompt tokens"
+          valueLabel="tokens"
+          totalLabel="Prompt"
           totalValue={15_937}
           formatter={formatInt}
           segments={[

--- a/app/stories/TokenCosts.stories.tsx
+++ b/app/stories/TokenCosts.stories.tsx
@@ -123,15 +123,15 @@ export const WithDetailedTooltip: Story = {
           completion={0.061}
           promptDetails={{
             input: 0.045,
-            "cache read": 0.012,
-            "cache write": 0.008,
+            cache_read: 0.012,
+            cache_write: 0.008,
             tool: 0.021,
             audio: 0.01,
           }}
           completionDetails={{
             output: 0.035,
             reasoning: 0.016,
-            "function calls": 0.01,
+            function_calls: 0.01,
           }}
         />
       </RichTooltip>
@@ -180,7 +180,7 @@ export const WithLoadingTooltip: Story = {
             completion={0.037}
             promptDetails={{
               input: 0.025,
-              "cache read": 0.015,
+              cache_read: 0.015,
               tool: 0.012,
             }}
             completionDetails={{
@@ -266,15 +266,15 @@ export const HighCostDetailed: Story = {
           completion={1.22}
           promptDetails={{
             input: 0.45,
-            "cache read": 0.23,
-            "cache write": 0.15,
+            cache_read: 0.23,
+            cache_write: 0.15,
             tool: 0.28,
             audio: 0.12,
           }}
           completionDetails={{
             output: 0.67,
             reasoning: 0.35,
-            "function calls": 0.2,
+            function_calls: 0.2,
           }}
         />
       </RichTooltip>
@@ -403,14 +403,14 @@ export const CostComparison: Story = {
               completion={0.089}
               promptDetails={{
                 input: 0.067,
-                "cache read": 0.023,
+                cache_read: 0.023,
                 tool: 0.034,
                 audio: 0.021,
               }}
               completionDetails={{
                 output: 0.045,
                 reasoning: 0.034,
-                "function calls": 0.01,
+                function_calls: 0.01,
               }}
             />
           </RichTooltip>

--- a/app/stories/TokenCount.stories.tsx
+++ b/app/stories/TokenCount.stories.tsx
@@ -78,8 +78,8 @@ export const WithBasicTooltip: Story = {
       </Pressable>
       <RichTooltip>
         <TokenCountDetails
-          total={1721}
-          prompt={230}
+          total={1699}
+          prompt={691}
           completion={1008}
           promptDetails={{
             tool: 461,
@@ -89,7 +89,7 @@ export const WithBasicTooltip: Story = {
     </TooltipTrigger>
   ),
   args: {
-    children: 1721,
+    children: 1699,
     size: "M",
   },
 };
@@ -106,19 +106,19 @@ export const WithDetailedTooltip: Story = {
       <RichTooltip>
         <TokenCountDetails
           total={3500}
-          prompt={1200}
+          prompt={1700}
           completion={1800}
           promptDetails={{
             audio: 100,
-            "cache read": 300,
-            "cache write": 150,
+            cache_read: 300,
+            cache_write: 150,
             tool: 500,
-            "system instructions": 200,
+            system_instructions: 200,
           }}
           completionDetails={{
             audio: 200,
             reasoning: 300,
-            "function calls": 150,
+            function_calls: 150,
           }}
         />
       </RichTooltip>
@@ -163,12 +163,12 @@ export const WithLoadingTooltip: Story = {
         <Suspense fallback={<Loading />}>
           <TokenCountDetails
             total={2500}
-            prompt={800}
+            prompt={1300}
             completion={1200}
             promptDetails={{
               audio: 150,
-              "cache read": 250,
-              "cache write": 100,
+              cache_read: 250,
+              cache_write: 100,
               tool: 500,
             }}
           />
@@ -230,6 +230,7 @@ export const MultipleTokenCounts: Story = {
         <RichTooltip>
           <TokenCountDetails
             total={461}
+            prompt={461}
             promptDetails={{
               tool: 461,
             }}

--- a/app/stories/TokenDetailsBreakdown.stories.tsx
+++ b/app/stories/TokenDetailsBreakdown.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Pressable } from "react-aria";
+
+import { RichTooltip, TooltipArrow, TooltipTrigger } from "@phoenix/components";
+import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
+import { TokenDetailsBreakdown } from "@phoenix/components/trace/TokenDetailsBreakdown";
+
+/**
+ * The body of every cost and token tooltip in the app. A total is split into
+ * prompt and completion and drawn as a proportional bar, so the split reads at
+ * a glance instead of having to be inferred from the numbers.
+ *
+ * Prompt and completion get a bar of their own when they break down further by
+ * token type. A group whose details amount to a single token type is left out,
+ * since its bar would restate the legend row above it.
+ *
+ * `TokenCostsDetails` and `TokenCountDetails` are thin wrappers over this
+ * component that fix the formatter and the value label.
+ */
+const meta = {
+  title: "Tokens/Token Details Breakdown",
+  component: TokenDetailsBreakdown,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    formatter: {
+      control: false,
+      description: "Renders a value in the unit being broken down.",
+    },
+  },
+} satisfies Meta<typeof TokenDetailsBreakdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const costFormatter = (value: number) => `$${value.toFixed(2)}`;
+const tokenFormatter = (value: number) => value.toLocaleString();
+
+/**
+ * Cost split between prompt and completion. With no token-type details, the
+ * breakdown is a single bar.
+ */
+export const Cost: Story = {
+  args: {
+    valueLabel: "cost",
+    formatter: costFormatter,
+    total: 27.09,
+    prompt: 24.04,
+    completion: 3.05,
+  },
+};
+
+/**
+ * A cached conversation. The prompt bar shows what the cache absorbed, which is
+ * the detail that explains an otherwise surprising prompt cost.
+ */
+export const CostWithCacheDetails: Story = {
+  args: {
+    valueLabel: "cost",
+    formatter: costFormatter,
+    total: 27.09,
+    prompt: 24.04,
+    completion: 3.05,
+    promptDetails: {
+      input: 4.04,
+      cache_read: 16.0,
+      cache_write: 4.0,
+    },
+  },
+};
+
+/**
+ * Token counts, with details on both sides of the split. Reasoning tokens keep
+ * the same color here that they carry in the project metrics charts.
+ */
+export const TokenCounts: Story = {
+  args: {
+    valueLabel: "tokens",
+    formatter: tokenFormatter,
+    total: 84_320,
+    prompt: 78_100,
+    completion: 6_220,
+    promptDetails: {
+      input: 12_774,
+      cache_read: 61_326,
+      cache_write: 4_000,
+    },
+    completionDetails: {
+      output: 4_220,
+      reasoning: 2_000,
+    },
+  },
+};
+
+/**
+ * Details recorded before a token type was tracked can add up to less than the
+ * group they belong to. The unaccounted remainder is attributed to Input or
+ * Output rather than left as a gap, so the bar still fills its total.
+ */
+export const IncompleteDetails: Story = {
+  args: {
+    valueLabel: "tokens",
+    formatter: tokenFormatter,
+    total: 84_320,
+    prompt: 78_100,
+    completion: 6_220,
+    // Only the cache is broken out; the remaining 16,774 prompt tokens
+    // surface as Input.
+    promptDetails: {
+      cache_read: 61_326,
+    },
+  },
+};
+
+/**
+ * An experiment average, where the total is labeled rather than "Total".
+ */
+export const AverageLabel: Story = {
+  args: {
+    valueLabel: "cost",
+    totalLabel: "Average",
+    formatter: costFormatter,
+    total: 0.34,
+    prompt: 0.28,
+    completion: 0.06,
+  },
+};
+
+/**
+ * Nothing was spent. The bar is dropped rather than drawn empty, which would
+ * read as a rendering failure.
+ */
+export const ZeroCost: Story = {
+  args: {
+    valueLabel: "cost",
+    formatter: costFormatter,
+    total: 0,
+    prompt: 0,
+    completion: 0,
+  },
+};
+
+/**
+ * How the breakdown is actually seen: inside the tooltip of a cost, where it
+ * has to stay legible at tooltip width.
+ */
+export const InTooltip: Story = {
+  render: (args) => (
+    <TooltipTrigger delay={0}>
+      <Pressable>
+        <TokenCosts role="button" tabIndex={0}>
+          {27.09}
+        </TokenCosts>
+      </Pressable>
+      <RichTooltip placement="bottom">
+        <TooltipArrow />
+        <TokenDetailsBreakdown {...args} />
+      </RichTooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    valueLabel: "cost",
+    formatter: costFormatter,
+    total: 27.09,
+    prompt: 24.04,
+    completion: 3.05,
+    promptDetails: {
+      input: 4.04,
+      cache_read: 16.0,
+      cache_write: 4.0,
+    },
+    completionDetails: {
+      output: 2.05,
+      reasoning: 1.0,
+    },
+  },
+};

--- a/app/stories/TokenDetailsBreakdown.stories.tsx
+++ b/app/stories/TokenDetailsBreakdown.stories.tsx
@@ -4,6 +4,7 @@ import { Pressable } from "react-aria";
 import { RichTooltip, TooltipArrow, TooltipTrigger } from "@phoenix/components";
 import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
 import { TokenDetailsBreakdown } from "@phoenix/components/trace/TokenDetailsBreakdown";
+import { formatCost, formatNumber } from "@phoenix/utils/numberFormatUtils";
 
 /**
  * The body of every cost and token tooltip in the app. A total is split into
@@ -35,9 +36,6 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const costFormatter = (value: number) => `$${value.toFixed(2)}`;
-const tokenFormatter = (value: number) => value.toLocaleString();
-
 /**
  * Cost split between prompt and completion. With no token-type details, the
  * breakdown is a single bar.
@@ -45,7 +43,7 @@ const tokenFormatter = (value: number) => value.toLocaleString();
 export const Cost: Story = {
   args: {
     valueLabel: "cost",
-    formatter: costFormatter,
+    formatter: formatCost,
     total: 27.09,
     prompt: 24.04,
     completion: 3.05,
@@ -59,7 +57,7 @@ export const Cost: Story = {
 export const CostWithCacheDetails: Story = {
   args: {
     valueLabel: "cost",
-    formatter: costFormatter,
+    formatter: formatCost,
     total: 27.09,
     prompt: 24.04,
     completion: 3.05,
@@ -78,7 +76,7 @@ export const CostWithCacheDetails: Story = {
 export const TokenCounts: Story = {
   args: {
     valueLabel: "tokens",
-    formatter: tokenFormatter,
+    formatter: formatNumber,
     total: 84_320,
     prompt: 78_100,
     completion: 6_220,
@@ -102,7 +100,7 @@ export const TokenCounts: Story = {
 export const IncompleteDetails: Story = {
   args: {
     valueLabel: "tokens",
-    formatter: tokenFormatter,
+    formatter: formatNumber,
     total: 84_320,
     prompt: 78_100,
     completion: 6_220,
@@ -121,7 +119,7 @@ export const AverageLabel: Story = {
   args: {
     valueLabel: "cost",
     totalLabel: "Average",
-    formatter: costFormatter,
+    formatter: formatCost,
     total: 0.34,
     prompt: 0.28,
     completion: 0.06,
@@ -135,7 +133,7 @@ export const AverageLabel: Story = {
 export const ZeroCost: Story = {
   args: {
     valueLabel: "cost",
-    formatter: costFormatter,
+    formatter: formatCost,
     total: 0,
     prompt: 0,
     completion: 0,
@@ -162,7 +160,7 @@ export const InTooltip: Story = {
   ),
   args: {
     valueLabel: "cost",
-    formatter: costFormatter,
+    formatter: formatCost,
     total: 27.09,
     prompt: 24.04,
     completion: 3.05,


### PR DESCRIPTION
Closes #14822

## What

Cost and token tooltips listed prompt, completion, and their token-type details as plain rows, so the split had to be inferred from the numbers. They now render through `RichTokenBreakdown` — the same segment bar the project stats panel and the PXI footer already use — so the proportions read at a glance.

Prompt and completion each get a bar of their own when they break down further by token type. A group whose details amount to a single token type is left out, since its bar would just restate the legend row above it.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm fmt`, and `pnpm test` (2055 passing) all clean. Screenshots below are from Storybook, light and dark.

| Cost tooltip | Token tooltip |
| --- | --- |
| <img width="360" src="https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14832-cost-tooltip-dark.png" /> | <img width="360" src="https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14832-token-tooltip-dark.png" /> |

| Light theme | Remainder attributed to Input |
| --- | --- |
| <img width="360" src="https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14832-token-breakdown-light.png" /> | <img width="360" src="https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14832-remainder-attribution.png" /> |


<img width="440" src="https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14832-pxi-cache-colors.png" />
