### PR TITLE
feat(cli): suggest upgrading on unknown command when a newer version exists

### DIFF
--- a/js/packages/phoenix-cli/src/cli.ts
+++ b/js/packages/phoenix-cli/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { Command } from "commander";
+import { Command, CommanderError } from "commander";
 
 import { printBanner } from "./banner";
 import {
@@ -22,7 +22,13 @@ import {
   createTraceAnnotationsCommand,
   createTraceCommand,
 } from "./commands";
-import { CLI_VERSION } from "./version";
+import { formatVersionStatus } from "./commands/self";
+import { writeError } from "./io";
+import {
+  CLI_VERSION,
+  getCliVersionStatus,
+  type FetchLatestPublishedCliVersionOptions,
+} from "./version";
 
 export function createProgram(): Command {
   const program = new Command();
@@ -30,6 +36,7 @@ export function createProgram(): Command {
   program.name("px");
   program.enablePositionalOptions();
   program.version(CLI_VERSION);
+  program.exitOverride();
 
   // Register commands
   program.addCommand(createAnnotationConfigCommand());
@@ -53,20 +60,67 @@ export function createProgram(): Command {
   return program;
 }
 
+/**
+ * Build the extra guidance shown after an "unknown command" error, comparing
+ * the installed version against the latest published one:
+ * - behind: show the version pair and point at `px self update`
+ * - up to date: point at `px --help` (the command is likely a typo)
+ * - version lookup failed: return null (fall back to the plain error)
+ */
+export async function buildUnknownCommandDiagnosis({
+  fetchFn,
+  timeoutMs,
+}: FetchLatestPublishedCliVersionOptions = {}): Promise<string | null> {
+  const status = await getCliVersionStatus({ fetchFn, timeoutMs });
+
+  if (status.latestVersion && status.hasUpdate) {
+    return [
+      formatVersionStatus({
+        currentVersion: status.currentVersion,
+        latestVersion: status.latestVersion,
+      }),
+      "",
+      "This command may not exist in your installed version.",
+      "Run `px self update` to upgrade.",
+    ].join("\n");
+  }
+
+  if (status.latestVersion) {
+    return `px is up to date (${status.currentVersion}). Run \`px --help\` for available commands.`;
+  }
+
+  return null;
+}
+
 // Phoenix CLI Main Logic
 export async function main({
   argv = process.argv,
+  fetchFn,
 }: {
   argv?: string[];
+  fetchFn?: typeof fetch;
 } = {}): Promise<void> {
   const program = createProgram();
 
   // Show banner and help if no command provided
   if (argv.length === 2) {
     await printBanner();
-    program.help();
+    program.outputHelp();
     return;
   }
 
-  await program.parseAsync(argv);
+  try {
+    await program.parseAsync(argv);
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      if (error.code === "commander.unknownCommand" && process.stdout.isTTY) {
+        const diagnosis = await buildUnknownCommandDiagnosis({ fetchFn });
+        if (diagnosis) {
+          writeError({ message: `\n${diagnosis}` });
+        }
+      }
+      process.exit(error.exitCode);
+    }
+    throw error;
+  }
 }

--- a/js/packages/phoenix-cli/src/commands/self.ts
+++ b/js/packages/phoenix-cli/src/commands/self.ts
@@ -495,7 +495,7 @@ function getCurrentInstallPackageManager({
   });
 }
 
-function formatVersionStatus({
+export function formatVersionStatus({
   currentVersion,
   latestVersion,
 }: {

--- a/js/packages/phoenix-cli/test/cli.test.ts
+++ b/js/packages/phoenix-cli/test/cli.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { createProgram, main } from "../src/cli";
+import { buildUnknownCommandDiagnosis, createProgram, main } from "../src/cli";
 import { CLI_VERSION } from "../src/version";
+
+const fetchReturningVersion = (version: string): typeof fetch =>
+  (async () => ({
+    ok: true,
+    json: async () => ({ version }),
+  })) as unknown as typeof fetch;
 
 describe("Phoenix CLI", () => {
   it("should have a main function", () => {
@@ -320,5 +326,39 @@ describe("Phoenix CLI", () => {
     expect(
       sessionAnnotationsCommand?.commands.map((command) => command.name())
     ).toEqual(expect.arrayContaining(["delete"]));
+  });
+});
+
+describe("unknown command diagnosis", () => {
+  it("suggests upgrading when a newer version is published", async () => {
+    const message = await buildUnknownCommandDiagnosis({
+      fetchFn: fetchReturningVersion("9999.0.0"),
+    });
+
+    expect(message).toContain("Current version:");
+    expect(message).toContain("9999.0.0");
+    expect(message).toContain("px self update");
+  });
+
+  it("does not suggest upgrading when already on the latest version", async () => {
+    const message = await buildUnknownCommandDiagnosis({
+      fetchFn: fetchReturningVersion(CLI_VERSION),
+    });
+
+    expect(message).toContain("up to date");
+    expect(message).toContain("px --help");
+    expect(message).not.toContain("px self update");
+  });
+
+  it("falls back to no extra guidance when the registry is unreachable", async () => {
+    const failingFetch: typeof fetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    const message = await buildUnknownCommandDiagnosis({
+      fetchFn: failingFetch,
+    });
+
+    expect(message).toBeNull();
   });
 });


### PR DESCRIPTION
`px` used commander's default unknown-command error (`error: unknown command 'x'`), which gave no hint that a stale install was the cause. Now, on an unknown command, `px` compares the installed version against the latest published one:

- behind → prints the version pair and points at `px self update`
- up to date → no upgrade suggestion; commander's did-you-mean plus a `px --help` pointer
- registry unreachable/slow → falls back to the plain error (fails open, never hangs)

The version check is skipped when stdout is not a TTY so CI stays fast. Covered by tests in `test/cli.test.ts` using an injected fetch.

This is forward-looking: the message ships in a new version, so it helps future stale installs, not the ones already predating it.

Closes #14878