### PR TITLE
refactor(agents): derive the agent session's otel session id from its pk

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -440,7 +440,6 @@ CREATE UNIQUE INDEX ix_users_username ON public.users
 -- ---------------------
 CREATE TABLE public.agent_sessions (
     id bigserial NOT NULL,
-    project_session_id VARCHAR NOT NULL,
     project_name VARCHAR NOT NULL,
     user_id BIGINT,
     title VARCHAR NOT NULL,
@@ -449,8 +448,6 @@ CREATE TABLE public.agent_sessions (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_agent_sessions PRIMARY KEY (id),
-    CONSTRAINT uq_agent_sessions_project_session_id_project_name
-        UNIQUE (project_session_id, project_name),
     CONSTRAINT fk_agent_sessions_user_id_users FOREIGN KEY
         (user_id)
         REFERENCES public.users (id)

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -81,7 +81,6 @@ def upgrade() -> None:
     op.create_table(
         "agent_sessions",
         sa.Column("id", _Integer, primary_key=True),
-        sa.Column("project_session_id", sa.String, nullable=False),
         sa.Column("project_name", sa.String, nullable=False),
         sa.Column(
             "user_id",
@@ -105,7 +104,6 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             onupdate=sa.func.now(),
         ),
-        sa.UniqueConstraint("project_session_id", "project_name"),
         sqlite_autoincrement=True,
     )
     op.create_index(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3303,7 +3303,6 @@ def _compile_matches_uuid_format_postgresql(
 
 class AgentSession(HasId):
     __tablename__ = "agent_sessions"
-    project_session_id: Mapped[str] = mapped_column(String, nullable=False)
     project_name: Mapped[str] = mapped_column(String, nullable=False)
     user_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"),
@@ -3329,7 +3328,6 @@ class AgentSession(HasId):
         back_populates="agent_session",
     )
     __table_args__ = (
-        UniqueConstraint("project_session_id", "project_name"),
         Index(
             "ix_agent_sessions_user_id_updated_at",
             "user_id",

--- a/src/phoenix/server/api/helpers/agent_sessions.py
+++ b/src/phoenix/server/api/helpers/agent_sessions.py
@@ -1,20 +1,15 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
+from strawberry.relay import GlobalID
+
 TURN_LOCK_STALENESS = timedelta(seconds=60)
 """How long after its last heartbeat a turn lock is considered abandoned."""
 
 
-def derive_otel_session_id(*, project_name: str, agent_session_rowid: int) -> str:
-    """The OpenTelemetry ``session.id`` an agent session's traces are grouped under.
-
-    Derived rather than stored: the session's autoincrementing primary key is
-    already unique, so the only thing a column bought was a second source of
-    truth to keep in sync. Qualifying the key with the project name keeps the id
-    self-describing in the traces UI and keeps it from colliding with session ids
-    minted by other producers writing into the same project.
-    """
-    return f"{project_name}:{agent_session_rowid}"
+def get_otel_session_id(*, project_name: str, agent_session_rowid: int) -> str:
+    agent_session_gid = GlobalID(type_name="AgentSession", node_id=str(agent_session_rowid))
+    return f"{project_name}:{agent_session_gid}"
 
 
 def is_turn_active(heartbeat_at: Optional[datetime], *, now: datetime) -> bool:

--- a/src/phoenix/server/api/helpers/agent_sessions.py
+++ b/src/phoenix/server/api/helpers/agent_sessions.py
@@ -5,6 +5,18 @@ TURN_LOCK_STALENESS = timedelta(seconds=60)
 """How long after its last heartbeat a turn lock is considered abandoned."""
 
 
+def derive_otel_session_id(*, project_name: str, agent_session_rowid: int) -> str:
+    """The OpenTelemetry ``session.id`` an agent session's traces are grouped under.
+
+    Derived rather than stored: the session's autoincrementing primary key is
+    already unique, so the only thing a column bought was a second source of
+    truth to keep in sync. Qualifying the key with the project name keeps the id
+    self-describing in the traces UI and keeps it from colliding with session ids
+    minted by other producers writing into the same project.
+    """
+    return f"{project_name}:{agent_session_rowid}"
+
+
 def is_turn_active(heartbeat_at: Optional[datetime], *, now: datetime) -> bool:
     """Whether a turn with a live (non-stale) heartbeat holds the session's lock.
 

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -124,7 +124,6 @@ class AgentSessionMutationMixin:
             raise BadRequest(str(exc)) from exc
         async with info.context.db() as session:
             agent_session = models.AgentSession(
-                project_session_id=str(uuid4()),
                 user_id=info.context.user_id,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
@@ -228,7 +227,6 @@ class AgentSessionMutationMixin:
                 message.model_copy(update={"id": str(uuid4())}) for message in message_prefix
             ]
             branch_session = models.AgentSession(
-                project_session_id=str(uuid4()),
                 user_id=info.context.user_id,
                 title=truncate_agent_session_title(source_session.title),
                 project_name=get_env_phoenix_agents_assistant_project_name(),

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -150,7 +150,7 @@ from phoenix.server.agents.vercel_ui_message_stream import (
 )
 from phoenix.server.api.helpers.agent_sessions import (
     TURN_LOCK_STALENESS,
-    derive_otel_session_id,
+    get_otel_session_id,
     is_turn_active,
 )
 from phoenix.server.api.helpers.playground_registry import (
@@ -2063,7 +2063,7 @@ def create_agents_router(
                 project_name = agent_session.project_name
                 session_needs_title = not agent_session.title
                 agent_session_rowid = agent_session.id
-                otel_session_id = derive_otel_session_id(
+                otel_session_id = get_otel_session_id(
                     project_name=project_name,
                     agent_session_rowid=agent_session_rowid,
                 )

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -148,7 +148,11 @@ from phoenix.server.agents.vercel_ui_message_stream import (
     create_streaming_ui_message_state,
     process_ui_message_stream,
 )
-from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, is_turn_active
+from phoenix.server.api.helpers.agent_sessions import (
+    TURN_LOCK_STALENESS,
+    derive_otel_session_id,
+    is_turn_active,
+)
 from phoenix.server.api.helpers.playground_registry import (
     PLAYGROUND_CLIENT_REGISTRY,
     PROVIDER_DEFAULT,
@@ -1739,7 +1743,6 @@ def create_agents_router(
         phoenix_user = user if isinstance(user, PhoenixUser) else None
         async with request.app.state.db() as session:
             agent_session = models.AgentSession(
-                project_session_id=str(uuid4()),
                 user_id=int(phoenix_user.identity) if phoenix_user is not None else None,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
@@ -2060,7 +2063,10 @@ def create_agents_router(
                 project_name = agent_session.project_name
                 session_needs_title = not agent_session.title
                 agent_session_rowid = agent_session.id
-                otel_session_id = agent_session.project_session_id
+                otel_session_id = derive_otel_session_id(
+                    project_name=project_name,
+                    agent_session_rowid=agent_session_rowid,
+                )
         except AgentError as exc:
             raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from uuid import uuid4
 
 import httpx
 from strawberry.relay import GlobalID
@@ -20,7 +19,6 @@ async def _insert_agent_session(
 ) -> models.AgentSession:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             project_name="pxi-test",
             title=title,
             expires_at=expires_at,

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -53,7 +53,7 @@ from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
 from phoenix.server.agents.ui_message_stream import iter_chunks_with_error_parts
 from phoenix.server.agents.vercel_ui_message_stream import read_ui_message_stream
-from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, derive_otel_session_id
+from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, get_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_message_metadata_chunk,
     _emit_turn_root_span,
@@ -817,8 +817,7 @@ async def test_chat_turn_persists_session_transcript(
                 .order_by(models.AgentSessionMessage.id)
             )
         )
-        # The OTel session id traces are grouped under is derived, not stored.
-        persisted_session_id = derive_otel_session_id(
+        persisted_session_id = get_otel_session_id(
             project_name=agent_session.project_name,
             agent_session_rowid=agent_session.id,
         )
@@ -2402,7 +2401,7 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
         project_session = await session.scalar(
             select(models.ProjectSession).where(
                 models.ProjectSession.session_id
-                == derive_otel_session_id(
+                == get_otel_session_id(
                     project_name=agent_session.project_name,
                     agent_session_rowid=agent_session.id,
                 )

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -53,7 +53,7 @@ from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
 from phoenix.server.agents.ui_message_stream import iter_chunks_with_error_parts
 from phoenix.server.agents.vercel_ui_message_stream import read_ui_message_stream
-from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS
+from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, derive_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_message_metadata_chunk,
     _emit_turn_root_span,
@@ -144,7 +144,6 @@ def _stream_chunks(response_text: str) -> list[dict[str, Any]]:
 async def _create_agent_session_row(
     db: DbSessionFactory,
     *,
-    project_session_id: str,
     title: str = "",
     messages: list[dict[str, Any]] | None = None,
 ) -> str:
@@ -152,7 +151,6 @@ async def _create_agent_session_row(
     does before its first chat request, optionally seeded with a transcript."""
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=project_session_id,
             user_id=None,
             title=title,
             project_name=get_env_phoenix_agents_assistant_project_name(),
@@ -390,7 +388,6 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
     ]
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="91919191-9191-4191-8191-919191919191",
         title="Existing session",
         messages=transcript,
     )
@@ -534,7 +531,6 @@ async def test_compact_agent_session_without_a_completed_turn_is_a_noop(
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _unexpected_build_model)
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="92929292-9292-4292-8292-929292929292",
         title="Incomplete turn",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -564,7 +560,6 @@ async def test_compact_is_rejected_while_a_turn_holds_the_session_lock(
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _unexpected_build_model)
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="93939393-9393-4393-8393-939393939393",
         title="Busy session",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -621,7 +616,6 @@ async def test_compact_takes_over_a_stale_session_lock(
     _mock_turn_models(monkeypatch, FunctionModel(function=compact_function))
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="94949494-9494-4494-8494-949494949494",
         title="Abandoned turn",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -668,7 +662,6 @@ async def test_chat_send_during_compaction_is_rejected_as_busy(
     concurrent_sends: list[tuple[int, dict[str, Any]]] = []
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Compacting session",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -738,7 +731,6 @@ async def test_server_agent_compact_route_matches_chat_route_gating(
     _mock_turn_models(monkeypatch, FunctionModel(function=compact_function))
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="96969696-9696-4696-8696-969696969696",
         title="Server session",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -786,7 +778,7 @@ async def test_chat_turn_persists_session_transcript(
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
     session_id = "44444444-4444-4444-8444-444444444444"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     body = _chat_body(
         session_id,
         _user_message("What datasets exist?"),
@@ -814,7 +806,6 @@ async def test_chat_turn_persists_session_transcript(
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
         assert agent_session.user_id is None
-        assert UUID(agent_session.project_session_id).version == 4
         assert agent_session.project_name == get_env_phoenix_agents_assistant_project_name()
         # The in-stream summary is persisted as the session title.
         assert agent_session.title == "a"
@@ -826,7 +817,11 @@ async def test_chat_turn_persists_session_transcript(
                 .order_by(models.AgentSessionMessage.id)
             )
         )
-        persisted_session_id = agent_session.project_session_id
+        # The OTel session id traces are grouped under is derived, not stored.
+        persisted_session_id = derive_otel_session_id(
+            project_name=agent_session.project_name,
+            agent_session_rowid=agent_session.id,
+        )
         # No bash command this turn, so no shell-state snapshot row.
         assert await session.scalar(select(models.AgentSessionSnapshot)) is None
 
@@ -920,7 +915,6 @@ async def test_failed_chat_turn_does_not_persist_partial_transcript(
     persisted_messages = [_user_message("earlier message")]
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
         messages=persisted_messages,
     )
@@ -955,7 +949,6 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
     session_id = "45454545-4545-4454-8454-454545454545"
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
     )
     model = _client_tool_model()
@@ -1476,7 +1469,7 @@ async def test_chat_stream_metadata_uses_turn_trace_context(
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
     session_id = "11111111-1111-4111-8111-111111111111"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
         _chat_url(agent_session_id),
@@ -1523,7 +1516,7 @@ async def test_chat_turn_without_a_message_is_rejected(
 ) -> None:
     """A submit request must carry the turn's new message."""
     session_id = "22222222-2222-4222-8222-222222222222"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
         _chat_url(agent_session_id),
@@ -1546,7 +1539,6 @@ async def test_chat_turn_with_stale_last_message_id_is_rejected(
     session_id = "23232323-2323-4323-8323-232323232323"
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
         messages=[
             _user_message("earlier question"),
@@ -1598,7 +1590,7 @@ async def test_chat_turn_on_an_empty_session_rejects_a_last_message_id(
     """Providing ``lastMessageId`` against an empty transcript is stale too:
     the client believes messages exist that the server does not have."""
     session_id = "24242424-2424-4424-8424-242424242424"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
         _chat_url(agent_session_id),
@@ -1628,7 +1620,6 @@ async def test_follow_up_send_from_a_compaction_message_passes_the_stale_check(
     session_id = "26262626-2626-4626-8626-262626262626"
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
         messages=[
             _user_message("earlier question"),
@@ -1795,7 +1786,6 @@ async def test_chat_endpoint_rejects_regenerate_requests(
     session_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
         messages=[
             _user_message("first question"),
@@ -1825,7 +1815,7 @@ async def test_generated_session_title_is_limited(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session_id = "33333333-3333-4333-8333-333333333333"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     generated_title = "x" * (MAX_AGENT_SESSION_TITLE_LENGTH + 20)
     _mock_turn_models(monkeypatch, _scripted_model(summary=generated_title))
 
@@ -1855,7 +1845,7 @@ async def test_failed_summary_leaves_session_untitled_until_a_later_turn(
     leaves the session untitled; the next turn retries summarization and the
     non-empty title then wins over the stored empty one."""
     session_id = "33333333-3333-4333-8333-333333333333"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     _mock_turn_models(
         monkeypatch,
         _scripted_model(summary=None),
@@ -1912,7 +1902,7 @@ async def test_bash_shell_state_persists_across_chat_turns(
     turns: the snapshot is persisted, left intact by turns without bash
     activity, and restored into the next turn's shell."""
     session_id = "55555555-5555-4555-8555-555555555555"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     note_path = "/home/user/workspace/note.txt"
     _mock_turn_models(
         monkeypatch,
@@ -1997,7 +1987,7 @@ async def test_server_agent_chat_turn_persists_session_transcript(
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
     session_id = "56565656-5656-4656-8656-565656565656"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
         _server_agent_chat_url(agent_session_id),
@@ -2048,7 +2038,7 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
     ``agent_id="server"``: pins the snapshot wiring ``build_server_agent``
     gained for the session route."""
     session_id = "57575757-5757-4757-8757-575757575757"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     note_path = "/home/user/workspace/note.txt"
     _mock_turn_models(
         monkeypatch,
@@ -2099,7 +2089,7 @@ async def test_server_agent_chat_is_forbidden_when_bash_is_disabled(
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
     session_id = "58585858-5858-4858-8858-585858585858"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     server_response = await httpx_client.post(
         _server_agent_chat_url(agent_session_id),
@@ -2233,7 +2223,7 @@ async def test_agents_router_is_forbidden_in_read_only_mode(
 ) -> None:
     """Read-only mode turns off the whole agents router, chat included."""
     session_id = "77777777-7777-4777-8777-777777777777"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     app.state.read_only = True
 
     create_response = await httpx_client.post("/agents/server/sessions", json={})
@@ -2346,7 +2336,7 @@ async def test_chat_turn_trace_ingestion_merges_backend_spans_into_browser_trace
     await _ingest_browser_trace(db)
     _mock_traced_test_model(monkeypatch)
     session_id = "66666666-6666-4666-8666-666666666666"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await _post_traced_chat_turn(httpx_client, session_id, agent_session_id)
     assert response.status_code == 200
@@ -2399,7 +2389,7 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
     await _ingest_browser_trace(db)
     _mock_traced_test_model(monkeypatch)
     session_id = "77777777-7777-4777-8777-777777777777"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", SAWarning)
@@ -2411,7 +2401,11 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
         assert agent_session is not None
         project_session = await session.scalar(
             select(models.ProjectSession).where(
-                models.ProjectSession.session_id == agent_session.project_session_id
+                models.ProjectSession.session_id
+                == derive_otel_session_id(
+                    project_name=agent_session.project_name,
+                    agent_session_rowid=agent_session.id,
+                )
             )
         )
         assert project_session is not None
@@ -2452,7 +2446,7 @@ async def test_resumed_chat_turn_keeps_original_trace_project(
     session_request_id = "88888888-8888-4888-8888-888888888888"
 
     monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", original_project_name)
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_request_id)
+    agent_session_id = await _create_agent_session_row(db)
     first_response = await httpx_client.post(
         _chat_url(agent_session_id),
         json=_chat_body(

--- a/tests/unit/server/agents/test_legacy_agents_router.py
+++ b/tests/unit/server/agents/test_legacy_agents_router.py
@@ -211,7 +211,6 @@ async def test_new_chat_route_is_unaffected_by_the_legacy_registration(
     session_id = "99999999-9999-4999-8999-999999999999"
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=session_id,
             user_id=None,
             title="Already titled",
             project_name=get_env_phoenix_agents_assistant_project_name(),
@@ -254,7 +253,6 @@ async def test_new_contract_body_on_the_server_agent_url_delegates_to_the_sessio
     session_id = "13131313-1313-4313-8313-131313131313"
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=session_id,
             user_id=None,
             title="Already titled",
             project_name=get_env_phoenix_agents_assistant_project_name(),

--- a/tests/unit/server/agents/test_session_history.py
+++ b/tests/unit/server/agents/test_session_history.py
@@ -45,7 +45,6 @@ async def test_load_agent_session_history_returns_the_full_uncompacted_transcrip
     ]
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             user_id=None,
             title="Session",
             project_name="assistant_agent",
@@ -90,7 +89,6 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
     ]
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             user_id=None,
             title="Session",
             project_name="assistant_agent",
@@ -127,7 +125,6 @@ async def test_uppercase_and_lowercase_uuids_are_both_accepted(
 ) -> None:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             user_id=None,
             title="Session",
             project_name="assistant_agent",

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -12,7 +12,7 @@ from phoenix.db.types.data_stream_protocol import (
     TextUIPart,
 )
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
-from phoenix.server.api.helpers.agent_sessions import derive_otel_session_id
+from phoenix.server.api.helpers.agent_sessions import get_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_compaction_message,
     _load_agent_session_history,
@@ -406,10 +406,10 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
         source_session, branch_session = sorted(
             agent_sessions, key=lambda agent_session: agent_session.id
         )
-        assert derive_otel_session_id(
+        assert get_otel_session_id(
             project_name=branch_session.project_name,
             agent_session_rowid=branch_session.id,
-        ) != derive_otel_session_id(
+        ) != get_otel_session_id(
             project_name=source_session.project_name,
             agent_session_rowid=source_session.id,
         )

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -12,6 +12,7 @@ from phoenix.db.types.data_stream_protocol import (
     TextUIPart,
 )
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
+from phoenix.server.api.helpers.agent_sessions import derive_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_compaction_message,
     _load_agent_session_history,
@@ -149,7 +150,6 @@ async def _seed_session_with_transcript(
 ) -> str:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="12121212-1212-4121-8121-121212121212",
             user_id=None,
             title=title,
             project_name="assistant_agent",
@@ -401,12 +401,18 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
         assert set(row.message_id for row in branch_messages).isdisjoint(
             row.message_id for row in source_messages
         )
-        # The branch mints its own OTel session identity and uses the currently
-        # configured trace project.
+        # The branch gets its own OTel session identity (derived from its own
+        # row id) and uses the currently configured trace project.
         source_session, branch_session = sorted(
             agent_sessions, key=lambda agent_session: agent_session.id
         )
-        assert branch_session.project_session_id != source_session.project_session_id
+        assert derive_otel_session_id(
+            project_name=branch_session.project_name,
+            agent_session_rowid=branch_session.id,
+        ) != derive_otel_session_id(
+            project_name=source_session.project_name,
+            agent_session_rowid=source_session.id,
+        )
         assert branch_session.project_name == configured_project_name
         assert branch_session.project_name != source_session.project_name
 
@@ -573,7 +579,6 @@ async def test_create_agent_session_creates_empty_owned_session(
         assert payload["id"] == str(GlobalID("AgentSession", str(agent_session.id)))
         assert agent_session.user_id is None
         assert agent_session.title == ""
-        assert agent_session.project_session_id
         assert agent_session.expires_at is None
         assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
 
@@ -638,10 +643,8 @@ async def test_create_agent_session_mints_distinct_sessions(
         != second.data["createAgentSession"]["agentSession"]["id"]
     )
     async with db() as session:
-        project_session_ids = (
-            await session.scalars(select(models.AgentSession.project_session_id))
-        ).all()
-        assert len(set(project_session_ids)) == 2
+        agent_session_rowids = (await session.scalars(select(models.AgentSession.id))).all()
+        assert len(set(agent_session_rowids)) == 2
 
 
 async def test_create_agent_session_rejects_long_title(
@@ -664,7 +667,6 @@ async def test_update_agent_session_title(
 ) -> None:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             user_id=None,
             title="Old title",
             project_name="assistant_agent",
@@ -692,7 +694,6 @@ async def test_update_agent_session_title_rejects_empty_title(
 ) -> None:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             user_id=None,
             title="Old title",
             project_name="assistant_agent",
@@ -718,7 +719,6 @@ async def test_update_agent_session_title_rejects_long_title(
 ) -> None:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             user_id=None,
             title="Old title",
             project_name="assistant_agent",
@@ -750,7 +750,6 @@ async def test_delete_agent_session_cascades_snapshot(
     now = datetime(2026, 1, 1, tzinfo=timezone.utc)
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             user_id=None,
             title="doomed session",
             project_name="assistant_agent",

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -60,16 +60,13 @@ class TestAgentSessionPersistence:
     ) -> None:
         async with db() as session:
             created = models.AgentSession(
-                project_session_id="11111111-1111-4111-8111-111111111111",
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
             )
             session.add(created)
             await session.flush()
-            assert created.project_session_id == "11111111-1111-4111-8111-111111111111"
             created_rowid = created.id
-            created_project_session_id = created.project_session_id
 
         async with db() as session:
             loaded = await _refresh_and_load_agent_session(
@@ -79,7 +76,6 @@ class TestAgentSessionPersistence:
             )
             assert loaded is not None
             assert loaded.id == created_rowid
-            assert loaded.project_session_id == created_project_session_id
             await session.execute(
                 delete(models.AgentSession).where(models.AgentSession.id == created_rowid)
             )
@@ -97,7 +93,6 @@ class TestAgentSessionPersistence:
     async def test_deleted_rowid_is_not_reused(self, db: DbSessionFactory) -> None:
         async with db() as session:
             first = models.AgentSession(
-                project_session_id="11111111-1111-4111-8111-111111111111",
                 user_id=None,
                 title="first",
                 project_name="assistant_agent",
@@ -109,7 +104,6 @@ class TestAgentSessionPersistence:
 
         async with db() as session:
             second = models.AgentSession(
-                project_session_id="22222222-2222-4222-8222-222222222222",
                 user_id=None,
                 title="second",
                 project_name="assistant_agent",
@@ -124,7 +118,6 @@ class TestAgentSessionPersistence:
     ) -> None:
         async with db() as session:
             temporary = models.AgentSession(
-                project_session_id="33333333-3333-4333-8333-333333333333",
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
@@ -161,7 +154,6 @@ class TestAgentSessionPersistence:
         stale = datetime.now(timezone.utc) - timedelta(days=30)
         async with db() as session:
             persistent = models.AgentSession(
-                project_session_id="44444444-4444-4444-8444-444444444444",
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
@@ -199,7 +191,6 @@ class TestAgentSessionPersistence:
     ) -> None:
         async with db() as session:
             temporary = models.AgentSession(
-                project_session_id="55555555-5555-4555-8555-555555555555",
                 user_id=None,
                 title="",
                 project_name="assistant_agent",

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from uuid import uuid4
 
 from sqlalchemy import select
 from strawberry.relay import GlobalID
@@ -24,7 +23,6 @@ async def _seed_agent_session(
 ) -> str:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             user_id=user_id,
             title=title,
             project_name="assistant_agent",

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from uuid import uuid4
 
 from sqlalchemy import select
 
@@ -33,7 +32,6 @@ async def _add_agent_session(
 ) -> int:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             project_name="assistant_agent",
             user_id=user_id,
             title=title,
@@ -81,21 +79,18 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
     now = datetime.now(timezone.utc)
     async with db() as session:
         expired = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             project_name="assistant_agent",
             user_id=None,
             title="expired",
             expires_at=now - timedelta(hours=1),
         )
         future = models.AgentSession(
-            project_session_id="22222222-2222-4222-8222-222222222222",
             project_name="assistant_agent",
             user_id=None,
             title="future",
             expires_at=now + timedelta(hours=1),
         )
         persistent = models.AgentSession(
-            project_session_id="33333333-3333-4333-8333-333333333333",
             project_name="assistant_agent",
             user_id=None,
             title="persistent",


### PR DESCRIPTION
Closes #14887

Part 2 of a 5-PR stack. **Base: `agent-sessions-message-schema` (#14907)** — review that one first.

Drops `agent_sessions.project_session_id`, deriving the OTel `session.id` from the project name and the session's relay node id instead. The stored UUID was a second source of truth for something the primary key already made unique.