### PR TITLE
refactor(agents): store session ephemerality as a flag, not a deadline

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -100,7 +100,7 @@ type AgentSession implements Node {
   latestOutput: String
 
   """Whether the session expires after a period of inactivity."""
-  isTemporary: Boolean!
+  isEphemeral: Boolean!
 
   """
   Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -772,7 +772,7 @@ input CreateAgentSessionInput {
   title: String! = ""
 
   """Whether the session should expire after a period of inactivity."""
-  temporary: Boolean! = false
+  isEphemeral: Boolean! = false
 }
 
 type CreateAgentSessionMutationPayload {

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1727,8 +1727,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -1753,8 +1753,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
         };
         /**
          * AgentSpanContext
@@ -2157,11 +2157,11 @@ export interface components {
              */
             title?: string;
             /**
-             * Temporary
+             * Is Ephemeral
              * @description Whether the session should expire after a period of inactivity.
              * @default false
              */
-            temporary?: boolean;
+            is_ephemeral?: boolean;
         };
         /** CreateAgentSessionResponseBody */
         CreateAgentSessionResponseBody: {

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -123,7 +123,7 @@ function AgentSessionsContent({
               id
               title
               ...EditAgentSessionTitleDialog_session
-              isTemporary
+              isTemporary: isEphemeral
               createdAt
               updatedAt
             }

--- a/app/src/components/agent/__generated__/AgentSessionsResourcePaginationQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourcePaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<06e11f57638515f75455be8f410c4c82>>
+ * @generated SignedSource<<bceb1d1bfd99b2569314bc38ce1df637>>
  * @lightSyntaxTransform
  */
 
@@ -117,10 +117,10 @@ return {
                     "storageKey": null
                   },
                   {
-                    "alias": null,
+                    "alias": "isTemporary",
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "isTemporary",
+                    "name": "isEphemeral",
                     "storageKey": null
                   },
                   {
@@ -197,16 +197,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b4aa0b78f54f056bd71628fd754ea303",
+    "cacheID": "b1c4d74d9e472d684ccaa359d9620207",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourcePaginationQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourcePaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...AgentSessionsResource_sessions_2HEEH6\n}\n\nfragment AgentSessionsResource_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after, viewerOnly: true) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "query AgentSessionsResourcePaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...AgentSessionsResource_sessions_2HEEH6\n}\n\nfragment AgentSessionsResource_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after, viewerOnly: true) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary: isEphemeral\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "433f0c5b7c523da05b9b2a1f7d6242f6";
+(node as any).hash = "f139691753745b6b9ab58de36be057c4";
 
 export default node;

--- a/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6528be05f80c7abbc017e0a5a83acc47>>
+ * @generated SignedSource<<9f152b21fde87ba5fdcf244ff1f1ddab>>
  * @lightSyntaxTransform
  */
 
@@ -104,10 +104,10 @@ return {
                     "storageKey": null
                   },
                   {
-                    "alias": null,
+                    "alias": "isTemporary",
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "isTemporary",
+                    "name": "isEphemeral",
                     "storageKey": null
                   },
                   {
@@ -184,12 +184,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f5e0b4e4e259e818ee95c0a45b60bc3a",
+    "cacheID": "347819b47fc2e5e986e683ee91fb07fe",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourceQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first, viewerOnly: true) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first, viewerOnly: true) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary: isEphemeral\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/AgentSessionsResource_sessions.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResource_sessions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e53fcab1aaf5f228a9e075d76edec4ec>>
+ * @generated SignedSource<<05f2cb9ce0229829d34661fd8e7bb974>>
  * @lightSyntaxTransform
  */
 
@@ -117,10 +117,10 @@ return {
                   "name": "EditAgentSessionTitleDialog_session"
                 },
                 {
-                  "alias": null,
+                  "alias": "isTemporary",
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "isTemporary",
+                  "name": "isEphemeral",
                   "storageKey": null
                 },
                 {
@@ -191,6 +191,6 @@ return {
 };
 })();
 
-(node as any).hash = "433f0c5b7c523da05b9b2a1f7d6242f6";
+(node as any).hash = "f139691753745b6b9ab58de36be057c4";
 
 export default node;

--- a/app/src/components/agent/__generated__/agentSessionRelaySessionQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/agentSessionRelaySessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f911423ffcf7bfc8b59fb172854cd0d5>>
+ * @generated SignedSource<<b0711c282d7d41a0bef57d1a35a79a50>>
  * @lightSyntaxTransform
  */
 
@@ -75,10 +75,10 @@ v4 = {
   "storageKey": null
 },
 v5 = {
-  "alias": null,
+  "alias": "isTemporary",
   "args": null,
   "kind": "ScalarField",
-  "name": "isTemporary",
+  "name": "isEphemeral",
   "storageKey": null
 },
 v6 = {
@@ -240,16 +240,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d5db0cbad69bfa0a719d1e260e54a6b4",
+    "cacheID": "4836634597c05ab5b6a082d4fa40a454",
     "id": null,
     "metadata": {},
     "name": "agentSessionRelaySessionQuery",
     "operationKind": "query",
-    "text": "query agentSessionRelaySessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      title\n      isTemporary\n      isActive\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n    id\n  }\n}\n"
+    "text": "query agentSessionRelaySessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      title\n      isTemporary: isEphemeral\n      isActive\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4c69ea26b4f6bd6062b44c40c90a3b3d";
+(node as any).hash = "898522d8afdc3e0dbb3ef55c2877b2bd";
 
 export default node;

--- a/app/src/components/agent/__generated__/useAgentChatBranchAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatBranchAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8ed6863de084a4ed0efda81283259d64>>
+ * @generated SignedSource<<5d5c25bd7fc69b84d8c73ac730a24306>>
  * @lightSyntaxTransform
  */
 
@@ -74,10 +74,10 @@ v4 = {
   "storageKey": null
 },
 v5 = {
-  "alias": null,
+  "alias": "isTemporary",
   "args": null,
   "kind": "ScalarField",
-  "name": "isTemporary",
+  "name": "isEphemeral",
   "storageKey": null
 },
 v6 = {
@@ -268,16 +268,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ee106d4c97f8f5c44af496a52566748a",
+    "cacheID": "f89b7b8b0f97a65da3e3761790631b80",
     "id": null,
     "metadata": {},
     "name": "useAgentChatBranchAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentChatBranchAgentSessionMutation(\n  $input: BranchAgentSessionInput!\n) {\n  branchAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "mutation useAgentChatBranchAgentSessionMutation(\n  $input: BranchAgentSessionInput!\n) {\n  branchAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary: isEphemeral\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ea4b5de46dbc482c61564732e61b63f4";
+(node as any).hash = "6354f2496c291bef8b6b164863a43f4d";
 
 export default node;

--- a/app/src/components/agent/__generated__/useAgentChatCreateAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatCreateAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ca5e913d1bdf416fceb3c6a163b19943>>
+ * @generated SignedSource<<ffe1d051af9f47adb4267c5c2a572782>>
  * @lightSyntaxTransform
  */
 
@@ -10,7 +10,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type CreateAgentSessionInput = {
-  temporary?: boolean;
+  isEphemeral?: boolean;
   title?: string;
 };
 export type useAgentChatCreateAgentSessionMutation$variables = {
@@ -73,10 +73,10 @@ v4 = {
   "storageKey": null
 },
 v5 = {
-  "alias": null,
+  "alias": "isTemporary",
   "args": null,
   "kind": "ScalarField",
-  "name": "isTemporary",
+  "name": "isEphemeral",
   "storageKey": null
 },
 v6 = {
@@ -258,16 +258,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "54928aa36e9c467058c835f7a21e286e",
+    "cacheID": "2039e2649105fef21ec6b368b88c0445",
     "id": null,
     "metadata": {},
     "name": "useAgentChatCreateAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentChatCreateAgentSessionMutation(\n  $input: CreateAgentSessionInput!\n) {\n  createAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "mutation useAgentChatCreateAgentSessionMutation(\n  $input: CreateAgentSessionInput!\n) {\n  createAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary: isEphemeral\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "bf2a214d202d18185d935badc2e9e6f4";
+(node as any).hash = "d68c9de400e08e55cb088409bf0b790e";
 
 export default node;

--- a/app/src/components/agent/agentSessionRelay.ts
+++ b/app/src/components/agent/agentSessionRelay.ts
@@ -25,7 +25,7 @@ export const agentSessionQuery = graphql`
       ... on AgentSession {
         id
         title
-        isTemporary
+        isTemporary: isEphemeral
         isActive
         createdAt
         updatedAt

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -134,7 +134,7 @@ const createAgentSessionMutation = graphql`
         id
         title
         ...EditAgentSessionTitleDialog_session
-        isTemporary
+        isTemporary: isEphemeral
         createdAt
         updatedAt
         firstInput
@@ -184,7 +184,7 @@ const branchAgentSessionMutation = graphql`
         id
         title
         ...EditAgentSessionTitleDialog_session
-        isTemporary
+        isTemporary: isEphemeral
         createdAt
         updatedAt
         firstInput
@@ -703,7 +703,7 @@ export function useAgentChat({
     const isTemporary = store.getState().isDraftSessionTemporary;
     commitCreateAgentSession({
       variables: {
-        input: { temporary: isTemporary },
+        input: { isEphemeral: isTemporary },
         connections: isTemporary
           ? [sessionsConnectionId]
           : [sessionsConnectionId, settingsSessionsConnectionId],

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -125,7 +125,7 @@ export async function createAgentSession({
   try {
     const { data: payload } = await client.POST("/agents/{agent_id}/sessions", {
       params: { path: { agent_id: SERVER_AGENT_ID } },
-      body: { title: "", temporary },
+      body: { title: "", is_ephemeral: temporary },
     });
     agentSessionId = payload?.data.id;
   } catch (error) {
@@ -184,11 +184,11 @@ export function createPxiSessionClient({
         );
       }
       return payload.data.map(
-        ({ id, title, updated_at, is_temporary }): PxiSessionSummary => ({
+        ({ id, title, updated_at, is_ephemeral }): PxiSessionSummary => ({
           id,
           title,
           updatedAt: updated_at,
-          isTemporary: is_temporary,
+          isTemporary: is_ephemeral,
         })
       );
     },
@@ -212,7 +212,7 @@ export function createPxiSessionClient({
         id: session.id,
         title: session.title,
         updatedAt: session.updated_at,
-        isTemporary: session.is_temporary,
+        isTemporary: session.is_ephemeral,
         // Read defensively: the CLI consumes phoenix-client's built types,
         // which may not carry `is_active` until that package rebuilds.
         // An absent field means no lock is held.

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -190,11 +190,11 @@ describe("PXI client", () => {
       async (_input: string | URL | Request, init?: RequestInit) => {
         const request =
           _input instanceof Request ? _input : new Request(_input, init);
-        const body = (await request.json()) as { temporary: boolean };
+        const body = (await request.json()) as { is_ephemeral: boolean };
         return new Response(
           JSON.stringify({
             data: {
-              id: body.temporary ? "temporary-session" : "persisted-session",
+              id: body.is_ephemeral ? "temporary-session" : "persisted-session",
             },
           }),
           { status: 201, headers: { "Content-Type": "application/json" } }
@@ -231,7 +231,7 @@ describe("PXI client", () => {
                 title: "Investigate traces",
                 created_at: "2026-07-24T11:00:00Z",
                 updated_at: "2026-07-24T12:00:00Z",
-                is_temporary: false,
+                is_ephemeral: false,
               },
             ],
             next_cursor: null,
@@ -247,7 +247,7 @@ describe("PXI client", () => {
               title: "Investigate traces",
               created_at: "2026-07-24T11:00:00Z",
               updated_at: "2026-07-24T12:00:00Z",
-              is_temporary: false,
+              is_ephemeral: false,
               messages: [
                 {
                   id: "user-1",

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1727,8 +1727,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -1753,8 +1753,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
         };
         /**
          * AgentSpanContext
@@ -2157,11 +2157,11 @@ export interface components {
              */
             title?: string;
             /**
-             * Temporary
+             * Is Ephemeral
              * @description Whether the session should expire after a period of inactivity.
              * @default false
              */
-            temporary?: boolean;
+            is_ephemeral?: boolean;
         };
         /** CreateAgentSessionResponseBody */
         CreateAgentSessionResponseBody: {

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1727,8 +1727,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -1753,8 +1753,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
         };
         /**
          * AgentSpanContext
@@ -2157,11 +2157,11 @@ export interface components {
              */
             title?: string;
             /**
-             * Temporary
+             * Is Ephemeral
              * @description Whether the session should expire after a period of inactivity.
              * @default false
              */
-            temporary?: boolean;
+            is_ephemeral?: boolean;
         };
         /** CreateAgentSessionResponseBody */
         CreateAgentSessionResponseBody: {

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -17,7 +17,7 @@ class AgentSessionSummary(TypedDict):
     title: str
     created_at: str
     updated_at: str
-    is_temporary: bool
+    is_ephemeral: bool
 
 
 class AgentSpanContext(TypedDict):
@@ -91,7 +91,7 @@ class CodeEvaluatorContext(TypedDict):
 
 class CreateAgentSessionRequestBody(TypedDict):
     title: NotRequired[str]
-    temporary: NotRequired[bool]
+    is_ephemeral: NotRequired[bool]
 
 
 class CreateAgentSessionResponseBody(TypedDict):
@@ -1925,7 +1925,7 @@ class AgentSessionData(TypedDict):
     title: str
     created_at: str
     updated_at: str
-    is_temporary: bool
+    is_ephemeral: bool
     is_active: bool
     messages: Sequence[PhoenixUIMessage]
 

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -8465,9 +8465,9 @@
             "format": "date-time",
             "title": "Updated At"
           },
-          "is_temporary": {
+          "is_ephemeral": {
             "type": "boolean",
-            "title": "Is Temporary"
+            "title": "Is Ephemeral"
           },
           "is_active": {
             "type": "boolean",
@@ -8488,7 +8488,7 @@
           "title",
           "created_at",
           "updated_at",
-          "is_temporary",
+          "is_ephemeral",
           "is_active",
           "messages"
         ],
@@ -8514,9 +8514,9 @@
             "format": "date-time",
             "title": "Updated At"
           },
-          "is_temporary": {
+          "is_ephemeral": {
             "type": "boolean",
-            "title": "Is Temporary"
+            "title": "Is Ephemeral"
           }
         },
         "type": "object",
@@ -8525,7 +8525,7 @@
           "title",
           "created_at",
           "updated_at",
-          "is_temporary"
+          "is_ephemeral"
         ],
         "title": "AgentSessionSummary"
       },
@@ -9575,9 +9575,9 @@
             "description": "Optional initial title.",
             "default": ""
           },
-          "temporary": {
+          "is_ephemeral": {
             "type": "boolean",
-            "title": "Temporary",
+            "title": "Is Ephemeral",
             "description": "Whether the session should expire after a period of inactivity.",
             "default": false
           }

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -443,7 +443,7 @@ CREATE TABLE public.agent_sessions (
     project_name VARCHAR NOT NULL,
     user_id BIGINT,
     title VARCHAR NOT NULL,
-    expires_at TIMESTAMP WITH TIME ZONE,
+    is_ephemeral BOOLEAN NOT NULL DEFAULT false,
     heartbeat_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
@@ -454,8 +454,8 @@ CREATE TABLE public.agent_sessions (
         ON DELETE CASCADE
 );
 
-CREATE INDEX ix_agent_sessions_expires_at ON public.agent_sessions
-    USING btree (expires_at) WHERE (expires_at IS NOT NULL);
+CREATE INDEX ix_agent_sessions_ephemeral_updated_at ON public.agent_sessions
+    USING btree (updated_at) WHERE (is_ephemeral IS TRUE);
 CREATE INDEX ix_agent_sessions_user_id_updated_at ON public.agent_sessions
     USING btree (user_id, updated_at DESC);
 

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -443,7 +443,7 @@ CREATE TABLE public.agent_sessions (
     project_name VARCHAR NOT NULL,
     user_id BIGINT,
     title VARCHAR NOT NULL,
-    is_ephemeral BOOLEAN NOT NULL DEFAULT false,
+    is_ephemeral BOOLEAN NOT NULL,
     heartbeat_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -3641,8 +3641,8 @@ PLAYGROUND_PROJECT_NAME = "playground"
 EPHEMERAL_EXPERIMENT_TIME_TO_LIVE_HOURS = 24
 """The time to live for ephemeral experiments in hours."""
 
-TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS = 24
-"""How many hours temporary assistant sessions live after their latest chat turn."""
+EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS = 24
+"""How many hours ephemeral assistant sessions live after their latest chat turn."""
 
 SYSTEM_USER_ID: Optional[int] = None
 """

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -89,12 +89,7 @@ def upgrade() -> None:
             nullable=True,  # sessions may be created while auth is disabled
         ),
         sa.Column("title", sa.String, nullable=False),
-        sa.Column(
-            "is_ephemeral",
-            sa.Boolean,
-            nullable=False,
-            server_default=sa.false(),
-        ),
+        sa.Column("is_ephemeral", sa.Boolean, nullable=False),
         sa.Column("heartbeat_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column(
             "created_at",

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -89,7 +89,12 @@ def upgrade() -> None:
             nullable=True,  # sessions may be created while auth is disabled
         ),
         sa.Column("title", sa.String, nullable=False),
-        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "is_ephemeral",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.false(),
+        ),
         sa.Column("heartbeat_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column(
             "created_at",
@@ -112,11 +117,11 @@ def upgrade() -> None:
         ["user_id", sa.column("updated_at").desc()],
     )
     op.create_index(
-        "ix_agent_sessions_expires_at",
+        "ix_agent_sessions_ephemeral_updated_at",
         "agent_sessions",
-        ["expires_at"],
-        postgresql_where=sa.text("expires_at IS NOT NULL"),
-        sqlite_where=sa.text("expires_at IS NOT NULL"),
+        ["updated_at"],
+        postgresql_where=sa.text("is_ephemeral IS TRUE"),
+        sqlite_where=sa.text("is_ephemeral IS TRUE"),
     )
 
     message = sa.Column("message", JSON_, nullable=False)

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3313,7 +3313,17 @@ class AgentSession(HasId):
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
     )
-    expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True)
+    is_ephemeral: Mapped[bool] = mapped_column(
+        default=False,
+        server_default=sa.false(),
+    )
+    """Whether the sweeper reaps this session once it has been idle for the ephemeral TTL.
+
+    A flag rather than a deadline column: the deadline was only ever
+    ``updated_at`` plus a fixed constant, so storing it duplicated a value the
+    row already carried and had to be rewritten on every turn to keep the
+    window sliding. Surfaced to clients as ``temporary``.
+    """
     heartbeat_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True)
     user: Mapped[Optional["User"]] = relationship("User")
     snapshot: Mapped[Optional["AgentSessionSnapshot"]] = relationship(
@@ -3334,10 +3344,10 @@ class AgentSession(HasId):
             updated_at.desc(),
         ),
         Index(
-            "ix_agent_sessions_expires_at",
-            "expires_at",
-            postgresql_where=text("expires_at IS NOT NULL"),
-            sqlite_where=text("expires_at IS NOT NULL"),
+            "ix_agent_sessions_ephemeral_updated_at",
+            "updated_at",
+            postgresql_where=text("is_ephemeral IS TRUE"),
+            sqlite_where=text("is_ephemeral IS TRUE"),
         ),
         dict(sqlite_autoincrement=True),
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3313,17 +3313,7 @@ class AgentSession(HasId):
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
     )
-    is_ephemeral: Mapped[bool] = mapped_column(
-        default=False,
-        server_default=sa.false(),
-    )
-    """Whether the sweeper reaps this session once it has been idle for the ephemeral TTL.
-
-    A flag rather than a deadline column: the deadline was only ever
-    ``updated_at`` plus a fixed constant, so storing it duplicated a value the
-    row already carried and had to be rewritten on every turn to keep the
-    window sliding. Surfaced to clients as ``temporary``.
-    """
+    is_ephemeral: Mapped[bool] = mapped_column(default=False)
     heartbeat_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True)
     user: Mapped[Optional["User"]] = relationship("User")
     snapshot: Mapped[Optional["AgentSessionSnapshot"]] = relationship(

--- a/src/phoenix/server/api/agent_helpers.py
+++ b/src/phoenix/server/api/agent_helpers.py
@@ -35,9 +35,10 @@ class CanAccessAgentSession(BasePermission):
                 fields.load((source.id, models.AgentSession.user_id)),
             )
         viewer_id = context.user_id
-        if agent_session_id is None or (
-            viewer_id is not None and not context.user.is_admin and owner_id != viewer_id
-        ):
+        session_exists = agent_session_id is not None
+        auth_is_enforced = viewer_id is not None and not context.user.is_admin
+        viewer_owns_session = owner_id == viewer_id
+        if not session_exists or (auth_is_enforced and not viewer_owns_session):
             raise _agent_session_not_found(source.id)
         return True
 

--- a/src/phoenix/server/api/agent_helpers.py
+++ b/src/phoenix/server/api/agent_helpers.py
@@ -1,7 +1,6 @@
 """GraphQL access controls and query helpers for agent sessions."""
 
 from asyncio import gather
-from datetime import datetime, timezone
 from typing import Any, Optional
 
 from sqlalchemy import ColumnElement
@@ -29,19 +28,15 @@ class CanAccessAgentSession(BasePermission):
         if source.db_record:
             agent_session_id = source.db_record.id
             owner_id = source.db_record.user_id
-            expires_at = source.db_record.expires_at
         else:
             fields = context.data_loaders.agent_session_fields
-            agent_session_id, owner_id, expires_at = await gather(
+            agent_session_id, owner_id = await gather(
                 fields.load((source.id, models.AgentSession.id)),
                 fields.load((source.id, models.AgentSession.user_id)),
-                fields.load((source.id, models.AgentSession.expires_at)),
             )
         viewer_id = context.user_id
-        if (
-            agent_session_id is None
-            or (viewer_id is not None and not context.user.is_admin and owner_id != viewer_id)
-            or (expires_at is not None and expires_at <= datetime.now(timezone.utc))
+        if agent_session_id is None or (
+            viewer_id is not None and not context.user.is_admin and owner_id != viewer_id
         ):
             raise _agent_session_not_found(source.id)
         return True

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -36,7 +36,7 @@ class CreateAgentSessionInput:
         default="",
         description=("Optional initial title."),
     )
-    temporary: bool = strawberry.field(
+    is_ephemeral: bool = strawberry.field(
         default=False,
         description="Whether the session should expire after a period of inactivity.",
     )
@@ -130,7 +130,7 @@ class AgentSessionMutationMixin:
                 user_id=info.context.user_id,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                is_ephemeral=input.temporary,
+                is_ephemeral=input.is_ephemeral,
             )
             session.add(agent_session)
             await session.flush()
@@ -327,7 +327,9 @@ async def _load_owned_agent_session(
         statement = statement.with_for_update()
     agent_session = await session.scalar(statement)
     viewer_id = info.context.user_id
-    if agent_session is None or (viewer_id is not None and agent_session.user_id != viewer_id):
+    auth_is_enforced = viewer_id is not None
+    viewer_owns_session = agent_session is not None and agent_session.user_id == viewer_id
+    if agent_session is None or (auth_is_enforced and not viewer_owns_session):
         raise NotFound(f"No agent session found for row ID '{agent_session_rowid}'")
     return agent_session
 

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -1,6 +1,5 @@
 """Mutations for persisted assistant chat sessions."""
 
-from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import strawberry
@@ -10,10 +9,7 @@ from sqlalchemy.orm import aliased
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
-from phoenix.config import (
-    TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS,
-    get_env_phoenix_agents_assistant_project_name,
-)
+from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.agents.session_titles import (
@@ -134,12 +130,7 @@ class AgentSessionMutationMixin:
                 user_id=info.context.user_id,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                expires_at=(
-                    datetime.now(timezone.utc)
-                    + timedelta(hours=TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS)
-                    if input.temporary
-                    else None
-                ),
+                is_ephemeral=input.temporary,
             )
             session.add(agent_session)
             await session.flush()
@@ -239,12 +230,7 @@ class AgentSessionMutationMixin:
                 user_id=info.context.user_id,
                 title=truncate_agent_session_title(source_session.title),
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                expires_at=(
-                    datetime.now(timezone.utc)
-                    + timedelta(hours=TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS)
-                    if source_session.expires_at is not None
-                    else None
-                ),
+                is_ephemeral=source_session.is_ephemeral,
             )
             session.add(branch_session)
             await session.flush()
@@ -341,14 +327,7 @@ async def _load_owned_agent_session(
         statement = statement.with_for_update()
     agent_session = await session.scalar(statement)
     viewer_id = info.context.user_id
-    if (
-        agent_session is None
-        or (viewer_id is not None and agent_session.user_id != viewer_id)
-        or (
-            agent_session.expires_at is not None
-            and agent_session.expires_at <= datetime.now(timezone.utc)
-        )
-    ):
+    if agent_session is None or (viewer_id is not None and agent_session.user_id != viewer_id):
         raise NotFound(f"No agent session found for row ID '{agent_session_rowid}'")
     return agent_session
 

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -1654,7 +1654,7 @@ class Query:
         viewer_only: bool = True,
     ) -> Connection[AgentSession]:
         page_size = first or 20
-        stmt = select(models.AgentSession).where(models.AgentSession.expires_at.is_(None))
+        stmt = select(models.AgentSession).where(models.AgentSession.is_ephemeral.is_(False))
         owner_filter = get_agent_session_owner_filter(info.context, viewer_only=viewer_only)
         if owner_filter is not None:
             stmt = stmt.where(owner_filter)

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -76,7 +76,6 @@ from strawberry.relay import GlobalID
 from typing_extensions import TypeIs, assert_never
 
 from phoenix.config import (
-    TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS,
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_disable_bash,
     get_env_phoenix_agents_force_tracing,
@@ -1347,7 +1346,6 @@ async def _refresh_and_load_agent_session(
         )
     except ValueError:
         raise HTTPException(status_code=404, detail="Session not found") from None
-    now = datetime.now(timezone.utc)
     session_owner_filter = (
         models.AgentSession.user_id.is_(None)
         if user_id is None
@@ -1356,41 +1354,22 @@ async def _refresh_and_load_agent_session(
     statement = select(models.AgentSession).where(
         models.AgentSession.id == agent_session_rowid,
         session_owner_filter,
-        or_(
-            models.AgentSession.expires_at.is_(None),
-            models.AgentSession.expires_at > now,
-        ),
     )
     if for_update:
         statement = statement.with_for_update()
-    loaded_agent_session = await session.scalar(statement)
-    if loaded_agent_session is None:
+    if await session.scalar(statement) is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    if loaded_agent_session.expires_at is None:
-        refreshed_agent_session = await session.scalar(
-            update(models.AgentSession)
-            .where(
-                models.AgentSession.id == agent_session_rowid,
-                models.AgentSession.expires_at.is_(None),
-            )
-            .values(updated_at=func.now())
-            .returning(models.AgentSession)
-        )
-        if refreshed_agent_session is None:
-            raise HTTPException(status_code=404, detail="Session not found")
-        return refreshed_agent_session
-    refreshed_expiry = now + timedelta(hours=TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS)
+    # Bumping updated_at is what keeps an ephemeral session alive: its deadline
+    # is that column plus a fixed TTL, so activity slides the window and there
+    # is no second timestamp to maintain.
     refreshed_agent_session = await session.scalar(
         update(models.AgentSession)
-        .where(
-            models.AgentSession.id == agent_session_rowid,
-            models.AgentSession.expires_at.is_not(None),
-            models.AgentSession.expires_at > now,
-        )
-        .values(expires_at=refreshed_expiry, updated_at=func.now())
+        .where(models.AgentSession.id == agent_session_rowid)
+        .values(updated_at=func.now())
         .returning(models.AgentSession)
     )
     if refreshed_agent_session is None:
+        # An unlocked read can lose the row to a sweep before the bump lands.
         raise HTTPException(status_code=404, detail="Session not found")
     return refreshed_agent_session
 
@@ -1719,7 +1698,7 @@ def _to_agent_session_summary(agent_session: models.AgentSession) -> AgentSessio
         title=agent_session.title,
         created_at=agent_session.created_at,
         updated_at=agent_session.updated_at,
-        is_temporary=agent_session.expires_at is not None,
+        is_temporary=agent_session.is_ephemeral,
     )
 
 
@@ -1758,12 +1737,7 @@ def create_agents_router(
                 user_id=int(phoenix_user.identity) if phoenix_user is not None else None,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                expires_at=(
-                    datetime.now(timezone.utc)
-                    + timedelta(hours=TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS)
-                    if request_body.temporary
-                    else None
-                ),
+                is_ephemeral=request_body.temporary,
             )
             session.add(agent_session)
             await session.flush()
@@ -1792,7 +1766,7 @@ def create_agents_router(
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
         if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
             raise HTTPException(status_code=403, detail="Server agent is disabled")
-        statement = select(models.AgentSession).where(models.AgentSession.expires_at.is_(None))
+        statement = select(models.AgentSession).where(models.AgentSession.is_ephemeral.is_(False))
         if (user_id := _get_request_user_id(request)) is not None:
             statement = statement.where(models.AgentSession.user_id == user_id)
         if cursor is not None:
@@ -1855,13 +1829,7 @@ def create_agents_router(
 
         statement = (
             select(models.AgentSession)
-            .where(
-                models.AgentSession.id == session_rowid,
-                or_(
-                    models.AgentSession.expires_at.is_(None),
-                    models.AgentSession.expires_at > datetime.now(timezone.utc),
-                ),
-            )
+            .where(models.AgentSession.id == session_rowid)
             .options(selectinload(models.AgentSession.messages))
         )
         if (user_id := _get_request_user_id(request)) is not None:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -355,7 +355,7 @@ class CreateAgentSessionRequestBody(V1RoutesBaseModel):
         max_length=MAX_AGENT_SESSION_TITLE_LENGTH,
         description="Optional initial title.",
     )
-    temporary: bool = Field(
+    is_ephemeral: bool = Field(
         default=False,
         description="Whether the session should expire after a period of inactivity.",
     )
@@ -376,7 +376,7 @@ class AgentSessionSummary(V1RoutesBaseModel):
     title: str
     created_at: datetime
     updated_at: datetime
-    is_temporary: bool
+    is_ephemeral: bool
 
 
 class AgentSessionData(AgentSessionSummary):
@@ -1359,9 +1359,7 @@ async def _refresh_and_load_agent_session(
         statement = statement.with_for_update()
     if await session.scalar(statement) is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    # Bumping updated_at is what keeps an ephemeral session alive: its deadline
-    # is that column plus a fixed TTL, so activity slides the window and there
-    # is no second timestamp to maintain.
+    # Bumping updated_at slides an ephemeral session's TTL window.
     refreshed_agent_session = await session.scalar(
         update(models.AgentSession)
         .where(models.AgentSession.id == agent_session_rowid)
@@ -1698,7 +1696,7 @@ def _to_agent_session_summary(agent_session: models.AgentSession) -> AgentSessio
         title=agent_session.title,
         created_at=agent_session.created_at,
         updated_at=agent_session.updated_at,
-        is_temporary=agent_session.is_ephemeral,
+        is_ephemeral=agent_session.is_ephemeral,
     )
 
 
@@ -1737,7 +1735,7 @@ def create_agents_router(
                 user_id=int(phoenix_user.identity) if phoenix_user is not None else None,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                is_ephemeral=request_body.temporary,
+                is_ephemeral=request_body.is_ephemeral,
             )
             session.add(agent_session)
             await session.flush()

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -96,7 +96,7 @@ class AgentSession(Node):
         description="Whether the session expires after a period of inactivity.",
         permission_classes=[CanAccessAgentSession],
     )  # type: ignore
-    async def is_temporary(self, info: Info[Context, None]) -> bool:
+    async def is_ephemeral(self, info: Info[Context, None]) -> bool:
         if self.db_record:
             return self.db_record.is_ephemeral
         is_ephemeral = await info.context.data_loaders.agent_session_fields.load(

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -98,11 +98,11 @@ class AgentSession(Node):
     )  # type: ignore
     async def is_temporary(self, info: Info[Context, None]) -> bool:
         if self.db_record:
-            return self.db_record.expires_at is not None
-        expires_at = await info.context.data_loaders.agent_session_fields.load(
-            (self.id, models.AgentSession.expires_at),
+            return self.db_record.is_ephemeral
+        is_ephemeral = await info.context.data_loaders.agent_session_fields.load(
+            (self.id, models.AgentSession.is_ephemeral),
         )
-        return expires_at is not None
+        return bool(is_ephemeral)
 
     @strawberry.field(
         description=(

--- a/src/phoenix/server/daemons/agent_session_sweeper.py
+++ b/src/phoenix/server/daemons/agent_session_sweeper.py
@@ -50,14 +50,7 @@ class AgentSessionSweeper(DaemonTask):
             await self._enforce_per_user_count_cap(retention.max_count_per_user)
 
     async def _delete_idle_sessions(self, *, is_ephemeral: bool, max_idle: timedelta) -> None:
-        """Delete sessions of one persistence kind left untouched for ``max_idle``.
-
-        The two kinds differ only in the flag and the length of the window: an
-        ephemeral session dies a fixed TTL after its last activity, which is
-        the same question retention asks of a persisted one. Sharing the query
-        also gives ephemeral deletes the batching that bounds how much cascade
-        work lands in a single transaction.
-        """
+        """Delete sessions of one persistence kind left untouched for ``max_idle``."""
         cutoff = datetime.now(timezone.utc) - max_idle
         total_deleted = 0
         while True:

--- a/src/phoenix/server/daemons/agent_session_sweeper.py
+++ b/src/phoenix/server/daemons/agent_session_sweeper.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 import sqlalchemy as sa
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.server.daemons.system_settings import SystemSettings
 from phoenix.server.types import DaemonTask, DbSessionFactory
@@ -19,7 +20,7 @@ _DELETE_BATCH_SIZE = 100
 
 
 class AgentSessionSweeper(DaemonTask):
-    """Periodically delete expired agent sessions."""
+    """Periodically delete agent sessions that have outlived their retention."""
 
     def __init__(self, db: DbSessionFactory, settings: SystemSettings) -> None:
         super().__init__()
@@ -35,32 +36,34 @@ class AgentSessionSweeper(DaemonTask):
             await sleep(_SLEEP_SECONDS + random.uniform(-_JITTER_SECONDS, _JITTER_SECONDS))
 
     async def _sweep(self) -> None:
-        await self._delete_expired_temporary_sessions()
+        await self._delete_idle_sessions(
+            is_ephemeral=True,
+            max_idle=timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS),
+        )
         retention = self._settings.agent_session_retention
         if retention.max_idle_days > 0:
-            await self._delete_idle_persisted_sessions(retention.max_idle_days)
+            await self._delete_idle_sessions(
+                is_ephemeral=False,
+                max_idle=timedelta(days=retention.max_idle_days),
+            )
         if retention.max_count_per_user > 0:
             await self._enforce_per_user_count_cap(retention.max_count_per_user)
 
-    async def _delete_expired_temporary_sessions(self) -> None:
-        stmt = (
-            sa.delete(models.AgentSession)
-            .where(models.AgentSession.expires_at.is_not(None))
-            .where(models.AgentSession.expires_at < datetime.now(timezone.utc))
-            .returning(models.AgentSession.id)
-        )
-        async with self._db() as session:
-            num_deleted = len((await session.scalars(stmt)).all())
-        if num_deleted:
-            logger.info("Deleted %d expired agent session(s).", num_deleted)
+    async def _delete_idle_sessions(self, *, is_ephemeral: bool, max_idle: timedelta) -> None:
+        """Delete sessions of one persistence kind left untouched for ``max_idle``.
 
-    async def _delete_idle_persisted_sessions(self, max_idle_days: int) -> None:
-        cutoff = datetime.now(timezone.utc) - timedelta(days=max_idle_days)
+        The two kinds differ only in the flag and the length of the window: an
+        ephemeral session dies a fixed TTL after its last activity, which is
+        the same question retention asks of a persisted one. Sharing the query
+        also gives ephemeral deletes the batching that bounds how much cascade
+        work lands in a single transaction.
+        """
+        cutoff = datetime.now(timezone.utc) - max_idle
         total_deleted = 0
         while True:
             batch = (
                 sa.select(models.AgentSession.id)
-                .where(models.AgentSession.expires_at.is_(None))
+                .where(models.AgentSession.is_ephemeral.is_(is_ephemeral))
                 .where(models.AgentSession.updated_at < cutoff)
                 .limit(_DELETE_BATCH_SIZE)
             )
@@ -69,7 +72,7 @@ class AgentSessionSweeper(DaemonTask):
             # spare a session that turned active after the batch was selected.
             stmt = (
                 sa.delete(models.AgentSession)
-                .where(models.AgentSession.expires_at.is_(None))
+                .where(models.AgentSession.is_ephemeral.is_(is_ephemeral))
                 .where(models.AgentSession.updated_at < cutoff)
                 .where(models.AgentSession.id.in_(batch))
             )
@@ -80,7 +83,11 @@ class AgentSessionSweeper(DaemonTask):
             if num_deleted < _DELETE_BATCH_SIZE:
                 break
         if total_deleted:
-            logger.info("Deleted %d idle agent session(s).", total_deleted)
+            logger.info(
+                "Deleted %d idle %s agent session(s).",
+                total_deleted,
+                "ephemeral" if is_ephemeral else "persisted",
+            )
 
     async def _enforce_per_user_count_cap(self, max_count_per_user: int) -> None:
         ranked = (
@@ -97,7 +104,7 @@ class AgentSessionSweeper(DaemonTask):
                 )
                 .label("rank"),
             )
-            .where(models.AgentSession.expires_at.is_(None))
+            .where(models.AgentSession.is_ephemeral.is_(False))
             .cte("ranked_agent_sessions")
         )
         # Matching on (id, updated_at) rather than id alone makes the delete's

--- a/src/phoenix/server/settings/registry.py
+++ b/src/phoenix/server/settings/registry.py
@@ -37,7 +37,7 @@ DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER = 30
 
 
 class AgentSessionRetentionSetting(BaseModel):
-    """Workspace-wide retention for non-temporary agent sessions."""
+    """Workspace-wide retention for non-ephemeral agent sessions."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
 

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -1990,13 +1990,13 @@ class TestApiAccessViaCookiesOrApiKeys:
         admin_client = _httpx_client(_app, admin.tokens)
         member_session_response = member_client.post(
             "agents/assistant/sessions",
-            json={"title": "Member session", "temporary": False},
+            json={"title": "Member session", "is_ephemeral": False},
         )
         member_session_response.raise_for_status()
         member_session_id = member_session_response.json()["data"]["id"]
         admin_session_response = admin_client.post(
             "agents/assistant/sessions",
-            json={"title": "Admin session", "temporary": False},
+            json={"title": "Admin session", "is_ephemeral": False},
         )
         admin_session_response.raise_for_status()
         admin_session_id = admin_session_response.json()["data"]["id"]

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 import httpx
 from strawberry.relay import GlobalID
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage, TextUIPart
 from phoenix.server.types import DbSessionFactory
@@ -14,14 +15,14 @@ async def _insert_agent_session(
     *,
     title: str,
     updated_at: datetime,
-    expires_at: datetime | None = None,
+    is_ephemeral: bool = False,
     messages: list[PhoenixUIMessage] | None = None,
 ) -> models.AgentSession:
     async with db() as session:
         agent_session = models.AgentSession(
             project_name="pxi-test",
             title=title,
-            expires_at=expires_at,
+            is_ephemeral=is_ephemeral,
             created_at=updated_at,
             updated_at=updated_at,
         )
@@ -54,7 +55,7 @@ class TestListAgentSessions:
             db,
             title="Temporary",
             updated_at=now + timedelta(minutes=1),
-            expires_at=now + timedelta(hours=1),
+            is_ephemeral=True,
         )
 
         response = await httpx_client.get("/agents/assistant/sessions")
@@ -157,7 +158,7 @@ class TestGetAgentSession:
         assert data["messages"][0]["parts"] == [{"type": "text", "text": "Hello"}]
         assert data["messages"][1]["parts"] == [{"type": "text", "text": "Hi"}]
 
-    async def test_gets_unexpired_temporary_session(
+    async def test_gets_temporary_session(
         self,
         httpx_client: httpx.AsyncClient,
         db: DbSessionFactory,
@@ -167,7 +168,7 @@ class TestGetAgentSession:
             db,
             title="Temporary",
             updated_at=now,
-            expires_at=now + timedelta(hours=1),
+            is_ephemeral=True,
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
@@ -176,23 +177,31 @@ class TestGetAgentSession:
         assert response.status_code == 200
         assert response.json()["data"]["is_temporary"] is True
 
-    async def test_hides_expired_session(
+    async def test_serves_an_ephemeral_session_the_sweeper_has_not_reached_yet(
         self,
         httpx_client: httpx.AsyncClient,
         db: DbSessionFactory,
     ) -> None:
-        now = datetime.now(timezone.utc)
+        """Past the TTL but not yet swept, the session is still readable.
+
+        Reads no longer second-guess the sweeper: with the deadline derived from
+        ``updated_at`` there is no stored expiry to compare against, so the row
+        stays visible to its owner for at most one sweep interval longer than
+        before.
+        """
         agent_session = await _insert_agent_session(
             db,
-            title="Expired",
-            updated_at=now,
-            expires_at=now - timedelta(hours=1),
+            title="Idle past its TTL",
+            updated_at=datetime.now(timezone.utc)
+            - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1),
+            is_ephemeral=True,
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
         response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
 
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert response.json()["data"]["is_temporary"] is True
 
     async def test_rejects_invalid_id(self, httpx_client: httpx.AsyncClient) -> None:
         response = await httpx_client.get("/agents/assistant/sessions/invalid")

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -68,14 +68,14 @@ class TestListAgentSessions:
                     "title": "Newer",
                     "created_at": now.isoformat(),
                     "updated_at": now.isoformat(),
-                    "is_temporary": False,
+                    "is_ephemeral": False,
                 },
                 {
                     "id": str(GlobalID("AgentSession", str(older.id))),
                     "title": "Older",
                     "created_at": (now - timedelta(minutes=2)).isoformat(),
                     "updated_at": (now - timedelta(minutes=2)).isoformat(),
-                    "is_temporary": False,
+                    "is_ephemeral": False,
                 },
             ],
             "next_cursor": None,
@@ -150,7 +150,7 @@ class TestGetAgentSession:
         data = response.json()["data"]
         assert data["id"] == session_id
         assert data["title"] == "Conversation"
-        assert data["is_temporary"] is False
+        assert data["is_ephemeral"] is False
         assert [message["id"] for message in data["messages"]] == [
             _message_uuid("user-message"),
             _message_uuid("assistant-message"),
@@ -175,7 +175,7 @@ class TestGetAgentSession:
         response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
 
         assert response.status_code == 200
-        assert response.json()["data"]["is_temporary"] is True
+        assert response.json()["data"]["is_ephemeral"] is True
 
     async def test_serves_an_ephemeral_session_the_sweeper_has_not_reached_yet(
         self,
@@ -201,7 +201,7 @@ class TestGetAgentSession:
         response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
 
         assert response.status_code == 200
-        assert response.json()["data"]["is_temporary"] is True
+        assert response.json()["data"]["is_ephemeral"] is True
 
     async def test_rejects_invalid_id(self, httpx_client: httpx.AsyncClient) -> None:
         response = await httpx_client.get("/agents/assistant/sessions/invalid")

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -2116,7 +2116,7 @@ async def test_create_session_route_creates_a_temporary_session(
 ) -> None:
     response = await httpx_client.post(
         "/agents/server/sessions",
-        json={"title": " CLI session ", "temporary": True},
+        json={"title": " CLI session ", "is_ephemeral": True},
     )
     assert response.status_code == 201
 
@@ -2170,7 +2170,7 @@ async def test_create_session_route_yields_a_chattable_session(
 
     created = await httpx_client.post(
         "/agents/server/sessions",
-        json={"temporary": True},
+        json={"is_ephemeral": True},
     )
     assert created.status_code == 201
 

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -2128,8 +2128,7 @@ async def test_create_session_route_creates_a_temporary_session(
         assert agent_session.title == "CLI session"
         assert agent_session.user_id is None
         assert agent_session.project_name == get_env_phoenix_agents_assistant_project_name()
-        assert agent_session.expires_at is not None
-        assert agent_session.expires_at > datetime.now(timezone.utc)
+        assert agent_session.is_ephemeral is True
 
 
 async def test_create_session_route_defaults_to_a_persistent_untitled_session(
@@ -2144,7 +2143,7 @@ async def test_create_session_route_defaults_to_a_persistent_untitled_session(
         agent_session = await session.get(models.AgentSession, int(global_id.node_id))
         assert agent_session is not None
         assert agent_session.title == ""
-        assert agent_session.expires_at is None
+        assert agent_session.is_ephemeral is False
 
 
 async def test_create_session_route_rejects_long_title(

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from sqlalchemy import func, select
 from strawberry.relay import GlobalID
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import (
     PhoenixUIMessage,
@@ -148,15 +149,18 @@ async def _seed_session_with_transcript(
     db: DbSessionFactory,
     *,
     title: str = "",
-    expires_at: datetime | None = None,
+    is_ephemeral: bool = False,
+    updated_at: datetime | None = None,
 ) -> str:
     async with db() as session:
         agent_session = models.AgentSession(
             user_id=None,
             title=title,
             project_name="assistant_agent",
-            expires_at=expires_at,
+            is_ephemeral=is_ephemeral,
         )
+        if updated_at is not None:
+            agent_session.created_at = agent_session.updated_at = updated_at
         session.add(agent_session)
         await session.flush()
         session.add_all(
@@ -328,13 +332,21 @@ async def test_truncate_agent_session_with_unknown_message_id_is_not_found(
         )
 
 
-async def test_truncate_agent_session_rejects_an_expired_temporary_session(
+async def test_truncate_agent_session_accepts_an_ephemeral_session_awaiting_the_sweeper(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
+    """A lapsed TTL no longer blocks writes, because it is no longer readable state.
+
+    The deadline is ``updated_at`` plus a constant, and truncating bumps
+    ``updated_at`` — so refusing the write would only have hidden a session the
+    same request was about to renew.
+    """
     agent_session_id = await _seed_session_with_transcript(
         db,
-        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        is_ephemeral=True,
+        updated_at=datetime.now(timezone.utc)
+        - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1),
     )
 
     response = await gql_client.execute(
@@ -342,11 +354,9 @@ async def test_truncate_agent_session_rejects_an_expired_temporary_session(
         variables={"id": agent_session_id, "messageId": _message_uuid("user-2")},
     )
 
-    assert response.errors
-    assert "No agent session found" in response.errors[0].message
-    # The expired session's transcript is left untouched.
+    assert not response.errors
     async with db() as session:
-        assert len((await session.scalars(select(models.AgentSessionMessage))).all()) == len(
+        assert len((await session.scalars(select(models.AgentSessionMessage))).all()) < len(
             _transcript_messages()
         )
 
@@ -489,10 +499,7 @@ async def test_branch_agent_session_preserves_temporary_mode(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    source_agent_session_id = await _seed_session_with_transcript(
-        db,
-        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
-    )
+    source_agent_session_id = await _seed_session_with_transcript(db, is_ephemeral=True)
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
@@ -539,13 +546,15 @@ async def test_branch_agent_session_with_unknown_message_id_is_not_found(
         assert len((await session.scalars(select(models.AgentSession))).all()) == 1
 
 
-async def test_branch_agent_session_rejects_an_expired_temporary_session(
+async def test_branch_agent_session_accepts_an_ephemeral_source_awaiting_the_sweeper(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
     source_agent_session_id = await _seed_session_with_transcript(
         db,
-        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        is_ephemeral=True,
+        updated_at=datetime.now(timezone.utc)
+        - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1),
     )
 
     response = await gql_client.execute(
@@ -553,11 +562,15 @@ async def test_branch_agent_session_rejects_an_expired_temporary_session(
         variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-1")},
     )
 
-    assert response.errors
-    assert "No agent session found" in response.errors[0].message
-    # No branch session is minted from an expired source.
+    assert not response.errors
+    assert response.data is not None
+    # The branch inherits ephemerality and starts its own TTL from its own
+    # activity, so it is not born already past the sweeper's cutoff.
+    assert response.data["branchAgentSession"]["agentSession"]["isTemporary"] is True
     async with db() as session:
-        assert len((await session.scalars(select(models.AgentSession))).all()) == 1
+        branched = (await session.scalars(select(models.AgentSession))).all()
+        assert len(branched) == 2
+        assert all(agent_session.is_ephemeral for agent_session in branched)
 
 
 async def test_create_agent_session_creates_empty_owned_session(
@@ -581,7 +594,7 @@ async def test_create_agent_session_creates_empty_owned_session(
         assert payload["id"] == str(GlobalID("AgentSession", str(agent_session.id)))
         assert agent_session.user_id is None
         assert agent_session.title == ""
-        assert agent_session.expires_at is None
+        assert agent_session.is_ephemeral is False
         assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
 
 
@@ -589,7 +602,6 @@ async def test_create_agent_session_can_create_temporary_session(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    before_creation = datetime.now(timezone.utc)
     response = await gql_client.execute(
         query="""
           mutation {
@@ -608,9 +620,9 @@ async def test_create_agent_session_can_create_temporary_session(
     async with db() as session:
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
-        assert agent_session.expires_at is not None
-        assert before_creation + timedelta(hours=23) < agent_session.expires_at
-        assert agent_session.expires_at < before_creation + timedelta(hours=25)
+        # The API says "temporary"; the column says "ephemeral". The GraphQL name
+        # is the one clients already depend on, so only storage was renamed.
+        assert agent_session.is_ephemeral is True
 
 
 async def test_create_agent_session_persists_a_trimmed_title(

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -31,7 +31,7 @@ _CREATE_MUTATION = """
       agentSession {
         id
         title
-        isTemporary
+        isEphemeral
         messages
       }
     }
@@ -55,7 +55,7 @@ _BRANCH_MUTATION = """
       agentSession {
         id
         title
-        isTemporary
+        isEphemeral
         messages
       }
     }
@@ -336,12 +336,6 @@ async def test_truncate_agent_session_accepts_an_ephemeral_session_awaiting_the_
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    """A lapsed TTL no longer blocks writes, because it is no longer readable state.
-
-    The deadline is ``updated_at`` plus a constant, and truncating bumps
-    ``updated_at`` — so refusing the write would only have hidden a session the
-    same request was about to renew.
-    """
     agent_session_id = await _seed_session_with_transcript(
         db,
         is_ephemeral=True,
@@ -508,7 +502,7 @@ async def test_branch_agent_session_preserves_temporary_mode(
 
     assert not response.errors
     assert response.data is not None
-    assert response.data["branchAgentSession"]["agentSession"]["isTemporary"] is True
+    assert response.data["branchAgentSession"]["agentSession"]["isEphemeral"] is True
 
 
 async def test_branch_agent_session_at_an_assistant_message_includes_it(
@@ -564,9 +558,7 @@ async def test_branch_agent_session_accepts_an_ephemeral_source_awaiting_the_swe
 
     assert not response.errors
     assert response.data is not None
-    # The branch inherits ephemerality and starts its own TTL from its own
-    # activity, so it is not born already past the sweeper's cutoff.
-    assert response.data["branchAgentSession"]["agentSession"]["isTemporary"] is True
+    assert response.data["branchAgentSession"]["agentSession"]["isEphemeral"] is True
     async with db() as session:
         branched = (await session.scalars(select(models.AgentSession))).all()
         assert len(branched) == 2
@@ -585,7 +577,7 @@ async def test_create_agent_session_creates_empty_owned_session(
     assert response.data is not None
     payload = response.data["createAgentSession"]["agentSession"]
     assert payload["title"] == ""
-    assert payload["isTemporary"] is False
+    assert payload["isEphemeral"] is False
     assert payload["messages"] == []
     async with db() as session:
         agent_sessions = (await session.scalars(select(models.AgentSession))).all()
@@ -605,9 +597,9 @@ async def test_create_agent_session_can_create_temporary_session(
     response = await gql_client.execute(
         query="""
           mutation {
-            createAgentSession(input: { temporary: true }) {
+            createAgentSession(input: { isEphemeral: true }) {
               agentSession {
-                isTemporary
+                isEphemeral
               }
             }
           }
@@ -616,12 +608,10 @@ async def test_create_agent_session_can_create_temporary_session(
 
     assert not response.errors
     assert response.data is not None
-    assert response.data["createAgentSession"]["agentSession"]["isTemporary"] is True
+    assert response.data["createAgentSession"]["agentSession"]["isEphemeral"] is True
     async with db() as session:
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
-        # The API says "temporary"; the column says "ephemeral". The GraphQL name
-        # is the one clients already depend on, so only storage was renamed.
         assert agent_session.is_ephemeral is True
 
 

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -6,8 +6,6 @@ from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-from fastapi import HTTPException
 from jinja2 import Template
 from opentelemetry.trace import (
     SpanContext,
@@ -20,6 +18,7 @@ from pydantic_ai.usage import RequestUsage
 from sqlalchemy import delete, func, select
 from strawberry.relay import GlobalID
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import TurnTraceContext
 from phoenix.db.types.identifier import Identifier
@@ -43,6 +42,11 @@ from phoenix.server.api.routers.agents import (
 from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
 from phoenix.server.types import DbSessionFactory, UserId
+
+
+def _ephemeral_sweep_cutoff() -> datetime:
+    """The updated_at below which the sweeper's ephemeral pass reaps a session."""
+    return datetime.now(timezone.utc) - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS)
 
 
 class _EventQueue:
@@ -112,42 +116,46 @@ class TestAgentSessionPersistence:
             await session.flush()
             assert second.id > first_rowid
 
-    async def test_refreshes_expiry_for_a_temporary_session(
+    async def test_slides_the_ttl_window_for_an_ephemeral_session(
         self,
         db: DbSessionFactory,
     ) -> None:
+        # Idle long enough that the sweeper's next pass would have reaped it.
+        stale = _ephemeral_sweep_cutoff() - timedelta(hours=1)
         async with db() as session:
-            temporary = models.AgentSession(
+            ephemeral = models.AgentSession(
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
-                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                is_ephemeral=True,
             )
-            session.add(temporary)
+            ephemeral.created_at = stale
+            ephemeral.updated_at = stale
+            session.add(ephemeral)
             await session.flush()
-            temporary_rowid = temporary.id
+            ephemeral_rowid = ephemeral.id
 
-        before_refresh = datetime.now(timezone.utc)
         async with db() as session:
             loaded = await _refresh_and_load_agent_session(
                 session,
-                agent_session_id=str(GlobalID("AgentSession", str(temporary_rowid))),
+                agent_session_id=str(GlobalID("AgentSession", str(ephemeral_rowid))),
                 user_id=None,
             )
-            # The sliding window is pushed well past the original near-term expiry.
-            assert loaded.expires_at is not None
-            assert loaded.expires_at > before_refresh + timedelta(hours=23)
+            # updated_at *is* the deadline now, so the bump is what buys another
+            # full TTL — and the session stays ephemeral through the refresh.
+            assert loaded.is_ephemeral is True
+            assert loaded.updated_at > _ephemeral_sweep_cutoff()
 
         async with db() as session:
-            persisted_expiry = await session.scalar(
-                select(models.AgentSession.expires_at).where(
-                    models.AgentSession.id == temporary_rowid
+            persisted_updated_at = await session.scalar(
+                select(models.AgentSession.updated_at).where(
+                    models.AgentSession.id == ephemeral_rowid
                 )
             )
-            assert persisted_expiry is not None
-            assert persisted_expiry > before_refresh + timedelta(hours=23)
+            assert persisted_updated_at is not None
+            assert persisted_updated_at > _ephemeral_sweep_cutoff()
 
-    async def test_marks_a_persistent_session_active_without_granting_expiry(
+    async def test_marks_a_persisted_session_active_without_making_it_ephemeral(
         self,
         db: DbSessionFactory,
     ) -> None:
@@ -171,7 +179,7 @@ class TestAgentSessionPersistence:
                 user_id=None,
             )
             assert loaded.id == persistent_rowid
-            assert loaded.expires_at is None
+            assert loaded.is_ephemeral is False
             # The turn-start updated_at bump keeps the retention sweeper from
             # treating an in-flight turn as idle.
             assert loaded.updated_at > stale
@@ -185,36 +193,46 @@ class TestAgentSessionPersistence:
             assert persisted_updated_at is not None
             assert persisted_updated_at > stale
 
-    async def test_rejects_an_expired_temporary_session(
+    async def test_resumes_an_ephemeral_session_the_sweeper_has_not_reached_yet(
         self,
         db: DbSessionFactory,
     ) -> None:
+        """A lapsed TTL is not a read-time gate — deletion is the sweeper's job alone.
+
+        The deadline used to be stored, so reads could compare against it and hide
+        a session the sweeper had not deleted yet. With the deadline derived from
+        ``updated_at`` there is nothing to compare that resuming would not have
+        reset anyway, so an idle ephemeral session stays resumable until a sweep
+        removes it — at most one sweep interval past its TTL.
+        """
+        stale = _ephemeral_sweep_cutoff() - timedelta(hours=1)
         async with db() as session:
-            temporary = models.AgentSession(
+            ephemeral = models.AgentSession(
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
-                expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+                is_ephemeral=True,
             )
-            session.add(temporary)
+            ephemeral.created_at = stale
+            ephemeral.updated_at = stale
+            session.add(ephemeral)
             await session.flush()
-            temporary_rowid = temporary.id
+            ephemeral_rowid = ephemeral.id
 
         async with db() as session:
-            with pytest.raises(HTTPException) as exc_info:
-                await _refresh_and_load_agent_session(
-                    session,
-                    agent_session_id=str(GlobalID("AgentSession", str(temporary_rowid))),
-                    user_id=None,
-                )
-            assert exc_info.value.status_code == 404
+            loaded = await _refresh_and_load_agent_session(
+                session,
+                agent_session_id=str(GlobalID("AgentSession", str(ephemeral_rowid))),
+                user_id=None,
+            )
+            assert loaded.id == ephemeral_rowid
 
-        # The refresh never deletes; the expired row is left for the sweeper.
+        # The refresh never deletes; the row is left for the sweeper.
         async with db() as session:
             surviving_rowid = await session.scalar(
-                select(models.AgentSession.id).where(models.AgentSession.id == temporary_rowid)
+                select(models.AgentSession.id).where(models.AgentSession.id == ephemeral_rowid)
             )
-            assert surviving_rowid == temporary_rowid
+            assert surviving_rowid == ephemeral_rowid
 
 
 class TestPersistDbTracesAndEmitEvent:

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -4,6 +4,7 @@ from typing import Any
 from sqlalchemy import select
 from strawberry.relay import GlobalID
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.types import DbSessionFactory
@@ -17,7 +18,7 @@ async def _seed_agent_session(
     title: str,
     updated_at: datetime,
     messages: list[dict[str, Any]] | None = None,
-    expires_at: datetime | None = None,
+    is_ephemeral: bool = False,
     user_id: int | None = None,
     heartbeat_at: datetime | None = None,
 ) -> str:
@@ -28,7 +29,7 @@ async def _seed_agent_session(
             project_name="assistant_agent",
             created_at=updated_at,
             updated_at=updated_at,
-            expires_at=expires_at,
+            is_ephemeral=is_ephemeral,
             heartbeat_at=heartbeat_at,
         )
         session.add(agent_session)
@@ -149,7 +150,7 @@ async def test_agent_sessions_excludes_temporary_sessions(
         db,
         title="temporary",
         updated_at=now,
-        expires_at=now + timedelta(days=1),
+        is_ephemeral=True,
     )
 
     response = await gql_client.execute(query=_LIST_QUERY)
@@ -264,18 +265,23 @@ async def test_agent_session_node_returns_not_found_when_missing(
     assert response.errors[0].message == f"Unknown agent session: {agent_session_id}"
 
 
-async def test_agent_session_node_returns_not_found_when_expired(
+async def test_agent_session_node_resolves_while_the_sweeper_has_not_reached_it(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    # A temporary session whose deadline has already passed reads as gone even
-    # though the sweeper has not yet deleted its row.
-    now = datetime.now(timezone.utc)
+    """An idle ephemeral session past its TTL still resolves by node id.
+
+    The permission check used to compare a stored deadline against the clock so
+    an unswept session read as gone. With the deadline derived from
+    ``updated_at`` there is nothing left to compare, and the owner keeps seeing
+    their own row until a sweep removes it.
+    """
     agent_session_id = await _seed_agent_session(
         db,
-        title="expired",
-        updated_at=now - timedelta(days=2),
-        expires_at=now - timedelta(seconds=1),
+        title="idle past its ttl",
+        updated_at=datetime.now(timezone.utc)
+        - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1),
+        is_ephemeral=True,
     )
 
     response = await gql_client.execute(
@@ -283,6 +289,6 @@ async def test_agent_session_node_returns_not_found_when_expired(
         variables={"id": agent_session_id},
     )
 
-    assert response.data is None
-    assert response.errors
-    assert response.errors[0].message == f"Unknown agent session: {agent_session_id}"
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["agentSession"]["id"] == agent_session_id

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -269,13 +269,6 @@ async def test_agent_session_node_resolves_while_the_sweeper_has_not_reached_it(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    """An idle ephemeral session past its TTL still resolves by node id.
-
-    The permission check used to compare a stored deadline against the clock so
-    an unswept session read as gone. With the deadline derived from
-    ``updated_at`` there is nothing left to compare, and the owner keeps seeing
-    their own row until a sweep removes it.
-    """
     agent_session_id = await _seed_agent_session(
         db,
         title="idle past its ttl",

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.daemons.agent_session_sweeper import AgentSessionSweeper
@@ -32,14 +33,14 @@ async def _add_agent_session(
     title: str,
     user_id: int | None = None,
     updated_at: datetime | None = None,
-    expires_at: datetime | None = None,
+    is_ephemeral: bool = False,
 ) -> int:
     async with db() as session:
         agent_session = models.AgentSession(
             project_name="assistant_agent",
             user_id=user_id,
             title=title,
-            expires_at=expires_at,
+            is_ephemeral=is_ephemeral,
         )
         if updated_at is not None:
             agent_session.created_at = updated_at
@@ -81,29 +82,33 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
     db: DbSessionFactory,
 ) -> None:
     now = datetime.now(timezone.utc)
+    ttl = timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS)
     async with db() as session:
         expired = models.AgentSession(
             project_name="assistant_agent",
             user_id=None,
             title="expired",
-            expires_at=now - timedelta(hours=1),
+            is_ephemeral=True,
         )
-        future = models.AgentSession(
+        expired.created_at = expired.updated_at = now - ttl - timedelta(hours=1)
+        active = models.AgentSession(
             project_name="assistant_agent",
             user_id=None,
-            title="future",
-            expires_at=now + timedelta(hours=1),
+            title="active",
+            is_ephemeral=True,
         )
+        active.created_at = active.updated_at = now - timedelta(hours=1)
         persistent = models.AgentSession(
             project_name="assistant_agent",
             user_id=None,
             title="persistent",
-            expires_at=None,
+            is_ephemeral=False,
         )
-        session.add_all((expired, future, persistent))
+        persistent.created_at = persistent.updated_at = now - ttl - timedelta(hours=1)
+        session.add_all((expired, active, persistent))
         await session.flush()
         expired_id = expired.id
-        future_id = future.id
+        active_id = active.id
         persistent_id = persistent.id
         session.add(
             models.AgentSessionMessage(
@@ -119,17 +124,22 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
         )
 
     settings = await _make_settings(db)
-    await AgentSessionSweeper(db, settings=settings)._delete_expired_temporary_sessions()
+    await AgentSessionSweeper(db, settings=settings)._delete_idle_sessions(
+        is_ephemeral=True,
+        max_idle=ttl,
+    )
 
     async with db() as session:
         remaining_ids = set((await session.scalars(select(models.AgentSession.id))).all())
-        assert remaining_ids == {future_id, persistent_id}
+        # The persisted session is equally idle and equally untouched: the
+        # ephemeral pass is scoped by the flag, not by idleness alone.
+        assert remaining_ids == {active_id, persistent_id}
         assert expired_id not in remaining_ids
         assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
         assert (await session.scalars(select(models.AgentSessionSnapshot))).all() == []
 
 
-async def test_idle_pass_deletes_idle_persisted_sessions_but_never_temporary_ones(
+async def test_idle_pass_deletes_idle_persisted_sessions_and_spares_active_ephemeral_ones(
     db: DbSessionFactory,
 ) -> None:
     now = datetime.now(timezone.utc)
@@ -143,18 +153,51 @@ async def test_idle_pass_deletes_idle_persisted_sessions_but_never_temporary_one
         title="active persisted",
         updated_at=now - timedelta(days=1),
     )
-    idle_temporary_id = await _add_agent_session(
+    active_ephemeral_id = await _add_agent_session(
         db,
-        title="idle temporary",
-        updated_at=now - timedelta(days=31),
-        expires_at=now + timedelta(hours=1),
+        title="active ephemeral",
+        updated_at=now - timedelta(hours=1),
+        is_ephemeral=True,
     )
 
     settings = await _make_settings(db, AgentSessionRetentionSetting(max_idle_days=30))
     await AgentSessionSweeper(db, settings=settings)._sweep()
 
-    assert await _remaining_session_ids(db) == {active_persisted_id, idle_temporary_id}
+    assert await _remaining_session_ids(db) == {active_persisted_id, active_ephemeral_id}
     assert idle_persisted_id not in await _remaining_session_ids(db)
+
+
+async def test_the_two_passes_apply_different_idle_windows_to_the_same_staleness(
+    db: DbSessionFactory,
+) -> None:
+    """The flag chooses the window, and nothing else about a session does.
+
+    Both sessions were last touched at the same moment; only ``is_ephemeral``
+    differs, and it is what decides whether the deadline is the fixed
+    ephemeral TTL or the workspace's much longer retention window.
+    """
+    idle_for = timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1)
+    updated_at = datetime.now(timezone.utc) - idle_for
+    assert idle_for < timedelta(days=30), "the persisted session must be inside retention"
+
+    ephemeral_id = await _add_agent_session(
+        db,
+        title="ephemeral past its ttl",
+        updated_at=updated_at,
+        is_ephemeral=True,
+    )
+    persisted_id = await _add_agent_session(
+        db,
+        title="persisted, same staleness",
+        updated_at=updated_at,
+    )
+
+    settings = await _make_settings(db, AgentSessionRetentionSetting(max_idle_days=30))
+    await AgentSessionSweeper(db, settings=settings)._sweep()
+
+    remaining_ids = await _remaining_session_ids(db)
+    assert remaining_ids == {persisted_id}
+    assert ephemeral_id not in remaining_ids
 
 
 async def test_count_pass_keeps_newest_sessions_per_user(
@@ -174,13 +217,15 @@ async def test_count_pass_keeps_newest_sessions_per_user(
         )
         for days_ago in (1, 2, 3, 4)
     ]
-    # The first user's oldest activity is a temporary session — exempt from the cap.
-    first_user_temporary_id = await _add_agent_session(
+    # The first user's most recent activity is an ephemeral session. It is exempt
+    # from the cap, so it must neither be trimmed itself nor occupy one of the
+    # user's two slots and push a persisted session out.
+    first_user_ephemeral_id = await _add_agent_session(
         db,
-        title="first-user temporary",
+        title="first-user ephemeral",
         user_id=first_user_id,
-        updated_at=now - timedelta(days=10),
-        expires_at=now + timedelta(hours=1),
+        updated_at=now - timedelta(hours=1),
+        is_ephemeral=True,
     )
     second_user_session_id = await _add_agent_session(
         db,
@@ -203,13 +248,13 @@ async def test_count_pass_keeps_newest_sessions_per_user(
 
     assert await _remaining_session_ids(db) == {
         *first_user_session_ids[:2],
-        first_user_temporary_id,
+        first_user_ephemeral_id,
         second_user_session_id,
         *anonymous_session_ids[:2],
     }
 
 
-async def test_all_zero_setting_runs_only_temporary_gc(
+async def test_all_zero_setting_runs_only_ephemeral_gc(
     db: DbSessionFactory,
 ) -> None:
     now = datetime.now(timezone.utc)
@@ -223,11 +268,11 @@ async def test_all_zero_setting_runs_only_temporary_gc(
         )
         for days_ago in (400, 500, 600)
     ]
-    expired_temporary_id = await _add_agent_session(
+    expired_ephemeral_id = await _add_agent_session(
         db,
-        title="expired temporary",
+        title="expired ephemeral",
         updated_at=now - timedelta(days=2),
-        expires_at=now - timedelta(hours=1),
+        is_ephemeral=True,
     )
 
     settings = await _make_settings(
@@ -237,7 +282,7 @@ async def test_all_zero_setting_runs_only_temporary_gc(
 
     remaining_ids = await _remaining_session_ids(db)
     assert remaining_ids == set(ancient_session_ids)
-    assert expired_temporary_id not in remaining_ids
+    assert expired_ephemeral_id not in remaining_ids
 
 
 async def test_setting_edits_apply_on_the_next_sweep(


### PR DESCRIPTION
Closes #14886

Part 5 of a 5-PR stack. **Base: `agent-sessions-storage-locked-errors` (#14910)** — review that one first.

Replaces `agent_sessions.expires_at` with an `is_ephemeral` flag: the deadline was always `updated_at` plus a fixed TTL, rewritten on every turn just to slide the window. The backend and GraphQL API now say `isEphemeral` throughout, while the frontend keeps its `temporary` vocabulary by aliasing the field in its Relay documents.