### PR TITLE
fix: keep trace tree duration labels on a single line

### DIFF
--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -446,6 +446,7 @@ const spanTimingCSS = css`
     justify-content: end !important;
     min-width: 2.5rem;
     float: right;
+    white-space: nowrap;
   }
 `;
 


### PR DESCRIPTION
Long durations in the trace tree render with a space between units (e.g. `1m 46s`). In the narrow timing column the label wrapped onto two lines, breaking the row layout.

Adds `white-space: nowrap` to the latency label so multi-unit durations stay on one line. Single-unit labels like `3.6s` were unaffected since they have no space to wrap on.

Closes #14842