### PR TITLE
feat: show tool and tool call counts in LLM span card headers

### DIFF
--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -3,6 +3,7 @@ import { Fragment } from "react";
 import type { CSSProperties } from "react";
 
 import { Flex, Text } from "@phoenix/components";
+import { inlineDividerCSS } from "@phoenix/components/core/styles";
 import type { TextSize } from "@phoenix/components/core/types";
 import { assertUnreachable } from "@phoenix/typeUtils";
 import { formatFloat } from "@phoenix/utils/numberFormatUtils";
@@ -28,15 +29,6 @@ const valuePartsCSS = css`
   display: inline-flex;
   align-items: center;
   gap: var(--global-dimension-size-100);
-`;
-
-// A thin separator between value pieces (e.g. a label and its score). Tinted
-// with the current text color so it inherits the optimization-direction color.
-const valueDividerCSS = css`
-  width: 1px;
-  height: 0.7em;
-  background-color: currentColor;
-  opacity: 0.2;
 `;
 
 /**
@@ -150,7 +142,7 @@ export function AnnotationNameAndValue({
             <span css={valuePartsCSS}>
               {valueParts.map((part, index) => (
                 <Fragment key={index}>
-                  {index > 0 && <span aria-hidden css={valueDividerCSS} />}
+                  {index > 0 && <span aria-hidden css={inlineDividerCSS} />}
                   <Text
                     fontFamily={part.fontFamily}
                     color="inherit"

--- a/app/src/components/core/styles.ts
+++ b/app/src/components/core/styles.ts
@@ -17,6 +17,18 @@ export const outlinedPillCSS = css`
 `;
 
 /**
+ * A thin vertical separator between inline text pieces (e.g. an annotation
+ * label and its score, or a model name and its tool count). Tinted with the
+ * current text color so it inherits the surrounding text's color.
+ */
+export const inlineDividerCSS = css`
+  width: 1px;
+  height: 0.7em;
+  background-color: currentColor;
+  opacity: 0.2;
+`;
+
+/**
  * Hover invitation for quiet interactive text (click-to-copy IDs, values that
  * reveal a tooltip): a subtle background wash that appears on hover without
  * shifting the text's position. Matches the quiet Button hover treatment.

--- a/app/src/pages/trace/span/LLMInput.tsx
+++ b/app/src/pages/trace/span/LLMInput.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { Card, CopyToClipboardButton, Flex } from "@phoenix/components";
+import { inlineDividerCSS } from "@phoenix/components/core/styles";
 import { GenerativeProviderIcon } from "@phoenix/components/generative";
 import {
   ConnectedMarkdownModeSelect,
@@ -54,26 +55,32 @@ export function LLMInput({
   /** The invocation parameters as a JSON string */
   invocationParameters: string;
 }) {
-  let modelNameEl: ReactNode = null;
-  if (modelName != null) {
+  const toolCount = toolSchemas.length;
+  let subTitleEl: ReactNode = null;
+  if (modelName != null || toolCount > 0) {
     const normalizedProvider = provider?.toUpperCase();
     // Only show a provider icon when the provider is known
     const providerIcon =
+      modelName != null &&
       typeof normalizedProvider === "string" &&
       isModelProvider(normalizedProvider) ? (
         <GenerativeProviderIcon provider={normalizedProvider} height={16} />
       ) : null;
-    modelNameEl = (
+    subTitleEl = (
       <Flex direction="row" gap="size-100" alignItems="center">
         {providerIcon}
         {modelName}
+        {modelName != null && toolCount > 0 && (
+          <span aria-hidden css={inlineDividerCSS} />
+        )}
+        {toolCount > 0 && `${toolCount} ${toolCount === 1 ? "tool" : "tools"}`}
       </Flex>
     );
   }
 
   const hasInput = input != null && input.value != null;
   const hasInputMessages = inputMessages.length > 0;
-  const hasLLMToolSchemas = toolSchemas.length > 0;
+  const hasLLMToolSchemas = toolCount > 0;
   const hasPrompts = prompts.length > 0;
   const hasInvocationParams =
     Object.keys(safelyParseJSON(invocationParameters).json || {}).length > 0;
@@ -114,7 +121,7 @@ export function LLMInput({
         {...defaultCardProps}
         {...cardProps}
         title="Input"
-        subTitle={modelNameEl}
+        subTitle={subTitleEl}
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isRawView && (

--- a/app/src/pages/trace/span/LLMMessage.tsx
+++ b/app/src/pages/trace/span/LLMMessage.tsx
@@ -1,7 +1,4 @@
-import {
-  MessageAttributePostfixes,
-  SemanticAttributePrefixes,
-} from "@arizeai/openinference-semantic-conventions";
+import { MessageAttributePostfixes } from "@arizeai/openinference-semantic-conventions";
 import { css } from "@emotion/react";
 
 import {
@@ -30,6 +27,7 @@ import {
 
 import { defaultCardProps } from "./constants";
 import { MessageContentsList } from "./MessageContentsList";
+import { getToolCalls } from "./utils";
 
 /**
  * Displays a single LLM message (input or output) including its contents,
@@ -42,16 +40,13 @@ export function LLMMessage({ message }: { message: AttributeMessage }) {
   });
   // as of multi-modal models, a message can also be a list
   const messagesContents = message[MessageAttributePostfixes.contents];
-  const toolCalls = message[MessageAttributePostfixes.tool_calls]
-    ?.map((obj) => obj[SemanticAttributePrefixes.tool_call])
-    .filter(Boolean);
+  const toolCalls = getToolCalls(message);
   const hasFunctionCall =
     message[MessageAttributePostfixes.function_call_arguments_json] &&
     message[MessageAttributePostfixes.function_call_name];
   const role = message[MessageAttributePostfixes.role] || "unknown";
   const messageStyles = useChatMessageStyles(role);
-  const toolCallDisclosureIds =
-    toolCalls?.map((_, idx) => `tool-call-${idx}`) || [];
+  const toolCallDisclosureIds = toolCalls.map((_, idx) => `tool-call-${idx}`);
   const toolResultId = message[MessageAttributePostfixes.tool_call_id];
 
   return (
@@ -136,11 +131,8 @@ export function LLMMessage({ message }: { message: AttributeMessage }) {
                 </ConnectedMarkdownBlock>
               </View>
             ) : null}
-            {(toolCalls?.length ?? 0) > 0
-              ? toolCalls?.map((toolCall, idx) => {
-                  if (!toolCall) {
-                    return null;
-                  }
+            {toolCalls.length > 0
+              ? toolCalls.map((toolCall, idx) => {
                   const id = toolCall.id;
                   const parsedArguments = safelyParseJSON(
                     toolCall?.function?.arguments as string

--- a/app/src/pages/trace/span/LLMOutput.tsx
+++ b/app/src/pages/trace/span/LLMOutput.tsx
@@ -12,6 +12,7 @@ import { LLMIOViewSelect, useLLMIOView } from "./LLMIOViewSelect";
 import { LLMMessagesList } from "./LLMMessagesList";
 import { MimeTypeCodeBlock } from "./MimeTypeCodeBlock";
 import type { SpanIOValue } from "./types";
+import { countToolCalls } from "./utils";
 
 /**
  * The output side of an LLM span — a card with a view select for the output
@@ -28,6 +29,7 @@ export function LLMOutput({
 }) {
   const hasOutput = output != null && output.value != null;
   const hasOutputMessages = outputMessages.length > 0;
+  const toolCallCount = countToolCalls(outputMessages);
 
   const views: LLMIOView[] = [];
   if (hasOutputMessages)
@@ -48,6 +50,11 @@ export function LLMOutput({
         {...defaultCardProps}
         {...cardProps}
         title="Output"
+        subTitle={
+          toolCallCount > 0
+            ? `${toolCallCount} ${toolCallCount === 1 ? "tool call" : "tool calls"}`
+            : undefined
+        }
         extra={
           <Flex direction="row" gap="size-100" alignItems="center">
             {isRawView && (

--- a/app/src/pages/trace/span/__tests__/utils.test.ts
+++ b/app/src/pages/trace/span/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { DocumentEvaluation } from "../types";
 import {
+  countToolCalls,
   getEmbeddingAttributes,
   getLLMAttributes,
   getRerankerAttributes,
@@ -95,6 +96,34 @@ describe("getLLMAttributes", () => {
       },
     });
     expect(result.prompts).toEqual([]);
+  });
+});
+
+describe("countToolCalls", () => {
+  it("sums the tool calls across messages, skipping empty entries", () => {
+    expect(
+      countToolCalls([
+        { role: "assistant", content: "no tool calls here" },
+        {
+          role: "assistant",
+          tool_calls: [
+            { tool_call: { id: "1", function: { name: "search" } } },
+            {},
+            { tool_call: { id: "2", function: { name: "calculate" } } },
+          ],
+        },
+        {
+          role: "assistant",
+          tool_calls: [
+            { tool_call: { id: "3", function: { name: "search" } } },
+          ],
+        },
+      ])
+    ).toBe(3);
+  });
+
+  it("returns zero when there are no messages", () => {
+    expect(countToolCalls([])).toBe(0);
   });
 });
 

--- a/app/src/pages/trace/span/utils.ts
+++ b/app/src/pages/trace/span/utils.ts
@@ -1,6 +1,7 @@
 import {
   EmbeddingAttributePostfixes,
   LLMAttributePostfixes,
+  MessageAttributePostfixes,
   RerankerAttributePostfixes,
   RetrievalAttributePostfixes,
   SemanticAttributePrefixes,
@@ -13,6 +14,7 @@ import type {
   AttributeLLMToolDefinition,
   AttributeMessage,
   AttributePromptTemplate,
+  AttributeToolCall,
 } from "@phoenix/openInference/tracing/types";
 import { isAttributeMessages } from "@phoenix/openInference/tracing/types";
 import { isStringArray } from "@phoenix/typeUtils";
@@ -67,6 +69,25 @@ function getMessages(messagesValue: unknown): AttributeMessage[] {
   return (messagesValue
     .map((obj) => obj[SemanticAttributePrefixes.message])
     .filter(Boolean) || []) as AttributeMessage[];
+}
+
+/**
+ * Extract the tool call objects from a message's tool calls attribute.
+ */
+export function getToolCalls(message: AttributeMessage): AttributeToolCall[] {
+  return (message[MessageAttributePostfixes.tool_calls]
+    ?.map((obj) => obj[SemanticAttributePrefixes.tool_call])
+    .filter(Boolean) || []) as AttributeToolCall[];
+}
+
+/**
+ * Count the tool calls across a set of messages.
+ */
+export function countToolCalls(messages: AttributeMessage[]): number {
+  return messages.reduce(
+    (count, message) => count + getToolCalls(message).length,
+    0
+  );
 }
 
 /**

--- a/app/stories/SpanInfo.stories.tsx
+++ b/app/stories/SpanInfo.stories.tsx
@@ -3,6 +3,8 @@ import { RelayEnvironmentProvider } from "react-relay";
 import { Environment, Network, RecordSource, Store } from "relay-runtime";
 
 import { SpanInfo } from "@phoenix/pages/trace/span";
+import { SpanAsideProvider } from "@phoenix/pages/trace/SpanAsideContext";
+import { SpanInfoCardsProvider } from "@phoenix/pages/trace/SpanInfoCardsContext";
 
 import {
   chainJsonIOSpan,
@@ -44,7 +46,11 @@ const meta: Meta<typeof SpanInfo> = {
   decorators: [
     (Story) => (
       <RelayEnvironmentProvider environment={mockRelayEnvironment}>
-        <Story />
+        <SpanAsideProvider>
+          <SpanInfoCardsProvider>
+            <Story />
+          </SpanInfoCardsProvider>
+        </SpanAsideProvider>
       </RelayEnvironmentProvider>
     ),
   ],


### PR DESCRIPTION
## Summary

Resolves #14712

When looking at an LLM span, you can now see at a glance:

- **Input card**: the number of tool definitions ("N tools") after the model name, separated by a thin divider — no need to open the Tools tab to know they're there
- **Output card**: the number of tool calls ("N tool calls") across the output messages

Both counts are hidden when zero, so spans without tools look exactly as before.

## Implementation notes

- `countToolCalls` / `getToolCalls` live in `span/utils.ts`; the `tool_calls[].tool_call` unwrap previously inlined in `LLMMessage` now uses the same shared helper
- The inline divider css was promoted to `components/core/styles.ts` (`inlineDividerCSS`), shared with `AnnotationNameAndValue` which had an identical private copy
- Fixed the `SpanInfo` stories, which were broken (missing the `SpanAsideProvider` and `SpanInfoCardsProvider` decorators)

## Test plan

- Unit tests for `countToolCalls` in `span/__tests__/utils.test.ts` (all 18 pass)
- Typecheck, oxlint, oxfmt clean
- Verified live against dev-server data (PXI spans with 20 tools, spans with 0 tools unchanged) and in Storybook (`Trace/SpanInfo` stories)

## Screenshots

Storybook `Trace/SpanInfo → LLMWithToolDefinitions` — the Input header shows the tool count after the model name behind a thin divider, and the Output header shows the tool call count:

![LLM span card headers with tool counts (dark)](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14841-llm-span-tool-counts-dark.png)

![LLM span card headers with tool counts (light)](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14841-llm-span-tool-counts-light.png)