### PR TITLE
feat(agents): Improve session sync and streaming ux

### DIFF
--- a/app/src/components/agent/AgentChatPanelView.tsx
+++ b/app/src/components/agent/AgentChatPanelView.tsx
@@ -152,6 +152,7 @@ export function AgentChatHeader({
   hasNextSessionPage,
   isLoadingNextSessionPage,
   onLoadNextSessionPage,
+  onSessionMenuOpenChange,
   onPositionChange,
   onClose,
 }: {
@@ -168,6 +169,7 @@ export function AgentChatHeader({
   hasNextSessionPage?: boolean;
   isLoadingNextSessionPage?: boolean;
   onLoadNextSessionPage?: () => void;
+  onSessionMenuOpenChange?: (isOpen: boolean) => void;
   onPositionChange?: (position: AgentPosition) => void;
   onClose: () => void;
 }) {
@@ -256,6 +258,7 @@ export function AgentChatHeader({
           hasNextPage={hasNextSessionPage}
           isLoadingNextPage={isLoadingNextSessionPage}
           onLoadNextPage={onLoadNextSessionPage}
+          onOpenChange={onSessionMenuOpenChange}
         />
         <Button
           variant="quiet"

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import {
   ConnectionHandler,
   commitLocalUpdate,
+  fetchQuery,
   graphql,
   useLazyLoadQuery,
   useMutation,
@@ -270,6 +271,26 @@ function AgentSessionsContent({
     [setActiveSession]
   );
   const panelState = useAgentChatPanelState();
+
+  // Refresh the session list in the background whenever the menu opens so
+  // sessions created elsewhere (e.g. another tab) show up. The store keeps
+  // rendering the cached list while the network response replaces the
+  // connection's first page.
+  const handleSessionMenuOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isOpen) {
+        return;
+      }
+      fetchQuery<AgentSessionsResourceQuery>(relayEnvironment, sessionsQuery, {
+        first: SESSION_PAGE_SIZE,
+      }).subscribe({
+        // Ignore failures — the menu still shows the cached session list.
+        error: () => {},
+      });
+    },
+    [relayEnvironment]
+  );
+
   const handleMissingSession = useCallback(
     (sessionId: string) => {
       commitLocalUpdate(relayEnvironment, (relayStore) => {
@@ -324,6 +345,7 @@ function AgentSessionsContent({
         hasNextSessionPage={hasNext}
         isLoadingNextSessionPage={isLoadingNext}
         onLoadNextSessionPage={() => loadNext(SESSION_PAGE_SIZE)}
+        onSessionMenuOpenChange={handleSessionMenuOpenChange}
         onPositionChange={panelState.setPosition}
         onClose={panelState.closePanel}
       />

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -81,10 +81,9 @@ export type { EmptyStateQuickAction } from "./ChatEmptyState";
 const CHAT_SIDEBAR_INSET_CSS = "var(--global-dimension-size-200)";
 
 /**
- * Keeps the trailing Thinking indicator visible whenever a request is in
- * flight and the latest assistant turn is not already streaming visible
- * content — the initial request wait, the gap between the stream opening and
- * the first rendered part, and while the turn ends in a tool call.
+ * Keeps the trailing Thinking indicator visible for the initial request wait
+ * (including the gap between the stream opening and the assistant message
+ * arriving) and while the latest assistant turn ends in a tool call.
  */
 function shouldShowThinkingIndicator({
   status,
@@ -106,14 +105,10 @@ function shouldShowThinkingIndicator({
     return true;
   }
 
-  // Only parts the transcript renders count as visible content; invisible
-  // parts (reasoning, step-start markers, whitespace-only text) leave the
-  // indicator up.
-  const latestVisiblePart = latestMessage.parts.findLast(
-    (part) =>
-      isToolUIPart(part) || (part.type === "text" && part.text.trim() !== "")
+  const latestRelevantPart = latestMessage.parts.findLast(
+    (part) => part.type !== "text" || part.text.trim() !== ""
   );
-  return latestVisiblePart == null || isToolUIPart(latestVisiblePart);
+  return latestRelevantPart != null && isToolUIPart(latestRelevantPart);
 }
 
 function createPendingElicitationDraft(

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -81,8 +81,10 @@ export type { EmptyStateQuickAction } from "./ChatEmptyState";
 const CHAT_SIDEBAR_INSET_CSS = "var(--global-dimension-size-200)";
 
 /**
- * Keeps the trailing Thinking indicator visible for the initial request wait
- * and while the latest assistant turn ends in a tool call.
+ * Keeps the trailing Thinking indicator visible whenever a request is in
+ * flight and the latest assistant turn is not already streaming visible
+ * content — the initial request wait, the gap between the stream opening and
+ * the first rendered part, and while the turn ends in a tool call.
  */
 function shouldShowThinkingIndicator({
   status,
@@ -100,13 +102,18 @@ function shouldShowThinkingIndicator({
 
   const latestMessage = messages.at(-1);
   if (latestMessage?.role !== "assistant") {
-    return false;
+    // The stream is open but no assistant message has arrived yet.
+    return true;
   }
 
-  const latestRelevantPart = latestMessage.parts.findLast(
-    (part) => part.type !== "text" || part.text.trim() !== ""
+  // Only parts the transcript renders count as visible content; invisible
+  // parts (reasoning, step-start markers, whitespace-only text) leave the
+  // indicator up.
+  const latestVisiblePart = latestMessage.parts.findLast(
+    (part) =>
+      isToolUIPart(part) || (part.type === "text" && part.text.trim() !== "")
   );
-  return latestRelevantPart != null && isToolUIPart(latestRelevantPart);
+  return latestVisiblePart == null || isToolUIPart(latestVisiblePart);
 }
 
 function createPendingElicitationDraft(

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -575,7 +575,7 @@ export function ChatView({
     );
   }, [sessionId, sendMessage, store]);
 
-  const showsEmptyState = messages.length === 0;
+  const showsEmptyState = messages.length === 0 && !isBusyElsewhere;
   const chatClassName = showsEmptyState ? "chat--empty" : "";
   const { missingCredentialsProvider, refreshCredentialStatus } =
     useAgentModelCredentialStatus(modelMenuValue);

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -70,6 +70,7 @@ import {
   type MessageRewindMode,
   type MessageRewindRole,
 } from "./MessageRewindDialog";
+import { isVisibleMessagePart } from "./partitionMessageParts";
 import { PxiGlyph } from "./PxiGlyph";
 import { useScrollAnchor } from "./scrollAnchor";
 import { TemporaryChatToggle } from "./TemporaryChatToggle";
@@ -81,9 +82,13 @@ export type { EmptyStateQuickAction } from "./ChatEmptyState";
 const CHAT_SIDEBAR_INSET_CSS = "var(--global-dimension-size-200)";
 
 /**
- * Keeps the trailing Thinking indicator visible for the initial request wait
- * (including the gap between the stream opening and the assistant message
- * arriving) and while the latest assistant turn ends in a tool call.
+ * Keeps the trailing Thinking indicator visible whenever a request is in
+ * flight and the latest assistant turn is not already streaming rendered
+ * content — the initial request wait, the gap between the stream opening and
+ * the first visible part (the stream leads with invisible parts such as
+ * `step-start` and reasoning), and while the turn ends in a tool call.
+ * Visibility is decided by the transcript renderer's own predicate so the
+ * two cannot drift.
  */
 function shouldShowThinkingIndicator({
   status,
@@ -105,10 +110,8 @@ function shouldShowThinkingIndicator({
     return true;
   }
 
-  const latestRelevantPart = latestMessage.parts.findLast(
-    (part) => part.type !== "text" || part.text.trim() !== ""
-  );
-  return latestRelevantPart != null && isToolUIPart(latestRelevantPart);
+  const latestVisiblePart = latestMessage.parts.findLast(isVisibleMessagePart);
+  return latestVisiblePart == null || isToolUIPart(latestVisiblePart);
 }
 
 function createPendingElicitationDraft(

--- a/app/src/components/agent/SessionListMenu.tsx
+++ b/app/src/components/agent/SessionListMenu.tsx
@@ -28,6 +28,7 @@ import { TemporarySessionIcon } from "./TemporarySessionIcon";
  * @param activeSessionId - ID of the currently active session (for highlight)
  * @param onSelectSession - called when the user clicks a session to switch to
  * @param onDeleteSession - called after the user confirms session deletion
+ * @param onOpenChange - called when the menu opens or closes
  */
 export type SessionListMenuProps = {
   sessions: AgentSessionListItem[];
@@ -37,6 +38,7 @@ export type SessionListMenuProps = {
   hasNextPage?: boolean;
   isLoadingNextPage?: boolean;
   onLoadNextPage?: () => void;
+  onOpenChange?: (isOpen: boolean) => void;
 };
 
 export type AgentSessionListItem = {
@@ -56,8 +58,17 @@ export function SessionListMenu({
   hasNextPage = false,
   isLoadingNextPage = false,
   onLoadNextPage,
+  onOpenChange,
 }: SessionListMenuProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setMenuOpen(isOpen);
+      onOpenChange?.(isOpen);
+    },
+    [onOpenChange]
+  );
 
   // Track which session is currently focused in the menu for keyboard shortcuts
   const focusedSessionRef = useRef<AgentSessionListItem | null>(null);
@@ -72,9 +83,9 @@ export function SessionListMenu({
   const handleDeleteSession = useCallback(
     (sessionId: string) => {
       onDeleteSession(sessionId);
-      setMenuOpen(false);
+      handleOpenChange(false);
     },
-    [onDeleteSession]
+    [onDeleteSession, handleOpenChange]
   );
 
   const handleMenuKeyDown = useCallback(
@@ -95,7 +106,7 @@ export function SessionListMenu({
   const selectedKeys = activeSessionId ? [activeSessionId] : [];
 
   return (
-    <MenuTrigger onOpenChange={setMenuOpen} isOpen={menuOpen}>
+    <MenuTrigger onOpenChange={handleOpenChange} isOpen={menuOpen}>
       <Button
         variant="quiet"
         size="S"

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -351,6 +351,43 @@ describe("ChatView", () => {
     expect(container.textContent).toContain("Thinking...");
   });
 
+  it("keeps the thinking indicator until the streaming turn has visible content", () => {
+    const userMessage = {
+      id: "user-message",
+      role: "user",
+      parts: [{ type: "text", text: "What is a trace?" }],
+    } as AgentUIMessage;
+    // The SDK inserts the assistant message before any parts arrive…
+    const emptyAssistantMessage = {
+      id: "assistant-message",
+      role: "assistant",
+      parts: [],
+    } as unknown as AgentUIMessage;
+    renderChatView(root, {
+      sessionId: "session-1",
+      status: "streaming",
+      chatMessages: [userMessage, emptyAssistantMessage],
+    });
+    expect(container.textContent).toContain("Thinking...");
+
+    // …then leads with invisible parts (step-start, reasoning) before text.
+    const invisiblePartsAssistantMessage = {
+      id: "assistant-message",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { type: "reasoning", text: "Considering the question" },
+        { type: "text", text: "  " },
+      ],
+    } as AgentUIMessage;
+    renderChatView(root, {
+      sessionId: "session-1",
+      status: "streaming",
+      chatMessages: [userMessage, invisiblePartsAssistantMessage],
+    });
+    expect(container.textContent).toContain("Thinking...");
+  });
+
   it("hides the thinking indicator once assistant text is streaming", () => {
     const userMessage = {
       id: "user-message",

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -351,30 +351,6 @@ describe("ChatView", () => {
     expect(container.textContent).toContain("Thinking...");
   });
 
-  it("keeps the thinking indicator while the streaming turn has no visible content", () => {
-    const userMessage = {
-      id: "user-message",
-      role: "user",
-      parts: [{ type: "text", text: "What is a trace?" }],
-    } as AgentUIMessage;
-    const assistantMessage = {
-      id: "assistant-message",
-      role: "assistant",
-      parts: [
-        { type: "step-start" },
-        { type: "reasoning", text: "Considering the question" },
-        { type: "text", text: "  " },
-      ],
-    } as AgentUIMessage;
-    renderChatView(root, {
-      sessionId: "session-1",
-      status: "streaming",
-      chatMessages: [userMessage, assistantMessage],
-    });
-
-    expect(container.textContent).toContain("Thinking...");
-  });
-
   it("hides the thinking indicator once assistant text is streaming", () => {
     const userMessage = {
       id: "user-message",

--- a/app/src/components/agent/__tests__/Chat.test.tsx
+++ b/app/src/components/agent/__tests__/Chat.test.tsx
@@ -104,7 +104,7 @@ function renderChatView(
     chatKey?: string;
     chatMessages?: AgentUIMessage[];
     error?: Error;
-    status?: "ready" | "error";
+    status?: "ready" | "error" | "submitted" | "streaming";
     initialDraftInputBySessionId?: Record<string, string>;
     isDraftSessionTemporary?: boolean;
     sendMessage?: ChatViewSendMessage;
@@ -319,6 +319,80 @@ describe("ChatView", () => {
       undefined
     );
     expect(textarea?.value).toBe("");
+  });
+
+  it("shows the thinking indicator as soon as a request is submitted", () => {
+    const userMessage = {
+      id: "user-message",
+      role: "user",
+      parts: [{ type: "text", text: "What is a trace?" }],
+    } as AgentUIMessage;
+    renderChatView(root, {
+      sessionId: "session-1",
+      status: "submitted",
+      chatMessages: [userMessage],
+    });
+
+    expect(container.textContent).toContain("Thinking...");
+  });
+
+  it("keeps the thinking indicator while streaming before assistant output arrives", () => {
+    const userMessage = {
+      id: "user-message",
+      role: "user",
+      parts: [{ type: "text", text: "What is a trace?" }],
+    } as AgentUIMessage;
+    renderChatView(root, {
+      sessionId: "session-1",
+      status: "streaming",
+      chatMessages: [userMessage],
+    });
+
+    expect(container.textContent).toContain("Thinking...");
+  });
+
+  it("keeps the thinking indicator while the streaming turn has no visible content", () => {
+    const userMessage = {
+      id: "user-message",
+      role: "user",
+      parts: [{ type: "text", text: "What is a trace?" }],
+    } as AgentUIMessage;
+    const assistantMessage = {
+      id: "assistant-message",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { type: "reasoning", text: "Considering the question" },
+        { type: "text", text: "  " },
+      ],
+    } as AgentUIMessage;
+    renderChatView(root, {
+      sessionId: "session-1",
+      status: "streaming",
+      chatMessages: [userMessage, assistantMessage],
+    });
+
+    expect(container.textContent).toContain("Thinking...");
+  });
+
+  it("hides the thinking indicator once assistant text is streaming", () => {
+    const userMessage = {
+      id: "user-message",
+      role: "user",
+      parts: [{ type: "text", text: "What is a trace?" }],
+    } as AgentUIMessage;
+    const assistantMessage = {
+      id: "assistant-message",
+      role: "assistant",
+      parts: [{ type: "text", text: "A trace is" }],
+    } as AgentUIMessage;
+    renderChatView(root, {
+      sessionId: "session-1",
+      status: "streaming",
+      chatMessages: [userMessage, assistantMessage],
+    });
+
+    expect(container.textContent).not.toContain("Thinking...");
   });
 
   it("runs /compact without sending it as a user message", async () => {

--- a/app/src/components/agent/partitionMessageParts.ts
+++ b/app/src/components/agent/partitionMessageParts.ts
@@ -9,19 +9,23 @@ export type MessagePart =
   | { kind: "generative-ui"; part: UIMessage["parts"][number]; index: number };
 
 /**
- * Returns true for parts that should be treated as "invisible" — they carry no
- * user-visible content and are not rendered.
+ * Returns true for parts the transcript actually renders: tool calls
+ * (including generative UI slots, which are tool parts) and non-empty text.
+ * Everything else is invisible —
  *
  * - `step-start` parts are AI SDK step boundary markers that appear between
  *   every auto-send cycle.
  * - Empty text parts (whitespace-only) sometimes appear at step boundaries.
  * - Other assistant parts that this renderer does not display (reasoning,
  *   sources, files, unknown data parts).
+ *
+ * Shared with the chat's Thinking indicator so "has anything visible streamed
+ * yet" stays in lockstep with what this partitioner draws.
  */
-function isTransparentPart(part: UIMessage["parts"][number]): boolean {
-  if (part.type === "step-start") return true;
-  if (isTextUIPart(part) && part.text.trim() === "") return true;
-  return !isTextUIPart(part);
+export function isVisibleMessagePart(
+  part: UIMessage["parts"][number]
+): boolean {
+  return isToolUIPart(part) || (isTextUIPart(part) && part.text.trim() !== "");
 }
 
 /**
@@ -53,7 +57,7 @@ export function partitionMessageParts(
       continue;
     }
 
-    if (isTransparentPart(part)) {
+    if (!isVisibleMessagePart(part)) {
       // Skip invisible parts — they carry no user-visible content.
       continue;
     }

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -6,7 +6,7 @@ import {
   isTextUIPart,
   isToolUIPart,
 } from "ai";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ConnectionHandler,
   commitLocalUpdate,
@@ -279,6 +279,12 @@ export function useAgentChat({
   // Guards the draft surface against double-submits while the create-session
   // mutation is in flight.
   const isCreatingSessionRef = useRef(false);
+  // The first message of a draft surface, echoed optimistically (with a
+  // "submitted" status, so the Thinking indicator shows) while the
+  // create-session mutation round-trip is in flight. The real message is sent
+  // through the new session's chat once the mutation returns.
+  const [pendingDraftUserMessage, setPendingDraftUserMessage] =
+    useState<AgentUIMessage | null>(null);
 
   /**
    * Builds the imperative AI SDK chat runtime for a persisted session. The
@@ -666,6 +672,15 @@ export function useAgentChat({
     }
     setOperationError(null);
     isCreatingSessionRef.current = true;
+    setPendingDraftUserMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      parts: [{ type: "text", text }],
+      metadata: buildUserMessageMetadata(),
+    });
+    // Pulse the collapsed-surface glyphs (widget, top nav) for the creation
+    // wait too; clearSessionEphemeralState removes the flag on success.
+    store.getState().setSessionResponsePending(DRAFT_SESSION_ID, true);
     const isTemporary = store.getState().isDraftSessionTemporary;
     commitCreateAgentSession({
       variables: {
@@ -688,6 +703,7 @@ export function useAgentChat({
           { text, metadata: buildUserMessageMetadata() },
           options
         );
+        setPendingDraftUserMessage(null);
         const state = store.getState();
         state.clearSessionEphemeralState(DRAFT_SESSION_ID);
         state.setIsDraftSessionTemporary(state.defaultTemporaryChat);
@@ -695,6 +711,8 @@ export function useAgentChat({
       },
       onError: (mutationError) => {
         isCreatingSessionRef.current = false;
+        setPendingDraftUserMessage(null);
+        store.getState().setSessionResponsePending(DRAFT_SESSION_ID, false);
         // Give the user their message back to retry.
         store.getState().setDraftInput(DRAFT_SESSION_ID, text);
         const errorMessages =
@@ -1052,11 +1070,19 @@ export function useAgentChat({
     ]
   );
 
+  const displayedMessages = useMemo(
+    () =>
+      pendingDraftUserMessage
+        ? [...messages, pendingDraftUserMessage]
+        : messages,
+    [messages, pendingDraftUserMessage]
+  );
+
   return {
-    messages,
+    messages: displayedMessages,
     sendMessage: handleSendMessage,
     stop: handleStopWithToolCleanup,
-    status,
+    status: pendingDraftUserMessage ? "submitted" : status,
     error,
     pendingElicitation,
     handleElicitationSubmit,

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -183,7 +183,6 @@ function PxiBanner() {
   );
 }
 
-
 /** Format a model selection for display (e.g. `ANTHROPIC/claude-opus-4-8`). */
 function getModelLabel({
   modelSelection,

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -918,6 +918,12 @@ export function PxiApp({
   const streamingAssistantMessageRef = useRef<PxiMessage | null>(null);
   const modelRequestIdRef = useRef(0);
   const sessionRequestIdRef = useRef(0);
+  /**
+   * Last successfully fetched session list. Lets the picker open instantly
+   * with the previous list while a background refresh fetches the latest —
+   * the terminal equivalent of the web menu's store-and-network refetch.
+   */
+  const cachedSessionListRef = useRef<PxiSessionSummary[] | null>(null);
   const serverSessionClient = useMemo(
     () => sessionClient ?? createPxiSessionClient({ config: options.config }),
     [options.config, sessionClient]
@@ -1011,9 +1017,12 @@ export function PxiApp({
     sessionRequestIdRef.current = requestId;
     setDraft(EMPTY_DRAFT_EDITOR_STATE);
     setError(null);
+    // Open instantly with the last fetched list (when there is one) while a
+    // background refresh fetches sessions created elsewhere in the meantime.
+    const cachedSessions = cachedSessionListRef.current;
     setSessionPicker({
-      status: "loading",
-      sessions: [],
+      status: cachedSessions ? "ready" : "loading",
+      sessions: cachedSessions ?? [],
       query: "",
       selectedIndex: 0,
       error: null,
@@ -1021,17 +1030,45 @@ export function PxiApp({
     void serverSessionClient
       .listSessions()
       .then((sessions) => {
+        cachedSessionListRef.current = sessions;
         if (sessionRequestIdRef.current !== requestId) return;
-        setSessionPicker({
-          status: "ready",
-          sessions,
-          query: "",
-          selectedIndex: 0,
-          error: null,
+        setSessionPicker((current) => {
+          if (!current) return null;
+          // The user may already be filtering or navigating the cached list;
+          // keep their selection on the same session after the refresh.
+          const selectedSession = getFilteredSessions({
+            sessions: current.sessions,
+            query: current.query,
+          })[current.selectedIndex];
+          const refreshedFilteredSessions = getFilteredSessions({
+            sessions,
+            query: current.query,
+          });
+          const refreshedSelectedIndex = selectedSession
+            ? refreshedFilteredSessions.findIndex(
+                (session) => session.id === selectedSession.id
+              )
+            : -1;
+          return {
+            ...current,
+            status: "ready",
+            sessions,
+            selectedIndex:
+              refreshedSelectedIndex === -1
+                ? Math.min(
+                    current.selectedIndex,
+                    Math.max(refreshedFilteredSessions.length - 1, 0)
+                  )
+                : refreshedSelectedIndex,
+            error: null,
+          };
         });
       })
       .catch((sessionError: unknown) => {
         if (sessionRequestIdRef.current !== requestId) return;
+        // With a cached list on screen the stale data is still usable, so a
+        // failed background refresh is ignored.
+        if (cachedSessions) return;
         setSessionPicker({
           status: "error",
           sessions: [],

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -935,7 +935,7 @@ export function PxiApp({
   const busySessionId = isSessionBusy ? (activeSession?.id ?? null) : null;
   useEffect(() => {
     if (!busySessionId) {
-      return;
+      return undefined;
     }
     let isStale = false;
     const pollSession = () => {

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -10,6 +10,7 @@ import type {
   PxiMessage,
   PxiRuntimeOptions,
   PxiSessionClient,
+  PxiSessionSummary,
 } from "../src/pxi/types";
 
 const ESCAPE_CHARACTER = String.fromCharCode(27);
@@ -1214,6 +1215,82 @@ describe("PXI app", () => {
     expect(getSession).toHaveBeenCalledWith({ sessionId: "session-2" });
     expect(stripAnsi(lastFrame() ?? "")).toContain("restored conversation");
     expect(stripAnsi(lastFrame() ?? "")).toContain("session: Second session");
+    unmount();
+  });
+
+  it("reopens the session picker with the cached list while refreshing in the background", async () => {
+    const initialSessions: PxiSessionSummary[] = [
+      {
+        id: "session-1",
+        title: "First session",
+        updatedAt: "2026-07-24T13:00:00Z",
+        isTemporary: false,
+      },
+    ];
+    let listCallCount = 0;
+    let resolveRefresh: (sessions: PxiSessionSummary[]) => void = () => {};
+    const sessionClient: PxiSessionClient = {
+      createSession: async () => {
+        throw new Error("not used");
+      },
+      listSessions: async () => {
+        listCallCount += 1;
+        if (listCallCount === 1) {
+          return initialSessions;
+        }
+        return new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      },
+      getSession: async () => {
+        throw new Error("not used");
+      },
+      compactSession: async () => {
+        throw new Error("not used");
+      },
+    };
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        sessionClient={sessionClient}
+      />
+    );
+
+    // First open fetches over the network and populates the cache.
+    await writeInput({ stdin, input: "/sessions" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    expect(stripAnsi(lastFrame() ?? "")).toContain("First session");
+
+    await writeInput({ stdin, input: ESCAPE_CHARACTER });
+    await flushPendingEscapeInput();
+    expect(stripAnsi(lastFrame() ?? "")).not.toContain("Recent sessions");
+
+    // Reopening shows the cached list immediately, with the refresh pending.
+    await writeInput({ stdin, input: "/sessions" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    expect(listCallCount).toBe(2);
+    expect(stripAnsi(lastFrame() ?? "")).toContain("First session");
+    expect(stripAnsi(lastFrame() ?? "")).not.toContain("Loading sessions");
+
+    // When the background refresh lands, sessions created elsewhere appear.
+    await act(async () => {
+      resolveRefresh([
+        {
+          id: "session-2",
+          title: "Fresh session",
+          updatedAt: "2026-07-24T14:00:00Z",
+          isTemporary: false,
+        },
+        ...initialSessions,
+      ]);
+      await Promise.resolve();
+    });
+    expect(stripAnsi(lastFrame() ?? "")).toContain("Fresh session");
+    expect(stripAnsi(lastFrame() ?? "")).toContain("First session");
     unmount();
   });
 

--- a/tests/unit/server/agents/fixtures/ui_message_stream/fixtures.json
+++ b/tests/unit/server/agents/fixtures/ui_message_stream/fixtures.json
@@ -1,6 +1,6 @@
 [
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > text",
     "input": {
@@ -105,7 +105,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > errors",
     "input": {
@@ -121,7 +121,7 @@
     "writes": []
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when text-delta is received without text-start",
     "input": {
@@ -156,7 +156,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when reasoning-delta is received without reasoning-start",
     "input": {
@@ -191,7 +191,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when tool-input-delta is received without tool-input-start",
     "input": {
@@ -226,7 +226,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should not read Object.prototype for missing text part ids",
     "input": {
@@ -261,7 +261,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should not read Object.prototype for missing reasoning part ids",
     "input": {
@@ -296,7 +296,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should not read Object.prototype for missing partial tool call ids",
     "input": {
@@ -331,7 +331,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when text-end is received without text-start",
     "input": {
@@ -365,7 +365,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw descriptive error when reasoning-end is received without reasoning-start",
     "input": {
@@ -399,7 +399,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw UIMessageStreamError with correct properties for text-delta without text-start",
     "input": {
@@ -434,7 +434,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > malformed stream errors > should throw UIMessageStreamError with correct properties for tool-input-delta without tool-input-start",
     "input": {
@@ -469,7 +469,7 @@
     }
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip",
     "input": {
@@ -655,7 +655,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip with existing assistant message",
     "input": {
@@ -910,7 +910,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip with multiple assistant texts",
     "input": {
@@ -1233,7 +1233,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip with multiple assistant reasoning",
     "input": {
@@ -1735,7 +1735,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > server-side tool roundtrip with output-error",
     "input": {
@@ -1911,7 +1911,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > message metadata",
     "input": {
@@ -2119,7 +2119,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > message metadata delayed after finish",
     "input": {
@@ -2228,7 +2228,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > message metadata with existing assistant lastMessage",
     "input": {
@@ -2346,7 +2346,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool call streaming",
     "input": {
@@ -2488,7 +2488,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > start with message id",
     "input": {
@@ -2593,7 +2593,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > reasoning",
     "input": {
@@ -3127,7 +3127,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > onToolCall is executed",
     "input": {
@@ -3183,7 +3183,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > sources",
     "input": {
@@ -3295,7 +3295,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > file parts",
     "input": {
@@ -3524,7 +3524,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > file parts with providerMetadata",
     "input": {
@@ -3613,7 +3613,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > data ui parts (single part)",
     "input": {
@@ -3661,7 +3661,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > data ui parts (transient part)",
     "input": {
@@ -3697,7 +3697,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > data ui parts (single part with id and replacement update)",
     "input": {
@@ -3766,7 +3766,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > data ui parts (single part with id and merge update)",
     "input": {
@@ -3847,7 +3847,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed static tools",
     "input": {
@@ -4054,7 +4054,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed static tools > should preserve separate call and result provider metadata for static tools",
     "input": {
@@ -4166,7 +4166,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed dynamic tools",
     "input": {
@@ -4386,7 +4386,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed dynamic tools > should preserve separate call and result provider metadata for dynamic tools",
     "input": {
@@ -4498,7 +4498,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > provider-executed dynamic tools > should preserve tool metadata on dynamic tool parts",
     "input": {
@@ -4594,7 +4594,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > should call onToolCall for client-executed tools",
     "input": {
@@ -4650,7 +4650,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > dynamic tools",
     "input": {
@@ -4863,7 +4863,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > provider metadata",
     "input": {
@@ -5062,7 +5062,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > provider metadata during input-streaming",
     "input": {
@@ -5204,7 +5204,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool input error",
     "input": {
@@ -5314,7 +5314,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool input error with dynamic flag mismatch",
     "input": {
@@ -5425,7 +5425,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > preliminary tool results",
     "input": {
@@ -5570,7 +5570,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool title support > static tool with title",
     "input": {
@@ -5696,7 +5696,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool title support > dynamic tool with title",
     "input": {
@@ -5837,7 +5837,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool title support > tool with title in error state",
     "input": {
@@ -5940,7 +5940,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval requests (static tool)",
     "input": {
@@ -6015,7 +6015,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval requests (dynamic tool)",
     "input": {
@@ -6093,7 +6093,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval request with signature",
     "input": {
@@ -6170,7 +6170,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval response with signature",
     "input": {
@@ -6274,7 +6274,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool approval request without signature",
     "input": {
@@ -6349,7 +6349,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > automatic tool approval denial (static tool)",
     "input": {
@@ -6482,7 +6482,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > automatic tool approval with execution (dynamic tool)",
     "input": {
@@ -6622,7 +6622,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > initial tool execution after approval (static tool)",
     "input": {
@@ -6797,7 +6797,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > initial tool execution after approval (dynamic tool)",
     "input": {
@@ -6978,7 +6978,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > initial tool execution with preliminary results after approval (static tool)",
     "input": {
@@ -7211,7 +7211,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool execution denial (static tool)",
     "input": {
@@ -7381,7 +7381,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > tool execution denial (dynamic tool)",
     "input": {
@@ -7556,7 +7556,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "upstream",
     "name": "processUIMessageStream > custom",
     "input": {
@@ -7605,7 +7605,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "phoenix",
     "name": "Phoenix custom chunks > durable error part and standard error",
     "input": {
@@ -7649,7 +7649,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "phoenix",
     "name": "Phoenix custom chunks > transient session and persistence events",
     "input": {
@@ -7683,7 +7683,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "phoenix",
     "name": "Phoenix protocol passthrough > abort and done do not change the message",
     "input": {
@@ -7712,7 +7712,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "phoenix",
     "name": "Phoenix protocol coverage > source document",
     "input": {
@@ -7745,7 +7745,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "phoenix",
     "name": "Phoenix stream > interleaved preliminary subagent output",
     "input": {
@@ -7974,7 +7974,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "phoenix",
     "name": "Phoenix stream > forced skill step before model output",
     "input": {
@@ -8147,7 +8147,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "phoenix",
     "name": "Phoenix stream > typed assistant metadata",
     "input": {
@@ -8191,7 +8191,7 @@
     ]
   },
   {
-    "upstreamTag": "ai@7.0.31",
+    "upstreamTag": "ai@7.0.37",
     "source": "phoenix",
     "name": "Phoenix stream > client tool continuation",
     "input": {


### PR DESCRIPTION
## Changes

**Web app**
- Session list menu refetches sessions in the background when opened (store-and-network), so sessions created in other tabs always appear
- Thinking indicator now shows immediately when sending the first message of a new chat — the draft message is echoed optimistically while the create-session mutation is in flight, and the widget/top-nav glyphs pulse during the wait
- Thinking indicator stays visible from send until the turn streams visible content (tool call or non-empty text) — the stream leads with invisible parts (`step-start`, reasoning), which previously blinked the indicator off; visibility is decided by a predicate shared with the transcript renderer so the two cannot drift
- Chat empty state no longer shows during the session busy poll

**Phoenix CLI (pxi)**
- `/sessions` picker opens instantly with the last-fetched session list and refreshes in the background; the filter query and selection are preserved when fresh data lands, and a failed refresh keeps the usable cached list

**Tests**
- Added coverage for the session picker cache/refresh flow (pxi) and the thinking-indicator states (web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)