### PR TITLE
fix(cli): handle stale OAuth profiles in auth status

### DIFF
--- a/js/.changeset/px-auth-status-anonymous-fallback.md
+++ b/js/.changeset/px-auth-status-anonymous-fallback.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": patch
+---
+
+Fix `px auth status` when a profile contains stale OAuth credentials but the Phoenix server now allows anonymous access

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -121,6 +121,31 @@ async function fetchViewer(config: PhoenixConfig): Promise<FetchViewerResult> {
 }
 
 /**
+ * Fetch the viewer for `auth status`, accounting for deployments that changed
+ * from OAuth authentication to anonymous access. An expired profile token can
+ * fail during refresh before `/v1/user` is requested, so retry without
+ * credentials and accept the result only when the server explicitly reports
+ * anonymous access.
+ */
+async function fetchViewerForStatus(
+  config: PhoenixConfig
+): Promise<FetchViewerResult> {
+  const result = await fetchViewer(config);
+  const canCheckAnonymousAccess =
+    config.credentialSource === "oauth" &&
+    (result.status === "auth_error" || result.status === "unknown_error");
+  if (!canCheckAnonymousAccess) {
+    return result;
+  }
+
+  const anonymousResult = await fetchViewer({ endpoint: config.endpoint });
+  const isAnonymous =
+    anonymousResult.status === "success" &&
+    anonymousResult.user.auth_method === "ANONYMOUS";
+  return isAnonymous ? anonymousResult : result;
+}
+
+/**
  * Format auth status output in gh-style format.
  */
 export function formatAuthStatus(
@@ -351,7 +376,7 @@ async function authStatusHandler(options: AuthStatusOptions): Promise<void> {
       ? getProfileByName(settingsFile, options.profile)?.name
       : getStoredActiveProfile(settingsFile)?.name;
 
-  const result = await fetchViewer(config);
+  const result = await fetchViewerForStatus(config);
   const oauthTokens = loadCurrentOAuthTokens({
     config,
     profileName: activeProfileName,

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -130,19 +130,20 @@ async function fetchViewer(config: PhoenixConfig): Promise<FetchViewerResult> {
 async function fetchViewerForStatus(
   config: PhoenixConfig
 ): Promise<FetchViewerResult> {
-  const result = await fetchViewer(config);
+  const viewerResult = await fetchViewer(config);
   const canCheckAnonymousAccess =
     config.credentialSource === "oauth" &&
-    (result.status === "auth_error" || result.status === "unknown_error");
+    (viewerResult.status === "auth_error" ||
+      viewerResult.status === "unknown_error");
   if (!canCheckAnonymousAccess) {
-    return result;
+    return viewerResult;
   }
 
   const anonymousResult = await fetchViewer({ endpoint: config.endpoint });
   const isAnonymous =
     anonymousResult.status === "success" &&
     anonymousResult.user.auth_method === "ANONYMOUS";
-  return isAnonymous ? anonymousResult : result;
+  return isAnonymous ? anonymousResult : viewerResult;
 }
 
 /**

--- a/js/packages/phoenix-cli/test/auth.test.ts
+++ b/js/packages/phoenix-cli/test/auth.test.ts
@@ -440,7 +440,7 @@ describe("Auth Commands", () => {
   });
 });
 
-describe("px auth login/logout", () => {
+describe("px auth status/login/logout", () => {
   let originalEnv: NodeJS.ProcessEnv;
   let tmpDir: string;
   let originalStdin: typeof process.stdin;
@@ -462,6 +462,107 @@ describe("px auth login/logout", () => {
     process.env = originalEnv;
     fs.rmSync(tmpDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+  });
+
+  it("reports anonymous access when stale OAuth credentials cannot refresh", async () => {
+    let server: Awaited<ReturnType<typeof withServer>> | undefined;
+    let userRequestCount = 0;
+    try {
+      server = await withServer((request, response) => {
+        if (request.url === "/oauth2/token") {
+          response.writeHead(405);
+          response.end();
+          return;
+        }
+        if (request.url === "/v1/user") {
+          userRequestCount += 1;
+          response.writeHead(200, { "Content-Type": "application/json" });
+          response.end(JSON.stringify({ data: { auth_method: "ANONYMOUS" } }));
+          return;
+        }
+        response.writeHead(404);
+        response.end();
+      });
+      writeTempSettings(tmpDir, {
+        activeProfile: "local",
+        profiles: {
+          local: {
+            endpoint: server.url,
+            oauthTokens: {
+              accessToken: "expired-access",
+              refreshToken: "expired-refresh",
+              expiresAt: "2000-01-01T00:00:00.000Z",
+              scope: "",
+            },
+          },
+        },
+      });
+      const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const exitSpy = mockProcessExit();
+
+      await runAuthCommand(["status", "--format", "raw"]);
+
+      expect(JSON.parse(captured(stdoutSpy))).toMatchObject({
+        credentialSource: "oauth",
+        status: "anonymous",
+        user: { auth_method: "ANONYMOUS" },
+      });
+      expect(userRequestCount).toBe(1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      await server?.close();
+    }
+  });
+
+  it("preserves an OAuth failure when anonymous access is rejected", async () => {
+    let server: Awaited<ReturnType<typeof withServer>> | undefined;
+    let userRequestCount = 0;
+    try {
+      server = await withServer((request, response) => {
+        if (request.url === "/oauth2/token") {
+          response.writeHead(401);
+          response.end();
+          return;
+        }
+        if (request.url === "/v1/user") {
+          userRequestCount += 1;
+          response.writeHead(401);
+          response.end();
+          return;
+        }
+        response.writeHead(404);
+        response.end();
+      });
+      writeTempSettings(tmpDir, {
+        activeProfile: "prod",
+        profiles: {
+          prod: {
+            endpoint: server.url,
+            oauthTokens: {
+              accessToken: "expired-access",
+              refreshToken: "expired-refresh",
+              expiresAt: "2000-01-01T00:00:00.000Z",
+              scope: "",
+            },
+          },
+        },
+      });
+      const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const exitSpy = mockProcessExit();
+
+      await runAuthCommand(["status", "--format", "raw"]);
+
+      expect(JSON.parse(captured(stdoutSpy))).toMatchObject({
+        credentialSource: "oauth",
+        status: "unverified",
+      });
+      expect(userRequestCount).toBe(1);
+      expect(exitSpy).toHaveBeenCalledWith(ExitCode.AUTH_REQUIRED);
+    } finally {
+      await server?.close();
+    }
   });
 
   it("logs in via pasted redirect URL against stubbed endpoints", async () => {


### PR DESCRIPTION
## Summary

- Retry `/v1/user` without credentials when OAuth verification fails during `px auth status`
- Accept the fallback only when Phoenix explicitly reports `ANONYMOUS`
- Preserve the original authentication failure and exit code for protected servers
- Add a patch changeset for `@arizeai/phoenix-cli`

## Root cause

An expired OAuth access token triggers silent refresh before the CLI requests `/v1/user`. If a Phoenix deployment has since disabled authentication, its OAuth token endpoint is unavailable and the refresh fails before `auth status` can discover that `/v1/user` allows anonymous access.

## User impact

`px auth status` now succeeds for anonymous Phoenix deployments even when the active profile still contains stale OAuth credentials. Authenticated deployments continue to reject invalid sessions with exit code 4.

## Tests

- `make build-ts`
- `make test-ts` (69 Phoenix CLI test files, 853 tests)
- `make typecheck-ts`
- `make lint-ts`
- Built CLI against `http://localhost:6006`: exit 0 with `status: "anonymous"`
