### PR TITLE
fix(cli): make px setup's trace verdict the run's result

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -104,10 +104,16 @@ falls back to the download. `--no-docs-mcp` suppresses the interactive offer.
 — check `tracesVerified`, which is set only when the API confirmed a trace
 arriving, not when the agent claims it finished.
 
-A run that instrumented and saw no trace exits `6`, not `0`: the configuration
-and edits are real, but tracing is not confirmed working. Treat that as a
-failure to report, not a success — and do not substitute the hand-off agent's
-own exit code or summary for the verdict.
+A run whose wait ran out with no trace exits `6`, not `0`: the configuration and
+edits are real, but tracing is not confirmed working. Treat that as a failure to
+report, not a success — and do not substitute the hand-off agent's own exit code
+or summary for the verdict. Registering without `--instrument`, and a human
+answering "verify later" at the timeout prompt, both exit `0`.
+
+`tracesVerified` is `false` for a registration-only run too, so it alone can't
+tell "nothing to verify" from "no trace arrived". Read `verification`
+(`verified` / `notVerified` / `deferred`, absent when there was nothing to
+verify) when you need the difference.
 
 Re-runnable slices, so an already-registered repo skips the questions:
 

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -104,6 +104,11 @@ falls back to the download. `--no-docs-mcp` suppresses the interactive offer.
 — check `tracesVerified`, which is set only when the API confirmed a trace
 arriving, not when the agent claims it finished.
 
+A run that instrumented and saw no trace exits `6`, not `0`: the configuration
+and edits are real, but tracing is not confirmed working. Treat that as a
+failure to report, not a success — and do not substitute the hand-off agent's
+own exit code or summary for the verdict.
+
 Re-runnable slices, so an already-registered repo skips the questions:
 
 ```bash

--- a/docs/phoenix/agent-assisted-setup.mdx
+++ b/docs/phoenix/agent-assisted-setup.mdx
@@ -62,6 +62,14 @@ px setup --no-input --endpoint http://localhost:6006 --project my-app
 px setup --no-input --instrument --agent claude --yolo --format raw
 ```
 
+A run that instruments only succeeds if a trace actually arrived — the agent's
+own claim that it finished doesn't count. **Exit code `6` means the wait ran out
+with no trace**, so tracing isn't confirmed working even though the connection,
+`.env.phoenix`, and the agent's edits are all in place. In a pipeline, treat `6`
+as "configured but unverified" rather than a hard failure: re-run
+`px setup instrument` or check the exporter. In `--format json|raw`, the
+`verification` field carries the same verdict.
+
 See the [CLI reference](/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli#px-setup) for the full list of flags.
 
 ## Use an unsupported agent

--- a/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
@@ -192,6 +192,22 @@ px setup --no-input --endpoint http://localhost:6006 --project my-app
 px setup --no-input --instrument --agent claude --yolo --language python --format raw
 ```
 
+Setup's definition of done is a trace the API confirmed arriving, not a completed
+hand-off, and the exit code says which happened:
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Verified, registered only, or you chose "verify later" at the prompt |
+| `6` | The wait ran out with no trace — tracing is not confirmed working |
+
+Other codes follow the CLI-wide contract: `2` cancelled, `3` invalid flags, `4`
+auth, `5` unreachable endpoint. In `--format json|raw`, `verification` is
+`verified`, `notVerified`, or `deferred` and is absent when there was nothing to
+verify; `tracesVerified` is the boolean shorthand for `verification ==
+"verified"`. Don't score a run on the hand-off agent's own exit code — it may
+edit the app correctly and then exit badly, or exit cleanly having delivered
+nothing.
+
 Re-run individual steps later with the subcommands:
 
 ```bash

--- a/js/packages/phoenix-cli/.agents/skills/phoenix-cli-development/SKILL.md
+++ b/js/packages/phoenix-cli/.agents/skills/phoenix-cli-development/SKILL.md
@@ -96,6 +96,7 @@ Defined in `src/exitCodes.ts`. Commands MUST use the named constants and MUST NO
 | 3    | `INVALID_ARGUMENT` | Bad CLI flags, missing required args, invalid input |
 | 4    | `AUTH_REQUIRED`    | Not authenticated or insufficient permissions       |
 | 5    | `NETWORK_ERROR`    | Failed to connect to server or network request      |
+| 6    | `NOT_VERIFIED`     | Ran, but could not verify the result it produces    |
 
 ### Interactive default with non-interactive mode
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -173,17 +173,27 @@ A run that instruments is only a success if a trace actually arrived — the
 agent's own claim that it finished doesn't count. Every output says so, and so
 does the exit code:
 
-| Exit | Meaning                                                            |
-| ---- | ------------------------------------------------------------------ |
-| `0`  | A trace was verified arriving, or the run only registered          |
-| `6`  | Instrumented, but no trace arrived — tracing is not confirmed      |
-| `2`  | Cancelled                                                          |
-| `3`  | Missing or invalid flags (the error prints the correct invocation) |
+| Exit | Meaning                                                              |
+| ---- | -------------------------------------------------------------------- |
+| `0`  | Verified, registered only, or you chose "verify later" at the prompt |
+| `1`  | Unexpected error                                                     |
+| `2`  | Cancelled                                                            |
+| `3`  | Missing or invalid flags (the error prints the correct invocation)   |
+| `4`  | Not authenticated, or the credentials lack permission                |
+| `5`  | Could not reach the Phoenix endpoint                                 |
+| `6`  | The wait ran out with no trace — tracing is not confirmed working    |
 
-`--format json|raw` carries the same verdict as `tracesVerified`; `--format
-pretty` prints a `traces:` line. Don't score a run on the agent's exit code —
-it may edit the app correctly and then exit badly, or exit cleanly having
-delivered nothing.
+Only a wait that ran out gives `6`. Registering without `--instrument`, and
+answering "Finish setup — I'll verify later" at the timeout prompt, both exit
+`0` — so `px setup && npm run dev` and `set -e` scripts keep working when you
+deliberately defer.
+
+In `--format json|raw`, `verification` is `verified`, `notVerified`, or
+`deferred`, and is absent when there was nothing to verify; `tracesVerified` is
+the boolean shorthand for `verification == "verified"`. `--format pretty`
+prints a `traces:` line. Don't score a run on the hand-off agent's own exit
+code — it may edit the app correctly and then exit badly, or exit cleanly
+having delivered nothing.
 
 Re-run pieces later with:
 

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -169,6 +169,22 @@ px setup --no-input --instrument --agent claude --yolo --language python --forma
 px setup --no-input --instrument --agent claude --yolo --docs-mcp --format raw
 ```
 
+A run that instruments is only a success if a trace actually arrived — the
+agent's own claim that it finished doesn't count. Every output says so, and so
+does the exit code:
+
+| Exit | Meaning                                                             |
+| ---- | ------------------------------------------------------------------- |
+| `0`  | A trace was verified arriving, or the run only registered           |
+| `6`  | Instrumented, but no trace arrived — tracing is not confirmed       |
+| `2`  | Cancelled                                                           |
+| `3`  | Missing or invalid flags (the error prints the correct invocation)   |
+
+`--format json|raw` carries the same verdict as `tracesVerified`; `--format
+pretty` prints a `traces:` line. Don't score a run on the agent's exit code —
+it may edit the app correctly and then exit badly, or exit cleanly having
+delivered nothing.
+
 Re-run pieces later with:
 
 ```bash

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -173,12 +173,12 @@ A run that instruments is only a success if a trace actually arrived — the
 agent's own claim that it finished doesn't count. Every output says so, and so
 does the exit code:
 
-| Exit | Meaning                                                             |
-| ---- | ------------------------------------------------------------------- |
-| `0`  | A trace was verified arriving, or the run only registered           |
-| `6`  | Instrumented, but no trace arrived — tracing is not confirmed       |
-| `2`  | Cancelled                                                           |
-| `3`  | Missing or invalid flags (the error prints the correct invocation)   |
+| Exit | Meaning                                                            |
+| ---- | ------------------------------------------------------------------ |
+| `0`  | A trace was verified arriving, or the run only registered          |
+| `6`  | Instrumented, but no trace arrived — tracing is not confirmed      |
+| `2`  | Cancelled                                                          |
+| `3`  | Missing or invalid flags (the error prints the correct invocation) |
 
 `--format json|raw` carries the same verdict as `tracesVerified`; `--format
 pretty` prints a `traces:` line. Don't score a run on the agent's exit code —

--- a/js/packages/phoenix-cli/src/commands/formatSetup.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSetup.ts
@@ -8,7 +8,7 @@
 
 import * as COPY from "../setup/copy";
 import type { McpSetupReport } from "../setup/mcp/runSetupMcp";
-import type { SetupReport } from "../setup/runSetup";
+import { tracesConfirmed, type SetupReport } from "../setup/runSetup";
 import type { ToolingResult } from "../setup/steps/installTooling";
 
 export type OutputFormat = "pretty" | "json" | "raw";
@@ -42,11 +42,17 @@ export interface SetupOutput {
   };
   /** True when the API confirmed a trace arrived after this run started. */
   tracesVerified: boolean;
+  /**
+   * How the wait ended, when there was one. Absent on a registration-only run,
+   * which is what distinguishes "nothing to verify" — a success, exit 0 — from
+   * `notVerified`. `tracesVerified` alone reads `false` for both.
+   */
+  verification?: "verified" | "notVerified" | "deferred";
   tooling?: ToolingResult;
 }
 
 export function toSetupOutput(report: SetupReport): SetupOutput {
-  const { docs, docsMcp, instrumentation } = report;
+  const { docs, docsMcp, instrumentation, verification } = report;
   return {
     endpoint: report.connection.endpoint,
     project: report.connection.projectName,
@@ -79,7 +85,8 @@ export function toSetupOutput(report: SetupReport): SetupOutput {
             exitCode: instrumentation.exitCode,
           }
         : { lane: instrumentation.kind }),
-    tracesVerified: report.tracesVerified === true,
+    tracesVerified: tracesConfirmed(report),
+    verification,
     tooling: report.tooling,
   };
 }
@@ -112,16 +119,16 @@ export function headlessSummary(report: SetupReport): string {
     `project: ${report.connection.projectName}`,
     `files: ${report.files.join(", ")}`,
   ];
-  if (!report.instrumentation) {
+  if (!report.verification) {
     return [...lines, "", COPY.HEADLESS.nextSteps(report.tracesUrl)].join("\n");
   }
-  const verified = report.tracesVerified === true;
+  const verified = tracesConfirmed(report);
   return [
     ...lines,
     `traces: ${verified ? "verified" : "NOT VERIFIED"}`,
     "",
     verified
-      ? COPY.VERIFY.received(report.tracesUrl)
+      ? COPY.HEADLESS.verifiedNextSteps(report.tracesUrl)
       : COPY.HEADLESS.notVerifiedNextSteps(report.tracesUrl),
   ].join("\n");
 }

--- a/js/packages/phoenix-cli/src/commands/formatSetup.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSetup.ts
@@ -95,14 +95,34 @@ function renderJson(value: unknown, format: OutputFormat): string | undefined {
   return undefined;
 }
 
-/** The pretty rendering — what a headless run prints on stdout. */
+/**
+ * The pretty rendering — what a headless run prints on stdout.
+ *
+ * All of setup's narration goes to stderr, so for anything reading stdout this
+ * summary is the whole report. It therefore has to carry the verification
+ * verdict: without it, a run where no trace ever landed prints byte-identical
+ * output to one where tracing works, and reads as success.
+ *
+ * A run that never instrumented has nothing to verify, so it gets no verdict
+ * line rather than a misleading "not verified".
+ */
 export function headlessSummary(report: SetupReport): string {
-  return [
+  const lines = [
     `endpoint: ${report.connection.endpoint}`,
     `project: ${report.connection.projectName}`,
     `files: ${report.files.join(", ")}`,
+  ];
+  if (!report.instrumentation) {
+    return [...lines, "", COPY.HEADLESS.nextSteps(report.tracesUrl)].join("\n");
+  }
+  const verified = report.tracesVerified === true;
+  return [
+    ...lines,
+    `traces: ${verified ? "verified" : "NOT VERIFIED"}`,
     "",
-    COPY.HEADLESS.nextSteps(report.tracesUrl),
+    verified
+      ? COPY.VERIFY.received(report.tracesUrl)
+      : COPY.HEADLESS.notVerifiedNextSteps(report.tracesUrl),
   ].join("\n");
 }
 

--- a/js/packages/phoenix-cli/src/commands/setup.ts
+++ b/js/packages/phoenix-cli/src/commands/setup.ts
@@ -28,8 +28,13 @@ import {
   type SetupInputs,
   type SetupOptions,
 } from "../setup/options";
-import type { SetupReport } from "../setup/runSetup";
-import { runInstrument, runSetup, runSkills } from "../setup/runSetup";
+import {
+  runInstrument,
+  runSetup,
+  runSkills,
+  verificationFailed,
+  type SetupReport,
+} from "../setup/runSetup";
 import { writeStructuredError } from "../structuredError";
 import { ENDPOINT_REQUIREMENT, isEndpointUrl } from "../validation/endpoint";
 import { WORKERS_REQUIREMENT } from "./docs";
@@ -237,12 +242,17 @@ function toSetupOptions(options: SetupCommandOptions): SetupOptions {
  *
  * It gets its own code rather than FAILURE because nothing failed: the
  * connection, the env file, and the agent's edits are all real and worth
- * keeping. A registration-only run has nothing to verify and exits 0.
+ * keeping.
+ *
+ * Only a wait that ran out counts. A run that never instrumented had nothing
+ * to verify, and a user who picked "Finish setup — I'll verify later" made a
+ * decision setup offered them — failing the process on either would break
+ * `px setup && npm run dev` and every `set -e` bootstrap script for a run that
+ * did exactly what was asked. `verificationFailed` owns that distinction so
+ * this and the printed verdict cannot disagree.
  */
 export function setupExitCode(report: SetupReport): ExitCode {
-  return report.instrumentation && report.tracesVerified !== true
-    ? ExitCode.NOT_VERIFIED
-    : ExitCode.SUCCESS;
+  return verificationFailed(report) ? ExitCode.NOT_VERIFIED : ExitCode.SUCCESS;
 }
 
 /**
@@ -407,8 +417,8 @@ Examples:
   px setup instrument --no-input --agent claude --yolo --format raw
 
 Exit codes:
-  0  A trace was verified arriving after the hand-off
-  6  Instrumented, but no trace arrived — tracing is not confirmed working
+  0  A trace was verified arriving, or you chose to verify later
+  6  The wait ran out with no trace — tracing is not confirmed working
 `
   );
 }
@@ -472,8 +482,8 @@ Subcommands:
   px setup mcp          Register the Phoenix MCP server with a coding agent
 
 Exit codes:
-  0  Setup completed — a trace was verified, or the run only registered
-  6  Instrumented, but no trace arrived — tracing is not confirmed working
+  0  Verified, registered only, or you chose to verify later
+  6  The wait ran out with no trace — tracing is not confirmed working
 `
     );
 

--- a/js/packages/phoenix-cli/src/commands/setup.ts
+++ b/js/packages/phoenix-cli/src/commands/setup.ts
@@ -28,6 +28,7 @@ import {
   type SetupInputs,
   type SetupOptions,
 } from "../setup/options";
+import type { SetupReport } from "../setup/runSetup";
 import { runInstrument, runSetup, runSkills } from "../setup/runSetup";
 import { writeStructuredError } from "../structuredError";
 import { ENDPOINT_REQUIREMENT, isEndpointUrl } from "../validation/endpoint";
@@ -155,8 +156,8 @@ interface SetupCommandOptions {
   workers?: number;
   /**
    * `--format <format>`: How the result is rendered on stdout. `pretty` is the
-   * human summary; `json`/`raw` emit the machine-readable report, including
-   * whether traces were verified.
+   * human summary; `json`/`raw` emit the machine-readable report. Every format
+   * states whether traces were verified, as does the exit code.
    *
    * @example "raw"
    */
@@ -228,16 +229,37 @@ function toSetupOptions(options: SetupCommandOptions): SetupOptions {
 }
 
 /**
+ * A run that handed off instrumentation and never saw a trace arrive is not a
+ * success: setup's definition of done is API-verified data flow, not a
+ * completed hand-off. Exiting 0 there makes the wizard indistinguishable from
+ * one that worked for any caller scoring runs by exit status — an onboarding
+ * harness, or the coding agent that invoked `px setup` in the first place.
+ *
+ * It gets its own code rather than FAILURE because nothing failed: the
+ * connection, the env file, and the agent's edits are all real and worth
+ * keeping. A registration-only run has nothing to verify and exits 0.
+ */
+export function setupExitCode(report: SetupReport): ExitCode {
+  return report.instrumentation && report.tracesVerified !== true
+    ? ExitCode.NOT_VERIFIED
+    : ExitCode.SUCCESS;
+}
+
+/**
  * Run one of the setup lanes, then print what it did in the requested format.
  *
  * Every lane goes through here, so the rule that a headless run always prints a
  * report — it has no interactive narration to fall back on — is stated once
  * instead of re-derived per subcommand.
+ *
+ * `exitCodeOf` lets a lane whose report carries a verdict fail the process on
+ * it; lanes without one (the tooling installs) exit 0 on return.
  */
 async function runLane<TReport>(
   commandOptions: SetupCommandOptions,
   lane: (deps: SetupDeps, inputs: SetupInputs) => Promise<TReport>,
-  render: (report: TReport, format: OutputFormat) => string
+  render: (report: TReport, format: OutputFormat) => string,
+  exitCodeOf: (report: TReport) => ExitCode = () => ExitCode.SUCCESS
 ): Promise<void> {
   const options = toSetupOptions(commandOptions);
   const format = commandOptions.format ?? "pretty";
@@ -259,23 +281,29 @@ async function runLane<TReport>(
     if (inputs.headless || format !== "pretty") {
       writeOutput({ message: render(report, format) });
     }
-    process.exit(ExitCode.SUCCESS);
+    process.exit(exitCodeOf(report));
   } catch (error) {
     exitWithError(error, format);
   }
 }
 
 async function setupHandler(options: SetupCommandOptions): Promise<void> {
-  await runLane(options, runSetup, (report, format) =>
-    formatSetupOutput({ report, format })
+  await runLane(
+    options,
+    runSetup,
+    (report, format) => formatSetupOutput({ report, format }),
+    setupExitCode
   );
 }
 
 async function setupInstrumentHandler(
   options: SetupCommandOptions
 ): Promise<void> {
-  await runLane(options, runInstrument, (report, format) =>
-    formatSetupOutput({ report, format })
+  await runLane(
+    options,
+    runInstrument,
+    (report, format) => formatSetupOutput({ report, format }),
+    setupExitCode
   );
 }
 
@@ -377,6 +405,10 @@ Examples:
   px setup instrument
   px setup instrument --agent claude --language python
   px setup instrument --no-input --agent claude --yolo --format raw
+
+Exit codes:
+  0  A trace was verified arriving after the hand-off
+  6  Instrumented, but no trace arrived — tracing is not confirmed working
 `
   );
 }
@@ -438,6 +470,10 @@ Subcommands:
   px setup instrument   Instrument and verify, without redoing the questions
   px setup skills       Install the coding-agent skills alone
   px setup mcp          Register the Phoenix MCP server with a coding agent
+
+Exit codes:
+  0  Setup completed — a trace was verified, or the run only registered
+  6  Instrumented, but no trace arrived — tracing is not confirmed working
 `
     );
 

--- a/js/packages/phoenix-cli/src/exitCodes.ts
+++ b/js/packages/phoenix-cli/src/exitCodes.ts
@@ -13,6 +13,7 @@
  * |  3   | Invalid argument | Bad CLI flags, missing required args, invalid input |
  * |  4   | Auth required    | Not authenticated or insufficient permissions       |
  * |  5   | Network error    | Failed to connect to server or network request      |
+ * |  6   | Not verified     | The command ran, but could not confirm its effect   |
  */
 export const ExitCode = {
   /** Command completed successfully */
@@ -27,6 +28,13 @@ export const ExitCode = {
   AUTH_REQUIRED: 4,
   /** Failed to connect to server or network request failed */
   NETWORK_ERROR: 5,
+  /**
+   * The command did the work it was asked to do, but could not verify the
+   * result it exists to produce. Distinct from FAILURE so a caller can tell
+   * "ran, no effect observed" from "did not run" — `px setup --instrument`
+   * returns it when no trace ever arrived.
+   */
+  NOT_VERIFIED: 6,
 } as const;
 
 export type ExitCode = (typeof ExitCode)[keyof typeof ExitCode];

--- a/js/packages/phoenix-cli/src/setup/copy.ts
+++ b/js/packages/phoenix-cli/src/setup/copy.ts
@@ -275,6 +275,13 @@ export const VERIFY = {
     ].join("\n"),
   received: (tracesUrl: string) =>
     `✓ Traces are flowing. View them: ${tracesUrl}`,
+  /**
+   * Emitted when the span search never came back with an answer. Distinct from
+   * "no traces yet" on purpose: this is setup unable to look, not the app
+   * failing to emit, and the two have opposite remediations.
+   */
+  unreachable: (endpoint: string) =>
+    `! Could not reach Phoenix at ${endpoint} to check for traces — check the endpoint and credentials in .env.phoenix. Traces may be arriving even though this could not confirm it.`,
   timeoutMessage: "No traces have arrived yet. Keep watching?",
   keepWatchingLabel: "Keep watching",
   finishLabel: "Finish setup — I'll verify later",
@@ -431,6 +438,18 @@ export const HEADLESS = {
       "  1. Export the vars:   set -a; source .env.phoenix; set +a",
       `  2. Instrument your app: ${DOCS.instrumentationIndex}`,
       `  3. Watch for traces:  ${tracesUrl}`,
+    ].join("\n"),
+  /**
+   * Next steps for a verified run. Still carries the export line: the trace
+   * came from the process setup handed the credentials to, so the user's own
+   * shell has them nowhere yet, and stdout is the only place a headless run
+   * says so.
+   */
+  verifiedNextSteps: (tracesUrl: string) =>
+    [
+      `✓ Traces are flowing. View them: ${tracesUrl}`,
+      "",
+      "To send traces from a new shell: set -a; source .env.phoenix; set +a",
     ].join("\n"),
   /**
    * Next steps for a run that instrumented and saw nothing arrive. Separate

--- a/js/packages/phoenix-cli/src/setup/copy.ts
+++ b/js/packages/phoenix-cli/src/setup/copy.ts
@@ -57,6 +57,15 @@ export const CANCEL_OUTRO = [
 
 export const OUTRO_TITLE = "You're set up.";
 
+/**
+ * Closing line for a run that instrumented but never saw a trace. Setup's
+ * definition of done is API-verified data flow, so the frame must not close on
+ * "You're set up." when the one thing it verifies did not happen — everything
+ * before this point is configuration, and configuration is not tracing.
+ */
+export const OUTRO_TITLE_NOT_VERIFIED =
+  "Setup finished, but no trace arrived — tracing is not confirmed working yet.";
+
 export const OUTRO_BODY = SUPPORT_LINKS;
 
 // ---------------------------------------------------------------------------
@@ -422,5 +431,20 @@ export const HEADLESS = {
       "  1. Export the vars:   set -a; source .env.phoenix; set +a",
       `  2. Instrument your app: ${DOCS.instrumentationIndex}`,
       `  3. Watch for traces:  ${tracesUrl}`,
+    ].join("\n"),
+  /**
+   * Next steps for a run that instrumented and saw nothing arrive. Separate
+   * from `nextSteps` because "instrument your app" is the wrong instruction
+   * here — the app was instrumented, and the exporter is what to look at.
+   */
+  notVerifiedNextSteps: (tracesUrl: string) =>
+    [
+      "The app was instrumented, but no trace arrived — do not treat tracing as working yet.",
+      "",
+      "Next steps:",
+      "  1. Export the vars:  set -a; source .env.phoenix; set +a",
+      "  2. Run your app so it makes one LLM call.",
+      `  3. Watch for traces: ${tracesUrl}`,
+      `  Still nothing? ${DOCS.troubleshooting}`,
     ].join("\n"),
 } as const;

--- a/js/packages/phoenix-cli/src/setup/runSetup.ts
+++ b/js/packages/phoenix-cli/src/setup/runSetup.ts
@@ -34,7 +34,7 @@ import { instrumentApp, type InstrumentationLane } from "./steps/instrumentApp";
 import type { DocsMcpResult } from "./steps/offerDocsMcp";
 import { offerPxProfile } from "./steps/offerPxProfile";
 import {
-  hasSpansInSkewWindow,
+  skewWindowIsClear,
   waitForFirstTrace,
   tracesUrl,
 } from "./steps/verifyTraces";
@@ -119,9 +119,24 @@ export async function runSetup(
   );
   // Untitled: the outro below already says it, and closes the rail.
   deps.prompter.note(COPY.OUTRO_BODY);
-  deps.prompter.outro(COPY.OUTRO_TITLE);
+  deps.prompter.outro(outroTitle(report));
 
   return { ...report, tooling };
+}
+
+/**
+ * The closing line, which is the last thing left on screen and so the run's
+ * verdict as the user reads it. It has to follow `tracesVerified`: the notes
+ * above it are informational either way, and closing on "You're set up." after
+ * an unverified hand-off is a success claim setup did not earn.
+ *
+ * A run that never instrumented has nothing to verify and keeps the plain
+ * title — registering is all it was asked to do.
+ */
+function outroTitle(report: SetupReport): string {
+  return report.instrumentation && !report.tracesVerified
+    ? COPY.OUTRO_TITLE_NOT_VERIFIED
+    : COPY.OUTRO_TITLE;
 }
 
 /**
@@ -144,7 +159,7 @@ export async function runInstrument(
   }
   const report = await registerAndInstrument(deps, inputs, { agentDetection });
   if (!inputs.headless) {
-    deps.prompter.outro(COPY.OUTRO_TITLE);
+    deps.prompter.outro(outroTitle(report));
   }
   return report;
 }
@@ -199,7 +214,7 @@ async function registerAndInstrument(
   // Any span already visible inside the clock-skew window predates this run —
   // verification must then require spans strictly after the start time, or a
   // pre-existing trace would falsely verify the hand-off.
-  const hadRecentSpans = await hasSpansInSkewWindow(deps, connection, {
+  const allowClockSkew = await skewWindowIsClear(deps, connection, {
     sinceMs: startedAt,
   });
 
@@ -232,7 +247,7 @@ async function registerAndInstrument(
   // even when no trace showed up.
   const tracesVerified = await waitForFirstTrace(deps, connection, {
     sinceMs: startedAt,
-    allowClockSkew: !hadRecentSpans,
+    allowClockSkew,
     headless: inputs.headless,
   });
 

--- a/js/packages/phoenix-cli/src/setup/runSetup.ts
+++ b/js/packages/phoenix-cli/src/setup/runSetup.ts
@@ -37,6 +37,7 @@ import {
   skewWindowIsClear,
   waitForFirstTrace,
   tracesUrl,
+  type TraceVerification,
 } from "./steps/verifyTraces";
 import { ENV_FILE_NAME, writeEnvFile } from "./steps/writeEnvFile";
 
@@ -53,10 +54,34 @@ export interface SetupReport {
   /** The docs MCP offer, when it was made (configured replaces `docs`). */
   docsMcp?: DocsMcpResult;
   instrumentation?: InstrumentationLane;
-  /** True once the API confirmed a trace arrived after this run started. */
-  tracesVerified?: boolean;
+  /**
+   * How the wait for the first trace ended. Absent on a run that never
+   * instrumented and so had nothing to verify.
+   */
+  verification?: TraceVerification;
   tooling?: ToolingResult;
   tracesUrl: string;
+}
+
+/**
+ * True once the API confirmed a trace arrived after this run started — setup's
+ * definition of done.
+ */
+export function tracesConfirmed(report: SetupReport): boolean {
+  return report.verification === "verified";
+}
+
+/**
+ * True when setup tried to verify data flow and did not get it. The one
+ * outcome that makes a run a failure: a `deferred` wait was the user's call,
+ * and an absent verification means there was nothing to verify.
+ *
+ * Every surface that reports the verdict — the closing line, the headless
+ * summary, the exit code — reads it from here or {@link tracesConfirmed}, so
+ * they cannot drift into disagreeing with each other.
+ */
+export function verificationFailed(report: SetupReport): boolean {
+  return report.verification === "notVerified";
 }
 
 /**
@@ -126,15 +151,19 @@ export async function runSetup(
 
 /**
  * The closing line, which is the last thing left on screen and so the run's
- * verdict as the user reads it. It has to follow `tracesVerified`: the notes
- * above it are informational either way, and closing on "You're set up." after
- * an unverified hand-off is a success claim setup did not earn.
+ * verdict as the user reads it. It has to follow the verification outcome: the
+ * notes above it are informational either way, and closing on "You're set up."
+ * after an unverified hand-off is a success claim setup did not earn.
+ *
+ * A deferred wait gets the same honest title as a failed one — the user chose
+ * to stop watching, which does not make tracing confirmed working. Only the
+ * exit code distinguishes them, because only that has a caller to mislead.
  *
  * A run that never instrumented has nothing to verify and keeps the plain
  * title — registering is all it was asked to do.
  */
 function outroTitle(report: SetupReport): string {
-  return report.instrumentation && !report.tracesVerified
+  return report.verification && !tracesConfirmed(report)
     ? COPY.OUTRO_TITLE_NOT_VERIFIED
     : COPY.OUTRO_TITLE;
 }
@@ -245,7 +274,7 @@ async function registerAndInstrument(
   // arriving, not the agent's own claim that it finished. It is reported, not
   // thrown on: the connection and hand-off files are real work worth keeping
   // even when no trace showed up.
-  const tracesVerified = await waitForFirstTrace(deps, connection, {
+  const verification = await waitForFirstTrace(deps, connection, {
     sinceMs: startedAt,
     allowClockSkew,
     headless: inputs.headless,
@@ -260,7 +289,7 @@ async function registerAndInstrument(
     files: [...base.files, ...(docsMcp?.files ?? [])],
     gitignored: [...base.gitignored, ...(docs?.gitignoreAppended ?? [])],
     instrumentation,
-    tracesVerified,
+    verification,
   };
 }
 

--- a/js/packages/phoenix-cli/src/setup/steps/verifyTraces.ts
+++ b/js/packages/phoenix-cli/src/setup/steps/verifyTraces.ts
@@ -7,7 +7,7 @@
  * anyway") — never asked to eyeball the UI as the definition of done.
  */
 
-import type { PhoenixClient } from "@arizeai/phoenix-client";
+import { HttpError, type PhoenixClient } from "@arizeai/phoenix-client";
 
 import * as COPY from "../copy";
 import type { SetupDeps } from "../deps";
@@ -35,20 +35,26 @@ function searchStartTime(sinceMs: number, skewMs: number): string {
 }
 
 /**
- * True when the project already has spans inside the clock-skew window at
- * `sinceMs`. Checked before instrumentation begins: any span visible at that
- * point predates this run, so verification must not credit the skew window.
+ * True when the clock-skew window at `sinceMs` is known to be empty, and so
+ * safe for verification to count as part of this run.
+ *
+ * Checked before instrumentation begins: any span already visible at that
+ * point predates this run, so verification must not credit the window. An
+ * indeterminate probe answers false for the same reason — widening the window
+ * on an answer we could not get would let a span from before this run satisfy
+ * verification, which is the false success this whole step exists to prevent.
  */
-export async function hasSpansInSkewWindow(
+export async function skewWindowIsClear(
   deps: Pick<SetupDeps, "createClient">,
   connection: Connection,
   { sinceMs }: { sinceMs: number }
 ): Promise<boolean> {
-  return hasNewSpans(
+  const probe = await probeForNewSpans(
     spanSearchClient(deps, connection),
     connection.projectName,
     searchStartTime(sinceMs, START_TIME_SKEW_MS)
   );
+  return probe === "none";
 }
 
 function spanSearchClient(
@@ -62,15 +68,19 @@ function spanSearchClient(
 }
 
 /**
- * One span-search request. Any failure is a "not yet": a 404 means the project
- * has no spans to have created it, and a network hiccup mid-poll should keep
- * setup watching rather than abort it.
+ * What one span search established. `unknown` is the important one: the
+ * request did not come back with an answer, which is not the same as an answer
+ * of "no". Polling treats both as "keep watching", but the skew pre-check must
+ * not read a failed request as proof the window was empty.
  */
-async function hasNewSpans(
+type SpanProbe = "found" | "none" | "unknown";
+
+/** One span-search request. */
+async function probeForNewSpans(
   client: PhoenixClient,
   projectName: string,
   startTime: string
-): Promise<boolean> {
+): Promise<SpanProbe> {
   try {
     const { data } = await client.GET(
       "/v1/projects/{project_identifier}/spans",
@@ -82,9 +92,16 @@ async function hasNewSpans(
         signal: AbortSignal.timeout(POLL_REQUEST_TIMEOUT_MS),
       }
     );
-    return (data?.data.length ?? 0) > 0;
-  } catch {
-    return false;
+    return (data?.data.length ?? 0) > 0 ? "found" : "none";
+  } catch (error) {
+    // The client's middleware turns every non-2xx into an HttpError, so a
+    // status is only reachable from here. A 404 is a definite "none": the
+    // project does not exist, so nothing has ever been delivered to it.
+    // Everything else — an auth rejection, a 5xx, a timeout, a dropped
+    // socket — is an answer we did not get.
+    return error instanceof HttpError && error.status === 404
+      ? "none"
+      : "unknown";
   }
 }
 
@@ -97,7 +114,10 @@ async function pollWindow(
 ): Promise<boolean> {
   const deadline = deps.clock.now() + POLL_WINDOW_MS;
   for (;;) {
-    if (await hasNewSpans(client, connection.projectName, startTime)) {
+    if (
+      (await probeForNewSpans(client, connection.projectName, startTime)) ===
+      "found"
+    ) {
       return true;
     }
     if (deps.clock.now() >= deadline) {
@@ -118,8 +138,8 @@ async function pollWindow(
  *
  * @param args.sinceMs - instrumentation start; only spans after it count.
  * @param args.allowClockSkew - widen the window by the skew tolerance. Pass
- * false when the project had spans before instrumentation began (see
- * `hasSpansInSkewWindow`), so stale spans cannot satisfy verification.
+ * false unless the window was confirmed empty before instrumentation began
+ * (see {@link skewWindowIsClear}), so stale spans cannot satisfy verification.
  * @param args.headless - no prompting; give up after one window.
  */
 export async function waitForFirstTrace(

--- a/js/packages/phoenix-cli/src/setup/steps/verifyTraces.ts
+++ b/js/packages/phoenix-cli/src/setup/steps/verifyTraces.ts
@@ -105,36 +105,55 @@ async function probeForNewSpans(
   }
 }
 
-/** Poll until a span arrives or the window elapses. */
+/**
+ * Poll until a span arrives or the window elapses, and report how it ended.
+ *
+ * The terminal probe is returned rather than a bare boolean so the caller can
+ * tell "Phoenix says there are no spans" from "Phoenix never answered" — the
+ * difference between the user's app not emitting and setup being unable to
+ * look, which need different remediation.
+ */
 async function pollWindow(
   deps: Pick<SetupDeps, "clock">,
   client: PhoenixClient,
   connection: Connection,
   startTime: string
-): Promise<boolean> {
+): Promise<SpanProbe> {
   const deadline = deps.clock.now() + POLL_WINDOW_MS;
   for (;;) {
-    if (
-      (await probeForNewSpans(client, connection.projectName, startTime)) ===
-      "found"
-    ) {
-      return true;
+    const probe = await probeForNewSpans(
+      client,
+      connection.projectName,
+      startTime
+    );
+    if (probe === "found") {
+      return probe;
     }
     if (deps.clock.now() >= deadline) {
-      return false;
+      return probe;
     }
     await deps.clock.sleep(POLL_INTERVAL_MS);
   }
 }
 
 /**
- * Watch for the first trace since `sinceMs`. Resolves true when a span is
- * observed via the API, false when the wait ends without one — the user gave
- * up at the timeout prompt, or, in a headless run, the first window elapsed.
+ * How the wait for the first trace ended.
+ *
+ * `deferred` is the outcome that is not a failure: the user was asked whether
+ * to keep watching and chose to stop. Verification was withdrawn, not attempted
+ * and lost, so setup must not report it as a broken setup — the escape hatch
+ * says "everything else is already configured" and means it.
+ */
+export type TraceVerification = "verified" | "notVerified" | "deferred";
+
+/**
+ * Watch for the first trace since `sinceMs`.
  *
  * The "keep watching?" prompt is the only thing that can extend the wait, so a
  * headless run gets exactly one window: there is no terminal to ask on, and
- * looping forever would hang an unattended caller.
+ * looping forever would hang an unattended caller. That also means only an
+ * interactive run can return `deferred` — a headless timeout is nobody's
+ * decision.
  *
  * @param args.sinceMs - instrumentation start; only spans after it count.
  * @param args.allowClockSkew - widen the window by the skew tolerance. Pass
@@ -150,7 +169,7 @@ export async function waitForFirstTrace(
     allowClockSkew = true,
     headless = false,
   }: { sinceMs: number; allowClockSkew?: boolean; headless?: boolean }
-): Promise<boolean> {
+): Promise<TraceVerification> {
   const url = tracesUrl(connection);
   const startTime = searchStartTime(
     sinceMs,
@@ -159,13 +178,20 @@ export async function waitForFirstTrace(
   const client = spanSearchClient(deps, connection);
   deps.prompter.note(COPY.VERIFY.waitingBody(url), COPY.VERIFY.title);
   for (;;) {
-    if (await pollWindow(deps, client, connection, startTime)) {
+    const probe = await pollWindow(deps, client, connection, startTime);
+    if (probe === "found") {
       deps.prompter.line(COPY.VERIFY.received(url));
-      return true;
+      return "verified";
+    }
+    // Say which problem this is. "No trace arrived" sends the user to look at
+    // their exporter; an unanswered probe means setup could not look at all,
+    // and pointing them at instrumentation would be a wild goose chase.
+    if (probe === "unknown") {
+      deps.prompter.line(COPY.VERIFY.unreachable(connection.endpoint));
     }
     if (headless) {
       deps.prompter.line(COPY.VERIFY.notVerifiedHeadless(url));
-      return false;
+      return "notVerified";
     }
     const keepWatching = await deps.prompter.select<boolean>({
       message: COPY.VERIFY.timeoutMessage,
@@ -183,7 +209,7 @@ export async function waitForFirstTrace(
         COPY.VERIFY.notVerifiedBody(url),
         COPY.VERIFY.notVerifiedTitle
       );
-      return false;
+      return "deferred";
     }
   }
 }

--- a/js/packages/phoenix-cli/test/formatSetup.test.ts
+++ b/js/packages/phoenix-cli/test/formatSetup.test.ts
@@ -29,7 +29,7 @@ const REPORT: SetupReport = {
     hasPagesOnDisk: true,
   },
   instrumentation: { kind: "agent", agent: "claude", exitCode: 0 },
-  tracesVerified: true,
+  verification: "verified",
   tooling: { cli: "skipped", skills: "installed" },
   tracesUrl: "http://localhost:6006/redirects/projects/my-app",
 };
@@ -55,6 +55,7 @@ describe("formatSetupOutput", () => {
       },
       instrumentation: { lane: "agent", agent: "claude", exitCode: 0 },
       tracesVerified: true,
+      verification: "verified",
       tooling: { cli: "skipped", skills: "installed" },
     });
   });
@@ -84,7 +85,7 @@ describe("formatSetupOutput", () => {
     const output = parse("json", {
       ...base,
       instrumentation: undefined,
-      tracesVerified: undefined,
+      verification: undefined,
       tooling: undefined,
     });
     expect(output.instrumentation).toBeUndefined();
@@ -93,6 +94,19 @@ describe("formatSetupOutput", () => {
     // Absent verification is reported as false, never omitted — agents branch
     // on this field.
     expect(output.tracesVerified).toBe(false);
+    // But `verification` is omitted, which is the only thing distinguishing
+    // "nothing to verify" (exit 0) from "no trace arrived" (exit 6) —
+    // `tracesVerified` alone reads false for both.
+    expect(output.verification).toBeUndefined();
+  });
+
+  it("json distinguishes a deferred wait from a failed one", () => {
+    expect(
+      parse("json", { ...REPORT, verification: "deferred" })
+    ).toMatchObject({ tracesVerified: false, verification: "deferred" });
+    expect(
+      parse("json", { ...REPORT, verification: "notVerified" })
+    ).toMatchObject({ tracesVerified: false, verification: "notVerified" });
   });
 
   it("a non-zero agent exit is reported, not swallowed", () => {
@@ -123,12 +137,16 @@ describe("formatSetupOutput", () => {
   it("pretty states the verdict on an instrumented run", () => {
     const verified = formatSetupOutput({ report: REPORT });
     const notVerified = formatSetupOutput({
-      report: { ...REPORT, tracesVerified: false },
+      report: { ...REPORT, verification: "notVerified" },
     });
     expect(verified).toContain("traces: verified");
     expect(notVerified).toContain("traces: NOT VERIFIED");
     expect(notVerified).toContain("no trace arrived");
     expect(notVerified).not.toBe(verified);
+    // A verified run still has to say how to export the credentials: the trace
+    // came from the process setup injected them into, not the user's shell.
+    expect(verified).toContain("source .env.phoenix");
+    expect(notVerified).toContain("source .env.phoenix");
   });
 
   it("pretty omits the verdict when nothing was instrumented", () => {
@@ -136,7 +154,7 @@ describe("formatSetupOutput", () => {
       report: {
         ...REPORT,
         instrumentation: undefined,
-        tracesVerified: undefined,
+        verification: undefined,
       },
     });
     // A register-only run had nothing to verify; "not verified" would misread

--- a/js/packages/phoenix-cli/test/formatSetup.test.ts
+++ b/js/packages/phoenix-cli/test/formatSetup.test.ts
@@ -117,4 +117,31 @@ describe("formatSetupOutput", () => {
       pretty
     );
   });
+
+  // All of setup's narration goes to stderr, so for a caller reading stdout the
+  // pretty summary is the entire report — it cannot be silent about the verdict.
+  it("pretty states the verdict on an instrumented run", () => {
+    const verified = formatSetupOutput({ report: REPORT });
+    const notVerified = formatSetupOutput({
+      report: { ...REPORT, tracesVerified: false },
+    });
+    expect(verified).toContain("traces: verified");
+    expect(notVerified).toContain("traces: NOT VERIFIED");
+    expect(notVerified).toContain("no trace arrived");
+    expect(notVerified).not.toBe(verified);
+  });
+
+  it("pretty omits the verdict when nothing was instrumented", () => {
+    const pretty = formatSetupOutput({
+      report: {
+        ...REPORT,
+        instrumentation: undefined,
+        tracesVerified: undefined,
+      },
+    });
+    // A register-only run had nothing to verify; "not verified" would misread
+    // as a failure of something it never attempted.
+    expect(pretty).not.toMatch(/^traces: /m);
+    expect(pretty).toContain("Instrument your app");
+  });
 });

--- a/js/packages/phoenix-cli/test/setup/runSetup.test.ts
+++ b/js/packages/phoenix-cli/test/setup/runSetup.test.ts
@@ -393,8 +393,15 @@ describe("runSetup", () => {
 
     const result = await runSetupLane(deps);
     expect(result.headless).toBe(false);
+    expect(result.tracesVerified).toBe(false);
     expect(
       prompter.output.some((message) => message.includes("Not seeing traces?"))
+    ).toBe(true);
+    // The closing line is the last thing on screen and so the run's verdict as
+    // the user reads it: it must not claim success the run did not earn.
+    expect(prompter.output).not.toContain("You're set up.");
+    expect(
+      prompter.output.some((message) => message.includes("no trace arrived"))
     ).toBe(true);
   });
 

--- a/js/packages/phoenix-cli/test/setup/runSetup.test.ts
+++ b/js/packages/phoenix-cli/test/setup/runSetup.test.ts
@@ -9,6 +9,8 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { headlessSummary } from "../../src/commands/formatSetup";
+import { setupExitCode } from "../../src/commands/setup";
+import { ExitCode } from "../../src/exitCodes";
 import type { SetupDeps } from "../../src/setup/deps";
 import {
   HeadlessInputError,
@@ -359,7 +361,7 @@ describe("runSetup", () => {
     // verified — the MCP failure cost nothing but the optimization.
     expect(result.docsMcp?.outcome).toBe("failed");
     expect(result.docs?.outputDir).toBe(".px/docs");
-    expect(result.tracesVerified).toBe(true);
+    expect(result.verification).toBe("verified");
     expect(launched).toHaveLength(1);
   });
 
@@ -393,7 +395,11 @@ describe("runSetup", () => {
 
     const result = await runSetupLane(deps);
     expect(result.headless).toBe(false);
-    expect(result.tracesVerified).toBe(false);
+    // Deferred, not failed: setup offered to stop watching and the user took
+    // it, so the process must still exit 0 or `px setup && npm run dev` breaks
+    // for a run that did exactly what was asked.
+    expect(result.verification).toBe("deferred");
+    expect(setupExitCode(result)).toBe(ExitCode.SUCCESS);
     expect(
       prompter.output.some((message) => message.includes("Not seeing traces?"))
     ).toBe(true);
@@ -403,6 +409,42 @@ describe("runSetup", () => {
     expect(
       prompter.output.some((message) => message.includes("no trace arrived"))
     ).toBe(true);
+  });
+
+  it("a headless wait that runs out fails, unlike a deferral", async () => {
+    let clock = 0;
+    const deps = buildFakeDeps({
+      context: { cwd: dir, settingsPath },
+      fetch: fakeFetch(
+        (url) =>
+          url.includes("/spans?") ? jsonResponse(200, { data: [] }) : undefined,
+        (url) =>
+          url.includes("/v1/projects?limit=1")
+            ? jsonResponse(200, { data: [] })
+            : undefined
+      ),
+      processes: {
+        exec: async (spec) =>
+          spec.command === "claude" && spec.args[0] === "--version"
+            ? { exitCode: 0, stdout: "1.0.0\n", stderr: "" }
+            : gitExecFake()(spec),
+      },
+      clock: { now: () => (clock += 61_000) },
+    });
+
+    const result = await runSetupLane(deps, {
+      noInput: true,
+      instrument: true,
+      agent: "claude",
+      bypassPermissions: true,
+      endpoint: LOCAL,
+      project: "my-app",
+    });
+    // Nobody chose this — the window elapsed with no trace, which is the
+    // silent-drop case the exit code exists to surface.
+    expect(result.verification).toBe("notVerified");
+    expect(setupExitCode(result)).toBe(ExitCode.NOT_VERIFIED);
+    expect(headlessSummary(result)).toContain("traces: NOT VERIFIED");
   });
 
   it("cancelling any prompt unwinds with SetupCancelledError", async () => {
@@ -527,7 +569,7 @@ describe("runSetup", () => {
       agent: "claude",
       exitCode: 0,
     });
-    expect(result.tracesVerified).toBe(true);
+    expect(result.verification).toBe("verified");
     expect(result.docs?.outputDir).toBe(".px/docs");
     expect(launched[0]?.args.slice(0, 2)).toEqual([
       "-p",
@@ -578,7 +620,7 @@ describe("runSetup", () => {
       project: "my-app",
     });
 
-    expect(result.tracesVerified).toBe(true);
+    expect(result.verification).toBe("verified");
     expect(result.docs?.written).toBe(1);
   });
 

--- a/js/packages/phoenix-cli/test/setup/verifyTraces.test.ts
+++ b/js/packages/phoenix-cli/test/setup/verifyTraces.test.ts
@@ -10,7 +10,12 @@ import {
   skewWindowIsClear,
   waitForFirstTrace,
 } from "../../src/setup/steps/verifyTraces";
-import { buildFakeDeps, fakeFetch, jsonResponse } from "./fakes";
+import {
+  buildFakeDeps,
+  fakeFetch,
+  jsonResponse,
+  scriptedPrompter,
+} from "./fakes";
 
 const CONNECTION = {
   endpoint: "http://localhost:6006",
@@ -96,7 +101,7 @@ describe("waitForFirstTrace", () => {
     const deps = buildFakeDeps({ fetch });
     expect(
       await waitForFirstTrace(deps, CONNECTION, { sinceMs: 120_000 })
-    ).toBe(true);
+    ).toBe("verified");
     expect(windowStarts).toEqual([60_000]);
   });
 
@@ -110,7 +115,7 @@ describe("waitForFirstTrace", () => {
     });
     expect(
       await waitForFirstTrace(deps, CONNECTION, { sinceMs: 0, headless: true })
-    ).toBe(false);
+    ).toBe("notVerified");
   });
 
   it("does not verify when the project does not exist", async () => {
@@ -125,6 +130,45 @@ describe("waitForFirstTrace", () => {
     });
     expect(
       await waitForFirstTrace(deps, CONNECTION, { sinceMs: 0, headless: true })
+    ).toBe("notVerified");
+  });
+
+  // "No trace arrived" sends the user to look at their exporter. If setup
+  // could not reach Phoenix to look at all, that is a different problem and
+  // the wrong remediation.
+  it("names an unreachable Phoenix rather than blaming the app", async () => {
+    const prompter = scriptedPrompter([]);
+    let clock = 0;
+    const deps = buildFakeDeps({
+      prompter,
+      fetch: (async () => {
+        throw new TypeError("connection reset");
+      }) as typeof fetch,
+      clock: { now: () => (clock += 61_000) },
+    });
+    await waitForFirstTrace(deps, CONNECTION, { sinceMs: 0, headless: true });
+    expect(
+      prompter.output.some((message) =>
+        message.includes(`Could not reach Phoenix at ${CONNECTION.endpoint}`)
+      )
+    ).toBe(true);
+  });
+
+  it("does not claim unreachable when Phoenix answered with no spans", async () => {
+    const prompter = scriptedPrompter([]);
+    let clock = 0;
+    const deps = buildFakeDeps({
+      prompter,
+      fetch: fakeFetch((url) =>
+        url.includes("/spans?") ? jsonResponse(200, { data: [] }) : undefined
+      ),
+      clock: { now: () => (clock += 61_000) },
+    });
+    await waitForFirstTrace(deps, CONNECTION, { sinceMs: 0, headless: true });
+    expect(
+      prompter.output.some((message) =>
+        message.includes("Could not reach Phoenix")
+      )
     ).toBe(false);
   });
 
@@ -136,7 +180,7 @@ describe("waitForFirstTrace", () => {
         sinceMs: 120_000,
         allowClockSkew: false,
       })
-    ).toBe(true);
+    ).toBe("verified");
     expect(windowStarts).toEqual([120_000]);
   });
 });

--- a/js/packages/phoenix-cli/test/setup/verifyTraces.test.ts
+++ b/js/packages/phoenix-cli/test/setup/verifyTraces.test.ts
@@ -1,12 +1,13 @@
 /**
  * Trace-verification window tests: the clock-skew allowance widens the span
- * query only when the project had no spans before instrumentation began.
+ * query only when the project was confirmed to have no spans before
+ * instrumentation began.
  */
 
 import { describe, expect, it } from "vitest";
 
 import {
-  hasSpansInSkewWindow,
+  skewWindowIsClear,
   waitForFirstTrace,
 } from "../../src/setup/steps/verifyTraces";
 import { buildFakeDeps, fakeFetch, jsonResponse } from "./fakes";
@@ -30,14 +31,62 @@ function recordingSpanFetch(data: unknown[]) {
   return { windowStarts, fetch };
 }
 
-describe("hasSpansInSkewWindow", () => {
+describe("skewWindowIsClear", () => {
   it("reaches back by the skew tolerance from the start time", async () => {
     const { windowStarts, fetch } = recordingSpanFetch([]);
     const deps = buildFakeDeps({ fetch });
     expect(
-      await hasSpansInSkewWindow(deps, CONNECTION, { sinceMs: 120_000 })
-    ).toBe(false);
+      await skewWindowIsClear(deps, CONNECTION, { sinceMs: 120_000 })
+    ).toBe(true);
     expect(windowStarts).toEqual([60_000]);
+  });
+
+  it("is not clear when the window already holds a span", async () => {
+    const { fetch } = recordingSpanFetch([{ id: "span1" }]);
+    const deps = buildFakeDeps({ fetch });
+    expect(
+      await skewWindowIsClear(deps, CONNECTION, { sinceMs: 120_000 })
+    ).toBe(false);
+  });
+
+  it("treats a project that does not exist as an empty window", async () => {
+    // 404 is a definite "no spans": the project has none to have created it.
+    const deps = buildFakeDeps({
+      fetch: fakeFetch((url) =>
+        url.includes("/spans?")
+          ? jsonResponse(404, { detail: "not found" })
+          : undefined
+      ),
+    });
+    expect(
+      await skewWindowIsClear(deps, CONNECTION, { sinceMs: 120_000 })
+    ).toBe(true);
+  });
+
+  it("fails closed when the probe cannot answer", async () => {
+    // A transport failure is not proof the window was empty, and granting the
+    // skew allowance on it would let a span from before this run verify it.
+    const deps = buildFakeDeps({
+      fetch: (async () => {
+        throw new TypeError("connection reset");
+      }) as typeof fetch,
+    });
+    expect(
+      await skewWindowIsClear(deps, CONNECTION, { sinceMs: 120_000 })
+    ).toBe(false);
+  });
+
+  it("fails closed when the probe is rejected", async () => {
+    const deps = buildFakeDeps({
+      fetch: fakeFetch((url) =>
+        url.includes("/spans?")
+          ? jsonResponse(401, { detail: "unauthorized" })
+          : undefined
+      ),
+    });
+    expect(
+      await skewWindowIsClear(deps, CONNECTION, { sinceMs: 120_000 })
+    ).toBe(false);
   });
 });
 
@@ -49,6 +98,34 @@ describe("waitForFirstTrace", () => {
       await waitForFirstTrace(deps, CONNECTION, { sinceMs: 120_000 })
     ).toBe(true);
     expect(windowStarts).toEqual([60_000]);
+  });
+
+  it("does not verify when the API never answers", async () => {
+    let clock = 0;
+    const deps = buildFakeDeps({
+      fetch: (async () => {
+        throw new TypeError("connection reset");
+      }) as typeof fetch,
+      clock: { now: () => (clock += 61_000) },
+    });
+    expect(
+      await waitForFirstTrace(deps, CONNECTION, { sinceMs: 0, headless: true })
+    ).toBe(false);
+  });
+
+  it("does not verify when the project does not exist", async () => {
+    let clock = 0;
+    const deps = buildFakeDeps({
+      fetch: fakeFetch((url) =>
+        url.includes("/spans?")
+          ? jsonResponse(404, { detail: "not found" })
+          : undefined
+      ),
+      clock: { now: () => (clock += 61_000) },
+    });
+    expect(
+      await waitForFirstTrace(deps, CONNECTION, { sinceMs: 0, headless: true })
+    ).toBe(false);
   });
 
   it("queries the exact start when the skew allowance is disabled", async () => {

--- a/js/packages/phoenix-cli/test/setupCommand.test.ts
+++ b/js/packages/phoenix-cli/test/setupCommand.test.ts
@@ -1,0 +1,71 @@
+/**
+ * `px setup`'s exit-code contract: the verdict a caller scoring runs by exit
+ * status reads, including the onboarding harness and the coding agent that
+ * invoked setup in the first place.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { setupExitCode } from "../src/commands/setup";
+import { ExitCode } from "../src/exitCodes";
+import type { SetupReport } from "../src/setup/runSetup";
+
+const REPORT: SetupReport = {
+  connection: {
+    endpoint: "http://localhost:6006",
+    projectName: "my-app",
+  },
+  authEnabled: false,
+  headless: true,
+  files: [".env.phoenix"],
+  gitignored: [".env.phoenix"],
+  instrumentation: { kind: "agent", agent: "claude", exitCode: 0 },
+  tracesVerified: true,
+  tracesUrl: "http://localhost:6006/redirects/projects/my-app",
+};
+
+describe("setupExitCode", () => {
+  it("succeeds when a trace was verified arriving", () => {
+    expect(setupExitCode(REPORT)).toBe(ExitCode.SUCCESS);
+  });
+
+  it("reports NOT_VERIFIED when instrumentation landed no trace", () => {
+    expect(setupExitCode({ ...REPORT, tracesVerified: false })).toBe(
+      ExitCode.NOT_VERIFIED
+    );
+  });
+
+  it("reports NOT_VERIFIED when verification never produced a verdict", () => {
+    expect(setupExitCode({ ...REPORT, tracesVerified: undefined })).toBe(
+      ExitCode.NOT_VERIFIED
+    );
+  });
+
+  it("succeeds on a registration-only run, which has nothing to verify", () => {
+    expect(
+      setupExitCode({
+        ...REPORT,
+        instrumentation: undefined,
+        tracesVerified: undefined,
+      })
+    ).toBe(ExitCode.SUCCESS);
+  });
+
+  // The agent's own exit code is not the verdict: it may have instrumented the
+  // app and then exited badly, or exited cleanly having delivered nothing.
+  it("ignores the agent's exit code in favour of the trace verdict", () => {
+    expect(
+      setupExitCode({
+        ...REPORT,
+        instrumentation: { kind: "agent", agent: "claude", exitCode: 1 },
+      })
+    ).toBe(ExitCode.SUCCESS);
+    expect(
+      setupExitCode({
+        ...REPORT,
+        instrumentation: { kind: "agent", agent: "claude", exitCode: 0 },
+        tracesVerified: false,
+      })
+    ).toBe(ExitCode.NOT_VERIFIED);
+  });
+});

--- a/js/packages/phoenix-cli/test/setupCommand.test.ts
+++ b/js/packages/phoenix-cli/test/setupCommand.test.ts
@@ -20,7 +20,7 @@ const REPORT: SetupReport = {
   files: [".env.phoenix"],
   gitignored: [".env.phoenix"],
   instrumentation: { kind: "agent", agent: "claude", exitCode: 0 },
-  tracesVerified: true,
+  verification: "verified",
   tracesUrl: "http://localhost:6006/redirects/projects/my-app",
 };
 
@@ -29,15 +29,18 @@ describe("setupExitCode", () => {
     expect(setupExitCode(REPORT)).toBe(ExitCode.SUCCESS);
   });
 
-  it("reports NOT_VERIFIED when instrumentation landed no trace", () => {
-    expect(setupExitCode({ ...REPORT, tracesVerified: false })).toBe(
+  it("reports NOT_VERIFIED when the wait ran out with no trace", () => {
+    expect(setupExitCode({ ...REPORT, verification: "notVerified" })).toBe(
       ExitCode.NOT_VERIFIED
     );
   });
 
-  it("reports NOT_VERIFIED when verification never produced a verdict", () => {
-    expect(setupExitCode({ ...REPORT, tracesVerified: undefined })).toBe(
-      ExitCode.NOT_VERIFIED
+  // Setup offers "Finish setup — I'll verify later" with the hint "everything
+  // else is already configured". Failing the process on the answer it invited
+  // would break `px setup && npm run dev` and every `set -e` bootstrap script.
+  it("succeeds when the user chose to verify later", () => {
+    expect(setupExitCode({ ...REPORT, verification: "deferred" })).toBe(
+      ExitCode.SUCCESS
     );
   });
 
@@ -46,7 +49,7 @@ describe("setupExitCode", () => {
       setupExitCode({
         ...REPORT,
         instrumentation: undefined,
-        tracesVerified: undefined,
+        verification: undefined,
       })
     ).toBe(ExitCode.SUCCESS);
   });
@@ -64,7 +67,7 @@ describe("setupExitCode", () => {
       setupExitCode({
         ...REPORT,
         instrumentation: { kind: "agent", agent: "claude", exitCode: 0 },
-        tracesVerified: false,
+        verification: "notVerified",
       })
     ).toBe(ExitCode.NOT_VERIFIED);
   });


### PR DESCRIPTION
Fixes #14876.

## Triage: verification was reached, and it did not fail open

It returned `false` correctly. **Everything downstream of it fails open.**

`registerAndInstrument` awaits `instrumentApp` (which awaits the agent's `spawnInteractive`), then calls `waitForFirstTrace` — so verification always runs after the agent exits. In the reported run the project didn't exist, the span search 404'd for the whole 60 s window, and `tracesVerified` came back `false`. Setup printed "You're set up." and exited 0 anyway.

`tracesVerified` was computed, stored on the report, and consumed by **nothing** except the `--format json|raw` envelope. Nothing branched on it.

Compounding it: every string setup narrates — including the honest `Traces not verified yet` note — goes to **stderr** (`clackPrompter`'s `TO_STDERR`). stdout carries only the summary, which in `pretty` mode never mentioned verification. So for anything reading stdout or `$?`, **a silent-drop run was byte-identical to a working one.**

### What was wrong

1. **Exit code was unconditionally 0.** `runLane` called `process.exit(ExitCode.SUCCESS)` as soon as the lane returned, whatever the report said. No code existed for "ran, but no trace landed". This is the one that made every harness run inherit the problem.
2. **The default `pretty` summary omitted the verdict.** `headlessSummary` printed `endpoint`/`project`/`files` + next-steps and nothing else. Its next-steps copy also read wrong on an instrumented run — step 2 was "Instrument your app".
3. **The interactive run ended on a success claim.** After `waitForFirstTrace` returned `false`, `runSetup` still printed the production hand-off note, the support links, and `outro("You're set up.")` — burying the not-verified note under two success-shaped notes. Same for the timeout escape hatch: "Finish setup — I'll verify later" landed on "You're set up."
4. **No test covered the unverified path.** All three `runSetup` verification assertions expected `true`; `formatSetup.test.ts` only covered the `undefined → false` envelope mapping. Nothing pinned the failure behaviour, which is how it drifted.
5. **A genuine latent fail-open in the clock-skew pre-check.** `hasNewSpans` swallowed *every* error as "not yet". Fail-closed for polling, but fail-**open** for the pre-check: `hasSpansInSkewWindow` erroring was indistinguishable from "no recent spans", so `allowClockSkew` stayed `true` and verification would then accept a span up to 60 s *older* than the run start. Re-running `px setup` on an app that emitted moments ago, or a slow Phoenix on the 5 s pre-check, could self-verify on a stale span. Not the cause here (no project ⇒ nothing to match), but the only path where verification itself can credit a trace the run didn't produce.

## What this PR changes

The verdict is now the run's result rather than a footnote.

**Exit code.** New `ExitCode.NOT_VERIFIED` (6), returned when a run instrumented and `tracesVerified !== true`. Its own code rather than `FAILURE` because nothing failed — the connection, `.env.phoenix`, and the agent's edits are real work worth keeping. A registration-only run has nothing to verify and still exits 0. `runLane` takes an `exitCodeOf` resolver so the tooling lane, whose report carries no verdict, is unaffected.

**`pretty` output.** Gains a `traces: verified` / `traces: NOT VERIFIED` line and, when unverified, next steps aimed at the exporter rather than at instrumenting:

```
endpoint: http://localhost:6006
project: mastra-noob
files: .env.phoenix
traces: NOT VERIFIED

The app was instrumented, but no trace arrived — do not treat tracing as working yet.

Next steps:
  1. Export the vars:  set -a; source .env.phoenix; set +a
  2. Run your app so it makes one LLM call.
  3. Watch for traces: http://localhost:6006/redirects/projects/mastra-noob
  Still nothing? https://arize.com/docs/phoenix/tracing/concepts-tracing/faqs-tracing
```

A register-only run gets no `traces:` line at all — "not verified" would misread as a failure of something it never attempted.

**Closing line.** `You're set up.` only when there's nothing to verify or a trace was verified; otherwise `Setup finished, but no trace arrived — tracing is not confirmed working yet.` Applies to both `px setup` and `px setup instrument`.

**Fail the skew pre-check closed.** The span probe is now tri-state (`found` / `none` / `unknown`). A 404 is a definite `none` — the project doesn't exist, so nothing was ever delivered to it. Any other non-2xx, timeout, or dropped socket is `unknown`. Polling treats `unknown` as "keep watching" exactly as before; the pre-check widens the window only on a confirmed `none`. `hasSpansInSkewWindow` becomes `skewWindowIsClear`, which reads as what the caller does with it and drops a double negative at the call site.

Note the Phoenix client's middleware throws `HttpError` on every non-2xx, so status is only reachable from the catch — the probe branches on `error.status`, matching how `establishConnection` and `chooseEndpoint` already read statuses.

## Tests

`pnpm test` → 70 files, 866 passing. New coverage, all of it on paths that had none:

- `setupExitCode`: verified → 0; unverified and undefined-verdict → 6; register-only → 0; and that the agent's own exit code doesn't move the verdict in either direction.
- `headlessSummary`: states the verdict both ways, and omits it on a register-only run.
- `runSetup`'s escape hatch now asserts `tracesVerified === false` and that the frame does **not** close on "You're set up."
- `skewWindowIsClear`: clear window, occupied window, 404-as-empty, and fails closed on both a transport failure and a 401.
- `waitForFirstTrace`: does not verify when the API never answers, or when the project doesn't exist.

## Docs

README gains an exit-code table for `px setup` and the "don't score a run on the agent's exit code" warning. The external `phoenix-cli` skill tells agents that exit 6 is a failure to report and not to substitute the hand-off agent's summary for the verdict. The CLI dev skill's exit-code table gains the row.

## Repro

```bash
px setup --no-input --instrument --agent claude --yolo   # against an app whose exporter can't deliver
echo $?
```

e.g. `@mastra/arize` with `PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006`, per #14875 / #14891. Before: no project in Phoenix, a success-shaped summary, `0`. After: `traces: NOT VERIFIED` and `6`.

## Scope and follow-ups

Independent of the endpoint-normalisation root cause in #14875 (fixed in #14891) — that's why spans were dropped; this is why the wizard didn't say so. Both should land.

- **Exit-code contract change.** Any caller currently treating `px setup --instrument` as pass/fail on `$?` will start seeing 6 on unverified runs. That's the point, but it wants a minor version and the onboarding harness should key off it.
- **Not done: diagnosing *why* verification failed.** The probe now knows the difference between a 404 and an empty window, but the not-verified copy doesn't use it. A 404 after a completed hand-off is a strong specific signal — the exporter never delivered anything — and would be worth saying out loud, distinct from "your app hasn't sent one yet". Left out to keep this diff to the reporting bug.
