### PR TITLE
feat(agents): keep active sessions synchronized

### DIFF
--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -377,6 +377,7 @@ function AgentSessionsContent({
           key={activeSessionId}
           sessionId={activeSessionId}
           initialMessages={[]}
+          shouldSyncOnMount
         />
       )}
     </>
@@ -424,6 +425,7 @@ function AgentSessionTranscript({
       sessionId={sessionId}
       initialMessages={messages}
       isActive={agentSession.isActive}
+      shouldSyncOnMount={false}
     />
   );
 }
@@ -432,11 +434,14 @@ function AgentChatController({
   sessionId,
   initialMessages,
   isActive,
+  shouldSyncOnMount,
 }: {
   sessionId: string;
   initialMessages: AgentUIMessage[];
   /** Relay-derived: another client's turn holds the session's server lock. */
   isActive?: boolean;
+  /** Whether this runtime skipped a fresh transcript query when it mounted. */
+  shouldSyncOnMount: boolean;
 }) {
   const { menuValue, handleModelChange } = useAgentChatPanelState();
   const {
@@ -459,6 +464,7 @@ function AgentChatController({
     sessionId,
     initialMessages,
     isActive,
+    shouldSyncOnMount,
   });
 
   return (

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -529,6 +529,8 @@ export function useAgentChat({
     }
   }, [persistedSessionId, chatInstance, isActive, store]);
 
+  const isSessionPollingPaused = isRequestActive(status) || isCompacting;
+
   // Keep idle sessions synchronized with turns completed by other clients.
   // Poll slowly during normal use and switch to the existing faster cadence
   // while another client holds the turn lock. This client's own generation
@@ -536,12 +538,7 @@ export function useAgentChat({
   // in-flight optimistic messages. Refetching through Relay normalizes session
   // metadata into every mounted view as well as refreshing this chat runtime.
   useEffect(() => {
-    if (
-      !persistedSessionId ||
-      !chatInstance ||
-      isRequestActive(status) ||
-      isCompacting
-    ) {
+    if (!persistedSessionId || !chatInstance || isSessionPollingPaused) {
       // A runtime first observed during its own generation will be canonicalized
       // by the turn-completion refetch, so it does not also need a mount sync.
       shouldSyncOnNextPollSetupRef.current = false;
@@ -596,9 +593,8 @@ export function useAgentChat({
     persistedSessionId,
     chatInstance,
     isBusyElsewhere,
-    isCompacting,
+    isSessionPollingPaused,
     relayEnvironment,
-    status,
     store,
   ]);
 

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -571,9 +571,10 @@ export function useAgentChat({
         // Transient failure: wait for the next poll tick.
       }
     };
-    if (isBusyElsewhere) {
-      void pollSession();
-    }
+    // Synchronize immediately when the session surface mounts instead of
+    // waiting for the first interval. This also detects a turn that another
+    // client started after the session's initial route data was loaded.
+    void pollSession();
     const intervalId = setInterval(
       () => void pollSession(),
       isBusyElsewhere ? SESSION_BUSY_POLL_INTERVAL_MS : SESSION_POLL_INTERVAL_MS

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -99,6 +99,7 @@ const SESSION_BUSY_ERROR_CODE = "agent_session_busy";
  * session and this client is rendering a stale transcript.
  */
 const SESSION_STALE_ERROR_CODE = "agent_session_stale";
+const SESSION_POLL_INTERVAL_MS = 10_000;
 const SESSION_BUSY_POLL_INTERVAL_MS = 3000;
 
 function buildAgentChatApiUrl(sessionId: string): string {
@@ -524,18 +525,23 @@ export function useAgentChat({
     }
   }, [persistedSessionId, chatInstance, isActive, store]);
 
-  // While in busy-elsewhere mode, poll the session's canonical Relay record
-  // until the other client's turn completes, then swap in the persisted
-  // transcript. Refetching through Relay (rather than the REST session read)
-  // normalizes the fresh title/timestamps/transcript into the store, so every
-  // mounted session view updates alongside the chat. Transient fetch failures
-  // keep the poll alive; unmounting or switching sessions stops it.
+  // Keep idle sessions synchronized with turns completed by other clients.
+  // Poll slowly during normal use and switch to the existing faster cadence
+  // while another client holds the turn lock. This client's own generation
+  // disables polling so an older persisted transcript cannot replace its
+  // in-flight optimistic messages. Refetching through Relay normalizes session
+  // metadata into every mounted view as well as refreshing this chat runtime.
   useEffect(() => {
-    if (!persistedSessionId || !chatInstance || !isBusyElsewhere) {
+    if (
+      !persistedSessionId ||
+      !chatInstance ||
+      isRequestActive(status) ||
+      isCompacting
+    ) {
       return undefined;
     }
     let disposed = false;
-    const pollTurnLock = async () => {
+    const pollSession = async () => {
       try {
         const data = await refetchAgentSession({
           environment: relayEnvironment,
@@ -545,15 +551,18 @@ export function useAgentChat({
           data?.agentSession.__typename === "AgentSession"
             ? data.agentSession
             : null;
-        if (!agentSession || agentSession.isActive || disposed) {
+        if (!agentSession || disposed) {
           return;
         }
-        // The other client's turn completed and its transcript persisted;
-        // mirror the rewind path by replacing the runtime chat's messages.
-        // Clear any lingering 409 error first: the SDK assigns error state
-        // AFTER onError runs, so entry-time clearing is timing-fragile —
-        // this is the deterministic point where nothing can re-error.
-        chatInstance.clearError();
+        if (agentSession.isActive) {
+          store.getState().setSessionBusyElsewhere(persistedSessionId, true);
+          return;
+        }
+        // Clear a lingering conflict error only after the other client's turn
+        // has completed; the SDK can assign error state after onError runs.
+        if (isBusyElsewhere) {
+          chatInstance.clearError();
+        }
         chatInstance.messages = Array.isArray(agentSession.messages)
           ? (agentSession.messages as AgentUIMessage[])
           : [];
@@ -562,10 +571,12 @@ export function useAgentChat({
         // Transient failure: wait for the next poll tick.
       }
     };
-    void pollTurnLock();
+    if (isBusyElsewhere) {
+      void pollSession();
+    }
     const intervalId = setInterval(
-      () => void pollTurnLock(),
-      SESSION_BUSY_POLL_INTERVAL_MS
+      () => void pollSession(),
+      isBusyElsewhere ? SESSION_BUSY_POLL_INTERVAL_MS : SESSION_POLL_INTERVAL_MS
     );
     return () => {
       disposed = true;
@@ -575,7 +586,9 @@ export function useAgentChat({
     persistedSessionId,
     chatInstance,
     isBusyElsewhere,
+    isCompacting,
     relayEnvironment,
+    status,
     store,
   ]);
 

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -223,6 +223,7 @@ export function useAgentChat({
   sessionId,
   initialMessages,
   isActive = false,
+  shouldSyncOnMount = false,
 }: {
   /**
    * The session's Relay node ID, or {@link DRAFT_SESSION_ID} (or null) for a
@@ -237,12 +238,15 @@ export function useAgentChat({
    * entry into busy-elsewhere mode; the hook then polls until the lock clears.
    */
   isActive?: boolean;
+  /** Immediately synchronize runtimes that mounted without a fresh session query. */
+  shouldSyncOnMount?: boolean;
 }) {
   const store = useAgentStore();
   const runtime = useAgentChatRuntime();
   const relayEnvironment = useRelayEnvironment();
   const [operationError, setOperationError] =
     useState<AgentChatOperationError | null>(null);
+  const shouldSyncOnNextPollSetupRef = useRef(shouldSyncOnMount);
   const [compactionStatus, setCompactionStatus] = useState<string | null>(null);
   const isDraft = sessionId == null || sessionId === DRAFT_SESSION_ID;
   const isCompacting = useAgentContext((state) =>
@@ -538,6 +542,9 @@ export function useAgentChat({
       isRequestActive(status) ||
       isCompacting
     ) {
+      // A runtime first observed during its own generation will be canonicalized
+      // by the turn-completion refetch, so it does not also need a mount sync.
+      shouldSyncOnNextPollSetupRef.current = false;
       return undefined;
     }
     let disposed = false;
@@ -554,6 +561,7 @@ export function useAgentChat({
         if (!agentSession || disposed) {
           return;
         }
+        shouldSyncOnNextPollSetupRef.current = false;
         if (agentSession.isActive) {
           store.getState().setSessionBusyElsewhere(persistedSessionId, true);
           return;
@@ -571,10 +579,11 @@ export function useAgentChat({
         // Transient failure: wait for the next poll tick.
       }
     };
-    // Synchronize immediately when the session surface mounts instead of
-    // waiting for the first interval. This also detects a turn that another
-    // client started after the session's initial route data was loaded.
-    void pollSession();
+    // Resident runtimes skip the transcript loader when reopened, so refresh
+    // those once on mount. Newly seeded runtimes already came from this query.
+    if (shouldSyncOnNextPollSetupRef.current) {
+      void pollSession();
+    }
     const intervalId = setInterval(
       () => void pollSession(),
       isBusyElsewhere ? SESSION_BUSY_POLL_INTERVAL_MS : SESSION_POLL_INTERVAL_MS

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -935,8 +935,9 @@ export function PxiApp({
   // generation disables polling so its in-flight messages cannot be replaced
   // by an older persisted transcript.
   const activeSessionId = activeSession?.id ?? null;
+  const isSessionPollingPaused = status === "streaming" || isCompacting;
   useEffect(() => {
-    if (!activeSessionId || status === "streaming" || isCompacting) {
+    if (!activeSessionId || isSessionPollingPaused) {
       return undefined;
     }
     let isStale = false;
@@ -969,10 +970,9 @@ export function PxiApp({
     };
   }, [
     activeSessionId,
-    isCompacting,
+    isSessionPollingPaused,
     isSessionBusy,
     serverSessionClient,
-    status,
   ]);
 
   const handleExit = () => {

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -113,7 +113,8 @@ const KITTY_BACKSPACE_INPUT_PATTERN =
 const KITTY_FORWARD_DELETE_INPUT_PATTERN = /^\x1B\[3;\d+:[12]~$/;
 const KEYBOARD_PROTOCOL_RESPONSE_PATTERN = /^\[\?\d+u$/;
 const INTERRUPTED_MESSAGE_TEXT = "\n\n[Interrupted by user before completion.]";
-/** How often to re-fetch a session while another client's turn holds its lock. */
+/** Normal and busy cadences for synchronizing the active session. */
+const SESSION_POLL_INTERVAL_MS = 10_000;
 const SESSION_BUSY_POLL_INTERVAL_MS = 3000;
 const SESSION_BUSY_STATUS_TEXT =
   "Session is being used elsewhere, the chat will refresh when complete";
@@ -928,25 +929,28 @@ export function PxiApp({
     [options.config, sessionClient]
   );
 
-  // While another client's turn holds the session lock, poll the session until
-  // the turn completes, then swap in the persisted transcript. Transient fetch
-  // failures keep the poll alive; switching sessions, /new, and unmounting
-  // (process exit) stop it via the effect cleanup.
-  const busySessionId = isSessionBusy ? (activeSession?.id ?? null) : null;
+  // Keep the active session synchronized with turns completed by other
+  // clients. Poll slowly during normal use and switch to the existing faster
+  // cadence while another client holds the turn lock. This client's own
+  // generation disables polling so its in-flight messages cannot be replaced
+  // by an older persisted transcript.
+  const activeSessionId = activeSession?.id ?? null;
   useEffect(() => {
-    if (!busySessionId) {
+    if (!activeSessionId || status === "streaming" || isCompacting) {
       return undefined;
     }
     let isStale = false;
     const pollSession = () => {
       void serverSessionClient
-        .getSession({ sessionId: busySessionId })
+        .getSession({ sessionId: activeSessionId })
         .then((session) => {
-          if (isStale || session.isActive) {
+          if (isStale) {
             return;
           }
-          // The other client's turn completed and its transcript persisted;
-          // mirror the session-restore path by replacing the message list.
+          if (session.isActive) {
+            setIsSessionBusy(true);
+            return;
+          }
           setActiveSession(session);
           setMessages(session.messages);
           setIsSessionBusy(false);
@@ -955,12 +959,21 @@ export function PxiApp({
           // Transient failure: wait for the next poll tick.
         });
     };
-    const intervalId = setInterval(pollSession, SESSION_BUSY_POLL_INTERVAL_MS);
+    const intervalId = setInterval(
+      pollSession,
+      isSessionBusy ? SESSION_BUSY_POLL_INTERVAL_MS : SESSION_POLL_INTERVAL_MS
+    );
     return () => {
       isStale = true;
       clearInterval(intervalId);
     };
-  }, [busySessionId, serverSessionClient]);
+  }, [
+    activeSessionId,
+    isCompacting,
+    isSessionBusy,
+    serverSessionClient,
+    status,
+  ]);
 
   const handleExit = () => {
     abortControllerRef.current?.abort();

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -1218,6 +1218,104 @@ describe("PXI app", () => {
     unmount();
   });
 
+  it("polls idle sessions for remote updates and pauses during local generation", async () => {
+    vi.useFakeTimers();
+    const originalMessage: PxiMessage = {
+      id: "original-message",
+      role: "user",
+      parts: [{ type: "text", text: "original conversation" }],
+    };
+    const synchronizedMessage: PxiMessage = {
+      id: "synchronized-message",
+      role: "assistant",
+      parts: [{ type: "text", text: "updated by another client" }],
+    };
+    let getSessionCallCount = 0;
+    const getSession = vi.fn(async ({ sessionId }: { sessionId: string }) => {
+      getSessionCallCount += 1;
+      return {
+        id: sessionId,
+        title: "Shared session",
+        updatedAt: "2026-07-24T12:00:00Z",
+        isTemporary: false,
+        isActive: getSessionCallCount === 2,
+        messages:
+          getSessionCallCount < 3 ? [originalMessage] : [synchronizedMessage],
+      };
+    });
+    const sessionClient: PxiSessionClient = {
+      createSession: async () => {
+        throw new Error("not used");
+      },
+      listSessions: async () => [
+        {
+          id: "session-1",
+          title: "Shared session",
+          updatedAt: "2026-07-24T12:00:00Z",
+          isTemporary: false,
+        },
+      ],
+      getSession,
+      compactSession: async () => {
+        throw new Error("not used");
+      },
+    };
+    const client: PxiChatClient = {
+      sendMessage: async () => new Promise(() => {}),
+    };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        sessionClient={sessionClient}
+      />
+    );
+
+    try {
+      await writeInput({ stdin, input: "/sessions" });
+      await writeInput({ stdin, input: "\r" });
+      await act(async () => Promise.resolve());
+      await writeInput({ stdin, input: "\r" });
+      await act(async () => Promise.resolve());
+
+      expect(getSession).toHaveBeenCalledTimes(1);
+      expect(stripAnsi(lastFrame() ?? "")).toContain("original conversation");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(getSession).toHaveBeenCalledTimes(2);
+      expect(stripAnsi(lastFrame() ?? "")).toContain(
+        "Session is being used elsewhere"
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_999);
+      });
+      expect(getSession).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(getSession).toHaveBeenCalledTimes(3);
+      expect(stripAnsi(lastFrame() ?? "")).toContain(
+        "updated by another client"
+      );
+
+      await writeInput({ stdin, input: "local question" });
+      await writeInput({ stdin, input: "\r" });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(getSession).toHaveBeenCalledTimes(3);
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
+  });
+
   it("reopens the session picker with the cached list while refreshing in the background", async () => {
     const initialSessions: PxiSessionSummary[] = [
       {


### PR DESCRIPTION
Resolves #14879


https://github.com/user-attachments/assets/560d8adc-7058-48e7-a59d-1bad15749e1c


Keeps web and CLI agent sessions synchronized with a 10-second poll, switching to 3 seconds while another client is busy. Polling pauses during local generation and compaction to protect in-flight messages.

**Tests:** frontend and PXI test suites; frontend and CLI typechecks.