### PR TITLE
fix: accept null provider in createModel and report the real conflict

### DIFF
--- a/src/phoenix/server/api/mutations/model_mutations.py
+++ b/src/phoenix/server/api/mutations/model_mutations.py
@@ -6,6 +6,7 @@ import sqlalchemy as sa
 import strawberry
 from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from strawberry.relay import GlobalID
@@ -94,20 +95,32 @@ class ModelMutationMixin:
             raise BadRequest("output cost is required")
         name_pattern = _compile_regular_expression(input.name_pattern)
         token_prices = [cost.token_prices for cost in input.costs]
+        # The database column is non-nullable and the empty string is how a
+        # provider-agnostic model is represented, so normalize null the same way
+        # `update_model` does.
+        provider = input.provider or ""
         model = models.GenerativeModel(
             name=input.name,
-            provider=input.provider,
+            provider=provider,
             name_pattern=name_pattern,
             is_built_in=False,
             token_prices=token_prices,
             start_time=input.start_time,
         )
         async with info.context.db() as session:
-            session.add(model)
             try:
-                await session.flush()
+                # The savepoint keeps the session usable after a rejected write, so the
+                # conflict can be diagnosed without the happy path paying for a pre-check.
+                async with session.begin_nested():
+                    session.add(model)
+                    await session.flush()
             except (PostgreSQLIntegrityError, SQLiteIntegrityError):
-                raise Conflict(f"Model with name '{input.name}' already exists")
+                raise await _conflicting_model_error(
+                    session,
+                    name=input.name,
+                    provider=provider,
+                    name_pattern=name_pattern,
+                )
 
         return CreateModelMutationPayload(
             model=GenerativeModel(id=model.id, db_record=model),
@@ -160,9 +173,16 @@ class ModelMutationMixin:
             model.updated_at = datetime.now(timezone.utc)
             session.add(model)
             try:
-                await session.flush()
+                async with session.begin_nested():
+                    await session.flush()
             except (PostgreSQLIntegrityError, SQLiteIntegrityError):
-                raise Conflict(f"Model with name '{input.name}' already exists")
+                raise await _conflicting_model_error(
+                    session,
+                    name=input.name,
+                    provider=input.provider or "",
+                    name_pattern=name_pattern,
+                    exclude_model_id=model_id,
+                )
 
         return UpdateModelMutationPayload(
             model=GenerativeModel(id=model.id, db_record=model),
@@ -197,6 +217,58 @@ class ModelMutationMixin:
             model=GenerativeModel(id=model.id, db_record=model),
             query=Query(),
         )
+
+
+async def _conflicting_model_error(
+    session: AsyncSession,
+    *,
+    name: str,
+    provider: str,
+    name_pattern: re.Pattern[str],
+    exclude_model_id: Optional[int] = None,
+) -> Conflict:
+    """
+    Describe the constraint that a rejected write actually violated.
+
+    Custom models are covered by two partial unique indexes over non-deleted rows:
+    `(name, is_built_in)` and `(name_pattern, provider, is_built_in)`. The failure
+    alone cannot tell them apart, because the backends describe it differently --
+    PostgreSQL names the index, SQLite names the columns -- so this looks up the
+    offending row rather than guessing, which is how an unrelated failure used to
+    be reported as a name conflict.
+
+    Only called once a write has been rejected, so the happy path does not pay for
+    it. Autoflush is suppressed because the rejected changes are still pending in
+    the session and would otherwise be retried by this query.
+    """
+    stmt = (
+        sa.select(models.GenerativeModel.name)
+        .where(models.GenerativeModel.deleted_at.is_(None))
+        .where(models.GenerativeModel.is_built_in.is_(False))
+        .where(
+            sa.or_(
+                models.GenerativeModel.name == name,
+                sa.and_(
+                    models.GenerativeModel.name_pattern == name_pattern,
+                    models.GenerativeModel.provider == provider,
+                ),
+            )
+        )
+    )
+    if exclude_model_id is not None:
+        stmt = stmt.where(models.GenerativeModel.id != exclude_model_id)
+    with session.no_autoflush:
+        conflicting_names = list(await session.scalars(stmt))
+    if name in conflicting_names:
+        return Conflict(f"Model with name '{name}' already exists")
+    if conflicting_names:
+        described_provider = f"provider '{provider}'" if provider else "no provider"
+        return Conflict(
+            f"Model '{conflicting_names[0]}' already uses name pattern "
+            f"'{name_pattern.pattern}' with {described_provider}"
+        )
+    # Some other constraint rejected the write, e.g. duplicate token prices.
+    return Conflict(f"Model '{name}' conflicts with an existing model")
 
 
 def _compile_regular_expression(maybe_regex: str) -> re.Pattern[str]:

--- a/tests/unit/server/api/mutations/test_model_mutations.py
+++ b/tests/unit/server/api/mutations/test_model_mutations.py
@@ -2,6 +2,7 @@ import re
 from typing import Any
 
 import pytest
+import sqlalchemy as sa
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
@@ -303,6 +304,141 @@ class TestModelMutations:
         assert len(result.errors) == 1
         assert result.errors[0].message == expected_error_message
         assert result.data is None
+
+    @pytest.mark.parametrize(
+        "provider_input",
+        [
+            pytest.param({"provider": None}, id="explicit-null-provider"),
+            pytest.param({}, id="omitted-provider"),
+            pytest.param({"provider": ""}, id="empty-string-provider"),
+        ],
+    )
+    async def test_create_model_without_provider_succeeds(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+        provider_input: dict[str, Any],
+        custom_model: models.GenerativeModel,
+    ) -> None:
+        """
+        A null or omitted provider is a provider-agnostic model, not a conflict.
+
+        Regression test for a bug where any name failed with "Model with name 'X'
+        already exists" whenever the provider was null, because the non-nullable
+        column raised an IntegrityError that was reported as a name conflict.
+        """
+        variables = {
+            "input": {
+                "name": "provider-agnostic-model",
+                "namePattern": "^provider-agnostic-model$",
+                "costs": [
+                    {
+                        "tokenType": "input",
+                        "kind": "PROMPT",
+                        "costPerMillionTokens": 1.0,
+                    },
+                    {
+                        "tokenType": "output",
+                        "kind": "COMPLETION",
+                        "costPerMillionTokens": 2.0,
+                    },
+                ],
+                **provider_input,
+            }
+        }
+        result = await gql_client.execute(
+            query=self.QUERY,
+            variables=variables,
+            operation_name="CreateModelMutation",
+        )
+        assert not result.errors
+        assert result.data is not None
+        model = result.data["createModel"]["model"]
+        assert model["name"] == "provider-agnostic-model"
+        # A provider-agnostic model reads back as null (`provider or None`) and is
+        # stored as the empty string the non-nullable column requires.
+        assert model["provider"] is None
+        async with db() as session:
+            stored_provider = await session.scalar(
+                sa.select(models.GenerativeModel.provider).where(
+                    models.GenerativeModel.name == "provider-agnostic-model"
+                )
+            )
+        assert stored_provider == ""
+
+    async def test_create_model_reusing_name_pattern_reports_pattern_conflict(
+        self,
+        gql_client: AsyncGraphQLClient,
+        custom_model: models.GenerativeModel,
+    ) -> None:
+        """
+        A duplicate (name_pattern, provider) is reported as such rather than as a
+        name conflict, which is what the blanket IntegrityError handler produced.
+        """
+        variables = {
+            "input": {
+                "name": "a-name-that-does-not-exist",
+                "provider": "anthropic",
+                "namePattern": "claude-*",
+                "costs": [
+                    {
+                        "tokenType": "input",
+                        "kind": "PROMPT",
+                        "costPerMillionTokens": 1.0,
+                    },
+                    {
+                        "tokenType": "output",
+                        "kind": "COMPLETION",
+                        "costPerMillionTokens": 2.0,
+                    },
+                ],
+            }
+        }
+        result = await gql_client.execute(
+            query=self.QUERY,
+            variables=variables,
+            operation_name="CreateModelMutation",
+        )
+        assert len(result.errors) == 1
+        assert result.errors[0].message == (
+            "Model 'custom-model' already uses name pattern 'claude-*' with provider 'anthropic'"
+        )
+        assert result.data is None
+
+    async def test_updating_model_to_its_own_values_succeeds(
+        self,
+        gql_client: AsyncGraphQLClient,
+        custom_model: models.GenerativeModel,
+    ) -> None:
+        """The conflict pre-check must not treat a model as conflicting with itself."""
+        variables = {
+            "input": {
+                "id": str(GlobalID(GenerativeModel.__name__, str(custom_model.id))),
+                "name": "custom-model",
+                "provider": "anthropic",
+                "namePattern": "claude-*",
+                "costs": [
+                    {
+                        "tokenType": "input",
+                        "kind": "PROMPT",
+                        "costPerMillionTokens": 5.0,
+                    },
+                    {
+                        "tokenType": "output",
+                        "kind": "COMPLETION",
+                        "costPerMillionTokens": 6.0,
+                    },
+                ],
+            }
+        }
+        result = await gql_client.execute(
+            query=self.QUERY,
+            variables=variables,
+            operation_name="UpdateModelMutation",
+        )
+        assert not result.errors
+        assert result.data is not None
+        assert result.data["updateModel"]["model"]["name"] == "custom-model"
 
     @pytest.mark.parametrize(
         "variables,expected_error_message",


### PR DESCRIPTION
resolves #14807

## Problem

`createModel` passed `input.provider` straight through to a non-nullable column, so a null or omitted provider raised an `IntegrityError`. The blanket `except IntegrityError` handler reported that as `Model with name 'X' already exists` — for **any** name, including names that had never been used before. The reporter's `createModel` calls failed no matter what name they picked.

Two separate defects were in play:

1. **The NOT NULL violation.** `updateModel` already did `model.provider = input.provider or ""`; `createModel` lacked the same coercion 11 lines away.
2. **The opaque error mapping.** Every integrity failure was reported as a name conflict, whether or not a name conflict was what happened — which is exactly how a `NOT NULL` violation came back as a phantom duplicate name.

The UI never hit this because `ModelForm.tsx:193` sends `provider: modelProvider || ""`. Only direct GraphQL clients sending `null` were affected.

## Fix

`createModel` now normalizes `input.provider or ""`, matching `updateModel`. The empty string is already the codebase's provider-agnostic sentinel — `cost_model_lookup` treats a falsy provider as the fallback bucket, and `GenerativeModel.provider` reads `""` back as `null`.

The catch-all error mapping is replaced with `_conflicting_model_error`, which looks up the row responsible. `generative_models` carries two partial unique indexes over non-deleted rows — `(name, is_built_in)` and `(name_pattern, provider, is_built_in)` — and a duplicate name pattern now says so instead of reporting a name conflict on a name nobody is using.

Two implementation notes for reviewers:

- **The write is attempted first; the lookup runs only after it is rejected.** The happy path keeps its original query count, and the database — not a prior read — remains the thing that decides a conflict exists, so there's no TOCTOU window.
- **The flush is wrapped in a savepoint** (`session.begin_nested()`), because PostgreSQL aborts the transaction on a failed statement and would otherwise leave the session unusable for the lookup. I verified this is load-bearing rather than defensive: with the savepoint removed, the pattern-conflict test fails on PostgreSQL. Autoflush is suppressed during the lookup, since the rejected changes are still pending in the session.

I diagnose via a query rather than by parsing the exception because the backends disagree on how they describe a violation: PostgreSQL names the index, SQLite names the columns (`UNIQUE constraint failed: generative_models.name, generative_models.is_built_in`). There's no portable way to recover the violated index from the error text.

## Testing

Five new cases, all run against both SQLite and PostgreSQL:

- `test_create_model_without_provider_succeeds` — null, omitted, and empty-string provider
- `test_create_model_reusing_name_pattern_reports_pattern_conflict`
- `test_updating_model_to_its_own_values_succeeds` — a model must not conflict with itself

348 tests pass on both backends (model mutations + cost tracking); `ruff` and `mypy` clean.

To confirm these are genuine regression tests, I reverted the source fix and re-ran them: 3 of 5 failed, with the `explicit-null-provider` case producing `Model with name 'provider-agnostic-model' already exists` — the reporter's exact symptom. The `empty-string-provider` case passed pre-fix, consistent with the UI never being affected.

## Notes

**No schema change.** `provider` stays nullable, and null now means provider-agnostic end to end: null in, stored as `""`, read back as null. That matches option (a) in the issue's expected behavior. Making `provider` required would be a breaking change that still wouldn't let a client express "provider-agnostic" without sending a magic `""`, so I didn't go that route.

Two adjacent items left out to keep the diff focused, both easy follow-ups:

- Duplicate cost entries (e.g. two `input`/`PROMPT` costs) violate the `token_prices` unique constraint and fall through to the generic message — same bug class.
- `UpdateModelMutationInput.provider` has no default, unlike its `create` counterpart. The SDL advertises it as optional (nullable input fields always are, per spec), but omitting it raises `TypeError: __init__() missing 1 required keyword-only argument: 'provider'` as an internal error rather than a clean validation failure. One-line fix: `provider: Optional[str] = None`.
