### PR TITLE
feat(agents): turn both chat retention rules on by default at 30

### DIFF
--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -12,10 +12,7 @@ import type { SettingsAgentsWorkspaceCardSetSessionRetentionMutation } from "./_
 import type { SettingsAgentsWorkspaceCardSetTraceRecordingMutation } from "./__generated__/SettingsAgentsWorkspaceCardSetTraceRecordingMutation.graphql";
 
 /**
- * Values restored when an admin re-enables a retention rule that was off.
- * These mirror the server-side defaults in
- * `phoenix.server.settings.registry.AgentSessionRetentionSetting`, so toggling
- * a rule back on returns it to the value the workspace started from.
+ * Values restored when an admin re-enables a retention rule that was off
  */
 const DEFAULT_SESSION_RETENTION_MAX_IDLE_DAYS = 30;
 const DEFAULT_SESSION_RETENTION_MAX_COUNT_PER_USER = 30;

--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -12,9 +12,12 @@ import type { SettingsAgentsWorkspaceCardSetSessionRetentionMutation } from "./_
 import type { SettingsAgentsWorkspaceCardSetTraceRecordingMutation } from "./__generated__/SettingsAgentsWorkspaceCardSetTraceRecordingMutation.graphql";
 
 /**
- * Values restored when an admin re-enables a retention rule that was off
+ * Values restored when an admin re-enables a retention rule that was off.
+ * These mirror the server-side defaults in
+ * `phoenix.server.settings.registry.AgentSessionRetentionSetting`, so toggling
+ * a rule back on returns it to the value the workspace started from.
  */
-const DEFAULT_SESSION_RETENTION_MAX_IDLE_DAYS = 7;
+const DEFAULT_SESSION_RETENTION_MAX_IDLE_DAYS = 30;
 const DEFAULT_SESSION_RETENTION_MAX_COUNT_PER_USER = 30;
 
 const settingsListCSS = css`

--- a/src/phoenix/server/settings/registry.py
+++ b/src/phoenix/server/settings/registry.py
@@ -37,14 +37,7 @@ DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER = 30
 
 
 class AgentSessionRetentionSetting(BaseModel):
-    """Workspace-wide retention for non-temporary agent sessions.
-
-    Both rules are on by default so a deployment that never visits the admin
-    settings still bounds how much chat history it accumulates. ``0`` means the
-    rule is off; these defaults apply when the
-    ``agent.assistant.session_retention`` row is absent, i.e. until an admin
-    saves a value of their own.
-    """
+    """Workspace-wide retention for non-temporary agent sessions."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
 

--- a/src/phoenix/server/settings/registry.py
+++ b/src/phoenix/server/settings/registry.py
@@ -32,13 +32,24 @@ class AgentAssistantEnabledSetting(BaseModel):
     enabled: bool = Field(default=True)
 
 
+DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS = 30
+DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER = 30
+
+
 class AgentSessionRetentionSetting(BaseModel):
-    """Workspace-wide retention for non-temporary agent sessions."""
+    """Workspace-wide retention for non-temporary agent sessions.
+
+    Both rules are on by default so a deployment that never visits the admin
+    settings still bounds how much chat history it accumulates. ``0`` means the
+    rule is off; these defaults apply when the
+    ``agent.assistant.session_retention`` row is absent, i.e. until an admin
+    saves a value of their own.
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
 
-    max_idle_days: int = Field(default=0, ge=0)
-    max_count_per_user: int = Field(default=0, ge=0)
+    max_idle_days: int = Field(default=DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS, ge=0)
+    max_count_per_user: int = Field(default=DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER, ge=0)
 
 
 SETTINGS_REGISTRY: Mapping[SystemSettingKey, type[BaseModel]] = MappingProxyType(

--- a/tests/unit/server/api/mutations/test_agent_session_retention_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_retention_mutations.py
@@ -6,6 +6,10 @@ from typing import Any
 
 import pytest
 
+from phoenix.server.settings.registry import (
+    DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER,
+    DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS,
+)
 from tests.unit.graphql import AsyncGraphQLClient
 
 _RETENTION_QUERY = """
@@ -54,6 +58,28 @@ async def test_mutation_persists_and_query_reflects_write(
 async def test_query_returns_defaults_when_setting_is_unset(
     gql_client: AsyncGraphQLClient,
 ) -> None:
+    """Both rules are on out of the box, so the admin switches render on."""
+    q = await gql_client.execute(_RETENTION_QUERY, {})
+    assert not q.errors
+    assert q.data is not None
+    config = q.data["agentsConfig"]
+    assert config["sessionRetentionMaxIdleDays"] == DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS == 30
+    assert (
+        config["sessionRetentionMaxCountPerUser"] == DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER == 30
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_returns_null_once_an_admin_turns_a_rule_off(
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    """Null still means off — the new defaults do not take that away."""
+    disabled = await gql_client.execute(
+        _SET_RETENTION_MUTATION,
+        {"input": {"maxIdleDays": None, "maxCountPerUser": None}},
+    )
+    assert not disabled.errors
+
     q = await gql_client.execute(_RETENTION_QUERY, {})
     assert not q.errors
     assert q.data is not None

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -6,7 +6,11 @@ from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.daemons.agent_session_sweeper import AgentSessionSweeper
 from phoenix.server.daemons.system_settings import SystemSettings
-from phoenix.server.settings.registry import SETTINGS_REGISTRY, AgentSessionRetentionSetting
+from phoenix.server.settings.registry import (
+    DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER,
+    SETTINGS_REGISTRY,
+    AgentSessionRetentionSetting,
+)
 from phoenix.server.types import DbSessionFactory
 from tests.unit._helpers import _message_uuid
 
@@ -254,3 +258,43 @@ async def test_setting_edits_apply_on_the_next_sweep(
     await settings.update_agent_session_retention(AgentSessionRetentionSetting(max_idle_days=30))
     await sweeper._sweep()
     assert await _remaining_session_ids(db) == set()
+
+
+async def test_default_settings_enforce_both_rules_without_admin_configuration(
+    db: DbSessionFactory,
+) -> None:
+    """A workspace that never saves a retention setting still gets both rules.
+
+    ``_make_settings`` with no override leaves the
+    ``agent.assistant.session_retention`` row absent, which is the state every
+    deployment starts in.
+    """
+    now = datetime.now(timezone.utc)
+    user_id = await _add_user(db, "default-retention-user", "MEMBER")
+    idle_session_id = await _add_agent_session(
+        db,
+        title="idle past the default 30 days",
+        user_id=user_id,
+        updated_at=now - timedelta(days=31),
+    )
+    recent_session_ids = [
+        await _add_agent_session(
+            db,
+            title=f"recent session {minutes_ago}",
+            user_id=user_id,
+            updated_at=now - timedelta(minutes=minutes_ago),
+        )
+        # One more than the default per-user cap, so the oldest is trimmed.
+        for minutes_ago in range(DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER + 1)
+    ]
+
+    settings = await _make_settings(db)
+    assert settings.agent_session_retention.max_idle_days == 30
+    assert settings.agent_session_retention.max_count_per_user == 30
+    await AgentSessionSweeper(db, settings=settings)._sweep()
+
+    remaining_ids = await _remaining_session_ids(db)
+    # The idle session is gone on the idle rule, and the count cap keeps only
+    # the 30 most recently active of the user's remaining sessions.
+    assert idle_session_id not in remaining_ids
+    assert remaining_ids == set(recent_session_ids[:DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER])

--- a/tests/unit/server/daemons/test_system_settings.py
+++ b/tests/unit/server/daemons/test_system_settings.py
@@ -7,6 +7,8 @@ import pytest
 from phoenix.db import models
 from phoenix.server.daemons.system_settings import SystemSettings
 from phoenix.server.settings.registry import (
+    DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER,
+    DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS,
     SETTINGS_REGISTRY,
     AgentSessionRetentionSetting,
     AgentTraceRecordingSetting,
@@ -48,11 +50,13 @@ async def test_update_agent_trace_recording_persists_and_updates_cache(
 async def test_agent_session_retention_defaults_when_unset(
     db: DbSessionFactory,
 ) -> None:
+    """Both retention rules are on by default, so a workspace that never opens
+    the admin settings still bounds how much chat history it keeps."""
     settings = SystemSettings(db=db, registry=SETTINGS_REGISTRY)
     await settings.bootstrap()
     retention = settings.agent_session_retention
-    assert retention.max_idle_days == 0
-    assert retention.max_count_per_user == 0
+    assert retention.max_idle_days == DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS == 30
+    assert retention.max_count_per_user == DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER == 30
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #14892

Part 3 of a 5-PR stack. **Base: `agent-sessions-derive-project-session-id` (#14908)** — review that one first.

Turns both agent-session retention rules on by default at 30 (`max_idle_days` and `max_count_per_user`, previously `0`/off). `0` still means off and admins who already saved a value keep it, since these only apply when the `agent.assistant.session_retention` row is absent.