### PR TITLE
fix(agents): truncate tool results sent to the summarizer

### DIFF
--- a/src/phoenix/server/agents/summarization.py
+++ b/src/phoenix/server/agents/summarization.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from typing import Any, TypeVar, cast
+
 from pydantic import BaseModel, Field, field_validator
 from pydantic_ai.messages import (
+    BaseToolReturnPart,
     InstructionPart,
     ModelMessage,
     ModelRequest,
@@ -24,6 +28,44 @@ from phoenix.server.agents.session_titles import (
 
 SUMMARY_TOOL_NAME = "summary"
 COMPACTION_TOOL_NAME = "conversation_checkpoint"
+
+MAX_SUMMARIZED_TOOL_RESULT_LENGTH = 2_000
+"""How much of each tool result the summarizer is allowed to see."""
+
+_ToolReturnPartT = TypeVar("_ToolReturnPartT", bound=BaseToolReturnPart)
+
+
+def _truncate_tool_result(part: _ToolReturnPartT) -> _ToolReturnPartT:
+    """Cap a tool result's text, keeping any multimodal files intact."""
+    text = part.model_response_str(wrap_if_error=False)
+    if len(text) <= MAX_SUMMARIZED_TOOL_RESULT_LENGTH:
+        return part
+    elided = len(text) - MAX_SUMMARIZED_TOOL_RESULT_LENGTH
+    truncated = (
+        f"{text[:MAX_SUMMARIZED_TOOL_RESULT_LENGTH]}"
+        f"\n[... {elided} characters truncated for summarization]"
+    )
+    files = part.files
+    return replace(part, content=[truncated, *files] if files else truncated)
+
+
+def _truncate_tool_results(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Return a copy of ``messages`` with every tool result capped in size.
+
+    Tool output is usually the bulk of a session's context and the reason a session needs
+    compacting in the first place, but a checkpoint or a title only needs durable facts, so
+    the summarizer sees a truncated copy. The persisted history is never modified.
+    """
+    truncated_messages: list[ModelMessage] = []
+    for message in messages:
+        parts = [
+            _truncate_tool_result(part) if isinstance(part, BaseToolReturnPart) else part
+            for part in message.parts
+        ]
+        if any(new is not old for new, old in zip(parts, message.parts)):
+            message = replace(message, parts=cast(Any, parts))
+        truncated_messages.append(message)
+    return truncated_messages
 
 
 class _Summary(BaseModel):
@@ -86,7 +128,7 @@ async def summarize_messages(
     try:
         response = await model.request(
             [
-                *messages,
+                *_truncate_tool_results(messages),
                 ModelRequest(
                     # Explicitly add user message to support anthropic models that forbid assistant
                     # message prefill
@@ -125,7 +167,7 @@ async def summarize_messages_for_compaction(
     try:
         response = await model.request(
             [
-                *messages,
+                *_truncate_tool_results(messages),
                 ModelRequest(
                     # Explicitly add user message to support anthropic models that forbid assistant
                     # message prefill

--- a/tests/unit/server/agents/test_summarization.py
+++ b/tests/unit/server/agents/test_summarization.py
@@ -1,0 +1,151 @@
+from typing import Any
+
+import pytest
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from phoenix.server.agents.summarization import (
+    MAX_SUMMARIZED_TOOL_RESULT_LENGTH,
+    summarize_messages,
+    summarize_messages_for_compaction,
+)
+
+CHECKPOINT: dict[str, Any] = {
+    "objectives": ["Investigate the trace"],
+    "constraints_and_preferences": [],
+    "decisions": [],
+    "completed_work": [],
+    "active_work": [],
+    "blockers": [],
+    "next_steps": [],
+    "important_details": [],
+}
+
+
+def _tool_result(content: Any) -> ModelRequest:
+    return ModelRequest(
+        parts=[ToolReturnPart(tool_name="get_spans", content=content, tool_call_id="call-1")]
+    )
+
+
+def _recording_model(
+    seen: list[ModelMessage],
+    *,
+    tool_name: str,
+    args: Any,
+) -> FunctionModel:
+    def function(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+        seen.extend(messages)
+        return ModelResponse(parts=[ToolCallPart(tool_name=tool_name, args=args)])
+
+    return FunctionModel(function=function)
+
+
+def _sent_tool_results(seen: list[ModelMessage]) -> list[ToolReturnPart]:
+    return [part for message in seen for part in message.parts if isinstance(part, ToolReturnPart)]
+
+
+async def test_compaction_truncates_oversized_tool_results() -> None:
+    seen: list[ModelMessage] = []
+    content = "x" * (MAX_SUMMARIZED_TOOL_RESULT_LENGTH + 500)
+    messages: list[ModelMessage] = [_tool_result(content)]
+
+    await summarize_messages_for_compaction(
+        messages=messages,
+        model=_recording_model(seen, tool_name="conversation_checkpoint", args=CHECKPOINT),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert sent.content == (
+        "x" * MAX_SUMMARIZED_TOOL_RESULT_LENGTH
+        + "\n[... 500 characters truncated for summarization]"
+    )
+    # the caller's messages are left untouched
+    assert isinstance(messages[0].parts[0], ToolReturnPart)
+    assert messages[0].parts[0].content == content
+
+
+async def test_summarization_truncates_oversized_tool_results() -> None:
+    seen: list[ModelMessage] = []
+    messages: list[ModelMessage] = [_tool_result("x" * (MAX_SUMMARIZED_TOOL_RESULT_LENGTH + 1))]
+
+    await summarize_messages(
+        messages=messages,
+        model=_recording_model(seen, tool_name="summary", args={"summary": "Trace triage"}),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert isinstance(sent.content, str)
+    assert sent.content.endswith("[... 1 characters truncated for summarization]")
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("x" * MAX_SUMMARIZED_TOOL_RESULT_LENGTH, id="text-at-the-limit"),
+        pytest.param({"spans": ["a", "b"]}, id="structured-content"),
+        pytest.param(["a", "b"], id="list-content"),
+    ],
+)
+async def test_tool_results_within_the_limit_are_passed_through_unchanged(content: Any) -> None:
+    seen: list[ModelMessage] = []
+    messages: list[ModelMessage] = [_tool_result(content)]
+
+    await summarize_messages_for_compaction(
+        messages=messages,
+        model=_recording_model(seen, tool_name="conversation_checkpoint", args=CHECKPOINT),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert sent.content == content
+
+
+async def test_oversized_structured_tool_results_are_truncated_as_json() -> None:
+    seen: list[ModelMessage] = []
+    messages: list[ModelMessage] = [
+        _tool_result({"spans": ["x" * MAX_SUMMARIZED_TOOL_RESULT_LENGTH]})
+    ]
+
+    await summarize_messages_for_compaction(
+        messages=messages,
+        model=_recording_model(seen, tool_name="conversation_checkpoint", args=CHECKPOINT),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert isinstance(sent.content, str)
+    assert sent.content.startswith('{"spans":["xxx')
+    assert sent.content.endswith("characters truncated for summarization]")
+
+
+async def test_truncation_keeps_multimodal_files_and_other_parts() -> None:
+    seen: list[ModelMessage] = []
+    image = BinaryContent(data=b"png-bytes", media_type="image/png")
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="Find the slow span")]),
+        ModelResponse(parts=[TextPart(content="Looking now")]),
+        _tool_result(["x" * (MAX_SUMMARIZED_TOOL_RESULT_LENGTH + 10), image]),
+    ]
+
+    await summarize_messages_for_compaction(
+        messages=messages,
+        model=_recording_model(seen, tool_name="conversation_checkpoint", args=CHECKPOINT),
+    )
+
+    (sent,) = _sent_tool_results(seen)
+    assert isinstance(sent.content, list)
+    truncated, kept_image = sent.content
+    assert isinstance(truncated, str)
+    assert truncated.endswith("characters truncated for summarization]")
+    assert kept_image == image
+    # untouched messages are forwarded as-is
+    assert seen[0] is messages[0]
+    assert seen[1] is messages[1]


### PR DESCRIPTION
Closes #14928

Compaction forwarded the session's message history verbatim to `summarize_messages_for_compaction`, tool results included. Since oversized tool output (bash output, file reads, GraphQL results) is usually *why* a session needs compacting, the summarization request could approach or exceed the model's context window exactly when compaction was most needed — failing with a `CompactionError`. Even when it succeeded, it shared no cacheable prefix with agent turns, so every byte was paid for cold.

## Change

`_truncate_tool_results` walks the history and caps each tool result at 2,000 characters, replacing the excess with `[... N characters truncated for summarization]`.

- **Only the copy sent to the model is truncated.** Parts are rebuilt with `dataclasses.replace`; messages with nothing to truncate are forwarded by identity, so persisted history and the live adapter's `messages` are never mutated.
- **Applies to every tool-result part**, in requests and responses alike (`ToolReturnPart`, `ToolSearchReturnPart`, `NativeToolReturnPart`, `LoadCapabilityReturnPart` — anything deriving from `BaseToolReturnPart`).
- **Multimodal files are preserved** — only the text portion is capped; images and other attachments pass through intact.
- **Structured content is left alone when it fits**, and serialized to JSON before truncation only when it's oversized.
- `summarize_messages` (session titles) has the same exposure and gets the same cap.

The checkpoint schema only records durable facts — objectives, decisions, blockers, identifiers — so full tool payloads were not carrying their weight in the summary.

## Testing

New `tests/unit/server/agents/test_summarization.py` covers truncation for both summarizers, non-mutation of the caller's messages, pass-through at and under the limit (text, dict, and list content), JSON truncation of oversized structured content, and file preservation. Full `tests/unit/server/agents` suite passes (398 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)