### PR TITLE
feat: add semantic coloring to project metric tooltips

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2947,7 +2947,17 @@ type Project implements Node {
   The bindable terms of the session filter expression language for this project, for autocomplete, agent discovery, and docs. Static terms derive from the filter compiler's own bindings so they cannot drift from what compiles; observed per-project names (session annotations, root-span attribute paths) are folded in. Observed names come from the project's 1000 most recently started sessions; root-span attributes are sampled newest-first within that window up to a 2 MiB scan budget. This is a discovery aid rather than a complete list: a name that only older sessions carry drops out of the suggestions once 1000 newer sessions exist, and still filters correctly when typed by hand.
   """
   sessionFilterVocabulary: [FilterVocabularyTerm!]!
-  annotationConfigs(first: Int = 50, last: Int = null, after: String = null, before: String = null): AnnotationConfigConnection!
+  annotationConfigs(
+    first: Int = 50
+    last: Int = null
+    after: String = null
+    before: String = null
+
+    """
+    When provided, return only annotation configs whose name exactly matches one of the given names.
+    """
+    names: [String!]
+  ): AnnotationConfigConnection!
   traceRetentionPolicy: ProjectTraceRetentionPolicy!
   createdAt: DateTime!
   updatedAt: DateTime!

--- a/app/src/components/annotation/AnnotationScoreText.tsx
+++ b/app/src/components/annotation/AnnotationScoreText.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import type { ReactNode } from "react";
 
 import type { TextProps } from "@phoenix/components";
-import { Text } from "@phoenix/components";
+import { Text, VisuallyHidden } from "@phoenix/components";
 
 type AnnotationScoreTextProps = Omit<TextProps, "children" | "color"> & {
   /**
@@ -63,6 +63,13 @@ export function AnnotationScoreText({
 
   return (
     <Text {...textProps} data-direction={direction} css={directionCSS}>
+      {direction && (
+        <VisuallyHidden>
+          {direction === "positive"
+            ? "Favorable score: "
+            : "Unfavorable score: "}
+        </VisuallyHidden>
+      )}
       {children}
     </Text>
   );

--- a/app/src/components/annotation/optimizationUtils.ts
+++ b/app/src/components/annotation/optimizationUtils.ts
@@ -2,6 +2,17 @@ import type { AnnotationConfig } from "./types";
 
 type OptimizationDirectionResult = "MAXIMIZE" | "MINIMIZE" | undefined;
 
+export type AnnotationOptimizationConfig = {
+  readonly annotationType: AnnotationConfig["annotationType"];
+  readonly optimizationDirection?: string | null;
+  readonly lowerBound?: number | null;
+  readonly upperBound?: number | null;
+  readonly threshold?: number | null;
+  readonly values?: ReadonlyArray<{
+    readonly score: number | null;
+  }>;
+};
+
 /**
  * Normalizes the optimization direction, treating "NONE" as undefined.
  */
@@ -20,7 +31,9 @@ function normalizeOptimizationDirection(
  * For categorical configs, calculates bounds from the min/max scores of the values.
  * For freeform configs, returns an optional threshold that overrides the midpoint computation.
  */
-export function getOptimizationBounds(config: AnnotationConfig | undefined): {
+export function getOptimizationBounds(
+  config: AnnotationOptimizationConfig | undefined
+): {
   lowerBound: number | undefined;
   upperBound: number | undefined;
   threshold: number | undefined;
@@ -140,7 +153,7 @@ export function getPositiveOptimizationFromConfig({
   config,
   score,
 }: {
-  config: AnnotationConfig | undefined;
+  config: AnnotationOptimizationConfig | undefined;
   score: number | null | undefined;
 }): boolean | null {
   const { lowerBound, upperBound, threshold, optimizationDirection } =

--- a/app/src/components/chart/AnnotationMetricsChart.tsx
+++ b/app/src/components/chart/AnnotationMetricsChart.tsx
@@ -15,6 +15,7 @@ import {
   YAxis,
 } from "recharts";
 
+import { AnnotationScoreText } from "@phoenix/components/annotation";
 import { useTheme } from "@phoenix/contexts";
 import { getWordColor } from "@phoenix/utils/colorUtils";
 import {
@@ -69,8 +70,10 @@ function AnnotationMetricsTooltip({
   active,
   payload,
   renderHeader,
+  getMeanScoreOptimization,
 }: TooltipContentProps & {
   renderHeader: (point: AnnotationMetricsChartPoint) => ReactNode;
+  getMeanScoreOptimization?: (meanScore: number) => boolean | null;
 }) {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -84,6 +87,10 @@ function AnnotationMetricsTooltip({
           return null;
         }
         const isMeanScore = entry.dataKey === MEAN_SCORE_DATA_KEY;
+        const numericValue = Number(entry.value);
+        const formattedValue = isMeanScore
+          ? floatFormatter(numericValue)
+          : formatAnnotationFraction(numericValue);
         return (
           <ChartTooltipItem
             key={String(entry.dataKey)}
@@ -91,9 +98,15 @@ function AnnotationMetricsTooltip({
             shape={isMeanScore ? "line" : "square"}
             name={String(entry.name)}
             value={
-              isMeanScore
-                ? floatFormatter(Number(entry.value))
-                : formatAnnotationFraction(Number(entry.value))
+              isMeanScore && getMeanScoreOptimization ? (
+                <AnnotationScoreText
+                  positiveOptimization={getMeanScoreOptimization(numericValue)}
+                >
+                  {formattedValue}
+                </AnnotationScoreText>
+              ) : (
+                formattedValue
+              )
             }
           />
         );
@@ -109,6 +122,7 @@ type AnnotationMetricsChartProps = {
   yAxisProps: YAxisProps;
   syncId: string;
   renderTooltipHeader: (point: AnnotationMetricsChartPoint) => ReactNode;
+  getMeanScoreOptimization?: (meanScore: number) => boolean | null;
   chartProps?: ComponentProps<typeof ComposedChart>;
   additionalLegendItems?: ReadonlyArray<LegendPayload>;
   emptyStateMessage?: string;
@@ -136,6 +150,7 @@ function AnnotationMetricsChartContent({
   yAxisProps,
   syncId,
   renderTooltipHeader,
+  getMeanScoreOptimization,
   chartProps,
   additionalLegendItems,
   renderReference,
@@ -214,6 +229,7 @@ function AnnotationMetricsChartContent({
               <AnnotationMetricsTooltip
                 {...props}
                 renderHeader={renderTooltipHeader}
+                getMeanScoreOptimization={getMeanScoreOptimization}
               />
             )}
           />

--- a/app/src/components/chart/AnnotationMetricsChart.tsx
+++ b/app/src/components/chart/AnnotationMetricsChart.tsx
@@ -16,6 +16,7 @@ import {
   YAxis,
 } from "recharts";
 
+import { AnnotationScoreText } from "@phoenix/components/annotation";
 import { useTheme } from "@phoenix/contexts";
 import { getWordColor } from "@phoenix/utils/colorUtils";
 import {
@@ -69,8 +70,10 @@ function AnnotationMetricsTooltip({
   active,
   payload,
   renderHeader,
+  getMeanScoreOptimization,
 }: TooltipContentProps & {
   renderHeader: (point: AnnotationMetricsChartPoint) => ReactNode;
+  getMeanScoreOptimization?: (meanScore: number) => boolean | null;
 }) {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -84,6 +87,10 @@ function AnnotationMetricsTooltip({
           return null;
         }
         const isMeanScore = entry.dataKey === MEAN_SCORE_DATA_KEY;
+        const numericValue = Number(entry.value);
+        const formattedValue = isMeanScore
+          ? floatFormatter(numericValue)
+          : formatAnnotationFraction(numericValue);
         return (
           <ChartTooltipItem
             key={String(entry.dataKey)}
@@ -91,9 +98,15 @@ function AnnotationMetricsTooltip({
             shape={isMeanScore ? "line" : "square"}
             name={String(entry.name)}
             value={
-              isMeanScore
-                ? floatFormatter(Number(entry.value))
-                : formatAnnotationFraction(Number(entry.value))
+              isMeanScore && getMeanScoreOptimization ? (
+                <AnnotationScoreText
+                  positiveOptimization={getMeanScoreOptimization(numericValue)}
+                >
+                  {formattedValue}
+                </AnnotationScoreText>
+              ) : (
+                formattedValue
+              )
             }
           />
         );
@@ -109,6 +122,7 @@ type AnnotationMetricsChartProps = {
   yAxisProps: YAxisProps;
   syncId: string;
   renderTooltipHeader: (point: AnnotationMetricsChartPoint) => ReactNode;
+  getMeanScoreOptimization?: (meanScore: number) => boolean | null;
   chartProps?: ComponentProps<typeof ComposedChart>;
   additionalLegendItems?: ReadonlyArray<LegendPayload>;
   emptyStateMessage?: string;
@@ -136,6 +150,7 @@ function AnnotationMetricsChartContent({
   yAxisProps,
   syncId,
   renderTooltipHeader,
+  getMeanScoreOptimization,
   chartProps,
   additionalLegendItems,
   renderReference,
@@ -214,6 +229,7 @@ function AnnotationMetricsChartContent({
               <AnnotationMetricsTooltip
                 {...props}
                 renderHeader={renderTooltipHeader}
+                getMeanScoreOptimization={getMeanScoreOptimization}
               />
             )}
           />

--- a/app/src/components/chart/ChartTooltip.tsx
+++ b/app/src/components/chart/ChartTooltip.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
-import type { PropsWithChildren } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
+import { isValidElement } from "react";
 
 import { Text } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
@@ -48,7 +49,7 @@ type ChartTooltipItemProps = {
    */
   color?: string;
   name: string;
-  value: string;
+  value: ReactNode;
 };
 
 /**
@@ -81,7 +82,7 @@ export function ChartTooltipItem(props: ChartTooltipItemProps) {
           <Truncate maxWidth="100%">{props.name}</Truncate>
         </Text>
       </div>
-      <Text>{props.value}</Text>
+      {isValidElement(props.value) ? props.value : <Text>{props.value}</Text>}
     </div>
   );
 }

--- a/app/src/pages/project/metrics/AnnotationScoreTimeSeriesChart.tsx
+++ b/app/src/pages/project/metrics/AnnotationScoreTimeSeriesChart.tsx
@@ -11,6 +11,11 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  AnnotationScoreText,
+  type AnnotationOptimizationConfig,
+  getPositiveOptimizationFromConfig,
+} from "@phoenix/components/annotation";
+import {
   ChartEmptyStateOverlay,
   ChartResponsiveContainer,
   ChartTooltip,
@@ -39,7 +44,14 @@ export type AnnotationScoreTimeSeriesDatum = {
   }>;
 };
 
-function TooltipContent({ active, payload, label }: TooltipContentProps) {
+function TooltipContent({
+  active,
+  payload,
+  label,
+  annotationConfigsByName,
+}: TooltipContentProps & {
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
+}) {
   const { fullTimeFormatter } = useTimeFormatters();
   if (active && payload && payload.length) {
     return (
@@ -51,13 +63,24 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
         )}
         {payload.map((entry, index) => {
           if (entry.value == null) return null;
+          const annotationName = String(entry.dataKey || "unknown");
+          const score = Number(entry.value);
           return (
             <ChartTooltipItem
               key={index}
               color={entry.color}
               shape="line"
-              name={String(entry.dataKey || "unknown")}
-              value={Number(entry.value).toFixed(2)}
+              name={annotationName}
+              value={
+                <AnnotationScoreText
+                  positiveOptimization={getPositiveOptimizationFromConfig({
+                    config: annotationConfigsByName.get(annotationName),
+                    score,
+                  })}
+                >
+                  {score.toFixed(2)}
+                </AnnotationScoreText>
+              }
             />
           );
         })}
@@ -96,12 +119,14 @@ export function AnnotationScoreTimeSeriesChart({
   scale,
   timeRange,
   onTimeRangeSelected,
+  annotationConfigsByName,
 }: {
   data: ReadonlyArray<AnnotationScoreTimeSeriesDatum>;
   names: ReadonlyArray<string>;
   scale: TimeBinScale;
   timeRange: TimeRange;
   onTimeRangeSelected?: (timeRange: TimeRange) => void;
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
 }) {
   // Transform the data to have one property per annotation label
   const chartData = useMemo(
@@ -150,7 +175,15 @@ export function AnnotationScoreTimeSeriesChart({
                 tickFormatter={(x) => formatFloat(x)}
               />
               <CartesianGrid {...defaultCartesianGridProps} />
-              <Tooltip content={TooltipContent} {...defaultTooltipProps} />
+              <Tooltip
+                content={(props) => (
+                  <TooltipContent
+                    {...props}
+                    annotationConfigsByName={annotationConfigsByName}
+                  />
+                )}
+                {...defaultTooltipProps}
+              />
 
               {names.map((name) => {
                 return (

--- a/app/src/pages/project/metrics/AnnotationScoreTimeSeriesChart.tsx
+++ b/app/src/pages/project/metrics/AnnotationScoreTimeSeriesChart.tsx
@@ -12,6 +12,11 @@ import {
 
 import { Text } from "@phoenix/components";
 import {
+  AnnotationScoreText,
+  type AnnotationOptimizationConfig,
+  getPositiveOptimizationFromConfig,
+} from "@phoenix/components/annotation";
+import {
   ChartEmptyStateOverlay,
   ChartTooltip,
   ChartTooltipItem,
@@ -39,7 +44,14 @@ export type AnnotationScoreTimeSeriesDatum = {
   }>;
 };
 
-function TooltipContent({ active, payload, label }: TooltipContentProps) {
+function TooltipContent({
+  active,
+  payload,
+  label,
+  annotationConfigsByName,
+}: TooltipContentProps & {
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
+}) {
   const { fullTimeFormatter } = useTimeFormatters();
   if (active && payload && payload.length) {
     return (
@@ -51,13 +63,24 @@ function TooltipContent({ active, payload, label }: TooltipContentProps) {
         )}
         {payload.map((entry, index) => {
           if (entry.value == null) return null;
+          const annotationName = String(entry.dataKey || "unknown");
+          const score = Number(entry.value);
           return (
             <ChartTooltipItem
               key={index}
               color={entry.color}
               shape="line"
-              name={String(entry.dataKey || "unknown")}
-              value={Number(entry.value).toFixed(2)}
+              name={annotationName}
+              value={
+                <AnnotationScoreText
+                  positiveOptimization={getPositiveOptimizationFromConfig({
+                    config: annotationConfigsByName.get(annotationName),
+                    score,
+                  })}
+                >
+                  {score.toFixed(2)}
+                </AnnotationScoreText>
+              }
             />
           );
         })}
@@ -96,12 +119,14 @@ export function AnnotationScoreTimeSeriesChart({
   scale,
   timeRange,
   onTimeRangeSelected,
+  annotationConfigsByName,
 }: {
   data: ReadonlyArray<AnnotationScoreTimeSeriesDatum>;
   names: ReadonlyArray<string>;
   scale: TimeBinScale;
   timeRange: TimeRange;
   onTimeRangeSelected?: (timeRange: TimeRange) => void;
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
 }) {
   // Transform the data to have one property per annotation label
   const chartData = useMemo(
@@ -150,7 +175,15 @@ export function AnnotationScoreTimeSeriesChart({
                 tickFormatter={(x) => formatFloat(x)}
               />
               <CartesianGrid {...defaultCartesianGridProps} />
-              <Tooltip content={TooltipContent} {...defaultTooltipProps} />
+              <Tooltip
+                content={(props) => (
+                  <TooltipContent
+                    {...props}
+                    annotationConfigsByName={annotationConfigsByName}
+                  />
+                )}
+                {...defaultTooltipProps}
+              />
 
               {names.map((name) => {
                 return (

--- a/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
+++ b/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
@@ -1,9 +1,13 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
 import { Suspense, useState } from "react";
-import { graphql, useLazyLoadQuery } from "react-relay";
+import { graphql, useFragment, useLazyLoadQuery } from "react-relay";
 
 import { Loading, Text } from "@phoenix/components";
+import {
+  type AnnotationOptimizationConfig,
+  getPositiveOptimizationFromConfig,
+} from "@phoenix/components/annotation";
 import {
   AnnotationMetricsChart,
   type AnnotationMetricsSeries,
@@ -30,6 +34,7 @@ import { getNonNoteAnnotationNames } from "../spanAnnotationUtils";
 import type { ProjectAnnotationMetricNamesSessionQuery } from "./__generated__/ProjectAnnotationMetricNamesSessionQuery.graphql";
 import type { ProjectAnnotationMetricNamesSpanQuery } from "./__generated__/ProjectAnnotationMetricNamesSpanQuery.graphql";
 import type { ProjectAnnotationMetricNamesTraceQuery } from "./__generated__/ProjectAnnotationMetricNamesTraceQuery.graphql";
+import type { ProjectAnnotationMetricsConfigFragment$key } from "./__generated__/ProjectAnnotationMetricsConfigFragment.graphql";
 import type { ProjectAnnotationMetricsSessionQuery } from "./__generated__/ProjectAnnotationMetricsSessionQuery.graphql";
 import type { ProjectAnnotationMetricsSpanQuery } from "./__generated__/ProjectAnnotationMetricsSpanQuery.graphql";
 import type { ProjectAnnotationMetricsTraceQuery } from "./__generated__/ProjectAnnotationMetricsTraceQuery.graphql";
@@ -53,6 +58,66 @@ type AnnotationMetricsData = ReadonlyArray<{
     }>;
   }>;
 }>;
+
+type ProjectAnnotationMetricsResult = {
+  annotationSeries: AnnotationMetricsSeries[];
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
+};
+
+function useProjectAnnotationConfigsByName(
+  project: ProjectAnnotationMetricsConfigFragment$key
+): ReadonlyMap<string, AnnotationOptimizationConfig> {
+  const data = useFragment(
+    graphql`
+      fragment ProjectAnnotationMetricsConfigFragment on Project {
+        annotationConfigs(first: 1, names: [$annotationName]) {
+          edges {
+            config: node {
+              ... on AnnotationConfigBase {
+                name
+                annotationType
+              }
+              ... on CategoricalAnnotationConfig {
+                optimizationDirection
+                values {
+                  label
+                  score
+                }
+              }
+              ... on ContinuousAnnotationConfig {
+                optimizationDirection
+                lowerBound
+                upperBound
+              }
+              ... on FreeformAnnotationConfig {
+                optimizationDirection
+                threshold
+                lowerBound
+                upperBound
+              }
+            }
+          }
+        }
+      }
+    `,
+    project
+  );
+  const configsByName = new Map<string, AnnotationOptimizationConfig>();
+  data.annotationConfigs.edges.forEach(({ config }) => {
+    if (config.name == null || config.annotationType == null) {
+      return;
+    }
+    configsByName.set(config.name, {
+      annotationType: config.annotationType,
+      optimizationDirection: config.optimizationDirection,
+      lowerBound: config.lowerBound,
+      upperBound: config.upperBound,
+      threshold: config.threshold,
+      values: config.values,
+    });
+  });
+  return configsByName;
+}
 
 function getProjectAnnotationMetricsSeries(
   data: AnnotationMetricsData
@@ -103,6 +168,7 @@ function ProjectAnnotationMetricsGridView({
 
 function ProjectAnnotationMetricsPanel({
   series,
+  annotationConfig,
   timeRange,
   timeTickFormatter,
   fullTimeFormatter,
@@ -110,6 +176,7 @@ function ProjectAnnotationMetricsPanel({
   fillHeight = false,
 }: {
   series: AnnotationMetricsSeries;
+  annotationConfig?: AnnotationOptimizationConfig;
   timeRange: TimeRange;
   timeTickFormatter: (date: Date) => string;
   fullTimeFormatter: (date: Date) => string;
@@ -150,6 +217,12 @@ function ProjectAnnotationMetricsPanel({
             yAxisProps={compactYAxisProps}
             syncId={PROJECT_METRICS_CHART_SYNC_ID}
             chartProps={chartProps}
+            getMeanScoreOptimization={(meanScore) =>
+              getPositiveOptimizationFromConfig({
+                config: annotationConfig,
+                score: meanScore,
+              })
+            }
             renderTooltipHeader={(point) => (
               <Text weight="heavy" size="S">
                 {fullTimeFormatter(new Date(point.x))}
@@ -218,10 +291,11 @@ export function ProjectAnnotationMetricPanel({
         }
       >
         <ProjectAnnotationMetricsSeriesLoader {...props}>
-          {(annotationSeries) => (
+          {({ annotationSeries, annotationConfigsByName }) => (
             <ProjectAnnotationMetricPanelContent
               {...props}
               annotationSeries={annotationSeries}
+              annotationConfigsByName={annotationConfigsByName}
               fillHeight={fillHeight}
             />
           )}
@@ -233,11 +307,13 @@ export function ProjectAnnotationMetricPanel({
 
 function ProjectAnnotationMetricPanelContent({
   annotationSeries,
+  annotationConfigsByName,
   annotationName,
   fillHeight,
   ...props
 }: ProjectMetricViewProps & {
   annotationSeries: AnnotationMetricsSeries[];
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
   annotationName: string;
   fillHeight: boolean;
 }) {
@@ -254,6 +330,7 @@ function ProjectAnnotationMetricPanelContent({
     <ProjectAnnotationMetricsPanel
       {...props}
       series={series}
+      annotationConfig={annotationConfigsByName.get(series.name)}
       timeTickFormatter={timeTickFormatter}
       fullTimeFormatter={fullTimeFormatter}
       fillHeight={fillHeight}
@@ -470,7 +547,7 @@ type ProjectAnnotationMetricsQueryProps = ProjectMetricViewProps & {
 type ProjectAnnotationMetricsSeriesLoaderProps =
   ProjectAnnotationMetricsQueryProps & {
     annotationLevel: MetricChartTableView;
-    children: (annotationSeries: AnnotationMetricsSeries[]) => ReactNode;
+    children: (result: ProjectAnnotationMetricsResult) => ReactNode;
   };
 
 // Keep these Relay queries below the nearest Suspense boundary. Suspending from
@@ -513,7 +590,7 @@ function SessionAnnotationMetricsSeriesLoader({
 
 function useSpanAnnotationMetricsSeries(
   props: ProjectAnnotationMetricsQueryProps
-) {
+): ProjectAnnotationMetricsResult {
   const scale = useTimeBinScale({ timeRange: props.timeRange });
   const utcOffsetMinutes = useUTCOffsetMinutes();
   const data = useLazyLoadQuery<ProjectAnnotationMetricsSpanQuery>(
@@ -526,6 +603,7 @@ function useSpanAnnotationMetricsSeries(
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             spanAnnotationMetricsTimeSeries(
               annotationName: $annotationName
               timeRange: $timeRange
@@ -550,14 +628,20 @@ function useSpanAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries(
-    data.project.spanAnnotationMetricsTimeSeries?.data ?? []
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
   );
+  return {
+    annotationSeries: getProjectAnnotationMetricsSeries(
+      data.project.spanAnnotationMetricsTimeSeries?.data ?? []
+    ),
+    annotationConfigsByName,
+  };
 }
 
 function useTraceAnnotationMetricsSeries(
   props: ProjectAnnotationMetricsQueryProps
-) {
+): ProjectAnnotationMetricsResult {
   const scale = useTimeBinScale({ timeRange: props.timeRange });
   const utcOffsetMinutes = useUTCOffsetMinutes();
   const data = useLazyLoadQuery<ProjectAnnotationMetricsTraceQuery>(
@@ -570,6 +654,7 @@ function useTraceAnnotationMetricsSeries(
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             traceAnnotationMetricsTimeSeries(
               annotationName: $annotationName
               timeRange: $timeRange
@@ -594,14 +679,20 @@ function useTraceAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries(
-    data.project.traceAnnotationMetricsTimeSeries?.data ?? []
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
   );
+  return {
+    annotationSeries: getProjectAnnotationMetricsSeries(
+      data.project.traceAnnotationMetricsTimeSeries?.data ?? []
+    ),
+    annotationConfigsByName,
+  };
 }
 
 function useSessionAnnotationMetricsSeries(
   props: ProjectAnnotationMetricsQueryProps
-) {
+): ProjectAnnotationMetricsResult {
   const scale = useTimeBinScale({ timeRange: props.timeRange });
   const utcOffsetMinutes = useUTCOffsetMinutes();
   const data = useLazyLoadQuery<ProjectAnnotationMetricsSessionQuery>(
@@ -614,6 +705,7 @@ function useSessionAnnotationMetricsSeries(
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             sessionAnnotationMetricsTimeSeries(
               annotationName: $annotationName
               timeRange: $timeRange
@@ -638,9 +730,15 @@ function useSessionAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries(
-    data.project.sessionAnnotationMetricsTimeSeries?.data ?? []
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
   );
+  return {
+    annotationSeries: getProjectAnnotationMetricsSeries(
+      data.project.sessionAnnotationMetricsTimeSeries?.data ?? []
+    ),
+    annotationConfigsByName,
+  };
 }
 
 function getQueryVariables({

--- a/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
+++ b/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
 import { Suspense, useState } from "react";
-import { graphql, useFragment, useLazyLoadQuery } from "react-relay";
+import { graphql, useLazyLoadQuery } from "react-relay";
 
 import { Loading, Text } from "@phoenix/components";
 import {
@@ -34,7 +34,6 @@ import { getNonNoteAnnotationNames } from "../spanAnnotationUtils";
 import type { ProjectAnnotationMetricNamesSessionQuery } from "./__generated__/ProjectAnnotationMetricNamesSessionQuery.graphql";
 import type { ProjectAnnotationMetricNamesSpanQuery } from "./__generated__/ProjectAnnotationMetricNamesSpanQuery.graphql";
 import type { ProjectAnnotationMetricNamesTraceQuery } from "./__generated__/ProjectAnnotationMetricNamesTraceQuery.graphql";
-import type { ProjectAnnotationMetricsConfigFragment$key } from "./__generated__/ProjectAnnotationMetricsConfigFragment.graphql";
 import type { ProjectAnnotationMetricsSessionQuery } from "./__generated__/ProjectAnnotationMetricsSessionQuery.graphql";
 import type { ProjectAnnotationMetricsSpanQuery } from "./__generated__/ProjectAnnotationMetricsSpanQuery.graphql";
 import type { ProjectAnnotationMetricsTraceQuery } from "./__generated__/ProjectAnnotationMetricsTraceQuery.graphql";
@@ -46,6 +45,7 @@ import {
   PROJECT_METRICS_CHART_SYNC_ID,
   useMetricQueryFetchOptions,
 } from "./types";
+import { useProjectAnnotationConfigsByName } from "./useProjectAnnotationConfigsByName";
 
 type AnnotationMetricsData = ReadonlyArray<{
   readonly timestamp: string;
@@ -63,61 +63,6 @@ type ProjectAnnotationMetricsResult = {
   annotationSeries: AnnotationMetricsSeries[];
   annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
 };
-
-function useProjectAnnotationConfigsByName(
-  project: ProjectAnnotationMetricsConfigFragment$key
-): ReadonlyMap<string, AnnotationOptimizationConfig> {
-  const data = useFragment(
-    graphql`
-      fragment ProjectAnnotationMetricsConfigFragment on Project {
-        annotationConfigs(first: 1, names: [$annotationName]) {
-          edges {
-            config: node {
-              ... on AnnotationConfigBase {
-                name
-                annotationType
-              }
-              ... on CategoricalAnnotationConfig {
-                optimizationDirection
-                values {
-                  label
-                  score
-                }
-              }
-              ... on ContinuousAnnotationConfig {
-                optimizationDirection
-                lowerBound
-                upperBound
-              }
-              ... on FreeformAnnotationConfig {
-                optimizationDirection
-                threshold
-                lowerBound
-                upperBound
-              }
-            }
-          }
-        }
-      }
-    `,
-    project
-  );
-  const configsByName = new Map<string, AnnotationOptimizationConfig>();
-  data.annotationConfigs.edges.forEach(({ config }) => {
-    if (config.name == null || config.annotationType == null) {
-      return;
-    }
-    configsByName.set(config.name, {
-      annotationType: config.annotationType,
-      optimizationDirection: config.optimizationDirection,
-      lowerBound: config.lowerBound,
-      upperBound: config.upperBound,
-      threshold: config.threshold,
-      values: config.values,
-    });
-  });
-  return configsByName;
-}
 
 function getProjectAnnotationMetricsSeries(
   data: AnnotationMetricsData
@@ -604,6 +549,7 @@ function useSpanAnnotationMetricsSeries(
         project: node(id: $projectId) {
           ... on Project {
             ...ProjectAnnotationMetricsConfigFragment
+              @arguments(annotationConfigNames: [$annotationName], first: 1)
             spanAnnotationMetricsTimeSeries(
               annotationName: $annotationName
               timeRange: $timeRange
@@ -655,6 +601,7 @@ function useTraceAnnotationMetricsSeries(
         project: node(id: $projectId) {
           ... on Project {
             ...ProjectAnnotationMetricsConfigFragment
+              @arguments(annotationConfigNames: [$annotationName], first: 1)
             traceAnnotationMetricsTimeSeries(
               annotationName: $annotationName
               timeRange: $timeRange
@@ -706,6 +653,7 @@ function useSessionAnnotationMetricsSeries(
         project: node(id: $projectId) {
           ... on Project {
             ...ProjectAnnotationMetricsConfigFragment
+              @arguments(annotationConfigNames: [$annotationName], first: 1)
             sessionAnnotationMetricsTimeSeries(
               annotationName: $annotationName
               timeRange: $timeRange

--- a/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
+++ b/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
 import { Suspense, useState } from "react";
-import { graphql, useFragment, useLazyLoadQuery } from "react-relay";
+import { graphql, useLazyLoadQuery } from "react-relay";
 
 import { Loading, Text } from "@phoenix/components";
 import {
@@ -32,7 +32,6 @@ import { getNonNoteAnnotationNames } from "../spanAnnotationUtils";
 import type { ProjectAnnotationMetricNamesSessionQuery } from "./__generated__/ProjectAnnotationMetricNamesSessionQuery.graphql";
 import type { ProjectAnnotationMetricNamesSpanQuery } from "./__generated__/ProjectAnnotationMetricNamesSpanQuery.graphql";
 import type { ProjectAnnotationMetricNamesTraceQuery } from "./__generated__/ProjectAnnotationMetricNamesTraceQuery.graphql";
-import type { ProjectAnnotationMetricsConfigFragment$key } from "./__generated__/ProjectAnnotationMetricsConfigFragment.graphql";
 import type { ProjectAnnotationMetricsSessionQuery } from "./__generated__/ProjectAnnotationMetricsSessionQuery.graphql";
 import type { ProjectAnnotationMetricsSpanQuery } from "./__generated__/ProjectAnnotationMetricsSpanQuery.graphql";
 import type { ProjectAnnotationMetricsTraceQuery } from "./__generated__/ProjectAnnotationMetricsTraceQuery.graphql";
@@ -41,6 +40,7 @@ import {
   PROJECT_METRICS_CHART_SYNC_ID,
   useMetricQueryFetchOptions,
 } from "./types";
+import { useProjectAnnotationConfigsByName } from "./useProjectAnnotationConfigsByName";
 
 type AnnotationMetricsData = ReadonlyArray<{
   readonly timestamp: string;
@@ -58,61 +58,6 @@ type ProjectAnnotationMetricsResult = {
   annotationSeries: AnnotationMetricsSeries[];
   annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
 };
-
-function useProjectAnnotationConfigsByName(
-  project: ProjectAnnotationMetricsConfigFragment$key
-): ReadonlyMap<string, AnnotationOptimizationConfig> {
-  const data = useFragment(
-    graphql`
-      fragment ProjectAnnotationMetricsConfigFragment on Project {
-        annotationConfigs(first: 100) {
-          edges {
-            config: node {
-              ... on AnnotationConfigBase {
-                name
-                annotationType
-              }
-              ... on CategoricalAnnotationConfig {
-                optimizationDirection
-                values {
-                  label
-                  score
-                }
-              }
-              ... on ContinuousAnnotationConfig {
-                optimizationDirection
-                lowerBound
-                upperBound
-              }
-              ... on FreeformAnnotationConfig {
-                optimizationDirection
-                threshold
-                lowerBound
-                upperBound
-              }
-            }
-          }
-        }
-      }
-    `,
-    project
-  );
-  const configsByName = new Map<string, AnnotationOptimizationConfig>();
-  data.annotationConfigs.edges.forEach(({ config }) => {
-    if (config.name == null || config.annotationType == null) {
-      return;
-    }
-    configsByName.set(config.name, {
-      annotationType: config.annotationType,
-      optimizationDirection: config.optimizationDirection,
-      lowerBound: config.lowerBound,
-      upperBound: config.upperBound,
-      threshold: config.threshold,
-      values: config.values,
-    });
-  });
-  return configsByName;
-}
 
 function getProjectAnnotationMetricsSeries({
   data,

--- a/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
+++ b/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
@@ -1,9 +1,13 @@
 import { css } from "@emotion/react";
 import type { ReactNode } from "react";
 import { Suspense, useState } from "react";
-import { graphql, useLazyLoadQuery } from "react-relay";
+import { graphql, useFragment, useLazyLoadQuery } from "react-relay";
 
 import { Loading, Text } from "@phoenix/components";
+import {
+  type AnnotationOptimizationConfig,
+  getPositiveOptimizationFromConfig,
+} from "@phoenix/components/annotation";
 import {
   AnnotationMetricsChart,
   type AnnotationMetricsSeries,
@@ -28,6 +32,7 @@ import { getNonNoteAnnotationNames } from "../spanAnnotationUtils";
 import type { ProjectAnnotationMetricNamesSessionQuery } from "./__generated__/ProjectAnnotationMetricNamesSessionQuery.graphql";
 import type { ProjectAnnotationMetricNamesSpanQuery } from "./__generated__/ProjectAnnotationMetricNamesSpanQuery.graphql";
 import type { ProjectAnnotationMetricNamesTraceQuery } from "./__generated__/ProjectAnnotationMetricNamesTraceQuery.graphql";
+import type { ProjectAnnotationMetricsConfigFragment$key } from "./__generated__/ProjectAnnotationMetricsConfigFragment.graphql";
 import type { ProjectAnnotationMetricsSessionQuery } from "./__generated__/ProjectAnnotationMetricsSessionQuery.graphql";
 import type { ProjectAnnotationMetricsSpanQuery } from "./__generated__/ProjectAnnotationMetricsSpanQuery.graphql";
 import type { ProjectAnnotationMetricsTraceQuery } from "./__generated__/ProjectAnnotationMetricsTraceQuery.graphql";
@@ -48,6 +53,66 @@ type AnnotationMetricsData = ReadonlyArray<{
     }>;
   }>;
 }>;
+
+type ProjectAnnotationMetricsResult = {
+  annotationSeries: AnnotationMetricsSeries[];
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
+};
+
+function useProjectAnnotationConfigsByName(
+  project: ProjectAnnotationMetricsConfigFragment$key
+): ReadonlyMap<string, AnnotationOptimizationConfig> {
+  const data = useFragment(
+    graphql`
+      fragment ProjectAnnotationMetricsConfigFragment on Project {
+        annotationConfigs(first: 100) {
+          edges {
+            config: node {
+              ... on AnnotationConfigBase {
+                name
+                annotationType
+              }
+              ... on CategoricalAnnotationConfig {
+                optimizationDirection
+                values {
+                  label
+                  score
+                }
+              }
+              ... on ContinuousAnnotationConfig {
+                optimizationDirection
+                lowerBound
+                upperBound
+              }
+              ... on FreeformAnnotationConfig {
+                optimizationDirection
+                threshold
+                lowerBound
+                upperBound
+              }
+            }
+          }
+        }
+      }
+    `,
+    project
+  );
+  const configsByName = new Map<string, AnnotationOptimizationConfig>();
+  data.annotationConfigs.edges.forEach(({ config }) => {
+    if (config.name == null || config.annotationType == null) {
+      return;
+    }
+    configsByName.set(config.name, {
+      annotationType: config.annotationType,
+      optimizationDirection: config.optimizationDirection,
+      lowerBound: config.lowerBound,
+      upperBound: config.upperBound,
+      threshold: config.threshold,
+      values: config.values,
+    });
+  });
+  return configsByName;
+}
 
 function getProjectAnnotationMetricsSeries({
   data,
@@ -81,10 +146,12 @@ const annotationGridCSS = css`
 
 function ProjectAnnotationMetricsGridView({
   annotationSeries,
+  annotationConfigsByName,
   timeRange,
   onTimeRangeSelected,
 }: {
   annotationSeries: AnnotationMetricsSeries[];
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
   timeRange: TimeRange;
   onTimeRangeSelected?: (timeRange: TimeRange) => void;
 }) {
@@ -101,6 +168,7 @@ function ProjectAnnotationMetricsGridView({
         <ProjectAnnotationMetricsPanel
           key={series.name}
           series={series}
+          annotationConfig={annotationConfigsByName.get(series.name)}
           timeRange={timeRange}
           timeTickFormatter={timeTickFormatter}
           fullTimeFormatter={fullTimeFormatter}
@@ -113,6 +181,7 @@ function ProjectAnnotationMetricsGridView({
 
 function ProjectAnnotationMetricsPanel({
   series,
+  annotationConfig,
   timeRange,
   timeTickFormatter,
   fullTimeFormatter,
@@ -120,6 +189,7 @@ function ProjectAnnotationMetricsPanel({
   fillHeight = false,
 }: {
   series: AnnotationMetricsSeries;
+  annotationConfig?: AnnotationOptimizationConfig;
   timeRange: TimeRange;
   timeTickFormatter: (date: Date) => string;
   fullTimeFormatter: (date: Date) => string;
@@ -160,6 +230,12 @@ function ProjectAnnotationMetricsPanel({
             yAxisProps={compactYAxisProps}
             syncId={PROJECT_METRICS_CHART_SYNC_ID}
             chartProps={chartProps}
+            getMeanScoreOptimization={(meanScore) =>
+              getPositiveOptimizationFromConfig({
+                config: annotationConfig,
+                score: meanScore,
+              })
+            }
             renderTooltipHeader={(point) => (
               <Text weight="heavy" size="S">
                 {fullTimeFormatter(new Date(point.x))}
@@ -196,10 +272,11 @@ export function ProjectAnnotationMetricPanel({
         }
       >
         <ProjectAnnotationMetricsSeriesLoader {...props}>
-          {(annotationSeries) => (
+          {({ annotationSeries, annotationConfigsByName }) => (
             <ProjectAnnotationMetricPanelContent
               {...props}
               annotationSeries={annotationSeries}
+              annotationConfigsByName={annotationConfigsByName}
               fillHeight={fillHeight}
             />
           )}
@@ -211,11 +288,13 @@ export function ProjectAnnotationMetricPanel({
 
 function ProjectAnnotationMetricPanelContent({
   annotationSeries,
+  annotationConfigsByName,
   annotationName,
   fillHeight,
   ...props
 }: ProjectMetricViewProps & {
   annotationSeries: AnnotationMetricsSeries[];
+  annotationConfigsByName: ReadonlyMap<string, AnnotationOptimizationConfig>;
   annotationName: string;
   fillHeight: boolean;
 }) {
@@ -232,6 +311,7 @@ function ProjectAnnotationMetricPanelContent({
     <ProjectAnnotationMetricsPanel
       {...props}
       series={series}
+      annotationConfig={annotationConfigsByName.get(series.name)}
       timeTickFormatter={timeTickFormatter}
       fullTimeFormatter={fullTimeFormatter}
       fillHeight={fillHeight}
@@ -250,10 +330,11 @@ export function ProjectAnnotationMetricsGrid({
           {...props}
           annotationLevel={annotationLevel}
         >
-          {(annotationSeries) => (
+          {({ annotationSeries, annotationConfigsByName }) => (
             <ProjectAnnotationMetricsGridView
               {...props}
               annotationSeries={annotationSeries}
+              annotationConfigsByName={annotationConfigsByName}
             />
           )}
         </ProjectAnnotationMetricsSeriesLoader>
@@ -338,7 +419,7 @@ type ProjectAnnotationMetricsQueryProps = ProjectMetricViewProps & {
 type ProjectAnnotationMetricsSeriesLoaderProps =
   ProjectAnnotationMetricsQueryProps & {
     annotationLevel: MetricChartTableView;
-    children: (annotationSeries: AnnotationMetricsSeries[]) => ReactNode;
+    children: (result: ProjectAnnotationMetricsResult) => ReactNode;
   };
 
 // Keep these Relay queries below the nearest Suspense boundary. Suspending from
@@ -381,7 +462,7 @@ function SessionAnnotationMetricsSeriesLoader({
 
 function useSpanAnnotationMetricsSeries(
   props: ProjectAnnotationMetricsQueryProps
-) {
+): ProjectAnnotationMetricsResult {
   const scale = useTimeBinScale({ timeRange: props.timeRange });
   const utcOffsetMinutes = useUTCOffsetMinutes();
   const data = useLazyLoadQuery<ProjectAnnotationMetricsSpanQuery>(
@@ -393,6 +474,7 @@ function useSpanAnnotationMetricsSeries(
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             spanAnnotationMetricsTimeSeries(
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
@@ -416,15 +498,21 @@ function useSpanAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries({
-    data: data.project.spanAnnotationMetricsTimeSeries?.data ?? [],
-    annotationName: props.annotationName,
-  });
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
+  );
+  return {
+    annotationSeries: getProjectAnnotationMetricsSeries({
+      data: data.project.spanAnnotationMetricsTimeSeries?.data ?? [],
+      annotationName: props.annotationName,
+    }),
+    annotationConfigsByName,
+  };
 }
 
 function useTraceAnnotationMetricsSeries(
   props: ProjectAnnotationMetricsQueryProps
-) {
+): ProjectAnnotationMetricsResult {
   const scale = useTimeBinScale({ timeRange: props.timeRange });
   const utcOffsetMinutes = useUTCOffsetMinutes();
   const data = useLazyLoadQuery<ProjectAnnotationMetricsTraceQuery>(
@@ -436,6 +524,7 @@ function useTraceAnnotationMetricsSeries(
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             traceAnnotationMetricsTimeSeries(
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
@@ -459,15 +548,21 @@ function useTraceAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries({
-    data: data.project.traceAnnotationMetricsTimeSeries?.data ?? [],
-    annotationName: props.annotationName,
-  });
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
+  );
+  return {
+    annotationSeries: getProjectAnnotationMetricsSeries({
+      data: data.project.traceAnnotationMetricsTimeSeries?.data ?? [],
+      annotationName: props.annotationName,
+    }),
+    annotationConfigsByName,
+  };
 }
 
 function useSessionAnnotationMetricsSeries(
   props: ProjectAnnotationMetricsQueryProps
-) {
+): ProjectAnnotationMetricsResult {
   const scale = useTimeBinScale({ timeRange: props.timeRange });
   const utcOffsetMinutes = useUTCOffsetMinutes();
   const data = useLazyLoadQuery<ProjectAnnotationMetricsSessionQuery>(
@@ -479,6 +574,7 @@ function useSessionAnnotationMetricsSeries(
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             sessionAnnotationMetricsTimeSeries(
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
@@ -502,10 +598,16 @@ function useSessionAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries({
-    data: data.project.sessionAnnotationMetricsTimeSeries?.data ?? [],
-    annotationName: props.annotationName,
-  });
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
+  );
+  return {
+    annotationSeries: getProjectAnnotationMetricsSeries({
+      data: data.project.sessionAnnotationMetricsTimeSeries?.data ?? [],
+      annotationName: props.annotationName,
+    }),
+    annotationConfigsByName,
+  };
 }
 
 function getQueryVariables({

--- a/app/src/pages/project/metrics/SessionAnnotationScoreTimeSeries.tsx
+++ b/app/src/pages/project/metrics/SessionAnnotationScoreTimeSeries.tsx
@@ -7,6 +7,7 @@ import type { SessionAnnotationScoreTimeSeriesQuery } from "./__generated__/Sess
 import { AnnotationScoreTimeSeriesChart } from "./AnnotationScoreTimeSeriesChart";
 import type { ProjectMetricViewProps } from "./types";
 import { useMetricQueryFetchOptions } from "./types";
+import { useProjectAnnotationConfigsByName } from "./useProjectAnnotationConfigsByName";
 
 export function SessionAnnotationScoreTimeSeries({
   projectId,
@@ -25,6 +26,7 @@ export function SessionAnnotationScoreTimeSeries({
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             sessionAnnotationScoreTimeSeries(
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
@@ -55,6 +57,9 @@ export function SessionAnnotationScoreTimeSeries({
     },
     useMetricQueryFetchOptions()
   );
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
+  );
 
   return (
     <AnnotationScoreTimeSeriesChart
@@ -63,6 +68,7 @@ export function SessionAnnotationScoreTimeSeries({
       scale={scale}
       timeRange={timeRange}
       onTimeRangeSelected={onTimeRangeSelected}
+      annotationConfigsByName={annotationConfigsByName}
     />
   );
 }

--- a/app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx
+++ b/app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx
@@ -7,6 +7,7 @@ import type { SpanAnnotationScoreTimeSeriesQuery } from "./__generated__/SpanAnn
 import { AnnotationScoreTimeSeriesChart } from "./AnnotationScoreTimeSeriesChart";
 import type { ProjectMetricViewProps } from "./types";
 import { useMetricQueryFetchOptions } from "./types";
+import { useProjectAnnotationConfigsByName } from "./useProjectAnnotationConfigsByName";
 
 export function SpanAnnotationScoreTimeSeries({
   projectId,
@@ -25,6 +26,7 @@ export function SpanAnnotationScoreTimeSeries({
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             spanAnnotationScoreTimeSeries(
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
@@ -55,6 +57,9 @@ export function SpanAnnotationScoreTimeSeries({
     },
     useMetricQueryFetchOptions()
   );
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
+  );
 
   return (
     <AnnotationScoreTimeSeriesChart
@@ -63,6 +68,7 @@ export function SpanAnnotationScoreTimeSeries({
       scale={scale}
       timeRange={timeRange}
       onTimeRangeSelected={onTimeRangeSelected}
+      annotationConfigsByName={annotationConfigsByName}
     />
   );
 }

--- a/app/src/pages/project/metrics/TraceAnnotationScoreTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceAnnotationScoreTimeSeries.tsx
@@ -7,6 +7,7 @@ import type { TraceAnnotationScoreTimeSeriesQuery } from "./__generated__/TraceA
 import { AnnotationScoreTimeSeriesChart } from "./AnnotationScoreTimeSeriesChart";
 import type { ProjectMetricViewProps } from "./types";
 import { useMetricQueryFetchOptions } from "./types";
+import { useProjectAnnotationConfigsByName } from "./useProjectAnnotationConfigsByName";
 
 export function TraceAnnotationScoreTimeSeries({
   projectId,
@@ -25,6 +26,7 @@ export function TraceAnnotationScoreTimeSeries({
       ) {
         project: node(id: $projectId) {
           ... on Project {
+            ...ProjectAnnotationMetricsConfigFragment
             traceAnnotationScoreTimeSeries(
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
@@ -55,6 +57,9 @@ export function TraceAnnotationScoreTimeSeries({
     },
     useMetricQueryFetchOptions()
   );
+  const annotationConfigsByName = useProjectAnnotationConfigsByName(
+    data.project
+  );
 
   return (
     <AnnotationScoreTimeSeriesChart
@@ -63,6 +68,7 @@ export function TraceAnnotationScoreTimeSeries({
       scale={scale}
       timeRange={timeRange}
       onTimeRangeSelected={onTimeRangeSelected}
+      annotationConfigsByName={annotationConfigsByName}
     />
   );
 }

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsConfigFragment.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsConfigFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c390223d34afd7872481dd549766bb0f>>
+ * @generated SignedSource<<d42d8cc34ff0ea40ca15726bcb104da5>>
  * @lightSyntaxTransform
  */
 
@@ -60,8 +60,14 @@ v2 = {
 return {
   "argumentDefinitions": [
     {
-      "kind": "RootArgument",
-      "name": "annotationName"
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "annotationConfigNames"
+    },
+    {
+      "defaultValue": 100,
+      "kind": "LocalArgument",
+      "name": "first"
     }
   ],
   "kind": "Fragment",
@@ -72,20 +78,14 @@ return {
       "alias": null,
       "args": [
         {
-          "kind": "Literal",
+          "kind": "Variable",
           "name": "first",
-          "value": 1
+          "variableName": "first"
         },
         {
-          "items": [
-            {
-              "kind": "Variable",
-              "name": "names.0",
-              "variableName": "annotationName"
-            }
-          ],
-          "kind": "ListValue",
-          "name": "names"
+          "kind": "Variable",
+          "name": "names",
+          "variableName": "annotationConfigNames"
         }
       ],
       "concreteType": "AnnotationConfigConnection",
@@ -205,6 +205,6 @@ return {
 };
 })();
 
-(node as any).hash = "316e08a477f85096f84b6565de3ab9eb";
+(node as any).hash = "a82fff4a15e2352c9d60726e3b112b63";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsConfigFragment.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsConfigFragment.graphql.ts
@@ -1,0 +1,210 @@
+/**
+ * @generated SignedSource<<c390223d34afd7872481dd549766bb0f>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AnnotationType = "CATEGORICAL" | "CONTINUOUS" | "FREEFORM";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+import { FragmentRefs } from "relay-runtime";
+export type ProjectAnnotationMetricsConfigFragment$data = {
+  readonly annotationConfigs: {
+    readonly edges: ReadonlyArray<{
+      readonly config: {
+        readonly annotationType?: AnnotationType;
+        readonly lowerBound?: number | null;
+        readonly name?: string;
+        readonly optimizationDirection?: OptimizationDirection;
+        readonly threshold?: number | null;
+        readonly upperBound?: number | null;
+        readonly values?: ReadonlyArray<{
+          readonly label: string;
+          readonly score: number | null;
+        }>;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "ProjectAnnotationMetricsConfigFragment";
+};
+export type ProjectAnnotationMetricsConfigFragment$key = {
+  readonly " $data"?: ProjectAnnotationMetricsConfigFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "annotationName"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ProjectAnnotationMetricsConfigFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        },
+        {
+          "items": [
+            {
+              "kind": "Variable",
+              "name": "names.0",
+              "variableName": "annotationName"
+            }
+          ],
+          "kind": "ListValue",
+          "name": "names"
+        }
+      ],
+      "concreteType": "AnnotationConfigConnection",
+      "kind": "LinkedField",
+      "name": "annotationConfigs",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationConfigEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "config",
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "annotationType",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "AnnotationConfigBase",
+                  "abstractKey": "__isAnnotationConfigBase"
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*:: as any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CategoricalAnnotationValue",
+                      "kind": "LinkedField",
+                      "name": "values",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "label",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "score",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "CategoricalAnnotationConfig",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*:: as any*/),
+                    (v1/*:: as any*/),
+                    (v2/*:: as any*/)
+                  ],
+                  "type": "ContinuousAnnotationConfig",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*:: as any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "threshold",
+                      "storageKey": null
+                    },
+                    (v1/*:: as any*/),
+                    (v2/*:: as any*/)
+                  ],
+                  "type": "FreeformAnnotationConfig",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "316e08a477f85096f84b6565de3ab9eb";
+
+export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsConfigFragment.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsConfigFragment.graphql.ts
@@ -1,0 +1,194 @@
+/**
+ * @generated SignedSource<<b3ae87441fb79fdd48ce4fe1cbc63516>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AnnotationType = "CATEGORICAL" | "CONTINUOUS" | "FREEFORM";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+import { FragmentRefs } from "relay-runtime";
+export type ProjectAnnotationMetricsConfigFragment$data = {
+  readonly annotationConfigs: {
+    readonly edges: ReadonlyArray<{
+      readonly config: {
+        readonly annotationType?: AnnotationType;
+        readonly lowerBound?: number | null;
+        readonly name?: string;
+        readonly optimizationDirection?: OptimizationDirection;
+        readonly threshold?: number | null;
+        readonly upperBound?: number | null;
+        readonly values?: ReadonlyArray<{
+          readonly label: string;
+          readonly score: number | null;
+        }>;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "ProjectAnnotationMetricsConfigFragment";
+};
+export type ProjectAnnotationMetricsConfigFragment$key = {
+  readonly " $data"?: ProjectAnnotationMetricsConfigFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ProjectAnnotationMetricsConfigFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 100
+        }
+      ],
+      "concreteType": "AnnotationConfigConnection",
+      "kind": "LinkedField",
+      "name": "annotationConfigs",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationConfigEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "config",
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "annotationType",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "AnnotationConfigBase",
+                  "abstractKey": "__isAnnotationConfigBase"
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*:: as any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CategoricalAnnotationValue",
+                      "kind": "LinkedField",
+                      "name": "values",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "label",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "score",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "CategoricalAnnotationConfig",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*:: as any*/),
+                    (v1/*:: as any*/),
+                    (v2/*:: as any*/)
+                  ],
+                  "type": "ContinuousAnnotationConfig",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*:: as any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "threshold",
+                      "storageKey": null
+                    },
+                    (v1/*:: as any*/),
+                    (v2/*:: as any*/)
+                  ],
+                  "type": "FreeformAnnotationConfig",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "annotationConfigs(first:100)"
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "658f9f685c25539657b0b97f1402466c";
+
+export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSessionQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7cb24c47ab4311607336af2b1c0a95ae>>
+ * @generated SignedSource<<afef2951a0df8e79ad4f14b0ee7b55ba>>
  * @lightSyntaxTransform
  */
 
@@ -76,20 +76,25 @@ v4 = [
   }
 ],
 v5 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 1
+},
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": [
     {
@@ -136,7 +141,7 @@ v7 = {
           "name": "annotationSummaries",
           "plural": true,
           "selections": [
-            (v5/*:: as any*/),
+            (v6/*:: as any*/),
             {
               "alias": null,
               "args": null,
@@ -152,7 +157,7 @@ v7 = {
               "name": "labelFractions",
               "plural": true,
               "selections": [
-                (v6/*:: as any*/),
+                (v7/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -172,35 +177,35 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "optimizationDirection",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lowerBound",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "upperBound",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -231,11 +236,24 @@ return {
             "kind": "InlineFragment",
             "selections": [
               {
-                "args": null,
+                "args": [
+                  {
+                    "items": [
+                      {
+                        "kind": "Variable",
+                        "name": "annotationConfigNames.0",
+                        "variableName": "annotationName"
+                      }
+                    ],
+                    "kind": "ListValue",
+                    "name": "annotationConfigNames"
+                  },
+                  (v5/*:: as any*/)
+                ],
                 "kind": "FragmentSpread",
                 "name": "ProjectAnnotationMetricsConfigFragment"
               },
-              (v7/*:: as any*/)
+              (v8/*:: as any*/)
             ],
             "type": "Project",
             "abstractKey": null
@@ -266,18 +284,14 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v8/*:: as any*/),
+          (v9/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
                 "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 1
-                  },
+                  (v5/*:: as any*/),
                   {
                     "items": [
                       {
@@ -311,11 +325,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v8/*:: as any*/),
+                          (v9/*:: as any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v5/*:: as any*/),
+                              (v6/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -330,7 +344,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -339,7 +353,7 @@ return {
                                 "name": "values",
                                 "plural": true,
                                 "selections": [
-                                  (v6/*:: as any*/),
+                                  (v7/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -357,9 +371,9 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
                               (v10/*:: as any*/),
-                              (v11/*:: as any*/)
+                              (v11/*:: as any*/),
+                              (v12/*:: as any*/)
                             ],
                             "type": "ContinuousAnnotationConfig",
                             "abstractKey": null
@@ -367,7 +381,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -375,8 +389,8 @@ return {
                                 "name": "threshold",
                                 "storageKey": null
                               },
-                              (v10/*:: as any*/),
-                              (v11/*:: as any*/)
+                              (v11/*:: as any*/),
+                              (v12/*:: as any*/)
                             ],
                             "type": "FreeformAnnotationConfig",
                             "abstractKey": null
@@ -384,7 +398,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v12/*:: as any*/)
+                              (v13/*:: as any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -398,28 +412,28 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*:: as any*/)
+              (v8/*:: as any*/)
             ],
             "type": "Project",
             "abstractKey": null
           },
-          (v12/*:: as any*/)
+          (v13/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "845b15f1b56d541ba1088cbf3729f53d",
+    "cacheID": "bece52a78d9054826a81964435991498",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsSessionQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsSessionQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      sessionAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsSessionQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment_3DyRD9\n      sessionAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment_3DyRD9 on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c06de64ee1e5d2dfeb78094a57214c44";
+(node as any).hash = "96d95da4b3d14416ac63100dd4157ebd";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSessionQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b559590e6cb93458df778cbfb2d258cf>>
+ * @generated SignedSource<<7cb24c47ab4311607336af2b1c0a95ae>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -38,6 +39,7 @@ export type ProjectAnnotationMetricsSessionQuery$data = {
         readonly timestamp: string;
       }>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type ProjectAnnotationMetricsSessionQuery = {
@@ -74,92 +76,88 @@ v4 = [
   }
 ],
 v5 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "annotationName",
+      "variableName": "annotationName"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationMetricsTimeSeries",
+  "kind": "LinkedField",
+  "name": "sessionAnnotationMetricsTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "annotationName",
-          "variableName": "annotationName"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationMetricsTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "sessionAnnotationMetricsTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
+          "kind": "ScalarField",
+          "name": "timestamp",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationSummary",
           "kind": "LinkedField",
-          "name": "data",
+          "name": "annotationSummaries",
           "plural": true,
           "selections": [
+            (v5/*:: as any*/),
             {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
-              "name": "timestamp",
+              "name": "meanScore",
               "storageKey": null
             },
             {
               "alias": null,
               "args": null,
-              "concreteType": "AnnotationSummary",
+              "concreteType": "LabelFraction",
               "kind": "LinkedField",
-              "name": "annotationSummaries",
+              "name": "labelFractions",
               "plural": true,
               "selections": [
+                (v6/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "meanScore",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LabelFraction",
-                  "kind": "LinkedField",
-                  "name": "labelFractions",
-                  "plural": true,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "label",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "fraction",
-                      "storageKey": null
-                    }
-                  ],
+                  "name": "fraction",
                   "storageKey": null
                 }
               ],
@@ -172,8 +170,42 @@ v5 = {
       "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -195,7 +227,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v7/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -222,37 +266,160 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v8/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 1
+                  },
+                  {
+                    "items": [
+                      {
+                        "kind": "Variable",
+                        "name": "names.0",
+                        "variableName": "annotationName"
+                      }
+                    ],
+                    "kind": "ListValue",
+                    "name": "names"
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v8/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v5/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v6/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v10/*:: as any*/),
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v12/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v7/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v5/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v12/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "12432efec3a268a16a45d1711f2706f0",
+    "cacheID": "845b15f1b56d541ba1088cbf3729f53d",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsSessionQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsSessionQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessionAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsSessionQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      sessionAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "44830346da58f8d9ab79e4ac927cdbe5";
+(node as any).hash = "c06de64ee1e5d2dfeb78094a57214c44";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSessionQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7dca1ee8e6bc0f7f6a69ac7badcbc866>>
+ * @generated SignedSource<<4c17bc57688e6325b5cbf52c642b47df>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -37,6 +38,7 @@ export type ProjectAnnotationMetricsSessionQuery$data = {
         readonly timestamp: string;
       }>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type ProjectAnnotationMetricsSessionQuery = {
@@ -68,87 +70,83 @@ v3 = [
   }
 ],
 v4 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationMetricsTimeSeries",
+  "kind": "LinkedField",
+  "name": "sessionAnnotationMetricsTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationMetricsTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "sessionAnnotationMetricsTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
+          "kind": "ScalarField",
+          "name": "timestamp",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationSummary",
           "kind": "LinkedField",
-          "name": "data",
+          "name": "annotationSummaries",
           "plural": true,
           "selections": [
+            (v4/*:: as any*/),
             {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
-              "name": "timestamp",
+              "name": "meanScore",
               "storageKey": null
             },
             {
               "alias": null,
               "args": null,
-              "concreteType": "AnnotationSummary",
+              "concreteType": "LabelFraction",
               "kind": "LinkedField",
-              "name": "annotationSummaries",
+              "name": "labelFractions",
               "plural": true,
               "selections": [
+                (v5/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "meanScore",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LabelFraction",
-                  "kind": "LinkedField",
-                  "name": "labelFractions",
-                  "plural": true,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "label",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "fraction",
-                      "storageKey": null
-                    }
-                  ],
+                  "name": "fraction",
                   "storageKey": null
                 }
               ],
@@ -161,8 +159,42 @@ v4 = {
       "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -183,7 +215,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v6/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -209,37 +253,149 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v7/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 100
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v7/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v4/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v5/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "annotationConfigs(first:100)"
+              },
+              (v6/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v4/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v11/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "7cb6893ceb88edac440d40c6fd3e4084",
+    "cacheID": "c731680b944c10a668123d52cf0e5cd9",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsSessionQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsSessionQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessionAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsSessionQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      sessionAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 100) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "07443607dcdc1026031d1d4cb6157f7f";
+(node as any).hash = "7d2a723fd20de7a504deeb6272f0964e";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSpanQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSpanQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6ba864683af320ddb58f89e156571760>>
+ * @generated SignedSource<<59472cb0779d4bb862d68fafc03e6fec>>
  * @lightSyntaxTransform
  */
 
@@ -76,20 +76,25 @@ v4 = [
   }
 ],
 v5 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 1
+},
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": [
     {
@@ -136,7 +141,7 @@ v7 = {
           "name": "annotationSummaries",
           "plural": true,
           "selections": [
-            (v5/*:: as any*/),
+            (v6/*:: as any*/),
             {
               "alias": null,
               "args": null,
@@ -152,7 +157,7 @@ v7 = {
               "name": "labelFractions",
               "plural": true,
               "selections": [
-                (v6/*:: as any*/),
+                (v7/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -172,35 +177,35 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "optimizationDirection",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lowerBound",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "upperBound",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -231,11 +236,24 @@ return {
             "kind": "InlineFragment",
             "selections": [
               {
-                "args": null,
+                "args": [
+                  {
+                    "items": [
+                      {
+                        "kind": "Variable",
+                        "name": "annotationConfigNames.0",
+                        "variableName": "annotationName"
+                      }
+                    ],
+                    "kind": "ListValue",
+                    "name": "annotationConfigNames"
+                  },
+                  (v5/*:: as any*/)
+                ],
                 "kind": "FragmentSpread",
                 "name": "ProjectAnnotationMetricsConfigFragment"
               },
-              (v7/*:: as any*/)
+              (v8/*:: as any*/)
             ],
             "type": "Project",
             "abstractKey": null
@@ -266,18 +284,14 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v8/*:: as any*/),
+          (v9/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
                 "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 1
-                  },
+                  (v5/*:: as any*/),
                   {
                     "items": [
                       {
@@ -311,11 +325,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v8/*:: as any*/),
+                          (v9/*:: as any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v5/*:: as any*/),
+                              (v6/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -330,7 +344,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -339,7 +353,7 @@ return {
                                 "name": "values",
                                 "plural": true,
                                 "selections": [
-                                  (v6/*:: as any*/),
+                                  (v7/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -357,9 +371,9 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
                               (v10/*:: as any*/),
-                              (v11/*:: as any*/)
+                              (v11/*:: as any*/),
+                              (v12/*:: as any*/)
                             ],
                             "type": "ContinuousAnnotationConfig",
                             "abstractKey": null
@@ -367,7 +381,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -375,8 +389,8 @@ return {
                                 "name": "threshold",
                                 "storageKey": null
                               },
-                              (v10/*:: as any*/),
-                              (v11/*:: as any*/)
+                              (v11/*:: as any*/),
+                              (v12/*:: as any*/)
                             ],
                             "type": "FreeformAnnotationConfig",
                             "abstractKey": null
@@ -384,7 +398,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v12/*:: as any*/)
+                              (v13/*:: as any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -398,28 +412,28 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*:: as any*/)
+              (v8/*:: as any*/)
             ],
             "type": "Project",
             "abstractKey": null
           },
-          (v12/*:: as any*/)
+          (v13/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "ee8a132b6d710fb63bde1b8e9802018c",
+    "cacheID": "e8a1283a79a9bf9e5e0ee542ffe9e19b",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsSpanQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsSpanQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      spanAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsSpanQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment_3DyRD9\n      spanAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment_3DyRD9 on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "94a5fc9e42b34163f053b1391f5dda5d";
+(node as any).hash = "dd03c54fb9301e3f0ae6e1d3d498879f";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSpanQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSpanQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2c4b5d8053add9d90fc3be129fc7335e>>
+ * @generated SignedSource<<6ba864683af320ddb58f89e156571760>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -38,6 +39,7 @@ export type ProjectAnnotationMetricsSpanQuery$data = {
         readonly timestamp: string;
       }>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type ProjectAnnotationMetricsSpanQuery = {
@@ -74,92 +76,88 @@ v4 = [
   }
 ],
 v5 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "annotationName",
+      "variableName": "annotationName"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationMetricsTimeSeries",
+  "kind": "LinkedField",
+  "name": "spanAnnotationMetricsTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "annotationName",
-          "variableName": "annotationName"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationMetricsTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "spanAnnotationMetricsTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
+          "kind": "ScalarField",
+          "name": "timestamp",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationSummary",
           "kind": "LinkedField",
-          "name": "data",
+          "name": "annotationSummaries",
           "plural": true,
           "selections": [
+            (v5/*:: as any*/),
             {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
-              "name": "timestamp",
+              "name": "meanScore",
               "storageKey": null
             },
             {
               "alias": null,
               "args": null,
-              "concreteType": "AnnotationSummary",
+              "concreteType": "LabelFraction",
               "kind": "LinkedField",
-              "name": "annotationSummaries",
+              "name": "labelFractions",
               "plural": true,
               "selections": [
+                (v6/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "meanScore",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LabelFraction",
-                  "kind": "LinkedField",
-                  "name": "labelFractions",
-                  "plural": true,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "label",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "fraction",
-                      "storageKey": null
-                    }
-                  ],
+                  "name": "fraction",
                   "storageKey": null
                 }
               ],
@@ -172,8 +170,42 @@ v5 = {
       "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -195,7 +227,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v7/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -222,37 +266,160 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v8/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 1
+                  },
+                  {
+                    "items": [
+                      {
+                        "kind": "Variable",
+                        "name": "names.0",
+                        "variableName": "annotationName"
+                      }
+                    ],
+                    "kind": "ListValue",
+                    "name": "names"
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v8/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v5/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v6/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v10/*:: as any*/),
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v12/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v7/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v5/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v12/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "3d3e53644df5b2201c8eed5b7be737da",
+    "cacheID": "ee8a132b6d710fb63bde1b8e9802018c",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsSpanQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsSpanQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsSpanQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      spanAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d074b302b78c8303950be1bd4305cc0d";
+(node as any).hash = "94a5fc9e42b34163f053b1391f5dda5d";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSpanQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSpanQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b56dfdf85955ae1ffbb339bec9f67118>>
+ * @generated SignedSource<<f8d87760f5bf791e065bb4a3d87653eb>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -37,6 +38,7 @@ export type ProjectAnnotationMetricsSpanQuery$data = {
         readonly timestamp: string;
       }>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type ProjectAnnotationMetricsSpanQuery = {
@@ -68,87 +70,83 @@ v3 = [
   }
 ],
 v4 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationMetricsTimeSeries",
+  "kind": "LinkedField",
+  "name": "spanAnnotationMetricsTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationMetricsTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "spanAnnotationMetricsTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
+          "kind": "ScalarField",
+          "name": "timestamp",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationSummary",
           "kind": "LinkedField",
-          "name": "data",
+          "name": "annotationSummaries",
           "plural": true,
           "selections": [
+            (v4/*:: as any*/),
             {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
-              "name": "timestamp",
+              "name": "meanScore",
               "storageKey": null
             },
             {
               "alias": null,
               "args": null,
-              "concreteType": "AnnotationSummary",
+              "concreteType": "LabelFraction",
               "kind": "LinkedField",
-              "name": "annotationSummaries",
+              "name": "labelFractions",
               "plural": true,
               "selections": [
+                (v5/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "meanScore",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LabelFraction",
-                  "kind": "LinkedField",
-                  "name": "labelFractions",
-                  "plural": true,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "label",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "fraction",
-                      "storageKey": null
-                    }
-                  ],
+                  "name": "fraction",
                   "storageKey": null
                 }
               ],
@@ -161,8 +159,42 @@ v4 = {
       "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -183,7 +215,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v6/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -209,37 +253,149 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v7/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 100
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v7/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v4/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v5/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "annotationConfigs(first:100)"
+              },
+              (v6/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v4/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v11/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "1f90d7ab8b73f67210030baad0d4f6db",
+    "cacheID": "20935f76b07deac28106af1663baf00a",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsSpanQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsSpanQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsSpanQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      spanAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 100) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "db2841f1151f38c2041612b45b54a0f3";
+(node as any).hash = "6745fbe63221972d05a5d6432b887298";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsTraceQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsTraceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<de0e630bd6ccb5880435a9894b3b8aba>>
+ * @generated SignedSource<<8b703ee414ea1b6f02474616bf957556>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -38,6 +39,7 @@ export type ProjectAnnotationMetricsTraceQuery$data = {
         readonly timestamp: string;
       }>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type ProjectAnnotationMetricsTraceQuery = {
@@ -74,92 +76,88 @@ v4 = [
   }
 ],
 v5 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "annotationName",
+      "variableName": "annotationName"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationMetricsTimeSeries",
+  "kind": "LinkedField",
+  "name": "traceAnnotationMetricsTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "annotationName",
-          "variableName": "annotationName"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationMetricsTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "traceAnnotationMetricsTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
+          "kind": "ScalarField",
+          "name": "timestamp",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationSummary",
           "kind": "LinkedField",
-          "name": "data",
+          "name": "annotationSummaries",
           "plural": true,
           "selections": [
+            (v5/*:: as any*/),
             {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
-              "name": "timestamp",
+              "name": "meanScore",
               "storageKey": null
             },
             {
               "alias": null,
               "args": null,
-              "concreteType": "AnnotationSummary",
+              "concreteType": "LabelFraction",
               "kind": "LinkedField",
-              "name": "annotationSummaries",
+              "name": "labelFractions",
               "plural": true,
               "selections": [
+                (v6/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "meanScore",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LabelFraction",
-                  "kind": "LinkedField",
-                  "name": "labelFractions",
-                  "plural": true,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "label",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "fraction",
-                      "storageKey": null
-                    }
-                  ],
+                  "name": "fraction",
                   "storageKey": null
                 }
               ],
@@ -172,8 +170,42 @@ v5 = {
       "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -195,7 +227,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v7/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -222,37 +266,160 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v8/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 1
+                  },
+                  {
+                    "items": [
+                      {
+                        "kind": "Variable",
+                        "name": "names.0",
+                        "variableName": "annotationName"
+                      }
+                    ],
+                    "kind": "ListValue",
+                    "name": "names"
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v8/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v5/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v6/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v10/*:: as any*/),
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v12/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v7/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v5/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v12/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "254ad3e30df31c19c2cea56bf520cf0a",
+    "cacheID": "ccb47dd9f2b25472980432524093001c",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsTraceQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsTraceQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsTraceQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      traceAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7380e4e417156c4b342bf16bee52a6f9";
+(node as any).hash = "159af501449580d6275f5737bf1c857a";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsTraceQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsTraceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8b703ee414ea1b6f02474616bf957556>>
+ * @generated SignedSource<<bcf85039f8e168a12ee52c6a25de038f>>
  * @lightSyntaxTransform
  */
 
@@ -76,20 +76,25 @@ v4 = [
   }
 ],
 v5 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 1
+},
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": [
     {
@@ -136,7 +141,7 @@ v7 = {
           "name": "annotationSummaries",
           "plural": true,
           "selections": [
-            (v5/*:: as any*/),
+            (v6/*:: as any*/),
             {
               "alias": null,
               "args": null,
@@ -152,7 +157,7 @@ v7 = {
               "name": "labelFractions",
               "plural": true,
               "selections": [
-                (v6/*:: as any*/),
+                (v7/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -172,35 +177,35 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "optimizationDirection",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lowerBound",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "upperBound",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -231,11 +236,24 @@ return {
             "kind": "InlineFragment",
             "selections": [
               {
-                "args": null,
+                "args": [
+                  {
+                    "items": [
+                      {
+                        "kind": "Variable",
+                        "name": "annotationConfigNames.0",
+                        "variableName": "annotationName"
+                      }
+                    ],
+                    "kind": "ListValue",
+                    "name": "annotationConfigNames"
+                  },
+                  (v5/*:: as any*/)
+                ],
                 "kind": "FragmentSpread",
                 "name": "ProjectAnnotationMetricsConfigFragment"
               },
-              (v7/*:: as any*/)
+              (v8/*:: as any*/)
             ],
             "type": "Project",
             "abstractKey": null
@@ -266,18 +284,14 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v8/*:: as any*/),
+          (v9/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
                 "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 1
-                  },
+                  (v5/*:: as any*/),
                   {
                     "items": [
                       {
@@ -311,11 +325,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v8/*:: as any*/),
+                          (v9/*:: as any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v5/*:: as any*/),
+                              (v6/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -330,7 +344,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -339,7 +353,7 @@ return {
                                 "name": "values",
                                 "plural": true,
                                 "selections": [
-                                  (v6/*:: as any*/),
+                                  (v7/*:: as any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -357,9 +371,9 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
                               (v10/*:: as any*/),
-                              (v11/*:: as any*/)
+                              (v11/*:: as any*/),
+                              (v12/*:: as any*/)
                             ],
                             "type": "ContinuousAnnotationConfig",
                             "abstractKey": null
@@ -367,7 +381,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v9/*:: as any*/),
+                              (v10/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -375,8 +389,8 @@ return {
                                 "name": "threshold",
                                 "storageKey": null
                               },
-                              (v10/*:: as any*/),
-                              (v11/*:: as any*/)
+                              (v11/*:: as any*/),
+                              (v12/*:: as any*/)
                             ],
                             "type": "FreeformAnnotationConfig",
                             "abstractKey": null
@@ -384,7 +398,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v12/*:: as any*/)
+                              (v13/*:: as any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -398,28 +412,28 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*:: as any*/)
+              (v8/*:: as any*/)
             ],
             "type": "Project",
             "abstractKey": null
           },
-          (v12/*:: as any*/)
+          (v13/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "ccb47dd9f2b25472980432524093001c",
+    "cacheID": "2dc91a3f8d7d5fdc20fe16e9d46fa278",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsTraceQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsTraceQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      traceAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsTraceQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment_3DyRD9\n      traceAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment_3DyRD9 on Project {\n  annotationConfigs(first: 1, names: [$annotationName]) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "159af501449580d6275f5737bf1c857a";
+(node as any).hash = "83749edaac3224bfbc04b0b5deab2f93";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsTraceQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsTraceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e5b8c2c9f30b60d3033e4de170fef7a7>>
+ * @generated SignedSource<<1c598c23bd4e58592d30565d79a58615>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -37,6 +38,7 @@ export type ProjectAnnotationMetricsTraceQuery$data = {
         readonly timestamp: string;
       }>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type ProjectAnnotationMetricsTraceQuery = {
@@ -68,87 +70,83 @@ v3 = [
   }
 ],
 v4 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "label",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationMetricsTimeSeries",
+  "kind": "LinkedField",
+  "name": "traceAnnotationMetricsTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationMetricsTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "traceAnnotationMetricsTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationMetricsTimeSeriesDataPoint",
+          "kind": "ScalarField",
+          "name": "timestamp",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AnnotationSummary",
           "kind": "LinkedField",
-          "name": "data",
+          "name": "annotationSummaries",
           "plural": true,
           "selections": [
+            (v4/*:: as any*/),
             {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
-              "name": "timestamp",
+              "name": "meanScore",
               "storageKey": null
             },
             {
               "alias": null,
               "args": null,
-              "concreteType": "AnnotationSummary",
+              "concreteType": "LabelFraction",
               "kind": "LinkedField",
-              "name": "annotationSummaries",
+              "name": "labelFractions",
               "plural": true,
               "selections": [
+                (v5/*:: as any*/),
                 {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "meanScore",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LabelFraction",
-                  "kind": "LinkedField",
-                  "name": "labelFractions",
-                  "plural": true,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "label",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "fraction",
-                      "storageKey": null
-                    }
-                  ],
+                  "name": "fraction",
                   "storageKey": null
                 }
               ],
@@ -161,8 +159,42 @@ v4 = {
       "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -183,7 +215,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v6/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -209,37 +253,149 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v7/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 100
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v7/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v4/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": [
+                                  (v5/*:: as any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "score",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v8/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v9/*:: as any*/),
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v11/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "annotationConfigs(first:100)"
+              },
+              (v6/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v4/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v11/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "1504bf8303abce125f34b7bc48dc693d",
+    "cacheID": "c73332e1346754cfb4b4f6e62ef0b4f0",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsTraceQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsTraceQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsTraceQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      traceAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 100) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "24d4b56936214dc3692569ed4677fe10";
+(node as any).hash = "0dab917651a50b77896cb633471385bd";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/SessionAnnotationScoreTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/SessionAnnotationScoreTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6b0539a68732001777593581e355a729>>
+ * @generated SignedSource<<8c1134f1a2fd5bbae47f3c73eddbe901>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -34,6 +35,7 @@ export type SessionAnnotationScoreTimeSeriesQuery$data = {
       }>;
       readonly names: ReadonlyArray<string>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type SessionAnnotationScoreTimeSeriesQuery = {
@@ -64,84 +66,113 @@ v3 = [
     "variableName": "projectId"
   }
 ],
-v4 = {
-  "kind": "InlineFragment",
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "label",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "score",
+    "storageKey": null
+  }
+],
+v5 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationScoreTimeSeries",
+  "kind": "LinkedField",
+  "name": "sessionAnnotationScoreTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationScoreTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationScoreTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "sessionAnnotationScoreTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationScoreTimeSeriesDataPoint",
-          "kind": "LinkedField",
-          "name": "data",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "timestamp",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "AnnotationScoreWithLabel",
-              "kind": "LinkedField",
-              "name": "scoresWithLabels",
-              "plural": true,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "label",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "score",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
+          "kind": "ScalarField",
+          "name": "timestamp",
           "storageKey": null
         },
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "names",
+          "concreteType": "AnnotationScoreWithLabel",
+          "kind": "LinkedField",
+          "name": "scoresWithLabels",
+          "plural": true,
+          "selections": (v4/*:: as any*/),
           "storageKey": null
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "names",
+      "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -162,7 +193,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v5/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -188,37 +231,146 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v6/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 100
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v6/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "name",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": (v4/*:: as any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "annotationConfigs(first:100)"
+              },
+              (v5/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v4/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v10/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "7883ad68336633bb6aa4f65a45983d5a",
+    "cacheID": "f54b8c8630396df7377c073e20872551",
     "id": null,
     "metadata": {},
     "name": "SessionAnnotationScoreTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query SessionAnnotationScoreTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessionAnnotationScoreTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          scoresWithLabels {\n            label\n            score\n          }\n        }\n        names\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query SessionAnnotationScoreTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      sessionAnnotationScoreTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          scoresWithLabels {\n            label\n            score\n          }\n        }\n        names\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 100) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "29705120976c4ef736259704531046e8";
+(node as any).hash = "e35b9c1d8f44bc2c65f9ffed502fbbd5";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/SpanAnnotationScoreTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/SpanAnnotationScoreTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<245bc9fb58429f9c30f945f96f56f2e8>>
+ * @generated SignedSource<<c6644a163338746ac3e039cf3113b738>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -34,6 +35,7 @@ export type SpanAnnotationScoreTimeSeriesQuery$data = {
       }>;
       readonly names: ReadonlyArray<string>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type SpanAnnotationScoreTimeSeriesQuery = {
@@ -64,84 +66,113 @@ v3 = [
     "variableName": "projectId"
   }
 ],
-v4 = {
-  "kind": "InlineFragment",
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "label",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "score",
+    "storageKey": null
+  }
+],
+v5 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationScoreTimeSeries",
+  "kind": "LinkedField",
+  "name": "spanAnnotationScoreTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationScoreTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationScoreTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "spanAnnotationScoreTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationScoreTimeSeriesDataPoint",
-          "kind": "LinkedField",
-          "name": "data",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "timestamp",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "AnnotationScoreWithLabel",
-              "kind": "LinkedField",
-              "name": "scoresWithLabels",
-              "plural": true,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "label",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "score",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
+          "kind": "ScalarField",
+          "name": "timestamp",
           "storageKey": null
         },
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "names",
+          "concreteType": "AnnotationScoreWithLabel",
+          "kind": "LinkedField",
+          "name": "scoresWithLabels",
+          "plural": true,
+          "selections": (v4/*:: as any*/),
           "storageKey": null
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "names",
+      "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -162,7 +193,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v5/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -188,37 +231,146 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v6/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 100
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v6/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "name",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": (v4/*:: as any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "annotationConfigs(first:100)"
+              },
+              (v5/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v4/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v10/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "7f0d6f5b5da2c7e87daa43a6f5f4bf3c",
+    "cacheID": "b2927fbb4a4dd0208088350d584a1ea9",
     "id": null,
     "metadata": {},
     "name": "SpanAnnotationScoreTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query SpanAnnotationScoreTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanAnnotationScoreTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          scoresWithLabels {\n            label\n            score\n          }\n        }\n        names\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query SpanAnnotationScoreTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      spanAnnotationScoreTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          scoresWithLabels {\n            label\n            score\n          }\n        }\n        names\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 100) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "709170f6d6e7e1273b1d5d924a3ba262";
+(node as any).hash = "877e411302cdc632c3638b5e1176003b";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/TraceAnnotationScoreTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/TraceAnnotationScoreTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<90a6c7b5f0e2a0e5998f6b4f1b3311de>>
+ * @generated SignedSource<<263d21d22b811533b113258a0418f665>>
  * @lightSyntaxTransform
  */
 
@@ -8,6 +8,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type TimeBinScale = "DAY" | "HOUR" | "MINUTE" | "MONTH" | "WEEK" | "YEAR";
 export type TimeRange = {
   end?: string | null;
@@ -34,6 +35,7 @@ export type TraceAnnotationScoreTimeSeriesQuery$data = {
       }>;
       readonly names: ReadonlyArray<string>;
     };
+    readonly " $fragmentSpreads": FragmentRefs<"ProjectAnnotationMetricsConfigFragment">;
   };
 };
 export type TraceAnnotationScoreTimeSeriesQuery = {
@@ -64,84 +66,113 @@ v3 = [
     "variableName": "projectId"
   }
 ],
-v4 = {
-  "kind": "InlineFragment",
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "label",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "score",
+    "storageKey": null
+  }
+],
+v5 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "timeBinConfig",
+      "variableName": "timeBinConfig"
+    },
+    {
+      "kind": "Variable",
+      "name": "timeRange",
+      "variableName": "timeRange"
+    }
+  ],
+  "concreteType": "AnnotationScoreTimeSeries",
+  "kind": "LinkedField",
+  "name": "traceAnnotationScoreTimeSeries",
+  "plural": false,
   "selections": [
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "timeBinConfig",
-          "variableName": "timeBinConfig"
-        },
-        {
-          "kind": "Variable",
-          "name": "timeRange",
-          "variableName": "timeRange"
-        }
-      ],
-      "concreteType": "AnnotationScoreTimeSeries",
+      "args": null,
+      "concreteType": "AnnotationScoreTimeSeriesDataPoint",
       "kind": "LinkedField",
-      "name": "traceAnnotationScoreTimeSeries",
-      "plural": false,
+      "name": "data",
+      "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "AnnotationScoreTimeSeriesDataPoint",
-          "kind": "LinkedField",
-          "name": "data",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "timestamp",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "AnnotationScoreWithLabel",
-              "kind": "LinkedField",
-              "name": "scoresWithLabels",
-              "plural": true,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "label",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "score",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
+          "kind": "ScalarField",
+          "name": "timestamp",
           "storageKey": null
         },
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "names",
+          "concreteType": "AnnotationScoreWithLabel",
+          "kind": "LinkedField",
+          "name": "scoresWithLabels",
+          "plural": true,
+          "selections": (v4/*:: as any*/),
           "storageKey": null
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "names",
+      "storageKey": null
     }
   ],
-  "type": "Project",
-  "abstractKey": null
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "optimizationDirection",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lowerBound",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "upperBound",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -162,7 +193,19 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ProjectAnnotationMetricsConfigFragment"
+              },
+              (v5/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -188,37 +231,146 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
+          (v6/*:: as any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 100
+                  }
+                ],
+                "concreteType": "AnnotationConfigConnection",
+                "kind": "LinkedField",
+                "name": "annotationConfigs",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AnnotationConfigEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "config",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v6/*:: as any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "name",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "annotationType",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "AnnotationConfigBase",
+                            "abstractKey": "__isAnnotationConfigBase"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationValue",
+                                "kind": "LinkedField",
+                                "name": "values",
+                                "plural": true,
+                                "selections": (v4/*:: as any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "CategoricalAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/)
+                            ],
+                            "type": "ContinuousAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v7/*:: as any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "threshold",
+                                "storageKey": null
+                              },
+                              (v8/*:: as any*/),
+                              (v9/*:: as any*/)
+                            ],
+                            "type": "FreeformAnnotationConfig",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v10/*:: as any*/)
+                            ],
+                            "type": "Node",
+                            "abstractKey": "__isNode"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "annotationConfigs(first:100)"
+              },
+              (v5/*:: as any*/)
+            ],
+            "type": "Project",
+            "abstractKey": null
           },
-          (v4/*:: as any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v10/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "8fc8b8201e9b9bc39d374ab5a06c8d4b",
+    "cacheID": "9a57817f79539e35d7657f6e890cc1ff",
     "id": null,
     "metadata": {},
     "name": "TraceAnnotationScoreTimeSeriesQuery",
     "operationKind": "query",
-    "text": "query TraceAnnotationScoreTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceAnnotationScoreTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          scoresWithLabels {\n            label\n            score\n          }\n        }\n        names\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query TraceAnnotationScoreTimeSeriesQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      ...ProjectAnnotationMetricsConfigFragment\n      traceAnnotationScoreTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          scoresWithLabels {\n            label\n            score\n          }\n        }\n        names\n      }\n    }\n    id\n  }\n}\n\nfragment ProjectAnnotationMetricsConfigFragment on Project {\n  annotationConfigs(first: 100) {\n    edges {\n      config: node {\n        __typename\n        ... on AnnotationConfigBase {\n          __isAnnotationConfigBase: __typename\n          name\n          annotationType\n        }\n        ... on CategoricalAnnotationConfig {\n          optimizationDirection\n          values {\n            label\n            score\n          }\n        }\n        ... on ContinuousAnnotationConfig {\n          optimizationDirection\n          lowerBound\n          upperBound\n        }\n        ... on FreeformAnnotationConfig {\n          optimizationDirection\n          threshold\n          lowerBound\n          upperBound\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "595076367e665ffa321498d8ab8bab14";
+(node as any).hash = "39985f776facb94014cc04426d2580df";
 
 export default node;

--- a/app/src/pages/project/metrics/useProjectAnnotationConfigsByName.ts
+++ b/app/src/pages/project/metrics/useProjectAnnotationConfigsByName.ts
@@ -1,0 +1,64 @@
+import { graphql, useFragment } from "react-relay";
+
+import type { AnnotationOptimizationConfig } from "@phoenix/components/annotation";
+
+import type { ProjectAnnotationMetricsConfigFragment$key } from "./__generated__/ProjectAnnotationMetricsConfigFragment.graphql";
+
+export function useProjectAnnotationConfigsByName(
+  project: ProjectAnnotationMetricsConfigFragment$key
+): ReadonlyMap<string, AnnotationOptimizationConfig> {
+  const data = useFragment(
+    graphql`
+      fragment ProjectAnnotationMetricsConfigFragment on Project
+      @argumentDefinitions(
+        annotationConfigNames: { type: "[String!]" }
+        first: { type: "Int", defaultValue: 100 }
+      ) {
+        annotationConfigs(first: $first, names: $annotationConfigNames) {
+          edges {
+            config: node {
+              ... on AnnotationConfigBase {
+                name
+                annotationType
+              }
+              ... on CategoricalAnnotationConfig {
+                optimizationDirection
+                values {
+                  label
+                  score
+                }
+              }
+              ... on ContinuousAnnotationConfig {
+                optimizationDirection
+                lowerBound
+                upperBound
+              }
+              ... on FreeformAnnotationConfig {
+                optimizationDirection
+                threshold
+                lowerBound
+                upperBound
+              }
+            }
+          }
+        }
+      }
+    `,
+    project
+  );
+  const configsByName = new Map<string, AnnotationOptimizationConfig>();
+  data.annotationConfigs.edges.forEach(({ config }) => {
+    if (config.name == null || config.annotationType == null) {
+      return;
+    }
+    configsByName.set(config.name, {
+      annotationType: config.annotationType,
+      optimizationDirection: config.optimizationDirection,
+      lowerBound: config.lowerBound,
+      upperBound: config.upperBound,
+      threshold: config.threshold,
+      values: config.values,
+    });
+  });
+  return configsByName;
+}

--- a/app/src/pages/project/metrics/useProjectAnnotationConfigsByName.ts
+++ b/app/src/pages/project/metrics/useProjectAnnotationConfigsByName.ts
@@ -1,0 +1,60 @@
+import { graphql, useFragment } from "react-relay";
+
+import type { AnnotationOptimizationConfig } from "@phoenix/components/annotation";
+
+import type { ProjectAnnotationMetricsConfigFragment$key } from "./__generated__/ProjectAnnotationMetricsConfigFragment.graphql";
+
+export function useProjectAnnotationConfigsByName(
+  project: ProjectAnnotationMetricsConfigFragment$key
+): ReadonlyMap<string, AnnotationOptimizationConfig> {
+  const data = useFragment(
+    graphql`
+      fragment ProjectAnnotationMetricsConfigFragment on Project {
+        annotationConfigs(first: 100) {
+          edges {
+            config: node {
+              ... on AnnotationConfigBase {
+                name
+                annotationType
+              }
+              ... on CategoricalAnnotationConfig {
+                optimizationDirection
+                values {
+                  label
+                  score
+                }
+              }
+              ... on ContinuousAnnotationConfig {
+                optimizationDirection
+                lowerBound
+                upperBound
+              }
+              ... on FreeformAnnotationConfig {
+                optimizationDirection
+                threshold
+                lowerBound
+                upperBound
+              }
+            }
+          }
+        }
+      }
+    `,
+    project
+  );
+  const configsByName = new Map<string, AnnotationOptimizationConfig>();
+  data.annotationConfigs.edges.forEach(({ config }) => {
+    if (config.name == null || config.annotationType == null) {
+      return;
+    }
+    configsByName.set(config.name, {
+      annotationType: config.annotationType,
+      optimizationDirection: config.optimizationDirection,
+      lowerBound: config.lowerBound,
+      upperBound: config.upperBound,
+      threshold: config.threshold,
+      values: config.values,
+    });
+  });
+  return configsByName;
+}

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -1416,6 +1416,13 @@ class Project(Node):
         last: Optional[int] = None,
         after: Optional[str] = None,
         before: Optional[str] = None,
+        names: Annotated[
+            Optional[list[str]],
+            strawberry.argument(
+                description="When provided, return only annotation configs whose name "
+                "exactly matches one of the given names."
+            ),
+        ] = UNSET,
     ) -> Connection[AnnotationConfig]:
         args = ConnectionArgs(
             first=first,
@@ -1423,8 +1430,21 @@ class Project(Node):
             last=last,
             before=before if isinstance(before, CursorString) else None,
         )
-        loader = info.context.data_loaders.annotation_configs_by_project
-        configs = await loader.load(self.id)
+        if names:
+            stmt = (
+                select(models.AnnotationConfig)
+                .join_from(models.ProjectAnnotationConfig, models.AnnotationConfig)
+                .where(
+                    models.ProjectAnnotationConfig.project_id == self.id,
+                    models.AnnotationConfig.name.in_(names),
+                )
+                .order_by(models.AnnotationConfig.name.asc())
+            )
+            async with info.context.db.read() as session:
+                configs = tuple(await session.scalars(stmt))
+        else:
+            loader = info.context.data_loaders.annotation_configs_by_project
+            configs = await loader.load(self.id)
         data = [to_gql_annotation_config(config) for config in configs]
         return connection_from_list(data=data, args=args)
 

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -18,6 +18,12 @@ from typing_extensions import assert_never
 
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
+from phoenix.db.types.annotation_configs import (
+    AnnotationType,
+    CategoricalAnnotationConfig,
+    CategoricalAnnotationValue,
+    OptimizationDirection,
+)
 from phoenix.server.api.input_types.TimeBinConfig import TimeBinConfig, TimeBinScale
 from phoenix.server.api.input_types.TimeRange import TimeRange
 from phoenix.server.api.types.pagination import Cursor, CursorSortColumn, CursorSortColumnDataType
@@ -2123,6 +2129,55 @@ class TestProject:
         assert (
             await self._node("sessionAnnotationNameCounts{name count}", project, httpx_client) == []
         )
+
+    async def test_annotation_configs_filter_by_name_and_project(
+        self,
+        db: DbSessionFactory,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        async with db() as session:
+            project = await _add_project(session, name="annotation-config-filter-test")
+            other_project = await _add_project(
+                session, name="annotation-config-filter-other-project"
+            )
+            configs = [
+                models.AnnotationConfig(
+                    name=name,
+                    config=CategoricalAnnotationConfig(
+                        type=AnnotationType.CATEGORICAL.value,
+                        optimization_direction=OptimizationDirection.MAXIMIZE,
+                        values=[CategoricalAnnotationValue(label="Good", score=1.0)],
+                    ),
+                )
+                for name in ("correctness", "relevance", "other-project-only")
+            ]
+            session.add_all(configs)
+            await session.flush()
+            session.add_all(
+                [
+                    models.ProjectAnnotationConfig(
+                        project_id=project.id,
+                        annotation_config_id=configs[0].id,
+                    ),
+                    models.ProjectAnnotationConfig(
+                        project_id=project.id,
+                        annotation_config_id=configs[1].id,
+                    ),
+                    models.ProjectAnnotationConfig(
+                        project_id=other_project.id,
+                        annotation_config_id=configs[2].id,
+                    ),
+                ]
+            )
+
+        annotation_configs = await self._node(
+            'annotationConfigs(names: ["relevance", "other-project-only"]) '
+            "{edges{node{... on AnnotationConfigBase{name}}}}",
+            project,
+            httpx_client,
+        )
+
+        assert annotation_configs == {"edges": [{"node": {"name": "relevance"}}]}
 
     @pytest.fixture
     async def _data(


### PR DESCRIPTION
## Summary

- render annotation score values in project metric tooltips with positive or negative semantic styling
- classify custom evaluation scores using their configured optimization direction and threshold or score range
- apply the same styling to individual and aggregate span, trace, and session annotation charts
- keep label distributions and built-in metrics without an absolute threshold neutral

## Screenshots

### Aggregate annotation scores

The combined chart applies each annotation’s own optimization configuration to its tooltip value.

![Aggregate annotation score tooltip](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14936-aggregate-annotation-tooltip-dark.png)

### Individual annotation score

Minimize-direction annotations render lower scores as positive and higher scores as negative.

![Individual minimize annotation tooltip](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/14936-minimize-annotation-tooltip-light.png)

## Test plan

- `pnpm build`
- `pnpm typecheck`
- focused `pnpm lint` and `oxfmt --check` on changed source files
- `pnpm exec vitest run src/components/annotation/__tests__/optimizationUtils.test.ts`
- verified individual and aggregate tooltip semantics in light and dark themes with maximize, minimize, threshold, continuous, and categorical configs

Related: #14481