### PR TITLE
fix(agents): hide draft session from session list menu

### DIFF
--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -177,9 +177,8 @@ function AgentSessionsContent({
   // row yet, so listing it would only offer a "New chat" entry that cannot be
   // deleted or meaningfully switched to. The header still labels the active
   // draft via the display-name fallback below.
-  const orderedSessions = serverSessions;
-  const orderedSessionsRef = useRef(orderedSessions);
-  orderedSessionsRef.current = orderedSessions;
+  const serverSessionsRef = useRef(serverSessions);
+  serverSessionsRef.current = serverSessions;
 
   // On first open with no selection, resume the most recent conversation, or
   // start a draft when the user has no sessions yet.
@@ -187,7 +186,7 @@ function AgentSessionsContent({
     if (activeSessionId !== null || store.getState().activeSessionId !== null) {
       return;
     }
-    const mostRecentSession = orderedSessionsRef.current[0];
+    const mostRecentSession = serverSessionsRef.current[0];
     setActiveSession(mostRecentSession?.id ?? DRAFT_SESSION_ID);
   }, [activeSessionId, setActiveSession, store]);
 
@@ -216,7 +215,7 @@ function AgentSessionsContent({
       }
       const isDeletingActiveSession = activeSessionId === sessionId;
       if (isDeletingActiveSession) {
-        const nextSession = orderedSessionsRef.current.find(
+        const nextSession = serverSessionsRef.current.find(
           (candidate) => candidate.id !== sessionId
         );
         setActiveSession(nextSession?.id ?? DRAFT_SESSION_ID);
@@ -252,7 +251,7 @@ function AgentSessionsContent({
     ]
   );
 
-  const activeSession = orderedSessions.find(
+  const activeSession = serverSessions.find(
     (session) => session.id === activeSessionId
   );
   const sessionDisplayName = activeSession?.title || EMPTY_SESSION_DISPLAY_NAME;
@@ -295,7 +294,7 @@ function AgentSessionsContent({
           ConnectionHandler.deleteNode(connection, sessionId);
         }
       });
-      const nextSession = orderedSessionsRef.current.find(
+      const nextSession = serverSessionsRef.current.find(
         (session) => session.id !== sessionId
       );
       setActiveSession(nextSession?.id ?? DRAFT_SESSION_ID);
@@ -320,7 +319,7 @@ function AgentSessionsContent({
     <>
       <AgentChatHeader
         sessionDisplayName={sessionDisplayName}
-        orderedSessions={orderedSessions}
+        orderedSessions={serverSessions}
         activeSessionId={activeSessionId}
         activeSessionTitleFragment={
           activeSessionId == null

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -173,17 +173,11 @@ function AgentSessionsContent({
         chatStatusBySessionId[node.id] === "streaming",
     })
   );
-  const draftSession: AgentSessionListItem | null =
-    activeSessionId === DRAFT_SESSION_ID
-      ? {
-          id: DRAFT_SESSION_ID,
-          title: "",
-          createdAt: Date.now(),
-        }
-      : null;
-  const orderedSessions = draftSession
-    ? [draftSession, ...serverSessions]
-    : serverSessions;
+  // The active draft is deliberately absent from the menu: it has no server
+  // row yet, so listing it would only offer a "New chat" entry that cannot be
+  // deleted or meaningfully switched to. The header still labels the active
+  // draft via the display-name fallback below.
+  const orderedSessions = serverSessions;
   const orderedSessionsRef = useRef(orderedSessions);
   orderedSessionsRef.current = orderedSessions;
 

--- a/app/src/components/agent/AgentSessionsResource.tsx
+++ b/app/src/components/agent/AgentSessionsResource.tsx
@@ -1,11 +1,4 @@
-import {
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
   ConnectionHandler,
@@ -162,33 +155,33 @@ function AgentSessionsContent({
     setActiveSession(DRAFT_SESSION_ID);
   }, [setActiveSession, store]);
 
-  const serverSessions: AgentSessionListItem[] = data.agentSessions.edges.map(
-    ({ node }) => ({
-      id: node.id,
-      title: node.title,
-      isTemporary: node.isTemporary,
-      createdAt: Date.parse(node.createdAt as string),
-      isDeleteDisabled:
-        chatStatusBySessionId[node.id] === "submitted" ||
-        chatStatusBySessionId[node.id] === "streaming",
-    })
-  );
   // The active draft is deliberately absent from the menu: it has no server
   // row yet, so listing it would only offer a "New chat" entry that cannot be
   // deleted or meaningfully switched to. The header still labels the active
   // draft via the display-name fallback below.
-  const serverSessionsRef = useRef(serverSessions);
-  serverSessionsRef.current = serverSessions;
+  const serverSessions: AgentSessionListItem[] = useMemo(
+    () =>
+      data.agentSessions.edges.map(({ node }) => ({
+        id: node.id,
+        title: node.title,
+        isTemporary: node.isTemporary,
+        createdAt: Date.parse(node.createdAt as string),
+        isDeleteDisabled:
+          chatStatusBySessionId[node.id] === "submitted" ||
+          chatStatusBySessionId[node.id] === "streaming",
+      })),
+    [chatStatusBySessionId, data.agentSessions.edges]
+  );
 
   // On first open with no selection, resume the most recent conversation, or
   // start a draft when the user has no sessions yet.
+  const mostRecentServerSessionId = data.agentSessions.edges[0]?.node.id;
   useEffect(() => {
     if (activeSessionId !== null || store.getState().activeSessionId !== null) {
       return;
     }
-    const mostRecentSession = serverSessionsRef.current[0];
-    setActiveSession(mostRecentSession?.id ?? DRAFT_SESSION_ID);
-  }, [activeSessionId, setActiveSession, store]);
+    setActiveSession(mostRecentServerSessionId ?? DRAFT_SESSION_ID);
+  }, [activeSessionId, mostRecentServerSessionId, setActiveSession, store]);
 
   const [commitDelete] =
     useMutation<AgentSessionsResourceDeleteMutation>(graphql`
@@ -215,7 +208,7 @@ function AgentSessionsContent({
       }
       const isDeletingActiveSession = activeSessionId === sessionId;
       if (isDeletingActiveSession) {
-        const nextSession = serverSessionsRef.current.find(
+        const nextSession = serverSessions.find(
           (candidate) => candidate.id !== sessionId
         );
         setActiveSession(nextSession?.id ?? DRAFT_SESSION_ID);
@@ -246,6 +239,7 @@ function AgentSessionsContent({
       commitDelete,
       connectionId,
       runtime,
+      serverSessions,
       setActiveSession,
       store,
     ]
@@ -294,12 +288,12 @@ function AgentSessionsContent({
           ConnectionHandler.deleteNode(connection, sessionId);
         }
       });
-      const nextSession = serverSessionsRef.current.find(
+      const nextSession = serverSessions.find(
         (session) => session.id !== sessionId
       );
       setActiveSession(nextSession?.id ?? DRAFT_SESSION_ID);
     },
-    [relayEnvironment, setActiveSession]
+    [relayEnvironment, serverSessions, setActiveSession]
   );
 
   // Decide once per session activation whether the surface must first seed


### PR DESCRIPTION
## Summary

The active draft session was injected into the session list menu as a synthetic "New chat" row with a delete button that had no server session to delete. The menu now lists only persisted server sessions:

- Panel header still labels the active draft "New chat" via the existing display-name fallback
- With no persisted sessions, the menu shows the "No sessions yet" empty state
- Next-session selection after delete and missing-session handling are unaffected

Fixes #14880