### PR TITLE
docs(tracing): clarify Phoenix OTLP/HTTP port is 6006, not 4318

### DIFF
--- a/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter.mdx
+++ b/docs/phoenix/tracing/concepts-tracing/otel-openinference/exporter.mdx
@@ -72,6 +72,10 @@ For a TLS-fronted Phoenix deployment, drop `insecure=True` and pass `credentials
 
 ## OTLP/HTTP Configuration
 
+Phoenix serves OTLP/HTTP on port `6006` — the same port as its UI — **not** the OTLP-standard
+HTTP port `4318`. Point the exporter at `http://<host>:6006/v1/traces` (the `4318` in the table
+above is the generic OTLP default, not Phoenix's).
+
 ```python
 from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -138,7 +142,7 @@ The traces-only variant takes priority over the generic one when both are set. F
 
 A few exporter failure modes worth knowing about up front:
 
-- **Wrong OTLP port or endpoint** — gRPC defaults to 4317, HTTP to 4318. Mixing them up surfaces as connection refused or 404s.
+- **Wrong OTLP port or endpoint** — Phoenix listens for OTLP/gRPC on `4317` and OTLP/HTTP on `6006` (its UI port, not the OTLP-standard `4318`). Mixing them up surfaces as connection refused or 404s.
 - **Wrong encoding for the transport** — gRPC requires Protobuf. Trying to send JSON over gRPC will silently fail.
 - **Proxies breaking gRPC** — corporate proxies, service meshes, and some load balancers don't handle HTTP/2 well. If you see flaky gRPC errors, switch to HTTP.
 - **TLS mismatches** — forgetting `insecure=True` when running against a local collector over `http://` fails. So does setting `insecure=False` against an `http://` endpoint. Match `insecure` to the scheme: `True` for `http://`, `False` (default) for `https://`.


### PR DESCRIPTION
The OTLP exporter page's HTTP example already used `6006`, but the transport-comparison table and the troubleshooting bullet cited `4318` (the OTLP-standard HTTP default) with no note that **Phoenix serves OTLP/HTTP on its UI port 6006**. A user following the troubleshooting bullet would try `4318` and get connection-refused/404s.

- Added an explicit line in **OTLP/HTTP Configuration** stating Phoenix uses 6006, not the OTLP-standard 4318.
- Corrected the **Common mistakes** bullet to name 4317 (gRPC) and 6006 (HTTP) for Phoenix.

gRPC `4317` was already stated correctly. Grounded in `packages/phoenix-otel/src/phoenix/otel/otel.py` (HTTP endpoint construction targets `:6006/v1/traces`). Surfaced while documenting #13521.