### PR TITLE
fix(server): make the monty binary discoverable in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,19 @@ ENV PHOENIX_WASM_BINARY_PATH=/opt/phoenix/wasm/python-3.12.0.wasm
 # distroless image's default PATH already includes /usr/local/bin, but
 # we set it explicitly to keep DENO discovery insensitive to base-image
 # PATH drift on future bumps.
-ENV PATH="/usr/local/bin:/usr/bin:/bin"
+#
+# /phoenix/.venv/bin is appended so console scripts shipped by wheels are
+# discoverable — today the `monty` binary from pydantic-monty-runtime,
+# which the Monty sandbox and MCP code mode spawn as a worker process.
+# The ENTRYPOINT runs the *system* interpreter with the venv's
+# site-packages on PYTHONPATH rather than the venv's own interpreter, so
+# sysconfig.get_path("scripts") reports /usr/local/bin and never the
+# venv's bin; PATH is the only lookup left that can reach it (see
+# pydantic_monty._binary.find_monty_binary). Appended rather than
+# prepended because the venv's python/python3/python3.13 symlinks point
+# at the builder image's interpreter and dangle here — the system
+# interpreter must keep winning any name collision.
+ENV PATH="/usr/local/bin:/usr/bin:/bin:/phoenix/.venv/bin"
 ENV PYTHONPATH="/phoenix/.venv/lib/python3.13/site-packages:$PYTHONPATH"
 ENV PYTHONUNBUFFERED=1
 # Expose the Phoenix port.

--- a/scripts/docker/devops/Dockerfile
+++ b/scripts/docker/devops/Dockerfile
@@ -107,6 +107,13 @@ COPY --chmod=755 --from=deno-binary /deno /usr/local/bin/deno
 COPY --from=backend-builder /wasm/python-3.12.0.wasm /opt/phoenix/wasm/python-3.12.0.wasm
 ENV PHOENIX_WASM_BINARY_PATH=/opt/phoenix/wasm/python-3.12.0.wasm
 
+# The `monty` worker binary that the Monty sandbox and MCP code mode spawn.
+# pydantic-monty-runtime installs it into the builder venv's bin directory,
+# which the site-packages-only copy above does not carry, so it has to come
+# across on its own. /usr/local/bin is both this image's scripts directory
+# and on PATH, so find_monty_binary() in pydantic_monty._binary resolves it.
+COPY --from=backend-builder /phoenix/.venv/bin/monty /usr/local/bin/monty
+
 # Environment setup
 ENV PYTHONPATH="/phoenix/env"
 ENV PYTHONUNBUFFERED=1

--- a/src/phoenix/server/monty_runtime.py
+++ b/src/phoenix/server/monty_runtime.py
@@ -141,7 +141,15 @@ class MontyRuntime:
                         checkout_timeout=self._checkout_timeout,
                     )
                 )
-            except (RuntimeError, OSError) as exc:
+            except Exception as exc:
+                # Any startup failure is a deployment fault, so catch broadly
+                # rather than by type. Binary resolution runs inside this call
+                # and does not restrict what it raises: a missing binary is
+                # FileNotFoundError, but ``find_monty_binary``'s editable-install
+                # probe walks four parent directories unguarded, so a deployment
+                # that installs the package nearer the filesystem root raises
+                # IndexError. Anything uncaught here would reach the caller as a
+                # bare exception, past every mapping onto a MontyServiceError.
                 await stack.aclose()
                 logger.exception("Failed to start the Monty worker pool.")
                 raise MontyUnavailable("The Monty worker pool could not be started") from exc

--- a/tests/unit/server/test_mcp_code_mode.py
+++ b/tests/unit/server/test_mcp_code_mode.py
@@ -283,6 +283,32 @@ async def test_unstartable_pool_reports_a_tool_error(monkeypatch: pytest.MonkeyP
         await runtime.aclose()
 
 
+async def test_pool_startup_failure_of_any_type_reports_a_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup failures are not confined to OSError.
+
+    Locating the worker binary happens inside pool startup, and upstream's
+    editable-install probe walks four parent directories unguarded, so an
+    install nearer the filesystem root — a container that flattens
+    site-packages onto its Python path, for one — raises IndexError instead of
+    FileNotFoundError. Type-based handling would let that reach the caller raw.
+    """
+
+    def unresolvable_binary(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise IndexError("tuple index out of range")
+
+    monkeypatch.setattr("pydantic_monty.AsyncMonty", unresolvable_binary)
+    runtime = MontyRuntime()
+    provider = MontyPoolSandboxProvider(runtime=runtime)
+    try:
+        with pytest.raises(ToolError, match="could not be started"):
+            await provider.run("return 1")
+    finally:
+        await runtime.aclose()
+
+
 async def test_dropped_pool_during_shutdown_reports_a_tool_error() -> None:
     """A call that loses its pool to shutdown reports shutdown, not RuntimeError."""
     runtime = MontyRuntime()


### PR DESCRIPTION
Fixes #14934

## Problem

Every MCP code-mode `execute` call fails in the published image with `MontyUnavailable`, so `/mcp` is non-functional out of the box for Docker deployments: discovery (`list_tools`, `get_schema`, `search`, `tags`) works, and then every call fails. `PHOENIX_ENABLE_MCP_CODE_MODE` defaults to true, and `execute` is the only way to invoke a tool in code mode.

The `monty` binary ships at `/phoenix/.venv/bin/monty` and runs correctly. Nothing is missing from the image — it is purely a discovery failure. No lookup step in `pydantic_monty._binary.find_monty_binary` can reach the binary:

- `MONTY_BIN` was unset.
- The entrypoint runs the **system** interpreter with the venv's site-packages injected via `PYTHONPATH`, rather than the venv's own interpreter, so `sysconfig.get_path("scripts")` reports `/usr/local/bin` and never the venv's bin.
- `PATH` was pinned to `/usr/local/bin:/usr/bin:/bin`, which omits the venv's bin.

The devops image (`scripts/docker/devops/Dockerfile`) has a worse variant of the same bug: it copies only `.venv/lib/python*/site-packages` into `/phoenix/env` and never copies `.venv/bin`, so the binary is absent entirely. In that flattened layout the resolver does not even reach its `FileNotFoundError` — `_development_binary()` does `Path(__file__).resolve().parents[4]` on a package that sits three levels below the root and raises `IndexError`. `MontyRuntime._ensure_pool` caught only `(RuntimeError, OSError)`, so that `IndexError` escaped past every mapping onto `MontyUnavailable` and would reach the MCP caller as a bare exception instead of a `ToolError`.

## Changes

- **`Dockerfile`** — append `/phoenix/.venv/bin` to `PATH`. Appended rather than prepended because the venv's `python`, `python3`, and `python3.13` entries are dangling symlinks to the builder image's interpreter in the final image (verified below); the system interpreter must keep winning any name collision. This also covers future wheels that ship binaries through the venv's bin.
- **`scripts/docker/devops/Dockerfile`** — copy the binary to `/usr/local/bin/monty`, mirroring how the Deno binary is bundled. That directory is both this image's scripts directory and on its `PATH`. Copying the whole `.venv/bin` would not work for that image: its console scripts carry `#!/phoenix/.venv/bin/python` shebangs, and this image has no venv at all.
- **`src/phoenix/server/monty_runtime.py`** — catch any exception from pool startup, so a resolver failure of any type becomes `MontyUnavailable` and reaches the caller as a `ToolError`.
- **`tests/unit/server/test_mcp_code_mode.py`** — regression test for that mapping; it fails with a raw `IndexError` on the old handler.

## Verification

End to end against a container built from this branch's `Dockerfile`, with the unmodified published image as a control. Both were started the same way, with no environment overrides beyond a writable working directory, and called over MCP with `execute` running `return sum(x * x for x in range(10))`.

Built from this branch:

```
PATH                : /usr/local/bin:/usr/bin:/bin:/phoenix/.venv/bin
which(monty)        : /phoenix/.venv/bin/monty
which(deno)         : /usr/local/bin/deno
find_monty_binary() : /phoenix/.venv/bin/monty
probe_runtime()     : True

MCP tools: ['search', 'get_schema', 'tags', 'list_tools', 'execute']
execute -> 285
```

Published `arizephoenix/phoenix:version-19.10.0`:

```
execute -> FAILED: ToolError The code-mode sandbox could not be started, so no code can run.
                   This is a server configuration problem; check the Phoenix logs.
```

`which(deno)` still resolving to `/usr/local/bin/deno` confirms the appended entry does not disturb the existing sandbox provider.

The published image also shows why the venv bin is appended rather than prepended:

```
python     -> /usr/local/bin/python3   BROKEN
python3    -> python                   BROKEN
python3.13 -> python                   BROKEN
```

Rebuilt devops image:

```
which(monty)        : /usr/local/bin/monty
find_monty_binary() : /usr/local/bin/monty
probe_runtime()     : True
```

`execute` over MCP against the rebuilt devops stack likewise returns `285`, where the tool previously failed on every call.

`tests/unit/server/test_mcp_code_mode.py` (35 passed), `tests/unit/server/sandbox/test_monty_backend.py` (11 passed), ruff, and mypy are clean.

## Not included

The issue also suggests surfacing the underlying `FileNotFoundError` in the MCP-facing error. I left that message generic, since including the path and exception would send server filesystem details to MCP clients, and the actionable message is already logged at exception level. A build-time or CI smoke check that would catch this class of regression is likewise not included here; happy to add one if reviewers want it.
