### PR TITLE
fix(ui): resolve span details project id from the span, not the route

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -10,7 +10,7 @@ import {
   type PanelImperativeHandle,
   Separator,
 } from "react-resizable-panels";
-import { useNavigate, useParams } from "react-router";
+import { useNavigate } from "react-router";
 
 import {
   Button,
@@ -85,7 +85,6 @@ export function SpanDetails({
 }
 
 function SpanDetailsContent({ spanNodeId }: { spanNodeId: string }) {
-  const { projectId } = useParams();
   const isAnnotatingSpans = usePreferencesContext(
     (state) => state.isAnnotatingSpans
   );
@@ -125,6 +124,11 @@ function SpanDetailsContent({ spanNodeId }: { spanNodeId: string }) {
             trace {
               id
               traceId
+            }
+            # sourced from the span rather than the route so span details work
+            # when embedded outside a /projects/:projectId route
+            project {
+              id
             }
             name
             spanKind
@@ -188,9 +192,6 @@ function SpanDetailsContent({ spanNodeId }: { spanNodeId: string }) {
       "Expected a span, but got a different type" + span.__typename
     );
   }
-  if (projectId == null) {
-    throw new Error("Project ID is required to download a span");
-  }
 
   useHotkeys(EDIT_ANNOTATION_HOTKEY, () => openSpanAside(), {
     preventDefault: true,
@@ -237,7 +238,7 @@ function SpanDetailsContent({ spanNodeId }: { spanNodeId: string }) {
                     buttonText={isCondensedView ? null : "Add to Dataset"}
                   />
                   <SpanDownloadMenu
-                    projectId={projectId}
+                    projectId={span.project.id}
                     spanId={span.spanId}
                     traceId={span.trace.traceId}
                     buttonText={isCondensedView ? null : "Download"}

--- a/app/src/pages/trace/__generated__/SpanDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<98ca2d0387afa9c30627035d2566b38b>>
+ * @generated SignedSource<<86349fe14f4d174ae1db898520b44d1e>>
  * @lightSyntaxTransform
  */
 
@@ -59,6 +59,9 @@ export type SpanDetailsQuery$data = {
       readonly value: string;
     } | null;
     readonly parentId: string | null;
+    readonly project: {
+      readonly id: string;
+    };
     readonly spanId: string;
     readonly spanKind: SpanKind;
     readonly startTime: string;
@@ -136,70 +139,73 @@ v5 = {
   ],
   "storageKey": null
 },
-v6 = {
+v6 = [
+  (v3/*:: as any*/)
+],
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "spanKind",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": "statusCode",
   "args": null,
   "kind": "ScalarField",
   "name": "propagatedStatusCode",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "statusMessage",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startTime",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "latencyMs",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "tokenCountTotal",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endTime",
   "storageKey": null
 },
-v15 = [
+v16 = [
   {
     "alias": null,
     "args": null,
@@ -215,34 +221,34 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "input",
   "plural": false,
-  "selections": (v15/*:: as any*/),
+  "selections": (v16/*:: as any*/),
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "output",
   "plural": false,
-  "selections": (v15/*:: as any*/),
+  "selections": (v16/*:: as any*/),
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "attributes",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanEvent",
@@ -250,7 +256,7 @@ v19 = {
   "name": "events",
   "plural": true,
   "selections": [
-    (v6/*:: as any*/),
+    (v7/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -268,7 +274,7 @@ v19 = {
   ],
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "DocumentRetrievalMetrics",
@@ -307,92 +313,90 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "annotatorKind",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "documentPosition",
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v24 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "score",
   "storageKey": null
 },
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "explanation",
   "storageKey": null
 },
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v27 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "updatedAt",
   "storageKey": null
 },
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "username",
   "storageKey": null
 },
-v29 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "profilePictureUrl",
   "storageKey": null
 },
-v30 = {
+v31 = {
   "kind": "InlineFragment",
-  "selections": [
-    (v3/*:: as any*/)
-  ],
+  "selections": (v6/*:: as any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v31 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "annotationType",
   "storageKey": null
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v33 = {
+v34 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -403,8 +407,8 @@ v33 = {
       "name": "values",
       "plural": true,
       "selections": [
-        (v23/*:: as any*/),
-        (v24/*:: as any*/)
+        (v24/*:: as any*/),
+        (v25/*:: as any*/)
       ],
       "storageKey": null
     }
@@ -412,14 +416,14 @@ v33 = {
   "type": "CategoricalAnnotationConfig",
   "abstractKey": null
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "optimizationDirection",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -436,16 +440,16 @@ v35 = {
       "name": "upperBound",
       "storageKey": null
     },
-    (v34/*:: as any*/)
+    (v35/*:: as any*/)
   ],
   "type": "ContinuousAnnotationConfig",
   "abstractKey": null
 },
-v36 = {
+v37 = {
   "kind": "InlineFragment",
   "selections": [
-    (v6/*:: as any*/),
-    (v34/*:: as any*/),
+    (v7/*:: as any*/),
+    (v35/*:: as any*/),
     {
       "alias": null,
       "args": null,
@@ -479,7 +483,16 @@ return {
               (v3/*:: as any*/),
               (v4/*:: as any*/),
               (v5/*:: as any*/),
-              (v6/*:: as any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Project",
+                "kind": "LinkedField",
+                "name": "project",
+                "plural": false,
+                "selections": (v6/*:: as any*/),
+                "storageKey": null
+              },
               (v7/*:: as any*/),
               (v8/*:: as any*/),
               (v9/*:: as any*/),
@@ -488,15 +501,16 @@ return {
               (v12/*:: as any*/),
               (v13/*:: as any*/),
               (v14/*:: as any*/),
-              (v16/*:: as any*/),
+              (v15/*:: as any*/),
               (v17/*:: as any*/),
               (v18/*:: as any*/),
+              (v19/*:: as any*/),
               {
                 "kind": "RequiredField",
-                "field": (v19/*:: as any*/),
+                "field": (v20/*:: as any*/),
                 "action": "THROW"
               },
-              (v20/*:: as any*/),
+              (v21/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -506,14 +520,14 @@ return {
                 "plural": true,
                 "selections": [
                   (v3/*:: as any*/),
-                  (v21/*:: as any*/),
                   (v22/*:: as any*/),
-                  (v6/*:: as any*/),
                   (v23/*:: as any*/),
+                  (v7/*:: as any*/),
                   (v24/*:: as any*/),
                   (v25/*:: as any*/),
                   (v26/*:: as any*/),
                   (v27/*:: as any*/),
+                  (v28/*:: as any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -522,8 +536,8 @@ return {
                     "name": "user",
                     "plural": false,
                     "selections": [
-                      (v28/*:: as any*/),
-                      (v29/*:: as any*/)
+                      (v29/*:: as any*/),
+                      (v30/*:: as any*/)
                     ],
                     "storageKey": null
                   }
@@ -572,7 +586,103 @@ return {
             "selections": [
               (v4/*:: as any*/),
               (v5/*:: as any*/),
-              (v6/*:: as any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Project",
+                "kind": "LinkedField",
+                "name": "project",
+                "plural": false,
+                "selections": [
+                  (v3/*:: as any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigConnection",
+                    "kind": "LinkedField",
+                    "name": "annotationConfigs",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AnnotationConfigEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v2/*:: as any*/),
+                              (v31/*:: as any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v7/*:: as any*/),
+                                  (v32/*:: as any*/),
+                                  (v33/*:: as any*/)
+                                ],
+                                "type": "AnnotationConfigBase",
+                                "abstractKey": "__isAnnotationConfigBase"
+                              },
+                              (v34/*:: as any*/),
+                              (v36/*:: as any*/),
+                              (v37/*:: as any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "configs",
+                        "args": null,
+                        "concreteType": "AnnotationConfigEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": "config",
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v2/*:: as any*/),
+                              (v31/*:: as any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v7/*:: as any*/),
+                                  (v33/*:: as any*/),
+                                  (v32/*:: as any*/)
+                                ],
+                                "type": "AnnotationConfigBase",
+                                "abstractKey": "__isAnnotationConfigBase"
+                              },
+                              (v34/*:: as any*/),
+                              (v36/*:: as any*/),
+                              (v37/*:: as any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
               (v7/*:: as any*/),
               (v8/*:: as any*/),
               (v9/*:: as any*/),
@@ -581,11 +691,12 @@ return {
               (v12/*:: as any*/),
               (v13/*:: as any*/),
               (v14/*:: as any*/),
-              (v16/*:: as any*/),
+              (v15/*:: as any*/),
               (v17/*:: as any*/),
               (v18/*:: as any*/),
               (v19/*:: as any*/),
               (v20/*:: as any*/),
+              (v21/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -595,14 +706,14 @@ return {
                 "plural": true,
                 "selections": [
                   (v3/*:: as any*/),
-                  (v21/*:: as any*/),
                   (v22/*:: as any*/),
-                  (v6/*:: as any*/),
                   (v23/*:: as any*/),
+                  (v7/*:: as any*/),
                   (v24/*:: as any*/),
                   (v25/*:: as any*/),
                   (v26/*:: as any*/),
                   (v27/*:: as any*/),
+                  (v28/*:: as any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -611,8 +722,8 @@ return {
                     "name": "user",
                     "plural": false,
                     "selections": [
-                      (v28/*:: as any*/),
                       (v29/*:: as any*/),
+                      (v30/*:: as any*/),
                       (v3/*:: as any*/)
                     ],
                     "storageKey": null
@@ -655,103 +766,6 @@ return {
                   }
                 ],
                 "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Project",
-                "kind": "LinkedField",
-                "name": "project",
-                "plural": false,
-                "selections": [
-                  (v3/*:: as any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AnnotationConfigConnection",
-                    "kind": "LinkedField",
-                    "name": "annotationConfigs",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "AnnotationConfigEdge",
-                        "kind": "LinkedField",
-                        "name": "edges",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": null,
-                            "kind": "LinkedField",
-                            "name": "node",
-                            "plural": false,
-                            "selections": [
-                              (v2/*:: as any*/),
-                              (v30/*:: as any*/),
-                              {
-                                "kind": "InlineFragment",
-                                "selections": [
-                                  (v6/*:: as any*/),
-                                  (v31/*:: as any*/),
-                                  (v32/*:: as any*/)
-                                ],
-                                "type": "AnnotationConfigBase",
-                                "abstractKey": "__isAnnotationConfigBase"
-                              },
-                              (v33/*:: as any*/),
-                              (v35/*:: as any*/),
-                              (v36/*:: as any*/)
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "configs",
-                        "args": null,
-                        "concreteType": "AnnotationConfigEdge",
-                        "kind": "LinkedField",
-                        "name": "edges",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "alias": "config",
-                            "args": null,
-                            "concreteType": null,
-                            "kind": "LinkedField",
-                            "name": "node",
-                            "plural": false,
-                            "selections": [
-                              (v2/*:: as any*/),
-                              (v30/*:: as any*/),
-                              {
-                                "kind": "InlineFragment",
-                                "selections": [
-                                  (v6/*:: as any*/),
-                                  (v32/*:: as any*/),
-                                  (v31/*:: as any*/)
-                                ],
-                                "type": "AnnotationConfigBase",
-                                "abstractKey": "__isAnnotationConfigBase"
-                              },
-                              (v33/*:: as any*/),
-                              (v35/*:: as any*/),
-                              (v36/*:: as any*/)
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
               }
             ],
             "type": "Span",
@@ -763,16 +777,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "63993bee8d0d8019eb1d19a474463885",
+    "cacheID": "d6b54ecbfbeabc4e3fe99e69e6e2f6da",
     "id": null,
     "metadata": {},
     "name": "SpanDetailsQuery",
     "operationKind": "query",
-    "text": "query SpanDetailsQuery(\n  $id: ID!\n) {\n  span: node(id: $id) {\n    __typename\n    ... on Span {\n      id\n      spanId\n      trace {\n        id\n        traceId\n      }\n      name\n      spanKind\n      statusCode: propagatedStatusCode\n      statusMessage\n      startTime\n      parentId\n      latencyMs\n      tokenCountTotal\n      endTime\n      input {\n        value\n        mimeType\n      }\n      output {\n        value\n        mimeType\n      }\n      attributes\n      events {\n        name\n        message\n        timestamp\n      }\n      documentRetrievalMetrics {\n        evaluationName\n        ndcg\n        precision\n        hit\n      }\n      documentEvaluations {\n        id\n        annotatorKind\n        documentPosition\n        name\n        label\n        score\n        explanation\n        createdAt\n        updatedAt\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n      }\n      ...SpanHeader_span\n      ...SpanAside_span\n    }\n    id\n  }\n}\n\nfragment AnnotationConfigListProjectAnnotationConfigFragment on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n          description\n        }\n        ... on CategoricalAnnotationConfig {\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          lowerBound\n          upperBound\n          optimizationDirection\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n          threshold\n        }\n      }\n    }\n  }\n}\n\nfragment SpanAside_span on Span {\n  id\n  project {\n    id\n    ...AnnotationConfigListProjectAnnotationConfigFragment\n    annotationConfigs {\n      configs: edges {\n        config: node {\n          __typename\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            name\n            description\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            values {\n              label\n              score\n            }\n          }\n          ... on ContinuousAnnotationConfig {\n            lowerBound\n            upperBound\n            optimizationDirection\n          }\n          ... on FreeformAnnotationConfig {\n            name\n            optimizationDirection\n            threshold\n          }\n        }\n      }\n    }\n  }\n  code: statusCode\n  startTime\n  endTime\n  tokenCountTotal\n}\n\nfragment SpanHeader_span on Span {\n  id\n  name\n  spanKind\n  spanId\n  code: statusCode\n  latencyMs\n  startTime\n  tokenCountTotal\n  costSummary {\n    total {\n      cost\n    }\n  }\n}\n"
+    "text": "query SpanDetailsQuery(\n  $id: ID!\n) {\n  span: node(id: $id) {\n    __typename\n    ... on Span {\n      id\n      spanId\n      trace {\n        id\n        traceId\n      }\n      project {\n        id\n      }\n      name\n      spanKind\n      statusCode: propagatedStatusCode\n      statusMessage\n      startTime\n      parentId\n      latencyMs\n      tokenCountTotal\n      endTime\n      input {\n        value\n        mimeType\n      }\n      output {\n        value\n        mimeType\n      }\n      attributes\n      events {\n        name\n        message\n        timestamp\n      }\n      documentRetrievalMetrics {\n        evaluationName\n        ndcg\n        precision\n        hit\n      }\n      documentEvaluations {\n        id\n        annotatorKind\n        documentPosition\n        name\n        label\n        score\n        explanation\n        createdAt\n        updatedAt\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n      }\n      ...SpanHeader_span\n      ...SpanAside_span\n    }\n    id\n  }\n}\n\nfragment AnnotationConfigListProjectAnnotationConfigFragment on Project {\n  annotationConfigs {\n    edges {\n      node {\n        __typename\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n          description\n        }\n        ... on CategoricalAnnotationConfig {\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          lowerBound\n          upperBound\n          optimizationDirection\n        }\n        ... on FreeformAnnotationConfig {\n          name\n          optimizationDirection\n          threshold\n        }\n      }\n    }\n  }\n}\n\nfragment SpanAside_span on Span {\n  id\n  project {\n    id\n    ...AnnotationConfigListProjectAnnotationConfigFragment\n    annotationConfigs {\n      configs: edges {\n        config: node {\n          __typename\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            name\n            description\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            values {\n              label\n              score\n            }\n          }\n          ... on ContinuousAnnotationConfig {\n            lowerBound\n            upperBound\n            optimizationDirection\n          }\n          ... on FreeformAnnotationConfig {\n            name\n            optimizationDirection\n            threshold\n          }\n        }\n      }\n    }\n  }\n  code: statusCode\n  startTime\n  endTime\n  tokenCountTotal\n}\n\nfragment SpanHeader_span on Span {\n  id\n  name\n  spanKind\n  spanId\n  code: statusCode\n  latencyMs\n  startTime\n  tokenCountTotal\n  costSummary {\n    total {\n      cost\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "77e427fec03740837a92368361624048";
+(node as any).hash = "8d27f06118eb62f5dd4ba579e8554206";
 
 export default node;

--- a/app/src/pages/trace/__tests__/SpanDetails.test.tsx
+++ b/app/src/pages/trace/__tests__/SpanDetails.test.tsx
@@ -1,0 +1,157 @@
+import { act, Suspense } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { RelayEnvironmentProvider } from "react-relay";
+import { MemoryRouter, Route, Routes } from "react-router";
+import {
+  Environment,
+  Network,
+  Observable,
+  RecordSource,
+  Store,
+} from "relay-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installTestMatchMedia } from "@phoenix/__tests__/installTestMatchMedia";
+import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
+import { PreferencesProvider, ThemeProvider } from "@phoenix/contexts";
+
+import { SpanDetails } from "../SpanDetails";
+import { SpanInfoCardsProvider } from "../SpanInfoCardsContext";
+
+// The panels below the header pull in annotation editors and code blocks that
+// have nothing to do with how the project id is resolved
+vi.mock("../SpanAside", () => ({
+  SpanAside: () => <div data-testid="span-aside" />,
+}));
+vi.mock("../span", () => ({
+  SpanInfo: () => <div data-testid="span-info" />,
+  SpanAttributesCard: () => <div data-testid="span-attributes-card" />,
+}));
+vi.mock("../SpanDownloadMenu", () => ({
+  SpanDownloadMenu: ({ projectId }: { projectId: string }) => (
+    <div data-testid="span-download-menu" data-project-id={projectId} />
+  ),
+}));
+
+installTestMatchMedia();
+installTestStorage();
+
+const SPAN_NODE_ID = "U3Bhbjox";
+const PROJECT_NODE_ID = "UHJvamVjdDox";
+
+// Mirrors the dataset evaluator trace route, which has no `:projectId` segment.
+const EVALUATOR_TRACE_ROUTE =
+  "/datasets/:datasetId/evaluators/:evaluatorId/:traceId";
+const EVALUATOR_TRACE_PATH =
+  "/datasets/RGF0YXNldDox/evaluators/RXZhbHVhdG9yOjE/trace-1";
+
+const spanPayload = {
+  __typename: "Span",
+  id: SPAN_NODE_ID,
+  spanId: "0123456789abcdef",
+  trace: {
+    __typename: "Trace",
+    id: "VHJhY2U6MQ==",
+    traceId: "trace-1",
+  },
+  project: {
+    __typename: "Project",
+    id: PROJECT_NODE_ID,
+    annotationConfigs: { configs: [], edges: [] },
+  },
+  name: "chat completion",
+  spanKind: "llm",
+  // aliased from `propagatedStatusCode` by SpanDetailsQuery
+  statusCode: "OK",
+  // aliased from `statusCode` by the SpanHeader_span and SpanAside_span fragments
+  code: "OK",
+  statusMessage: "",
+  startTime: "2026-01-01T00:00:00.000Z",
+  endTime: "2026-01-01T00:00:01.000Z",
+  parentId: null,
+  latencyMs: 1000,
+  tokenCountTotal: 42,
+  costSummary: { total: { cost: 0.01 } },
+  input: { value: "hello", mimeType: "text" },
+  output: { value: "world", mimeType: "text" },
+  attributes: "{}",
+  events: [],
+  documentRetrievalMetrics: [],
+  documentEvaluations: [],
+};
+
+function createTestEnvironment() {
+  return new Environment({
+    network: Network.create(() =>
+      Observable.create((sink) => {
+        sink.next({ data: { span: spanPayload } });
+        sink.complete();
+      })
+    ),
+    store: new Store(new RecordSource()),
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function renderSpanDetails() {
+  await act(async () => {
+    root.render(
+      <RelayEnvironmentProvider environment={createTestEnvironment()}>
+        <ThemeProvider themeMode="dark">
+          <PreferencesProvider>
+            <MemoryRouter initialEntries={[EVALUATOR_TRACE_PATH]}>
+              <Routes>
+                <Route
+                  path={EVALUATOR_TRACE_ROUTE}
+                  element={
+                    <SpanInfoCardsProvider>
+                      <Suspense fallback={<div>loading</div>}>
+                        <SpanDetails spanNodeId={SPAN_NODE_ID} />
+                      </Suspense>
+                    </SpanInfoCardsProvider>
+                  }
+                />
+              </Routes>
+            </MemoryRouter>
+          </PreferencesProvider>
+        </ThemeProvider>
+      </RelayEnvironmentProvider>
+    );
+  });
+}
+
+describe("SpanDetails", () => {
+  it("renders a span when embedded outside a :projectId route", async () => {
+    await renderSpanDetails();
+
+    expect(container.querySelector("[data-testid='span-header-row']")).not.toBe(
+      null
+    );
+    expect(container.textContent).toContain("chat completion");
+  });
+
+  it("resolves the download project id from the span rather than the route", async () => {
+    await renderSpanDetails();
+
+    const downloadMenu = container.querySelector(
+      "[data-testid='span-download-menu']"
+    );
+    expect(downloadMenu?.getAttribute("data-project-id")).toBe(PROJECT_NODE_ID);
+  });
+});


### PR DESCRIPTION
resolves #14916

## Problem

`SpanDetailsContent` read `projectId` from `useParams()` solely to feed `SpanDownloadMenu`, and threw when the route had no `:projectId` segment:

```ts
if (projectId == null) {
  throw new Error("Project ID is required to download a span");
}
```

The throw sits at the top of the component, so it takes down the entire span-details view rather than just the download action. Dataset evaluator traces (`/datasets/:datasetId/evaluators/:evaluatorId/:traceId`) and the experiment run trace dialog both render `TraceDetails` outside a project route, so selecting a span there hit the page-level error boundary.

Introduced in a61a86c50 (#14738, "feat: add span detail downloads"), first shipped in v19.7.0. Both affected surfaces predate it — `TraceDetailsDialog` since #9847, `EvaluatorTracePage` since #11066.

## Fix

Source the project ID from the span instead of the route: `SpanDetailsQuery` now selects `project { id }`, and the download menu gets `span.project.id`. The `useParams` read and the throw are gone.

I chose this over threading `projectId` down from `TraceDetails` (the issue's first suggestion) because it makes `SpanDetails` correct in *every* embedding — including `SessionDetailsTracesView`, which renders it directly — with no prop plumbing and no new failure mode if a future surface forgets to pass it. `Span.project` is already in the schema and `SpanAside_span` already selects it, so the field is effectively free.

## Tests

New `app/src/pages/trace/__tests__/SpanDetails.test.tsx` renders `SpanDetails` under a memory router at the evaluator trace path (no `:projectId`) with a Relay environment serving a span payload, and asserts the span renders and the download menu receives the span's project ID.

Verified it's a real regression test — stashing the source change makes both cases fail with `Error: Project ID is required to download a span`.

- `tsc --noEmit` — clean
- `vitest run src/pages/trace` — 4 files, 24 tests passed

Not manually exercised in a running Phoenix instance; coverage above is automated only.