### PR TITLE
docs: add Eden AI to the LLM providers integrations

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -600,6 +600,13 @@
                 ]
               },
               {
+                "group": "Eden AI",
+                "pages": [
+                  "docs/phoenix/integrations/llm-providers/edenai",
+                  "docs/phoenix/integrations/llm-providers/edenai/openai-tracing"
+                ]
+              },
+              {
                 "group": "Together AI",
                 "pages": [
                   "docs/phoenix/integrations/llm-providers/together",

--- a/docs.json
+++ b/docs.json
@@ -585,6 +585,13 @@
                 ]
               },
               {
+                "group": "Eden AI",
+                "pages": [
+                  "docs/phoenix/integrations/llm-providers/edenai",
+                  "docs/phoenix/integrations/llm-providers/edenai/openai-tracing"
+                ]
+              },
+              {
                 "group": "VertexAI",
                 "pages": [
                   "docs/phoenix/integrations/llm-providers/vertexai",

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -149,6 +149,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="LiteLLM" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/a22c16d3-image.avif" href="/docs/phoenix/integrations/llm-providers/litellm" />
   <Card title="OpenRouter" img="https://storage.googleapis.com/arize-assets/gitbook_openrouter.png" href="/docs/phoenix/integrations/llm-providers/openrouter" />
   <Card title="OrcaRouter" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/orcarouter-card.avif" href="/docs/phoenix/integrations/llm-providers/orcarouter" />
+  <Card title="Eden AI" icon="globe" href="/docs/phoenix/integrations/llm-providers/edenai" />
   <Card title="Ollama" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/ollama.svg" href="/docs/phoenix/integrations/llm-providers/ollama" />
   <Card title="Together AI" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/together-card.png" href="/docs/phoenix/integrations/llm-providers/together" />
 </CardGroup>

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -148,6 +148,7 @@ Phoenix provides native tracing support for all major LLM providers:
   <Card title="LiteLLM" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/a22c16d3-image.avif" href="/docs/phoenix/integrations/llm-providers/litellm" />
   <Card title="OpenRouter" img="https://storage.googleapis.com/arize-assets/gitbook_openrouter.png" href="/docs/phoenix/integrations/llm-providers/openrouter" />
   <Card title="OrcaRouter" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/orcarouter-card.avif" href="/docs/phoenix/integrations/llm-providers/orcarouter" />
+  <Card title="Eden AI" icon="globe" href="/docs/phoenix/integrations/llm-providers/edenai" />
 </CardGroup>
 
 ### Platforms

--- a/docs/phoenix/integrations/llm-providers/edenai.mdx
+++ b/docs/phoenix/integrations/llm-providers/edenai.mdx
@@ -1,0 +1,13 @@
+---
+title: "Eden AI"
+description: "Eden AI is an EU-based, OpenAI-compatible AI gateway that routes requests to models from many upstream providers. Use Phoenix tracing to observe which upstream model served each request."
+sidebarTitle: "Overview"
+---
+
+<Card title="Eden AI" href="https://www.edenai.co/" icon="globe" horizontal>
+**Website**: [](https://www.edenai.co/)
+</Card>
+
+<Columns cols={2}>
+  <Card title="Eden AI Tracing" href="/docs/phoenix/integrations/llm-providers/edenai/openai-tracing" icon="chart-line" horizontal/>
+</Columns>

--- a/docs/phoenix/integrations/llm-providers/edenai.mdx
+++ b/docs/phoenix/integrations/llm-providers/edenai.mdx
@@ -1,0 +1,13 @@
+---
+title: "Eden AI"
+description: "Eden AI is an EU-based, OpenAI-compatible AI gateway that routes requests to 700+ models across many upstream providers. Use Phoenix tracing to observe which upstream model served each request."
+sidebarTitle: "Overview"
+---
+
+<Card title="Eden AI" href="https://www.edenai.co/" icon="globe" horizontal>
+**Website**: [](https://www.edenai.co/)
+</Card>
+
+<Columns cols={2}>
+  <Card title="Eden AI Tracing" href="/docs/phoenix/integrations/llm-providers/edenai/openai-tracing" icon="chart-line" horizontal/>
+</Columns>

--- a/docs/phoenix/integrations/llm-providers/edenai/openai-tracing.mdx
+++ b/docs/phoenix/integrations/llm-providers/edenai/openai-tracing.mdx
@@ -1,0 +1,69 @@
+---
+title: "Eden AI Tracing"
+description: "Phoenix provides auto-instrumentation for Eden AI through the OpenAI Python Library since Eden AI provides a fully OpenAI-compatible API endpoint."
+---
+
+import RegisterTracerPython from "../../../../snippets/register-tracer-python.mdx";
+
+## Install
+
+```bash
+pip install openinference-instrumentation-openai openai
+```
+
+## Setup
+
+Add your Eden AI API key as an environment variable:
+
+```bash
+export EDENAI_API_KEY='your_edenai_api_key'
+```
+
+<RegisterTracerPython projectName="my-llm-app" />
+
+## Run Eden AI
+
+```python
+import os
+import openai
+
+client = openai.OpenAI(
+    base_url="https://api.edenai.run/v3",
+    api_key=os.environ["EDENAI_API_KEY"]
+)
+
+response = client.chat.completions.create(
+    model="mistral/mistral-small-latest",
+    messages=[{"role": "user", "content": "Write a haiku about observability."}],
+)
+print(response.choices[0].message.content)
+```
+
+Eden AI addresses models as `<provider>/<model>` (e.g. `openai/gpt-4o-mini`, `anthropic/claude-haiku-4-5`, `mistral/mistral-small-latest`). One key routes to 700+ models across many upstream providers.
+
+## Observe
+
+Now that you have tracing set up, all invocations of the OpenAI client pointed at Eden AI will be streamed to your running Phoenix for observability and evaluation.
+
+## What Gets Traced
+
+All Eden AI model calls are automatically traced and include:
+
+* Request/response data and timing
+* Model name — the resolved `<provider>/<model>` identifier
+* Token usage and cost data
+* Error handling and debugging information
+
+## Common Issues
+
+* **API Key**: Use your Eden AI API key, not an OpenAI key
+* **Model Names**: Use the `<provider>/<model>` format (e.g. `openai/gpt-4o-mini`, `anthropic/claude-haiku-4-5`). See [Eden AI's documentation](https://docs.edenai.co) for the full model catalog
+* **Base URL**: Ensure you're using `https://api.edenai.run/v3` as the base URL
+* **EU data residency**: for GDPR-sensitive workloads, Eden AI is EU-headquartered by default; no separate regional endpoint is required
+
+## Resources
+
+<Columns cols={2}>
+  <Card title="Eden AI Documentation" href="https://docs.edenai.co" icon="book" horizontal description="Eden AI setup docs"/>
+  <Card title="OpenInference OpenAI Instrumentation" href="https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai" icon="puzzle-piece" horizontal description="OpenAI instrumentation package"/>
+</Columns>

--- a/docs/phoenix/integrations/llm-providers/edenai/openai-tracing.mdx
+++ b/docs/phoenix/integrations/llm-providers/edenai/openai-tracing.mdx
@@ -1,0 +1,82 @@
+---
+title: "Eden AI Tracing"
+description: "Phoenix provides auto-instrumentation for Eden AI through the OpenAI Python Library since Eden AI provides a fully OpenAI-compatible API endpoint."
+---
+
+import RegisterTracerPython from "../../../../snippets/register-tracer-python.mdx";
+
+## Install
+
+```bash
+pip install openinference-instrumentation-openai openai
+```
+
+## Setup
+
+Add your Eden AI API key as an environment variable:
+
+```bash
+export EDENAI_API_KEY='your_edenai_api_key'
+```
+
+<RegisterTracerPython projectName="my-llm-app" />
+
+## Run Eden AI
+
+```python
+import os
+import openai
+
+client = openai.OpenAI(
+    base_url="https://api.edenai.run/v3",
+    api_key=os.environ["EDENAI_API_KEY"]
+)
+
+response = client.chat.completions.create(
+    model="mistral/mistral-small-latest",
+    messages=[{"role": "user", "content": "Write a haiku about observability."}],
+)
+print(response.choices[0].message.content)
+```
+
+Eden AI addresses models as `<provider>/<model>`, for example `openai/gpt-4o-mini`, `anthropic/claude-haiku-4-5` or `mistral/mistral-small-latest`. One key reaches every upstream provider in the catalogue, which is public and needs no authentication at [api.edenai.run/v3/models](https://api.edenai.run/v3/models).
+
+## Observe
+
+Now that you have tracing set up, all invocations of the OpenAI client pointed at Eden AI will be streamed to your running Phoenix for observability and evaluation.
+
+## What Gets Traced
+
+All Eden AI model calls are automatically traced and include:
+
+* Request/response data and timing
+* Model name, the resolved `<provider>/<model>` identifier
+* Token usage and cost data
+* Error handling and debugging information
+
+## EU Data Residency
+
+Eden AI runs a separate EU gateway for teams with data-residency requirements. Point the client at it instead:
+
+```python
+client = openai.OpenAI(
+    base_url="https://api.eu.edenai.run/v3",
+    api_key=os.environ["EDENAI_API_KEY"]
+)
+```
+
+Some models are also published as a region-pinned variant with an `@eu` suffix, which pins the upstream provider's region as well, for example `vertex/gemini-3.6-flash@eu`. Tracing is unaffected either way: the model identifier Phoenix records is the one you passed.
+
+## Common Issues
+
+* **API Key**: Use your Eden AI API key, not an OpenAI key
+* **Model Names**: Use the `<provider>/<model>` format. Copy the identifier exactly as [api.edenai.run/v3/models](https://api.edenai.run/v3/models) returns it, rather than relying on a static list
+* **Base URL**: Ensure you're using `https://api.edenai.run/v3`, or `https://api.eu.edenai.run/v3` for the EU gateway
+* **Embeddings**: embedding models are served on a separate endpoint and are listed at [api.edenai.run/v3/embeddings/models](https://api.edenai.run/v3/embeddings/models), not in the chat catalogue above
+
+## Resources
+
+<Columns cols={2}>
+  <Card title="Eden AI Documentation" href="https://docs.edenai.co" icon="book" horizontal description="Eden AI setup docs"/>
+  <Card title="OpenInference OpenAI Instrumentation" href="https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai" icon="puzzle-piece" horizontal description="OpenAI instrumentation package"/>
+</Columns>


### PR DESCRIPTION
## What

You mentioned being happy to take a docs PR for Eden AI similar to OrcaRouter (#14576), so here it is.

Adds Eden AI (https://www.edenai.co/), an EU-based, OpenAI-compatible gateway routing to 700+ models across many upstream providers, addressed as `<provider>/<model>`.

- `docs/phoenix/integrations/llm-providers/edenai.mdx` — overview page
- `docs/phoenix/integrations/llm-providers/edenai/openai-tracing.mdx` — tracing setup, mirrors `orcarouter/openai-tracing.mdx`
- Wired into the integrations index CardGroup and `docs.json` navigation (same spot as OrcaRouter)

## Testing

Verified live against the real Eden AI API using the exact snippet in the docs (`mistral/mistral-small-latest` via the OpenAI Python client, base_url `https://api.edenai.run/v3`) — got a real completion back.

Closes #14576