### PR TITLE
feat(project): fetch annotation metric charts independently

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2829,6 +2829,21 @@ type Project implements Node {
   sessionAnnotationNames: [String!]!
 
   """
+  Names of span annotations with a score or label in the requested time range.
+  """
+  spanAnnotationMetricNames(timeRange: TimeRange!): [String!]!
+
+  """
+  Names of trace annotations with a score or label in the requested time range.
+  """
+  traceAnnotationMetricNames(timeRange: TimeRange!): [String!]!
+
+  """
+  Names of session annotations with a score or label in the requested time range.
+  """
+  sessionAnnotationMetricNames(timeRange: TimeRange!): [String!]!
+
+  """
   Span annotation names along with the number of span annotations that have been added for each name in this project.
   """
   spanAnnotationNameCounts: [AnnotationNameCount!]!
@@ -2873,9 +2888,9 @@ type Project implements Node {
   spanAnnotationScoreTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig): AnnotationScoreTimeSeries!
   traceAnnotationScoreTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig): AnnotationScoreTimeSeries!
   sessionAnnotationScoreTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig): AnnotationScoreTimeSeries!
-  spanAnnotationMetricsTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig): AnnotationMetricsTimeSeries!
-  traceAnnotationMetricsTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig): AnnotationMetricsTimeSeries!
-  sessionAnnotationMetricsTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig): AnnotationMetricsTimeSeries!
+  spanAnnotationMetricsTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig, annotationName: String): AnnotationMetricsTimeSeries!
+  traceAnnotationMetricsTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig, annotationName: String): AnnotationMetricsTimeSeries!
+  sessionAnnotationMetricsTimeSeries(timeRange: TimeRange!, timeBinConfig: TimeBinConfig, annotationName: String): AnnotationMetricsTimeSeries!
   topModelsByCost(timeRange: TimeRange!): [GenerativeModel!]!
   topModelsByTokenCount(timeRange: TimeRange!): [GenerativeModel!]!
 }

--- a/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
+++ b/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
@@ -31,6 +31,9 @@ import type { ProjectAnnotationMetricNamesTraceQuery } from "./__generated__/Pro
 import type { ProjectAnnotationMetricsSessionQuery } from "./__generated__/ProjectAnnotationMetricsSessionQuery.graphql";
 import type { ProjectAnnotationMetricsSpanQuery } from "./__generated__/ProjectAnnotationMetricsSpanQuery.graphql";
 import type { ProjectAnnotationMetricsTraceQuery } from "./__generated__/ProjectAnnotationMetricsTraceQuery.graphql";
+import type { ProjectAnnotationMetricTimeRangeNamesSessionQuery } from "./__generated__/ProjectAnnotationMetricTimeRangeNamesSessionQuery.graphql";
+import type { ProjectAnnotationMetricTimeRangeNamesSpanQuery } from "./__generated__/ProjectAnnotationMetricTimeRangeNamesSpanQuery.graphql";
+import type { ProjectAnnotationMetricTimeRangeNamesTraceQuery } from "./__generated__/ProjectAnnotationMetricTimeRangeNamesTraceQuery.graphql";
 import type { ProjectMetricViewProps } from "./types";
 import {
   PROJECT_METRICS_CHART_SYNC_ID,
@@ -49,22 +52,13 @@ type AnnotationMetricsData = ReadonlyArray<{
   }>;
 }>;
 
-function getProjectAnnotationMetricsSeries({
-  data,
-  annotationName,
-}: {
-  data: AnnotationMetricsData;
-  annotationName?: string;
-}): AnnotationMetricsSeries[] {
+function getProjectAnnotationMetricsSeries(
+  data: AnnotationMetricsData
+): AnnotationMetricsSeries[] {
   return normalizeAnnotationMetrics({
     points: data.map((point) => ({
       x: new Date(point.timestamp).getTime(),
-      summaries:
-        annotationName == null
-          ? point.annotationSummaries
-          : point.annotationSummaries.filter(
-              (summary) => summary.name === annotationName
-            ),
+      summaries: point.annotationSummaries,
     })),
   });
 }
@@ -80,31 +74,25 @@ const annotationGridCSS = css`
 `;
 
 function ProjectAnnotationMetricsGridView({
-  annotationSeries,
-  timeRange,
-  onTimeRangeSelected,
-}: {
-  annotationSeries: AnnotationMetricsSeries[];
-  timeRange: TimeRange;
-  onTimeRangeSelected?: (timeRange: TimeRange) => void;
+  annotationNames,
+  annotationLevel,
+  ...props
+}: ProjectMetricViewProps & {
+  annotationNames: ReadonlyArray<string>;
+  annotationLevel: MetricChartTableView;
 }) {
-  const scale = useTimeBinScale({ timeRange });
-  const timeTickFormatter = useBinTimeTickFormatter({ scale });
-  const { fullTimeFormatter } = useTimeFormatters();
-  if (annotationSeries.length === 0) {
+  if (annotationNames.length === 0) {
     return null;
   }
 
   return (
     <div css={annotationGridCSS}>
-      {annotationSeries.map((series) => (
-        <ProjectAnnotationMetricsPanel
-          key={series.name}
-          series={series}
-          timeRange={timeRange}
-          timeTickFormatter={timeTickFormatter}
-          fullTimeFormatter={fullTimeFormatter}
-          onTimeRangeSelected={onTimeRangeSelected}
+      {annotationNames.map((annotationName) => (
+        <ProjectAnnotationMetricPanel
+          {...props}
+          key={annotationName}
+          annotationLevel={annotationLevel}
+          annotationName={annotationName}
         />
       ))}
     </div>
@@ -246,17 +234,18 @@ export function ProjectAnnotationMetricsGrid({
   return (
     <ErrorBoundary>
       <Suspense fallback={<Loading />}>
-        <ProjectAnnotationMetricsSeriesLoader
+        <ProjectAnnotationMetricNamesLoader
           {...props}
           annotationLevel={annotationLevel}
         >
-          {(annotationSeries) => (
+          {(annotationNames) => (
             <ProjectAnnotationMetricsGridView
               {...props}
-              annotationSeries={annotationSeries}
+              annotationLevel={annotationLevel}
+              annotationNames={annotationNames}
             />
           )}
-        </ProjectAnnotationMetricsSeriesLoader>
+        </ProjectAnnotationMetricNamesLoader>
       </Suspense>
     </ErrorBoundary>
   );
@@ -331,8 +320,117 @@ export function useSessionAnnotationMetricNames(
   );
 }
 
+type ProjectAnnotationMetricNamesLoaderProps = ProjectMetricViewProps & {
+  annotationLevel: MetricChartTableView;
+  children: (annotationNames: ReadonlyArray<string>) => ReactNode;
+};
+
+function ProjectAnnotationMetricNamesLoader({
+  annotationLevel,
+  ...props
+}: ProjectAnnotationMetricNamesLoaderProps) {
+  switch (annotationLevel) {
+    case "spans":
+      return <SpanAnnotationMetricNamesLoader {...props} />;
+    case "traces":
+      return <TraceAnnotationMetricNamesLoader {...props} />;
+    case "sessions":
+      return <SessionAnnotationMetricNamesLoader {...props} />;
+  }
+  return null;
+}
+
+function SpanAnnotationMetricNamesLoader({
+  children,
+  ...props
+}: Omit<ProjectAnnotationMetricNamesLoaderProps, "annotationLevel">) {
+  return children(useSpanAnnotationMetricTimeRangeNames(props));
+}
+
+function TraceAnnotationMetricNamesLoader({
+  children,
+  ...props
+}: Omit<ProjectAnnotationMetricNamesLoaderProps, "annotationLevel">) {
+  return children(useTraceAnnotationMetricTimeRangeNames(props));
+}
+
+function SessionAnnotationMetricNamesLoader({
+  children,
+  ...props
+}: Omit<ProjectAnnotationMetricNamesLoaderProps, "annotationLevel">) {
+  return children(useSessionAnnotationMetricTimeRangeNames(props));
+}
+
+function useSpanAnnotationMetricTimeRangeNames(
+  props: ProjectMetricViewProps
+): ReadonlyArray<string> {
+  const data = useLazyLoadQuery<ProjectAnnotationMetricTimeRangeNamesSpanQuery>(
+    graphql`
+      query ProjectAnnotationMetricTimeRangeNamesSpanQuery(
+        $projectId: ID!
+        $timeRange: TimeRange!
+      ) {
+        project: node(id: $projectId) {
+          ... on Project {
+            spanAnnotationMetricNames(timeRange: $timeRange)
+          }
+        }
+      }
+    `,
+    getTimeRangeQueryVariables(props),
+    useMetricQueryFetchOptions()
+  );
+  return data.project.spanAnnotationMetricNames ?? [];
+}
+
+function useTraceAnnotationMetricTimeRangeNames(
+  props: ProjectMetricViewProps
+): ReadonlyArray<string> {
+  const data =
+    useLazyLoadQuery<ProjectAnnotationMetricTimeRangeNamesTraceQuery>(
+      graphql`
+        query ProjectAnnotationMetricTimeRangeNamesTraceQuery(
+          $projectId: ID!
+          $timeRange: TimeRange!
+        ) {
+          project: node(id: $projectId) {
+            ... on Project {
+              traceAnnotationMetricNames(timeRange: $timeRange)
+            }
+          }
+        }
+      `,
+      getTimeRangeQueryVariables(props),
+      useMetricQueryFetchOptions()
+    );
+  return data.project.traceAnnotationMetricNames ?? [];
+}
+
+function useSessionAnnotationMetricTimeRangeNames(
+  props: ProjectMetricViewProps
+): ReadonlyArray<string> {
+  const data =
+    useLazyLoadQuery<ProjectAnnotationMetricTimeRangeNamesSessionQuery>(
+      graphql`
+        query ProjectAnnotationMetricTimeRangeNamesSessionQuery(
+          $projectId: ID!
+          $timeRange: TimeRange!
+        ) {
+          project: node(id: $projectId) {
+            ... on Project {
+              sessionAnnotationMetricNames(timeRange: $timeRange)
+            }
+          }
+        }
+      `,
+      getTimeRangeQueryVariables(props),
+      useMetricQueryFetchOptions()
+    );
+  return data.project.sessionAnnotationMetricNames ?? [];
+}
+
 type ProjectAnnotationMetricsQueryProps = ProjectMetricViewProps & {
-  annotationName?: string;
+  annotationName: string;
 };
 
 type ProjectAnnotationMetricsSeriesLoaderProps =
@@ -388,12 +486,14 @@ function useSpanAnnotationMetricsSeries(
     graphql`
       query ProjectAnnotationMetricsSpanQuery(
         $projectId: ID!
+        $annotationName: String!
         $timeRange: TimeRange!
         $timeBinConfig: TimeBinConfig!
       ) {
         project: node(id: $projectId) {
           ... on Project {
             spanAnnotationMetricsTimeSeries(
+              annotationName: $annotationName
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
             ) {
@@ -416,10 +516,9 @@ function useSpanAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries({
-    data: data.project.spanAnnotationMetricsTimeSeries?.data ?? [],
-    annotationName: props.annotationName,
-  });
+  return getProjectAnnotationMetricsSeries(
+    data.project.spanAnnotationMetricsTimeSeries?.data ?? []
+  );
 }
 
 function useTraceAnnotationMetricsSeries(
@@ -431,12 +530,14 @@ function useTraceAnnotationMetricsSeries(
     graphql`
       query ProjectAnnotationMetricsTraceQuery(
         $projectId: ID!
+        $annotationName: String!
         $timeRange: TimeRange!
         $timeBinConfig: TimeBinConfig!
       ) {
         project: node(id: $projectId) {
           ... on Project {
             traceAnnotationMetricsTimeSeries(
+              annotationName: $annotationName
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
             ) {
@@ -459,10 +560,9 @@ function useTraceAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries({
-    data: data.project.traceAnnotationMetricsTimeSeries?.data ?? [],
-    annotationName: props.annotationName,
-  });
+  return getProjectAnnotationMetricsSeries(
+    data.project.traceAnnotationMetricsTimeSeries?.data ?? []
+  );
 }
 
 function useSessionAnnotationMetricsSeries(
@@ -474,12 +574,14 @@ function useSessionAnnotationMetricsSeries(
     graphql`
       query ProjectAnnotationMetricsSessionQuery(
         $projectId: ID!
+        $annotationName: String!
         $timeRange: TimeRange!
         $timeBinConfig: TimeBinConfig!
       ) {
         project: node(id: $projectId) {
           ... on Project {
             sessionAnnotationMetricsTimeSeries(
+              annotationName: $annotationName
               timeRange: $timeRange
               timeBinConfig: $timeBinConfig
             ) {
@@ -502,27 +604,37 @@ function useSessionAnnotationMetricsSeries(
     getQueryVariables({ ...props, scale, utcOffsetMinutes }),
     useMetricQueryFetchOptions()
   );
-  return getProjectAnnotationMetricsSeries({
-    data: data.project.sessionAnnotationMetricsTimeSeries?.data ?? [],
-    annotationName: props.annotationName,
-  });
+  return getProjectAnnotationMetricsSeries(
+    data.project.sessionAnnotationMetricsTimeSeries?.data ?? []
+  );
 }
 
 function getQueryVariables({
   projectId,
+  annotationName,
   timeRange,
   scale,
   utcOffsetMinutes,
-}: ProjectMetricViewProps & {
+}: ProjectAnnotationMetricsQueryProps & {
   scale: TimeBinScale;
   utcOffsetMinutes: number;
 }) {
+  return {
+    ...getTimeRangeQueryVariables({ projectId, timeRange }),
+    annotationName,
+    timeBinConfig: { scale, utcOffsetMinutes },
+  };
+}
+
+function getTimeRangeQueryVariables({
+  projectId,
+  timeRange,
+}: Pick<ProjectMetricViewProps, "projectId" | "timeRange">) {
   return {
     projectId,
     timeRange: {
       start: timeRange.start.toISOString(),
       end: timeRange.end.toISOString(),
     },
-    timeBinConfig: { scale, utcOffsetMinutes },
   };
 }

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricTimeRangeNamesSessionQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricTimeRangeNamesSessionQuery.graphql.ts
@@ -1,0 +1,139 @@
+/**
+ * @generated SignedSource<<1838d8d5fb713aa60885edb9901392ba>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type ProjectAnnotationMetricTimeRangeNamesSessionQuery$variables = {
+  projectId: string;
+  timeRange: TimeRange;
+};
+export type ProjectAnnotationMetricTimeRangeNamesSessionQuery$data = {
+  readonly project: {
+    readonly sessionAnnotationMetricNames?: ReadonlyArray<string>;
+  };
+};
+export type ProjectAnnotationMetricTimeRangeNamesSessionQuery = {
+  response: ProjectAnnotationMetricTimeRangeNamesSessionQuery$data;
+  variables: ProjectAnnotationMetricTimeRangeNamesSessionQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "timeRange"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "timeRange",
+          "variableName": "timeRange"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "sessionAnnotationMetricNames",
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAnnotationMetricTimeRangeNamesSessionQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "ProjectAnnotationMetricTimeRangeNamesSessionQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b534b802250bc188481720c66dac0665",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAnnotationMetricTimeRangeNamesSessionQuery",
+    "operationKind": "query",
+    "text": "query ProjectAnnotationMetricTimeRangeNamesSessionQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessionAnnotationMetricNames(timeRange: $timeRange)\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "32803ad64f5e4478a58e2dc0a5d18af4";
+
+export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricTimeRangeNamesSpanQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricTimeRangeNamesSpanQuery.graphql.ts
@@ -1,0 +1,139 @@
+/**
+ * @generated SignedSource<<f087ab9c3f68dc94c0ccf8c3af62c7ee>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type ProjectAnnotationMetricTimeRangeNamesSpanQuery$variables = {
+  projectId: string;
+  timeRange: TimeRange;
+};
+export type ProjectAnnotationMetricTimeRangeNamesSpanQuery$data = {
+  readonly project: {
+    readonly spanAnnotationMetricNames?: ReadonlyArray<string>;
+  };
+};
+export type ProjectAnnotationMetricTimeRangeNamesSpanQuery = {
+  response: ProjectAnnotationMetricTimeRangeNamesSpanQuery$data;
+  variables: ProjectAnnotationMetricTimeRangeNamesSpanQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "timeRange"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "timeRange",
+          "variableName": "timeRange"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "spanAnnotationMetricNames",
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAnnotationMetricTimeRangeNamesSpanQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "ProjectAnnotationMetricTimeRangeNamesSpanQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1757f206d1382138d9880180d2718d70",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAnnotationMetricTimeRangeNamesSpanQuery",
+    "operationKind": "query",
+    "text": "query ProjectAnnotationMetricTimeRangeNamesSpanQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanAnnotationMetricNames(timeRange: $timeRange)\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "19f5686552fc2341a0b5b88e042f18bc";
+
+export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricTimeRangeNamesTraceQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricTimeRangeNamesTraceQuery.graphql.ts
@@ -1,0 +1,139 @@
+/**
+ * @generated SignedSource<<a90001c02fa62f7fd4a92b3ea2a7fce4>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TimeRange = {
+  end?: string | null;
+  start?: string | null;
+};
+export type ProjectAnnotationMetricTimeRangeNamesTraceQuery$variables = {
+  projectId: string;
+  timeRange: TimeRange;
+};
+export type ProjectAnnotationMetricTimeRangeNamesTraceQuery$data = {
+  readonly project: {
+    readonly traceAnnotationMetricNames?: ReadonlyArray<string>;
+  };
+};
+export type ProjectAnnotationMetricTimeRangeNamesTraceQuery = {
+  response: ProjectAnnotationMetricTimeRangeNamesTraceQuery$data;
+  variables: ProjectAnnotationMetricTimeRangeNamesTraceQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "timeRange"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "timeRange",
+          "variableName": "timeRange"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "traceAnnotationMetricNames",
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAnnotationMetricTimeRangeNamesTraceQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "ProjectAnnotationMetricTimeRangeNamesTraceQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "72397435acaeeb8c3a5b2a88d9404a3e",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAnnotationMetricTimeRangeNamesTraceQuery",
+    "operationKind": "query",
+    "text": "query ProjectAnnotationMetricTimeRangeNamesTraceQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceAnnotationMetricNames(timeRange: $timeRange)\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f1df6510bf3bb9db7c8e0e713f6ee3be";
+
+export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSessionQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7dca1ee8e6bc0f7f6a69ac7badcbc866>>
+ * @generated SignedSource<<b559590e6cb93458df778cbfb2d258cf>>
  * @lightSyntaxTransform
  */
 
@@ -18,6 +18,7 @@ export type TimeBinConfig = {
   utcOffsetMinutes?: number;
 };
 export type ProjectAnnotationMetricsSessionQuery$variables = {
+  annotationName: string;
   projectId: string;
   timeBinConfig: TimeBinConfig;
   timeRange: TimeRange;
@@ -48,31 +49,41 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "projectId"
+  "name": "annotationName"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "timeBinConfig"
+  "name": "projectId"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "timeBinConfig"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v3 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "projectId"
   }
 ],
-v4 = {
+v5 = {
   "kind": "InlineFragment",
   "selections": [
     {
       "alias": null,
       "args": [
+        {
+          "kind": "Variable",
+          "name": "annotationName",
+          "variableName": "annotationName"
+        },
         {
           "kind": "Variable",
           "name": "timeBinConfig",
@@ -169,7 +180,8 @@ return {
     "argumentDefinitions": [
       (v0/*:: as any*/),
       (v1/*:: as any*/),
-      (v2/*:: as any*/)
+      (v2/*:: as any*/),
+      (v3/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -177,13 +189,13 @@ return {
     "selections": [
       {
         "alias": "project",
-        "args": (v3/*:: as any*/),
+        "args": (v4/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          (v5/*:: as any*/)
         ],
         "storageKey": null
       }
@@ -194,16 +206,17 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
+      (v1/*:: as any*/),
       (v0/*:: as any*/),
-      (v2/*:: as any*/),
-      (v1/*:: as any*/)
+      (v3/*:: as any*/),
+      (v2/*:: as any*/)
     ],
     "kind": "Operation",
     "name": "ProjectAnnotationMetricsSessionQuery",
     "selections": [
       {
         "alias": "project",
-        "args": (v3/*:: as any*/),
+        "args": (v4/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -216,7 +229,7 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v4/*:: as any*/),
+          (v5/*:: as any*/),
           {
             "alias": null,
             "args": null,
@@ -230,16 +243,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7cb6893ceb88edac440d40c6fd3e4084",
+    "cacheID": "12432efec3a268a16a45d1711f2706f0",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsSessionQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsSessionQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessionAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsSessionQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      sessionAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "07443607dcdc1026031d1d4cb6157f7f";
+(node as any).hash = "44830346da58f8d9ab79e4ac927cdbe5";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSpanQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsSpanQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b56dfdf85955ae1ffbb339bec9f67118>>
+ * @generated SignedSource<<2c4b5d8053add9d90fc3be129fc7335e>>
  * @lightSyntaxTransform
  */
 
@@ -18,6 +18,7 @@ export type TimeBinConfig = {
   utcOffsetMinutes?: number;
 };
 export type ProjectAnnotationMetricsSpanQuery$variables = {
+  annotationName: string;
   projectId: string;
   timeBinConfig: TimeBinConfig;
   timeRange: TimeRange;
@@ -48,31 +49,41 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "projectId"
+  "name": "annotationName"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "timeBinConfig"
+  "name": "projectId"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "timeBinConfig"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v3 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "projectId"
   }
 ],
-v4 = {
+v5 = {
   "kind": "InlineFragment",
   "selections": [
     {
       "alias": null,
       "args": [
+        {
+          "kind": "Variable",
+          "name": "annotationName",
+          "variableName": "annotationName"
+        },
         {
           "kind": "Variable",
           "name": "timeBinConfig",
@@ -169,7 +180,8 @@ return {
     "argumentDefinitions": [
       (v0/*:: as any*/),
       (v1/*:: as any*/),
-      (v2/*:: as any*/)
+      (v2/*:: as any*/),
+      (v3/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -177,13 +189,13 @@ return {
     "selections": [
       {
         "alias": "project",
-        "args": (v3/*:: as any*/),
+        "args": (v4/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          (v5/*:: as any*/)
         ],
         "storageKey": null
       }
@@ -194,16 +206,17 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
+      (v1/*:: as any*/),
       (v0/*:: as any*/),
-      (v2/*:: as any*/),
-      (v1/*:: as any*/)
+      (v3/*:: as any*/),
+      (v2/*:: as any*/)
     ],
     "kind": "Operation",
     "name": "ProjectAnnotationMetricsSpanQuery",
     "selections": [
       {
         "alias": "project",
-        "args": (v3/*:: as any*/),
+        "args": (v4/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -216,7 +229,7 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v4/*:: as any*/),
+          (v5/*:: as any*/),
           {
             "alias": null,
             "args": null,
@@ -230,16 +243,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1f90d7ab8b73f67210030baad0d4f6db",
+    "cacheID": "3d3e53644df5b2201c8eed5b7be737da",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsSpanQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsSpanQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsSpanQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      spanAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "db2841f1151f38c2041612b45b54a0f3";
+(node as any).hash = "d074b302b78c8303950be1bd4305cc0d";
 
 export default node;

--- a/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsTraceQuery.graphql.ts
+++ b/app/src/pages/project/metrics/__generated__/ProjectAnnotationMetricsTraceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e5b8c2c9f30b60d3033e4de170fef7a7>>
+ * @generated SignedSource<<de0e630bd6ccb5880435a9894b3b8aba>>
  * @lightSyntaxTransform
  */
 
@@ -18,6 +18,7 @@ export type TimeBinConfig = {
   utcOffsetMinutes?: number;
 };
 export type ProjectAnnotationMetricsTraceQuery$variables = {
+  annotationName: string;
   projectId: string;
   timeBinConfig: TimeBinConfig;
   timeRange: TimeRange;
@@ -48,31 +49,41 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "projectId"
+  "name": "annotationName"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "timeBinConfig"
+  "name": "projectId"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "timeBinConfig"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "timeRange"
 },
-v3 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "projectId"
   }
 ],
-v4 = {
+v5 = {
   "kind": "InlineFragment",
   "selections": [
     {
       "alias": null,
       "args": [
+        {
+          "kind": "Variable",
+          "name": "annotationName",
+          "variableName": "annotationName"
+        },
         {
           "kind": "Variable",
           "name": "timeBinConfig",
@@ -169,7 +180,8 @@ return {
     "argumentDefinitions": [
       (v0/*:: as any*/),
       (v1/*:: as any*/),
-      (v2/*:: as any*/)
+      (v2/*:: as any*/),
+      (v3/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -177,13 +189,13 @@ return {
     "selections": [
       {
         "alias": "project",
-        "args": (v3/*:: as any*/),
+        "args": (v4/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*:: as any*/)
+          (v5/*:: as any*/)
         ],
         "storageKey": null
       }
@@ -194,16 +206,17 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
+      (v1/*:: as any*/),
       (v0/*:: as any*/),
-      (v2/*:: as any*/),
-      (v1/*:: as any*/)
+      (v3/*:: as any*/),
+      (v2/*:: as any*/)
     ],
     "kind": "Operation",
     "name": "ProjectAnnotationMetricsTraceQuery",
     "selections": [
       {
         "alias": "project",
-        "args": (v3/*:: as any*/),
+        "args": (v4/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -216,7 +229,7 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v4/*:: as any*/),
+          (v5/*:: as any*/),
           {
             "alias": null,
             "args": null,
@@ -230,16 +243,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1504bf8303abce125f34b7bc48dc693d",
+    "cacheID": "254ad3e30df31c19c2cea56bf520cf0a",
     "id": null,
     "metadata": {},
     "name": "ProjectAnnotationMetricsTraceQuery",
     "operationKind": "query",
-    "text": "query ProjectAnnotationMetricsTraceQuery(\n  $projectId: ID!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceAnnotationMetricsTimeSeries(timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ProjectAnnotationMetricsTraceQuery(\n  $projectId: ID!\n  $annotationName: String!\n  $timeRange: TimeRange!\n  $timeBinConfig: TimeBinConfig!\n) {\n  project: node(id: $projectId) {\n    __typename\n    ... on Project {\n      traceAnnotationMetricsTimeSeries(annotationName: $annotationName, timeRange: $timeRange, timeBinConfig: $timeBinConfig) {\n        data {\n          timestamp\n          annotationSummaries {\n            name\n            meanScore\n            labelFractions {\n              label\n              fraction\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "24d4b56936214dc3692569ed4677fe10";
+(node as any).hash = "7380e4e417156c4b342bf16bee52a6f9";
 
 export default node;

--- a/app/src/pages/project/metrics/__tests__/ProjectAnnotationMetrics.test.tsx
+++ b/app/src/pages/project/metrics/__tests__/ProjectAnnotationMetrics.test.tsx
@@ -1,0 +1,164 @@
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { RelayEnvironmentProvider } from "react-relay";
+import {
+  Environment,
+  Network,
+  Observable,
+  RecordSource,
+  Store,
+} from "relay-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as PhoenixChart from "@phoenix/components/chart";
+import type { MetricChartTableView } from "@phoenix/pages/project/constants";
+
+import { ProjectAnnotationMetricsGrid } from "../ProjectAnnotationMetrics";
+
+vi.mock("@phoenix/components/chart", async (importOriginal) => ({
+  ...(await importOriginal<typeof PhoenixChart>()),
+  ChartPanel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ChartSkeleton: () => <div>loading chart</div>,
+}));
+
+type RequestedOperation = {
+  name: string;
+  text: string | null | undefined;
+  variables: Record<string, unknown>;
+  resolve: (data: Record<string, unknown>) => void;
+};
+
+const PROJECT_ID = "project-1";
+const TIME_RANGE = {
+  start: new Date("2024-01-01T01:00:00.000Z"),
+  end: new Date("2024-01-01T02:00:00.000Z"),
+};
+const TIME_RANGE_VARIABLE = {
+  start: TIME_RANGE.start.toISOString(),
+  end: TIME_RANGE.end.toISOString(),
+};
+
+const LEVEL_CASES: ReadonlyArray<{
+  annotationLevel: MetricChartTableView;
+  namesOperationName: string;
+  namesField: string;
+  metricsOperationName: string;
+}> = [
+  {
+    annotationLevel: "spans",
+    namesOperationName: "ProjectAnnotationMetricTimeRangeNamesSpanQuery",
+    namesField: "spanAnnotationMetricNames",
+    metricsOperationName: "ProjectAnnotationMetricsSpanQuery",
+  },
+  {
+    annotationLevel: "traces",
+    namesOperationName: "ProjectAnnotationMetricTimeRangeNamesTraceQuery",
+    namesField: "traceAnnotationMetricNames",
+    metricsOperationName: "ProjectAnnotationMetricsTraceQuery",
+  },
+  {
+    annotationLevel: "sessions",
+    namesOperationName: "ProjectAnnotationMetricTimeRangeNamesSessionQuery",
+    namesField: "sessionAnnotationMetricNames",
+    metricsOperationName: "ProjectAnnotationMetricsSessionQuery",
+  },
+];
+
+describe("ProjectAnnotationMetricsGrid", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it.each(LEVEL_CASES)(
+    "loads $annotationLevel annotation metrics independently",
+    async ({
+      annotationLevel,
+      namesOperationName,
+      namesField,
+      metricsOperationName,
+    }) => {
+      const requestedOperations: RequestedOperation[] = [];
+      const environment = new Environment({
+        network: Network.create((operation, variables) =>
+          Observable.create((sink) => {
+            requestedOperations.push({
+              name: operation.name,
+              text: operation.text,
+              variables: variables as Record<string, unknown>,
+              resolve: (data) => {
+                sink.next({ data });
+                sink.complete();
+              },
+            });
+          })
+        ),
+        store: new Store(new RecordSource()),
+      });
+
+      await act(async () => {
+        root.render(
+          <RelayEnvironmentProvider environment={environment}>
+            <ProjectAnnotationMetricsGrid
+              annotationLevel={annotationLevel}
+              projectId={PROJECT_ID}
+              timeRange={TIME_RANGE}
+            />
+          </RelayEnvironmentProvider>
+        );
+      });
+
+      expect(requestedOperations).toHaveLength(1);
+      const namesOperation = requestedOperations[0];
+      expect(namesOperation?.name).toBe(namesOperationName);
+      expect(namesOperation?.variables).toEqual({
+        projectId: PROJECT_ID,
+        timeRange: TIME_RANGE_VARIABLE,
+      });
+      expect(namesOperation?.text).toContain(namesField);
+      expect(namesOperation?.text).not.toContain("annotationSummaries");
+      expect(namesOperation?.text).not.toContain("meanScore");
+      expect(namesOperation?.text).not.toContain("labelFractions");
+
+      await act(async () => {
+        namesOperation?.resolve({
+          project: {
+            __typename: "Project",
+            id: PROJECT_ID,
+            [namesField]: ["quality", "toxicity"],
+          },
+        });
+      });
+
+      const metricsOperations = requestedOperations.filter(
+        ({ name }) => name === metricsOperationName
+      );
+      expect(metricsOperations).toHaveLength(2);
+      expect(
+        new Set(
+          metricsOperations.map(({ variables }) => variables.annotationName)
+        )
+      ).toEqual(new Set(["quality", "toxicity"]));
+      for (const metricsOperation of metricsOperations) {
+        expect(metricsOperation.variables).toMatchObject({
+          projectId: PROJECT_ID,
+          timeRange: TIME_RANGE_VARIABLE,
+        });
+        expect(metricsOperation.variables.annotationName).toEqual(
+          expect.any(String)
+        );
+      }
+      expect(requestedOperations).toHaveLength(3);
+    }
+  );
+});

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -883,6 +883,90 @@ class Project(Node):
             return list(await session.scalars(stmt))
 
     @strawberry.field(
+        description="Names of span annotations with a score or label in the requested time range."
+    )  # type: ignore
+    async def span_annotation_metric_names(
+        self,
+        info: Info[Context, None],
+        time_range: TimeRange,
+    ) -> list[str]:
+        stmt = (
+            select(distinct(models.SpanAnnotation.name))
+            .join(models.Span)
+            .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
+            .where(models.Trace.project_rowid == self.id)
+            .where(
+                or_(
+                    models.SpanAnnotation.score.is_not(None),
+                    models.SpanAnnotation.label.is_not(None),
+                )
+            )
+            .order_by(models.SpanAnnotation.name)
+        )
+        return await _annotation_metric_names(
+            db=info.context.db,
+            stmt=stmt,
+            time_range=time_range,
+            start_time_col=models.Trace.start_time,
+        )
+
+    @strawberry.field(
+        description="Names of trace annotations with a score or label in the requested time range."
+    )  # type: ignore
+    async def trace_annotation_metric_names(
+        self,
+        info: Info[Context, None],
+        time_range: TimeRange,
+    ) -> list[str]:
+        stmt = (
+            select(distinct(models.TraceAnnotation.name))
+            .join(models.Trace)
+            .where(models.Trace.project_rowid == self.id)
+            .where(
+                or_(
+                    models.TraceAnnotation.score.is_not(None),
+                    models.TraceAnnotation.label.is_not(None),
+                )
+            )
+            .order_by(models.TraceAnnotation.name)
+        )
+        return await _annotation_metric_names(
+            db=info.context.db,
+            stmt=stmt,
+            time_range=time_range,
+            start_time_col=models.Trace.start_time,
+        )
+
+    @strawberry.field(
+        description=(
+            "Names of session annotations with a score or label in the requested time range."
+        )
+    )  # type: ignore
+    async def session_annotation_metric_names(
+        self,
+        info: Info[Context, None],
+        time_range: TimeRange,
+    ) -> list[str]:
+        stmt = (
+            select(distinct(models.ProjectSessionAnnotation.name))
+            .join(models.ProjectSession)
+            .where(models.ProjectSession.project_id == self.id)
+            .where(
+                or_(
+                    models.ProjectSessionAnnotation.score.is_not(None),
+                    models.ProjectSessionAnnotation.label.is_not(None),
+                )
+            )
+            .order_by(models.ProjectSessionAnnotation.name)
+        )
+        return await _annotation_metric_names(
+            db=info.context.db,
+            stmt=stmt,
+            time_range=time_range,
+            start_time_col=models.ProjectSession.start_time,
+        )
+
+    @strawberry.field(
         description="Span annotation names along with the number of span annotations "
         "that have been added for each name in this project."
     )  # type: ignore
@@ -1886,6 +1970,7 @@ class Project(Node):
         info: Info[Context, None],
         time_range: TimeRange,
         time_bin_config: Optional[TimeBinConfig] = UNSET,
+        annotation_name: Optional[str] = UNSET,
     ) -> "AnnotationMetricsTimeSeries":
         stride, utc_offset_minutes = _time_bin_stride(time_bin_config)
         bucket = date_trunc(
@@ -1917,6 +2002,8 @@ class Project(Node):
                 )
             )
         )
+        if isinstance(annotation_name, str):
+            stmt = stmt.where(models.SpanAnnotation.name == annotation_name)
         return await _annotation_metrics_time_series(
             db=info.context.db,
             stmt=stmt,
@@ -1932,6 +2019,7 @@ class Project(Node):
         info: Info[Context, None],
         time_range: TimeRange,
         time_bin_config: Optional[TimeBinConfig] = UNSET,
+        annotation_name: Optional[str] = UNSET,
     ) -> "AnnotationMetricsTimeSeries":
         stride, utc_offset_minutes = _time_bin_stride(time_bin_config)
         bucket = date_trunc(
@@ -1958,6 +2046,8 @@ class Project(Node):
                 )
             )
         )
+        if isinstance(annotation_name, str):
+            stmt = stmt.where(models.TraceAnnotation.name == annotation_name)
         return await _annotation_metrics_time_series(
             db=info.context.db,
             stmt=stmt,
@@ -1973,6 +2063,7 @@ class Project(Node):
         info: Info[Context, None],
         time_range: TimeRange,
         time_bin_config: Optional[TimeBinConfig] = UNSET,
+        annotation_name: Optional[str] = UNSET,
     ) -> "AnnotationMetricsTimeSeries":
         stride, utc_offset_minutes = _time_bin_stride(time_bin_config)
         # Match `session_annotation_score_time_series` in this file: assign each
@@ -2002,6 +2093,8 @@ class Project(Node):
                 )
             )
         )
+        if isinstance(annotation_name, str):
+            stmt = stmt.where(models.ProjectSessionAnnotation.name == annotation_name)
         return await _annotation_metrics_time_series(
             db=info.context.db,
             stmt=stmt,
@@ -2321,6 +2414,21 @@ async def _annotation_score_time_series(
         data=sorted(data.values(), key=lambda x: x.timestamp),
         names=sorted(unique_names),
     )
+
+
+async def _annotation_metric_names(
+    db: DbSessionFactory,
+    stmt: Select[Any],
+    time_range: TimeRange,
+    start_time_col: InstrumentedAttribute[datetime],
+) -> list[str]:
+    if time_range.start is None:
+        raise BadRequest("Start time is required")
+    stmt = stmt.where(time_range.start <= start_time_col)
+    if time_range.end:
+        stmt = stmt.where(start_time_col < time_range.end)
+    async with db.read() as session:
+        return list(await session.scalars(stmt))
 
 
 async def _annotation_metrics_time_series(

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -5952,6 +5952,164 @@ class TestAnnotationMetricsTimeSeries:
             ]
             assert metrics["data"][2]["annotationSummaries"] == []
 
+    async def test_annotation_metrics_time_series_filters_by_name_at_all_levels(
+        self,
+        _annotation_metrics_data: models.Project,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        query = """
+            query(
+                $id: ID!
+                $annotationName: String!
+                $timeRange: TimeRange!
+                $timeBinConfig: TimeBinConfig
+            ) {
+                node(id: $id) {
+                    ... on Project {
+                        span: spanAnnotationMetricsTimeSeries(
+                            annotationName: $annotationName
+                            timeRange: $timeRange
+                            timeBinConfig: $timeBinConfig
+                        ) { ...metrics }
+                        trace: traceAnnotationMetricsTimeSeries(
+                            annotationName: $annotationName
+                            timeRange: $timeRange
+                            timeBinConfig: $timeBinConfig
+                        ) { ...metrics }
+                        session: sessionAnnotationMetricsTimeSeries(
+                            annotationName: $annotationName
+                            timeRange: $timeRange
+                            timeBinConfig: $timeBinConfig
+                        ) { ...metrics }
+                    }
+                }
+            }
+
+            fragment metrics on AnnotationMetricsTimeSeries {
+                names
+                data {
+                    timestamp
+                    annotationSummaries {
+                        name
+                    }
+                }
+            }
+        """
+        response = await gql_client.execute(
+            query=query,
+            variables={
+                "id": str(GlobalID(type_name="Project", node_id=str(_annotation_metrics_data.id))),
+                "annotationName": "mixed",
+                "timeRange": {
+                    "start": "2024-01-01T01:00:00+00:00",
+                    "end": "2024-01-01T04:00:00+00:00",
+                },
+                "timeBinConfig": {"scale": "HOUR", "utcOffsetMinutes": 0},
+            },
+        )
+        assert not response.errors
+        assert response.data is not None
+        for level in ("span", "trace", "session"):
+            metrics = response.data["node"][level]
+            assert metrics["names"] == ["mixed"]
+            assert [point["timestamp"] for point in metrics["data"]] == [
+                "2024-01-01T01:00:00+00:00",
+                "2024-01-01T02:00:00+00:00",
+                "2024-01-01T03:00:00+00:00",
+            ]
+            assert [
+                [summary["name"] for summary in point["annotationSummaries"]]
+                for point in metrics["data"]
+            ] == [["mixed"], ["mixed"], []]
+
+    async def test_annotation_metric_names_are_chartable_and_time_range_scoped(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        annotations = (
+            ("before", "2024-01-01T00:59:00+00:00", 0.1, None, None),
+            ("z-start", "2024-01-01T01:00:00+00:00", 0.2, None, None),
+            (
+                "explanation-only",
+                "2024-01-01T01:15:00+00:00",
+                None,
+                None,
+                "not chartable",
+            ),
+            ("a-within", "2024-01-01T01:30:00+00:00", None, "pass", None),
+            ("at-end", "2024-01-01T02:00:00+00:00", 0.9, None, None),
+        )
+        async with db() as session:
+            project = await _add_project(session)
+            for name, timestamp_string, score, label, explanation in annotations:
+                timestamp = datetime.fromisoformat(timestamp_string)
+                project_session = await _add_project_session(session, project, start_time=timestamp)
+                trace = await _add_trace(
+                    session,
+                    project,
+                    project_session,
+                    start_time=timestamp,
+                )
+                span = await _add_span(session, trace, start_time=timestamp)
+                common_annotation_fields: dict[str, Any] = {
+                    "name": name,
+                    "label": label,
+                    "score": score,
+                    "explanation": explanation,
+                    "metadata_": {},
+                    "annotator_kind": "HUMAN",
+                    "identifier": name,
+                    "source": "APP",
+                    "user_id": None,
+                }
+                session.add_all(
+                    [
+                        models.SpanAnnotation(
+                            span_rowid=span.id,
+                            **common_annotation_fields,
+                        ),
+                        models.TraceAnnotation(
+                            trace_rowid=trace.id,
+                            **common_annotation_fields,
+                        ),
+                        models.ProjectSessionAnnotation(
+                            project_session_id=project_session.id,
+                            **common_annotation_fields,
+                        ),
+                    ]
+                )
+
+        query = """
+            query($id: ID!, $timeRange: TimeRange!) {
+                node(id: $id) {
+                    ... on Project {
+                        spanAnnotationMetricNames(timeRange: $timeRange)
+                        traceAnnotationMetricNames(timeRange: $timeRange)
+                        sessionAnnotationMetricNames(timeRange: $timeRange)
+                    }
+                }
+            }
+        """
+        response = await gql_client.execute(
+            query=query,
+            variables={
+                "id": str(GlobalID(type_name="Project", node_id=str(project.id))),
+                "timeRange": {
+                    "start": "2024-01-01T01:00:00+00:00",
+                    "end": "2024-01-01T02:00:00+00:00",
+                },
+            },
+        )
+        assert not response.errors
+        assert response.data is not None
+        expected_names = ["a-within", "z-start"]
+        assert response.data["node"] == {
+            "spanAnnotationMetricNames": expected_names,
+            "traceAnnotationMetricNames": expected_names,
+            "sessionAnnotationMetricNames": expected_names,
+        }
+
     async def test_label_fractions_weight_entities_instead_of_annotation_rows(
         self,
         db: DbSessionFactory,

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -6053,13 +6053,11 @@ class TestAnnotationMetricsTimeSeries:
                 )
                 span = await _add_span(session, trace, start_time=timestamp)
                 common_annotation_fields: dict[str, Any] = {
-                    "name": name,
                     "label": label,
                     "score": score,
                     "explanation": explanation,
                     "metadata_": {},
                     "annotator_kind": "HUMAN",
-                    "identifier": name,
                     "source": "APP",
                     "user_id": None,
                 }
@@ -6067,18 +6065,73 @@ class TestAnnotationMetricsTimeSeries:
                     [
                         models.SpanAnnotation(
                             span_rowid=span.id,
+                            name=f"span-{name}",
+                            identifier=f"span-{name}",
                             **common_annotation_fields,
                         ),
                         models.TraceAnnotation(
                             trace_rowid=trace.id,
+                            name=f"trace-{name}",
+                            identifier=f"trace-{name}",
                             **common_annotation_fields,
                         ),
                         models.ProjectSessionAnnotation(
                             project_session_id=project_session.id,
+                            name=f"session-{name}",
+                            identifier=f"session-{name}",
                             **common_annotation_fields,
                         ),
                     ]
                 )
+
+            other_project = await _add_project(
+                session,
+                name="other-annotation-metrics-project",
+            )
+            other_timestamp = datetime.fromisoformat("2024-01-01T01:45:00+00:00")
+            other_project_session = await _add_project_session(
+                session,
+                other_project,
+                start_time=other_timestamp,
+            )
+            other_trace = await _add_trace(
+                session,
+                other_project,
+                other_project_session,
+                start_time=other_timestamp,
+            )
+            other_span = await _add_span(session, other_trace, start_time=other_timestamp)
+            other_annotation_fields: dict[str, Any] = {
+                "label": None,
+                "score": 1.0,
+                "explanation": None,
+                "metadata_": {},
+                "annotator_kind": "HUMAN",
+                "source": "APP",
+                "user_id": None,
+            }
+            session.add_all(
+                [
+                    models.SpanAnnotation(
+                        span_rowid=other_span.id,
+                        name="other-project-span",
+                        identifier="other-project-span",
+                        **other_annotation_fields,
+                    ),
+                    models.TraceAnnotation(
+                        trace_rowid=other_trace.id,
+                        name="other-project-trace",
+                        identifier="other-project-trace",
+                        **other_annotation_fields,
+                    ),
+                    models.ProjectSessionAnnotation(
+                        project_session_id=other_project_session.id,
+                        name="other-project-session",
+                        identifier="other-project-session",
+                        **other_annotation_fields,
+                    ),
+                ]
+            )
 
         query = """
             query($id: ID!, $timeRange: TimeRange!) {
@@ -6103,11 +6156,10 @@ class TestAnnotationMetricsTimeSeries:
         )
         assert not response.errors
         assert response.data is not None
-        expected_names = ["a-within", "z-start"]
         assert response.data["node"] == {
-            "spanAnnotationMetricNames": expected_names,
-            "traceAnnotationMetricNames": expected_names,
-            "sessionAnnotationMetricNames": expected_names,
+            "spanAnnotationMetricNames": ["span-a-within", "span-z-start"],
+            "traceAnnotationMetricNames": ["trace-a-within", "trace-z-start"],
+            "sessionAnnotationMetricNames": ["session-a-within", "session-z-start"],
         }
 
     async def test_label_fractions_weight_entities_instead_of_annotation_rows(


### PR DESCRIPTION
## Summary

- add lightweight, time-range-scoped annotation metric name discovery for spans, traces, and sessions
- add optional `annotationName` filtering to the existing annotation metrics time-series fields while preserving unfiltered callers
- render one independently suspended Relay panel and filtered operation per annotation chart
- keep the existing charts, score/label toggles, brushing, synchronization, catalog-selected charts, and visual fallbacks

## Why

Project annotation metric grids currently fetch every annotation series in a single operation. Splitting discovery from per-annotation data fetching follows the experiment metrics architecture and makes each chart independently queryable, preparing the grids for viewport-triggered loading with the deferred chart pattern introduced by #14901.

This change intentionally partitions the operations without adding viewport deferral yet, so initial request count can increase until the follow-up lazy-loading work lands.

## Test strategy

Frontend coverage is intentionally limited to the Relay orchestration contract: discovery must remain lightweight and two discovered names must produce exactly two filtered metric operations. Filtering, chartability, time boundaries, explanation-only annotations, unfiltered compatibility, and empty-bin behavior are covered by backend GraphQL tests.

## Validation

- `make graphql`
- targeted `TestAnnotationMetricsTimeSeries` backend tests
- `pnpm exec vitest run src/pages/project/metrics/__tests__/ProjectAnnotationMetrics.test.tsx`
- `make typecheck-frontend`
- `make typecheck-python`
- Python formatting/lint and app formatting/lint commit hooks
- browser validation with seeded span, trace, and session annotations, confirming three discovery operations followed by one filtered operation per chart

Related to #14901
