### PR TITLE
chore(cli): add changeset for unknown-command upgrade hint

### DIFF
--- a/js/.changeset/cli-unknown-command-upgrade-hint.md
+++ b/js/.changeset/cli-unknown-command-upgrade-hint.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Suggest upgrading `px` when an unknown command is run and a newer version is published.


### PR DESCRIPTION
Follow-up to #14906, which merged without a changeset. Without it, the `px` unknown-command upgrade hint won't bump `@arizeai/phoenix-cli` or land in the changelog on the next release.

This adds a `minor` changeset (new user-facing feature, matching the repo's convention for `feat` changes).