### PR TITLE
docs: Audit and update llms.txt

### DIFF
--- a/docs/phoenix/llms.txt
+++ b/docs/phoenix/llms.txt
@@ -24,6 +24,7 @@
 
 ## Tracing
 
+- [How to: Tracing](https://arize.com/docs/phoenix/tracing/how-to-tracing): Index of tracing guides — setup, metadata, annotations, import/export, advanced config
 
 ### Tutorial
 
@@ -78,15 +79,12 @@
 - [Multimodal Tracing](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/multimodal-tracing): Capture image, audio, and multimodal data in traces
 - [Suppress Tracing](https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/suppress-tracing): Disable tracing for specific code blocks
 
-
-- [How to: Tracing](https://arize.com/docs/phoenix/tracing/how-to-tracing): Guides on how to use traces
 ## Evaluation
 
 
 ### Overview
 
 - [LLM Evals](https://arize.com/docs/phoenix/evaluation/llm-evals): LLM-as-judge evaluation with pre-built and custom evaluators
-- [Evals Quickstart](https://arize.com/docs/phoenix/evaluation/evals): Evaluate data from your LLM application with arize-phoenix-evals
 
 ### How-to
 
@@ -94,12 +92,10 @@
 - [Custom LLM Evaluators](https://arize.com/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators): Build evaluators with custom prompts and scoring logic
 - [Configuring the LLM](https://arize.com/docs/phoenix/evaluation/how-to-evals/configuring-the-llm): Set up LLM providers for evaluations
 - [Prompt Formats](https://arize.com/docs/phoenix/evaluation/how-to-evals/prompt-formats): Customize evaluator prompt structures
-- [Code Evaluators](https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluators): Deterministic evaluation with Python or TypeScript
+- [Code Evaluators (SDK)](https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluators): Deterministic evaluation with Python or TypeScript
 - [Code Evaluator Output Shapes](https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluator-output-shapes): All accepted return shapes, multi-output routing, and explanation field semantics
 - [Batch Evaluations](https://arize.com/docs/phoenix/evaluation/how-to-evals/batch-evaluations): Run evaluations at scale with automatic concurrency
 - [Using Evals with Phoenix](https://arize.com/docs/phoenix/evaluation/how-to-evals/using-evals-with-phoenix): Run evals on traces, datasets, or custom data sources
-- [Executors](https://arize.com/docs/phoenix/evaluation/llm-evals/executors): Speed up large eval runs with concurrent executors in arize-phoenix-evals
-- [Evaluator Traces](https://arize.com/docs/phoenix/evaluation/llm-evals/evaluator-traces): Trace every evaluator run to inspect LLM reasoning and align evals with human judgment
 
 ### Running Evals as Tests
 
@@ -120,10 +116,9 @@
 
 - [Server Evals Overview](https://arize.com/docs/phoenix/evaluation/server-evals/overview): Attach evaluators to datasets so they run server-side on every Playground experiment
 - [LLM Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/llm-evaluators): Configure LLM-as-judge evaluators server-side
-- [Code Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/code-evaluators): Write custom Python or TypeScript evaluators that Phoenix runs in a managed sandbox
+- [Server Code Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/code-evaluators): Write custom Python or TypeScript evaluators that Phoenix runs in a managed sandbox
 - [Server Eval Input Mapping](https://arize.com/docs/phoenix/evaluation/server-evals/input-mapping): Map span attributes to server-side evaluator input variables
 - [Server Pre-Built Metrics](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics): All server-side code metrics — contains, exact match, regex, JSON distance, Levenshtein, tool
-- [Server Built-in Evaluators](https://arize.com/docs/phoenix/evaluation/server-evals/builtin-evaluators): Label and score experiment outputs server-side with code evaluators — no LLM or API keys required
 
 
 ### Pre-Built Metrics — Individual Pages
@@ -142,19 +137,19 @@
 - [Summarization](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/summarization-eval): Legacy evaluator — score whether a summary faithfully captures the source document
 - [Agent Function Calling Eval](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-calling-eval): Legacy evaluator — score tool selection, parameter extraction, and generated tool call code
 - [Tool Invocation](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-invocation): Evaluate whether LLM tool calls have correct arguments and formatting
-- [Tool Response Handling](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-response-handling): Evaluate whether AI agents correctly process tool results, including error handling, data extraction, and
+- [Tool Response Handling](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-response-handling): Evaluate how agents process tool results — error handling, data extraction, and recovery
 - [Tool Selection](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/tool-selection): Evaluate whether LLMs select the correct tools for given tasks
 - [Toxicity](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/toxicity): Legacy evaluator — detect toxic, harmful, or offensive content in LLM responses
 - [User Friction](https://arize.com/docs/phoenix/evaluation/pre-built-metrics/user-friction): Detect when a user expresses friction or frustration with an assistant's preceding response
 
 - [Contains](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/contains): Check whether a text contains one or more specified words
-- [Correctness](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/correctness): Evaluate whether LLM responses are generally correct and complete using a Phoenix-managed judge model
-- [Exact Match](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/exact-match): Check whether two strings are identical
+- [Server Correctness](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/correctness): Score answer correctness server-side with a Phoenix-managed judge model
+- [Server Exact Match](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/exact-match): Check whether two strings are identical, server-side
 - [JSON Distance](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/json-distance): Measure the number of structural differences between two JSON values
 - [Levenshtein Distance](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/levenshtein-distance): Measure the edit distance between two strings
 - [Regex Match](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/regex): Check whether a text matches a regular expression pattern
-- [Tool Invocation](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/tool-invocation): Evaluate whether LLM tool calls have correct arguments and formatting using a Phoenix-managed judge model
-- [Tool Selection](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/tool-selection): Evaluate whether LLMs select the correct tools for given tasks using a Phoenix-managed judge model
+- [Server Tool Invocation](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/tool-invocation): Score tool-call arguments and formatting server-side with a Phoenix-managed judge model
+- [Server Tool Selection](https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics/tool-selection): Score tool choice server-side with a Phoenix-managed judge model
 
 ### Server-Side Code Evaluators — Examples
 
@@ -168,7 +163,8 @@
 
 ## Datasets & Experiments
 
-- [Datasets & Experiments Quickstart](https://arize.com/docs/phoenix/datasets-and-experiments/quickstart-datasets): Create a dataset and run your first experiment to evaluate and iteratively improve performance
+- [How to: Datasets](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets): Index of dataset guides — create, update, export, and link examples to spans
+- [How to: Experiments](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments): Index of experiment guides — run tasks, attach evaluators, repetitions, and splits
 
 ### Tutorial
 
@@ -183,6 +179,7 @@
 - [Creating Datasets](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/creating-datasets): Build from traces, code, CSV, or curated examples
 - [Updating Datasets](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/updating-datasets): Diff and update existing dataset examples using stable IDs with example_id_key
 - [Exporting Datasets](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/exporting-datasets): Export datasets in JSONL and CSV formats
+- [Linking Examples to Source Spans](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/linking-examples-to-spans): Resolve an example's source span over REST and log evaluations back onto it
 
 ### Experiments
 
@@ -192,12 +189,11 @@
 - [Repetitions](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/repetitions): Run multiple iterations for statistical confidence
 - [Splits](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/splits): Organize datasets into train/test/validation splits
 - [Eval CI with pytest](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/eval-ci-with-pytest): Run LLM evals as pytest tests, record them as Phoenix experiments, and gate CI on the pytest exit code with arize-phoenix-client[pytest]
+- [Run Experiments in the Background](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background): Start Playground experiments that keep running after you close the browser
 
-
-- [How to: Datasets](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets): Datasets are critical assets for building robust prompts, evals, fine-tuning,
-- [How to: Experiments](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments): How to: Experiments
-- [Run Experiments in the Background](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background): Start experiments from the Playground that keep running after you close the browser, survive server restarts
 ## Prompt Engineering
+
+- [How to: Prompts](https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts): Index of prompt guides — create, test, tag, load, and configure providers
 
 ### Tutorial
 
@@ -225,8 +221,6 @@
 - [Using a Prompt](https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/using-a-prompt): Load prompts programmatically via SDK
 - [Use Provider Tools](https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/use-provider-tools): Add vendor-specific built-in tools (web search, code execution, computer use) to Phoenix prompts
 
-
-- [How to: Prompts](https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts): Guides on how to do prompt engineering with Phoenix
 ## Integrations
 
 - [Integrations Overview](https://arize.com/docs/phoenix/integrations): All Phoenix integrations — LLM providers, frameworks, platforms
@@ -283,7 +277,7 @@
 - [CrewAI Tracing](https://arize.com/docs/phoenix/integrations/python/crewai/crewai-tracing): Auto-instrument CrewAI agent crews
 - [DSPy Tracing](https://arize.com/docs/phoenix/integrations/python/dspy/dspy-tracing): Auto-instrument DSPy modules and optimizers
 - [Google ADK Tracing (Python)](https://arize.com/docs/phoenix/integrations/python/google-adk/google-adk-tracing): Auto-instrument Google ADK agents
-- [Graphite Integration](https://arize.com/docs/phoenix/integrations/python/graphite/graphite-integration-guide): Integrate Graphite knowledge graphs with Phoenix
+- [Graphite Integration Guide](https://arize.com/docs/phoenix/integrations/python/graphite/graphite-integration-guide): Instrument Graphite multi-agent workflows and send spans to Phoenix
 - [Guardrails AI Tracing](https://arize.com/docs/phoenix/integrations/python/guardrails-ai/guardrails-ai-tracing): Auto-instrument Guardrails AI validation
 - [Haystack Tracing](https://arize.com/docs/phoenix/integrations/python/haystack/haystack-tracing): Auto-instrument Haystack pipelines
 - [smolagents Tracing](https://arize.com/docs/phoenix/integrations/python/hugging-face-smolagents/smolagents-tracing): Auto-instrument Hugging Face smolagents
@@ -327,10 +321,6 @@
 
 ### Evaluation Integrations
 
-
-
-### Evaluation Integrations — Individual Libraries
-
 - [Cleanlab](https://arize.com/docs/phoenix/integrations/evaluation-integrations/cleanlab): Use Cleanlab TLM confidence scores to flag untrustworthy LLM outputs in Phoenix
 - [MLflow](https://arize.com/docs/phoenix/integrations/evaluation-integrations/mlflow): Use Phoenix evaluators as MLflow scorers for GenAI evaluation workflows
 - [Ragas](https://arize.com/docs/phoenix/integrations/evaluation-integrations/ragas): Evaluate agents and RAG pipelines using Ragas metrics alongside Phoenix tracing
@@ -345,61 +335,62 @@
 
 ### Platforms — Additional
 
-- [Dify](https://arize.com/docs/phoenix/integrations/platforms/dify): Dify lets you visually build, orchestrate, and deploy AI-native apps using LLMs, with low-code workflows and
-- [Flowise](https://arize.com/docs/phoenix/integrations/platforms/flowise): Flowise is a low-code platform for building customized chatflows and agentflows
-- [LangFlow](https://arize.com/docs/phoenix/integrations/platforms/langflow): Langflow is an open-source visual framework that enables developers to rapidly design, prototype, and deploy
-- [Prompt flow](https://arize.com/docs/phoenix/integrations/platforms/prompt-flow): PromptFlow is a framework for designing, orchestrating, testing, and monitoring end-to-end LLM prompt
+- [Dify Integration](https://arize.com/docs/phoenix/integrations/platforms/dify): Connect Dify's low-code LLM app builder to Phoenix
+- [Flowise Integration](https://arize.com/docs/phoenix/integrations/platforms/flowise): Connect Flowise chatflows and agentflows to Phoenix
+- [LangFlow Integration](https://arize.com/docs/phoenix/integrations/platforms/langflow): Connect LangFlow's visual workflow builder to Phoenix
+- [Prompt Flow Integration](https://arize.com/docs/phoenix/integrations/platforms/prompt-flow): Connect Azure Prompt Flow orchestrations to Phoenix
 
 ### Java Frameworks — Additional
 
-- [Arconia](https://arize.com/docs/phoenix/integrations/java/arconia): Arconia is an open-source framework and set of tools for building modern, cloud-native enterprise
-- [LangChain4j](https://arize.com/docs/phoenix/integrations/java/langchain4j): LangChain4j is a Java library that provides APIs, tools, and patterns to easily build and integrate
-- [Spring AI](https://arize.com/docs/phoenix/integrations/java/springai): Spring AI extends the Spring Framework, making it easier to integrate AI capabilities into Java applications
+- [Arconia Integration](https://arize.com/docs/phoenix/integrations/java/arconia): Connect Arconia's cloud-native Spring tooling to Phoenix
+- [LangChain4j Integration](https://arize.com/docs/phoenix/integrations/java/langchain4j): Connect LangChain4j Java chains and agents to Phoenix
+- [Spring AI Integration](https://arize.com/docs/phoenix/integrations/java/springai): Connect Spring AI applications to Phoenix
 
 ### TypeScript Frameworks — Additional
 
-- [BeeAI](https://arize.com/docs/phoenix/integrations/typescript/beeai): BeeAI is an open-source platform that enables developers to discover, run, and compose AI agents from any
-- [LangChain](https://arize.com/docs/phoenix/integrations/typescript/langchain): LangChain is an open-source framework for building language model applications with prompt chaining, memory
-- [Mastra](https://arize.com/docs/phoenix/integrations/typescript/mastra): Mastra is an open-source TypeScript AI agent framework designed for building production-ready AI applications
-- [MCP](https://arize.com/docs/phoenix/integrations/typescript/mcp): Model Context Protocol (MCP) is an open protocol that enables secure connections between AI assistants and
-- [TanStack AI](https://arize.com/docs/phoenix/integrations/typescript/tanstack-ai): TanStack AI is a TypeScript framework for building chat, tool-calling, and agent-loop experiences across any
-- [Vercel](https://arize.com/docs/phoenix/integrations/typescript/vercel): Vercel is a cloud platform that simplifies building, deploying, and scaling modern web applications with
+- [BeeAI Integration (TypeScript)](https://arize.com/docs/phoenix/integrations/typescript/beeai): Connect BeeAI agent composition to Phoenix from TypeScript
+- [LangChain.js Integration](https://arize.com/docs/phoenix/integrations/typescript/langchain): Connect LangChain.js chains, memory, and agents to Phoenix
+- [Mastra Integration](https://arize.com/docs/phoenix/integrations/typescript/mastra): Connect Mastra TypeScript agent workflows to Phoenix
+- [MCP Integration (TypeScript)](https://arize.com/docs/phoenix/integrations/typescript/mcp): Connect Model Context Protocol clients and servers to Phoenix from TypeScript
+- [TanStack AI Integration](https://arize.com/docs/phoenix/integrations/typescript/tanstack-ai): Connect TanStack AI chat and agent loops to Phoenix
+- [Vercel Integration](https://arize.com/docs/phoenix/integrations/typescript/vercel): Connect Vercel AI SDK and Eve agents to Phoenix
 
 ### Python Frameworks — Additional
 
-- [Agent Spec](https://arize.com/docs/phoenix/integrations/python/agentspec): Open Agent Spec (Agent Spec) is a portable language for defining agentic systems. It defines building blocks
-- [Agno](https://arize.com/docs/phoenix/integrations/python/agno): Agno is an open-source Python framework for building lightweight, model-agnostic AI agents with built-in
-- [AutoGen](https://arize.com/docs/phoenix/integrations/python/autogen): AutoGen is an open-source Python framework for orchestrating multi-agent LLM interactions with shared memory
-- [BeeAI](https://arize.com/docs/phoenix/integrations/python/beeai): BeeAI is an open-source platform that enables developers to discover, run, and compose AI agents from any
-- [CrewAI](https://arize.com/docs/phoenix/integrations/python/crewai): CrewAI is an open-source Python framework for orchestrating role-playing, autonomous AI agents into
-- [DSPy](https://arize.com/docs/phoenix/integrations/python/dspy): DSPy is an open-source Python framework for declaratively programming modular LLM pipelines and automatically
-- [Google ADK](https://arize.com/docs/phoenix/integrations/python/google-adk): Google ADK is a Python SDK for building AI applications with Google's Gemini models and agent framework
-- [Graphite](https://arize.com/docs/phoenix/integrations/python/graphite): Stream traces from Graphite's visual multi-agent LLM workflows into Phoenix
-- [Guardrails AI](https://arize.com/docs/phoenix/integrations/python/guardrails-ai): Guardrails is an open-source Python framework for adding programmable input/output validators to LLM
-- [Haystack](https://arize.com/docs/phoenix/integrations/python/haystack): Haystack is an open-source framework for building scalable semantic search and QA pipelines with document
-- [Hugging Face Smolagents](https://arize.com/docs/phoenix/integrations/python/hugging-face-smolagents): Hugging Face smolagents is a minimalist Python library for building powerful AI agents with simple
-- [Instructor](https://arize.com/docs/phoenix/integrations/python/instructor): Instructor is a library that helps you define structured output formats for LLMs
-- [LangChain](https://arize.com/docs/phoenix/integrations/python/langchain): LangChain is an open-source framework for building language model applications with prompt chaining, memory
-- [LangGraph](https://arize.com/docs/phoenix/integrations/python/langgraph): LangGraph is an open-source framework for building graph-based LLM pipelines with modular nodes and seamless
-- [LlamaIndex](https://arize.com/docs/phoenix/integrations/python/llamaindex): LlamaIndex is an open-source framework that streamlines connecting, ingesting, indexing, and retrieving
-- [NVIDIA](https://arize.com/docs/phoenix/integrations/python/nvidia): NVIDIA NeMo Agent Toolkit is a flexible, lightweight library for connecting enterprise agents to data sources
-- [Portkey](https://arize.com/docs/phoenix/integrations/python/portkey): Portkey is an AI Gateway and observability platform that provides routing,  guardrails, caching, and
-- [Pydantic AI](https://arize.com/docs/phoenix/integrations/python/pydantic): PydanticAI is a Python agent framework designed to make it less painful to  build production-grade
-- [Restate](https://arize.com/docs/phoenix/integrations/python/restate): Restate is a durable execution platform that makes AI agents and workflows resumable and resilient, with
-- [Strands Agents](https://arize.com/docs/phoenix/integrations/python/strands-agents): Strands Agents is an open-source AI agent SDK that uses model-driven orchestration to build production-ready
+- [Agent Spec Integration](https://arize.com/docs/phoenix/integrations/python/agentspec): Connect Open Agent Spec agentic systems to Phoenix
+- [Agno Integration](https://arize.com/docs/phoenix/integrations/python/agno): Connect Agno model-agnostic Python agents to Phoenix
+- [AutoGen Integration](https://arize.com/docs/phoenix/integrations/python/autogen): Connect AutoGen multi-agent conversations to Phoenix
+- [BeeAI Integration (Python)](https://arize.com/docs/phoenix/integrations/python/beeai): Connect BeeAI agent composition to Phoenix from Python
+- [CrewAI Integration](https://arize.com/docs/phoenix/integrations/python/crewai): Connect CrewAI role-playing agent crews to Phoenix
+- [DSPy Integration](https://arize.com/docs/phoenix/integrations/python/dspy): Connect DSPy modules and optimizers to Phoenix
+- [Google ADK Integration](https://arize.com/docs/phoenix/integrations/python/google-adk): Connect Google ADK Gemini agents to Phoenix
+- [Graphite Integration](https://arize.com/docs/phoenix/integrations/python/graphite): Connect Graphite's visual multi-agent workflows to Phoenix
+- [Guardrails AI Integration](https://arize.com/docs/phoenix/integrations/python/guardrails-ai): Connect Guardrails AI input/output validators to Phoenix
+- [Haystack Integration](https://arize.com/docs/phoenix/integrations/python/haystack): Connect Haystack search and QA pipelines to Phoenix
+- [Hugging Face Smolagents Integration](https://arize.com/docs/phoenix/integrations/python/hugging-face-smolagents): Connect Hugging Face smolagents to Phoenix
+- [Instructor Integration](https://arize.com/docs/phoenix/integrations/python/instructor): Connect Instructor structured-output calls to Phoenix
+- [LangChain Integration (Python)](https://arize.com/docs/phoenix/integrations/python/langchain): Connect LangChain chains, memory, and agents to Phoenix
+- [LangGraph Integration](https://arize.com/docs/phoenix/integrations/python/langgraph): Connect LangGraph stateful graph pipelines to Phoenix
+- [LlamaIndex Integration](https://arize.com/docs/phoenix/integrations/python/llamaindex): Connect LlamaIndex ingestion, indexing, and retrieval to Phoenix
+- [NVIDIA NeMo Integration](https://arize.com/docs/phoenix/integrations/python/nvidia): Connect the NVIDIA NeMo Agent Toolkit to Phoenix
+- [Portkey Integration](https://arize.com/docs/phoenix/integrations/python/portkey): Connect the Portkey AI gateway's routing and caching to Phoenix
+- [Pydantic AI Integration](https://arize.com/docs/phoenix/integrations/python/pydantic): Connect Pydantic AI agents and its evals framework to Phoenix
+- [Restate Integration](https://arize.com/docs/phoenix/integrations/python/restate): Connect Restate durable agent executions to Phoenix
+- [Strands Agents Integration](https://arize.com/docs/phoenix/integrations/python/strands-agents): Connect Strands Agents model-driven orchestration to Phoenix
 
 ### LLM Providers — Additional
 
-- [Amazon Bedrock](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock): Amazon Bedrock is a managed service that provides access to top AI models for building scalable applications
-- [Anthropic](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic): Anthropic is an AI research company that develops LLMs, including Claude, with a focus on alignment and
-- [Google](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai): Google GenAI is a suite of AI tools and models from Google Cloud, designed to help businesses build, deploy
-- [Groq](https://arize.com/docs/phoenix/integrations/llm-providers/groq): Groq provides ultra-low latency inference for LLMs through its custom-built LPU™ architecture
-- [LiteLLM](https://arize.com/docs/phoenix/integrations/llm-providers/litellm): LiteLLM is an open-source platform that provides a unified interface to manage and access over 100 LLMs from
-- [MistralAI](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai): Mistral AI develops open-weight large language models, focusing on efficiency, customization, and
-- [OpenAI](https://arize.com/docs/phoenix/integrations/llm-providers/openai): OpenAI provides state-of-the-art LLMs for natural language understanding and generation
-- [OpenRouter](https://arize.com/docs/phoenix/integrations/llm-providers/openrouter): OpenRouter is a platform that connects developers to multiple AI models through a unified API, making it
-- [OrcaRouter](https://arize.com/docs/phoenix/integrations/llm-providers/orcarouter): OrcaRouter is an OpenAI-compatible AI gateway that routes requests across 200+ models
-- [VertexAI](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai): Vertex AI is a fully managed platform by Google Cloud for building, deploying, and scaling machine learning
+- [Amazon Bedrock Integration](https://arize.com/docs/phoenix/integrations/llm-providers/amazon-bedrock): Pick a Bedrock tracing or evals path across Python, TypeScript, and Agents
+- [Anthropic Integration](https://arize.com/docs/phoenix/integrations/llm-providers/anthropic): Pick an Anthropic Claude tracing or evals path across Python, TypeScript, and Go
+- [Google GenAI Integration](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai): Pick a Google GenAI and Gemini tracing or evals path
+- [Groq Integration](https://arize.com/docs/phoenix/integrations/llm-providers/groq): Trace Groq's low-latency LPU inference calls in Phoenix
+- [LiteLLM Integration](https://arize.com/docs/phoenix/integrations/llm-providers/litellm): Trace and evaluate calls routed through LiteLLM's unified 100+ model interface
+- [MistralAI Integration](https://arize.com/docs/phoenix/integrations/llm-providers/mistralai): Trace and evaluate Mistral open-weight model calls in Phoenix
+- [OpenAI Integration](https://arize.com/docs/phoenix/integrations/llm-providers/openai): Pick an OpenAI tracing or evals path across Python, Node.js, Go, and Agents SDK
+- [OpenRouter Integration](https://arize.com/docs/phoenix/integrations/llm-providers/openrouter): Trace calls routed through OpenRouter's unified multi-model API
+- [OrcaRouter Integration](https://arize.com/docs/phoenix/integrations/llm-providers/orcarouter): Trace calls through OrcaRouter's OpenAI-compatible gateway to 200+ models
+- [VertexAI Integration](https://arize.com/docs/phoenix/integrations/llm-providers/vertexai): Trace and evaluate Google Cloud Vertex AI model calls in Phoenix
+
 ## Settings
 
 - [Access Control RBAC](https://arize.com/docs/phoenix/settings/access-control-rbac): Role-based permissions and project access
@@ -454,9 +445,7 @@
 ### Evaluation
 
 - [LLM as a Judge](https://arize.com/docs/phoenix/evaluation/concepts-evals/llm-as-a-judge): LLM-based evaluation best practices
-- [Evaluators](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluators): Understand the evaluator abstraction, evaluator types, and the Score object
 - [Eval Data Types](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluation-types): Understand evaluation output types — categorical labels, continuous scores, and more
-- [Input Mapping](https://arize.com/docs/phoenix/evaluation/concepts-evals/input-mapping): Map and transform nested input data into the shape an evaluator's schema expects
 - [Custom Task Evaluation](https://arize.com/docs/phoenix/evaluation/concepts-evals/building-your-own-evals): Build custom LLM-as-judge eval templates for any task with arize-phoenix-evals
 - [Evaluating Multi-Agent Systems](https://arize.com/docs/phoenix/evaluation/concepts-evals/evaluating-multi-agent-systems): Evaluate multi-agent architectures with strategies for routing, coordination, and handoffs
 
@@ -467,20 +456,20 @@
 - [Phoenix to Arize AX Migration](https://arize.com/docs/phoenix/resources/phoenix-to-arize-ax-migration): Migration guide from Phoenix to Arize AX
 
 
-- [Braintrust Open Source Alternative? LLM Evaluation Platform Comparison](https://arize.com/docs/phoenix/resources/frequently-asked-questions/braintrust-open-source-alternative-llm-evaluation-platform-comparison): Braintrust is an evaluation platform that serves as an alternative to Arize Phoenix. Both platforms support
-- [Can I add other users to my Phoenix Instance?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-add-other-users-to-my-phoenix-instance): Can I add other users to my Phoenix Instance?
-- [Can I persist data in a notebook?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-persist-data-in-a-notebook): You can persist data in the notebook by either setting the `use_temp_dir` flag to false in `px.launch_app`
-- [Can I run Phoenix on Sagemaker?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-run-phoenix-on-sagemaker): With SageMaker notebooks, phoenix leverages the jupyter-server-proy to host the server under
-- [Can I use Azure OpenAI?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-azure-openai): Can I use Azure OpenAI?
-- [Can I use gRPC for trace collection?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-grpc-for-trace-collection): Phoenix does natively support gRPC for trace collection post 4.0 release. See
-- [Can I use Phoenix locally from a remote Jupyter instance?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-phoenix-locally-from-a-remote-jupyter-instance): Yes, you can use either of the two methods below
-- [How can I configure the backend to send the data to the phoenix UI in another container?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/how-can-i-configure-the-backend-to-send-the-data-to-the-phoenix-ui-in-another-container): _If you are working on an API whose endpoints perform RAG, but would like the phoenix server not to be
-- [How do I resolve Phoenix Evals showing NOT\_PARSABLE?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/how-do-i-resolve-phoenix-evals-showing-not_parsable): `NOT_PARSABLE` errors often occur when LLM responses exceed the `max_tokens` limit or produce incomplete JSON
-- [Langfuse alternative? Arize Phoenix vs Langfuse: Key differences](https://arize.com/docs/phoenix/resources/frequently-asked-questions/langfuse-alternative-arize-phoenix-vs-langfuse-key-differences): Langfuse alternative? Arize Phoenix vs Langfuse: Key differences
+- [Braintrust Open Source Alternative? LLM Evaluation Platform Comparison](https://arize.com/docs/phoenix/resources/frequently-asked-questions/braintrust-open-source-alternative-llm-evaluation-platform-comparison): Compare Phoenix and Braintrust across tracing, evaluation, and licensing
+- [Can I add other users to my Phoenix Instance?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-add-other-users-to-my-phoenix-instance): Enable authentication and invite teammates to a Phoenix deployment
+- [Can I persist data in a notebook?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-persist-data-in-a-notebook): Keep notebook traces across restarts with `use_temp_dir=False` or a database URL
+- [Can I run Phoenix on Sagemaker?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-run-phoenix-on-sagemaker): Serve Phoenix from a SageMaker notebook through jupyter-server-proxy
+- [Can I use Azure OpenAI?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-azure-openai): Configure Azure OpenAI deployments for tracing, evals, and the Playground
+- [Can I use gRPC for trace collection?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-grpc-for-trace-collection): Send spans over gRPC on port 4317 in Phoenix 4.0+
+- [Can I use Phoenix locally from a remote Jupyter instance?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/can-i-use-phoenix-locally-from-a-remote-jupyter-instance): Reach a locally running Phoenix from a remote notebook via port forwarding
+- [How can I configure the backend to send the data to the phoenix UI in another container?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/how-can-i-configure-the-backend-to-send-the-data-to-the-phoenix-ui-in-another-container): Point an app container's collector endpoint at a separate Phoenix container
+- [How do I resolve Phoenix Evals showing NOT\_PARSABLE?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/how-do-i-resolve-phoenix-evals-showing-not_parsable): Fix `NOT_PARSABLE` scores caused by `max_tokens` truncation or malformed JSON
+- [Langfuse alternative? Arize Phoenix vs Langfuse: Key differences](https://arize.com/docs/phoenix/resources/frequently-asked-questions/langfuse-alternative-arize-phoenix-vs-langfuse-key-differences): Compare Phoenix and Langfuse across tracing, evals, and self-hosting
 - [Open Source LangSmith Alternative: Arize Phoenix vs. LangSmith](https://arize.com/docs/phoenix/resources/frequently-asked-questions/open-source-langsmith-alternative-arize-phoenix-vs.-langsmith): Compare Phoenix and LangSmith across observability, evaluation, and open-source features
-- [What is my Phoenix Endpoint?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-my-phoenix-endpoint): What is my Phoenix Endpoint?
-- [What is the difference between GRPC and HTTP?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-grpc-and-http): gRPC and HTTP are communication protocols used to transfer data between client and server applications
-- [What is the difference between Phoenix and Arize?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize): Arize is the company that makes Phoenix. Phoenix is an open source LLM observability tool offered by Arize
+- [What is my Phoenix Endpoint?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-my-phoenix-endpoint): Find the collector endpoint and base URL to point your SDK at
+- [What is the difference between GRPC and HTTP?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-grpc-and-http): Choose between the gRPC and HTTP OTLP transports for span export
+- [What is the difference between Phoenix and Arize?](https://arize.com/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize): Understand how open-source Phoenix relates to the Arize AX platform
 ## SDK & API Reference
 
 - [SDK Overview](https://arize.com/docs/phoenix/sdk-api-reference): Navigate all Phoenix SDK and API reference docs
@@ -560,6 +549,16 @@
 - [Delete Span Annotations By Filter](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-span-annotations-by-filter): DELETE /v1/projects/{project_identifier}/span_annotations — hard-delete span annotations matching AND-ed filters (name, identifier, annotator_kind, created_after, created_before); at least one filter required
 - [Delete Trace Annotations By Filter](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-trace-annotations-by-filter): DELETE /v1/projects/{project_identifier}/trace_annotations — hard-delete trace annotations matching AND-ed filters; returns 204 idempotently
 - [Delete Session Annotations By Filter](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/annotations/delete-session-annotations-by-filter): DELETE /v1/projects/{project_identifier}/session_annotations — hard-delete session annotations matching AND-ed filters; returns 204 idempotently
+
+### REST API — API Keys
+
+- [List The Authenticated User's API Keys](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/api-keys/list-the-authenticated-users-api-keys): GET /v1/user/api_keys — list the calling user's own API keys
+- [Create An API Key For The Authenticated User](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/api-keys/create-an-api-key-for-the-authenticated-user): POST /v1/user/api_keys — mint a user API key and return the bearer token
+- [Delete A User API Key](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/api-keys/delete-a-user-api-key): DELETE /v1/user/api_keys/{api_key_id} — revoke a user API key
+- [List All User API Keys](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/api-keys/list-all-user-api-keys): GET /v1/users/api_keys — list every user API key in the workspace (admin)
+- [List System API Keys](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/api-keys/list-system-api-keys): GET /v1/system/api_keys — list system API keys used by services (admin)
+- [Create A System API Key](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/api-keys/create-a-system-api-key): POST /v1/system/api_keys — mint a system API key for CI or service-to-service calls (admin)
+- [Delete A System API Key](https://arize.com/docs/phoenix/sdk-api-reference/rest-api/api-reference/api-keys/delete-a-system-api-key): DELETE /v1/system/api_keys/{api_key_id} — revoke a system API key (admin)
 
 ### REST API — Datasets
 
@@ -703,51 +702,51 @@
 
 ### Individual Cookbook Pages
 
-- [Agent Workflow Patterns](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns): Workflows are the backbone of many successful LLM applications. They define how language models interact with
-- [AutoGen](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/autogen): Use Phoenix to trace and evaluate AutoGen agents
-- [CrewAI](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/crewai): **CrewAI** is an open-source framework for building and orchestrating collaborative AI agents that act like a
-- [Google GenAI SDK (manual orchestration)](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/google-genai-sdk-manual-orchestration): Everything you need to know about Google's GenAI framework
-- [LangGraph](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/langgraph): Use Phoenix to trace and evaluate agent frameworks built using Langgraph
-- [OpenAI Agents](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/openai-agents): [**OpenAI-Agents**](https://openai.github.io/openai-agents-python/) is a lightweight Python library for
-- [Smolagents](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/smolagents): **SmolAgents** is a lightweight Python library for composing tool-using, task-oriented agents. This guide
+- [Agent Workflow Patterns](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns): Compare router, chaining, and parallel agent workflow patterns and trace each in Phoenix
+- [AutoGen Cookbook](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/autogen): Trace and evaluate AutoGen multi-agent conversations end-to-end
+- [CrewAI Cookbook](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/crewai): Trace and evaluate collaborative CrewAI agent crews
+- [Google GenAI SDK Cookbook (Manual Orchestration)](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/google-genai-sdk-manual-orchestration): Hand-orchestrate Gemini tool-calling loops and trace each step in Phoenix
+- [LangGraph Cookbook](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/langgraph): Trace and evaluate graph-based LangGraph agents
+- [OpenAI Agents Cookbook](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/openai-agents): Trace and evaluate OpenAI Agents SDK handoffs, tools, and guardrails
+- [Smolagents Cookbook](https://arize.com/docs/phoenix/cookbook/agent-workflow-patterns/smolagents): Trace and evaluate tool-using Hugging Face smolagents
 - [Run Repetition Experiments on Customer Review Evals](https://arize.com/docs/phoenix/cookbook/ai-engineering-workflows/analyzing-customer-review-evals-with-repetition-experiments): Use repetitions to reduce variance and validate improvements in LLM eval experiments
-- [Iterative Evaluation & Experimentation Workflow (Python)](https://arize.com/docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-python): Phoenix Tracing, Evaluating, and Experimentation Walkthrough
-- [Iterative Evaluation & Experimentation Workflow (TypeScript)](https://arize.com/docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-typescript): Phoenix Tracing, Evaluating, and Experimentation Walkthrough
-- [Analyzing Customer Review Evals with Repetition Experiments](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/analyzing-customer-review-evals-with-repetition-experiments): Large Language Models (LLMs) are probabilistic; the same prompt can yield different outputs across runs. This
-- [Comparing LlamaIndex Query Engines with a Pairwise Evaluator](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/comparing-llamaindex-query-engines-with-a-pairwise-evaluator): This tutorial sets up an experiment to determine which LlamaIndex query engine is preferred by an evaluation
-- [More Cookbooks](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/cookbooks): More Cookbooks
-- [Experiment with a Customer Support Agent](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/experiment-with-a-customer-support-agent): This guide shows you how to create and evaluate agents with Phoenix to improve performance
-- [Prompt Template Iteration for a Summarization Service](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/summarization): Imagine you're deploying a service for your media company's summarization model that condenses daily news
-- [Text2SQL Experiments](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/text2sql): Building effective text-to-SQL systems requires rigorous evaluation and systematic experimentation. In this
+- [Iterative Evaluation & Experimentation Workflow (Python)](https://arize.com/docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-python): Walk one Python app from first traces through evals to comparative experiments
+- [Iterative Evaluation & Experimentation Workflow (TypeScript)](https://arize.com/docs/phoenix/cookbook/ai-engineering-workflows/iterative-evaluation-and-experimentation-workflow-typescript): Walk one TypeScript app from first traces through evals to comparative experiments
+- [Analyzing Customer Review Evals with Repetition Experiments](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/analyzing-customer-review-evals-with-repetition-experiments): Quantify run-to-run eval variance on customer reviews with repeated experiment runs
+- [Comparing LlamaIndex Query Engines with a Pairwise Evaluator](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/comparing-llamaindex-query-engines-with-a-pairwise-evaluator): Pick between LlamaIndex query engines using a head-to-head LLM judge
+- [More Dataset & Experiment Cookbooks](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/cookbooks): Index of notebook examples for datasets, experiments, and pairwise comparison
+- [Experiment with a Customer Support Agent](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/experiment-with-a-customer-support-agent): Build a support agent, then iterate on it with dataset-backed experiments
+- [Prompt Template Iteration for a Summarization Service](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/summarization): Compare summarization prompt templates on a news dataset with ROUGE and LLM judges
+- [Text2SQL Experiments](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/text2sql): Build a text-to-SQL system and measure query accuracy across prompt and model changes
 - [Why Public Benchmarks Lie: Building Your Own Eval Harness](https://arize.com/docs/phoenix/cookbook/datasets-and-experiments/building-your-own-eval-harness): A model that wins on MMLU can lose on your task. Build a domain-specific harness and compare models fairly on your own data and metric.
 - [Code Readability Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/code-readability-evaluation): Classify code as readable or unreadable using benchmark datasets with ground-truth labels
-- [More Cookbooks](https://arize.com/docs/phoenix/cookbook/evaluation/cookbooks): Use Phoenix Evals to evaluate your application for faithfulness, toxicity, relevance of retrieved documents
-- [Creating a Custom LLM Evaluator with a Benchmark Dataset](https://arize.com/docs/phoenix/cookbook/evaluation/creating-a-custom-llm-evaluator-with-a-benchmark-dataset): Learn how to build a custom LLM-as-a-Judge evaluator by creating a benchmark dataset tailored to your use
-- [Evaluate a Talk-to-Your-Data Agent](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-an-agent): Evaluate a Talk-to-Your-Data Agent
+- [More Evaluation Cookbooks](https://arize.com/docs/phoenix/cookbook/evaluation/cookbooks): Index of notebook examples for faithfulness, toxicity, and retrieval relevance evals
+- [Creating a Custom LLM Evaluator with a Benchmark Dataset](https://arize.com/docs/phoenix/cookbook/evaluation/creating-a-custom-llm-evaluator-with-a-benchmark-dataset): Build an LLM-as-a-Judge evaluator and validate it against a labeled benchmark
+- [Evaluate a Talk-to-Your-Data Agent](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-an-agent): Score router choices, tool calls, and answers for a data-querying agent
 - [Trace-level Evaluation: Beyond Input/Output Checks](https://arize.com/docs/phoenix/cookbook/evaluation/trace-level-evaluation): Evaluate an agent's intermediate reasoning, tool selection, and decision path — not just its final answer.
 - [Session-level Evaluation: Scoring the Whole Conversation](https://arize.com/docs/phoenix/cookbook/evaluation/session-level-evaluation): Evaluate a multi-turn session as a whole - coherence, goal completion, and user frustration that turn-by-turn checks miss.
 - [Designing Realtime Guardrails: Input, Output, and the Cost of Blocking](https://arize.com/docs/phoenix/cookbook/guardrails/designing-realtime-guardrails): Decide what to guard at input vs. output, trade latency against coverage, and layer guardrails without blocking real users.
 - [Evaluate RAG](https://arize.com/docs/phoenix/cookbook/evaluation/evaluate-rag): Building a RAG pipeline and evaluating it with Phoenix Evals
-- [OpenAI Agents SDK Cookbook](https://arize.com/docs/phoenix/cookbook/evaluation/openai-agents-sdk-cookbook): This guide shows you how to create and evaluate agents with Phoenix to improve performance
+- [OpenAI Agents SDK Cookbook](https://arize.com/docs/phoenix/cookbook/evaluation/openai-agents-sdk-cookbook): Instrument an OpenAI Agents SDK app and evaluate its handoffs and tool calls
 - [Relevance Classification Evaluation](https://arize.com/docs/phoenix/cookbook/evaluation/relevance-classification-evaluation): Evaluate the relevance of documents retrieved by RAG applications using Phoenix's evaluation framework
-- [Using Ragas to Evaluate a Math Problem-Solving Agent](https://arize.com/docs/phoenix/cookbook/evaluation/using-ragas-to-evaluate-a-math-problem-solving-agent): Using Ragas to Evaluate a Math Problem-Solving Agent
+- [Using Ragas to Evaluate a Math Problem-Solving Agent](https://arize.com/docs/phoenix/cookbook/evaluation/using-ragas-to-evaluate-a-math-problem-solving-agent): Score agent reasoning steps with Ragas metrics and log results to Phoenix
 - [Jailbreak and Prompt Injection Defense](https://arize.com/docs/phoenix/cookbook/guardrails/jailbreak-and-prompt-injection-defense): Red-team a support assistant across a taxonomy of jailbreak and injection attacks, score Attack Success Rate, and find which defenses actually work, including the indirect injection that input filtering can't see
-- [Aligning LLM Evals with Human Feedback (TypeScript)](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/aligning-llm-evals-with-human-annotations-typescript): In this tutorial, we’ll run a Mastra agent and build a custom evaluator for it. The goal is to understand the
+- [Aligning LLM Evals with Human Feedback (TypeScript)](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/aligning-llm-evals-with-human-annotations-typescript): Tune a custom Mastra-agent evaluator until it agrees with human annotations
 - [Using Human Annotations for Eval Driven Development](https://arize.com/docs/phoenix/cookbook/human-in-the-loop-workflows-annotations/using-human-annotations-for-eval-driven-development): How to leverage human annotations to build evaluations and experiments that improve your system
-- [Chain of Thought Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/chain-of-thought-prompting): Chain of Thought Prompting
-- [Few Shot Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/few-shot-prompting): Few-shot prompting is a powerful technique in prompt engineering that helps LLMs perform tasks more
-- [LLM-as-a-Judge Prompt Optimization](https://arize.com/docs/phoenix/cookbook/prompt-engineering/llm-as-a-judge-prompt-optimization): LLM-as-a-Judge Prompt Optimization
+- [Chain of Thought Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/chain-of-thought-prompting): Measure whether step-by-step reasoning prompts beat direct answers on your dataset
+- [Few Shot Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/few-shot-prompting): Compare zero-shot, one-shot, and few-shot prompt variants in an experiment
+- [LLM-as-a-Judge Prompt Optimization](https://arize.com/docs/phoenix/cookbook/prompt-engineering/llm-as-a-judge-prompt-optimization): Iterate on a judge's prompt until its scores track human labels
 - [Optimizing Coding Agent Prompts - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/optimizing-coding-agent-prompts-prompt-learning): Optimizing coding agent prompts and tracking coding agent improvement
 - [Optimizing Prompts for LLM Classification - Prompt Learning](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-learning-optimizing-prompts-for-classification): Using Prompt Learning to boost accuracy on a classification dataset
-- [Prompt Optimization Techniques](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-optimization): This tutorial will use Phoenix to compare the performance of different prompt optimization techniques
-- [ReAct Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/react-prompting): **ReAct (Reasoning + Acting)** is a prompting technique that enables LLMs to think step-by-step before taking
+- [Prompt Optimization Techniques](https://arize.com/docs/phoenix/cookbook/prompt-engineering/prompt-optimization): Benchmark meta-prompting, few-shot, and gradient-style prompt optimizers side by side
+- [ReAct Prompting](https://arize.com/docs/phoenix/cookbook/prompt-engineering/react-prompting): Build and evaluate a reason-then-act prompting loop with tool calls
 - [Agentic RAG Tracing](https://arize.com/docs/phoenix/cookbook/tracing/agentic-rag-tracing): Build and trace an agentic RAG system using LlamaIndex's ReAct agent with vector and SQL query tools
 - [Identifying High-Signal Traces](https://arize.com/docs/phoenix/cookbook/tracing/identify-high-signal-traces): Surface anomalies, latency outliers, and failure clusters worth investigating across millions of production traces
 - [OpenInference Best Practices](https://arize.com/docs/phoenix/cookbook/tracing/openinference-best-practices): Enrich auto-instrumented traces with LLM, tool, agent, chain, and session attributes using OpenInference span kinds
-- [More Cookbooks](https://arize.com/docs/phoenix/cookbook/tracing/cookbooks): Trace through the execution of your LLM application to understand its internal structure and to troubleshoot
-- [Generating Synthetic Datasets for LLM Evaluators & Agents](https://arize.com/docs/phoenix/cookbook/tracing/generating-synthetic-datasets-for-llm-evaluators-and-agents): Learn different strategies for dataset generation and show how they can be used to run experiments and test
-- [Product Recommendation Agent: Google Agent Engine & LangGraph](https://arize.com/docs/phoenix/cookbook/tracing/product-recommendation-agent-google-agent-engine-and-langgraph): This notebook is adapted from Google's \"Building and Deploying a LangGraph Application with Agent Engine in
-- [Structured Data Extraction](https://arize.com/docs/phoenix/cookbook/tracing/structured-data-extraction): Structured Data Extraction
+- [More Tracing Cookbooks](https://arize.com/docs/phoenix/cookbook/tracing/cookbooks): Index of notebook examples for instrumenting and troubleshooting LLM applications
+- [Generating Synthetic Datasets for LLM Evaluators & Agents](https://arize.com/docs/phoenix/cookbook/tracing/generating-synthetic-datasets-for-llm-evaluators-and-agents): Generate synthetic test cases to seed evaluator benchmarks and agent experiments
+- [Product Recommendation Agent: Google Agent Engine & LangGraph](https://arize.com/docs/phoenix/cookbook/tracing/product-recommendation-agent-google-agent-engine-and-langgraph): Deploy a LangGraph agent on Google Agent Engine and trace it in Phoenix
+- [Structured Data Extraction](https://arize.com/docs/phoenix/cookbook/tracing/structured-data-extraction): Trace and evaluate schema-constrained extraction from unstructured text
 
 ## Release Notes
 
@@ -811,6 +810,7 @@
 - [07.07.2026: Metric Charts, Trace Search, and REST API Expansion](https://arize.com/docs/phoenix/release-notes/07-2026/07-07-2026-metric-charts-trace-search-and-rest-api): Pin metric charts above data tables, search the trace tree, manage labels and annotation configs over REST, and use Claude Sonnet 5 in the Playground
 - [07.14.2026: Command Palette, Session Tools, and Table Customization](https://arize.com/docs/phoenix/release-notes/07-2026/07-14-2026-command-palette-sessions-and-tables): Jump anywhere with the ⌘K command palette, reorder table columns, inspect session stats, and use the GPT 5.6 family in the Playground
 - [07.17.2026: OAuth2 Authorization Server & Remote MCP](https://arize.com/docs/phoenix/release-notes/07-2026/07-17-2026-oauth2-authorization-server): Phoenix 19 becomes its own OAuth2 server with browser-based px CLI login, a built-in Remote MCP server, and REST API-key management
+- [07.22.2026: MCP Client Setup, Provider Filtering, and User Friction Evals](https://arize.com/docs/phoenix/release-notes/07-2026/07-22-2026-mcp-setup-provider-filter-and-evals): Wire an MCP client with one `px setup mcp` command, scope the Playground picker to provisioned providers, and trace Vercel AI SDK v7
 
 ### 2025
 


### PR DESCRIPTION
## Summary

Audited `docs/phoenix/llms.txt` against the full docs tree (`docs.json` navigation ∩ `docs/phoenix/**/*.mdx`), added the missing pages, removed stale entries, and cleaned up descriptions and titles that violated the index's own conventions.

Net: **682 entries** (was 680) — 9 pages added, 7 stale entries removed.

## Coverage gaps filled (9 entries)

**REST API — API Keys** (new subsection, 7 endpoints)

The entire `api-keys` endpoint group was nav-published but absent from the index — agents building API-key provisioning had no way to find it:

- `GET`/`POST`/`DELETE /v1/user/api_keys` — the caller's own keys
- `GET /v1/users/api_keys` — all user keys (admin)
- `GET`/`POST`/`DELETE /v1/system/api_keys` — service keys for CI and service-to-service calls (admin)

**Datasets**

- `Linking Examples to Source Spans` — resolving an example's source span over REST and logging evals back onto it

**Release Notes / 2026**

- `07.22.2026: MCP Client Setup, Provider Filtering, and User Friction Evals`

## Stale entries removed (7)

Each of these is a **redirect `source`** in `docs.json` — the URL no longer serves content, it bounces elsewhere. In every case the redirect destination was already indexed, so nothing was lost:

| Removed entry | Redirects to (already indexed) |
| --- | --- |
| `datasets-and-experiments/quickstart-datasets` | `get-started/get-started-datasets-and-experiments` |
| `evaluation/evals` | `evaluation/llm-evals` |
| `evaluation/llm-evals/executors` | `evaluation/llm-evals` |
| `evaluation/llm-evals/evaluator-traces` | `evaluation/llm-evals` |
| `evaluation/concepts-evals/evaluators` | `evaluation/how-to-evals` |
| `evaluation/concepts-evals/input-mapping` | `evaluation/how-to-evals` |
| `evaluation/server-evals/builtin-evaluators` | `evaluation/server-evals/pre-built-metrics` |

## Description quality

Roughly 60 descriptions were verbatim first-sentence dumps from page bodies — several truncated mid-sentence, some carrying raw markdown that breaks the `- [Title](url): description` line format. Rewrote them as short, action-oriented lines:

- **Truncated mid-sentence** — e.g. Tool Response Handling ("…data extraction, and"), all four Platform hub pages, all three Java hub pages, and 20 Python framework hub pages.
- **Markdown inside descriptions** — the OpenAI Agents cookbook description was an embedded `[**link**](url)`; CrewAI, Smolagents, and ReAct Prompting carried `**bold**` markers.
- **Restating the title** — 10 FAQ and cookbook entries whose description was a copy of their own title ("Can I use Azure OpenAI?", "Structured Data Extraction", "Chain of Thought Prompting", …) now say what the page teaches you to do.
- **Duplicate descriptions** — the two Iterative Evaluation & Experimentation Workflow pages, and the two agent-experiment cookbooks, shared identical text; each now distinguishes itself.

## Duplicate titles

The spec requires every `[Title]` to be unique, since titles are read outside their section context. Nine collisions were resolved:

- `Code Evaluators` → `Code Evaluators (SDK)` / `Server Code Evaluators`
- `Correctness`, `Exact Match`, `Tool Invocation`, `Tool Selection` → server-side variants prefixed `Server …`
- `More Cookbooks` ×3 → `More Dataset & Experiment Cookbooks` / `More Evaluation Cookbooks` / `More Tracing Cookbooks`
- `BeeAI` ×2 and `LangChain` ×2 → language-qualified
- Integration hub pages renamed `<Name> Integration` so they no longer collide with their `<Name> Tracing` children

## Structure

- Hoisted four orphaned entries (`How to: Tracing`, `How to: Datasets`, `How to: Experiments`, `How to: Prompts`) out of the gaps between sections and into their proper `##` section intros; `Run Experiments in the Background` moved under `### Experiments`.
- Removed an empty `### Evaluation Integrations` heading and merged it with the `— Individual Libraries` list that followed it.
- Restored the blank line before `## Evaluation`, `## Prompt Engineering`, `## Integrations`, and `## Settings`, which were butted directly against the preceding entry.
- Moved `### REST API — API Keys` after `### REST API — Annotations` to match the alphabetical grouping used by the rest of the REST sections.

## Pages deliberately excluded

Verified as neither nav pages nor redirect destinations, so they 404 or carry nothing an agent can use:

- 9 orphaned `llm-providers/<provider>/<provider>-evals` pages and `llm-providers/google-adk/google-adk-tracing`
- 9 orphaned `01-2026`/`02-2026` release notes and 13 REST API group index stubs
- `integrations/model-context-protocol`, `integrations/sign-up-for-phoenix-sign-up`, `prompt-engineering/concepts-prompts`, `evaluation/{python,typescript}-quickstart`, `evaluation/llm-evals/use-any-llm`, `tracing/features-tracing`, `tracing/how-to-tracing/advanced/constructing-urls`, `cookbook/ai-engineering-workflows/aligning-evals-with-human-feedback`
- `resources/github` and `resources/openinference` (frontmatter-only external links); `resources/python-api` and `resources/typescript-api` (redirect stubs to already-indexed SDK pages)
- Per the standing rules: `agent-assisted-setup`, `phoenix-demo`, `end-to-end-features-notebook`, and the `documentation/{jp,zh}` translations

## Verification

- Every one of the 682 entries matches the CLI parser's regex in `js/packages/phoenix-cli/src/commands/docs.ts` (`^-\s+\[([^\]]+)\]\((https?:\/\/[^)]+)\)(?::\s+(.*))?$`), and all `##` section names consumed by `WORKFLOW_SECTION_MAP` are unchanged.
- `pnpm test -- --grep "docs"` could not be run in this environment (command execution was restricted), so the parser test suite has **not** been executed — worth confirming in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
