### PR TITLE
refactor(agents): read the assistant trace project from config, not the session row

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -100,7 +100,7 @@ type AgentSession implements Node {
   latestOutput: String
 
   """Whether the session expires after a period of inactivity."""
-  isTemporary: Boolean!
+  isEphemeral: Boolean!
 
   """
   Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -772,7 +772,7 @@ input CreateAgentSessionInput {
   title: String! = ""
 
   """Whether the session should expire after a period of inactivity."""
-  temporary: Boolean! = false
+  isEphemeral: Boolean! = false
 }
 
 type CreateAgentSessionMutationPayload {

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1727,8 +1727,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -1753,8 +1753,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
         };
         /**
          * AgentSpanContext
@@ -2157,11 +2157,11 @@ export interface components {
              */
             title?: string;
             /**
-             * Temporary
+             * Is Ephemeral
              * @description Whether the session should expire after a period of inactivity.
              * @default false
              */
-            temporary?: boolean;
+            is_ephemeral?: boolean;
         };
         /** CreateAgentSessionResponseBody */
         CreateAgentSessionResponseBody: {

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -124,7 +124,7 @@ function AgentSessionsContent({
               id
               title
               ...EditAgentSessionTitleDialog_session
-              isTemporary
+              isTemporary: isEphemeral
               createdAt
               updatedAt
             }

--- a/app/src/components/agent/ChatErrorMessage.tsx
+++ b/app/src/components/agent/ChatErrorMessage.tsx
@@ -20,13 +20,7 @@ export function isApiKeyError(message: string | null | undefined): boolean {
   return message != null && API_KEY_ERROR_PATTERN.test(message);
 }
 
-/**
- * Matches the message the server reports when the database has run out of
- * storage and writes are locked: the HTTP 507 body from `is_not_locked`, the
- * `InsufficientStorage` GraphQL error from `IsLocked`, and the notice appended
- * when a turn's transcript could not be written. All three are built from
- * `INSUFFICIENT_STORAGE_MESSAGE` on the server, so this tracks one sentence.
- */
+/** Matches the message the server reports when writes are locked for storage. */
 const INSUFFICIENT_STORAGE_ERROR_PATTERN = /insufficient storage/i;
 
 /** Return whether an error message reports that the database is out of storage. */
@@ -95,7 +89,6 @@ export function ChatErrorMessage({
   onRewind?: MessageRewindRequest;
 }) {
   const isStorageError = isInsufficientStorageError(error.message);
-  // Retrying against a locked database fails identically, so don't offer it.
   const canRetry = onRetry != null && !isStorageError;
   const canUndoOrFork = latestUserMessageId != null && onRewind != null;
   const isCredentialError = !isStorageError && isApiKeyError(error.message);

--- a/app/src/components/agent/ChatErrorMessage.tsx
+++ b/app/src/components/agent/ChatErrorMessage.tsx
@@ -20,6 +20,22 @@ export function isApiKeyError(message: string | null | undefined): boolean {
   return message != null && API_KEY_ERROR_PATTERN.test(message);
 }
 
+/**
+ * Matches the message the server reports when the database has run out of
+ * storage and writes are locked: the HTTP 507 body from `is_not_locked`, the
+ * `InsufficientStorage` GraphQL error from `IsLocked`, and the notice appended
+ * when a turn's transcript could not be written. All three are built from
+ * `INSUFFICIENT_STORAGE_MESSAGE` on the server, so this tracks one sentence.
+ */
+const INSUFFICIENT_STORAGE_ERROR_PATTERN = /insufficient storage/i;
+
+/** Return whether an error message reports that the database is out of storage. */
+export function isInsufficientStorageError(
+  message: string | null | undefined
+): boolean {
+  return message != null && INSUFFICIENT_STORAGE_ERROR_PATTERN.test(message);
+}
+
 const chatErrorMessageCSS = css`
   align-self: flex-start;
   display: flex;
@@ -78,21 +94,27 @@ export function ChatErrorMessage({
   onRetry?: () => void;
   onRewind?: MessageRewindRequest;
 }) {
-  const canRetry = onRetry != null;
+  const isStorageError = isInsufficientStorageError(error.message);
+  // Retrying against a locked database fails identically, so don't offer it.
+  const canRetry = onRetry != null && !isStorageError;
   const canUndoOrFork = latestUserMessageId != null && onRewind != null;
-  const isCredentialError = isApiKeyError(error.message);
+  const isCredentialError = !isStorageError && isApiKeyError(error.message);
 
   return (
     <div css={chatErrorMessageCSS} role="alert">
       <div className="chat-error-message__title">
-        {isCredentialError
-          ? "The model provider rejected your API key."
-          : "The assistant response failed."}
+        {isStorageError
+          ? "Phoenix has run out of database storage."
+          : isCredentialError
+            ? "The model provider rejected your API key."
+            : "The assistant response failed."}
       </div>
       <p className="chat-error-message__copy">
-        {isCredentialError
-          ? "The API key for the selected model is missing, invalid, or misconfigured. Add a valid key in AI provider settings, then retry."
-          : "You can retry the response, undo this turn, or branch before the error."}
+        {isStorageError
+          ? "Writes are locked until space is freed, so this turn was not saved. Delete old data or increase storage, then send the message again."
+          : isCredentialError
+            ? "The API key for the selected model is missing, invalid, or misconfigured. Add a valid key in AI provider settings, then retry."
+            : "You can retry the response, undo this turn, or branch before the error."}
       </p>
       {canRetry || canUndoOrFork || isCredentialError ? (
         <div className="chat-error-message__actions">

--- a/app/src/components/agent/__generated__/AgentSessionsResourcePaginationQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourcePaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bfdffcbe36cfb053789650cc407b4866>>
+ * @generated SignedSource<<e06a768f1e9f1dc1eb63c45c124debcd>>
  * @lightSyntaxTransform
  */
 
@@ -107,10 +107,10 @@ return {
                     "storageKey": null
                   },
                   {
-                    "alias": null,
+                    "alias": "isTemporary",
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "isTemporary",
+                    "name": "isEphemeral",
                     "storageKey": null
                   },
                   {
@@ -187,16 +187,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ccc1a8ebf1cd1a20762752202bf217e9",
+    "cacheID": "f6179616c0de05d749519c79321b970f",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourcePaginationQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourcePaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...AgentSessionsResource_sessions_2HEEH6\n}\n\nfragment AgentSessionsResource_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "query AgentSessionsResourcePaginationQuery(\n  $after: String = null\n  $first: Int = 20\n) {\n  ...AgentSessionsResource_sessions_2HEEH6\n}\n\nfragment AgentSessionsResource_sessions_2HEEH6 on Query {\n  agentSessions(first: $first, after: $after) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary: isEphemeral\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "af28af2b0d4c3d22bbd920a5ae1c00f6";
+(node as any).hash = "6a59df4b2e220ab7c4e447ded2ebe04b";
 
 export default node;

--- a/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResourceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<10f8fa07eb58bf63347a620f624c0936>>
+ * @generated SignedSource<<fd09bb9b24ac1299b46090e39440db43>>
  * @lightSyntaxTransform
  */
 
@@ -102,10 +102,10 @@ return {
                     "storageKey": null
                   },
                   {
-                    "alias": null,
+                    "alias": "isTemporary",
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "isTemporary",
+                    "name": "isEphemeral",
                     "storageKey": null
                   },
                   {
@@ -224,12 +224,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cbd0f1f6f2d3f06bf44a736e3c1f968a",
+    "cacheID": "e86f271e169a4fa6806d9c9fecc0665d",
     "id": null,
     "metadata": {},
     "name": "AgentSessionsResourceQuery",
     "operationKind": "query",
-    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query AgentSessionsResourceQuery(\n  $first: Int!\n) {\n  ...AgentSessionsResource_sessions_3ASum4\n  ...SettingsAgentSessionsCard_sessions_3ASum4\n}\n\nfragment AgentSessionsResource_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        isTemporary: isEphemeral\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n\nfragment SettingsAgentSessionsCard_sessions_3ASum4 on Query {\n  agentSessions(first: $first) {\n    edges {\n      node {\n        id\n        title\n        ...EditAgentSessionTitleDialog_session\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n        firstInput\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/agent/__generated__/AgentSessionsResource_sessions.graphql.ts
+++ b/app/src/components/agent/__generated__/AgentSessionsResource_sessions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0a787187bb107c264ebdf2cc48327cdd>>
+ * @generated SignedSource<<fefab0587f0e7968aa04ddb20131d4d1>>
  * @lightSyntaxTransform
  */
 
@@ -117,10 +117,10 @@ return {
                   "name": "EditAgentSessionTitleDialog_session"
                 },
                 {
-                  "alias": null,
+                  "alias": "isTemporary",
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "isTemporary",
+                  "name": "isEphemeral",
                   "storageKey": null
                 },
                 {
@@ -191,6 +191,6 @@ return {
 };
 })();
 
-(node as any).hash = "af28af2b0d4c3d22bbd920a5ae1c00f6";
+(node as any).hash = "6a59df4b2e220ab7c4e447ded2ebe04b";
 
 export default node;

--- a/app/src/components/agent/__generated__/agentSessionRelaySessionQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/agentSessionRelaySessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f911423ffcf7bfc8b59fb172854cd0d5>>
+ * @generated SignedSource<<b0711c282d7d41a0bef57d1a35a79a50>>
  * @lightSyntaxTransform
  */
 
@@ -75,10 +75,10 @@ v4 = {
   "storageKey": null
 },
 v5 = {
-  "alias": null,
+  "alias": "isTemporary",
   "args": null,
   "kind": "ScalarField",
-  "name": "isTemporary",
+  "name": "isEphemeral",
   "storageKey": null
 },
 v6 = {
@@ -240,16 +240,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d5db0cbad69bfa0a719d1e260e54a6b4",
+    "cacheID": "4836634597c05ab5b6a082d4fa40a454",
     "id": null,
     "metadata": {},
     "name": "agentSessionRelaySessionQuery",
     "operationKind": "query",
-    "text": "query agentSessionRelaySessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      title\n      isTemporary\n      isActive\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n    id\n  }\n}\n"
+    "text": "query agentSessionRelaySessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      title\n      isTemporary: isEphemeral\n      isActive\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4c69ea26b4f6bd6062b44c40c90a3b3d";
+(node as any).hash = "898522d8afdc3e0dbb3ef55c2877b2bd";
 
 export default node;

--- a/app/src/components/agent/__generated__/useAgentChatBranchAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatBranchAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8ed6863de084a4ed0efda81283259d64>>
+ * @generated SignedSource<<5d5c25bd7fc69b84d8c73ac730a24306>>
  * @lightSyntaxTransform
  */
 
@@ -74,10 +74,10 @@ v4 = {
   "storageKey": null
 },
 v5 = {
-  "alias": null,
+  "alias": "isTemporary",
   "args": null,
   "kind": "ScalarField",
-  "name": "isTemporary",
+  "name": "isEphemeral",
   "storageKey": null
 },
 v6 = {
@@ -268,16 +268,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ee106d4c97f8f5c44af496a52566748a",
+    "cacheID": "f89b7b8b0f97a65da3e3761790631b80",
     "id": null,
     "metadata": {},
     "name": "useAgentChatBranchAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentChatBranchAgentSessionMutation(\n  $input: BranchAgentSessionInput!\n) {\n  branchAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "mutation useAgentChatBranchAgentSessionMutation(\n  $input: BranchAgentSessionInput!\n) {\n  branchAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary: isEphemeral\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ea4b5de46dbc482c61564732e61b63f4";
+(node as any).hash = "6354f2496c291bef8b6b164863a43f4d";
 
 export default node;

--- a/app/src/components/agent/__generated__/useAgentChatCreateAgentSessionMutation.graphql.ts
+++ b/app/src/components/agent/__generated__/useAgentChatCreateAgentSessionMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ca5e913d1bdf416fceb3c6a163b19943>>
+ * @generated SignedSource<<ffe1d051af9f47adb4267c5c2a572782>>
  * @lightSyntaxTransform
  */
 
@@ -10,7 +10,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type CreateAgentSessionInput = {
-  temporary?: boolean;
+  isEphemeral?: boolean;
   title?: string;
 };
 export type useAgentChatCreateAgentSessionMutation$variables = {
@@ -73,10 +73,10 @@ v4 = {
   "storageKey": null
 },
 v5 = {
-  "alias": null,
+  "alias": "isTemporary",
   "args": null,
   "kind": "ScalarField",
-  "name": "isTemporary",
+  "name": "isEphemeral",
   "storageKey": null
 },
 v6 = {
@@ -258,16 +258,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "54928aa36e9c467058c835f7a21e286e",
+    "cacheID": "2039e2649105fef21ec6b368b88c0445",
     "id": null,
     "metadata": {},
     "name": "useAgentChatCreateAgentSessionMutation",
     "operationKind": "mutation",
-    "text": "mutation useAgentChatCreateAgentSessionMutation(\n  $input: CreateAgentSessionInput!\n) {\n  createAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
+    "text": "mutation useAgentChatCreateAgentSessionMutation(\n  $input: CreateAgentSessionInput!\n) {\n  createAgentSession(input: $input) {\n    agentSession {\n      id\n      title\n      ...EditAgentSessionTitleDialog_session\n      isTemporary: isEphemeral\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n    }\n  }\n}\n\nfragment EditAgentSessionTitleDialog_session on AgentSession {\n  id\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "bf2a214d202d18185d935badc2e9e6f4";
+(node as any).hash = "d68c9de400e08e55cb088409bf0b790e";
 
 export default node;

--- a/app/src/components/agent/__tests__/ChatErrorMessage.test.tsx
+++ b/app/src/components/agent/__tests__/ChatErrorMessage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isApiKeyError, isInsufficientStorageError } from "../ChatErrorMessage";
+import { isApiKeyError } from "../ChatErrorMessage";
 
 describe("isApiKeyError", () => {
   it("matches server-emitted API key guidance", () => {
@@ -33,45 +33,5 @@ describe("isApiKeyError", () => {
     expect(isApiKeyError("connection reset by peer")).toBe(false);
     expect(isApiKeyError(null)).toBe(false);
     expect(isApiKeyError(undefined)).toBe(false);
-  });
-});
-
-describe("isInsufficientStorageError", () => {
-  const serverMessage =
-    "Database operations are disabled due to insufficient storage. " +
-    "Please delete old data or increase storage.";
-
-  it("matches the HTTP 507 body from a locked chat or compact request", () => {
-    expect(isInsufficientStorageError(serverMessage)).toBe(true);
-  });
-
-  it("matches the message with a support contact appended", () => {
-    expect(
-      isInsufficientStorageError(
-        `${serverMessage} Need help? Contact us at support@example.com`
-      )
-    ).toBe(true);
-  });
-
-  it("matches the notice raised when a turn's transcript could not be saved", () => {
-    expect(
-      isInsufficientStorageError(
-        "The assistant replied, but the conversation could not be saved, " +
-          `so this turn will be missing when you reload. ${serverMessage}`
-      )
-    ).toBe(true);
-  });
-
-  it("does not match unrelated errors", () => {
-    expect(isInsufficientStorageError("The assistant response failed.")).toBe(
-      false
-    );
-    expect(isInsufficientStorageError("401 Unauthorized")).toBe(false);
-    expect(isInsufficientStorageError(null)).toBe(false);
-    expect(isInsufficientStorageError(undefined)).toBe(false);
-  });
-
-  it("is disjoint from the API-key matcher, so the two banners cannot collide", () => {
-    expect(isApiKeyError(serverMessage)).toBe(false);
   });
 });

--- a/app/src/components/agent/__tests__/ChatErrorMessage.test.tsx
+++ b/app/src/components/agent/__tests__/ChatErrorMessage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isApiKeyError } from "../ChatErrorMessage";
+import { isApiKeyError, isInsufficientStorageError } from "../ChatErrorMessage";
 
 describe("isApiKeyError", () => {
   it("matches server-emitted API key guidance", () => {
@@ -33,5 +33,45 @@ describe("isApiKeyError", () => {
     expect(isApiKeyError("connection reset by peer")).toBe(false);
     expect(isApiKeyError(null)).toBe(false);
     expect(isApiKeyError(undefined)).toBe(false);
+  });
+});
+
+describe("isInsufficientStorageError", () => {
+  const serverMessage =
+    "Database operations are disabled due to insufficient storage. " +
+    "Please delete old data or increase storage.";
+
+  it("matches the HTTP 507 body from a locked chat or compact request", () => {
+    expect(isInsufficientStorageError(serverMessage)).toBe(true);
+  });
+
+  it("matches the message with a support contact appended", () => {
+    expect(
+      isInsufficientStorageError(
+        `${serverMessage} Need help? Contact us at support@example.com`
+      )
+    ).toBe(true);
+  });
+
+  it("matches the notice raised when a turn's transcript could not be saved", () => {
+    expect(
+      isInsufficientStorageError(
+        "The assistant replied, but the conversation could not be saved, " +
+          `so this turn will be missing when you reload. ${serverMessage}`
+      )
+    ).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isInsufficientStorageError("The assistant response failed.")).toBe(
+      false
+    );
+    expect(isInsufficientStorageError("401 Unauthorized")).toBe(false);
+    expect(isInsufficientStorageError(null)).toBe(false);
+    expect(isInsufficientStorageError(undefined)).toBe(false);
+  });
+
+  it("is disjoint from the API-key matcher, so the two banners cannot collide", () => {
+    expect(isApiKeyError(serverMessage)).toBe(false);
   });
 });

--- a/app/src/components/agent/__tests__/useAgentChat.test.ts
+++ b/app/src/components/agent/__tests__/useAgentChat.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 
-import { getRemovedUserMessageText } from "../useAgentChat";
+import {
+  getAgentCompactErrorMessage,
+  getRemovedUserMessageText,
+} from "../useAgentChat";
 
 describe("getRemovedUserMessageText", () => {
   it("does not restore a compaction checkpoint into the composer", () => {
@@ -32,6 +35,38 @@ describe("getRemovedUserMessageText", () => {
 
     expect(getRemovedUserMessageText([userMessage], userMessage.id)).toBe(
       "What is a trace?"
+    );
+  });
+});
+
+describe("getAgentCompactErrorMessage", () => {
+  it("uses the detail of a JSON error body", () => {
+    const body = { detail: "Conversation compaction failed: upstream refused" };
+    expect(getAgentCompactErrorMessage(body, JSON.stringify(body), 502)).toBe(
+      "Conversation compaction failed: upstream refused"
+    );
+  });
+
+  it("uses a plain-text body, which is how the server sends HTTPException details", () => {
+    // `plain_text_http_exception_handler` returns text/plain, so the 507 raised
+    // when storage is locked has no JSON to parse. Falling through to the
+    // status would have thrown the server's guidance away.
+    const rawBody =
+      "Database operations are disabled due to insufficient storage. " +
+      "Please delete old data or increase storage.";
+
+    expect(getAgentCompactErrorMessage(null, rawBody, 507)).toBe(rawBody);
+  });
+
+  it("trims surrounding whitespace from a plain-text body", () => {
+    expect(
+      getAgentCompactErrorMessage(null, "  Agents are disabled\n", 403)
+    ).toBe("Agents are disabled");
+  });
+
+  it("falls back to the status only when the response had no body", () => {
+    expect(getAgentCompactErrorMessage(null, "", 507)).toBe(
+      "Compaction failed with status 507."
     );
   });
 });

--- a/app/src/components/agent/__tests__/useAgentChat.test.ts
+++ b/app/src/components/agent/__tests__/useAgentChat.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 
-import {
-  getAgentCompactErrorMessage,
-  getRemovedUserMessageText,
-} from "../useAgentChat";
+import { getRemovedUserMessageText } from "../useAgentChat";
 
 describe("getRemovedUserMessageText", () => {
   it("does not restore a compaction checkpoint into the composer", () => {
@@ -35,38 +32,6 @@ describe("getRemovedUserMessageText", () => {
 
     expect(getRemovedUserMessageText([userMessage], userMessage.id)).toBe(
       "What is a trace?"
-    );
-  });
-});
-
-describe("getAgentCompactErrorMessage", () => {
-  it("uses the detail of a JSON error body", () => {
-    const body = { detail: "Conversation compaction failed: upstream refused" };
-    expect(getAgentCompactErrorMessage(body, JSON.stringify(body), 502)).toBe(
-      "Conversation compaction failed: upstream refused"
-    );
-  });
-
-  it("uses a plain-text body, which is how the server sends HTTPException details", () => {
-    // `plain_text_http_exception_handler` returns text/plain, so the 507 raised
-    // when storage is locked has no JSON to parse. Falling through to the
-    // status would have thrown the server's guidance away.
-    const rawBody =
-      "Database operations are disabled due to insufficient storage. " +
-      "Please delete old data or increase storage.";
-
-    expect(getAgentCompactErrorMessage(null, rawBody, 507)).toBe(rawBody);
-  });
-
-  it("trims surrounding whitespace from a plain-text body", () => {
-    expect(
-      getAgentCompactErrorMessage(null, "  Agents are disabled\n", 403)
-    ).toBe("Agents are disabled");
-  });
-
-  it("falls back to the status only when the response had no body", () => {
-    expect(getAgentCompactErrorMessage(null, "", 507)).toBe(
-      "Compaction failed with status 507."
     );
   });
 });

--- a/app/src/components/agent/agentSessionRelay.ts
+++ b/app/src/components/agent/agentSessionRelay.ts
@@ -25,7 +25,7 @@ export const agentSessionQuery = graphql`
       ... on AgentSession {
         id
         title
-        isTemporary
+        isTemporary: isEphemeral
         isActive
         createdAt
         updatedAt

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -804,17 +804,8 @@ export function useAgentChat({
           }),
         });
         if (!response.ok) {
-          // The route's conflict codes come back as JSON, but every
-          // HTTPException detail — 403, 404, 422, and the 507 raised when
-          // storage is locked — comes back as text/plain. Read the body once
-          // and parse JSON opportunistically so neither shape is discarded.
-          const rawErrorBody = await response.text().catch(() => "");
-          const errorBody = parseJsonOrNull(rawErrorBody);
-          if (
-            response.status === 409 &&
-            isRecord(errorBody) &&
-            errorBody.code === SESSION_BUSY_ERROR_CODE
-          ) {
+          const errorBody = await response.text().catch(() => "");
+          if (response.status === 409 && isSessionBusyConflict(errorBody)) {
             // Another client's turn holds the session lock: enter
             // busy-elsewhere mode (the poll swaps in the fresh transcript
             // when the turn completes) instead of raising a red error.
@@ -823,11 +814,7 @@ export function useAgentChat({
             return;
           }
           throw new Error(
-            getAgentCompactErrorMessage(
-              errorBody,
-              rawErrorBody,
-              response.status
-            )
+            getAgentCompactErrorMessage(errorBody, response.status)
           );
         }
         const result: unknown = await response.json();
@@ -1166,33 +1153,20 @@ function isRequestActive(status: ChatStatus): boolean {
 }
 
 /**
- * The message to show for a failed `/compact` request, preferring whatever the
- * server actually said. `rawBody` covers the plain-text `HTTPException` details
- * the server returns for 403/404/422/507; the status fallback is only reached
- * when the response had no body at all.
+ * A lock conflict is the one failure the route answers with JSON; every other
+ * failure is an `HTTPException` detail, which the server renders as plain text.
  */
-export function getAgentCompactErrorMessage(
-  body: unknown,
-  rawBody: string,
-  status: number
-): string {
-  if (isRecord(body) && typeof body.detail === "string") {
-    return body.detail;
+function isSessionBusyConflict(body: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    return isRecord(parsed) && parsed.code === SESSION_BUSY_ERROR_CODE;
+  } catch {
+    return false;
   }
-  const text = rawBody.trim();
-  if (text) {
-    return text;
-  }
-  return `Compaction failed with status ${status}.`;
 }
 
-/** Parse `text` as JSON, or return null when it is not JSON (e.g. plain text). */
-function parseJsonOrNull(text: string): unknown {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
+function getAgentCompactErrorMessage(body: string, status: number): string {
+  return body.trim() || `Compaction failed with status ${status}.`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -133,7 +133,7 @@ const createAgentSessionMutation = graphql`
         id
         title
         ...EditAgentSessionTitleDialog_session
-        isTemporary
+        isTemporary: isEphemeral
         createdAt
         updatedAt
         firstInput
@@ -183,7 +183,7 @@ const branchAgentSessionMutation = graphql`
         id
         title
         ...EditAgentSessionTitleDialog_session
-        isTemporary
+        isTemporary: isEphemeral
         createdAt
         updatedAt
         firstInput
@@ -684,7 +684,7 @@ export function useAgentChat({
     const isTemporary = store.getState().isDraftSessionTemporary;
     commitCreateAgentSession({
       variables: {
-        input: { temporary: isTemporary },
+        input: { isEphemeral: isTemporary },
         connections: isTemporary
           ? [sessionsConnectionId]
           : [sessionsConnectionId, settingsSessionsConnectionId],

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -804,7 +804,12 @@ export function useAgentChat({
           }),
         });
         if (!response.ok) {
-          const errorBody: unknown = await response.json().catch(() => null);
+          // The route's conflict codes come back as JSON, but every
+          // HTTPException detail — 403, 404, 422, and the 507 raised when
+          // storage is locked — comes back as text/plain. Read the body once
+          // and parse JSON opportunistically so neither shape is discarded.
+          const rawErrorBody = await response.text().catch(() => "");
+          const errorBody = parseJsonOrNull(rawErrorBody);
           if (
             response.status === 409 &&
             isRecord(errorBody) &&
@@ -818,7 +823,11 @@ export function useAgentChat({
             return;
           }
           throw new Error(
-            getAgentCompactErrorMessage(errorBody, response.status)
+            getAgentCompactErrorMessage(
+              errorBody,
+              rawErrorBody,
+              response.status
+            )
           );
         }
         const result: unknown = await response.json();
@@ -1156,11 +1165,34 @@ function isRequestActive(status: ChatStatus): boolean {
   return status === "submitted" || status === "streaming";
 }
 
-function getAgentCompactErrorMessage(body: unknown, status: number): string {
+/**
+ * The message to show for a failed `/compact` request, preferring whatever the
+ * server actually said. `rawBody` covers the plain-text `HTTPException` details
+ * the server returns for 403/404/422/507; the status fallback is only reached
+ * when the response had no body at all.
+ */
+export function getAgentCompactErrorMessage(
+  body: unknown,
+  rawBody: string,
+  status: number
+): string {
   if (isRecord(body) && typeof body.detail === "string") {
     return body.detail;
   }
+  const text = rawBody.trim();
+  if (text) {
+    return text;
+  }
   return `Compaction failed with status ${status}.`;
+}
+
+/** Parse `text` as JSON, or return null when it is not JSON (e.g. plain text). */
+function parseJsonOrNull(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -12,10 +12,7 @@ import type { SettingsAgentsWorkspaceCardSetSessionRetentionMutation } from "./_
 import type { SettingsAgentsWorkspaceCardSetTraceRecordingMutation } from "./__generated__/SettingsAgentsWorkspaceCardSetTraceRecordingMutation.graphql";
 
 /**
- * Values restored when an admin re-enables a retention rule that was off.
- * These mirror the server-side defaults in
- * `phoenix.server.settings.registry.AgentSessionRetentionSetting`, so toggling
- * a rule back on returns it to the value the workspace started from.
+ * Values restored when an admin re-enables a retention rule that was off
  */
 const DEFAULT_SESSION_RETENTION_MAX_IDLE_DAYS = 30;
 const DEFAULT_SESSION_RETENTION_MAX_COUNT_PER_USER = 30;

--- a/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
+++ b/app/src/pages/settings/SettingsAgentsWorkspaceCard.tsx
@@ -12,9 +12,12 @@ import type { SettingsAgentsWorkspaceCardSetSessionRetentionMutation } from "./_
 import type { SettingsAgentsWorkspaceCardSetTraceRecordingMutation } from "./__generated__/SettingsAgentsWorkspaceCardSetTraceRecordingMutation.graphql";
 
 /**
- * Values restored when an admin re-enables a retention rule that was off
+ * Values restored when an admin re-enables a retention rule that was off.
+ * These mirror the server-side defaults in
+ * `phoenix.server.settings.registry.AgentSessionRetentionSetting`, so toggling
+ * a rule back on returns it to the value the workspace started from.
  */
-const DEFAULT_SESSION_RETENTION_MAX_IDLE_DAYS = 7;
+const DEFAULT_SESSION_RETENTION_MAX_IDLE_DAYS = 30;
 const DEFAULT_SESSION_RETENTION_MAX_COUNT_PER_USER = 30;
 
 const settingsListCSS = css`

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -125,7 +125,7 @@ export async function createAgentSession({
   try {
     const { data: payload } = await client.POST("/agents/{agent_id}/sessions", {
       params: { path: { agent_id: SERVER_AGENT_ID } },
-      body: { title: "", temporary },
+      body: { title: "", is_ephemeral: temporary },
     });
     agentSessionId = payload?.data.id;
   } catch (error) {
@@ -184,11 +184,11 @@ export function createPxiSessionClient({
         );
       }
       return payload.data.map(
-        ({ id, title, updated_at, is_temporary }): PxiSessionSummary => ({
+        ({ id, title, updated_at, is_ephemeral }): PxiSessionSummary => ({
           id,
           title,
           updatedAt: updated_at,
-          isTemporary: is_temporary,
+          isTemporary: is_ephemeral,
         })
       );
     },
@@ -212,7 +212,7 @@ export function createPxiSessionClient({
         id: session.id,
         title: session.title,
         updatedAt: session.updated_at,
-        isTemporary: session.is_temporary,
+        isTemporary: session.is_ephemeral,
         // Read defensively: the CLI consumes phoenix-client's built types,
         // which may not carry `is_active` until that package rebuilds.
         // An absent field means no lock is held.

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -190,11 +190,11 @@ describe("PXI client", () => {
       async (_input: string | URL | Request, init?: RequestInit) => {
         const request =
           _input instanceof Request ? _input : new Request(_input, init);
-        const body = (await request.json()) as { temporary: boolean };
+        const body = (await request.json()) as { is_ephemeral: boolean };
         return new Response(
           JSON.stringify({
             data: {
-              id: body.temporary ? "temporary-session" : "persisted-session",
+              id: body.is_ephemeral ? "temporary-session" : "persisted-session",
             },
           }),
           { status: 201, headers: { "Content-Type": "application/json" } }
@@ -231,7 +231,7 @@ describe("PXI client", () => {
                 title: "Investigate traces",
                 created_at: "2026-07-24T11:00:00Z",
                 updated_at: "2026-07-24T12:00:00Z",
-                is_temporary: false,
+                is_ephemeral: false,
               },
             ],
             next_cursor: null,
@@ -247,7 +247,7 @@ describe("PXI client", () => {
               title: "Investigate traces",
               created_at: "2026-07-24T11:00:00Z",
               updated_at: "2026-07-24T12:00:00Z",
-              is_temporary: false,
+              is_ephemeral: false,
               messages: [
                 {
                   id: "user-1",

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1727,8 +1727,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -1753,8 +1753,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
         };
         /**
          * AgentSpanContext
@@ -2157,11 +2157,11 @@ export interface components {
              */
             title?: string;
             /**
-             * Temporary
+             * Is Ephemeral
              * @description Whether the session should expire after a period of inactivity.
              * @default false
              */
-            temporary?: boolean;
+            is_ephemeral?: boolean;
         };
         /** CreateAgentSessionResponseBody */
         CreateAgentSessionResponseBody: {

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1727,8 +1727,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
             /**
              * Is Active
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
@@ -1753,8 +1753,8 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /** Is Temporary */
-            is_temporary: boolean;
+            /** Is Ephemeral */
+            is_ephemeral: boolean;
         };
         /**
          * AgentSpanContext
@@ -2157,11 +2157,11 @@ export interface components {
              */
             title?: string;
             /**
-             * Temporary
+             * Is Ephemeral
              * @description Whether the session should expire after a period of inactivity.
              * @default false
              */
-            temporary?: boolean;
+            is_ephemeral?: boolean;
         };
         /** CreateAgentSessionResponseBody */
         CreateAgentSessionResponseBody: {

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -17,7 +17,7 @@ class AgentSessionSummary(TypedDict):
     title: str
     created_at: str
     updated_at: str
-    is_temporary: bool
+    is_ephemeral: bool
 
 
 class AgentSpanContext(TypedDict):
@@ -91,7 +91,7 @@ class CodeEvaluatorContext(TypedDict):
 
 class CreateAgentSessionRequestBody(TypedDict):
     title: NotRequired[str]
-    temporary: NotRequired[bool]
+    is_ephemeral: NotRequired[bool]
 
 
 class CreateAgentSessionResponseBody(TypedDict):
@@ -1925,7 +1925,7 @@ class AgentSessionData(TypedDict):
     title: str
     created_at: str
     updated_at: str
-    is_temporary: bool
+    is_ephemeral: bool
     is_active: bool
     messages: Sequence[PhoenixUIMessage]
 

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -8465,9 +8465,9 @@
             "format": "date-time",
             "title": "Updated At"
           },
-          "is_temporary": {
+          "is_ephemeral": {
             "type": "boolean",
-            "title": "Is Temporary"
+            "title": "Is Ephemeral"
           },
           "is_active": {
             "type": "boolean",
@@ -8488,7 +8488,7 @@
           "title",
           "created_at",
           "updated_at",
-          "is_temporary",
+          "is_ephemeral",
           "is_active",
           "messages"
         ],
@@ -8514,9 +8514,9 @@
             "format": "date-time",
             "title": "Updated At"
           },
-          "is_temporary": {
+          "is_ephemeral": {
             "type": "boolean",
-            "title": "Is Temporary"
+            "title": "Is Ephemeral"
           }
         },
         "type": "object",
@@ -8525,7 +8525,7 @@
           "title",
           "created_at",
           "updated_at",
-          "is_temporary"
+          "is_ephemeral"
         ],
         "title": "AgentSessionSummary"
       },
@@ -9575,9 +9575,9 @@
             "description": "Optional initial title.",
             "default": ""
           },
-          "temporary": {
+          "is_ephemeral": {
             "type": "boolean",
-            "title": "Temporary",
+            "title": "Is Ephemeral",
             "description": "Whether the session should expire after a period of inactivity.",
             "default": false
           }

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -445,9 +445,9 @@ CREATE TABLE public.agent_sessions (
     user_id BIGINT,
     title VARCHAR NOT NULL,
     expires_at TIMESTAMP WITH TIME ZONE,
+    heartbeat_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-    heartbeat_at TIMESTAMP WITH TIME ZONE,
     CONSTRAINT pk_agent_sessions PRIMARY KEY (id),
     CONSTRAINT uq_agent_sessions_project_session_id_project_name
         UNIQUE (project_session_id, project_name),
@@ -468,16 +468,14 @@ CREATE INDEX ix_agent_sessions_user_id_updated_at ON public.agent_sessions
 CREATE TABLE public.agent_session_messages (
     id bigserial NOT NULL,
     agent_session_id BIGINT NOT NULL,
-    position INTEGER NOT NULL,
     message JSONB NOT NULL,
     message_id VARCHAR GENERATED ALWAYS AS (((message ->> 'id'::text))::character varying) STORED NOT NULL,
     is_compaction_message BOOLEAN GENERATED ALWAYS AS (COALESCE(((message #>> '{metadata,isCompactionMessage}'::text[]))::boolean, false)) STORED NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_agent_session_messages PRIMARY KEY (id),
-    CONSTRAINT uq_agent_session_messages_agent_session_id_position
-        UNIQUE (agent_session_id, position),
     CONSTRAINT uq_agent_session_messages_message_id
         UNIQUE (message_id),
+    CHECK (((message_id)::text ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'::text)),
     CONSTRAINT fk_agent_session_messages_agent_session_id_agent_sessions
         FOREIGN KEY
         (agent_session_id)
@@ -486,7 +484,7 @@ CREATE TABLE public.agent_session_messages (
 );
 
 CREATE INDEX ix_agent_session_messages_compaction ON public.agent_session_messages
-    USING btree (agent_session_id, "position" DESC) WHERE is_compaction_message;
+    USING btree (agent_session_id, id DESC) WHERE is_compaction_message;
 
 
 -- Table: agent_session_snapshots

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -440,7 +440,6 @@ CREATE UNIQUE INDEX ix_users_username ON public.users
 -- ---------------------
 CREATE TABLE public.agent_sessions (
     id bigserial NOT NULL,
-    project_session_id VARCHAR NOT NULL,
     project_name VARCHAR NOT NULL,
     user_id BIGINT,
     title VARCHAR NOT NULL,
@@ -449,8 +448,6 @@ CREATE TABLE public.agent_sessions (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     CONSTRAINT pk_agent_sessions PRIMARY KEY (id),
-    CONSTRAINT uq_agent_sessions_project_session_id_project_name
-        UNIQUE (project_session_id, project_name),
     CONSTRAINT fk_agent_sessions_user_id_users FOREIGN KEY
         (user_id)
         REFERENCES public.users (id)

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -440,7 +440,6 @@ CREATE UNIQUE INDEX ix_users_username ON public.users
 -- ---------------------
 CREATE TABLE public.agent_sessions (
     id bigserial NOT NULL,
-    project_name VARCHAR NOT NULL,
     user_id BIGINT,
     title VARCHAR NOT NULL,
     is_ephemeral BOOLEAN NOT NULL,

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -443,7 +443,7 @@ CREATE TABLE public.agent_sessions (
     project_name VARCHAR NOT NULL,
     user_id BIGINT,
     title VARCHAR NOT NULL,
-    expires_at TIMESTAMP WITH TIME ZONE,
+    is_ephemeral BOOLEAN NOT NULL DEFAULT false,
     heartbeat_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
@@ -454,8 +454,8 @@ CREATE TABLE public.agent_sessions (
         ON DELETE CASCADE
 );
 
-CREATE INDEX ix_agent_sessions_expires_at ON public.agent_sessions
-    USING btree (expires_at) WHERE (expires_at IS NOT NULL);
+CREATE INDEX ix_agent_sessions_ephemeral_updated_at ON public.agent_sessions
+    USING btree (updated_at) WHERE (is_ephemeral IS TRUE);
 CREATE INDEX ix_agent_sessions_user_id_updated_at ON public.agent_sessions
     USING btree (user_id, updated_at DESC);
 

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -443,7 +443,7 @@ CREATE TABLE public.agent_sessions (
     project_name VARCHAR NOT NULL,
     user_id BIGINT,
     title VARCHAR NOT NULL,
-    is_ephemeral BOOLEAN NOT NULL DEFAULT false,
+    is_ephemeral BOOLEAN NOT NULL,
     heartbeat_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -3641,8 +3641,8 @@ PLAYGROUND_PROJECT_NAME = "playground"
 EPHEMERAL_EXPERIMENT_TIME_TO_LIVE_HOURS = 24
 """The time to live for ephemeral experiments in hours."""
 
-TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS = 24
-"""How many hours temporary assistant sessions live after their latest chat turn."""
+EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS = 24
+"""How many hours ephemeral assistant sessions live after their latest chat turn."""
 
 SYSTEM_USER_ID: Optional[int] = None
 """

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -89,12 +89,7 @@ def upgrade() -> None:
             nullable=True,  # sessions may be created while auth is disabled
         ),
         sa.Column("title", sa.String, nullable=False),
-        sa.Column(
-            "is_ephemeral",
-            sa.Boolean,
-            nullable=False,
-            server_default=sa.false(),
-        ),
+        sa.Column("is_ephemeral", sa.Boolean, nullable=False),
         sa.Column("heartbeat_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column(
             "created_at",

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -81,7 +81,6 @@ def upgrade() -> None:
     op.create_table(
         "agent_sessions",
         sa.Column("id", _Integer, primary_key=True),
-        sa.Column("project_name", sa.String, nullable=False),
         sa.Column(
             "user_id",
             _Integer,

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -89,7 +89,12 @@ def upgrade() -> None:
             nullable=True,  # sessions may be created while auth is disabled
         ),
         sa.Column("title", sa.String, nullable=False),
-        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "is_ephemeral",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.false(),
+        ),
         sa.Column("heartbeat_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column(
             "created_at",
@@ -112,11 +117,11 @@ def upgrade() -> None:
         ["user_id", sa.column("updated_at").desc()],
     )
     op.create_index(
-        "ix_agent_sessions_expires_at",
+        "ix_agent_sessions_ephemeral_updated_at",
         "agent_sessions",
-        ["expires_at"],
-        postgresql_where=sa.text("expires_at IS NOT NULL"),
-        sqlite_where=sa.text("expires_at IS NOT NULL"),
+        ["updated_at"],
+        postgresql_where=sa.text("is_ephemeral IS TRUE"),
+        sqlite_where=sa.text("is_ephemeral IS TRUE"),
     )
 
     message = sa.Column("message", JSON_, nullable=False)

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -6,13 +6,14 @@ Create Date: 2026-07-08 15:16:23.608705
 
 """
 
-from typing import Any, Sequence, Union
+from typing import Any, Literal, Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import JSON
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.compiler import compiles
+from typing_extensions import TypeAlias, assert_never
 
 
 class JSONB(JSON):
@@ -44,8 +45,19 @@ _Integer = sa.Integer().with_variant(
 _UUID_GLOB = "-".join("[0-9a-fA-F]" * length for length in (8, 4, 4, 4, 12))
 _UUID_REGEX = "^{}$".format("-".join(f"[0-9a-fA-F]{{{length}}}" for length in (8, 4, 4, 4, 12)))
 
+_DialectName: TypeAlias = Literal["postgresql", "sqlite"]
 
-def _uuid_format_check(column_name: str, dialect_name: str) -> str:
+
+def _bind_dialect_name() -> _DialectName:
+    dialect_name = op.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        return "postgresql"
+    elif dialect_name == "sqlite":
+        return "sqlite"
+    raise RuntimeError(f"Unsupported SQL dialect: {dialect_name}")
+
+
+def _uuid_format_check(column_name: str, dialect_name: _DialectName) -> str:
     """SQL for "this column holds a UUID in 8-4-4-4-12 hex form".
 
     SQLite has ``GLOB`` but no regex operator; PostgreSQL has ``~`` but no
@@ -53,7 +65,9 @@ def _uuid_format_check(column_name: str, dialect_name: str) -> str:
     """
     if dialect_name == "postgresql":
         return f"{column_name} ~ '{_UUID_REGEX}'"
-    return f"{column_name} GLOB '{_UUID_GLOB}'"
+    elif dialect_name == "sqlite":
+        return f"{column_name} GLOB '{_UUID_GLOB}'"
+    assert_never(dialect_name)
 
 
 # revision identifiers, used by Alembic.
@@ -144,7 +158,7 @@ def upgrade() -> None:
             server_default=sa.func.now(),
         ),
         sa.CheckConstraint(
-            _uuid_format_check("message_id", op.get_bind().dialect.name),
+            _uuid_format_check("message_id", _bind_dialect_name()),
             name="valid_message_id",
         ),
         sqlite_autoincrement=True,

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -81,7 +81,6 @@ def upgrade() -> None:
     op.create_table(
         "agent_sessions",
         sa.Column("id", _Integer, primary_key=True),
-        sa.Column("project_session_id", sa.String, nullable=False),
         sa.Column("project_name", sa.String, nullable=False),
         sa.Column(
             "user_id",
@@ -105,7 +104,6 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             onupdate=sa.func.now(),
         ),
-        sa.UniqueConstraint("project_session_id", "project_name"),
         sqlite_autoincrement=True,
     )
     op.create_index(

--- a/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
+++ b/src/phoenix/db/migrations/versions/e767d3c57f32_create_agent_sessions_and_agent_session_.py
@@ -41,6 +41,21 @@ _Integer = sa.Integer().with_variant(
     "postgresql",
 )
 
+_UUID_GLOB = "-".join("[0-9a-fA-F]" * length for length in (8, 4, 4, 4, 12))
+_UUID_REGEX = "^{}$".format("-".join(f"[0-9a-fA-F]{{{length}}}" for length in (8, 4, 4, 4, 12)))
+
+
+def _uuid_format_check(column_name: str, dialect_name: str) -> str:
+    """SQL for "this column holds a UUID in 8-4-4-4-12 hex form".
+
+    SQLite has ``GLOB`` but no regex operator; PostgreSQL has ``~`` but no
+    ``GLOB``, so the CHECK is spelled per-dialect.
+    """
+    if dialect_name == "postgresql":
+        return f"{column_name} ~ '{_UUID_REGEX}'"
+    return f"{column_name} GLOB '{_UUID_GLOB}'"
+
+
 # revision identifiers, used by Alembic.
 revision: str = "e767d3c57f32"
 down_revision: Union[str, None] = "c9d0e1f2a3b4"
@@ -102,7 +117,6 @@ def upgrade() -> None:
             sa.ForeignKey("agent_sessions.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("position", sa.Integer, nullable=False),
         message,
         sa.Column(
             "message_id",
@@ -129,13 +143,16 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint("agent_session_id", "position"),
+        sa.CheckConstraint(
+            _uuid_format_check("message_id", op.get_bind().dialect.name),
+            name="valid_message_id",
+        ),
         sqlite_autoincrement=True,
     )
     op.create_index(
         "ix_agent_session_messages_compaction",
         "agent_session_messages",
-        ["agent_session_id", sa.column("position").desc()],
+        ["agent_session_id", sa.column("id").desc()],
         postgresql_where=sa.text("is_compaction_message"),
         sqlite_where=sa.text("is_compaction_message"),
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3313,7 +3313,17 @@ class AgentSession(HasId):
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
     )
-    expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True)
+    is_ephemeral: Mapped[bool] = mapped_column(
+        default=False,
+        server_default=sa.false(),
+    )
+    """Whether the sweeper reaps this session once it has been idle for the ephemeral TTL.
+
+    A flag rather than a deadline column: the deadline was only ever
+    ``updated_at`` plus a fixed constant, so storing it duplicated a value the
+    row already carried and had to be rewritten on every turn to keep the
+    window sliding. Surfaced to clients as ``temporary``.
+    """
     heartbeat_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True)
     user: Mapped[Optional["User"]] = relationship("User")
     snapshot: Mapped[Optional["AgentSessionSnapshot"]] = relationship(
@@ -3334,10 +3344,10 @@ class AgentSession(HasId):
             updated_at.desc(),
         ),
         Index(
-            "ix_agent_sessions_expires_at",
-            "expires_at",
-            postgresql_where=text("expires_at IS NOT NULL"),
-            sqlite_where=text("expires_at IS NOT NULL"),
+            "ix_agent_sessions_ephemeral_updated_at",
+            "updated_at",
+            postgresql_where=text("is_ephemeral IS TRUE"),
+            sqlite_where=text("is_ephemeral IS TRUE"),
         ),
         dict(sqlite_autoincrement=True),
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3324,7 +3324,6 @@ class AgentSession(HasId):
     )
     messages: Mapped[list["AgentSessionMessage"]] = relationship(
         "AgentSessionMessage",
-        # Transcript order is insertion order, i.e. ascending primary key.
         order_by="AgentSessionMessage.id",
         cascade="all, delete-orphan",
         back_populates="agent_session",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3262,6 +3262,45 @@ def validate_provider_config(_: Any, __: Any, target: "GenerativeModelCustomProv
         raise ValueError("Config is not encrypted")
 
 
+_UUID_GLOB = "-".join("[0-9a-fA-F]" * length for length in (8, 4, 4, 4, 12))  # SQLite GLOB pattern
+_UUID_REGEX = "^{}$".format(
+    "-".join(f"[0-9a-fA-F]{{{length}}}" for length in (8, 4, 4, 4, 12))
+)  # PostgreSQL POSIX pattern
+
+
+class matches_uuid_format(ColumnElement[bool]):  # noqa: N801  -- a SQL construct
+    """A ``CHECK``-able predicate: does a column hold a UUID in 8-4-4-4-12 hex form?
+
+    SQLite has ``GLOB`` but no regex operator; PostgreSQL has ``~`` but no
+    ``GLOB``. Neither spelling is portable, so the predicate renders per
+    dialect and callers get one expression that works on both.
+    """
+
+    inherit_cache = True
+    type = Boolean()
+
+    def __init__(self, column_name: str) -> None:
+        self.column_name = column_name
+
+
+@compiles(matches_uuid_format, "sqlite")
+def _compile_matches_uuid_format_sqlite(
+    element: matches_uuid_format,
+    compiler: SQLCompiler,
+    **kw: Any,
+) -> str:
+    return f"{compiler.preparer.quote(element.column_name)} GLOB '{_UUID_GLOB}'"
+
+
+@compiles(matches_uuid_format, "postgresql")
+def _compile_matches_uuid_format_postgresql(
+    element: matches_uuid_format,
+    compiler: SQLCompiler,
+    **kw: Any,
+) -> str:
+    return f"{compiler.preparer.quote(element.column_name)} ~ '{_UUID_REGEX}'"
+
+
 class AgentSession(HasId):
     __tablename__ = "agent_sessions"
     project_session_id: Mapped[str] = mapped_column(String, nullable=False)
@@ -3285,7 +3324,8 @@ class AgentSession(HasId):
     )
     messages: Mapped[list["AgentSessionMessage"]] = relationship(
         "AgentSessionMessage",
-        order_by="AgentSessionMessage.position",
+        # Transcript order is insertion order, i.e. ascending primary key.
+        order_by="AgentSessionMessage.id",
         cascade="all, delete-orphan",
         back_populates="agent_session",
     )
@@ -3312,7 +3352,6 @@ class AgentSessionMessage(HasId):
         ForeignKey("agent_sessions.id", ondelete="CASCADE"),
         nullable=False,
     )
-    position: Mapped[int] = mapped_column(Integer, nullable=False)
     message: Mapped[PhoenixUIMessage] = mapped_column(_UIMessage, nullable=False)
     message_id: Mapped[str] = mapped_column(
         String,
@@ -3343,11 +3382,11 @@ class AgentSessionMessage(HasId):
         back_populates="messages",
     )
     __table_args__ = (
-        UniqueConstraint("agent_session_id", "position"),
+        CheckConstraint(matches_uuid_format("message_id"), name="valid_message_id"),
         Index(
             "ix_agent_session_messages_compaction",
             "agent_session_id",
-            position.desc(),
+            sa.desc("id"),
             postgresql_where=text("is_compaction_message"),
             sqlite_where=text("is_compaction_message"),
         ),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3303,7 +3303,6 @@ def _compile_matches_uuid_format_postgresql(
 
 class AgentSession(HasId):
     __tablename__ = "agent_sessions"
-    project_name: Mapped[str] = mapped_column(String, nullable=False)
     user_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=True,  # sessions may be created while auth is disabled

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3303,7 +3303,6 @@ def _compile_matches_uuid_format_postgresql(
 
 class AgentSession(HasId):
     __tablename__ = "agent_sessions"
-    project_session_id: Mapped[str] = mapped_column(String, nullable=False)
     project_name: Mapped[str] = mapped_column(String, nullable=False)
     user_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"),
@@ -3329,7 +3328,6 @@ class AgentSession(HasId):
         back_populates="agent_session",
     )
     __table_args__ = (
-        UniqueConstraint("project_session_id", "project_name"),
         Index(
             "ix_agent_sessions_user_id_updated_at",
             "user_id",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -3313,17 +3313,7 @@ class AgentSession(HasId):
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
     )
-    is_ephemeral: Mapped[bool] = mapped_column(
-        default=False,
-        server_default=sa.false(),
-    )
-    """Whether the sweeper reaps this session once it has been idle for the ephemeral TTL.
-
-    A flag rather than a deadline column: the deadline was only ever
-    ``updated_at`` plus a fixed constant, so storing it duplicated a value the
-    row already carried and had to be rewritten on every turn to keep the
-    window sliding. Surfaced to clients as ``temporary``.
-    """
+    is_ephemeral: Mapped[bool] = mapped_column(default=False)
     heartbeat_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp, nullable=True)
     user: Mapped[Optional["User"]] = relationship("User")
     snapshot: Mapped[Optional["AgentSessionSnapshot"]] = relationship(

--- a/src/phoenix/server/agents/summarization.py
+++ b/src/phoenix/server/agents/summarization.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from typing import Any, TypeVar, cast
+
 from pydantic import BaseModel, Field, field_validator
 from pydantic_ai.messages import (
+    BaseToolReturnPart,
     InstructionPart,
     ModelMessage,
     ModelRequest,
@@ -24,6 +28,44 @@ from phoenix.server.agents.session_titles import (
 
 SUMMARY_TOOL_NAME = "summary"
 COMPACTION_TOOL_NAME = "conversation_checkpoint"
+
+MAX_SUMMARIZED_TOOL_RESULT_LENGTH = 2_000
+"""How much of each tool result the summarizer is allowed to see."""
+
+_ToolReturnPartT = TypeVar("_ToolReturnPartT", bound=BaseToolReturnPart)
+
+
+def _truncate_tool_result(part: _ToolReturnPartT) -> _ToolReturnPartT:
+    """Cap a tool result's text, keeping any multimodal files intact."""
+    text = part.model_response_str(wrap_if_error=False)
+    if len(text) <= MAX_SUMMARIZED_TOOL_RESULT_LENGTH:
+        return part
+    elided = len(text) - MAX_SUMMARIZED_TOOL_RESULT_LENGTH
+    truncated = (
+        f"{text[:MAX_SUMMARIZED_TOOL_RESULT_LENGTH]}"
+        f"\n[... {elided} characters truncated for summarization]"
+    )
+    files = part.files
+    return replace(part, content=[truncated, *files] if files else truncated)
+
+
+def _truncate_tool_results(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Return a copy of ``messages`` with every tool result capped in size.
+
+    Tool output is usually the bulk of a session's context and the reason a session needs
+    compacting in the first place, but a checkpoint or a title only needs durable facts, so
+    the summarizer sees a truncated copy. The persisted history is never modified.
+    """
+    truncated_messages: list[ModelMessage] = []
+    for message in messages:
+        parts = [
+            _truncate_tool_result(part) if isinstance(part, BaseToolReturnPart) else part
+            for part in message.parts
+        ]
+        if any(new is not old for new, old in zip(parts, message.parts)):
+            message = replace(message, parts=cast(Any, parts))
+        truncated_messages.append(message)
+    return truncated_messages
 
 
 class _Summary(BaseModel):
@@ -86,7 +128,7 @@ async def summarize_messages(
     try:
         response = await model.request(
             [
-                *messages,
+                *_truncate_tool_results(messages),
                 ModelRequest(
                     # Explicitly add user message to support anthropic models that forbid assistant
                     # message prefill
@@ -125,7 +167,7 @@ async def summarize_messages_for_compaction(
     try:
         response = await model.request(
             [
-                *messages,
+                *_truncate_tool_results(messages),
                 ModelRequest(
                     # Explicitly add user message to support anthropic models that forbid assistant
                     # message prefill

--- a/src/phoenix/server/api/agent_helpers.py
+++ b/src/phoenix/server/api/agent_helpers.py
@@ -35,9 +35,10 @@ class CanAccessAgentSession(BasePermission):
                 fields.load((source.id, models.AgentSession.user_id)),
             )
         viewer_id = context.user_id
-        if agent_session_id is None or (
-            viewer_id is not None and not context.user.is_admin and owner_id != viewer_id
-        ):
+        session_exists = agent_session_id is not None
+        auth_is_enforced = viewer_id is not None and not context.user.is_admin
+        viewer_owns_session = owner_id == viewer_id
+        if not session_exists or (auth_is_enforced and not viewer_owns_session):
             raise _agent_session_not_found(source.id)
         return True
 

--- a/src/phoenix/server/api/agent_helpers.py
+++ b/src/phoenix/server/api/agent_helpers.py
@@ -1,7 +1,6 @@
 """GraphQL access controls and query helpers for agent sessions."""
 
 from asyncio import gather
-from datetime import datetime, timezone
 from typing import Any, Optional
 
 from sqlalchemy import ColumnElement
@@ -29,19 +28,15 @@ class CanAccessAgentSession(BasePermission):
         if source.db_record:
             agent_session_id = source.db_record.id
             owner_id = source.db_record.user_id
-            expires_at = source.db_record.expires_at
         else:
             fields = context.data_loaders.agent_session_fields
-            agent_session_id, owner_id, expires_at = await gather(
+            agent_session_id, owner_id = await gather(
                 fields.load((source.id, models.AgentSession.id)),
                 fields.load((source.id, models.AgentSession.user_id)),
-                fields.load((source.id, models.AgentSession.expires_at)),
             )
         viewer_id = context.user_id
-        if (
-            agent_session_id is None
-            or (viewer_id is not None and not context.user.is_admin and owner_id != viewer_id)
-            or (expires_at is not None and expires_at <= datetime.now(timezone.utc))
+        if agent_session_id is None or (
+            viewer_id is not None and not context.user.is_admin and owner_id != viewer_id
         ):
             raise _agent_session_not_found(source.id)
         return True

--- a/src/phoenix/server/api/auth.py
+++ b/src/phoenix/server/api/auth.py
@@ -5,8 +5,8 @@ from strawberry import Info
 from strawberry.permission import BasePermission
 from typing_extensions import override
 
-from phoenix.config import get_env_support_email
 from phoenix.server.api.exceptions import BadRequest, InsufficientStorage, Unauthorized
+from phoenix.server.authorization import insufficient_storage_message
 from phoenix.server.bearer_auth import PhoenixUser
 
 
@@ -70,13 +70,7 @@ class IsLocked(BasePermission):
     @override
     def on_unauthorized(self) -> None:
         """Create user-friendly error message when storage operations are blocked."""
-        message = (
-            "Database operations are disabled due to insufficient storage. "
-            "Please delete old data or increase storage."
-        )
-        if support_email := get_env_support_email():
-            message += f" Need help? Contact us at {support_email}"
-        raise InsufficientStorage(message)
+        raise InsufficientStorage(insufficient_storage_message())
 
     @override
     def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:

--- a/src/phoenix/server/api/dataloaders/agent_session_message_text.py
+++ b/src/phoenix/server/api/dataloaders/agent_session_message_text.py
@@ -31,7 +31,7 @@ class AgentSessionMessageTextDataLoader(DataLoader[Key, Result]):
                 func.row_number()
                 .over(
                     partition_by=message.agent_session_id,
-                    order_by=message.position.asc(),
+                    order_by=message.id.asc(),
                 )
                 .label("rank"),
             ).where(
@@ -45,7 +45,7 @@ class AgentSessionMessageTextDataLoader(DataLoader[Key, Result]):
                 func.row_number()
                 .over(
                     partition_by=message.agent_session_id,
-                    order_by=message.position.desc(),
+                    order_by=message.id.desc(),
                 )
                 .label("rank"),
             ).where(message.message["role"].as_string() == "assistant")

--- a/src/phoenix/server/api/helpers/agent_sessions.py
+++ b/src/phoenix/server/api/helpers/agent_sessions.py
@@ -1,20 +1,15 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
+from strawberry.relay import GlobalID
+
 TURN_LOCK_STALENESS = timedelta(seconds=60)
 """How long after its last heartbeat a turn lock is considered abandoned."""
 
 
-def derive_otel_session_id(*, project_name: str, agent_session_rowid: int) -> str:
-    """The OpenTelemetry ``session.id`` an agent session's traces are grouped under.
-
-    Derived rather than stored: the session's autoincrementing primary key is
-    already unique, so the only thing a column bought was a second source of
-    truth to keep in sync. Qualifying the key with the project name keeps the id
-    self-describing in the traces UI and keeps it from colliding with session ids
-    minted by other producers writing into the same project.
-    """
-    return f"{project_name}:{agent_session_rowid}"
+def get_otel_session_id(*, project_name: str, agent_session_rowid: int) -> str:
+    agent_session_gid = GlobalID(type_name="AgentSession", node_id=str(agent_session_rowid))
+    return f"{project_name}:{agent_session_gid}"
 
 
 def is_turn_active(heartbeat_at: Optional[datetime], *, now: datetime) -> bool:

--- a/src/phoenix/server/api/helpers/agent_sessions.py
+++ b/src/phoenix/server/api/helpers/agent_sessions.py
@@ -5,6 +5,18 @@ TURN_LOCK_STALENESS = timedelta(seconds=60)
 """How long after its last heartbeat a turn lock is considered abandoned."""
 
 
+def derive_otel_session_id(*, project_name: str, agent_session_rowid: int) -> str:
+    """The OpenTelemetry ``session.id`` an agent session's traces are grouped under.
+
+    Derived rather than stored: the session's autoincrementing primary key is
+    already unique, so the only thing a column bought was a second source of
+    truth to keep in sync. Qualifying the key with the project name keeps the id
+    self-describing in the traces UI and keeps it from colliding with session ids
+    minted by other producers writing into the same project.
+    """
+    return f"{project_name}:{agent_session_rowid}"
+
+
 def is_turn_active(heartbeat_at: Optional[datetime], *, now: datetime) -> bool:
     """Whether a turn with a live (non-stale) heartbeat holds the session's lock.
 

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm import aliased
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
-from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.agents.session_titles import (
@@ -129,7 +128,6 @@ class AgentSessionMutationMixin:
             agent_session = models.AgentSession(
                 user_id=info.context.user_id,
                 title=title,
-                project_name=get_env_phoenix_agents_assistant_project_name(),
                 is_ephemeral=input.is_ephemeral,
             )
             session.add(agent_session)
@@ -229,7 +227,6 @@ class AgentSessionMutationMixin:
             branch_session = models.AgentSession(
                 user_id=info.context.user_id,
                 title=truncate_agent_session_title(source_session.title),
-                project_name=get_env_phoenix_agents_assistant_project_name(),
                 is_ephemeral=source_session.is_ephemeral,
             )
             session.add(branch_session)

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -148,8 +148,6 @@ class AgentSessionMutationMixin:
             query=Query(),
         )
 
-    # Not gated by IsLocked: truncating only deletes messages, and deletes stay
-    # available while storage is locked so users can free space.
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAgentAssistantEnabled])  # type: ignore
     async def truncate_agent_session(
         self,
@@ -297,7 +295,6 @@ class AgentSessionMutationMixin:
             query=Query(),
         )
 
-    # Not gated by IsLocked: deleting a session is how a user frees space.
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
     async def delete_agent_session(
         self,

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -21,7 +21,12 @@ from phoenix.server.agents.session_titles import (
     validate_agent_session_title,
 )
 from phoenix.server.api.agent_helpers import get_agent_session_owner_filter
-from phoenix.server.api.auth import IsAgentAssistantEnabled, IsNotReadOnly, IsNotViewer
+from phoenix.server.api.auth import (
+    IsAgentAssistantEnabled,
+    IsLocked,
+    IsNotReadOnly,
+    IsNotViewer,
+)
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, NotFound
 from phoenix.server.api.queries import Query
@@ -111,7 +116,9 @@ class DeleteAgentSessionMutationPayload:
 
 @strawberry.type
 class AgentSessionMutationMixin:
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAgentAssistantEnabled])  # type: ignore
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsAgentAssistantEnabled, IsLocked]
+    )  # type: ignore
     async def create_agent_session(
         self,
         info: Info[Context, None],
@@ -141,6 +148,8 @@ class AgentSessionMutationMixin:
             query=Query(),
         )
 
+    # Not gated by IsLocked: truncating only deletes messages, and deletes stay
+    # available while storage is locked so users can free space.
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAgentAssistantEnabled])  # type: ignore
     async def truncate_agent_session(
         self,
@@ -193,7 +202,9 @@ class AgentSessionMutationMixin:
             query=Query(),
         )
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsAgentAssistantEnabled])  # type: ignore
+    @strawberry.mutation(
+        permission_classes=[IsNotReadOnly, IsNotViewer, IsAgentAssistantEnabled, IsLocked]
+    )  # type: ignore
     async def branch_agent_session(
         self,
         info: Info[Context, None],
@@ -252,7 +263,7 @@ class AgentSessionMutationMixin:
             query=Query(),
         )
 
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
     async def update_agent_session_title(
         self,
         info: Info[Context, None],
@@ -286,6 +297,7 @@ class AgentSessionMutationMixin:
             query=Query(),
         )
 
+    # Not gated by IsLocked: deleting a session is how a user frees space.
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer])  # type: ignore
     async def delete_agent_session(
         self,

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -166,7 +166,7 @@ class AgentSessionMutationMixin:
             target = (
                 await session.execute(
                     select(
-                        models.AgentSessionMessage.position,
+                        models.AgentSessionMessage.id,
                         models.AgentSessionMessage.message["role"].as_string(),
                     ).where(
                         models.AgentSessionMessage.agent_session_id == agent_session.id,
@@ -176,16 +176,16 @@ class AgentSessionMutationMixin:
             ).one_or_none()
             if target is None:
                 raise NotFound(f"No message found for ID '{input.message_id}'")
-            target_position, target_role = target
+            target_rowid, target_role = target
             # A user target is removed along with everything after it; an
             # assistant target is kept, so deletion starts just after it.
-            delete_from_position = target_position
+            delete_from_rowid = target_rowid
             if target_role == "assistant":
-                delete_from_position += 1
+                delete_from_rowid += 1
             await session.execute(
                 delete(models.AgentSessionMessage).where(
                     models.AgentSessionMessage.agent_session_id == agent_session.id,
-                    models.AgentSessionMessage.position >= delete_from_position,
+                    models.AgentSessionMessage.id >= delete_from_rowid,
                 )
             )
             agent_session.updated_at = func.now()
@@ -244,10 +244,9 @@ class AgentSessionMutationMixin:
             regenerated_message_rows = [
                 models.AgentSessionMessage(
                     agent_session_id=branch_session.id,
-                    position=position,
                     message=message,
                 )
-                for position, message in enumerate(regenerated_messages)
+                for message in regenerated_messages
             ]
             session.add_all(regenerated_message_rows)
         return BranchAgentSessionMutationPayload(
@@ -354,8 +353,8 @@ async def _load_session_message_prefix(
     message_id: str,
 ) -> list[PhoenixUIMessage]:
     target_message = aliased(models.AgentSessionMessage)
-    target_position = (
-        select(target_message.position)
+    target_rowid = (
+        select(target_message.id)
         .where(
             target_message.agent_session_id == agent_session_rowid,
             target_message.message_id == message_id,
@@ -367,8 +366,8 @@ async def _load_session_message_prefix(
             select(models.AgentSessionMessage.message)
             .where(
                 models.AgentSessionMessage.agent_session_id == agent_session_rowid,
-                models.AgentSessionMessage.position <= target_position,
+                models.AgentSessionMessage.id <= target_rowid,
             )
-            .order_by(models.AgentSessionMessage.position)
+            .order_by(models.AgentSessionMessage.id)
         )
     )

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -124,7 +124,6 @@ class AgentSessionMutationMixin:
             raise BadRequest(str(exc)) from exc
         async with info.context.db() as session:
             agent_session = models.AgentSession(
-                project_session_id=str(uuid4()),
                 user_id=info.context.user_id,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
@@ -228,7 +227,6 @@ class AgentSessionMutationMixin:
                 message.model_copy(update={"id": str(uuid4())}) for message in message_prefix
             ]
             branch_session = models.AgentSession(
-                project_session_id=str(uuid4()),
                 user_id=info.context.user_id,
                 title=truncate_agent_session_title(source_session.title),
                 project_name=get_env_phoenix_agents_assistant_project_name(),

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -36,7 +36,7 @@ class CreateAgentSessionInput:
         default="",
         description=("Optional initial title."),
     )
-    temporary: bool = strawberry.field(
+    is_ephemeral: bool = strawberry.field(
         default=False,
         description="Whether the session should expire after a period of inactivity.",
     )
@@ -130,7 +130,7 @@ class AgentSessionMutationMixin:
                 user_id=info.context.user_id,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                is_ephemeral=input.temporary,
+                is_ephemeral=input.is_ephemeral,
             )
             session.add(agent_session)
             await session.flush()
@@ -327,7 +327,9 @@ async def _load_owned_agent_session(
         statement = statement.with_for_update()
     agent_session = await session.scalar(statement)
     viewer_id = info.context.user_id
-    if agent_session is None or (viewer_id is not None and agent_session.user_id != viewer_id):
+    auth_is_enforced = viewer_id is not None
+    viewer_owns_session = agent_session is not None and agent_session.user_id == viewer_id
+    if agent_session is None or (auth_is_enforced and not viewer_owns_session):
         raise NotFound(f"No agent session found for row ID '{agent_session_rowid}'")
     return agent_session
 

--- a/src/phoenix/server/api/mutations/agent_session_mutations.py
+++ b/src/phoenix/server/api/mutations/agent_session_mutations.py
@@ -1,6 +1,5 @@
 """Mutations for persisted assistant chat sessions."""
 
-from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import strawberry
@@ -10,10 +9,7 @@ from sqlalchemy.orm import aliased
 from strawberry.relay import GlobalID
 from strawberry.types import Info
 
-from phoenix.config import (
-    TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS,
-    get_env_phoenix_agents_assistant_project_name,
-)
+from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.agents.session_titles import (
@@ -134,12 +130,7 @@ class AgentSessionMutationMixin:
                 user_id=info.context.user_id,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                expires_at=(
-                    datetime.now(timezone.utc)
-                    + timedelta(hours=TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS)
-                    if input.temporary
-                    else None
-                ),
+                is_ephemeral=input.temporary,
             )
             session.add(agent_session)
             await session.flush()
@@ -239,12 +230,7 @@ class AgentSessionMutationMixin:
                 user_id=info.context.user_id,
                 title=truncate_agent_session_title(source_session.title),
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                expires_at=(
-                    datetime.now(timezone.utc)
-                    + timedelta(hours=TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS)
-                    if source_session.expires_at is not None
-                    else None
-                ),
+                is_ephemeral=source_session.is_ephemeral,
             )
             session.add(branch_session)
             await session.flush()
@@ -341,14 +327,7 @@ async def _load_owned_agent_session(
         statement = statement.with_for_update()
     agent_session = await session.scalar(statement)
     viewer_id = info.context.user_id
-    if (
-        agent_session is None
-        or (viewer_id is not None and agent_session.user_id != viewer_id)
-        or (
-            agent_session.expires_at is not None
-            and agent_session.expires_at <= datetime.now(timezone.utc)
-        )
-    ):
+    if agent_session is None or (viewer_id is not None and agent_session.user_id != viewer_id):
         raise NotFound(f"No agent session found for row ID '{agent_session_rowid}'")
     return agent_session
 

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -1653,7 +1653,7 @@ class Query:
         after: Optional[CursorString] = UNSET,
     ) -> Connection[AgentSession]:
         page_size = first or 20
-        stmt = select(models.AgentSession).where(models.AgentSession.expires_at.is_(None))
+        stmt = select(models.AgentSession).where(models.AgentSession.is_ephemeral.is_(False))
         if (owner_filter := get_agent_session_owner_filter(info.context)) is not None:
             stmt = stmt.where(owner_filter)
         after_cursor = Cursor.from_string(after) if isinstance(after, CursorString) else None

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -76,7 +76,6 @@ from strawberry.relay import GlobalID
 from typing_extensions import TypeIs, assert_never
 
 from phoenix.config import (
-    TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS,
     get_env_phoenix_agents_assistant_project_name,
     get_env_phoenix_agents_disable_bash,
     get_env_phoenix_agents_force_tracing,
@@ -1347,7 +1346,6 @@ async def _refresh_and_load_agent_session(
         )
     except ValueError:
         raise HTTPException(status_code=404, detail="Session not found") from None
-    now = datetime.now(timezone.utc)
     session_owner_filter = (
         models.AgentSession.user_id.is_(None)
         if user_id is None
@@ -1356,41 +1354,22 @@ async def _refresh_and_load_agent_session(
     statement = select(models.AgentSession).where(
         models.AgentSession.id == agent_session_rowid,
         session_owner_filter,
-        or_(
-            models.AgentSession.expires_at.is_(None),
-            models.AgentSession.expires_at > now,
-        ),
     )
     if for_update:
         statement = statement.with_for_update()
-    loaded_agent_session = await session.scalar(statement)
-    if loaded_agent_session is None:
+    if await session.scalar(statement) is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    if loaded_agent_session.expires_at is None:
-        refreshed_agent_session = await session.scalar(
-            update(models.AgentSession)
-            .where(
-                models.AgentSession.id == agent_session_rowid,
-                models.AgentSession.expires_at.is_(None),
-            )
-            .values(updated_at=func.now())
-            .returning(models.AgentSession)
-        )
-        if refreshed_agent_session is None:
-            raise HTTPException(status_code=404, detail="Session not found")
-        return refreshed_agent_session
-    refreshed_expiry = now + timedelta(hours=TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS)
+    # Bumping updated_at is what keeps an ephemeral session alive: its deadline
+    # is that column plus a fixed TTL, so activity slides the window and there
+    # is no second timestamp to maintain.
     refreshed_agent_session = await session.scalar(
         update(models.AgentSession)
-        .where(
-            models.AgentSession.id == agent_session_rowid,
-            models.AgentSession.expires_at.is_not(None),
-            models.AgentSession.expires_at > now,
-        )
-        .values(expires_at=refreshed_expiry, updated_at=func.now())
+        .where(models.AgentSession.id == agent_session_rowid)
+        .values(updated_at=func.now())
         .returning(models.AgentSession)
     )
     if refreshed_agent_session is None:
+        # An unlocked read can lose the row to a sweep before the bump lands.
         raise HTTPException(status_code=404, detail="Session not found")
     return refreshed_agent_session
 
@@ -1719,7 +1698,7 @@ def _to_agent_session_summary(agent_session: models.AgentSession) -> AgentSessio
         title=agent_session.title,
         created_at=agent_session.created_at,
         updated_at=agent_session.updated_at,
-        is_temporary=agent_session.expires_at is not None,
+        is_temporary=agent_session.is_ephemeral,
     )
 
 
@@ -1758,12 +1737,7 @@ def create_agents_router(
                 user_id=int(phoenix_user.identity) if phoenix_user is not None else None,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                expires_at=(
-                    datetime.now(timezone.utc)
-                    + timedelta(hours=TEMPORARY_AGENT_SESSION_TIME_TO_LIVE_HOURS)
-                    if request_body.temporary
-                    else None
-                ),
+                is_ephemeral=request_body.temporary,
             )
             session.add(agent_session)
             await session.flush()
@@ -1792,7 +1766,7 @@ def create_agents_router(
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
         if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
             raise HTTPException(status_code=403, detail="Server agent is disabled")
-        statement = select(models.AgentSession).where(models.AgentSession.expires_at.is_(None))
+        statement = select(models.AgentSession).where(models.AgentSession.is_ephemeral.is_(False))
         if (user_id := _get_request_user_id(request)) is not None:
             statement = statement.where(models.AgentSession.user_id == user_id)
         if cursor is not None:
@@ -1855,13 +1829,7 @@ def create_agents_router(
 
         statement = (
             select(models.AgentSession)
-            .where(
-                models.AgentSession.id == session_rowid,
-                or_(
-                    models.AgentSession.expires_at.is_(None),
-                    models.AgentSession.expires_at > datetime.now(timezone.utc),
-                ),
-            )
+            .where(models.AgentSession.id == session_rowid)
             .options(selectinload(models.AgentSession.messages))
         )
         if (user_id := _get_request_user_id(request)) is not None:

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1543,15 +1543,19 @@ async def _update_trailing_assistant_message(
     session: AsyncSession,
     *,
     agent_session_rowid: int,
-    position: int,
     message: PhoenixUIMessage,
 ) -> None:
     """Replace the matching trailing assistant message or reject a stale continuation."""
+    latest_message_rowid = (
+        select(func.max(models.AgentSessionMessage.id))
+        .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
+        .scalar_subquery()
+    )
     updated_message_rowid = await session.scalar(
         update(models.AgentSessionMessage)
         .where(
             models.AgentSessionMessage.agent_session_id == agent_session_rowid,
-            models.AgentSessionMessage.position == position,
+            models.AgentSessionMessage.id == latest_message_rowid,
             models.AgentSessionMessage.message_id == message.id,
         )
         .values(message=message)
@@ -1592,28 +1596,22 @@ async def _persist_agent_session_turn(
                 len(new_messages),
             )
             return
-        next_position = await session.scalar(
-            select(func.coalesce(func.max(models.AgentSessionMessage.position), -1) + 1).where(
-                models.AgentSessionMessage.agent_session_id == agent_session_rowid
-            )
-        )
-        assert next_position is not None
         if new_messages[0].role == "assistant":
             # Client-tool continuations replace the persisted assistant message.
             await _update_trailing_assistant_message(
                 session,
                 agent_session_rowid=agent_session_rowid,
-                position=next_position - 1,
                 message=new_messages[0],
             )
             new_messages = new_messages[1:]
+        # Transcript order is the order these rows are inserted in, which the
+        # autoincrementing primary key records for us.
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session_rowid,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(new_messages, start=next_position)
+            for message in new_messages
         )
         if bashkit_snapshot is not None:
             await _upsert_agent_session_snapshot(
@@ -1641,13 +1639,13 @@ async def _load_agent_session_history(
     agent_session_rowid: int,
 ) -> list[models.AgentSessionMessage]:
     """Load messages from the latest surviving compaction point onward."""
-    latest_compaction_position = (
-        select(models.AgentSessionMessage.position)
+    latest_compaction_rowid = (
+        select(models.AgentSessionMessage.id)
         .where(
             models.AgentSessionMessage.agent_session_id == agent_session_rowid,
             models.AgentSessionMessage.is_compaction_message,
         )
-        .order_by(models.AgentSessionMessage.position.desc())
+        .order_by(models.AgentSessionMessage.id.desc())
         .limit(1)
         .scalar_subquery()
     )
@@ -1656,9 +1654,9 @@ async def _load_agent_session_history(
             select(models.AgentSessionMessage)
             .where(
                 models.AgentSessionMessage.agent_session_id == agent_session_rowid,
-                models.AgentSessionMessage.position >= func.coalesce(latest_compaction_position, 0),
+                models.AgentSessionMessage.id >= func.coalesce(latest_compaction_rowid, 0),
             )
-            .order_by(models.AgentSessionMessage.position)
+            .order_by(models.AgentSessionMessage.id)
         )
     )
 
@@ -1981,9 +1979,10 @@ def create_agents_router(
                     message_id=str(uuid4()),
                     summary=summary,
                 )
+                # The boundary row was just confirmed to be the session's last
+                # message, so appending puts the checkpoint right after it.
                 compaction_message_row = models.AgentSessionMessage(
                     agent_session_id=agent_session_rowid,
-                    position=boundary_row.position + 1,
                     message=compaction_message,
                 )
                 session.add(compaction_message_row)

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -355,7 +355,7 @@ class CreateAgentSessionRequestBody(V1RoutesBaseModel):
         max_length=MAX_AGENT_SESSION_TITLE_LENGTH,
         description="Optional initial title.",
     )
-    temporary: bool = Field(
+    is_ephemeral: bool = Field(
         default=False,
         description="Whether the session should expire after a period of inactivity.",
     )
@@ -376,7 +376,7 @@ class AgentSessionSummary(V1RoutesBaseModel):
     title: str
     created_at: datetime
     updated_at: datetime
-    is_temporary: bool
+    is_ephemeral: bool
 
 
 class AgentSessionData(AgentSessionSummary):
@@ -1359,9 +1359,7 @@ async def _refresh_and_load_agent_session(
         statement = statement.with_for_update()
     if await session.scalar(statement) is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    # Bumping updated_at is what keeps an ephemeral session alive: its deadline
-    # is that column plus a fixed TTL, so activity slides the window and there
-    # is no second timestamp to maintain.
+    # Bumping updated_at slides an ephemeral session's TTL window.
     refreshed_agent_session = await session.scalar(
         update(models.AgentSession)
         .where(models.AgentSession.id == agent_session_rowid)
@@ -1698,7 +1696,7 @@ def _to_agent_session_summary(agent_session: models.AgentSession) -> AgentSessio
         title=agent_session.title,
         created_at=agent_session.created_at,
         updated_at=agent_session.updated_at,
-        is_temporary=agent_session.is_ephemeral,
+        is_ephemeral=agent_session.is_ephemeral,
     )
 
 
@@ -1737,7 +1735,7 @@ def create_agents_router(
                 user_id=int(phoenix_user.identity) if phoenix_user is not None else None,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
-                is_ephemeral=request_body.temporary,
+                is_ephemeral=request_body.is_ephemeral,
             )
             session.add(agent_session)
             await session.flush()

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1624,21 +1624,12 @@ async def _persist_agent_session_turn(
             )
 
 
-TRANSCRIPT_NOT_SAVED_MESSAGE = (
-    "The assistant replied, but the conversation could not be saved, "
-    "so this turn will be missing when you reload."
-)
-
-
 def _transcript_persistence_error(db: DbSessionFactory) -> Exception:
-    """The error text shown when a turn ran but its transcript could not be written.
-
-    Storage exhaustion is the expected cause and the only one the user can act
-    on, so it gets named explicitly when the disk-usage monitor has locked
-    writes. Anything else keeps the generic notice — better to say the turn was
-    lost than to guess at why.
-    """
-    message = TRANSCRIPT_NOT_SAVED_MESSAGE
+    """The error shown when a turn ran but its transcript could not be written."""
+    message = (
+        "The assistant replied, but the conversation could not be saved, "
+        "so this turn will be missing when you reload."
+    )
     if db.should_not_insert_or_update:
         message += f" {insufficient_storage_message()}"
     return RuntimeError(message)
@@ -2452,10 +2443,6 @@ def create_agents_router(
                             title=session_title,
                         )
                     except Exception as exc:
-                        # The turn itself succeeded; only the write failed. The
-                        # stream handler puts whatever this raises in front of
-                        # the user, so say what happened instead of leaking the
-                        # driver's error text.
                         logger.exception(
                             "Failed to persist the transcript for agent session %r",
                             str(GlobalID("AgentSession", str(agent_session_rowid))),

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -150,7 +150,7 @@ from phoenix.server.agents.vercel_ui_message_stream import (
 )
 from phoenix.server.api.helpers.agent_sessions import (
     TURN_LOCK_STALENESS,
-    derive_otel_session_id,
+    get_otel_session_id,
     is_turn_active,
 )
 from phoenix.server.api.helpers.playground_registry import (
@@ -2063,7 +2063,7 @@ def create_agents_router(
                 project_name = agent_session.project_name
                 session_needs_title = not agent_session.title
                 agent_session_rowid = agent_session.id
-                otel_session_id = derive_otel_session_id(
+                otel_session_id = get_otel_session_id(
                     project_name=project_name,
                     agent_session_rowid=agent_session_rowid,
                 )

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1734,7 +1734,6 @@ def create_agents_router(
             agent_session = models.AgentSession(
                 user_id=int(phoenix_user.identity) if phoenix_user is not None else None,
                 title=title,
-                project_name=get_env_phoenix_agents_assistant_project_name(),
                 is_ephemeral=request_body.is_ephemeral,
             )
             session.add(agent_session)
@@ -2002,6 +2001,7 @@ def create_agents_router(
             allow_local_traces=recording.allow_local_traces,
             allow_remote_export=recording.allow_remote_export,
         )
+        project_name = get_env_phoenix_agents_assistant_project_name()
         resolved_contexts = resolve_contexts(body.contexts)
         user = request.user if "user" in request.scope else None
         phoenix_user = user if isinstance(user, PhoenixUser) else None
@@ -2038,7 +2038,6 @@ def create_agents_router(
                     agent_session_rowid=agent_session.id,
                 ):
                     return JSONResponse({"code": "agent_session_busy"}, status_code=409)
-                project_name = agent_session.project_name
                 session_needs_title = not agent_session.title
                 agent_session_rowid = agent_session.id
                 otel_session_id = get_otel_session_id(

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -148,7 +148,11 @@ from phoenix.server.agents.vercel_ui_message_stream import (
     create_streaming_ui_message_state,
     process_ui_message_stream,
 )
-from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, is_turn_active
+from phoenix.server.api.helpers.agent_sessions import (
+    TURN_LOCK_STALENESS,
+    derive_otel_session_id,
+    is_turn_active,
+)
 from phoenix.server.api.helpers.playground_registry import (
     PLAYGROUND_CLIENT_REGISTRY,
     PROVIDER_DEFAULT,
@@ -1739,7 +1743,6 @@ def create_agents_router(
         phoenix_user = user if isinstance(user, PhoenixUser) else None
         async with request.app.state.db() as session:
             agent_session = models.AgentSession(
-                project_session_id=str(uuid4()),
                 user_id=int(phoenix_user.identity) if phoenix_user is not None else None,
                 title=title,
                 project_name=get_env_phoenix_agents_assistant_project_name(),
@@ -2060,7 +2063,10 @@ def create_agents_router(
                 project_name = agent_session.project_name
                 session_needs_title = not agent_session.title
                 agent_session_rowid = agent_session.id
-                otel_session_id = agent_session.project_session_id
+                otel_session_id = derive_otel_session_id(
+                    project_name=project_name,
+                    agent_session_rowid=agent_session_rowid,
+                )
         except AgentError as exc:
             raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1604,8 +1604,6 @@ async def _persist_agent_session_turn(
                 message=new_messages[0],
             )
             new_messages = new_messages[1:]
-        # Transcript order is the order these rows are inserted in, which the
-        # autoincrementing primary key records for us.
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session_rowid,
@@ -1979,8 +1977,6 @@ def create_agents_router(
                     message_id=str(uuid4()),
                     summary=summary,
                 )
-                # The boundary row was just confirmed to be the session's last
-                # message, so appending puts the checkpoint right after it.
                 compaction_message_row = models.AgentSessionMessage(
                     agent_session_id=agent_session_rowid,
                     message=compaction_message,

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -171,6 +171,7 @@ from phoenix.server.api.types.SandboxConfig import (
     get_sandbox_backend_info,
 )
 from phoenix.server.authorization import (
+    insufficient_storage_message,
     is_agent_assistant_enabled,
     is_not_locked,
     prevent_access_in_read_only_mode,
@@ -1623,6 +1624,26 @@ async def _persist_agent_session_turn(
             )
 
 
+TRANSCRIPT_NOT_SAVED_MESSAGE = (
+    "The assistant replied, but the conversation could not be saved, "
+    "so this turn will be missing when you reload."
+)
+
+
+def _transcript_persistence_error(db: DbSessionFactory) -> Exception:
+    """The error text shown when a turn ran but its transcript could not be written.
+
+    Storage exhaustion is the expected cause and the only one the user can act
+    on, so it gets named explicitly when the disk-usage monitor has locked
+    writes. Anything else keeps the generic notice — better to say the turn was
+    lost than to guess at why.
+    """
+    message = TRANSCRIPT_NOT_SAVED_MESSAGE
+    if db.should_not_insert_or_update:
+        message += f" {insufficient_storage_message()}"
+    return RuntimeError(message)
+
+
 async def _load_bash_snapshot(
     session: AsyncSession,
     *,
@@ -2421,14 +2442,25 @@ def create_agents_router(
                     else:
                         # Persist the submitted user message and its generated response.
                         turn_messages = [body.message, generated_assistant_message]
-                    await _persist_agent_session_turn(
-                        request.app.state.db,
-                        agent_session_rowid=agent_session_rowid,
-                        user_id=request_user_id,
-                        new_messages=turn_messages,
-                        bashkit_snapshot=bash_snapshot_to_persist,
-                        title=session_title,
-                    )
+                    try:
+                        await _persist_agent_session_turn(
+                            request.app.state.db,
+                            agent_session_rowid=agent_session_rowid,
+                            user_id=request_user_id,
+                            new_messages=turn_messages,
+                            bashkit_snapshot=bash_snapshot_to_persist,
+                            title=session_title,
+                        )
+                    except Exception as exc:
+                        # The turn itself succeeded; only the write failed. The
+                        # stream handler puts whatever this raises in front of
+                        # the user, so say what happened instead of leaking the
+                        # driver's error text.
+                        logger.exception(
+                            "Failed to persist the transcript for agent session %r",
+                            str(GlobalID("AgentSession", str(agent_session_rowid))),
+                        )
+                        raise _transcript_persistence_error(request.app.state.db) from exc
                     return TranscriptPersistedChunk(
                         data=TranscriptPersistedData(message_id=turn_messages[-1].id)
                     )

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -129,7 +129,7 @@ class AgentSession(Node):
         stmt = (
             select(models.AgentSessionMessage.message)
             .where(models.AgentSessionMessage.agent_session_id == self.id)
-            .order_by(models.AgentSessionMessage.position)
+            .order_by(models.AgentSessionMessage.id)
         )
         async with info.context.db.read() as session:
             messages = (await session.scalars(stmt)).all()

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -96,7 +96,7 @@ class AgentSession(Node):
         description="Whether the session expires after a period of inactivity.",
         permission_classes=[CanAccessAgentSession],
     )  # type: ignore
-    async def is_temporary(self, info: Info[Context, None]) -> bool:
+    async def is_ephemeral(self, info: Info[Context, None]) -> bool:
         if self.db_record:
             return self.db_record.is_ephemeral
         is_ephemeral = await info.context.data_loaders.agent_session_fields.load(

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -98,11 +98,11 @@ class AgentSession(Node):
     )  # type: ignore
     async def is_temporary(self, info: Info[Context, None]) -> bool:
         if self.db_record:
-            return self.db_record.expires_at is not None
-        expires_at = await info.context.data_loaders.agent_session_fields.load(
-            (self.id, models.AgentSession.expires_at),
+            return self.db_record.is_ephemeral
+        is_ephemeral = await info.context.data_loaders.agent_session_fields.load(
+            (self.id, models.AgentSession.is_ephemeral),
         )
-        return expires_at is not None
+        return bool(is_ephemeral)
 
     @strawberry.field(
         description=(

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -114,6 +114,7 @@ from phoenix.server.api.routers.oauth2_authorization_server import (
 )
 from phoenix.server.api.routers.v1 import REST_API_VERSION
 from phoenix.server.api.schema import build_graphql_schema
+from phoenix.server.authorization import insufficient_storage_message
 from phoenix.server.bearer_auth import BearerTokenAuthBackend, PhoenixUser, is_authenticated
 from phoenix.server.daemons.agent_session_sweeper import AgentSessionSweeper
 from phoenix.server.daemons.db_disk_usage_monitor import DbDiskUsageMonitor
@@ -896,13 +897,10 @@ class DbDiskUsageInterceptor(AsyncServerInterceptor):
             method_name.endswith("trace.v1.TraceService/Export")
             and self._db.should_not_insert_or_update
         ):
-            details = (
-                "Database operations are disabled due to insufficient storage. "
-                "Please delete old data or increase storage."
+            await context.abort(
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                insufficient_storage_message(),
             )
-            if support_email := get_env_support_email():
-                details += f" Need help? Contact us at {support_email}"
-            await context.abort(grpc.StatusCode.RESOURCE_EXHAUSTED, details)
         return await method(request_or_iterator, context)
 
 

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -117,21 +117,11 @@ def require_admin(request: Request) -> None:
         )
 
 
-INSUFFICIENT_STORAGE_MESSAGE = (
-    "Database operations are disabled due to insufficient storage. "
-    "Please delete old data or increase storage."
-)
-"""The single wording every insufficient-storage surface reports.
-
-REST (HTTP 507), GraphQL (``IsLocked``), the OTLP gRPC interceptor, and the
-browser all key off this one sentence, so it must stay stable: the assistant UI
-recognizes a storage failure by matching it.
-"""
-
-
 def insufficient_storage_message() -> str:
-    """``INSUFFICIENT_STORAGE_MESSAGE`` plus the support contact, when configured."""
-    message = INSUFFICIENT_STORAGE_MESSAGE
+    message = (
+        "Database operations are disabled due to insufficient storage. "
+        "Please delete old data or increase storage."
+    )
     if support_email := get_env_support_email():
         message += f" Need help? Contact us at {support_email}"
     return message

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -117,6 +117,26 @@ def require_admin(request: Request) -> None:
         )
 
 
+INSUFFICIENT_STORAGE_MESSAGE = (
+    "Database operations are disabled due to insufficient storage. "
+    "Please delete old data or increase storage."
+)
+"""The single wording every insufficient-storage surface reports.
+
+REST (HTTP 507), GraphQL (``IsLocked``), the OTLP gRPC interceptor, and the
+browser all key off this one sentence, so it must stay stable: the assistant UI
+recognizes a storage failure by matching it.
+"""
+
+
+def insufficient_storage_message() -> str:
+    """``INSUFFICIENT_STORAGE_MESSAGE`` plus the support contact, when configured."""
+    message = INSUFFICIENT_STORAGE_MESSAGE
+    if support_email := get_env_support_email():
+        message += f" Need help? Contact us at {support_email}"
+    return message
+
+
 def is_not_locked(request: Request) -> None:
     """
     FastAPI dependency to ensure database operations are not locked due to insufficient storage.
@@ -138,13 +158,7 @@ def is_not_locked(request: Request) -> None:
             information if configured.
     """
     if request.app.state.db.should_not_insert_or_update:
-        detail = (
-            "Database operations are disabled due to insufficient storage. "
-            "Please delete old data or increase storage."
-        )
-        if support_email := get_env_support_email():
-            detail += f" Need help? Contact us at {support_email}"
         raise HTTPException(
             status_code=507,
-            detail=detail,
+            detail=insufficient_storage_message(),
         )

--- a/src/phoenix/server/daemons/agent_session_sweeper.py
+++ b/src/phoenix/server/daemons/agent_session_sweeper.py
@@ -50,14 +50,7 @@ class AgentSessionSweeper(DaemonTask):
             await self._enforce_per_user_count_cap(retention.max_count_per_user)
 
     async def _delete_idle_sessions(self, *, is_ephemeral: bool, max_idle: timedelta) -> None:
-        """Delete sessions of one persistence kind left untouched for ``max_idle``.
-
-        The two kinds differ only in the flag and the length of the window: an
-        ephemeral session dies a fixed TTL after its last activity, which is
-        the same question retention asks of a persisted one. Sharing the query
-        also gives ephemeral deletes the batching that bounds how much cascade
-        work lands in a single transaction.
-        """
+        """Delete sessions of one persistence kind left untouched for ``max_idle``."""
         cutoff = datetime.now(timezone.utc) - max_idle
         total_deleted = 0
         while True:

--- a/src/phoenix/server/daemons/agent_session_sweeper.py
+++ b/src/phoenix/server/daemons/agent_session_sweeper.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 import sqlalchemy as sa
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.server.daemons.system_settings import SystemSettings
 from phoenix.server.types import DaemonTask, DbSessionFactory
@@ -19,7 +20,7 @@ _DELETE_BATCH_SIZE = 100
 
 
 class AgentSessionSweeper(DaemonTask):
-    """Periodically delete expired agent sessions."""
+    """Periodically delete agent sessions that have outlived their retention."""
 
     def __init__(self, db: DbSessionFactory, settings: SystemSettings) -> None:
         super().__init__()
@@ -35,32 +36,34 @@ class AgentSessionSweeper(DaemonTask):
             await sleep(_SLEEP_SECONDS + random.uniform(-_JITTER_SECONDS, _JITTER_SECONDS))
 
     async def _sweep(self) -> None:
-        await self._delete_expired_temporary_sessions()
+        await self._delete_idle_sessions(
+            is_ephemeral=True,
+            max_idle=timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS),
+        )
         retention = self._settings.agent_session_retention
         if retention.max_idle_days > 0:
-            await self._delete_idle_persisted_sessions(retention.max_idle_days)
+            await self._delete_idle_sessions(
+                is_ephemeral=False,
+                max_idle=timedelta(days=retention.max_idle_days),
+            )
         if retention.max_count_per_user > 0:
             await self._enforce_per_user_count_cap(retention.max_count_per_user)
 
-    async def _delete_expired_temporary_sessions(self) -> None:
-        stmt = (
-            sa.delete(models.AgentSession)
-            .where(models.AgentSession.expires_at.is_not(None))
-            .where(models.AgentSession.expires_at < datetime.now(timezone.utc))
-            .returning(models.AgentSession.id)
-        )
-        async with self._db() as session:
-            num_deleted = len((await session.scalars(stmt)).all())
-        if num_deleted:
-            logger.info("Deleted %d expired agent session(s).", num_deleted)
+    async def _delete_idle_sessions(self, *, is_ephemeral: bool, max_idle: timedelta) -> None:
+        """Delete sessions of one persistence kind left untouched for ``max_idle``.
 
-    async def _delete_idle_persisted_sessions(self, max_idle_days: int) -> None:
-        cutoff = datetime.now(timezone.utc) - timedelta(days=max_idle_days)
+        The two kinds differ only in the flag and the length of the window: an
+        ephemeral session dies a fixed TTL after its last activity, which is
+        the same question retention asks of a persisted one. Sharing the query
+        also gives ephemeral deletes the batching that bounds how much cascade
+        work lands in a single transaction.
+        """
+        cutoff = datetime.now(timezone.utc) - max_idle
         total_deleted = 0
         while True:
             batch = (
                 sa.select(models.AgentSession.id)
-                .where(models.AgentSession.expires_at.is_(None))
+                .where(models.AgentSession.is_ephemeral.is_(is_ephemeral))
                 .where(models.AgentSession.updated_at < cutoff)
                 .limit(_DELETE_BATCH_SIZE)
             )
@@ -69,7 +72,7 @@ class AgentSessionSweeper(DaemonTask):
             # spare a session that turned active after the batch was selected.
             stmt = (
                 sa.delete(models.AgentSession)
-                .where(models.AgentSession.expires_at.is_(None))
+                .where(models.AgentSession.is_ephemeral.is_(is_ephemeral))
                 .where(models.AgentSession.updated_at < cutoff)
                 .where(models.AgentSession.id.in_(batch))
             )
@@ -80,7 +83,11 @@ class AgentSessionSweeper(DaemonTask):
             if num_deleted < _DELETE_BATCH_SIZE:
                 break
         if total_deleted:
-            logger.info("Deleted %d idle agent session(s).", total_deleted)
+            logger.info(
+                "Deleted %d idle %s agent session(s).",
+                total_deleted,
+                "ephemeral" if is_ephemeral else "persisted",
+            )
 
     async def _enforce_per_user_count_cap(self, max_count_per_user: int) -> None:
         ranked = (
@@ -97,7 +104,7 @@ class AgentSessionSweeper(DaemonTask):
                 )
                 .label("rank"),
             )
-            .where(models.AgentSession.expires_at.is_(None))
+            .where(models.AgentSession.is_ephemeral.is_(False))
             .cte("ranked_agent_sessions")
         )
         # Matching on (id, updated_at) rather than id alone makes the delete's

--- a/src/phoenix/server/settings/registry.py
+++ b/src/phoenix/server/settings/registry.py
@@ -37,14 +37,7 @@ DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER = 30
 
 
 class AgentSessionRetentionSetting(BaseModel):
-    """Workspace-wide retention for non-temporary agent sessions.
-
-    Both rules are on by default so a deployment that never visits the admin
-    settings still bounds how much chat history it accumulates. ``0`` means the
-    rule is off; these defaults apply when the
-    ``agent.assistant.session_retention`` row is absent, i.e. until an admin
-    saves a value of their own.
-    """
+    """Workspace-wide retention for non-temporary agent sessions."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
 

--- a/src/phoenix/server/settings/registry.py
+++ b/src/phoenix/server/settings/registry.py
@@ -37,7 +37,7 @@ DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER = 30
 
 
 class AgentSessionRetentionSetting(BaseModel):
-    """Workspace-wide retention for non-temporary agent sessions."""
+    """Workspace-wide retention for non-ephemeral agent sessions."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
 

--- a/src/phoenix/server/settings/registry.py
+++ b/src/phoenix/server/settings/registry.py
@@ -32,13 +32,24 @@ class AgentAssistantEnabledSetting(BaseModel):
     enabled: bool = Field(default=True)
 
 
+DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS = 30
+DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER = 30
+
+
 class AgentSessionRetentionSetting(BaseModel):
-    """Workspace-wide retention for non-temporary agent sessions."""
+    """Workspace-wide retention for non-temporary agent sessions.
+
+    Both rules are on by default so a deployment that never visits the admin
+    settings still bounds how much chat history it accumulates. ``0`` means the
+    rule is off; these defaults apply when the
+    ``agent.assistant.session_retention`` row is absent, i.e. until an admin
+    saves a value of their own.
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True, validate_assignment=True)
 
-    max_idle_days: int = Field(default=0, ge=0)
-    max_count_per_user: int = Field(default=0, ge=0)
+    max_idle_days: int = Field(default=DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS, ge=0)
+    max_count_per_user: int = Field(default=DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER, ge=0)
 
 
 SETTINGS_REGISTRY: Mapping[SystemSettingKey, type[BaseModel]] = MappingProxyType(

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -1990,13 +1990,13 @@ class TestApiAccessViaCookiesOrApiKeys:
         admin_client = _httpx_client(_app, admin.tokens)
         member_session_response = member_client.post(
             "agents/assistant/sessions",
-            json={"title": "Member session", "temporary": False},
+            json={"title": "Member session", "is_ephemeral": False},
         )
         member_session_response.raise_for_status()
         member_session_id = member_session_response.json()["data"]["id"]
         admin_session_response = admin_client.post(
             "agents/assistant/sessions",
-            json={"title": "Admin session", "temporary": False},
+            json={"title": "Admin session", "is_ephemeral": False},
         )
         admin_session_response.raise_for_status()
         admin_session_id = admin_session_response.json()["data"]["id"]

--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 from functools import singledispatch
 from secrets import token_hex
 from typing import Any, Dict, Optional, Sequence, Type, TypeVar, Union, cast
+from uuid import UUID, uuid5
 
 import httpx
 from sqlalchemy import select
@@ -13,6 +14,19 @@ from phoenix.db import models
 from phoenix.server.api.types.node import from_global_id
 from phoenix.server.api.types.ProjectSession import ProjectSession
 from phoenix.server.api.types.Span import Span
+
+_MESSAGE_ID_NAMESPACE = UUID("6f1a7f5e-3f4d-4a5b-8c9d-0e1f2a3b4c5d")
+
+
+def _message_uuid(label: str) -> str:
+    """A stable UUID standing in for a readable transcript-message label.
+
+    ``agent_session_messages.message_id`` is CHECK-constrained to UUID form at
+    the database level, so a bare label like ``"user-1"`` cannot be used as a
+    message id. This keeps the label readable at the call site and returns the
+    same id every time, so a test can still refer to a message by its label.
+    """
+    return str(uuid5(_MESSAGE_ID_NAMESPACE, label))
 
 
 @singledispatch

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 import httpx
 from strawberry.relay import GlobalID
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage, TextUIPart
 from phoenix.server.types import DbSessionFactory
@@ -14,14 +15,14 @@ async def _insert_agent_session(
     *,
     title: str,
     updated_at: datetime,
-    expires_at: datetime | None = None,
+    is_ephemeral: bool = False,
     messages: list[PhoenixUIMessage] | None = None,
 ) -> models.AgentSession:
     async with db() as session:
         agent_session = models.AgentSession(
             project_name="pxi-test",
             title=title,
-            expires_at=expires_at,
+            is_ephemeral=is_ephemeral,
             created_at=updated_at,
             updated_at=updated_at,
         )
@@ -54,7 +55,7 @@ class TestListAgentSessions:
             db,
             title="Temporary",
             updated_at=now + timedelta(minutes=1),
-            expires_at=now + timedelta(hours=1),
+            is_ephemeral=True,
         )
 
         response = await httpx_client.get("/agents/assistant/sessions")
@@ -157,7 +158,7 @@ class TestGetAgentSession:
         assert data["messages"][0]["parts"] == [{"type": "text", "text": "Hello"}]
         assert data["messages"][1]["parts"] == [{"type": "text", "text": "Hi"}]
 
-    async def test_gets_unexpired_temporary_session(
+    async def test_gets_temporary_session(
         self,
         httpx_client: httpx.AsyncClient,
         db: DbSessionFactory,
@@ -167,7 +168,7 @@ class TestGetAgentSession:
             db,
             title="Temporary",
             updated_at=now,
-            expires_at=now + timedelta(hours=1),
+            is_ephemeral=True,
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
@@ -176,23 +177,31 @@ class TestGetAgentSession:
         assert response.status_code == 200
         assert response.json()["data"]["is_temporary"] is True
 
-    async def test_hides_expired_session(
+    async def test_serves_an_ephemeral_session_the_sweeper_has_not_reached_yet(
         self,
         httpx_client: httpx.AsyncClient,
         db: DbSessionFactory,
     ) -> None:
-        now = datetime.now(timezone.utc)
+        """Past the TTL but not yet swept, the session is still readable.
+
+        Reads no longer second-guess the sweeper: with the deadline derived from
+        ``updated_at`` there is no stored expiry to compare against, so the row
+        stays visible to its owner for at most one sweep interval longer than
+        before.
+        """
         agent_session = await _insert_agent_session(
             db,
-            title="Expired",
-            updated_at=now,
-            expires_at=now - timedelta(hours=1),
+            title="Idle past its TTL",
+            updated_at=datetime.now(timezone.utc)
+            - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1),
+            is_ephemeral=True,
         )
         session_id = str(GlobalID("AgentSession", str(agent_session.id)))
 
         response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
 
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert response.json()["data"]["is_temporary"] is True
 
     async def test_rejects_invalid_id(self, httpx_client: httpx.AsyncClient) -> None:
         response = await httpx_client.get("/agents/assistant/sessions/invalid")

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -20,7 +20,6 @@ async def _insert_agent_session(
 ) -> models.AgentSession:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_name="pxi-test",
             title=title,
             is_ephemeral=is_ephemeral,
             created_at=updated_at,

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from uuid import uuid4
 
 import httpx
 from strawberry.relay import GlobalID
@@ -20,7 +19,6 @@ async def _insert_agent_session(
 ) -> models.AgentSession:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             project_name="pxi-test",
             title=title,
             expires_at=expires_at,

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -68,14 +68,14 @@ class TestListAgentSessions:
                     "title": "Newer",
                     "created_at": now.isoformat(),
                     "updated_at": now.isoformat(),
-                    "is_temporary": False,
+                    "is_ephemeral": False,
                 },
                 {
                     "id": str(GlobalID("AgentSession", str(older.id))),
                     "title": "Older",
                     "created_at": (now - timedelta(minutes=2)).isoformat(),
                     "updated_at": (now - timedelta(minutes=2)).isoformat(),
-                    "is_temporary": False,
+                    "is_ephemeral": False,
                 },
             ],
             "next_cursor": None,
@@ -150,7 +150,7 @@ class TestGetAgentSession:
         data = response.json()["data"]
         assert data["id"] == session_id
         assert data["title"] == "Conversation"
-        assert data["is_temporary"] is False
+        assert data["is_ephemeral"] is False
         assert [message["id"] for message in data["messages"]] == [
             _message_uuid("user-message"),
             _message_uuid("assistant-message"),
@@ -175,7 +175,7 @@ class TestGetAgentSession:
         response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
 
         assert response.status_code == 200
-        assert response.json()["data"]["is_temporary"] is True
+        assert response.json()["data"]["is_ephemeral"] is True
 
     async def test_serves_an_ephemeral_session_the_sweeper_has_not_reached_yet(
         self,
@@ -201,7 +201,7 @@ class TestGetAgentSession:
         response = await httpx_client.get(f"/agents/assistant/sessions/{session_id}")
 
         assert response.status_code == 200
-        assert response.json()["data"]["is_temporary"] is True
+        assert response.json()["data"]["is_ephemeral"] is True
 
     async def test_rejects_invalid_id(self, httpx_client: httpx.AsyncClient) -> None:
         response = await httpx_client.get("/agents/assistant/sessions/invalid")

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -7,6 +7,7 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage, TextUIPart
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 
 
 async def _insert_agent_session(
@@ -28,11 +29,10 @@ async def _insert_agent_session(
         )
         session.add(agent_session)
         await session.flush()
-        for position, message in enumerate(messages or []):
+        for message in messages or []:
             session.add(
                 models.AgentSessionMessage(
                     agent_session_id=agent_session.id,
-                    position=position,
                     message=message,
                 )
             )
@@ -127,12 +127,12 @@ class TestGetAgentSession:
         now = datetime.now(timezone.utc)
         messages = [
             PhoenixUIMessage(
-                id="user-message",
+                id=_message_uuid("user-message"),
                 role="user",
                 parts=[TextUIPart(type="text", text="Hello")],
             ),
             PhoenixUIMessage(
-                id="assistant-message",
+                id=_message_uuid("assistant-message"),
                 role="assistant",
                 parts=[TextUIPart(type="text", text="Hi")],
             ),
@@ -153,8 +153,8 @@ class TestGetAgentSession:
         assert data["title"] == "Conversation"
         assert data["is_temporary"] is False
         assert [message["id"] for message in data["messages"]] == [
-            "user-message",
-            "assistant-message",
+            _message_uuid("user-message"),
+            _message_uuid("assistant-message"),
         ]
         assert data["messages"][0]["parts"] == [{"type": "text", "text": "Hello"}]
         assert data["messages"][1]["parts"] == [{"type": "text", "text": "Hi"}]

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -2116,7 +2116,7 @@ async def test_create_session_route_creates_a_temporary_session(
 ) -> None:
     response = await httpx_client.post(
         "/agents/server/sessions",
-        json={"title": " CLI session ", "temporary": True},
+        json={"title": " CLI session ", "is_ephemeral": True},
     )
     assert response.status_code == 201
 
@@ -2170,7 +2170,7 @@ async def test_create_session_route_yields_a_chattable_session(
 
     created = await httpx_client.post(
         "/agents/server/sessions",
-        json={"temporary": True},
+        json={"is_ephemeral": True},
     )
     assert created.status_code == 201
 

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -55,6 +55,7 @@ from phoenix.server.agents.ui_message_stream import iter_chunks_with_error_parts
 from phoenix.server.agents.vercel_ui_message_stream import read_ui_message_stream
 from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, get_otel_session_id
 from phoenix.server.api.routers.agents import (
+    TRANSCRIPT_NOT_SAVED_MESSAGE,
     _build_message_metadata_chunk,
     _emit_turn_root_span,
     _get_span_context,
@@ -64,6 +65,7 @@ from phoenix.server.api.routers.agents import (
     _synthesize_client_tool_spans,
     _turn_parent_context,
 )
+from phoenix.server.authorization import INSUFFICIENT_STORAGE_MESSAGE
 from phoenix.server.settings.registry import (
     AgentAssistantEnabledSetting,
     AgentTraceRecordingSetting,
@@ -2502,3 +2504,73 @@ async def test_resumed_chat_turn_keeps_original_trace_project(
             )
             == 0
         )
+
+
+async def test_chat_is_rejected_with_storage_guidance_when_writes_are_already_locked(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+) -> None:
+    """A locked database rejects the turn before it starts, with the reason."""
+    session_id = "79797979-7979-4979-8979-797979797979"
+    agent_session_id = await _create_agent_session_row(db, title="Already titled")
+
+    db.should_not_insert_or_update = True
+    try:
+        response = await httpx_client.post(
+            _chat_url(agent_session_id),
+            json=_chat_body(session_id, _user_message("will be rejected")),
+        )
+    finally:
+        db.should_not_insert_or_update = False
+
+    assert response.status_code == 507
+    # The handler returns HTTPException details as text/plain, not JSON.
+    assert INSUFFICIENT_STORAGE_MESSAGE in response.text
+
+
+async def test_transcript_write_failure_is_reported_as_an_unsaved_turn(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A write that fails after the turn ran must not leak the driver's error.
+
+    The stream handler puts whatever the persistence step raises straight into
+    an error chunk, so a disk that fills mid-turn used to show the user a raw
+    SQLAlchemy message.
+    """
+
+    async def _fake_build_model(*args: object, **kwargs: object) -> TestModel:
+        return TestModel(call_tools=[])
+
+    monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
+
+    async def _failing_persist(*args: object, **kwargs: object) -> None:
+        # The disk fills while the turn is streaming, i.e. after the route's
+        # up-front `is_not_locked` check has already passed.
+        db.should_not_insert_or_update = True
+        raise RuntimeError("database or disk is full")
+
+    monkeypatch.setattr(
+        "phoenix.server.api.routers.agents._persist_agent_session_turn",
+        _failing_persist,
+    )
+    session_id = "78787878-7878-4878-8878-787878787878"
+    agent_session_id = await _create_agent_session_row(db, title="Already titled")
+
+    try:
+        response = await httpx_client.post(
+            _chat_url(agent_session_id),
+            json=_chat_body(session_id, _user_message("will not be saved")),
+        )
+    finally:
+        db.should_not_insert_or_update = False
+
+    assert response.status_code == 200
+    error_chunk = next(chunk for chunk in _stream_chunks(response.text) if chunk["type"] == "error")
+    assert TRANSCRIPT_NOT_SAVED_MESSAGE in error_chunk["errorText"]
+    # Storage is the actionable cause, so it is named alongside the notice.
+    assert INSUFFICIENT_STORAGE_MESSAGE in error_chunk["errorText"]
+    # The raw driver text is not what the user reads.
+    assert "database or disk is full" not in error_chunk["errorText"]
+    assert "data-transcript-persisted" not in response.text

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -55,7 +55,6 @@ from phoenix.server.agents.ui_message_stream import iter_chunks_with_error_parts
 from phoenix.server.agents.vercel_ui_message_stream import read_ui_message_stream
 from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, get_otel_session_id
 from phoenix.server.api.routers.agents import (
-    TRANSCRIPT_NOT_SAVED_MESSAGE,
     _build_message_metadata_chunk,
     _emit_turn_root_span,
     _get_span_context,
@@ -65,7 +64,7 @@ from phoenix.server.api.routers.agents import (
     _synthesize_client_tool_spans,
     _turn_parent_context,
 )
-from phoenix.server.authorization import INSUFFICIENT_STORAGE_MESSAGE
+from phoenix.server.authorization import insufficient_storage_message
 from phoenix.server.settings.registry import (
     AgentAssistantEnabledSetting,
     AgentTraceRecordingSetting,
@@ -2524,8 +2523,7 @@ async def test_chat_is_rejected_with_storage_guidance_when_writes_are_already_lo
         db.should_not_insert_or_update = False
 
     assert response.status_code == 507
-    # The handler returns HTTPException details as text/plain, not JSON.
-    assert INSUFFICIENT_STORAGE_MESSAGE in response.text
+    assert insufficient_storage_message() in response.text
 
 
 async def test_transcript_write_failure_is_reported_as_an_unsaved_turn(
@@ -2568,9 +2566,9 @@ async def test_transcript_write_failure_is_reported_as_an_unsaved_turn(
 
     assert response.status_code == 200
     error_chunk = next(chunk for chunk in _stream_chunks(response.text) if chunk["type"] == "error")
-    assert TRANSCRIPT_NOT_SAVED_MESSAGE in error_chunk["errorText"]
+    assert "the conversation could not be saved" in error_chunk["errorText"]
     # Storage is the actionable cause, so it is named alongside the notice.
-    assert INSUFFICIENT_STORAGE_MESSAGE in error_chunk["errorText"]
+    assert insufficient_storage_message() in error_chunk["errorText"]
     # The raw driver text is not what the user reads.
     assert "database or disk is full" not in error_chunk["errorText"]
     assert "data-transcript-persisted" not in response.text

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -53,7 +53,7 @@ from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
 from phoenix.server.agents.ui_message_stream import iter_chunks_with_error_parts
 from phoenix.server.agents.vercel_ui_message_stream import read_ui_message_stream
-from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, derive_otel_session_id
+from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, get_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_message_metadata_chunk,
     _emit_turn_root_span,
@@ -817,8 +817,7 @@ async def test_chat_turn_persists_session_transcript(
                 .order_by(models.AgentSessionMessage.id)
             )
         )
-        # The OTel session id traces are grouped under is derived, not stored.
-        persisted_session_id = derive_otel_session_id(
+        persisted_session_id = get_otel_session_id(
             project_name=agent_session.project_name,
             agent_session_rowid=agent_session.id,
         )
@@ -2402,7 +2401,7 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
         project_session = await session.scalar(
             select(models.ProjectSession).where(
                 models.ProjectSession.session_id
-                == derive_otel_session_id(
+                == get_otel_session_id(
                     project_name=agent_session.project_name,
                     agent_session_rowid=agent_session.id,
                 )

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -53,7 +53,7 @@ from phoenix.server.agents.pydantic_ai import OpenInferenceModelWrapper
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
 from phoenix.server.agents.ui_message_stream import iter_chunks_with_error_parts
 from phoenix.server.agents.vercel_ui_message_stream import read_ui_message_stream
-from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS
+from phoenix.server.api.helpers.agent_sessions import TURN_LOCK_STALENESS, derive_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_message_metadata_chunk,
     _emit_turn_root_span,
@@ -144,7 +144,6 @@ def _stream_chunks(response_text: str) -> list[dict[str, Any]]:
 async def _create_agent_session_row(
     db: DbSessionFactory,
     *,
-    project_session_id: str,
     title: str = "",
     messages: list[dict[str, Any]] | None = None,
 ) -> str:
@@ -152,7 +151,6 @@ async def _create_agent_session_row(
     does before its first chat request, optionally seeded with a transcript."""
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=project_session_id,
             user_id=None,
             title=title,
             project_name=get_env_phoenix_agents_assistant_project_name(),
@@ -390,7 +388,6 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
     ]
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="91919191-9191-4191-8191-919191919191",
         title="Existing session",
         messages=transcript,
     )
@@ -534,7 +531,6 @@ async def test_compact_agent_session_without_a_completed_turn_is_a_noop(
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _unexpected_build_model)
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="92929292-9292-4292-8292-929292929292",
         title="Incomplete turn",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -564,7 +560,6 @@ async def test_compact_is_rejected_while_a_turn_holds_the_session_lock(
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _unexpected_build_model)
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="93939393-9393-4393-8393-939393939393",
         title="Busy session",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -621,7 +616,6 @@ async def test_compact_takes_over_a_stale_session_lock(
     _mock_turn_models(monkeypatch, FunctionModel(function=compact_function))
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="94949494-9494-4494-8494-949494949494",
         title="Abandoned turn",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -668,7 +662,6 @@ async def test_chat_send_during_compaction_is_rejected_as_busy(
     concurrent_sends: list[tuple[int, dict[str, Any]]] = []
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Compacting session",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -738,7 +731,6 @@ async def test_server_agent_compact_route_matches_chat_route_gating(
     _mock_turn_models(monkeypatch, FunctionModel(function=compact_function))
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id="96969696-9696-4696-8696-969696969696",
         title="Server session",
         messages=[
             _user_message("Hello", message_id=_message_uuid("user-1")),
@@ -786,7 +778,7 @@ async def test_chat_turn_persists_session_transcript(
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
     session_id = "44444444-4444-4444-8444-444444444444"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     body = _chat_body(
         session_id,
         _user_message("What datasets exist?"),
@@ -814,7 +806,6 @@ async def test_chat_turn_persists_session_transcript(
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
         assert agent_session.user_id is None
-        assert UUID(agent_session.project_session_id).version == 4
         assert agent_session.project_name == get_env_phoenix_agents_assistant_project_name()
         # The in-stream summary is persisted as the session title.
         assert agent_session.title == "a"
@@ -826,7 +817,11 @@ async def test_chat_turn_persists_session_transcript(
                 .order_by(models.AgentSessionMessage.id)
             )
         )
-        persisted_session_id = agent_session.project_session_id
+        # The OTel session id traces are grouped under is derived, not stored.
+        persisted_session_id = derive_otel_session_id(
+            project_name=agent_session.project_name,
+            agent_session_rowid=agent_session.id,
+        )
         # No bash command this turn, so no shell-state snapshot row.
         assert await session.scalar(select(models.AgentSessionSnapshot)) is None
 
@@ -920,7 +915,6 @@ async def test_failed_chat_turn_does_not_persist_partial_transcript(
     persisted_messages = [_user_message("earlier message")]
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
         messages=persisted_messages,
     )
@@ -955,7 +949,6 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
     session_id = "45454545-4545-4454-8454-454545454545"
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
     )
     model = _client_tool_model()
@@ -1476,7 +1469,7 @@ async def test_chat_stream_metadata_uses_turn_trace_context(
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
     session_id = "11111111-1111-4111-8111-111111111111"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
         _chat_url(agent_session_id),
@@ -1523,7 +1516,7 @@ async def test_chat_turn_without_a_message_is_rejected(
 ) -> None:
     """A submit request must carry the turn's new message."""
     session_id = "22222222-2222-4222-8222-222222222222"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
         _chat_url(agent_session_id),
@@ -1546,7 +1539,6 @@ async def test_chat_turn_with_stale_last_message_id_is_rejected(
     session_id = "23232323-2323-4323-8323-232323232323"
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
         messages=[
             _user_message("earlier question"),
@@ -1598,7 +1590,7 @@ async def test_chat_turn_on_an_empty_session_rejects_a_last_message_id(
     """Providing ``lastMessageId`` against an empty transcript is stale too:
     the client believes messages exist that the server does not have."""
     session_id = "24242424-2424-4424-8424-242424242424"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
         _chat_url(agent_session_id),
@@ -1628,7 +1620,6 @@ async def test_follow_up_send_from_a_compaction_message_passes_the_stale_check(
     session_id = "26262626-2626-4626-8626-262626262626"
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
         messages=[
             _user_message("earlier question"),
@@ -1795,7 +1786,6 @@ async def test_chat_endpoint_rejects_regenerate_requests(
     session_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
     agent_session_id = await _create_agent_session_row(
         db,
-        project_session_id=session_id,
         title="Already titled",
         messages=[
             _user_message("first question"),
@@ -1825,7 +1815,7 @@ async def test_generated_session_title_is_limited(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session_id = "33333333-3333-4333-8333-333333333333"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     generated_title = "x" * (MAX_AGENT_SESSION_TITLE_LENGTH + 20)
     _mock_turn_models(monkeypatch, _scripted_model(summary=generated_title))
 
@@ -1855,7 +1845,7 @@ async def test_failed_summary_leaves_session_untitled_until_a_later_turn(
     leaves the session untitled; the next turn retries summarization and the
     non-empty title then wins over the stored empty one."""
     session_id = "33333333-3333-4333-8333-333333333333"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     _mock_turn_models(
         monkeypatch,
         _scripted_model(summary=None),
@@ -1912,7 +1902,7 @@ async def test_bash_shell_state_persists_across_chat_turns(
     turns: the snapshot is persisted, left intact by turns without bash
     activity, and restored into the next turn's shell."""
     session_id = "55555555-5555-4555-8555-555555555555"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     note_path = "/home/user/workspace/note.txt"
     _mock_turn_models(
         monkeypatch,
@@ -1997,7 +1987,7 @@ async def test_server_agent_chat_turn_persists_session_transcript(
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
     session_id = "56565656-5656-4656-8656-565656565656"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await httpx_client.post(
         _server_agent_chat_url(agent_session_id),
@@ -2048,7 +2038,7 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
     ``agent_id="server"``: pins the snapshot wiring ``build_server_agent``
     gained for the session route."""
     session_id = "57575757-5757-4757-8757-575757575757"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     note_path = "/home/user/workspace/note.txt"
     _mock_turn_models(
         monkeypatch,
@@ -2099,7 +2089,7 @@ async def test_server_agent_chat_is_forbidden_when_bash_is_disabled(
 
     monkeypatch.setattr(_BUILD_MODEL_PATCH_TARGET, _fake_build_model)
     session_id = "58585858-5858-4858-8858-585858585858"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     server_response = await httpx_client.post(
         _server_agent_chat_url(agent_session_id),
@@ -2233,7 +2223,7 @@ async def test_agents_router_is_forbidden_in_read_only_mode(
 ) -> None:
     """Read-only mode turns off the whole agents router, chat included."""
     session_id = "77777777-7777-4777-8777-777777777777"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
     app.state.read_only = True
 
     create_response = await httpx_client.post("/agents/server/sessions", json={})
@@ -2346,7 +2336,7 @@ async def test_chat_turn_trace_ingestion_merges_backend_spans_into_browser_trace
     await _ingest_browser_trace(db)
     _mock_traced_test_model(monkeypatch)
     session_id = "66666666-6666-4666-8666-666666666666"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     response = await _post_traced_chat_turn(httpx_client, session_id, agent_session_id)
     assert response.status_code == 200
@@ -2399,7 +2389,7 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
     await _ingest_browser_trace(db)
     _mock_traced_test_model(monkeypatch)
     session_id = "77777777-7777-4777-8777-777777777777"
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_id)
+    agent_session_id = await _create_agent_session_row(db)
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", SAWarning)
@@ -2411,7 +2401,11 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
         assert agent_session is not None
         project_session = await session.scalar(
             select(models.ProjectSession).where(
-                models.ProjectSession.session_id == agent_session.project_session_id
+                models.ProjectSession.session_id
+                == derive_otel_session_id(
+                    project_name=agent_session.project_name,
+                    agent_session_rowid=agent_session.id,
+                )
             )
         )
         assert project_session is not None
@@ -2452,7 +2446,7 @@ async def test_resumed_chat_turn_keeps_original_trace_project(
     session_request_id = "88888888-8888-4888-8888-888888888888"
 
     monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", original_project_name)
-    agent_session_id = await _create_agent_session_row(db, project_session_id=session_request_id)
+    agent_session_id = await _create_agent_session_row(db)
     first_response = await httpx_client.post(
         _chat_url(agent_session_id),
         json=_chat_body(

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -154,7 +154,6 @@ async def _create_agent_session_row(
         agent_session = models.AgentSession(
             user_id=None,
             title=title,
-            project_name=get_env_phoenix_agents_assistant_project_name(),
         )
         session.add(agent_session)
         await session.flush()
@@ -807,7 +806,6 @@ async def test_chat_turn_persists_session_transcript(
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
         assert agent_session.user_id is None
-        assert agent_session.project_name == get_env_phoenix_agents_assistant_project_name()
         # The in-stream summary is persisted as the session title.
         assert agent_session.title == "a"
         messages = await _load_session_messages(session, agent_session.id)
@@ -819,7 +817,7 @@ async def test_chat_turn_persists_session_transcript(
             )
         )
         persisted_session_id = get_otel_session_id(
-            project_name=agent_session.project_name,
+            project_name=get_env_phoenix_agents_assistant_project_name(),
             agent_session_rowid=agent_session.id,
         )
         # No bash command this turn, so no shell-state snapshot row.
@@ -2127,7 +2125,6 @@ async def test_create_session_route_creates_a_temporary_session(
         assert agent_session is not None
         assert agent_session.title == "CLI session"
         assert agent_session.user_id is None
-        assert agent_session.project_name == get_env_phoenix_agents_assistant_project_name()
         assert agent_session.is_ephemeral is True
 
 
@@ -2402,7 +2399,7 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
             select(models.ProjectSession).where(
                 models.ProjectSession.session_id
                 == get_otel_session_id(
-                    project_name=agent_session.project_name,
+                    project_name=get_env_phoenix_agents_assistant_project_name(),
                     agent_session_rowid=agent_session.id,
                 )
             )
@@ -2415,13 +2412,13 @@ async def test_chat_turn_trace_ingestion_links_project_session_without_orm_warni
         assert merged_trace.project_session_rowid == project_session.id
 
 
-async def test_resumed_chat_turn_keeps_original_trace_project(
+async def test_resumed_chat_turn_follows_the_configured_trace_project(
     db: DbSessionFactory,
     app: FastAPI,
     httpx_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A session's persisted project remains authoritative after configuration changes."""
+    """Every turn traces to the project configured when the turn runs."""
     await _enable_local_trace_recording(app)
     tracer_project_names: list[str] = []
 
@@ -2478,30 +2475,49 @@ async def test_resumed_chat_turn_keeps_original_trace_project(
     )
     assert second_response.status_code == 200
 
-    assert tracer_project_names == [original_project_name, original_project_name]
+    assert tracer_project_names == [original_project_name, changed_project_name]
     async with db() as session:
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
-        assert agent_session.project_name == original_project_name
-        traces = (
-            await session.scalars(
-                select(models.Trace).where(
-                    models.Trace.trace_id.in_([first_trace_id, second_trace_id])
+        traces = {
+            trace.trace_id: trace
+            for trace in (
+                await session.scalars(
+                    select(models.Trace).where(
+                        models.Trace.trace_id.in_([first_trace_id, second_trace_id])
+                    )
+                )
+            ).all()
+        }
+        assert len(traces) == 2
+        project_names = {}
+        for trace_id, trace in traces.items():
+            project = await session.get(models.Project, trace.project_rowid)
+            assert project is not None
+            project_names[trace_id] = project.name
+        assert project_names == {
+            first_trace_id: original_project_name,
+            second_trace_id: changed_project_name,
+        }
+        # The OTel session id embeds the project name, so the two turns group
+        # under one project session per project rather than one for the session.
+        session_ids = {}
+        for trace_id, trace in traces.items():
+            session_ids[trace_id] = await session.scalar(
+                select(models.ProjectSession.session_id).where(
+                    models.ProjectSession.id == trace.project_session_rowid
                 )
             )
-        ).all()
-        assert len(traces) == 2
-        assert len({trace.project_rowid for trace in traces}) == 1
-        assert len({trace.project_session_rowid for trace in traces}) == 1
-        project = await session.get(models.Project, traces[0].project_rowid)
-        assert project is not None
-        assert project.name == original_project_name
-        assert (
-            await session.scalar(
-                select(func.count()).where(models.Project.name == changed_project_name)
-            )
-            == 0
-        )
+        assert session_ids == {
+            first_trace_id: get_otel_session_id(
+                project_name=original_project_name,
+                agent_session_rowid=agent_session.id,
+            ),
+            second_trace_id: get_otel_session_id(
+                project_name=changed_project_name,
+                agent_session_rowid=agent_session.id,
+            ),
+        }
 
 
 async def test_chat_is_rejected_with_storage_guidance_when_writes_are_already_locked(

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -2128,8 +2128,7 @@ async def test_create_session_route_creates_a_temporary_session(
         assert agent_session.title == "CLI session"
         assert agent_session.user_id is None
         assert agent_session.project_name == get_env_phoenix_agents_assistant_project_name()
-        assert agent_session.expires_at is not None
-        assert agent_session.expires_at > datetime.now(timezone.utc)
+        assert agent_session.is_ephemeral is True
 
 
 async def test_create_session_route_defaults_to_a_persistent_untitled_session(
@@ -2144,7 +2143,7 @@ async def test_create_session_route_defaults_to_a_persistent_untitled_session(
         agent_session = await session.get(models.AgentSession, int(global_id.node_id))
         assert agent_session is not None
         assert agent_session.title == ""
-        assert agent_session.expires_at is None
+        assert agent_session.is_ephemeral is False
 
 
 async def test_create_session_route_rejects_long_title(

--- a/tests/unit/server/agents/test_agents_router.py
+++ b/tests/unit/server/agents/test_agents_router.py
@@ -70,11 +70,15 @@ from phoenix.server.settings.registry import (
 )
 from phoenix.server.types import DbSessionFactory
 from phoenix.tracers import Tracer, extract_otel_context
+from tests.unit._helpers import _message_uuid
 
 _BUILD_MODEL_PATCH_TARGET = "phoenix.server.api.routers.agents.build_model"
 
 
-def _user_message(text: str, *, message_id: str = "msg-user-1") -> dict[str, Any]:
+_DEFAULT_USER_MESSAGE_ID = _message_uuid("msg-user-1")
+
+
+def _user_message(text: str, *, message_id: str = _DEFAULT_USER_MESSAGE_ID) -> dict[str, Any]:
     return {
         "id": message_id,
         "role": "user",
@@ -158,10 +162,9 @@ async def _create_agent_session_row(
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=PhoenixUIMessage.model_validate(message),
             )
-            for position, message in enumerate(messages or [])
+            for message in messages or []
         )
         return str(GlobalID("AgentSession", str(agent_session.id)))
 
@@ -172,7 +175,7 @@ async def _last_stored_message_id(db: DbSessionFactory) -> str:
     async with db() as session:
         message_id = await session.scalar(
             select(models.AgentSessionMessage.message_id)
-            .order_by(models.AgentSessionMessage.position.desc())
+            .order_by(models.AgentSessionMessage.id.desc())
             .limit(1)
         )
     assert message_id is not None
@@ -217,7 +220,7 @@ async def _load_session_messages(
         await session.scalars(
             select(models.AgentSessionMessage.message)
             .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
-            .order_by(models.AgentSessionMessage.position)
+            .order_by(models.AgentSessionMessage.id)
         )
     ).all()
     return [
@@ -372,15 +375,15 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
     )
 
     transcript = [
-        _user_message("Find the slow span", message_id="user-1"),
+        _user_message("Find the slow span", message_id=_message_uuid("user-1")),
         {
-            "id": "assistant-1",
+            "id": _message_uuid("assistant-1"),
             "role": "assistant",
             "parts": [{"type": "text", "text": "The slow span is trace-id-123."}],
         },
-        _user_message("What should I inspect next?", message_id="user-2"),
+        _user_message("What should I inspect next?", message_id=_message_uuid("user-2")),
         {
-            "id": "assistant-2",
+            "id": _message_uuid("assistant-2"),
             "role": "assistant",
             "parts": [{"type": "text", "text": "Inspect the latest model call."}],
         },
@@ -447,10 +450,10 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
         )
     assert compaction_message_count == 1
     assert [message["id"] for message in original_messages] == [
-        "user-1",
-        "assistant-1",
-        "user-2",
-        "assistant-2",
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("user-2"),
+        _message_uuid("assistant-2"),
         compaction_message["id"],
     ]
 
@@ -458,7 +461,7 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
         _chat_url(agent_session_id),
         json=_chat_body(
             "91919191-9191-4191-8191-919191919191",
-            _user_message("Continue", message_id="user-3"),
+            _user_message("Continue", message_id=_message_uuid("user-3")),
             lastMessageId=compaction_message["id"],
         ),
     )
@@ -474,13 +477,13 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
     async with db() as session:
         stored_messages = await _load_session_messages(session, agent_session_rowid)
     assert [message["id"] for message in stored_messages[:5]] == [
-        "user-1",
-        "assistant-1",
-        "user-2",
-        "assistant-2",
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("user-2"),
+        _message_uuid("assistant-2"),
         compaction_message["id"],
     ]
-    assert stored_messages[5]["id"] == "user-3"
+    assert stored_messages[5]["id"] == _message_uuid("user-3")
 
     second_compact_response = await httpx_client.post(
         _compact_url(agent_session_id),
@@ -507,7 +510,7 @@ async def test_compact_agent_session_persists_durable_points_and_loads_latest_hi
         _chat_url(agent_session_id),
         json=_chat_body(
             "91919191-9191-4191-8191-919191919191",
-            _user_message("Finish", message_id="user-4"),
+            _user_message("Finish", message_id=_message_uuid("user-4")),
             lastMessageId=second_compaction_message["id"],
         ),
     )
@@ -534,7 +537,7 @@ async def test_compact_agent_session_without_a_completed_turn_is_a_noop(
         project_session_id="92929292-9292-4292-8292-929292929292",
         title="Incomplete turn",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
         ],
     )
 
@@ -564,9 +567,9 @@ async def test_compact_is_rejected_while_a_turn_holds_the_session_lock(
         project_session_id="93939393-9393-4393-8393-939393939393",
         title="Busy session",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "Hi there."}],
             },
@@ -621,9 +624,9 @@ async def test_compact_takes_over_a_stale_session_lock(
         project_session_id="94949494-9494-4494-8494-949494949494",
         title="Abandoned turn",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "Hi there."}],
             },
@@ -668,9 +671,9 @@ async def test_chat_send_during_compaction_is_rejected_as_busy(
         project_session_id=session_id,
         title="Compacting session",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "Hi there."}],
             },
@@ -686,8 +689,8 @@ async def test_chat_send_during_compaction_is_rejected_as_busy(
             _chat_url(agent_session_id),
             json=_chat_body(
                 session_id,
-                _user_message("follow-up", message_id="user-2"),
-                lastMessageId="assistant-1",
+                _user_message("follow-up", message_id=_message_uuid("user-2")),
+                lastMessageId=_message_uuid("assistant-1"),
             ),
         )
         concurrent_sends.append((chat_response.status_code, chat_response.json()))
@@ -738,9 +741,9 @@ async def test_server_agent_compact_route_matches_chat_route_gating(
         project_session_id="96969696-9696-4696-8696-969696969696",
         title="Server session",
         messages=[
-            _user_message("Hello", message_id="user-1"),
+            _user_message("Hello", message_id=_message_uuid("user-1")),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "Hi there."}],
             },
@@ -820,7 +823,7 @@ async def test_chat_turn_persists_session_transcript(
             await session.scalars(
                 select(models.AgentSessionMessage.id)
                 .where(models.AgentSessionMessage.agent_session_id == agent_session.id)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         )
         persisted_session_id = agent_session.project_session_id
@@ -845,7 +848,7 @@ async def test_chat_turn_persists_session_transcript(
     async with db() as session:
         stored_message_rows = (
             await session.scalars(
-                select(models.AgentSessionMessage).order_by(models.AgentSessionMessage.position)
+                select(models.AgentSessionMessage).order_by(models.AgentSessionMessage.id)
             )
         ).all()
         assert [row.message_id for row in stored_message_rows] == [
@@ -858,7 +861,7 @@ async def test_chat_turn_persists_session_transcript(
         _chat_url(agent_session_id),
         json={
             **body,
-            "message": _user_message("And experiments?", message_id="msg-user-2"),
+            "message": _user_message("And experiments?", message_id=_message_uuid("msg-user-2")),
             "lastMessageId": assistant_messages[-1]["id"],
         },
     )
@@ -881,14 +884,14 @@ async def test_chat_turn_persists_session_transcript(
             await session.scalars(
                 select(models.AgentSessionMessage.id)
                 .where(models.AgentSessionMessage.agent_session_id == agent_session.id)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         )
     # The merged transcript contains both turns in order, assembled server-side.
     user_message_ids = [
         message["id"] for message in second_turn_messages if message["role"] == "user"
     ]
-    assert user_message_ids == ["msg-user-1", "msg-user-2"]
+    assert user_message_ids == [_message_uuid("msg-user-1"), _message_uuid("msg-user-2")]
     assert len(second_turn_messages) > len(messages)
     assert second_turn_message_rowids[: len(message_rowids)] == message_rowids
 
@@ -926,8 +929,8 @@ async def test_failed_chat_turn_does_not_persist_partial_transcript(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("new message", message_id="msg-user-2"),
-            lastMessageId="msg-user-1",
+            _user_message("new message", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("msg-user-1"),
         ),
     )
 
@@ -1002,7 +1005,7 @@ async def test_client_tool_continuation_extends_the_persisted_assistant_message(
             await session.scalars(
                 select(models.AgentSessionMessage)
                 .where(models.AgentSessionMessage.agent_session_id == agent_session_rowid)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         ).all()
     assert len(stored_rows) == 2
@@ -1089,14 +1092,14 @@ def test_synthesizes_root_and_clamped_client_tool_span() -> None:
     messages = [
         UIMessage.model_validate(
             {
-                "id": "user-1",
+                "id": _message_uuid("user-1"),
                 "role": "user",
                 "parts": [{"type": "text", "text": "Use the tool"}],
             }
         ),
         UIMessage.model_validate(
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [
                     {
@@ -1165,14 +1168,14 @@ def test_error_parts_record_exception_events() -> None:
     messages = [
         UIMessage.model_validate(
             {
-                "id": "user-1",
+                "id": _message_uuid("user-1"),
                 "role": "user",
                 "parts": [{"type": "text", "text": "Use the tool"}],
             }
         ),
         UIMessage.model_validate(
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [
                     {
@@ -1548,7 +1551,7 @@ async def test_chat_turn_with_stale_last_message_id_is_rejected(
         messages=[
             _user_message("earlier question"),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "earlier answer"}],
             },
@@ -1558,7 +1561,9 @@ async def test_chat_turn_with_stale_last_message_id_is_rejected(
     # Omitted while the transcript is non-empty.
     omitted_response = await httpx_client.post(
         _chat_url(agent_session_id),
-        json=_chat_body(session_id, _user_message("follow-up", message_id="msg-user-2")),
+        json=_chat_body(
+            session_id, _user_message("follow-up", message_id=_message_uuid("msg-user-2"))
+        ),
     )
     assert omitted_response.status_code == 409
     assert omitted_response.json() == {"code": "agent_session_stale"}
@@ -1568,8 +1573,8 @@ async def test_chat_turn_with_stale_last_message_id_is_rejected(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("follow-up", message_id="msg-user-2"),
-            lastMessageId="msg-user-1",
+            _user_message("follow-up", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("msg-user-1"),
         ),
     )
     assert stale_response.status_code == 409
@@ -1600,7 +1605,7 @@ async def test_chat_turn_on_an_empty_session_rejects_a_last_message_id(
         json=_chat_body(
             session_id,
             _user_message("hello"),
-            lastMessageId="msg-user-0",
+            lastMessageId=_message_uuid("msg-user-0"),
         ),
     )
     assert response.status_code == 409
@@ -1628,12 +1633,12 @@ async def test_follow_up_send_from_a_compaction_message_passes_the_stale_check(
         messages=[
             _user_message("earlier question"),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "earlier answer"}],
             },
             {
-                "id": "compaction-1",
+                "id": _message_uuid("compaction-1"),
                 "role": "user",
                 "metadata": {
                     "type": "user",
@@ -1651,8 +1656,8 @@ async def test_follow_up_send_from_a_compaction_message_passes_the_stale_check(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("follow-up", message_id="msg-user-2"),
-            lastMessageId="assistant-1",
+            _user_message("follow-up", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("assistant-1"),
         ),
     )
     assert stale_response.status_code == 409
@@ -1663,8 +1668,8 @@ async def test_follow_up_send_from_a_compaction_message_passes_the_stale_check(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("follow-up", message_id="msg-user-2"),
-            lastMessageId="compaction-1",
+            _user_message("follow-up", message_id=_message_uuid("msg-user-2")),
+            lastMessageId=_message_uuid("compaction-1"),
         ),
     )
     assert follow_up_response.status_code == 200
@@ -1691,7 +1696,7 @@ def _validated_messages(raw_messages: list[dict[str, Any]]) -> list[PhoenixUIMes
 
 def _assistant_message_with_tool_states() -> dict[str, Any]:
     return {
-        "id": "assistant-1",
+        "id": _message_uuid("assistant-1"),
         "role": "assistant",
         "parts": [
             {"type": "text", "text": "Working on it"},
@@ -1725,11 +1730,15 @@ def test_merge_appends_user_message_without_modifying_persisted_messages() -> No
     merged = _merge_messages(
         old_messages=persisted,
         new_message=PhoenixUIMessage.model_validate(
-            _user_message("never mind", message_id="msg-user-2")
+            _user_message("never mind", message_id=_message_uuid("msg-user-2"))
         ),
     )
 
-    assert [message.id for message in merged] == ["msg-user-1", "assistant-1", "msg-user-2"]
+    assert [message.id for message in merged] == [
+        _message_uuid("msg-user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("msg-user-2"),
+    ]
     assert merged[1] is persisted[1]
 
 
@@ -1739,7 +1748,7 @@ def test_merge_replaces_the_trailing_assistant_message() -> None:
     )
     resolved_assistant = PhoenixUIMessage.model_validate(
         {
-            "id": "assistant-1",
+            "id": _message_uuid("assistant-1"),
             "role": "assistant",
             "parts": [
                 {
@@ -1758,14 +1767,17 @@ def test_merge_replaces_the_trailing_assistant_message() -> None:
         new_message=resolved_assistant,
     )
 
-    assert [message.id for message in merged] == ["msg-user-1", "assistant-1"]
+    assert [message.id for message in merged] == [
+        _message_uuid("msg-user-1"),
+        _message_uuid("assistant-1"),
+    ]
     assert merged[-1] is resolved_assistant
 
 
 def test_merge_rejects_an_assistant_message_that_is_not_the_trailing_one() -> None:
     persisted = _validated_messages([_user_message("hello")])
     stale_assistant = PhoenixUIMessage.model_validate(
-        {"id": "assistant-stale", "role": "assistant", "parts": []}
+        {"id": _message_uuid("assistant-stale"), "role": "assistant", "parts": []}
     )
 
     with pytest.raises(HTTPException) as exc_info:
@@ -1788,7 +1800,7 @@ async def test_chat_endpoint_rejects_regenerate_requests(
         messages=[
             _user_message("first question"),
             {
-                "id": "assistant-1",
+                "id": _message_uuid("assistant-1"),
                 "role": "assistant",
                 "parts": [{"type": "text", "text": "stale answer"}],
             },
@@ -1801,7 +1813,7 @@ async def test_chat_endpoint_rejects_regenerate_requests(
             session_id,
             None,
             trigger="regenerate-message",
-            messageId="assistant-1",
+            messageId=_message_uuid("assistant-1"),
         ),
     )
     assert response.status_code == 422
@@ -1870,7 +1882,7 @@ async def test_failed_summary_leaves_session_untitled_until_a_later_turn(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("second question", message_id="msg-user-2"),
+            _user_message("second question", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -1939,7 +1951,7 @@ async def test_bash_shell_state_persists_across_chat_turns(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("thanks", message_id="msg-user-2"),
+            _user_message("thanks", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -1955,7 +1967,7 @@ async def test_bash_shell_state_persists_across_chat_turns(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("read it back", message_id="msg-user-3"),
+            _user_message("read it back", message_id=_message_uuid("msg-user-3")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -2013,7 +2025,7 @@ async def test_server_agent_chat_turn_persists_session_transcript(
         _server_agent_chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("And experiments?", message_id="msg-user-2"),
+            _user_message("And experiments?", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -2023,7 +2035,7 @@ async def test_server_agent_chat_turn_persists_session_transcript(
     user_message_ids = [
         message["id"] for message in second_turn_messages if message["role"] == "user"
     ]
-    assert user_message_ids == ["msg-user-1", "msg-user-2"]
+    assert user_message_ids == [_message_uuid("msg-user-1"), _message_uuid("msg-user-2")]
     assert len(second_turn_messages) > len(messages)
 
 
@@ -2058,7 +2070,7 @@ async def test_server_agent_bash_shell_state_persists_across_chat_turns(
         _server_agent_chat_url(agent_session_id),
         json=_chat_body(
             session_id,
-            _user_message("read it back", message_id="msg-user-2"),
+            _user_message("read it back", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
         ),
     )
@@ -2461,7 +2473,7 @@ async def test_resumed_chat_turn_keeps_original_trace_project(
         _chat_url(agent_session_id),
         json=_chat_body(
             session_request_id,
-            _user_message("second question", message_id="msg-user-2"),
+            _user_message("second question", message_id=_message_uuid("msg-user-2")),
             lastMessageId=await _last_stored_message_id(db),
             ingestTraces=True,
             turnTraceContext={

--- a/tests/unit/server/agents/test_legacy_agents_router.py
+++ b/tests/unit/server/agents/test_legacy_agents_router.py
@@ -211,7 +211,6 @@ async def test_new_chat_route_is_unaffected_by_the_legacy_registration(
     session_id = "99999999-9999-4999-8999-999999999999"
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=session_id,
             user_id=None,
             title="Already titled",
             project_name=get_env_phoenix_agents_assistant_project_name(),
@@ -254,7 +253,6 @@ async def test_new_contract_body_on_the_server_agent_url_delegates_to_the_sessio
     session_id = "13131313-1313-4313-8313-131313131313"
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=session_id,
             user_id=None,
             title="Already titled",
             project_name=get_env_phoenix_agents_assistant_project_name(),

--- a/tests/unit/server/agents/test_legacy_agents_router.py
+++ b/tests/unit/server/agents/test_legacy_agents_router.py
@@ -21,6 +21,7 @@ from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
 from phoenix.server.types import DbSessionFactory
 from phoenix.tracers import Tracer
+from tests.unit._helpers import _message_uuid
 
 _LEGACY_BUILD_MODEL_PATCH_TARGET = "phoenix.server.api.routers.legacy_agents.build_model"
 _BUILD_MODEL_PATCH_TARGET = "phoenix.server.api.routers.agents.build_model"
@@ -28,7 +29,10 @@ _BUILD_MODEL_PATCH_TARGET = "phoenix.server.api.routers.agents.build_model"
 _CLIENT_MINTED_SESSION_ID = "12345678-1234-4123-8123-123456789012"
 
 
-def _user_message(text: str, *, message_id: str = "msg-user-1") -> dict[str, Any]:
+_DEFAULT_USER_MESSAGE_ID = _message_uuid("msg-user-1")
+
+
+def _user_message(text: str, *, message_id: str = _DEFAULT_USER_MESSAGE_ID) -> dict[str, Any]:
     return {
         "id": message_id,
         "role": "user",
@@ -131,7 +135,7 @@ async def test_legacy_chat_route_accepts_a_multi_turn_transcript(
     transcript = [
         _user_message("first question"),
         {
-            "id": "assistant-1",
+            "id": _message_uuid("assistant-1"),
             "role": "assistant",
             "parts": [{"type": "text", "text": "first answer"}],
             "metadata": {
@@ -139,7 +143,7 @@ async def test_legacy_chat_route_accepts_a_multi_turn_transcript(
                 "usage": {"tokens": {"prompt": 1, "completion": 2, "total": 3}},
             },
         },
-        _user_message("second question", message_id="msg-user-2"),
+        _user_message("second question", message_id=_message_uuid("msg-user-2")),
     ]
 
     response = await httpx_client.post(

--- a/tests/unit/server/agents/test_legacy_agents_router.py
+++ b/tests/unit/server/agents/test_legacy_agents_router.py
@@ -213,7 +213,6 @@ async def test_new_chat_route_is_unaffected_by_the_legacy_registration(
         agent_session = models.AgentSession(
             user_id=None,
             title="Already titled",
-            project_name=get_env_phoenix_agents_assistant_project_name(),
         )
         session.add(agent_session)
         await session.flush()
@@ -255,7 +254,6 @@ async def test_new_contract_body_on_the_server_agent_url_delegates_to_the_sessio
         agent_session = models.AgentSession(
             user_id=None,
             title="Already titled",
-            project_name=get_env_phoenix_agents_assistant_project_name(),
         )
         session.add(agent_session)
         await session.flush()

--- a/tests/unit/server/agents/test_session_history.py
+++ b/tests/unit/server/agents/test_session_history.py
@@ -47,7 +47,6 @@ async def test_load_agent_session_history_returns_the_full_uncompacted_transcrip
         agent_session = models.AgentSession(
             user_id=None,
             title="Session",
-            project_name="assistant_agent",
         )
         session.add(agent_session)
         await session.flush()
@@ -91,7 +90,6 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
         agent_session = models.AgentSession(
             user_id=None,
             title="Session",
-            project_name="assistant_agent",
         )
         session.add(agent_session)
         await session.flush()
@@ -127,7 +125,6 @@ async def test_uppercase_and_lowercase_uuids_are_both_accepted(
         agent_session = models.AgentSession(
             user_id=None,
             title="Session",
-            project_name="assistant_agent",
         )
         session.add(agent_session)
         await session.flush()

--- a/tests/unit/server/agents/test_session_history.py
+++ b/tests/unit/server/agents/test_session_history.py
@@ -45,7 +45,6 @@ async def test_load_agent_session_history_returns_the_full_uncompacted_transcrip
     ]
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             user_id=None,
             title="Session",
             project_name="assistant_agent",
@@ -90,7 +89,6 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
     ]
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             user_id=None,
             title="Session",
             project_name="assistant_agent",
@@ -127,7 +125,6 @@ async def test_uppercase_and_lowercase_uuids_are_both_accepted(
 ) -> None:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             user_id=None,
             title="Session",
             project_name="assistant_agent",

--- a/tests/unit/server/agents/test_session_history.py
+++ b/tests/unit/server/agents/test_session_history.py
@@ -1,6 +1,5 @@
 from uuid import uuid4
 
-import pytest
 from sqlalchemy import select
 
 from phoenix.db import models
@@ -121,102 +120,6 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
     ]
     assert history[0].is_compaction_point
     assert history[0].message.id == _message_uuid("compaction-2")
-
-
-async def test_transcript_order_follows_insertion_order_not_message_content(
-    db: DbSessionFactory,
-) -> None:
-    """Transcript order is the primary key's ascending order.
-
-    Nothing in the row content encodes position, so appending a message after
-    the fact must land it at the end of the transcript.
-    """
-    async with db() as session:
-        agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
-            user_id=None,
-            title="Session",
-            project_name="assistant_agent",
-        )
-        session.add(agent_session)
-        await session.flush()
-        agent_session_rowid = agent_session.id
-        session.add_all(
-            models.AgentSessionMessage(
-                agent_session_id=agent_session_rowid,
-                message=_message(message_id=_message_uuid(label), role=role, text=label),
-            )
-            for label, role in (("user-1", "user"), ("assistant-1", "assistant"))
-        )
-
-    # A later transaction appends a third message.
-    async with db() as session:
-        session.add(
-            models.AgentSessionMessage(
-                agent_session_id=agent_session_rowid,
-                message=_message(message_id=_message_uuid("user-2"), role="user", text="user-2"),
-            )
-        )
-
-    async with db() as session:
-        history = await _load_agent_session_history(
-            session,
-            agent_session_rowid=agent_session_rowid,
-        )
-
-    assert [row.message.id for row in history] == [
-        _message_uuid("user-1"),
-        _message_uuid("assistant-1"),
-        _message_uuid("user-2"),
-    ]
-    assert [row.id for row in history] == sorted(row.id for row in history)
-
-
-async def test_message_id_must_be_a_uuid_at_the_database_level(
-    db: DbSessionFactory,
-) -> None:
-    """``message_id`` is a generated column, so the CHECK is the only thing
-    standing between a malformed client id and the transcript."""
-    async with db() as session:
-        agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
-            user_id=None,
-            title="Session",
-            project_name="assistant_agent",
-        )
-        session.add(agent_session)
-        await session.flush()
-        agent_session_rowid = agent_session.id
-
-    for bad_message_id in (
-        "not-a-uuid",
-        "",
-        # Right length and shape, but 'z' is not a hex digit.
-        "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
-        # A UUID with the hyphens stripped out.
-        uuid4().hex,
-        # Trailing junk after an otherwise valid UUID.
-        f"{uuid4()}-extra",
-    ):
-        # The exception class differs by driver — SQLAlchemy translates the
-        # PostgreSQL driver's error but re-raises sqlean's untranslated — so the
-        # named constraint in the message is what this pins.
-        with pytest.raises(Exception, match="valid_message_id"):
-            async with db() as session:
-                session.add(
-                    models.AgentSessionMessage(
-                        agent_session_id=agent_session_rowid,
-                        message=_message(
-                            message_id=bad_message_id,
-                            role="user",
-                            text="rejected",
-                        ),
-                    )
-                )
-                await session.flush()
-
-    async with db() as session:
-        assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
 
 
 async def test_uppercase_and_lowercase_uuids_are_both_accepted(

--- a/tests/unit/server/agents/test_session_history.py
+++ b/tests/unit/server/agents/test_session_history.py
@@ -1,5 +1,8 @@
 from uuid import uuid4
 
+import pytest
+from sqlalchemy import select
+
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage, TextUIPart, UserMessageMetadata
 from phoenix.server.api.routers.agents import (
@@ -7,6 +10,7 @@ from phoenix.server.api.routers.agents import (
     _load_agent_session_history,
 )
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 
 
 def _message(*, message_id: str, role: str, text: str) -> PhoenixUIMessage:
@@ -21,7 +25,7 @@ def _message(*, message_id: str, role: str, text: str) -> PhoenixUIMessage:
 
 def test_build_compaction_message_creates_a_marked_user_message() -> None:
     message = _build_compaction_message(
-        message_id="compaction-1",
+        message_id=_message_uuid("compaction-1"),
         summary='{"objectives":["continue"]}',
     )
 
@@ -37,8 +41,8 @@ async def test_load_agent_session_history_returns_the_full_uncompacted_transcrip
     db: DbSessionFactory,
 ) -> None:
     messages = [
-        _message(message_id="user-1", role="user", text="question"),
-        _message(message_id="assistant-1", role="assistant", text="answer"),
+        _message(message_id=_message_uuid("user-1"), role="user", text="question"),
+        _message(message_id=_message_uuid("assistant-1"), role="assistant", text="answer"),
     ]
     async with db() as session:
         agent_session = models.AgentSession(
@@ -52,10 +56,9 @@ async def test_load_agent_session_history_returns_the_full_uncompacted_transcrip
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(messages)
+            for message in messages
         )
         agent_session_rowid = agent_session.id
 
@@ -73,14 +76,18 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
     db: DbSessionFactory,
 ) -> None:
     messages = [
-        _message(message_id="user-1", role="user", text="old question"),
-        _message(message_id="assistant-1", role="assistant", text="old answer"),
-        _build_compaction_message(message_id="compaction-1", summary="first summary"),
-        _message(message_id="user-2", role="user", text="newer question"),
-        _message(message_id="assistant-2", role="assistant", text="newer answer"),
-        _build_compaction_message(message_id="compaction-2", summary="second summary"),
-        _message(message_id="user-3", role="user", text="retained question"),
-        _message(message_id="assistant-3", role="assistant", text="retained answer"),
+        _message(message_id=_message_uuid("user-1"), role="user", text="old question"),
+        _message(message_id=_message_uuid("assistant-1"), role="assistant", text="old answer"),
+        _build_compaction_message(
+            message_id=_message_uuid("compaction-1"), summary="first summary"
+        ),
+        _message(message_id=_message_uuid("user-2"), role="user", text="newer question"),
+        _message(message_id=_message_uuid("assistant-2"), role="assistant", text="newer answer"),
+        _build_compaction_message(
+            message_id=_message_uuid("compaction-2"), summary="second summary"
+        ),
+        _message(message_id=_message_uuid("user-3"), role="user", text="retained question"),
+        _message(message_id=_message_uuid("assistant-3"), role="assistant", text="retained answer"),
     ]
     async with db() as session:
         agent_session = models.AgentSession(
@@ -94,10 +101,9 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
         message_rows = [
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(messages)
+            for message in messages
         ]
         session.add_all(message_rows)
         agent_session_rowid = agent_session.id
@@ -109,9 +115,133 @@ async def test_load_agent_session_history_starts_at_the_latest_compaction_point(
         )
 
     assert [row.message.id for row in history] == [
-        "compaction-2",
-        "user-3",
-        "assistant-3",
+        _message_uuid("compaction-2"),
+        _message_uuid("user-3"),
+        _message_uuid("assistant-3"),
     ]
     assert history[0].is_compaction_point
-    assert history[0].message.id == "compaction-2"
+    assert history[0].message.id == _message_uuid("compaction-2")
+
+
+async def test_transcript_order_follows_insertion_order_not_message_content(
+    db: DbSessionFactory,
+) -> None:
+    """Transcript order is the primary key's ascending order.
+
+    Nothing in the row content encodes position, so appending a message after
+    the fact must land it at the end of the transcript.
+    """
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id=str(uuid4()),
+            user_id=None,
+            title="Session",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_rowid = agent_session.id
+        session.add_all(
+            models.AgentSessionMessage(
+                agent_session_id=agent_session_rowid,
+                message=_message(message_id=_message_uuid(label), role=role, text=label),
+            )
+            for label, role in (("user-1", "user"), ("assistant-1", "assistant"))
+        )
+
+    # A later transaction appends a third message.
+    async with db() as session:
+        session.add(
+            models.AgentSessionMessage(
+                agent_session_id=agent_session_rowid,
+                message=_message(message_id=_message_uuid("user-2"), role="user", text="user-2"),
+            )
+        )
+
+    async with db() as session:
+        history = await _load_agent_session_history(
+            session,
+            agent_session_rowid=agent_session_rowid,
+        )
+
+    assert [row.message.id for row in history] == [
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("user-2"),
+    ]
+    assert [row.id for row in history] == sorted(row.id for row in history)
+
+
+async def test_message_id_must_be_a_uuid_at_the_database_level(
+    db: DbSessionFactory,
+) -> None:
+    """``message_id`` is a generated column, so the CHECK is the only thing
+    standing between a malformed client id and the transcript."""
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id=str(uuid4()),
+            user_id=None,
+            title="Session",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_rowid = agent_session.id
+
+    for bad_message_id in (
+        "not-a-uuid",
+        "",
+        # Right length and shape, but 'z' is not a hex digit.
+        "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
+        # A UUID with the hyphens stripped out.
+        uuid4().hex,
+        # Trailing junk after an otherwise valid UUID.
+        f"{uuid4()}-extra",
+    ):
+        # The exception class differs by driver — SQLAlchemy translates the
+        # PostgreSQL driver's error but re-raises sqlean's untranslated — so the
+        # named constraint in the message is what this pins.
+        with pytest.raises(Exception, match="valid_message_id"):
+            async with db() as session:
+                session.add(
+                    models.AgentSessionMessage(
+                        agent_session_id=agent_session_rowid,
+                        message=_message(
+                            message_id=bad_message_id,
+                            role="user",
+                            text="rejected",
+                        ),
+                    )
+                )
+                await session.flush()
+
+    async with db() as session:
+        assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
+
+
+async def test_uppercase_and_lowercase_uuids_are_both_accepted(
+    db: DbSessionFactory,
+) -> None:
+    async with db() as session:
+        agent_session = models.AgentSession(
+            project_session_id=str(uuid4()),
+            user_id=None,
+            title="Session",
+            project_name="assistant_agent",
+        )
+        session.add(agent_session)
+        await session.flush()
+        agent_session_rowid = agent_session.id
+        lowercase_id = str(uuid4())
+        uppercase_id = str(uuid4()).upper()
+        session.add_all(
+            models.AgentSessionMessage(
+                agent_session_id=agent_session_rowid,
+                message=_message(message_id=message_id, role="user", text="accepted"),
+            )
+            for message_id in (lowercase_id, uppercase_id)
+        )
+
+    async with db() as session:
+        stored = list(await session.scalars(select(models.AgentSessionMessage.message_id)))
+    assert stored == [lowercase_id, uppercase_id]

--- a/tests/unit/server/agents/test_summarization.py
+++ b/tests/unit/server/agents/test_summarization.py
@@ -1,0 +1,151 @@
+from typing import Any
+
+import pytest
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from phoenix.server.agents.summarization import (
+    MAX_SUMMARIZED_TOOL_RESULT_LENGTH,
+    summarize_messages,
+    summarize_messages_for_compaction,
+)
+
+CHECKPOINT: dict[str, Any] = {
+    "objectives": ["Investigate the trace"],
+    "constraints_and_preferences": [],
+    "decisions": [],
+    "completed_work": [],
+    "active_work": [],
+    "blockers": [],
+    "next_steps": [],
+    "important_details": [],
+}
+
+
+def _tool_result(content: Any) -> ModelRequest:
+    return ModelRequest(
+        parts=[ToolReturnPart(tool_name="get_spans", content=content, tool_call_id="call-1")]
+    )
+
+
+def _recording_model(
+    seen: list[ModelMessage],
+    *,
+    tool_name: str,
+    args: Any,
+) -> FunctionModel:
+    def function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+        seen.extend(messages)
+        return ModelResponse(parts=[ToolCallPart(tool_name=tool_name, args=args)])
+
+    return FunctionModel(function=function)
+
+
+def _sent_tool_results(seen: list[ModelMessage]) -> list[ToolReturnPart]:
+    return [part for message in seen for part in message.parts if isinstance(part, ToolReturnPart)]
+
+
+async def test_compaction_truncates_oversized_tool_results() -> None:
+    seen: list[ModelMessage] = []
+    content = "x" * (MAX_SUMMARIZED_TOOL_RESULT_LENGTH + 500)
+    messages: list[ModelMessage] = [_tool_result(content)]
+
+    await summarize_messages_for_compaction(
+        messages=messages,
+        model=_recording_model(seen, tool_name="conversation_checkpoint", args=CHECKPOINT),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert sent.content == (
+        "x" * MAX_SUMMARIZED_TOOL_RESULT_LENGTH
+        + "\n[... 500 characters truncated for summarization]"
+    )
+    # the caller's messages are left untouched
+    assert isinstance(messages[0].parts[0], ToolReturnPart)
+    assert messages[0].parts[0].content == content
+
+
+async def test_summarization_truncates_oversized_tool_results() -> None:
+    seen: list[ModelMessage] = []
+    messages: list[ModelMessage] = [_tool_result("x" * (MAX_SUMMARIZED_TOOL_RESULT_LENGTH + 1))]
+
+    await summarize_messages(
+        messages=messages,
+        model=_recording_model(seen, tool_name="summary", args={"summary": "Trace triage"}),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert isinstance(sent.content, str)
+    assert sent.content.endswith("[... 1 characters truncated for summarization]")
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("x" * MAX_SUMMARIZED_TOOL_RESULT_LENGTH, id="text-at-the-limit"),
+        pytest.param({"spans": ["a", "b"]}, id="structured-content"),
+        pytest.param(["a", "b"], id="list-content"),
+    ],
+)
+async def test_tool_results_within_the_limit_are_passed_through_unchanged(content: Any) -> None:
+    seen: list[ModelMessage] = []
+    messages: list[ModelMessage] = [_tool_result(content)]
+
+    await summarize_messages_for_compaction(
+        messages=messages,
+        model=_recording_model(seen, tool_name="conversation_checkpoint", args=CHECKPOINT),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert sent.content == content
+
+
+async def test_oversized_structured_tool_results_are_truncated_as_json() -> None:
+    seen: list[ModelMessage] = []
+    messages: list[ModelMessage] = [
+        _tool_result({"spans": ["x" * MAX_SUMMARIZED_TOOL_RESULT_LENGTH]})
+    ]
+
+    await summarize_messages_for_compaction(
+        messages=messages,
+        model=_recording_model(seen, tool_name="conversation_checkpoint", args=CHECKPOINT),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert isinstance(sent.content, str)
+    assert sent.content.startswith('{"spans":["xxx')
+    assert sent.content.endswith("characters truncated for summarization]")
+
+
+async def test_truncation_keeps_multimodal_files_and_other_parts() -> None:
+    seen: list[ModelMessage] = []
+    image = BinaryContent(data=b"png-bytes", media_type="image/png")
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="Find the slow span")]),
+        ModelResponse(parts=[TextPart(content="Looking now")]),
+        _tool_result(["x" * (MAX_SUMMARIZED_TOOL_RESULT_LENGTH + 10), image]),
+    ]
+
+    await summarize_messages_for_compaction(
+        messages=messages,
+        model=_recording_model(seen, tool_name="conversation_checkpoint", args=CHECKPOINT),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert isinstance(sent.content, list)
+    truncated, kept_image = sent.content
+    assert isinstance(truncated, str)
+    assert truncated.endswith("characters truncated for summarization]")
+    assert kept_image == image
+    # untouched messages are forwarded as-is
+    assert seen[0] is messages[0]
+    assert seen[1] is messages[1]

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -18,6 +18,7 @@ from phoenix.server.api.routers.agents import (
 )
 from phoenix.server.settings.registry import AgentAssistantEnabledSetting
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 from tests.unit.graphql import AsyncGraphQLClient
 
 _CREATE_MUTATION = """
@@ -118,22 +119,22 @@ def _transcript_messages() -> list[PhoenixUIMessage]:
     """A two-turn transcript."""
     return [
         PhoenixUIMessage(
-            id="user-1",
+            id=_message_uuid("user-1"),
             role="user",
             parts=[TextUIPart(text="How do I trace OpenAI?")],
         ),
         PhoenixUIMessage(
-            id="assistant-1",
+            id=_message_uuid("assistant-1"),
             role="assistant",
             parts=[TextUIPart(text="Use register().")],
         ),
         PhoenixUIMessage(
-            id="user-2",
+            id=_message_uuid("user-2"),
             role="user",
             parts=[TextUIPart(text="Show "), TextUIPart(text="an example")],
         ),
         PhoenixUIMessage(
-            id="assistant-2",
+            id=_message_uuid("assistant-2"),
             role="assistant",
             parts=[TextUIPart(text="Here is an example.")],
         ),
@@ -159,10 +160,9 @@ async def _seed_session_with_transcript(
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(_transcript_messages())
+            for message in _transcript_messages()
         )
         return str(GlobalID("AgentSession", str(agent_session.id)))
 
@@ -176,31 +176,37 @@ async def test_truncate_agent_session_at_a_user_message_removes_it_and_later_tur
         retained_message_rowids = list(
             await session.scalars(
                 select(models.AgentSessionMessage.id)
-                .where(models.AgentSessionMessage.position < 2)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
+                .limit(2)
             )
         )
 
     response = await gql_client.execute(
         query=_TRUNCATE_MUTATION,
-        variables={"id": agent_session_id, "messageId": "user-2"},
+        variables={"id": agent_session_id, "messageId": _message_uuid("user-2")},
     )
     assert not response.errors
     assert response.data is not None
     payload = response.data["truncateAgentSession"]
     # The user target and everything after it are removed.
     assert [message["id"] for message in payload["agentSession"]["messages"]] == [
-        "user-1",
-        "assistant-1",
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
     ]
     async with db() as session:
         stored_message_rows = (
             await session.scalars(
-                select(models.AgentSessionMessage).order_by(models.AgentSessionMessage.position)
+                select(models.AgentSessionMessage).order_by(models.AgentSessionMessage.id)
             )
         ).all()
-    assert [row.message.id for row in stored_message_rows] == ["user-1", "assistant-1"]
-    assert [row.message_id for row in stored_message_rows] == ["user-1", "assistant-1"]
+    assert [row.message.id for row in stored_message_rows] == [
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+    ]
+    assert [row.message_id for row in stored_message_rows] == [
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+    ]
     assert [row.id for row in stored_message_rows] == retained_message_rowids
 
 
@@ -212,22 +218,22 @@ async def test_truncate_agent_session_at_an_assistant_message_retains_it(
 
     response = await gql_client.execute(
         query=_TRUNCATE_MUTATION,
-        variables={"id": agent_session_id, "messageId": "assistant-2"},
+        variables={"id": agent_session_id, "messageId": _message_uuid("assistant-2")},
     )
     assert not response.errors
     assert response.data is not None
     payload = response.data["truncateAgentSession"]
     messages = payload["agentSession"]["messages"]
     assert [message["id"] for message in messages] == [
-        "user-1",
-        "assistant-1",
-        "user-2",
-        "assistant-2",
+        _message_uuid("user-1"),
+        _message_uuid("assistant-1"),
+        _message_uuid("user-2"),
+        _message_uuid("assistant-2"),
     ]
     async with db() as session:
         stored_message = await session.scalar(
             select(models.AgentSessionMessage).where(
-                models.AgentSessionMessage.message_id == "assistant-2"
+                models.AgentSessionMessage.message_id == _message_uuid("assistant-2")
             )
         )
         assert stored_message is not None
@@ -243,25 +249,29 @@ async def test_truncate_agent_session_restores_the_latest_surviving_compaction_p
         agent_session_rowid = await session.scalar(select(models.AgentSession.id))
         assert agent_session_rowid is not None
         additional_messages = [
-            _build_compaction_message(message_id="compaction-1", summary="first summary"),
+            _build_compaction_message(
+                message_id=_message_uuid("compaction-1"), summary="first summary"
+            ),
             PhoenixUIMessage(
-                id="user-3",
+                id=_message_uuid("user-3"),
                 role="user",
                 parts=[TextUIPart(text="Continue")],
             ),
             PhoenixUIMessage(
-                id="assistant-3",
+                id=_message_uuid("assistant-3"),
                 role="assistant",
                 parts=[TextUIPart(text="Continued")],
             ),
-            _build_compaction_message(message_id="compaction-2", summary="second summary"),
+            _build_compaction_message(
+                message_id=_message_uuid("compaction-2"), summary="second summary"
+            ),
             PhoenixUIMessage(
-                id="user-4",
+                id=_message_uuid("user-4"),
                 role="user",
                 parts=[TextUIPart(text="Continue again")],
             ),
             PhoenixUIMessage(
-                id="assistant-4",
+                id=_message_uuid("assistant-4"),
                 role="assistant",
                 parts=[TextUIPart(text="Continued again")],
             ),
@@ -269,22 +279,21 @@ async def test_truncate_agent_session_restores_the_latest_surviving_compaction_p
         additional_rows = [
             models.AgentSessionMessage(
                 agent_session_id=agent_session_rowid,
-                position=position,
                 message=message,
             )
-            for position, message in enumerate(additional_messages, start=4)
+            for message in additional_messages
         ]
         session.add_all(additional_rows)
 
     response = await gql_client.execute(
         query=_TRUNCATE_MUTATION,
-        variables={"id": agent_session_id, "messageId": "user-3"},
+        variables={"id": agent_session_id, "messageId": _message_uuid("user-3")},
     )
 
     assert not response.errors
     assert response.data is not None
     messages = response.data["truncateAgentSession"]["agentSession"]["messages"]
-    assert [message["id"] for message in messages][-1] == "compaction-1"
+    assert [message["id"] for message in messages][-1] == _message_uuid("compaction-1")
     async with db() as session:
         surviving_compaction_message_count = await session.scalar(
             select(func.count())
@@ -296,7 +305,7 @@ async def test_truncate_agent_session_restores_the_latest_surviving_compaction_p
             agent_session_rowid=agent_session_rowid,
         )
     assert surviving_compaction_message_count == 1
-    assert [row.message.id for row in history] == ["compaction-1"]
+    assert [row.message.id for row in history] == [_message_uuid("compaction-1")]
 
 
 async def test_truncate_agent_session_with_unknown_message_id_is_not_found(
@@ -328,7 +337,7 @@ async def test_truncate_agent_session_rejects_an_expired_temporary_session(
 
     response = await gql_client.execute(
         query=_TRUNCATE_MUTATION,
-        variables={"id": agent_session_id, "messageId": "user-2"},
+        variables={"id": agent_session_id, "messageId": _message_uuid("user-2")},
     )
 
     assert response.errors
@@ -351,7 +360,7 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "user-2"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("user-2")},
     )
     assert not response.errors
     assert response.data is not None
@@ -362,7 +371,9 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
     branch_message_ids = [message["id"] for message in branch["messages"]]
     assert len(branch_message_ids) == 2
     assert all(UUID(message_id).version == 4 for message_id in branch_message_ids)
-    assert set(branch_message_ids).isdisjoint({"user-1", "assistant-1"})
+    assert set(branch_message_ids).isdisjoint(
+        {_message_uuid("user-1"), _message_uuid("assistant-1")}
+    )
     async with db() as session:
         agent_sessions = (await session.scalars(select(models.AgentSession))).all()
         assert len(agent_sessions) == 2
@@ -372,14 +383,14 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
             await session.scalars(
                 select(models.AgentSessionMessage)
                 .where(models.AgentSessionMessage.agent_session_id == source_rowid)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         ).all()
         branch_messages = (
             await session.scalars(
                 select(models.AgentSessionMessage)
                 .where(models.AgentSessionMessage.agent_session_id == branch_rowid)
-                .order_by(models.AgentSessionMessage.position)
+                .order_by(models.AgentSessionMessage.id)
             )
         ).all()
         assert len(source_messages) == len(_transcript_messages())
@@ -410,17 +421,15 @@ async def test_branch_agent_session_copies_durable_compaction_points(
         assert source_session_rowid is not None
         compaction_row = models.AgentSessionMessage(
             agent_session_id=source_session_rowid,
-            position=4,
             message=_build_compaction_message(
-                message_id="source-compaction",
+                message_id=_message_uuid("source-compaction"),
                 summary="durable summary",
             ),
         )
         assistant_row = models.AgentSessionMessage(
             agent_session_id=source_session_rowid,
-            position=5,
             message=PhoenixUIMessage(
-                id="assistant-after-compaction",
+                id=_message_uuid("assistant-after-compaction"),
                 role="assistant",
                 parts=[TextUIPart(text="retained answer")],
             ),
@@ -431,7 +440,7 @@ async def test_branch_agent_session_copies_durable_compaction_points(
         query=_BRANCH_MUTATION,
         variables={
             "id": source_agent_session_id,
-            "messageId": "assistant-after-compaction",
+            "messageId": _message_uuid("assistant-after-compaction"),
         },
     )
 
@@ -443,7 +452,7 @@ async def test_branch_agent_session_copies_durable_compaction_points(
         for message in branch_messages
         if message.get("metadata", {}).get("isCompactionMessage") is True
     )
-    assert copied_compaction["id"] != "source-compaction"
+    assert copied_compaction["id"] != _message_uuid("source-compaction")
     async with db() as session:
         compaction_message_count = await session.scalar(
             select(func.count())
@@ -461,7 +470,7 @@ async def test_branch_agent_session_copies_the_source_title(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "assistant-1"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-1")},
     )
     assert not response.errors
     assert response.data is not None
@@ -479,7 +488,7 @@ async def test_branch_agent_session_preserves_temporary_mode(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "assistant-1"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-1")},
     )
 
     assert not response.errors
@@ -495,7 +504,7 @@ async def test_branch_agent_session_at_an_assistant_message_includes_it(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "assistant-2"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-2")},
     )
 
     assert not response.errors
@@ -533,7 +542,7 @@ async def test_branch_agent_session_rejects_an_expired_temporary_session(
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
-        variables={"id": source_agent_session_id, "messageId": "assistant-1"},
+        variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-1")},
     )
 
     assert response.errors
@@ -760,8 +769,7 @@ async def test_delete_agent_session_cascades_snapshot(
         session.add(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=0,
-                message=PhoenixUIMessage(id="m1", role="user", parts=[]),
+                message=PhoenixUIMessage(id=_message_uuid("m1"), role="user", parts=[]),
             )
         )
 

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -7,7 +7,10 @@ from fastapi import FastAPI
 from sqlalchemy import func, select
 from strawberry.relay import GlobalID
 
-from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
+from phoenix.config import (
+    EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS,
+    get_env_phoenix_agents_assistant_project_name,
+)
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import (
     PhoenixUIMessage,
@@ -156,7 +159,6 @@ async def _seed_session_with_transcript(
         agent_session = models.AgentSession(
             user_id=None,
             title=title,
-            project_name="assistant_agent",
             is_ephemeral=is_ephemeral,
         )
         if updated_at is not None:
@@ -358,11 +360,8 @@ async def test_truncate_agent_session_accepts_an_ephemeral_session_awaiting_the_
 async def test_branch_agent_session_copies_the_truncated_transcript(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_agent_session_id = await _seed_session_with_transcript(db)
-    configured_project_name = "configured-assistant-project"
-    monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", configured_project_name)
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
@@ -407,20 +406,18 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
         assert set(row.message_id for row in branch_messages).isdisjoint(
             row.message_id for row in source_messages
         )
-        # The branch gets its own OTel session identity (derived from its own
-        # row id) and uses the currently configured trace project.
+        # The branch gets its own OTel session identity, derived from its own row id.
         source_session, branch_session = sorted(
             agent_sessions, key=lambda agent_session: agent_session.id
         )
+        project_name = get_env_phoenix_agents_assistant_project_name()
         assert get_otel_session_id(
-            project_name=branch_session.project_name,
+            project_name=project_name,
             agent_session_rowid=branch_session.id,
         ) != get_otel_session_id(
-            project_name=source_session.project_name,
+            project_name=project_name,
             agent_session_rowid=source_session.id,
         )
-        assert branch_session.project_name == configured_project_name
-        assert branch_session.project_name != source_session.project_name
 
 
 async def test_branch_agent_session_copies_durable_compaction_points(
@@ -673,7 +670,6 @@ async def test_update_agent_session_title(
         agent_session = models.AgentSession(
             user_id=None,
             title="Old title",
-            project_name="assistant_agent",
         )
         session.add(agent_session)
         await session.flush()
@@ -700,7 +696,6 @@ async def test_update_agent_session_title_rejects_empty_title(
         agent_session = models.AgentSession(
             user_id=None,
             title="Old title",
-            project_name="assistant_agent",
         )
         session.add(agent_session)
         await session.flush()
@@ -725,7 +720,6 @@ async def test_update_agent_session_title_rejects_long_title(
         agent_session = models.AgentSession(
             user_id=None,
             title="Old title",
-            project_name="assistant_agent",
         )
         session.add(agent_session)
         await session.flush()
@@ -756,7 +750,6 @@ async def test_delete_agent_session_cascades_snapshot(
         agent_session = models.AgentSession(
             user_id=None,
             title="doomed session",
-            project_name="assistant_agent",
             created_at=now,
             updated_at=now,
         )

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -18,7 +18,7 @@ from phoenix.server.api.routers.agents import (
     _build_compaction_message,
     _load_agent_session_history,
 )
-from phoenix.server.authorization import INSUFFICIENT_STORAGE_MESSAGE
+from phoenix.server.authorization import insufficient_storage_message
 from phoenix.server.settings.registry import AgentAssistantEnabledSetting
 from phoenix.server.types import DbSessionFactory
 from tests.unit._helpers import _message_uuid
@@ -827,7 +827,7 @@ async def test_write_mutations_report_insufficient_storage_when_writes_are_locke
         response = await gql_client.execute(query=mutation, variables=variables)
 
         assert response.errors, mutation
-        assert INSUFFICIENT_STORAGE_MESSAGE in response.errors[0].message, mutation
+        assert insufficient_storage_message() in response.errors[0].message, mutation
 
 
 async def test_truncate_and_delete_still_work_when_writes_are_locked(

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -12,7 +12,7 @@ from phoenix.db.types.data_stream_protocol import (
     TextUIPart,
 )
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
-from phoenix.server.api.helpers.agent_sessions import derive_otel_session_id
+from phoenix.server.api.helpers.agent_sessions import get_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_compaction_message,
     _load_agent_session_history,
@@ -406,10 +406,10 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
         source_session, branch_session = sorted(
             agent_sessions, key=lambda agent_session: agent_session.id
         )
-        assert derive_otel_session_id(
+        assert get_otel_session_id(
             project_name=branch_session.project_name,
             agent_session_rowid=branch_session.id,
-        ) != derive_otel_session_id(
+        ) != get_otel_session_id(
             project_name=source_session.project_name,
             agent_session_rowid=source_session.id,
         )

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from sqlalchemy import func, select
 from strawberry.relay import GlobalID
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import (
     PhoenixUIMessage,
@@ -148,15 +149,18 @@ async def _seed_session_with_transcript(
     db: DbSessionFactory,
     *,
     title: str = "",
-    expires_at: datetime | None = None,
+    is_ephemeral: bool = False,
+    updated_at: datetime | None = None,
 ) -> str:
     async with db() as session:
         agent_session = models.AgentSession(
             user_id=None,
             title=title,
             project_name="assistant_agent",
-            expires_at=expires_at,
+            is_ephemeral=is_ephemeral,
         )
+        if updated_at is not None:
+            agent_session.created_at = agent_session.updated_at = updated_at
         session.add(agent_session)
         await session.flush()
         session.add_all(
@@ -328,13 +332,21 @@ async def test_truncate_agent_session_with_unknown_message_id_is_not_found(
         )
 
 
-async def test_truncate_agent_session_rejects_an_expired_temporary_session(
+async def test_truncate_agent_session_accepts_an_ephemeral_session_awaiting_the_sweeper(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
+    """A lapsed TTL no longer blocks writes, because it is no longer readable state.
+
+    The deadline is ``updated_at`` plus a constant, and truncating bumps
+    ``updated_at`` — so refusing the write would only have hidden a session the
+    same request was about to renew.
+    """
     agent_session_id = await _seed_session_with_transcript(
         db,
-        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        is_ephemeral=True,
+        updated_at=datetime.now(timezone.utc)
+        - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1),
     )
 
     response = await gql_client.execute(
@@ -342,11 +354,9 @@ async def test_truncate_agent_session_rejects_an_expired_temporary_session(
         variables={"id": agent_session_id, "messageId": _message_uuid("user-2")},
     )
 
-    assert response.errors
-    assert "No agent session found" in response.errors[0].message
-    # The expired session's transcript is left untouched.
+    assert not response.errors
     async with db() as session:
-        assert len((await session.scalars(select(models.AgentSessionMessage))).all()) == len(
+        assert len((await session.scalars(select(models.AgentSessionMessage))).all()) < len(
             _transcript_messages()
         )
 
@@ -489,10 +499,7 @@ async def test_branch_agent_session_preserves_temporary_mode(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    source_agent_session_id = await _seed_session_with_transcript(
-        db,
-        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
-    )
+    source_agent_session_id = await _seed_session_with_transcript(db, is_ephemeral=True)
 
     response = await gql_client.execute(
         query=_BRANCH_MUTATION,
@@ -539,13 +546,15 @@ async def test_branch_agent_session_with_unknown_message_id_is_not_found(
         assert len((await session.scalars(select(models.AgentSession))).all()) == 1
 
 
-async def test_branch_agent_session_rejects_an_expired_temporary_session(
+async def test_branch_agent_session_accepts_an_ephemeral_source_awaiting_the_sweeper(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
     source_agent_session_id = await _seed_session_with_transcript(
         db,
-        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        is_ephemeral=True,
+        updated_at=datetime.now(timezone.utc)
+        - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1),
     )
 
     response = await gql_client.execute(
@@ -553,11 +562,15 @@ async def test_branch_agent_session_rejects_an_expired_temporary_session(
         variables={"id": source_agent_session_id, "messageId": _message_uuid("assistant-1")},
     )
 
-    assert response.errors
-    assert "No agent session found" in response.errors[0].message
-    # No branch session is minted from an expired source.
+    assert not response.errors
+    assert response.data is not None
+    # The branch inherits ephemerality and starts its own TTL from its own
+    # activity, so it is not born already past the sweeper's cutoff.
+    assert response.data["branchAgentSession"]["agentSession"]["isTemporary"] is True
     async with db() as session:
-        assert len((await session.scalars(select(models.AgentSession))).all()) == 1
+        branched = (await session.scalars(select(models.AgentSession))).all()
+        assert len(branched) == 2
+        assert all(agent_session.is_ephemeral for agent_session in branched)
 
 
 async def test_create_agent_session_creates_empty_owned_session(
@@ -581,7 +594,7 @@ async def test_create_agent_session_creates_empty_owned_session(
         assert payload["id"] == str(GlobalID("AgentSession", str(agent_session.id)))
         assert agent_session.user_id is None
         assert agent_session.title == ""
-        assert agent_session.expires_at is None
+        assert agent_session.is_ephemeral is False
         assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
 
 
@@ -589,7 +602,6 @@ async def test_create_agent_session_can_create_temporary_session(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    before_creation = datetime.now(timezone.utc)
     response = await gql_client.execute(
         query="""
           mutation {
@@ -608,9 +620,9 @@ async def test_create_agent_session_can_create_temporary_session(
     async with db() as session:
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
-        assert agent_session.expires_at is not None
-        assert before_creation + timedelta(hours=23) < agent_session.expires_at
-        assert agent_session.expires_at < before_creation + timedelta(hours=25)
+        # The API says "temporary"; the column says "ephemeral". The GraphQL name
+        # is the one clients already depend on, so only storage was renamed.
+        assert agent_session.is_ephemeral is True
 
 
 async def test_create_agent_session_persists_a_trimmed_title(

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from typing import Iterator
 from uuid import UUID
 
 import pytest
@@ -17,6 +18,7 @@ from phoenix.server.api.routers.agents import (
     _build_compaction_message,
     _load_agent_session_history,
 )
+from phoenix.server.authorization import INSUFFICIENT_STORAGE_MESSAGE
 from phoenix.server.settings.registry import AgentAssistantEnabledSetting
 from phoenix.server.types import DbSessionFactory
 from tests.unit._helpers import _message_uuid
@@ -794,3 +796,58 @@ async def test_delete_agent_session_not_found(
     )
     assert response.errors
     assert "No agent session found" in response.errors[0].message
+
+
+@pytest.fixture
+def locked_storage(db: DbSessionFactory) -> Iterator[None]:
+    """Put the database in the state the disk-usage monitor sets when full."""
+    db.should_not_insert_or_update = True
+    try:
+        yield
+    finally:
+        db.should_not_insert_or_update = False
+
+
+async def test_write_mutations_report_insufficient_storage_when_writes_are_locked(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+    locked_storage: None,
+) -> None:
+    """A locked database must say so, not fail with whatever the driver raised."""
+    agent_session_id = await _seed_session_with_transcript(db)
+
+    for mutation, variables in (
+        (_CREATE_MUTATION, {"title": ""}),
+        (
+            _BRANCH_MUTATION,
+            {"id": agent_session_id, "messageId": _message_uuid("assistant-1")},
+        ),
+        (_UPDATE_TITLE_MUTATION, {"id": agent_session_id, "title": "New title"}),
+    ):
+        response = await gql_client.execute(query=mutation, variables=variables)
+
+        assert response.errors, mutation
+        assert INSUFFICIENT_STORAGE_MESSAGE in response.errors[0].message, mutation
+
+
+async def test_truncate_and_delete_still_work_when_writes_are_locked(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+    locked_storage: None,
+) -> None:
+    """Deleting is how a user frees space, so it must not be gated on storage."""
+    agent_session_id = await _seed_session_with_transcript(db)
+
+    truncated = await gql_client.execute(
+        query=_TRUNCATE_MUTATION,
+        variables={"id": agent_session_id, "messageId": _message_uuid("user-2")},
+    )
+    assert not truncated.errors
+
+    deleted = await gql_client.execute(
+        query=_DELETE_MUTATION,
+        variables={"id": agent_session_id},
+    )
+    assert not deleted.errors
+    async with db() as session:
+        assert (await session.scalars(select(models.AgentSession))).all() == []

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -31,7 +31,7 @@ _CREATE_MUTATION = """
       agentSession {
         id
         title
-        isTemporary
+        isEphemeral
         messages
       }
     }
@@ -55,7 +55,7 @@ _BRANCH_MUTATION = """
       agentSession {
         id
         title
-        isTemporary
+        isEphemeral
         messages
       }
     }
@@ -336,12 +336,6 @@ async def test_truncate_agent_session_accepts_an_ephemeral_session_awaiting_the_
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    """A lapsed TTL no longer blocks writes, because it is no longer readable state.
-
-    The deadline is ``updated_at`` plus a constant, and truncating bumps
-    ``updated_at`` — so refusing the write would only have hidden a session the
-    same request was about to renew.
-    """
     agent_session_id = await _seed_session_with_transcript(
         db,
         is_ephemeral=True,
@@ -508,7 +502,7 @@ async def test_branch_agent_session_preserves_temporary_mode(
 
     assert not response.errors
     assert response.data is not None
-    assert response.data["branchAgentSession"]["agentSession"]["isTemporary"] is True
+    assert response.data["branchAgentSession"]["agentSession"]["isEphemeral"] is True
 
 
 async def test_branch_agent_session_at_an_assistant_message_includes_it(
@@ -564,9 +558,7 @@ async def test_branch_agent_session_accepts_an_ephemeral_source_awaiting_the_swe
 
     assert not response.errors
     assert response.data is not None
-    # The branch inherits ephemerality and starts its own TTL from its own
-    # activity, so it is not born already past the sweeper's cutoff.
-    assert response.data["branchAgentSession"]["agentSession"]["isTemporary"] is True
+    assert response.data["branchAgentSession"]["agentSession"]["isEphemeral"] is True
     async with db() as session:
         branched = (await session.scalars(select(models.AgentSession))).all()
         assert len(branched) == 2
@@ -585,7 +577,7 @@ async def test_create_agent_session_creates_empty_owned_session(
     assert response.data is not None
     payload = response.data["createAgentSession"]["agentSession"]
     assert payload["title"] == ""
-    assert payload["isTemporary"] is False
+    assert payload["isEphemeral"] is False
     assert payload["messages"] == []
     async with db() as session:
         agent_sessions = (await session.scalars(select(models.AgentSession))).all()
@@ -605,9 +597,9 @@ async def test_create_agent_session_can_create_temporary_session(
     response = await gql_client.execute(
         query="""
           mutation {
-            createAgentSession(input: { temporary: true }) {
+            createAgentSession(input: { isEphemeral: true }) {
               agentSession {
-                isTemporary
+                isEphemeral
               }
             }
           }
@@ -616,12 +608,10 @@ async def test_create_agent_session_can_create_temporary_session(
 
     assert not response.errors
     assert response.data is not None
-    assert response.data["createAgentSession"]["agentSession"]["isTemporary"] is True
+    assert response.data["createAgentSession"]["agentSession"]["isEphemeral"] is True
     async with db() as session:
         agent_session = await session.scalar(select(models.AgentSession))
         assert agent_session is not None
-        # The API says "temporary"; the column says "ephemeral". The GraphQL name
-        # is the one clients already depend on, so only storage was renamed.
         assert agent_session.is_ephemeral is True
 
 

--- a/tests/unit/server/api/mutations/test_agent_session_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_mutations.py
@@ -12,6 +12,7 @@ from phoenix.db.types.data_stream_protocol import (
     TextUIPart,
 )
 from phoenix.server.agents.session_titles import MAX_AGENT_SESSION_TITLE_LENGTH
+from phoenix.server.api.helpers.agent_sessions import derive_otel_session_id
 from phoenix.server.api.routers.agents import (
     _build_compaction_message,
     _load_agent_session_history,
@@ -149,7 +150,6 @@ async def _seed_session_with_transcript(
 ) -> str:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="12121212-1212-4121-8121-121212121212",
             user_id=None,
             title=title,
             project_name="assistant_agent",
@@ -401,12 +401,18 @@ async def test_branch_agent_session_copies_the_truncated_transcript(
         assert set(row.message_id for row in branch_messages).isdisjoint(
             row.message_id for row in source_messages
         )
-        # The branch mints its own OTel session identity and uses the currently
-        # configured trace project.
+        # The branch gets its own OTel session identity (derived from its own
+        # row id) and uses the currently configured trace project.
         source_session, branch_session = sorted(
             agent_sessions, key=lambda agent_session: agent_session.id
         )
-        assert branch_session.project_session_id != source_session.project_session_id
+        assert derive_otel_session_id(
+            project_name=branch_session.project_name,
+            agent_session_rowid=branch_session.id,
+        ) != derive_otel_session_id(
+            project_name=source_session.project_name,
+            agent_session_rowid=source_session.id,
+        )
         assert branch_session.project_name == configured_project_name
         assert branch_session.project_name != source_session.project_name
 
@@ -573,7 +579,6 @@ async def test_create_agent_session_creates_empty_owned_session(
         assert payload["id"] == str(GlobalID("AgentSession", str(agent_session.id)))
         assert agent_session.user_id is None
         assert agent_session.title == ""
-        assert agent_session.project_session_id
         assert agent_session.expires_at is None
         assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
 
@@ -638,10 +643,8 @@ async def test_create_agent_session_mints_distinct_sessions(
         != second.data["createAgentSession"]["agentSession"]["id"]
     )
     async with db() as session:
-        project_session_ids = (
-            await session.scalars(select(models.AgentSession.project_session_id))
-        ).all()
-        assert len(set(project_session_ids)) == 2
+        agent_session_rowids = (await session.scalars(select(models.AgentSession.id))).all()
+        assert len(set(agent_session_rowids)) == 2
 
 
 async def test_create_agent_session_rejects_long_title(
@@ -664,7 +667,6 @@ async def test_update_agent_session_title(
 ) -> None:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             user_id=None,
             title="Old title",
             project_name="assistant_agent",
@@ -692,7 +694,6 @@ async def test_update_agent_session_title_rejects_empty_title(
 ) -> None:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             user_id=None,
             title="Old title",
             project_name="assistant_agent",
@@ -718,7 +719,6 @@ async def test_update_agent_session_title_rejects_long_title(
 ) -> None:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             user_id=None,
             title="Old title",
             project_name="assistant_agent",
@@ -750,7 +750,6 @@ async def test_delete_agent_session_cascades_snapshot(
     now = datetime(2026, 1, 1, tzinfo=timezone.utc)
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             user_id=None,
             title="doomed session",
             project_name="assistant_agent",

--- a/tests/unit/server/api/mutations/test_agent_session_retention_mutations.py
+++ b/tests/unit/server/api/mutations/test_agent_session_retention_mutations.py
@@ -6,6 +6,10 @@ from typing import Any
 
 import pytest
 
+from phoenix.server.settings.registry import (
+    DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER,
+    DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS,
+)
 from tests.unit.graphql import AsyncGraphQLClient
 
 _RETENTION_QUERY = """
@@ -54,6 +58,28 @@ async def test_mutation_persists_and_query_reflects_write(
 async def test_query_returns_defaults_when_setting_is_unset(
     gql_client: AsyncGraphQLClient,
 ) -> None:
+    """Both rules are on out of the box, so the admin switches render on."""
+    q = await gql_client.execute(_RETENTION_QUERY, {})
+    assert not q.errors
+    assert q.data is not None
+    config = q.data["agentsConfig"]
+    assert config["sessionRetentionMaxIdleDays"] == DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS == 30
+    assert (
+        config["sessionRetentionMaxCountPerUser"] == DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER == 30
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_returns_null_once_an_admin_turns_a_rule_off(
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    """Null still means off — the new defaults do not take that away."""
+    disabled = await gql_client.execute(
+        _SET_RETENTION_MUTATION,
+        {"input": {"maxIdleDays": None, "maxCountPerUser": None}},
+    )
+    assert not disabled.errors
+
     q = await gql_client.execute(_RETENTION_QUERY, {})
     assert not q.errors
     assert q.data is not None

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -66,7 +66,6 @@ class TestAgentSessionPersistence:
             created = models.AgentSession(
                 user_id=None,
                 title="",
-                project_name="assistant_agent",
             )
             session.add(created)
             await session.flush()
@@ -99,7 +98,6 @@ class TestAgentSessionPersistence:
             first = models.AgentSession(
                 user_id=None,
                 title="first",
-                project_name="assistant_agent",
             )
             session.add(first)
             await session.flush()
@@ -110,7 +108,6 @@ class TestAgentSessionPersistence:
             second = models.AgentSession(
                 user_id=None,
                 title="second",
-                project_name="assistant_agent",
             )
             session.add(second)
             await session.flush()
@@ -126,7 +123,6 @@ class TestAgentSessionPersistence:
             ephemeral = models.AgentSession(
                 user_id=None,
                 title="",
-                project_name="assistant_agent",
                 is_ephemeral=True,
             )
             ephemeral.created_at = stale
@@ -164,7 +160,6 @@ class TestAgentSessionPersistence:
             persistent = models.AgentSession(
                 user_id=None,
                 title="",
-                project_name="assistant_agent",
             )
             persistent.created_at = stale
             persistent.updated_at = stale
@@ -210,7 +205,6 @@ class TestAgentSessionPersistence:
             ephemeral = models.AgentSession(
                 user_id=None,
                 title="",
-                project_name="assistant_agent",
                 is_ephemeral=True,
             )
             ephemeral.created_at = stale

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -6,8 +6,6 @@ from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-from fastapi import HTTPException
 from jinja2 import Template
 from opentelemetry.trace import (
     SpanContext,
@@ -20,6 +18,7 @@ from pydantic_ai.usage import RequestUsage
 from sqlalchemy import delete, func, select
 from strawberry.relay import GlobalID
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import TurnTraceContext
 from phoenix.db.types.identifier import Identifier
@@ -43,6 +42,11 @@ from phoenix.server.api.routers.agents import (
 from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.dml_event import DmlEvent, SpanInsertEvent
 from phoenix.server.types import DbSessionFactory, UserId
+
+
+def _ephemeral_sweep_cutoff() -> datetime:
+    """The updated_at below which the sweeper's ephemeral pass reaps a session."""
+    return datetime.now(timezone.utc) - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS)
 
 
 class _EventQueue:
@@ -112,42 +116,46 @@ class TestAgentSessionPersistence:
             await session.flush()
             assert second.id > first_rowid
 
-    async def test_refreshes_expiry_for_a_temporary_session(
+    async def test_slides_the_ttl_window_for_an_ephemeral_session(
         self,
         db: DbSessionFactory,
     ) -> None:
+        # Idle long enough that the sweeper's next pass would have reaped it.
+        stale = _ephemeral_sweep_cutoff() - timedelta(hours=1)
         async with db() as session:
-            temporary = models.AgentSession(
+            ephemeral = models.AgentSession(
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
-                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                is_ephemeral=True,
             )
-            session.add(temporary)
+            ephemeral.created_at = stale
+            ephemeral.updated_at = stale
+            session.add(ephemeral)
             await session.flush()
-            temporary_rowid = temporary.id
+            ephemeral_rowid = ephemeral.id
 
-        before_refresh = datetime.now(timezone.utc)
         async with db() as session:
             loaded = await _refresh_and_load_agent_session(
                 session,
-                agent_session_id=str(GlobalID("AgentSession", str(temporary_rowid))),
+                agent_session_id=str(GlobalID("AgentSession", str(ephemeral_rowid))),
                 user_id=None,
             )
-            # The sliding window is pushed well past the original near-term expiry.
-            assert loaded.expires_at is not None
-            assert loaded.expires_at > before_refresh + timedelta(hours=23)
+            # updated_at *is* the deadline now, so the bump is what buys another
+            # full TTL — and the session stays ephemeral through the refresh.
+            assert loaded.is_ephemeral is True
+            assert loaded.updated_at > _ephemeral_sweep_cutoff()
 
         async with db() as session:
-            persisted_expiry = await session.scalar(
-                select(models.AgentSession.expires_at).where(
-                    models.AgentSession.id == temporary_rowid
+            persisted_updated_at = await session.scalar(
+                select(models.AgentSession.updated_at).where(
+                    models.AgentSession.id == ephemeral_rowid
                 )
             )
-            assert persisted_expiry is not None
-            assert persisted_expiry > before_refresh + timedelta(hours=23)
+            assert persisted_updated_at is not None
+            assert persisted_updated_at > _ephemeral_sweep_cutoff()
 
-    async def test_marks_a_persistent_session_active_without_granting_expiry(
+    async def test_marks_a_persisted_session_active_without_making_it_ephemeral(
         self,
         db: DbSessionFactory,
     ) -> None:
@@ -171,7 +179,7 @@ class TestAgentSessionPersistence:
                 user_id=None,
             )
             assert loaded.id == persistent_rowid
-            assert loaded.expires_at is None
+            assert loaded.is_ephemeral is False
             # The turn-start updated_at bump keeps the retention sweeper from
             # treating an in-flight turn as idle.
             assert loaded.updated_at > stale
@@ -185,36 +193,46 @@ class TestAgentSessionPersistence:
             assert persisted_updated_at is not None
             assert persisted_updated_at > stale
 
-    async def test_rejects_an_expired_temporary_session(
+    async def test_resumes_an_ephemeral_session_the_sweeper_has_not_reached_yet(
         self,
         db: DbSessionFactory,
     ) -> None:
+        """A lapsed TTL is not a read-time gate — deletion is the sweeper's job alone.
+
+        The deadline used to be stored, so reads could compare against it and hide
+        a session the sweeper had not deleted yet. With the deadline derived from
+        ``updated_at`` there is nothing to compare that resuming would not have
+        reset anyway, so an idle ephemeral session stays resumable until a sweep
+        removes it — at most one sweep interval past its TTL.
+        """
+        stale = _ephemeral_sweep_cutoff() - timedelta(hours=1)
         async with db() as session:
-            temporary = models.AgentSession(
+            ephemeral = models.AgentSession(
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
-                expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+                is_ephemeral=True,
             )
-            session.add(temporary)
+            ephemeral.created_at = stale
+            ephemeral.updated_at = stale
+            session.add(ephemeral)
             await session.flush()
-            temporary_rowid = temporary.id
+            ephemeral_rowid = ephemeral.id
 
         async with db() as session:
-            with pytest.raises(HTTPException) as exc_info:
-                await _refresh_and_load_agent_session(
-                    session,
-                    agent_session_id=str(GlobalID("AgentSession", str(temporary_rowid))),
-                    user_id=None,
-                )
-            assert exc_info.value.status_code == 404
+            loaded = await _refresh_and_load_agent_session(
+                session,
+                agent_session_id=str(GlobalID("AgentSession", str(ephemeral_rowid))),
+                user_id=None,
+            )
+            assert loaded.id == ephemeral_rowid
 
-        # The refresh never deletes; the expired row is left for the sweeper.
+        # The refresh never deletes; the row is left for the sweeper.
         async with db() as session:
             surviving_rowid = await session.scalar(
-                select(models.AgentSession.id).where(models.AgentSession.id == temporary_rowid)
+                select(models.AgentSession.id).where(models.AgentSession.id == ephemeral_rowid)
             )
-            assert surviving_rowid == temporary_rowid
+            assert surviving_rowid == ephemeral_rowid
 
 
 class TestPersistDbTracesAndEmitEvent:

--- a/tests/unit/server/api/routers/test_agents.py
+++ b/tests/unit/server/api/routers/test_agents.py
@@ -60,16 +60,13 @@ class TestAgentSessionPersistence:
     ) -> None:
         async with db() as session:
             created = models.AgentSession(
-                project_session_id="11111111-1111-4111-8111-111111111111",
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
             )
             session.add(created)
             await session.flush()
-            assert created.project_session_id == "11111111-1111-4111-8111-111111111111"
             created_rowid = created.id
-            created_project_session_id = created.project_session_id
 
         async with db() as session:
             loaded = await _refresh_and_load_agent_session(
@@ -79,7 +76,6 @@ class TestAgentSessionPersistence:
             )
             assert loaded is not None
             assert loaded.id == created_rowid
-            assert loaded.project_session_id == created_project_session_id
             await session.execute(
                 delete(models.AgentSession).where(models.AgentSession.id == created_rowid)
             )
@@ -97,7 +93,6 @@ class TestAgentSessionPersistence:
     async def test_deleted_rowid_is_not_reused(self, db: DbSessionFactory) -> None:
         async with db() as session:
             first = models.AgentSession(
-                project_session_id="11111111-1111-4111-8111-111111111111",
                 user_id=None,
                 title="first",
                 project_name="assistant_agent",
@@ -109,7 +104,6 @@ class TestAgentSessionPersistence:
 
         async with db() as session:
             second = models.AgentSession(
-                project_session_id="22222222-2222-4222-8222-222222222222",
                 user_id=None,
                 title="second",
                 project_name="assistant_agent",
@@ -124,7 +118,6 @@ class TestAgentSessionPersistence:
     ) -> None:
         async with db() as session:
             temporary = models.AgentSession(
-                project_session_id="33333333-3333-4333-8333-333333333333",
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
@@ -161,7 +154,6 @@ class TestAgentSessionPersistence:
         stale = datetime.now(timezone.utc) - timedelta(days=30)
         async with db() as session:
             persistent = models.AgentSession(
-                project_session_id="44444444-4444-4444-8444-444444444444",
                 user_id=None,
                 title="",
                 project_name="assistant_agent",
@@ -199,7 +191,6 @@ class TestAgentSessionPersistence:
     ) -> None:
         async with db() as session:
             temporary = models.AgentSession(
-                project_session_id="55555555-5555-4555-8555-555555555555",
                 user_id=None,
                 title="",
                 project_name="assistant_agent",

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from uuid import uuid4
 
 from sqlalchemy import select
 from strawberry.relay import GlobalID
@@ -24,7 +23,6 @@ async def _seed_agent_session(
 ) -> str:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             user_id=user_id,
             title=title,
             project_name="assistant_agent",

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -8,6 +8,7 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 from tests.unit.graphql import AsyncGraphQLClient
 
 
@@ -37,10 +38,9 @@ async def _seed_agent_session(
         session.add_all(
             models.AgentSessionMessage(
                 agent_session_id=agent_session.id,
-                position=position,
                 message=PhoenixUIMessage.model_validate(message),
             )
-            for position, message in enumerate(messages or [])
+            for message in messages or []
         )
         return str(GlobalID("AgentSession", str(agent_session.id)))
 
@@ -194,17 +194,17 @@ async def test_agent_session_loads_transcript_by_id(
         user_id = user.id
     messages: list[dict[str, Any]] = [
         {
-            "id": "message-1",
+            "id": _message_uuid("message-1"),
             "role": "user",
             "parts": [{"type": "text", "text": "First question"}],
         },
         {
-            "id": "message-2",
+            "id": _message_uuid("message-2"),
             "role": "assistant",
             "parts": [{"type": "text", "text": "Earlier answer"}],
         },
         {
-            "id": "compaction-1",
+            "id": _message_uuid("compaction-1"),
             "role": "user",
             "metadata": {
                 "type": "user",
@@ -215,7 +215,7 @@ async def test_agent_session_loads_transcript_by_id(
             "parts": [{"type": "text", "text": '{"objectives":["test"]}'}],
         },
         {
-            "id": "message-3",
+            "id": _message_uuid("message-3"),
             "role": "assistant",
             "parts": [
                 {"type": "text", "text": "Latest"},

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -4,6 +4,7 @@ from typing import Any
 from sqlalchemy import select
 from strawberry.relay import GlobalID
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.types import DbSessionFactory
@@ -17,7 +18,7 @@ async def _seed_agent_session(
     title: str,
     updated_at: datetime,
     messages: list[dict[str, Any]] | None = None,
-    expires_at: datetime | None = None,
+    is_ephemeral: bool = False,
     user_id: int | None = None,
     heartbeat_at: datetime | None = None,
 ) -> str:
@@ -28,7 +29,7 @@ async def _seed_agent_session(
             project_name="assistant_agent",
             created_at=updated_at,
             updated_at=updated_at,
-            expires_at=expires_at,
+            is_ephemeral=is_ephemeral,
             heartbeat_at=heartbeat_at,
         )
         session.add(agent_session)
@@ -149,7 +150,7 @@ async def test_agent_sessions_excludes_temporary_sessions(
         db,
         title="temporary",
         updated_at=now,
-        expires_at=now + timedelta(days=1),
+        is_ephemeral=True,
     )
 
     response = await gql_client.execute(query=_LIST_QUERY)
@@ -264,18 +265,23 @@ async def test_agent_session_node_returns_not_found_when_missing(
     assert response.errors[0].message == f"Unknown agent session: {agent_session_id}"
 
 
-async def test_agent_session_node_returns_not_found_when_expired(
+async def test_agent_session_node_resolves_while_the_sweeper_has_not_reached_it(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    # A temporary session whose deadline has already passed reads as gone even
-    # though the sweeper has not yet deleted its row.
-    now = datetime.now(timezone.utc)
+    """An idle ephemeral session past its TTL still resolves by node id.
+
+    The permission check used to compare a stored deadline against the clock so
+    an unswept session read as gone. With the deadline derived from
+    ``updated_at`` there is nothing left to compare, and the owner keeps seeing
+    their own row until a sweep removes it.
+    """
     agent_session_id = await _seed_agent_session(
         db,
-        title="expired",
-        updated_at=now - timedelta(days=2),
-        expires_at=now - timedelta(seconds=1),
+        title="idle past its ttl",
+        updated_at=datetime.now(timezone.utc)
+        - timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1),
+        is_ephemeral=True,
     )
 
     response = await gql_client.execute(
@@ -283,6 +289,6 @@ async def test_agent_session_node_returns_not_found_when_expired(
         variables={"id": agent_session_id},
     )
 
-    assert response.data is None
-    assert response.errors
-    assert response.errors[0].message == f"Unknown agent session: {agent_session_id}"
+    assert not response.errors
+    assert response.data is not None
+    assert response.data["agentSession"]["id"] == agent_session_id

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -269,13 +269,6 @@ async def test_agent_session_node_resolves_while_the_sweeper_has_not_reached_it(
     db: DbSessionFactory,
     gql_client: AsyncGraphQLClient,
 ) -> None:
-    """An idle ephemeral session past its TTL still resolves by node id.
-
-    The permission check used to compare a stored deadline against the clock so
-    an unswept session read as gone. With the deadline derived from
-    ``updated_at`` there is nothing left to compare, and the owner keeps seeing
-    their own row until a sweep removes it.
-    """
     agent_session_id = await _seed_agent_session(
         db,
         title="idle past its ttl",

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -26,7 +26,6 @@ async def _seed_agent_session(
         agent_session = models.AgentSession(
             user_id=user_id,
             title=title,
-            project_name="assistant_agent",
             created_at=updated_at,
             updated_at=updated_at,
             is_ephemeral=is_ephemeral,

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -37,7 +37,6 @@ async def _add_agent_session(
 ) -> int:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_name="assistant_agent",
             user_id=user_id,
             title=title,
             is_ephemeral=is_ephemeral,
@@ -85,21 +84,18 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
     ttl = timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS)
     async with db() as session:
         expired = models.AgentSession(
-            project_name="assistant_agent",
             user_id=None,
             title="expired",
             is_ephemeral=True,
         )
         expired.created_at = expired.updated_at = now - ttl - timedelta(hours=1)
         active = models.AgentSession(
-            project_name="assistant_agent",
             user_id=None,
             title="active",
             is_ephemeral=True,
         )
         active.created_at = active.updated_at = now - timedelta(hours=1)
         persistent = models.AgentSession(
-            project_name="assistant_agent",
             user_id=None,
             title="persistent",
             is_ephemeral=False,

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from uuid import uuid4
 
 from sqlalchemy import select
 
@@ -33,7 +32,6 @@ async def _add_agent_session(
 ) -> int:
     async with db() as session:
         agent_session = models.AgentSession(
-            project_session_id=str(uuid4()),
             project_name="assistant_agent",
             user_id=user_id,
             title=title,
@@ -81,21 +79,18 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
     now = datetime.now(timezone.utc)
     async with db() as session:
         expired = models.AgentSession(
-            project_session_id="11111111-1111-4111-8111-111111111111",
             project_name="assistant_agent",
             user_id=None,
             title="expired",
             expires_at=now - timedelta(hours=1),
         )
         future = models.AgentSession(
-            project_session_id="22222222-2222-4222-8222-222222222222",
             project_name="assistant_agent",
             user_id=None,
             title="future",
             expires_at=now + timedelta(hours=1),
         )
         persistent = models.AgentSession(
-            project_session_id="33333333-3333-4333-8333-333333333333",
             project_name="assistant_agent",
             user_id=None,
             title="persistent",

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -9,6 +9,7 @@ from phoenix.server.daemons.agent_session_sweeper import AgentSessionSweeper
 from phoenix.server.daemons.system_settings import SystemSettings
 from phoenix.server.settings.registry import SETTINGS_REGISTRY, AgentSessionRetentionSetting
 from phoenix.server.types import DbSessionFactory
+from tests.unit._helpers import _message_uuid
 
 
 async def _make_settings(
@@ -108,8 +109,7 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
         session.add(
             models.AgentSessionMessage(
                 agent_session_id=expired_id,
-                position=0,
-                message=PhoenixUIMessage(id="message-1", role="user", parts=[]),
+                message=PhoenixUIMessage(id=_message_uuid("message-1"), role="user", parts=[]),
             )
         )
         session.add(

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -6,7 +6,11 @@ from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.daemons.agent_session_sweeper import AgentSessionSweeper
 from phoenix.server.daemons.system_settings import SystemSettings
-from phoenix.server.settings.registry import SETTINGS_REGISTRY, AgentSessionRetentionSetting
+from phoenix.server.settings.registry import (
+    DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER,
+    SETTINGS_REGISTRY,
+    AgentSessionRetentionSetting,
+)
 from phoenix.server.types import DbSessionFactory
 from tests.unit._helpers import _message_uuid
 
@@ -254,3 +258,43 @@ async def test_setting_edits_apply_on_the_next_sweep(
     await settings.update_agent_session_retention(AgentSessionRetentionSetting(max_idle_days=30))
     await sweeper._sweep()
     assert await _remaining_session_ids(db) == set()
+
+
+async def test_default_settings_enforce_both_rules_without_admin_configuration(
+    db: DbSessionFactory,
+) -> None:
+    """A workspace that never saves a retention setting still gets both rules.
+
+    ``_make_settings`` with no override leaves the
+    ``agent.assistant.session_retention`` row absent, which is the state every
+    deployment starts in.
+    """
+    now = datetime.now(timezone.utc)
+    user_id = await _add_user(db, "default-retention-user", "MEMBER")
+    idle_session_id = await _add_agent_session(
+        db,
+        title="idle past the default 30 days",
+        user_id=user_id,
+        updated_at=now - timedelta(days=31),
+    )
+    recent_session_ids = [
+        await _add_agent_session(
+            db,
+            title=f"recent session {minutes_ago}",
+            user_id=user_id,
+            updated_at=now - timedelta(minutes=minutes_ago),
+        )
+        # One more than the default per-user cap, so the oldest is trimmed.
+        for minutes_ago in range(DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER + 1)
+    ]
+
+    settings = await _make_settings(db)
+    assert settings.agent_session_retention.max_idle_days == 30
+    assert settings.agent_session_retention.max_count_per_user == 30
+    await AgentSessionSweeper(db, settings=settings)._sweep()
+
+    remaining_ids = await _remaining_session_ids(db)
+    # The idle session is gone on the idle rule, and the count cap keeps only
+    # the 30 most recently active of the user's remaining sessions.
+    assert idle_session_id not in remaining_ids
+    assert remaining_ids == set(recent_session_ids[:DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER])

--- a/tests/unit/server/daemons/test_agent_session_sweeper.py
+++ b/tests/unit/server/daemons/test_agent_session_sweeper.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
 
+from phoenix.config import EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS
 from phoenix.db import models
 from phoenix.db.types.data_stream_protocol import PhoenixUIMessage
 from phoenix.server.daemons.agent_session_sweeper import AgentSessionSweeper
@@ -32,14 +33,14 @@ async def _add_agent_session(
     title: str,
     user_id: int | None = None,
     updated_at: datetime | None = None,
-    expires_at: datetime | None = None,
+    is_ephemeral: bool = False,
 ) -> int:
     async with db() as session:
         agent_session = models.AgentSession(
             project_name="assistant_agent",
             user_id=user_id,
             title=title,
-            expires_at=expires_at,
+            is_ephemeral=is_ephemeral,
         )
         if updated_at is not None:
             agent_session.created_at = updated_at
@@ -81,29 +82,33 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
     db: DbSessionFactory,
 ) -> None:
     now = datetime.now(timezone.utc)
+    ttl = timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS)
     async with db() as session:
         expired = models.AgentSession(
             project_name="assistant_agent",
             user_id=None,
             title="expired",
-            expires_at=now - timedelta(hours=1),
+            is_ephemeral=True,
         )
-        future = models.AgentSession(
+        expired.created_at = expired.updated_at = now - ttl - timedelta(hours=1)
+        active = models.AgentSession(
             project_name="assistant_agent",
             user_id=None,
-            title="future",
-            expires_at=now + timedelta(hours=1),
+            title="active",
+            is_ephemeral=True,
         )
+        active.created_at = active.updated_at = now - timedelta(hours=1)
         persistent = models.AgentSession(
             project_name="assistant_agent",
             user_id=None,
             title="persistent",
-            expires_at=None,
+            is_ephemeral=False,
         )
-        session.add_all((expired, future, persistent))
+        persistent.created_at = persistent.updated_at = now - ttl - timedelta(hours=1)
+        session.add_all((expired, active, persistent))
         await session.flush()
         expired_id = expired.id
-        future_id = future.id
+        active_id = active.id
         persistent_id = persistent.id
         session.add(
             models.AgentSessionMessage(
@@ -119,17 +124,22 @@ async def test_agent_session_sweeper_deletes_only_expired_sessions_and_cascades(
         )
 
     settings = await _make_settings(db)
-    await AgentSessionSweeper(db, settings=settings)._delete_expired_temporary_sessions()
+    await AgentSessionSweeper(db, settings=settings)._delete_idle_sessions(
+        is_ephemeral=True,
+        max_idle=ttl,
+    )
 
     async with db() as session:
         remaining_ids = set((await session.scalars(select(models.AgentSession.id))).all())
-        assert remaining_ids == {future_id, persistent_id}
+        # The persisted session is equally idle and equally untouched: the
+        # ephemeral pass is scoped by the flag, not by idleness alone.
+        assert remaining_ids == {active_id, persistent_id}
         assert expired_id not in remaining_ids
         assert (await session.scalars(select(models.AgentSessionMessage))).all() == []
         assert (await session.scalars(select(models.AgentSessionSnapshot))).all() == []
 
 
-async def test_idle_pass_deletes_idle_persisted_sessions_but_never_temporary_ones(
+async def test_idle_pass_deletes_idle_persisted_sessions_and_spares_active_ephemeral_ones(
     db: DbSessionFactory,
 ) -> None:
     now = datetime.now(timezone.utc)
@@ -143,18 +153,51 @@ async def test_idle_pass_deletes_idle_persisted_sessions_but_never_temporary_one
         title="active persisted",
         updated_at=now - timedelta(days=1),
     )
-    idle_temporary_id = await _add_agent_session(
+    active_ephemeral_id = await _add_agent_session(
         db,
-        title="idle temporary",
-        updated_at=now - timedelta(days=31),
-        expires_at=now + timedelta(hours=1),
+        title="active ephemeral",
+        updated_at=now - timedelta(hours=1),
+        is_ephemeral=True,
     )
 
     settings = await _make_settings(db, AgentSessionRetentionSetting(max_idle_days=30))
     await AgentSessionSweeper(db, settings=settings)._sweep()
 
-    assert await _remaining_session_ids(db) == {active_persisted_id, idle_temporary_id}
+    assert await _remaining_session_ids(db) == {active_persisted_id, active_ephemeral_id}
     assert idle_persisted_id not in await _remaining_session_ids(db)
+
+
+async def test_the_two_passes_apply_different_idle_windows_to_the_same_staleness(
+    db: DbSessionFactory,
+) -> None:
+    """The flag chooses the window, and nothing else about a session does.
+
+    Both sessions were last touched at the same moment; only ``is_ephemeral``
+    differs, and it is what decides whether the deadline is the fixed
+    ephemeral TTL or the workspace's much longer retention window.
+    """
+    idle_for = timedelta(hours=EPHEMERAL_AGENT_SESSION_TIME_TO_LIVE_HOURS + 1)
+    updated_at = datetime.now(timezone.utc) - idle_for
+    assert idle_for < timedelta(days=30), "the persisted session must be inside retention"
+
+    ephemeral_id = await _add_agent_session(
+        db,
+        title="ephemeral past its ttl",
+        updated_at=updated_at,
+        is_ephemeral=True,
+    )
+    persisted_id = await _add_agent_session(
+        db,
+        title="persisted, same staleness",
+        updated_at=updated_at,
+    )
+
+    settings = await _make_settings(db, AgentSessionRetentionSetting(max_idle_days=30))
+    await AgentSessionSweeper(db, settings=settings)._sweep()
+
+    remaining_ids = await _remaining_session_ids(db)
+    assert remaining_ids == {persisted_id}
+    assert ephemeral_id not in remaining_ids
 
 
 async def test_count_pass_keeps_newest_sessions_per_user(
@@ -174,13 +217,15 @@ async def test_count_pass_keeps_newest_sessions_per_user(
         )
         for days_ago in (1, 2, 3, 4)
     ]
-    # The first user's oldest activity is a temporary session — exempt from the cap.
-    first_user_temporary_id = await _add_agent_session(
+    # The first user's most recent activity is an ephemeral session. It is exempt
+    # from the cap, so it must neither be trimmed itself nor occupy one of the
+    # user's two slots and push a persisted session out.
+    first_user_ephemeral_id = await _add_agent_session(
         db,
-        title="first-user temporary",
+        title="first-user ephemeral",
         user_id=first_user_id,
-        updated_at=now - timedelta(days=10),
-        expires_at=now + timedelta(hours=1),
+        updated_at=now - timedelta(hours=1),
+        is_ephemeral=True,
     )
     second_user_session_id = await _add_agent_session(
         db,
@@ -203,13 +248,13 @@ async def test_count_pass_keeps_newest_sessions_per_user(
 
     assert await _remaining_session_ids(db) == {
         *first_user_session_ids[:2],
-        first_user_temporary_id,
+        first_user_ephemeral_id,
         second_user_session_id,
         *anonymous_session_ids[:2],
     }
 
 
-async def test_all_zero_setting_runs_only_temporary_gc(
+async def test_all_zero_setting_runs_only_ephemeral_gc(
     db: DbSessionFactory,
 ) -> None:
     now = datetime.now(timezone.utc)
@@ -223,11 +268,11 @@ async def test_all_zero_setting_runs_only_temporary_gc(
         )
         for days_ago in (400, 500, 600)
     ]
-    expired_temporary_id = await _add_agent_session(
+    expired_ephemeral_id = await _add_agent_session(
         db,
-        title="expired temporary",
+        title="expired ephemeral",
         updated_at=now - timedelta(days=2),
-        expires_at=now - timedelta(hours=1),
+        is_ephemeral=True,
     )
 
     settings = await _make_settings(
@@ -237,7 +282,7 @@ async def test_all_zero_setting_runs_only_temporary_gc(
 
     remaining_ids = await _remaining_session_ids(db)
     assert remaining_ids == set(ancient_session_ids)
-    assert expired_temporary_id not in remaining_ids
+    assert expired_ephemeral_id not in remaining_ids
 
 
 async def test_setting_edits_apply_on_the_next_sweep(

--- a/tests/unit/server/daemons/test_system_settings.py
+++ b/tests/unit/server/daemons/test_system_settings.py
@@ -7,6 +7,8 @@ import pytest
 from phoenix.db import models
 from phoenix.server.daemons.system_settings import SystemSettings
 from phoenix.server.settings.registry import (
+    DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER,
+    DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS,
     SETTINGS_REGISTRY,
     AgentSessionRetentionSetting,
     AgentTraceRecordingSetting,
@@ -48,11 +50,13 @@ async def test_update_agent_trace_recording_persists_and_updates_cache(
 async def test_agent_session_retention_defaults_when_unset(
     db: DbSessionFactory,
 ) -> None:
+    """Both retention rules are on by default, so a workspace that never opens
+    the admin settings still bounds how much chat history it keeps."""
     settings = SystemSettings(db=db, registry=SETTINGS_REGISTRY)
     await settings.bootstrap()
     retention = settings.agent_session_retention
-    assert retention.max_idle_days == 0
-    assert retention.max_count_per_user == 0
+    assert retention.max_idle_days == DEFAULT_AGENT_SESSION_MAX_IDLE_DAYS == 30
+    assert retention.max_count_per_user == DEFAULT_AGENT_SESSION_MAX_COUNT_PER_USER == 30
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part 6 of the stack. **Base: `agent-sessions-is-ephemeral` (#14914)** — review that one first.

Drops `agent_sessions.project_name`. Nothing ever wrote a value other than `get_env_phoenix_agents_assistant_project_name()` — the REST create route and the `createAgentSession` / `branchAgentSession` mutations all stamped the same env-derived string, and the chat route read it back a turn later. The chat route now reads the config directly, which is what the legacy `/agents/chat` route already did.

## Behavior

A change to `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME` now takes effect on the next turn of an existing session, not just on sessions created after the change. That turn's spans land in the newly configured project, and since the OTel session id is `"{project_name}:{AgentSession GlobalID}"`, the turn groups under a new project session there. Earlier turns stay where they were written.

That is the intended reading of the setting: it names where assistant traces go, not where a given session's traces went once. Pinning was only ever honored for local ingestion anyway — remote export routes by the resource attributes the tracer is built with, and that value is read fresh.

## Migration

Edited into `e767d3c57f32` in place, as the rest of the stack does — the table is unreleased, so there is no deployed column to drop. `scripts/ddl/postgresql_schema.sql` regenerated.

## API surface

Untouched. The column was never exposed over GraphQL or REST, so `app/schema.graphql` and `schemas/openapi.json` are byte-identical and no frontend code changes.

## Tests

`test_resumed_chat_turn_keeps_original_trace_project` pinned the old contract, so it becomes `test_resumed_chat_turn_follows_the_configured_trace_project` and asserts what replaced it: the two turns build tracers for the original and the changed project, their traces land in those two projects, and each turn's project session carries the OTel session id derived from the project configured at the time. The branch-mutation test drops its "branch adopts the currently configured project" assertion and keeps the part that still holds.

Verified: 457 pytest across the agents, agent-session mutation/type/router and sweeper suites; `mypy`, `ruff`, and `make schema-ddl` (Alembic on ephemeral PostgreSQL) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)