### PR TITLE
fix(ui): address code review on AI filter search

### DIFF
--- a/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/app/src/components/filter/DSLFilterConditionField.tsx
@@ -36,7 +36,10 @@ import {
   TooltipTrigger,
   VisuallyHidden,
 } from "@phoenix/components";
-import { PxiOutline, type PxiOutlineState } from "@phoenix/components/agent";
+import {
+  PxiOutline,
+  type PxiOutlineState,
+} from "@phoenix/components/agent/PxiOutline";
 import { pierreDark, pierreLight } from "@phoenix/components/code";
 import { useTheme } from "@phoenix/contexts";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
@@ -468,16 +471,21 @@ function DSLFilterConditionFieldImpl<
   // extensions memo below), so key handlers reach the current AI state
   // through this ref rather than closing over it
   const aiRuntimeRef = useRef<{
-    maybeConvert: () => boolean;
+    maybeConvert: (currentText: string) => boolean;
     handleEscape: () => boolean;
   } | null>(null);
   useEffect(() => {
     aiRuntimeRef.current = {
-      maybeConvert: () => {
+      // The editor's own document is the query, not the `value` prop: a
+      // consumer whose onChange defers the update (e.g. through
+      // startTransition) can still be a render behind the keystroke that
+      // preceded Enter, and converting -- or restoring on cancel -- a stale
+      // draft would drop the user's last words
+      maybeConvert: (currentText: string) => {
         if (!isAIActive || isConverting) {
           return false;
         }
-        const query = value.trim();
+        const query = currentText.trim();
         if (!query || looksLikeDSLExpression(query)) {
           return false;
         }
@@ -543,7 +551,9 @@ function DSLFilterConditionFieldImpl<
             // otherwise a natural-language draft converts via AI search.
             // Always swallow the key so no newline is inserted.
             if (!acceptCompletion(editorView)) {
-              aiRuntimeRef.current?.maybeConvert();
+              aiRuntimeRef.current?.maybeConvert(
+                editorView.state.doc.toString()
+              );
             }
             return true;
           },

--- a/app/src/components/filter/__tests__/detectFilterExpression.test.ts
+++ b/app/src/components/filter/__tests__/detectFilterExpression.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { looksLikeDSLExpression } from "../ai/detectFilterExpression";
+
+describe("looksLikeDSLExpression", () => {
+  it("recognizes DSL syntax", () => {
+    expect(looksLikeDSLExpression("span_kind == 'LLM'")).toBe(true);
+    expect(looksLikeDSLExpression("latency_ms > 1000")).toBe(true);
+    expect(looksLikeDSLExpression("'error' in output.value")).toBe(true);
+    expect(looksLikeDSLExpression('"error" in output.value')).toBe(true);
+    expect(looksLikeDSLExpression("attributes['llm']['provider']")).toBe(true);
+    expect(looksLikeDSLExpression("parent_id is None")).toBe(true);
+    expect(looksLikeDSLExpression("metadata['key'] is not None")).toBe(true);
+  });
+
+  it("treats plain language as plain language", () => {
+    expect(looksLikeDSLExpression("llm spans that errored")).toBe(false);
+    expect(looksLikeDSLExpression("slow spans")).toBe(false);
+  });
+
+  it("does not mistake apostrophes for a string literal", () => {
+    // Two contractions in one sentence produce a pair of apostrophes; they
+    // are not a quoted literal, and reading them as one would withhold the
+    // AI affordance and flag the field invalid instead
+    expect(
+      looksLikeDSLExpression("spans that didn't error and weren't retried")
+    ).toBe(false);
+    expect(
+      looksLikeDSLExpression("spans where the user's request wasn't answered")
+    ).toBe(false);
+  });
+});

--- a/app/src/components/filter/ai/detectFilterExpression.ts
+++ b/app/src/components/filter/ai/detectFilterExpression.ts
@@ -1,4 +1,19 @@
 /**
+ * A quoted literal, i.e. a quote that opens and closes outside of a word.
+ * The word boundaries matter: without them, two apostrophes anywhere in a
+ * sentence ("spans that didn't error and weren't retried") read as a string
+ * literal, which would misclassify ordinary English as DSL — the direction
+ * that actually hurts, since it withholds the AI affordance and asks the
+ * validator about prose.
+ */
+const quotedLiteral =
+  /(?<![A-Za-z])'[^']*'(?![A-Za-z])|(?<![A-Za-z])"[^"]*"(?![A-Za-z])/;
+
+const dslSyntax = new RegExp(
+  `(==|!=|<=|>=|<|>|${quotedLiteral.source}|\\[|\\bis\\s+(not\\s+)?None\\b)`
+);
+
+/**
  * Heuristic for whether typed text reads as a DSL filter expression rather
  * than plain language: comparison operators, quoted literals, subscripts,
  * and `is None` checks are all syntax plain language doesn't produce.
@@ -8,7 +23,5 @@
  * Enter still only converts when they ask it to.
  */
 export function looksLikeDSLExpression(text: string): boolean {
-  return /(==|!=|<=|>=|<|>|'[^']*'|"[^"]*"|\[|\bis\s+(not\s+)?None\b)/.test(
-    text
-  );
+  return dslSyntax.test(text);
 }

--- a/app/src/components/filter/ai/index.ts
+++ b/app/src/components/filter/ai/index.ts
@@ -5,7 +5,6 @@ export * from "./AISearchSettingsForm";
 export * from "./browserModel";
 export {
   AI_SEARCH_PROVIDERS,
-  isAISearchProvider,
   type ProviderCredentials,
 } from "./providerModels";
 export * from "./createAISearchDSL";

--- a/app/src/components/filter/ai/providerModels.ts
+++ b/app/src/components/filter/ai/providerModels.ts
@@ -62,10 +62,6 @@ export const AI_SEARCH_PROVIDERS: ModelProvider[] = [
   ...OPENAI_COMPATIBLE_PROVIDERS,
 ];
 
-export function isAISearchProvider(provider: ModelProvider): boolean {
-  return AI_SEARCH_PROVIDERS.includes(provider);
-}
-
 /**
  * Reads the provider's (first) required API key from the browser-held
  * credentials, throwing a message that tells the user what to configure
@@ -104,6 +100,14 @@ export async function createProviderModel({
   modelName: string;
   credentials: ProviderCredentials | undefined;
 }): Promise<LanguageModel> {
+  // Switching providers in the settings form clears the model name (only
+  // OpenAI has a sensible default), so an unfilled field would otherwise
+  // reach the provider as an empty model id and come back as an opaque 404
+  if (modelName.trim() === "") {
+    throw new Error(
+      `Choose a model name for ${ModelProviders[provider]} in the AI search settings.`
+    );
+  }
   switch (provider) {
     case "OPENAI": {
       const apiKey = requireApiKey(provider, credentials);

--- a/app/src/components/filter/ai/useAISearch.ts
+++ b/app/src/components/filter/ai/useAISearch.ts
@@ -65,7 +65,6 @@ export function useAISearch({ dsl, validate }: UseAISearchArgs) {
   );
   const [status, setStatus] = useState<AISearchStatus>("idle");
   const [downloadProgress, setDownloadProgress] = useState<number>(0);
-  const [error, setError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const generate = async (
@@ -76,7 +75,6 @@ export function useAISearch({ dsl, validate }: UseAISearchArgs) {
     abortControllerRef.current?.abort();
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
-    setError(null);
     try {
       if (modelConfig.kind === "browser") {
         const availability = await getBrowserModelAvailability();
@@ -123,9 +121,7 @@ export function useAISearch({ dsl, validate }: UseAISearchArgs) {
       if (abortController.signal.aborted) {
         return { outcome: "cancelled" };
       }
-      const message = toErrorMessage(caught);
-      setError(message);
-      return { outcome: "error", message };
+      return { outcome: "error", message: toErrorMessage(caught) };
     } finally {
       // A superseding run owns the status now — only the latest run resets it
       if (abortControllerRef.current === abortController) {
@@ -139,17 +135,11 @@ export function useAISearch({ dsl, validate }: UseAISearchArgs) {
     abortControllerRef.current?.abort();
   };
 
-  const clearError = () => {
-    setError(null);
-  };
-
   return {
     status,
     downloadProgress,
-    error,
     modelConfig,
     generate,
     cancel,
-    clearError,
   };
 }


### PR DESCRIPTION
Review fixes on top of #14939 (targets `mikeldking/ai-search`, so the diff here is only the fixes).

### Correctness

- **`detectFilterExpression.ts`** — `'[^']*'` matched any two apostrophes, so prose with two contractions ("spans that didn't error and weren't retried") was classified as DSL: Enter would not convert it, and the field went red from validating English. Quote literals now have to open and close outside a word.
- **`DSLFilterConditionField.tsx`** — `maybeConvert` read the `value` prop, but both consumers push `onChange` through `startTransition`, so Enter could convert (and, on cancel/failure, overwrite the editor with) a draft one render stale. It now reads `editorView.state.doc`.
- **`providerModels.ts`** — switching providers in the settings form clears the model name (only OpenAI has a suggested default), so a non-OpenAI provider could receive an empty model id and return an opaque 404. `createProviderModel` now throws an actionable message instead.

### Cleanup

- Import `PxiOutline` from its module rather than the agent barrel, which dragged Chat and `@ai-sdk/react` into the filter field and its unit test.
- Remove the `error`/`clearError` state in `useAISearch` that no consumer reads, and the unused `isAISearchProvider` export.

### Tests

Added `app/src/components/filter/__tests__/detectFilterExpression.test.ts` covering the heuristic (contractions, quoted literals, operators, subscripts, `is None`).

Verified: `tsc --noEmit` clean, `oxlint` and prettier clean on touched files, `vitest run src/components/filter` 31 passed, `pnpm run build` succeeds.

### Not fixed here

- Undo/Escape restores the prose but does not un-apply the generated condition, leaving the table and URL filtered by an expression no longer shown. That is a product decision.
- `vite.config.mts`'s catch-all `vendor` group eagerly bundles the browser-model deps (~110 KB) and the nominally lazy `@ai-sdk/*` imports; the fix belongs in the bundler config, outside this diff.
- `@ai-sdk/openai` / `@ai-sdk/anthropic` are devDependencies but are imported by production code — needs a lockfile regeneration.

---
_Generated by [Claude Code](https://claude.ai/code/session_019jvzL7StyYLmTHLBz2Groz)_