### PR TITLE
feat(sandboxes): use Pydantic logo for Monty provider icon

### DIFF
--- a/app/src/components/sandbox/SandboxProviderIcon.tsx
+++ b/app/src/components/sandbox/SandboxProviderIcon.tsx
@@ -1,8 +1,6 @@
 import { css } from "@emotion/react";
 import { useId } from "react";
 
-import { PythonSVG } from "@phoenix/components/core/icon/Icons";
-
 const iconWrapCSS = css`
   display: inline-flex;
   flex-shrink: 0;
@@ -13,9 +11,16 @@ import type { SandboxBackendType } from "@phoenix/types";
 type IconProps = { height: number };
 
 const MontySVG = ({ height }: IconProps) => (
-  <span style={{ display: "inline-flex", height }}>
-    <PythonSVG />
-  </span>
+  <svg
+    viewBox="0 0 120 120"
+    width={height}
+    height={height}
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>Monty</title>
+    <path d="M 119.18,86.64 98.02,57.3 c 0,0 0,0 0,0 L 63.77,9.8 c -1.74,-2.4 -5.76,-2.4 -7.49,0 l -34.24,47.49 c 0,0 0,0 0,0 L 0.87,86.64 c -0.86,1.2 -1.1,2.73 -0.65,4.13 0.46,1.4 1.55,2.5 2.95,2.96 l 55.41,18.14 c 0,0 0,0 0.01,9e-4 0.46,0.15 0.94,0.23 1.43,0.23 0.49,0 0.97,-0.08 1.43,-0.23 0,0 0,0 0.01,0 L 116.87,93.73 c 1.4,-0.46 2.5,-1.55 2.95,-2.96 0.46,-1.4 0.22,-2.93 -0.65,-4.13 z m -59.15,-66.25 22.21,30.8 -20.77,-6.8 c -0.16,-0.05 -0.33,-0.04 -0.49,-0.08 -0.16,-0.04 -0.32,-0.06 -0.48,-0.08 -0.16,-0.02 -0.31,-0.08 -0.47,-0.08 -0.16,0 -0.31,0.06 -0.47,0.08 -0.17,0.02 -0.32,0.04 -0.48,0.08 -0.16,0.03 -0.33,0.03 -0.48,0.08 h 0 l -20.64,6.76 -0.13,0.04 22.21,-30.8 z m -31.38,43.52 24.18,-7.92 2.58,-0.84 V 101.12 L 12.06,86.92 Z m 36,37.2 V 55.15 l 26.76,8.76 16.59,23 z" />
+  </svg>
 );
 
 const DaytonaSVG = ({ height }: IconProps) => (


### PR DESCRIPTION
## Summary
- Replace the placeholder Python icon for the Monty sandbox provider with the Pydantic brand mark, inlined from [pydantic/brand](https://github.com/pydantic/brand)
- Use `fill="currentColor"` (the source SVG hardcodes white) so the icon adapts to light/dark themes, consistent with the other monochrome provider icons (Daytona, Vercel, E2B, Deno)