### PR TITLE
docs: move toxicity evaluator out of the legacy nav section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -217,6 +217,7 @@
                       "docs/phoenix/evaluation/pre-built-metrics/tool-invocation",
                       "docs/phoenix/evaluation/pre-built-metrics/tool-response-handling",
                       "docs/phoenix/evaluation/pre-built-metrics/refusal",
+                      "docs/phoenix/evaluation/pre-built-metrics/toxicity",
                       "docs/phoenix/evaluation/pre-built-metrics/user-friction",
                       "docs/phoenix/evaluation/pre-built-metrics/exact-match",
                       "docs/phoenix/evaluation/pre-built-metrics/matches-regex",
@@ -228,7 +229,6 @@
                           "docs/phoenix/evaluation/pre-built-metrics/q-and-a-on-retrieved-data",
                           "docs/phoenix/evaluation/pre-built-metrics/retrieval-rag-relevance",
                           "docs/phoenix/evaluation/pre-built-metrics/summarization-eval",
-                          "docs/phoenix/evaluation/pre-built-metrics/toxicity",
                           "docs/phoenix/evaluation/pre-built-metrics/sql-generation-eval",
                           "docs/phoenix/evaluation/pre-built-metrics/tool-calling-eval"
                         ]


### PR DESCRIPTION
The toxicity evaluator page is a current pre-built metric, but the docs sidebar listed it under the Legacy subgroup. Moves it up into the main Pre-Built Metrics list (after refusal). Nav-only change; the page path and URL are unchanged.

Closes #14902