### PR TITLE
refactor(agents): derive message order from pk, enforce uuid message_id in db

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -445,9 +445,9 @@ CREATE TABLE public.agent_sessions (
     user_id BIGINT,
     title VARCHAR NOT NULL,
     expires_at TIMESTAMP WITH TIME ZONE,
+    heartbeat_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-    heartbeat_at TIMESTAMP WITH TIME ZONE,
     CONSTRAINT pk_agent_sessions PRIMARY KEY (id),
     CONSTRAINT uq_agent_sessions_project_session_id_project_name
         UNIQUE (project_session_id, project_name),
@@ -468,16 +468,14 @@ CREATE INDEX ix_agent_sessions_user_id_updated_at ON public.agent_sessions
 CREATE TABLE public.agent_session_messages (
     id bigserial NOT NULL,
     agent_session_id BIGINT NOT NULL,
-    position INTEGER NOT NULL,
     message JSONB NOT NULL,
     message_id VARCHAR GENERATED ALWAYS AS (((message ->> 'id'::text))::character varying) STORED NOT NULL,
     is_compaction_message BOOLEAN GENERATED ALWAYS AS (COALESCE(((message #>> '{metadata,isCompactionMessage}'::text[]))::boolean, false)) STORED NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_agent_session_messages PRIMARY KEY (id),
-    CONSTRAINT uq_agent_session_messages_agent_session_id_position
-        UNIQUE (agent_session_id, position),
     CONSTRAINT uq_agent_session_messages_message_id
         UNIQUE (message_id),
+    CHECK (((message_id)::text ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'::text)),
     CONSTRAINT fk_agent_session_messages_agent_session_id_agent_sessions
         FOREIGN KEY
         (agent_session_id)
@@ -486,7 +484,7 @@ CREATE TABLE public.agent_session_messages (
 );
 
 CREATE INDEX ix_agent_session_messages_compaction ON public.agent_session_messages
-    USING btree (agent_session_id, "position" DESC) WHERE is_compaction_message;
+    USING btree (agent_session_id, id DESC) WHERE is_compaction_message;
 
 
 -- Table: agent_session_snapshots

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -6,13 +6,14 @@ Create Date: 2026-07-08 15:16:23.608705
 
 """
 
-from typing import Any, Sequence, Union
+from typing import Any, Literal, Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import JSON
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.compiler import compiles
+from typing_extensions import TypeAlias, assert_never
 
 
 class JSONB(JSON):
@@ -44,8 +45,19 @@ _Integer = sa.Integer().with_variant(
 _UUID_GLOB = "-".join("[0-9a-fA-F]" * length for length in (8, 4, 4, 4, 12))
 _UUID_REGEX = "^{}$".format("-".join(f"[0-9a-fA-F]{{{length}}}" for length in (8, 4, 4, 4, 12)))
 
+_DialectName: TypeAlias = Literal["postgresql", "sqlite"]
 
-def _uuid_format_check(column_name: str, dialect_name: str) -> str:
+
+def _bind_dialect_name() -> _DialectName:
+    dialect_name = op.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        return "postgresql"
+    elif dialect_name == "sqlite":
+        return "sqlite"
+    raise RuntimeError(f"Unsupported SQL dialect: {dialect_name}")
+
+
+def _uuid_format_check(column_name: str, dialect_name: _DialectName) -> str:
     """SQL for "this column holds a UUID in 8-4-4-4-12 hex form".
 
     SQLite has ``GLOB`` but no regex operator; PostgreSQL has ``~`` but no
@@ -53,7 +65,9 @@ def _uuid_format_check(column_name: str, dialect_name: str) -> str:
     """
     if dialect_name == "postgresql":
         return f"{column_name} ~ '{_UUID_REGEX}'"
-    return f"{column_name} GLOB '{_UUID_GLOB}'"
+    elif dialect_name == "sqlite":
+        return f"{column_name} GLOB '{_UUID_GLOB}'"
+    assert_never(dialect_name)
 
 
 # revision identifiers, used by Alembic.
@@ -144,7 +158,7 @@ def upgrade() -> None:
             server_default=sa.func.now(),
         ),
         sa.CheckConstraint(
-            _uuid_format_check("message_id", op.get_bind().dialect.name),
+            _uuid_format_check("message_id", _bind_dialect_name()),
             name="valid_message_id",
         ),
         sqlite_autoincrement=True,

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -41,6 +41,21 @@ _Integer = sa.Integer().with_variant(
     "postgresql",
 )
 
+_UUID_GLOB = "-".join("[0-9a-fA-F]" * length for length in (8, 4, 4, 4, 12))
+_UUID_REGEX = "^{}$".format("-".join(f"[0-9a-fA-F]{{{length}}}" for length in (8, 4, 4, 4, 12)))
+
+
+def _uuid_format_check(column_name: str, dialect_name: str) -> str:
+    """SQL for "this column holds a UUID in 8-4-4-4-12 hex form".
+
+    SQLite has ``GLOB`` but no regex operator; PostgreSQL has ``~`` but no
+    ``GLOB``, so the CHECK is spelled per-dialect.
+    """
+    if dialect_name == "postgresql":
+        return f"{column_name} ~ '{_UUID_REGEX}'"
+    return f"{column_name} GLOB '{_UUID_GLOB}'"
+
+
 # revision identifiers, used by Alembic.
 revision: str = "e767d3c57f32"
 down_revision: Union[str, None] = "c9d0e1f2a3b4"
@@ -102,7 +117,6 @@ def upgrade() -> None:
             sa.ForeignKey("agent_sessions.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("position", sa.Integer, nullable=False),
         message,
         sa.Column(
             "message_id",
@@ -129,13 +143,16 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint("agent_session_id", "position"),
+        sa.CheckConstraint(
+            _uuid_format_check("message_id", op.get_bind().dialect.name),
+            name="valid_message_id",
+        ),
         sqlite_autoincrement=True,
     )
     op.create_index(
         "ix_agent_session_messages_compaction",
         "agent_session_messages",
-        ["agent_session_id", sa.column("position").desc()],
+        ["agent_session_id", sa.column("id").desc()],
         postgresql_where=sa.text("is_compaction_message"),
         sqlite_where=sa.text("is_compaction_message"),
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3324,7 +3324,6 @@ class AgentSession(HasId):
     )
     messages: Mapped[list["AgentSessionMessage"]] = relationship(
         "AgentSessionMessage",
-        # Transcript order is insertion order, i.e. ascending primary key.
         order_by="AgentSessionMessage.id",
         cascade="all, delete-orphan",
         back_populates="agent_session",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3262,6 +3262,45 @@ def validate_provider_config(_: Any, __: Any, target: "GenerativeModelCustomProv
         raise ValueError("Config is not encrypted")
 
 
+_UUID_GLOB = "-".join("[0-9a-fA-F]" * length for length in (8, 4, 4, 4, 12))  # SQLite GLOB pattern
+_UUID_REGEX = "^{}$".format(
+    "-".join(f"[0-9a-fA-F]{{{length}}}" for length in (8, 4, 4, 4, 12))
+)  # PostgreSQL POSIX pattern
+
+
+class matches_uuid_format(ColumnElement[bool]):  # noqa: N801  -- a SQL construct
+    """A ``CHECK``-able predicate: does a column hold a UUID in 8-4-4-4-12 hex form?
+
+    SQLite has ``GLOB`` but no regex operator; PostgreSQL has ``~`` but no
+    ``GLOB``. Neither spelling is portable, so the predicate renders per
+    dialect and callers get one expression that works on both.
+    """
+
+    inherit_cache = True
+    type = Boolean()
+
+    def __init__(self, column_name: str) -> None:
+        self.column_name = column_name
+
+
+@compiles(matches_uuid_format, "sqlite")
+def _compile_matches_uuid_format_sqlite(
+    element: matches_uuid_format,
+    compiler: SQLCompiler,
+    **kw: Any,
+) -> str:
+    return f"{compiler.preparer.quote(element.column_name)} GLOB '{_UUID_GLOB}'"
+
+
+@compiles(matches_uuid_format, "postgresql")
+def _compile_matches_uuid_format_postgresql(
+    element: matches_uuid_format,
+    compiler: SQLCompiler,
+    **kw: Any,
+) -> str:
+    return f"{compiler.preparer.quote(element.column_name)} ~ '{_UUID_REGEX}'"
+
+
 class AgentSession(HasId):
     __tablename__ = "agent_sessions"
     project_session_id: Mapped[str] = mapped_column(String, nullable=False)
@@ -3285,7 +3324,8 @@ class AgentSession(HasId):
     )
     messages: Mapped[list["AgentSessionMessage"]] = relationship(
         "AgentSessionMessage",
-        order_by="AgentSessionMessage.position",
+        # Transcript order is insertion order, i.e. ascending primary key.
+        order_by="AgentSessionMessage.id",
         cascade="all, delete-orphan",
         back_populates="agent_session",
     )
@@ -3312,7 +3352,6 @@ class AgentSessionMessage(HasId):
         ForeignKey("agent_sessions.id", ondelete="CASCADE"),
         nullable=False,
     )
-    position: Mapped[int] = mapped_column(Integer, nullable=False)
     message: Mapped[PhoenixUIMessage] = mapped_column(_UIMessage, nullable=False)
     message_id: Mapped[str] = mapped_column(
         String,
@@ -3343,11 +3382,11 @@ class AgentSessionMessage(HasId):
         back_populates="messages",
     )
     __table_args__ = (
-        UniqueConstraint("agent_session_id", "position"),
+        CheckConstraint(matches_uuid_format("message_id"), name="valid_message_id"),
         Index(
             "ix_agent_session_messages_compaction",
             "agent_session_id",
-            position.desc(),
+            sa.desc("id"),
             postgresql_where=text("is_compaction_message"),
             sqlite_where=text("is_compaction_message"),
         ),

--- a/src/phoenix/server/api/dataloaders/agent_session_message_text.py
+++ b/src/phoenix/server/api/dataloaders/agent_session_message_text.py
@@ -31,7 +31,7 @@ class AgentSessionMessageTextDataLoader(DataLoader[Key, Result]):
                 func.row_number()
                 .over(
                     partition_by=message.agent_session_id,
-                    order_by=message.position.asc(),
+                    order_by=message.id.asc(),
                 )
                 .label("rank"),
             ).where(
@@ -45,7 +45,7 @@ class AgentSessionMessageTextDataLoader(DataLoader[Key, Result]):
                 func.row_number()
                 .over(
                     partition_by=message.agent_session_id,
-                    order_by=message.position.desc(),
+                    order_by=message.id.desc(),
                 )
                 .label("rank"),
             ).where(message.message["role"].as_string() == "assistant")

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -166,7 +166,7 @@ class AgentSessionMutationMixin:
             target = (
                 await session.execute(
                     select(
-                        models.AgentSessionMessage.position,
+                        models.AgentSessionMessage.id,
                         models.AgentSessionMessage.message["role"].as_string(),
                     ).where(
                         models.AgentSessionMessage.agent_session_id == agent_session.id,
@@ -176,16 +176,16 @@ class AgentSessionMutationMixin:
             ).one_or_none()
             if target is None:
                 raise NotFound(f"No message found for ID '{input.message_id}'")
-            target_position, target_role = target
+            target_rowid, target_role = target
             # A user target is removed along with everything after it; an
             # assistant target is kept, so deletion starts just after it.
-            delete_from_position = target_position
+            delete_from_rowid = target_rowid
             if target_role == "assistant":
-                delete_from_position += 1
+                delete_from_rowid += 1
             await session.execute(
                 delete(models.AgentSessionMessage).where(
                     models.AgentSessionMessage.agent_session_id == agent_session.id,
-                    models.AgentSessionMessage.position >= delete_from_position,
+                    models.AgentSessionMessage.id >= delete_from_rowid,
                 )
             )
             agent_session.updated_at = func.now()
@@ -244,10 +244,9 @@ class AgentSessionMutationMixin:
             regenerated_message_rows = [
                 models.AgentSessionMessage(
                     agent_session_id=branch_session.id,
-                    position=position,
                     message=message,
                 )
-                for position, message in enumerate(regenerated_messages)
+                for message in regenerated_messages
             ]
             session.add_all(regenerated_message_rows)
         return BranchAgentSessionMutationPayload(
@@ -354,8 +353,8 @@ async def _load_session_message_prefix(
     message_id: str,
 ) -> list[PhoenixUIMessage]:
     target_message = aliased(models.AgentSessionMessage)
-    target_position = (
-        select(target_message.position)
+    target_rowid = (
+        select(target_message.id)
         .where(
             target_message.agent_session_id == agent_session_rowid,
             target_message.message_id == message_id,
@@ -367,8 +366,8 @@ async def _load_session_message_prefix(
             select(models.AgentSessionMessage.message)
             .where(
                 models.AgentSessionMessage.agent_session_id == agent_session_rowid,
-                models.AgentSessionMessage.position <= target_position,
+                models.AgentSessionMessage.id <= target_rowid,
             )
-            .order_by(models.AgentSessionMessage.position)
+            .order_by(models.AgentSessionMessage.id)
         )
     )

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1543,15 +1543,19 @@ async def _update_trailing_assistant_message(
     session: AsyncSession,
     *,
     agent_session_rowid: int,
-    position: int,
     message: PhoenixUIMessage,
 ) -> None:
     """Replace the matching trailing assistant message or reject a stale continuation."""
+    latest_message_rowid = (
+        select(func.max(models.AgentSessionMessage.id))
+        .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
+        .scalar_subquery()
+    )
     updated_message_rowid = await session.scalar(
         update(models.AgentSessionMessage)
         .where(
             models.AgentSessionMessage.agent_session_id == agent_session_rowid,
-            models.AgentSessionMessage.position == position,
+            models.AgentSessionMessage.id == latest_message_rowid,
             models.AgentSessionMessage.message_id == message.id,
         )
         .values(message=message)
@@ -1592,28 +1596,22 @@ async def _persist_agent_session_turn(
                 len(new_messages),
             )
             return
-        next_position = await session.scalar(
-            select(func.coalesce(func.max(models.AgentSessionMessage.position), -1) + 1).where(
-                models.AgentSessionMessage.agent_session_id == agent_session_rowid
-            )
-        )
-        assert next_position is not None
         if new_messages[0].role == "assistant":
             # Client-tool continuations replace the persisted assistant message.
             await _update_trailing_assistant_message(
                 session,
                 agent_session_rowid=agent_session_rowid,
-                position=next_position - 1,
                 message=new_messages[0],
             )
             new_messages = new_messages[1:]
+        # Transcript order is the order these rows are inserted in, which the
+        # autoincrementing primary key records for us.
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session_rowid,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(new_messages, start=next_position)
+            for message in new_messages
         )
         if bashkit_snapshot is not None:
             await _upsert_agent_session_snapshot(
@@ -1641,13 +1639,13 @@ async def _load_agent_session_history(
     agent_session_rowid: int,
 ) -> list[models.AgentSessionMessage]:
     """Load messages from the latest surviving compaction point onward."""
-    latest_compaction_position = (
-        select(models.AgentSessionMessage.position)
+    latest_compaction_rowid = (
+        select(models.AgentSessionMessage.id)
         .where(
             models.AgentSessionMessage.agent_session_id == agent_session_rowid,
             models.AgentSessionMessage.is_compaction_message,
         )
-        .order_by(models.AgentSessionMessage.position.desc())
+        .order_by(models.AgentSessionMessage.id.desc())
         .limit(1)
         .scalar_subquery()
     )
@@ -1656,9 +1654,9 @@ async def _load_agent_session_history(
             select(models.AgentSessionMessage)
             .where(
                 models.AgentSessionMessage.agent_session_id == agent_session_rowid,
-                models.AgentSessionMessage.position >= func.coalesce(latest_compaction_position, 0),
+                models.AgentSessionMessage.id >= func.coalesce(latest_compaction_rowid, 0),
             )
-            .order_by(models.AgentSessionMessage.position)
+            .order_by(models.AgentSessionMessage.id)
         )
     )
 
@@ -1981,9 +1979,10 @@ def create_agents_router(
                     message_id=str(uuid4()),
                     summary=summary,
                 )
+                # The boundary row was just confirmed to be the session's last
+                # message, so appending puts the checkpoint right after it.
                 compaction_message_row = models.AgentSessionMessage(
                     agent_session_id=agent_session_rowid,
-                    position=boundary_row.position + 1,
                     message=compaction_message,
                 )
                 session.add(compaction_message_row)

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1604,8 +1604,6 @@ async def _persist_agent_session_turn(
                 message=new_messages[0],
             )
             new_messages = new_messages[1:]
-        # Transcript order is the order these rows are inserted in, which the
-        # autoincrementing primary key records for us.
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session_rowid,
@@ -1979,8 +1977,6 @@ def create_agents_router(
                     message_id=str(uuid4()),
                     summary=summary,
                 )
-                # The boundary row was just confirmed to be the session's last
-                # message, so appending puts the checkpoint right after it.
                 compaction_message_row = models.AgentSessionMessage(
                     agent_session_id=agent_session_rowid,
                     message=compaction_message,

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -129,7 +129,7 @@ class AgentSession(Node):
         stmt = (
             select(models.AgentSessionMessage.message)
             .where(models.AgentSessionMessage.agent_session_id == self.id)
-            .order_by(models.AgentSessionMessage.position)
+            .order_by(models.AgentSessionMessage.id)
         )
         async with info.context.db.read() as session:
             messages = (await session.scalars(stmt)).all()

--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 from functools import singledispatch
 from secrets import token_hex
 from typing import Any, Dict, Optional, Sequence, Type, TypeVar, Union, cast
+from uuid import UUID, uuid5
 
 import httpx
 from sqlalchemy import select
@@ -13,6 +14,19 @@ from phoenix.db import models
 from phoenix.server.api.types.node import from_global_id
 from phoenix.server.api.types.ProjectSession import ProjectSession
 from phoenix.server.api.types.Span import Span
+
+_MESSAGE_ID_NAMESPACE = UUID("6f1a7f5e-3f4d-4a5b-8c9d-0e1f2a3b4c5d")
+
+
+def _message_uuid(label: str) -> str:
+    """A stable UUID standing in for a readable transcript-message label.
+
+    ``agent_session_messages.message_id`` is CHECK-constrained to UUID form at
+    the database level, so a bare label like ``"user-1"`` cannot be used as a
+    message id. This keeps the label readable at the call site and returns the
+    same id every time, so a test can still refer to a message by its label.
+    """
+    return str(uuid5(_MESSAGE_ID_NAMESPACE, label))
 
 
 @singledispatch

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -7,6 +7,7 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage, TextUIPart
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 
 
 async def _insert_agent_session(
@@ -28,11 +29,10 @@ async def _insert_agent_session(
         )
         session.add(agent_session)
         await session.flush()
-        for position, message in enumerate(messages or []):
+        for message in messages or []:
             session.add(
                 models.AgentSessionMessage(
                     agent_session_id=agent_session.id,
-                    position=position,
                     message=message,
                 )
             )
@@ -127,12 +127,12 @@ class TestGetAgentSession:
         now = datetime.now(timezone.utc)
         messages = [
             PhoenixUIMessage(
-                id="user-message",
+                id=_message_uuid("user-message"),
                 role="user",
                 parts=[TextUIPart(type="text", text="Hello")],
             ),
             PhoenixUIMessage(
-                id="assistant-message",
+                id=_message_uuid("assistant-message"),
                 role="assistant",
                 parts=[TextUIPart(type="text", text="Hi")],
             ),
@@ -153,8 +153,8 @@ class TestGetAgentSession:
         assert data["title"] == "Conversation"
         assert data["is_temporary"] is False
         assert [message["id"] for message in data["messages"]] == [
-            "user-message",
-            "assistant-message",
+            _message_uuid("user-message"),
+            _message_uuid("assistant-message"),
         ]
         assert data["messages"][0]["parts"] == [{"type": "text", "text": "Hello"}]
         assert data["messages"][1]["parts"] == [{"type": "text", "text": "Hi"}]

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -70,11 +70,15 @@ from phoenix.server.settings.registry import (
 )
 from phoenix.server.types import DbSessionFactory
 from phoenix.tracers import Tracer, extract_otel_context
+from tests.unit._helpers import _message_uuid
 
 _BUILD_MODEL_PATCH_TARGET = "phoenix.server.api.routers.agents.build_model"
 
 
-def _user_message(text: str, *, message_id: str = "msg-user-1") -> dict[str, Any]:
+_DEFAULT_USER_MESSAGE_ID = _message_uuid("msg-user-1")
+
+
+def _user_message(text: str, *, message_id: str = _DEFAULT_USER_MESSAGE_ID) -> dict[str, Any]:
     return {
         "id": message_id,
         "role": "user",
@@ -158,10 +162,9 @@ async def _create_agent_session_row(
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=PhoenixUIMessage.model_validate(message),
             )
-            for position, message in enumerate(messages or [])
+            for message in messages or []
         )
         return str(GlobalID("AgentSession", str(agent_session.id)))
 
@@ -172,7 +175,7 @@ async def _last_stored_message_id(db: DbSessionFactory) -> str:
     async with db() as session:
         message_id = await session.scalar(
             select(models.AgentSessionMessage.message_id)
-            .order_by(models.AgentSessionMessage.position.desc())
+            .order_by(models.AgentSessionMessage.id.desc())
             .limit(1)
         )
     assert message_id is not None
@@ -217,7 +220,7 @@ async def _load_session_messages(
         await session.scalars(
             select(models.AgentSessionMessage.message)
             .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
-            .order_by(models.AgentSessionMessage.position)
+            .order_by(models.AgentSessionMessage.id)
         )
     ).all()
     return [
@@ -372,15 +375,15 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
     )
 
     transcript = [
-        _user_message("Find the slow span", message_id="user-1"),
+        _user_message("Find the slow span", message_id=_message_uuid("user-1")),
         {
-            "id": "assistant-1",
+            "id": _message_uuid("assistant-1"),
             "role": "assistant",
             "parts": [{"type": "text", "text": "The slow span is trace-id-123."}],
         },
-        _user_message("What should I inspect next?", message_id="user-2"),
+        _user_message("What should I inspect next?", message_id=_message_uuid("user-2")),
         {
-            "id": "assistant-2",
+            "id": _message_uuid("assistant-2"),
             "role": "assistant",
             "parts": [{"type": "text", "text": "Inspect the latest model call."}],
         },
@@ -447,10 +450,10 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
         )
     assert compaction_message_count == 1
     assert [message["id"] for message in original_messages] == [
-        "user-1",
-        "assistant-1",
-        "user-2",
-        "assistant-2",
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("user-2"),
+        _message_uuid("assistant-2"),
         compaction_message["id"],
     ]
 
@@ -458,7 +461,7 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
         _chat_url(agent_session_id),
         json=_chat_body(
             "91919191-9191-4191-8191-919191919191",
-            _user_message("Continue", message_id="user-3"),
+            _user_message("Continue", message_id=_message_uuid("user-3")),
             lastMessageId=compaction_message["id"],
         ),
     )
@@ -474,13 +477,13 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
     async with db() as session:
         stored_messages = await _load_session_messages(session, agent_session_rowid)
     assert [message["id"] for message in stored_messages[:5]] == [
-        "user-1",
-        "assistant-1",
-        "user-2",
-        "assistant-2",
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("user-2"),
+        _message_uuid("assistant-2"),
         compaction_message["id"],
     ]
-    assert stored_messages[5]["id"] == "user-3"
+    assert stored_messages[5]["id"] == _message_uuid("user-3")
 
     second_compact_response = await httpx_client.post(
         _compact_url(agent_session_id),
@@ -507,7 +510,7 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
         _chat_url(agent_session_id),
         json=_chat_body(
             "91919191-9191-4191-8191-919191919191",
-            _user_message("Finish", message_id="user-4"),
+            _user_message("Finish", message_id=_message_uuid("user-4")),
             lastMessageId=second_compaction_message["id"],
         ),
     )
@@ -534,7 +537,7 @@ async def test_compact_agent_session_without_a_completed_turn_is_a_noop(
         project_session_id="92929292-9292-4292-8292-929292929292",
         title="Incomplete turn",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
         ],
     )
 
@@ -564,9 +567,9 @@ async def test_compact_is_rejected_while_a_turn_holds_the_session_lock(
         project_session_id="93939393-9393-4393-8393-939393939393",
         title="Busy session",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "Hi there."}],
             },
@@ -621,9 +624,9 @@ async def test_compact_takes_over_a_stale_session_lock(
         project_session_id="94949494-9494-4494-8494-949494949494",
         title="Abandoned turn",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "Hi there."}],
             },
@@ -668,9 +671,9 @@ async def test_chat_send_during_compaction_is_rejected_as_busy(
         project_session_id=session_id,
         title="Compacting session",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "Hi there."}],
             },
@@ -686,8 +689,8 @@ async def test_chat_send_during_compaction_is_rejected_as_busy(
             _chat_url(agent_session_id),
             json=_chat_body(
                 session_id,
-                _user_message("follow-up", message_id="user-2"),
-                lastMessageId="assistant-1",
+                _user_message("follow-up", message_id=_message_uuid("user-2")),
+                lastMessageId=_message_uuid("assistant-1"),
             ),
         )
         concurrent_sends.append((chat_response.status_code, chat_response.json()))
@@ -738,9 +741,9 @@ async def test_server_agent_compact_route_matches_chat_route_gating(
         project_session_id="96969696-9696-4696-8696-969696969696",
         title="Server session",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "Hi there."}],
             },
@@ -820,7 +823,7 @@ async def test_chat_turn_persists_session_transcript(
             await session.scalars(
                 select(models.AgentSessionMessage.id)
                 .where(models.AgentSessionMessage.agent_session_id == agent_session.id)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         )
         persisted_session_id = agent_session.project_session_id
@@ -845,7 +848,7 @@ async def test_chat_turn_persists_session_transcript(
     async with db() as session:
         stored_message_rows = (
             await session.scalars(
-                select(models.AgentSessionMessage).order_by(models.AgentSessionMessage.position)
+                select(models.AgentSessionMessage).order_by(models.AgentSessionMessage.id)
             )
         ).all()
         assert [row.message_id for row in stored_message_rows] == [
@@ -858,7 +861,7 @@ async def test_chat_turn_persists_session_transcript(
         _chat_url(agent_session_id),
         json={
             **body,
-            "message": _user_message("And experiments?", message_id="msg-user-2"),
+            "message": _user_message("And experiments?", message_id=_message_uuid("msg-user-2")),
             "lastMessageId": assistant_messages[-1]["id"],
         },
     )
@@ -881,14 +884,14 @@ async def test_chat_turn_persists_session_transcript(
             await session.scalars(
                 select(models.AgentSessionMessage.id)
                 .where(models.AgentSessionMessage.agent_session_id == agent_session.id)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         )
     # The merged transcript contains both turns in order, assembled server-side.
     user_message_ids = [
         message["id"] for message in second_turn_messages if message["role"] == "user"
     ]
-    assert user_message_ids == ["msg-user-1", "msg-user-2"]
+    assert user_message_ids == [_message_uuid("msg-user-1"), _message_uuid("msg-user-2")]
     assert len(second_turn_messages) > len(messages)
     assert second_turn_message_rowids[: len(message_rowids)] == message_rowids
 
@@ -926,8 +929,8 @@ async def test_failed_chat_turn_does_not_persist_partial_transcript(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("new message", message_id="msg-user-2"),
-            lastMessageId="msg-user-1",
+            _user_message("new message", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("msg-user-1"),
         ),
     )
 
@@ -1002,7 +1005,7 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
             await session.scalars(
                 select(models.AgentSessionMessage)
                 .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         ).all()
     assert len(stored_rows) == 2
@@ -1089,14 +1092,14 @@ def test_synthesizes_root_and_clamped_client_tool_span() -> None:
     messages = [
         UIMessage.model_validate(
             {
-                "id": "user-1",
+                "id": _message_uuid("user-1"),
                 "role": "user",
                 "parts": [{"type": "text", "text": "Use the tool"}],
             }
         ),
         UIMessage.model_validate(
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [
                     {
@@ -1165,14 +1168,14 @@ def test_error_parts_record_exception_events() -> None:
     messages = [
         UIMessage.model_validate(
             {
-                "id": "user-1",
+                "id": _message_uuid("user-1"),
                 "role": "user",
                 "parts": [{"type": "text", "text": "Use the tool"}],
             }
         ),
         UIMessage.model_validate(
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [
                     {
@@ -1548,7 +1551,7 @@ async def test_chat_turn_with_stale_last_message_id_is_rejected(
         messages=[
             _user_message("earlier question"),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "earlier answer"}],
             },
@@ -1558,7 +1561,9 @@ async def test_chat_turn_with_stale_last_message_id_is_rejected(
     # Omitted while the transcript is non-empty.
     omitted_response = await httpx_client.post(
         _chat_url(agent_session_id),
-        json=_chat_body(session_id, _user_message("follow-up", message_id="msg-user-2")),
+        json=_chat_body(
+            session_id, _user_message("follow-up", message_id=_message_uuid("msg-user-2"))
+        ),
     )
     assert omitted_response.status_code == 409
     assert omitted_response.json() == {"code": "agent_session_stale"}
@@ -1568,8 +1573,8 @@ async def test_chat_turn_with_stale_last_message_id_is_rejected(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("follow-up", message_id="msg-user-2"),
-            lastMessageId="msg-user-1",
+            _user_message("follow-up", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("msg-user-1"),
         ),
     )
     assert stale_response.status_code == 409
@@ -1600,7 +1605,7 @@ async def test_chat_turn_on_an_empty_session_rejects_a_last_message_id(
         json=_chat_body(
             session_id,
             _user_message("hello"),
-            lastMessageId="msg-user-0",
+            lastMessageId=_message_uuid("msg-user-0"),
         ),
     )
     assert response.status_code == 409
@@ -1628,12 +1633,12 @@ async def test_follow_up_send_from_a_compaction_message_passes_the_stale_check(
         messages=[
             _user_message("earlier question"),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "earlier answer"}],
             },
             {
-                "id": "compaction-1",
+                "id": _message_uuid("compaction-1"),
                 "role": "user",
                 "metadata": {
                     "type": "user",
@@ -1651,8 +1656,8 @@ async def test_follow_up_send_from_a_compaction_message_passes_the_stale_check(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("follow-up", message_id="msg-user-2"),
-            lastMessageId="assistant-1",
+            _user_message("follow-up", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("assistant-1"),
         ),
     )
     assert stale_response.status_code == 409
@@ -1663,8 +1668,8 @@ async def test_follow_up_send_from_a_compaction_message_passes_the_stale_check(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("follow-up", message_id="msg-user-2"),
-            lastMessageId="compaction-1",
+            _user_message("follow-up", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("compaction-1"),
         ),
     )
     assert follow_up_response.status_code == 200
@@ -1691,7 +1696,7 @@ def _validated_messages(raw_messages: list[dict[str, Any]]) -> list[PhoenixUIMes
 
 def _assistant_message_with_tool_states() -> dict[str, Any]:
     return {
-        "id": "assistant-1",
+        "id": _message_uuid("assistant-1"),
         "role": "assistant",
         "parts": [
             {"type": "text", "text": "Working on it"},
@@ -1725,11 +1730,15 @@ def test_merge_appends_user_message_without_modifying_persisted_messages() -> No
     merged = _merge_messages(
         old_messages=persisted,
         new_message=PhoenixUIMessage.model_validate(
-            _user_message("never mind", message_id="msg-user-2")
+            _user_message("never mind", message_id=_message_uuid("msg-user-2"))
         ),
     )
 
-    assert [message.id for message in merged] == ["msg-user-1", "assistant-1", "msg-user-2"]
+    assert [message.id for message in merged] == [
+        _message_uuid("msg-user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("msg-user-2"),
+    ]
     assert merged[1] is persisted[1]
 
 
@@ -1739,7 +1748,7 @@ def test_merge_replaces_the_trailing_assistant_message() -> None:
     )
     resolved_assistant = PhoenixUIMessage.model_validate(
         {
-            "id": "assistant-1",
+            "id": _message_uuid("assistant-1"),
             "role": "assistant",
             "parts": [
                 {
@@ -1758,14 +1767,17 @@ def test_merge_replaces_the_trailing_assistant_message() -> None:
         new_message=resolved_assistant,
     )
 
-    assert [message.id for message in merged] == ["msg-user-1", "assistant-1"]
+    assert [message.id for message in merged] == [
+        _message_uuid("msg-user-1"),
+        _message_uuid("assistant-1"),
+    ]
     assert merged[-1] is resolved_assistant
 
 
 def test_merge_rejects_an_assistant_message_that_is_not_the_trailing_one() -> None:
     persisted = _validated_messages([_user_message("hello")])
     stale_assistant = PhoenixUIMessage.model_validate(
-        {"id": "assistant-stale", "role": "assistant", "parts": []}
+        {"id": _message_uuid("assistant-stale"), "role": "assistant", "parts": []}
     )
 
     with pytest.raises(HTTPException) as exc_info:
@@ -1788,7 +1800,7 @@ async def test_chat_endpoint_rejects_regenerate_requests(
         messages=[
             _user_message("first question"),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "stale answer"}],
             },
@@ -1801,7 +1813,7 @@ async def test_chat_endpoint_rejects_regenerate_requests(
             session_id,
             None,
             trigger="regenerate-message",
-            messageId="assistant-1",
+            messageId=_message_uuid("assistant-1"),
         ),
     )
     assert response.status_code == 422
@@ -1870,7 +1882,7 @@ async def test_failed_summary_leaves_session_untitled_until_a_later_turn(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("second question", message_id="msg-user-2"),
+            _user_message("second question", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -1939,7 +1951,7 @@ async def test_bash_shell_state_persists_across_chat_turns(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("thanks", message_id="msg-user-2"),
+            _user_message("thanks", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -1955,7 +1967,7 @@ async def test_bash_shell_state_persists_across_chat_turns(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("read it back", message_id="msg-user-3"),
+            _user_message("read it back", message_id=_message_uuid("msg-user-3")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -2013,7 +2025,7 @@ async def test_server_agent_chat_turn_persists_session_transcript(
         _server_agent_chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("And experiments?", message_id="msg-user-2"),
+            _user_message("And experiments?", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -2023,7 +2035,7 @@ async def test_server_agent_chat_turn_persists_session_transcript(
     user_message_ids = [
         message["id"] for message in second_turn_messages if message["role"] == "user"
     ]
-    assert user_message_ids == ["msg-user-1", "msg-user-2"]
+    assert user_message_ids == [_message_uuid("msg-user-1"), _message_uuid("msg-user-2")]
     assert len(second_turn_messages) > len(messages)
 
 
@@ -2058,7 +2070,7 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
         _server_agent_chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("read it back", message_id="msg-user-2"),
+            _user_message("read it back", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -2461,7 +2473,7 @@ async def test_resumed_chat_turn_keeps_original_trace_project(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_request_id,
-            _user_message("second question", message_id="msg-user-2"),
+            _user_message("second question", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
             ingestTraces=True,
             turnTraceContext={

--- a/tests/unit/server/agents/test_legacy_agents_router.py
+++ b/tests/unit/server/agents/test_legacy_agents_router.py
@@ -21,6 +21,7 @@ from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
 from phoenix.tracers import Tracer
+from tests.unit._helpers import _message_uuid
 
 _LEGACY_BUILD_MODEL_PATCH_TARGET = "phoenix.server.api.routers.legacy_agents.build_model"
 _BUILD_MODEL_PATCH_TARGET = "phoenix.server.api.routers.agents.build_model"
@@ -28,7 +29,10 @@ _BUILD_MODEL_PATCH_TARGET = "phoenix.server.api.routers.agents.build_model"
 _CLIENT_MINTED_SESSION_ID = "12345678-1234-4123-8123-123456789012"
 
 
-def _user_message(text: str, *, message_id: str = "msg-user-1") -> dict[str, Any]:
+_DEFAULT_USER_MESSAGE_ID = _message_uuid("msg-user-1")
+
+
+def _user_message(text: str, *, message_id: str = _DEFAULT_USER_MESSAGE_ID) -> dict[str, Any]:
     return {
         "id": message_id,
         "role": "user",
@@ -131,7 +135,7 @@ async def test_legacy_chat_route_accepts_a_multi_turn_transcript(
     transcript = [
         _user_message("first question"),
         {
-            "id": "assistant-1",
+            "id": _message_uuid("assistant-1"),
             "role": "assistant",
             "parts": [{"type": "text", "text": "first answer"}],
             "metadata": {
@@ -139,7 +143,7 @@ async def test_legacy_chat_route_accepts_a_multi_turn_transcript(
                 "usage": {"tokens": {"prompt": 1, "completion": 2, "total": 3}},
             },
         },
-        _user_message("second question", message_id="msg-user-2"),
+        _user_message("second question", message_id=_message_uuid("msg-user-2")),
     ]
 
     response = await httpx_client.post(

--- a/tests/unit/server/agents/test_session_history.py
+++ b/tests/unit/server/agents/test_session_history.py
@@ -1,6 +1,5 @@
 from uuid import uuid4
 
-import pytest
 from sqlalchemy import select
 
 from phoenix.db import models
@@ -121,102 +120,6 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
     ]
     assert history[0].is_compaction_point
     assert history[0].message.id == _message_uuid("compaction-2")
-
-
-async def test_transcript_order_follows_insertion_order_not_message_content(
-    db: DbSessionFactory,
-) -> None:
-    """Transcript order is the primary key's ascending order.
-
-    Nothing in the row content encodes position, so appending a message after
-    the fact must land it at the end of the transcript.
-    """
-    async with db() as session:
-        agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
-            user_id=None,
-            title="Session",
-            project_name="assistant_agent",
-        )
-        session.add(agent_session)
-        await session.flush()
-        agent_session_rowid = agent_session.id
-        session.add_all(
-            models.AgentSessionMessage(
-                agent_session_id=agent_session_rowid,
-                message=_message(message_id=_message_uuid(label), role=role, text=label),
-            )
-            for label, role in (("user-1", "user"), ("assistant-1", "assistant"))
-        )
-
-    # A later transaction appends a third message.
-    async with db() as session:
-        session.add(
-            models.AgentSessionMessage(
-                agent_session_id=agent_session_rowid,
-                message=_message(message_id=_message_uuid("user-2"), role="user", text="user-2"),
-            )
-        )
-
-    async with db() as session:
-        history = await _load_agent_session_history(
-            session,
-            agent_session_rowid=agent_session_rowid,
-        )
-
-    assert [row.message.id for row in history] == [
-        _message_uuid("user-1"),
-        _message_uuid("assistant-1"),
-        _message_uuid("user-2"),
-    ]
-    assert [row.id for row in history] == sorted(row.id for row in history)
-
-
-async def test_message_id_must_be_a_uuid_at_the_database_level(
-    db: DbSessionFactory,
-) -> None:
-    """``message_id`` is a generated column, so the CHECK is the only thing
-    standing between a malformed client id and the transcript."""
-    async with db() as session:
-        agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
-            user_id=None,
-            title="Session",
-            project_name="assistant_agent",
-        )
-        session.add(agent_session)
-        await session.flush()
-        agent_session_rowid = agent_session.id
-
-    for bad_message_id in (
-        "not-a-uuid",
-        "",
-        # Right length and shape, but 'z' is not a hex digit.
-        "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
-        # A UUID with the hyphens stripped out.
-        uuid4().hex,
-        # Trailing junk after an otherwise valid UUID.
-        f"{uuid4()}-extra",
-    ):
-        # The exception class differs by driver — SQLAlchemy translates the
-        # PostgreSQL driver's error but re-raises sqlean's untranslated — so the
-        # named constraint in the message is what this pins.
-        with pytest.raises(Exception, match="valid_message_id"):
-            async with db() as session:
-                session.add(
-                    models.AgentSessionMessage(
-                        agent_session_id=agent_session_rowid,
-                        message=_message(
-                            message_id=bad_message_id,
-                            role="user",
-                            text="rejected",
-                        ),
-                    )
-                )
-                await session.flush()
-
-    async with db() as session:
-        assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
 
 
 async def test_uppercase_and_lowercase_uuids_are_both_accepted(

--- a/tests/unit/server/agents/test_session_history.py
+++ b/tests/unit/server/agents/test_session_history.py
@@ -1,5 +1,8 @@
 from uuid import uuid4
 
+import pytest
+from sqlalchemy import select
+
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage, TextUIPart, UserMessageMetadata
 from phoenix.server.api.routers.agents import (
@@ -7,6 +10,7 @@ from phoenix.server.api.routers.agents import (
     _load_agent_session_history,
 )
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 
 
 def _message(*, message_id: str, role: str, text: str) -> PhoenixUIMessage:
@@ -21,7 +25,7 @@ def _message(*, message_id: str, role: str, text: str) -> PhoenixUIMessage:
 
 def test_build_compaction_message_creates_a_marked_user_message() -> None:
     message = _build_compaction_message(
-        message_id="compaction-1",
+        message_id=_message_uuid("compaction-1"),
         summary='{"objectives":["continue"]}',
     )
 
@@ -37,8 +41,8 @@ async def test_load_agent_session_history_returns_the_full_uncompacted_transcrip
     db: DbSessionFactory,
 ) -> None:
     messages = [
-        _message(message_id="user-1", role="user", text="question"),
-        _message(message_id="assistant-1", role="assistant", text="answer"),
+        _message(message_id=_message_uuid("user-1"), role="user", text="question"),
+        _message(message_id=_message_uuid("assistant-1"), role="assistant", text="answer"),
     ]
     async with db() as session:
         agent_session = models.AgentSession(
@@ -52,10 +56,9 @@ async def test_load_agent_session_history_returns_the_full_uncompacted_transcrip
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(messages)
+            for message in messages
         )
         agent_session_rowid = agent_session.id
 
@@ -73,14 +76,18 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
     db: DbSessionFactory,
 ) -> None:
     messages = [
-        _message(message_id="user-1", role="user", text="old question"),
-        _message(message_id="assistant-1", role="assistant", text="old answer"),
-        _build_compaction_message(message_id="compaction-1", summary="first summary"),
-        _message(message_id="user-2", role="user", text="newer question"),
-        _message(message_id="assistant-2", role="assistant", text="newer answer"),
-        _build_compaction_message(message_id="compaction-2", summary="second summary"),
-        _message(message_id="user-3", role="user", text="retained question"),
-        _message(message_id="assistant-3", role="assistant", text="retained answer"),
+        _message(message_id=_message_uuid("user-1"), role="user", text="old question"),
+        _message(message_id=_message_uuid("assistant-1"), role="assistant", text="old answer"),
+        _build_compaction_message(
+            message_id=_message_uuid("compaction-1"), summary="first summary"
+        ),
+        _message(message_id=_message_uuid("user-2"), role="user", text="newer question"),
+        _message(message_id=_message_uuid("assistant-2"), role="assistant", text="newer answer"),
+        _build_compaction_message(
+            message_id=_message_uuid("compaction-2"), summary="second summary"
+        ),
+        _message(message_id=_message_uuid("user-3"), role="user", text="retained question"),
+        _message(message_id=_message_uuid("assistant-3"), role="assistant", text="retained answer"),
     ]
     async with db() as session:
         agent_session = models.AgentSession(
@@ -94,10 +101,9 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
         message_rows = [
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(messages)
+            for message in messages
         ]
         session.add_all(message_rows)
         agent_session_rowid = agent_session.id
@@ -109,9 +115,133 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
         )
 
     assert [row.message.id for row in history] == [
-        "compaction-2",
-        "user-3",
-        "assistant-3",
+        _message_uuid("compaction-2"),
+        _message_uuid("user-3"),
+        _message_uuid("assistant-3"),
     ]
     assert history[0].is_compaction_point
-    assert history[0].message.id == "compaction-2"
+    assert history[0].message.id == _message_uuid("compaction-2")
+
+
+async def test_transcript_order_follows_insertion_order_not_message_content(
+    db: DbSessionFactory,
+) -> None:
+    """Transcript order is the primary key's ascending order.
+
+    Nothing in the row content encodes position, so appending a message after
+    the fact must land it at the end of the transcript.
+    """
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id=str(uuid4()),
+            user_id=None,
+            title="Session",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_rowid = agent_session.id
+        session.add_all(
+            models.AgentSessionMessage(
+                agent_session_id=agent_session_rowid,
+                message=_message(message_id=_message_uuid(label), role=role, text=label),
+            )
+            for label, role in (("user-1", "user"), ("assistant-1", "assistant"))
+        )
+
+    # A later transaction appends a third message.
+    async with db() as session:
+        session.add(
+            models.AgentSessionMessage(
+                agent_session_id=agent_session_rowid,
+                message=_message(message_id=_message_uuid("user-2"), role="user", text="user-2"),
+            )
+        )
+
+    async with db() as session:
+        history = await _load_agent_session_history(
+            session,
+            agent_session_rowid=agent_session_rowid,
+        )
+
+    assert [row.message.id for row in history] == [
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("user-2"),
+    ]
+    assert [row.id for row in history] == sorted(row.id for row in history)
+
+
+async def test_message_id_must_be_a_uuid_at_the_database_level(
+    db: DbSessionFactory,
+) -> None:
+    """``message_id`` is a generated column, so the CHECK is the only thing
+    standing between a malformed client id and the transcript."""
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id=str(uuid4()),
+            user_id=None,
+            title="Session",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_rowid = agent_session.id
+
+    for bad_message_id in (
+        "not-a-uuid",
+        "",
+        # Right length and shape, but 'z' is not a hex digit.
+        "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
+        # A UUID with the hyphens stripped out.
+        uuid4().hex,
+        # Trailing junk after an otherwise valid UUID.
+        f"{uuid4()}-extra",
+    ):
+        # The exception class differs by driver — SQLAlchemy translates the
+        # PostgreSQL driver's error but re-raises sqlean's untranslated — so the
+        # named constraint in the message is what this pins.
+        with pytest.raises(Exception, match="valid_message_id"):
+            async with db() as session:
+                session.add(
+                    models.AgentSessionMessage(
+                        agent_session_id=agent_session_rowid,
+                        message=_message(
+                            message_id=bad_message_id,
+                            role="user",
+                            text="rejected",
+                        ),
+                    )
+                )
+                await session.flush()
+
+    async with db() as session:
+        assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
+
+
+async def test_uppercase_and_lowercase_uuids_are_both_accepted(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id=str(uuid4()),
+            user_id=None,
+            title="Session",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_rowid = agent_session.id
+        lowercase_id = str(uuid4())
+        uppercase_id = str(uuid4()).upper()
+        session.add_all(
+            models.AgentSessionMessage(
+                agent_session_id=agent_session_rowid,
+                message=_message(message_id=message_id, role="user", text="accepted"),
+            )
+            for message_id in (lowercase_id, uppercase_id)
+        )
+
+    async with db() as session:
+        stored = list(await session.scalars(select(models.AgentSessionMessage.message_id)))
+    assert stored == [lowercase_id, uppercase_id]

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -18,6 +18,7 @@ from phoenix.server.api.routers.agents import (
 )
 from phoenix.server.settings.registry import AgentAssistantEnabledSetting
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 from tests.unit.graphql import AsyncGraphQLClient
 
 _CREATE_MUTATION = """
@@ -118,22 +119,22 @@ def _transcript_messages() -> list[PhoenixUIMessage]:
     """A two-turn transcript."""
     return [
         PhoenixUIMessage(
-            id="user-1",
+            id=_message_uuid("user-1"),
             role="user",
             parts=[TextUIPart(text="How do I trace OpenAI?")],
         ),
         PhoenixUIMessage(
-            id="assistant-1",
+            id=_message_uuid("assistant-1"),
             role="assistant",
             parts=[TextUIPart(text="Use register().")],
         ),
         PhoenixUIMessage(
-            id="user-2",
+            id=_message_uuid("user-2"),
             role="user",
             parts=[TextUIPart(text="Show "), TextUIPart(text="an example")],
         ),
         PhoenixUIMessage(
-            id="assistant-2",
+            id=_message_uuid("assistant-2"),
             role="assistant",
             parts=[TextUIPart(text="Here is an example.")],
         ),
@@ -159,10 +160,9 @@ async def _seed_session_with_transcript(
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(_transcript_messages())
+            for message in _transcript_messages()
         )
         return str(GlobalID("AgentSession", str(agent_session.id)))
 
@@ -176,31 +176,37 @@ async def test_truncate_agent_session_at_a_user_message_removes_it_and_later_tur
         retained_message_rowids = list(
             await session.scalars(
                 select(models.AgentSessionMessage.id)
-                .where(models.AgentSessionMessage.position < 2)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
+                .limit(2)
             )
         )
 
     response = await gql_client.execute(
         query=_TRUNCATE_MUTATION,
-        variables={"id": agent_session_id, "messageId": "user-2"},
+        variables={"id": agent_session_id, "messageId": _message_uuid("user-2")},
     )
     assert not response.errors
     assert response.data is not None
     payload = response.data["truncateAgentSession"]
     # The user target and everything after it are removed.
     assert [message["id"] for message in payload["agentSession"]["messages"]] == [
-        "user-1",
-        "assistant-1",
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
     ]
     async with db() as session:
         stored_message_rows = (
             await session.scalars(
-                select(models.AgentSessionMessage).order_by(models.AgentSessionMessage.position)
+                select(models.AgentSessionMessage).order_by(models.AgentSessionMessage.id)
             )
         ).all()
-    assert [row.message.id for row in stored_message_rows] == ["user-1", "assistant-1"]
-    assert [row.message_id for row in stored_message_rows] == ["user-1", "assistant-1"]
+    assert [row.message.id for row in stored_message_rows] == [
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+    ]
+    assert [row.message_id for row in stored_message_rows] == [
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+    ]
     assert [row.id for row in stored_message_rows] == retained_message_rowids
 
 
@@ -212,22 +218,22 @@ async def test_truncate_agent_session_at_an_assistant_message_retains_it(
 
     response = await gql_client.execute(
         query=_TRUNCATE_MUTATION,
-        variables={"id": agent_session_id, "messageId": "assistant-2"},
+        variables={"id": agent_session_id, "messageId": _message_uuid("assistant-2")},
     )
     assert not response.errors
     assert response.data is not None
     payload = response.data["truncateAgentSession"]
     messages = payload["agentSession"]["messages"]
     assert [message["id"] for message in messages] == [
-        "user-1",
-        "assistant-1",
-        "user-2",
-        "assistant-2",
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("user-2"),
+        _message_uuid("assistant-2"),
     ]
     async with db() as session:
         stored_message = await session.scalar(
             select(models.AgentSessionMessage).where(
-                models.AgentSessionMessage.message_id == "assistant-2"
+                models.AgentSessionMessage.message_id == _message_uuid("assistant-2")
             )
         )
         assert stored_message is not None
@@ -243,25 +249,29 @@ async def test_truncate_agent_session_restores_the_latest_surviving_compaction_p
         agent_session_rowid = await session.scalar(select(models.AgentSession.id))
         assert agent_session_rowid is not None
         additional_messages = [
-            _build_compaction_message(message_id="compaction-1", summary="first summary"),
+            _build_compaction_message(
+                message_id=_message_uuid("compaction-1"), summary="first summary"
+            ),
             PhoenixUIMessage(
-                id="user-3",
+                id=_message_uuid("user-3"),
                 role="user",
                 parts=[TextUIPart(text="Continue")],
             ),
             PhoenixUIMessage(
-                id="assistant-3",
+                id=_message_uuid("assistant-3"),
                 role="assistant",
                 parts=[TextUIPart(text="Continued")],
             ),
-            _build_compaction_message(message_id="compaction-2", summary="second summary"),
+            _build_compaction_message(
+                message_id=_message_uuid("compaction-2"), summary="second summary"
+            ),
             PhoenixUIMessage(
-                id="user-4",
+                id=_message_uuid("user-4"),
                 role="user",
                 parts=[TextUIPart(text="Continue again")],
             ),
             PhoenixUIMessage(
-                id="assistant-4",
+                id=_message_uuid("assistant-4"),
                 role="assistant",
                 parts=[TextUIPart(text="Continued again")],
             ),
@@ -269,22 +279,21 @@ async def test_truncate_agent_session_restores_the_latest_surviving_compaction_p
         additional_rows = [
             models.AgentSessionMessage(
                 agent_session_id=agent_session_rowid,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(additional_messages, start=4)
+            for message in additional_messages
         ]
         session.add_all(additional_rows)
 
     response = await gql_client.execute(
         query=_TRUNCATE_MUTATION,
-        variables={"id": agent_session_id, "messageId": "user-3"},
+        variables={"id": agent_session_id, "messageId": _message_uuid("user-3")},
     )
 
     assert not response.errors
     assert response.data is not None
     messages = response.data["truncateAgentSession"]["agentSession"]["messages"]
-    assert [message["id"] for message in messages][-1] == "compaction-1"
+    assert [message["id"] for message in messages][-1] == _message_uuid("compaction-1")
     async with db() as session:
         surviving_compaction_message_count = await session.scalar(
             select(func.count())
@@ -296,7 +305,7 @@ async def test_truncate_agent_session_restores_the_latest_surviving_compaction_p
             agent_session_rowid=agent_session_rowid,
         )
     assert surviving_compaction_message_count == 1
-    assert [row.message.id for row in history] == ["compaction-1"]
+    assert [row.message.id for row in history] == [_message_uuid("compaction-1")]
 
 
 async def test_truncate_agent_session_with_unknown_message_id_is_not_found(
@@ -328,7 +337,7 @@ async def test_truncate_agent_session_rejects_an_expired_temporary_session(
 
     response = await gql_client.execute(
         query=_TRUNCATE_MUTATION,
-        variables={"id": agent_session_id, "messageId": "user-2"},
+        variables={"id": agent_session_id, "messageId": _message_uuid("user-2")},
     )
 
     assert response.errors
@@ -351,7 +360,7 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "user-2"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("user-2")},
     )
     assert not response.errors
     assert response.data is not None
@@ -362,7 +371,9 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
     branch_message_ids = [message["id"] for message in branch["messages"]]
     assert len(branch_message_ids) == 2
     assert all(UUID(message_id).version == 4 for message_id in branch_message_ids)
-    assert set(branch_message_ids).isdisjoint({"user-1", "assistant-1"})
+    assert set(branch_message_ids).isdisjoint(
+        {_message_uuid("user-1"), _message_uuid("assistant-1")}
+    )
     async with db() as session:
         agent_sessions = (await session.scalars(select(models.AgentSession))).all()
         assert len(agent_sessions) == 2
@@ -372,14 +383,14 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
             await session.scalars(
                 select(models.AgentSessionMessage)
                 .where(models.AgentSessionMessage.agent_session_id == source_rowid)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         ).all()
         branch_messages = (
             await session.scalars(
                 select(models.AgentSessionMessage)
                 .where(models.AgentSessionMessage.agent_session_id == branch_rowid)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         ).all()
         assert len(source_messages) == len(_transcript_messages())
@@ -410,17 +421,15 @@ async def test_branch_agent_session_copies_durable_compaction_points(
         assert source_session_rowid is not None
         compaction_row = models.AgentSessionMessage(
             agent_session_id=source_session_rowid,
-            position=4,
             message=_build_compaction_message(
-                message_id="source-compaction",
+                message_id=_message_uuid("source-compaction"),
                 summary="durable summary",
             ),
         )
         assistant_row = models.AgentSessionMessage(
             agent_session_id=source_session_rowid,
-            position=5,
             message=PhoenixUIMessage(
-                id="assistant-after-compaction",
+                id=_message_uuid("assistant-after-compaction"),
                 role="assistant",
                 parts=[TextUIPart(text="retained answer")],
             ),
@@ -431,7 +440,7 @@ async def test_branch_agent_session_copies_durable_compaction_points(
         query=_BRANCH_MUTATION,
         variables={
             "id": source_agent_session_id,
-            "messageId": "assistant-after-compaction",
+            "messageId": _message_uuid("assistant-after-compaction"),
         },
     )
 
@@ -443,7 +452,7 @@ async def test_branch_agent_session_copies_durable_compaction_points(
         for message in branch_messages
         if message.get("metadata", {}).get("isCompactionMessage") is True
     )
-    assert copied_compaction["id"] != "source-compaction"
+    assert copied_compaction["id"] != _message_uuid("source-compaction")
     async with db() as session:
         compaction_message_count = await session.scalar(
             select(func.count())
@@ -461,7 +470,7 @@ async def test_branch_agent_session_copies_the_source_title(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "assistant-1"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-1")},
     )
     assert not response.errors
     assert response.data is not None
@@ -479,7 +488,7 @@ async def test_branch_agent_session_preserves_temporary_mode(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "assistant-1"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-1")},
     )
 
     assert not response.errors
@@ -495,7 +504,7 @@ async def test_branch_agent_session_at_an_assistant_message_includes_it(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "assistant-2"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-2")},
     )
 
     assert not response.errors
@@ -533,7 +542,7 @@ async def test_branch_agent_session_rejects_an_expired_temporary_session(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "assistant-1"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-1")},
     )
 
     assert response.errors
@@ -760,8 +769,7 @@ async def test_delete_agent_session_cascades_snapshot(
         session.add(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=0,
-                message=PhoenixUIMessage(id="m1", role="user", parts=[]),
+                message=PhoenixUIMessage(id=_message_uuid("m1"), role="user", parts=[]),
             )
         )
 

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -8,6 +8,7 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -37,10 +38,9 @@ async def _seed_agent_session(
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=PhoenixUIMessage.model_validate(message),
             )
-            for position, message in enumerate(messages or [])
+            for message in messages or []
         )
         return str(GlobalID("AgentSession", str(agent_session.id)))
 
@@ -194,17 +194,17 @@ async def test_agent_session_loads_transcript_by_id(
         user_id = user.id
     messages: list[dict[str, Any]] = [
         {
-            "id": "message-1",
+            "id": _message_uuid("message-1"),
             "role": "user",
             "parts": [{"type": "text", "text": "First question"}],
         },
         {
-            "id": "message-2",
+            "id": _message_uuid("message-2"),
             "role": "assistant",
             "parts": [{"type": "text", "text": "Earlier answer"}],
         },
         {
-            "id": "compaction-1",
+            "id": _message_uuid("compaction-1"),
             "role": "user",
             "metadata": {
                 "type": "user",
@@ -215,7 +215,7 @@ async def test_agent_session_loads_transcript_by_id(
             "parts": [{"type": "text", "text": '{"objectives":["test"]}'}],
         },
         {
-            "id": "message-3",
+            "id": _message_uuid("message-3"),
             "role": "assistant",
             "parts": [
                 {"type": "text", "text": "Latest"},

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -9,6 +9,7 @@ from phoenix.server.daemons.agent_session_sweeper import AgentSessionSweeper
 from phoenix.server.daemons.system_settings import SystemSettings
 from phoenix.server.settings.registry import SETTINGS_REGISTRY, AgentSessionRetentionSetting
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 
 
 async def _make_settings(
@@ -108,8 +109,7 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
         session.add(
             models.AgentSessionMessage(
                 agent_session_id=expired_id,
-                position=0,
-                message=PhoenixUIMessage(id="message-1", role="user", parts=[]),
+                message=PhoenixUIMessage(id=_message_uuid("message-1"), role="user", parts=[]),
             )
         )
         session.add(


### PR DESCRIPTION
Closes #14888
Closes #14896

Part 1 of a 5-PR stack. **Base: `version-agent-session-persistence`.**

Drops `agent_session_messages.position` in favor of the autoincrementing primary key, which already records insertion order, and adds a CHECK constraint requiring `message_id` to be a UUID. Both changes land in the same `CREATE TABLE` in migration `e767d3c57f32`, so they ship together.