### PR TITLE
test(ui): update profile preferences description expectation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -40,9 +40,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/google": "4.0.27",
+    "@ai-sdk/openai-compatible": "3.0.16",
     "@ai-sdk/react": "^4.0.40",
     "@apollo/client": "^4.2.8",
     "@arizeai/openinference-semantic-conventions": "^2.5.0",
+    "@browser-ai/core": "2.1.13",
     "@codemirror/autocomplete": "6.20.3",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/lang-javascript": "^6.2.5",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -10,6 +10,12 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/google':
+        specifier: 4.0.27
+        version: 4.0.27(zod@4.4.3)
+      '@ai-sdk/openai-compatible':
+        specifier: 3.0.16
+        version: 3.0.16(zod@4.4.3)
       '@ai-sdk/react':
         specifier: ^4.0.40
         version: 4.0.40(react@19.2.7)(zod@4.4.3)
@@ -19,6 +25,9 @@ importers:
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.5.0
         version: 2.5.0
+      '@browser-ai/core':
+        specifier: 2.1.13
+        version: 2.1.13(ai@7.0.37(zod@4.4.3))
       '@codemirror/autocomplete':
         specifier: 6.20.3
         version: 6.20.3
@@ -135,7 +144,7 @@ importers:
         version: 4.4.0
       just-bash:
         specifier: ^2.14.5
-        version: 2.14.5
+        version: 2.14.5(supports-color@10.2.2)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -229,7 +238,7 @@ importers:
         version: 4.0.11(zod@4.4.3)
       '@arizeai/phoenix-client':
         specifier: 6.12.1
-        version: 6.12.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.37(zod@4.4.3))(vitest@4.1.10)
+        version: 6.12.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.37(zod@4.4.3))(supports-color@10.2.2)(vitest@4.1.10)
       '@arizeai/phoenix-evals':
         specifier: ^1.2.0
         version: 1.2.0
@@ -238,7 +247,7 @@ importers:
         version: 10.0.1
       '@figma/code-connect':
         specifier: ^1.4.9
-        version: 1.4.9
+        version: 1.4.9(supports-color@10.2.2)
       '@lezer/generator':
         specifier: ^1.8.0
         version: 1.8.0
@@ -404,6 +413,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/google@4.0.27':
+    resolution: {integrity: sha512-u44UuLypwwHqEaHPRV1iZ1N+xO9dCKzQX6L2DtPPxvlsSdSzNobUBz8oaDv6NzC35qYSb6JFs7TG1Tz2Nxlg/Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/mcp@2.0.10':
     resolution: {integrity: sha512-LP47CEk3e6BwCqXamvv4nKbgOWQ5z5T/qS/J2fola5h98KTy7JT7I1yw5LKtB89MZBLviYmEh98Ep4ovHOz/vA==}
     engines: {node: '>=22'}
@@ -412,6 +427,12 @@ packages:
 
   '@ai-sdk/mcp@2.0.16':
     resolution: {integrity: sha512-jC2r+StEuk8uIldfP4j8nBwOEBJ2TRwy/bz71SHMZ3NG6PSbvRPXGfyoHHR6JTm1O5GcIww0f6B8LznzkrseDA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@3.0.16':
+    resolution: {integrity: sha512-beXoYtlCnI02BYZU6oGfOPI40xC8MJx+Ek0SM8XZ8RcBBP7SaQ0qIV5DO3Y1euHMLMD92zE7nNHM0WcnnnX58A==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -434,6 +455,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.14':
+    resolution: {integrity: sha512-HW+Ys98cr2BRQzP6jTlp2bRKIqt+oAjYNLm9gqUUQkLz7QERtaPgDZOoXHz9IXSXoOtz175p4Q17qKQdEX0Hag==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.7':
     resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
     engines: {node: '>=22'}
@@ -446,6 +473,10 @@ packages:
 
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
     engines: {node: '>=22'}
 
   '@ai-sdk/react@4.0.40':
@@ -633,6 +664,11 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@browser-ai/core@2.1.13':
+    resolution: {integrity: sha512-viVIDRJGWtBZUKRcbtEX5TKMvkfzU8lm7ZP0pzxdLC+GYQjEWffBxRUl66Yt+0j+ehNIC7uWP37QwQghmqAulQ==}
+    peerDependencies:
+      ai: ^6.0.0
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
@@ -1217,6 +1253,9 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mediapipe/tasks-text@0.10.35':
+    resolution: {integrity: sha512-BlRWXZAHakqtAos8hNgSU0jy4mh60R9ewzwckS3q2nV7Q/7L65otCtoDrgslRBhlfbElfcHbHQXKRahlMRCf4Q==}
 
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
@@ -5853,6 +5892,12 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/google@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/mcp@2.0.10(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
@@ -5865,6 +5910,12 @@ snapshots:
       '@ai-sdk/provider': 4.0.3
       '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@3.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/openai@4.0.11(zod@4.4.3)':
@@ -5888,6 +5939,14 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.14(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
@@ -5901,6 +5960,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
 
@@ -5966,12 +6029,12 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/semantic-conventions'
 
-  '@arizeai/phoenix-client@6.12.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.37(zod@4.4.3))(vitest@4.1.10)':
+  '@arizeai/phoenix-client@6.12.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.37(zod@4.4.3))(supports-color@10.2.2)(vitest@4.1.10)':
     dependencies:
       '@arizeai/openinference-semantic-conventions': 2.5.0
       '@arizeai/openinference-vercel': 2.8.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)
       '@arizeai/phoenix-config': 0.2.0
-      '@arizeai/phoenix-otel': 1.1.0(@opentelemetry/semantic-conventions@1.43.0)
+      '@arizeai/phoenix-otel': 1.1.0(@opentelemetry/semantic-conventions@1.43.0)(supports-color@10.2.2)
       async: 3.2.6
       openapi-fetch: 0.17.0
       tiny-invariant: 1.3.3
@@ -5995,7 +6058,7 @@ snapshots:
       mustache: 4.2.0
       zod: 4.4.3
 
-  '@arizeai/phoenix-otel@1.1.0(@opentelemetry/semantic-conventions@1.43.0)':
+  '@arizeai/phoenix-otel@1.1.0(@opentelemetry/semantic-conventions@1.43.0)(supports-color@10.2.2)':
     dependencies:
       '@arizeai/openinference-core': 2.4.0
       '@arizeai/openinference-semantic-conventions': 2.5.0
@@ -6005,7 +6068,7 @@ snapshots:
       '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto': 0.218.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
@@ -6154,6 +6217,11 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@browser-ai/core@2.1.13(ai@7.0.37(zod@4.4.3))':
+    dependencies:
+      '@mediapipe/tasks-text': 0.10.35
+      ai: 7.0.37(zod@4.4.3)
 
   '@chevrotain/types@11.1.2': {}
 
@@ -6525,7 +6593,7 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@figma/code-connect@1.4.9':
+  '@figma/code-connect@1.4.9(supports-color@10.2.2)':
     dependencies:
       boxen: 5.1.1
       chalk: 4.1.2
@@ -6536,7 +6604,7 @@ snapshots:
       fast-fuzzy: 1.12.0
       find-up: 5.0.0
       glob: 11.1.0
-      jsdom: 24.1.3
+      jsdom: 24.1.3(supports-color@10.2.2)
       lodash: 4.18.1
       minimatch: 9.0.9
       ora: 5.4.1
@@ -6720,6 +6788,8 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
+  '@mediapipe/tasks-text@0.10.35': {}
+
   '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
@@ -6801,12 +6871,12 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.218.0
       import-in-the-middle: 3.3.2
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7594,7 +7664,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       token-types: 6.1.2
@@ -8912,9 +8982,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  file-type@21.3.4:
+  file-type@21.3.4(supports-color@10.2.2):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@10.2.2)
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -9171,7 +9241,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
@@ -9323,14 +9393,14 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@24.1.3:
+  jsdom@24.1.3(supports-color@10.2.2):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       form-data: 4.0.6
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.24
@@ -9411,11 +9481,11 @@ snapshots:
 
   junk@4.0.1: {}
 
-  just-bash@2.14.5:
+  just-bash@2.14.5(supports-color@10.2.2):
     dependencies:
       diff: 8.0.4
       fast-xml-parser: 5.10.1
-      file-type: 21.3.4
+      file-type: 21.3.4(supports-color@10.2.2)
       ini: 6.0.0
       minimatch: 10.2.5
       modern-tar: 0.7.7
@@ -10716,7 +10786,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       module-details-from-path: 1.0.4

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -262,12 +262,12 @@ export const appRouteObjects = createRoutesFromElements(
               agentRoute: {
                 label: "Profile Preferences",
                 description:
-                  "Choose your theme, timezone, code language, and package manager defaults.",
+                  "Choose your theme, timezone, code language, and package manager defaults, and configure AI search for filter fields (enable it and pick the in-browser model or a provider).",
               },
               navigation: {
                 section: "Profile",
                 label: "Preferences",
-                description: "Theme, timezone, and code defaults",
+                description: "Theme, timezone, code defaults, and AI search",
                 icon: "Options",
               },
             }}
@@ -957,7 +957,7 @@ export const appRouteObjects = createRoutesFromElements(
               agentRoute: {
                 label: "AI Providers",
                 description:
-                  "Configure AI providers, custom providers, provider credentials, base URLs, default model, and provider headers.",
+                  "Configure AI providers, custom providers, provider credentials, base URLs, default model, provider headers, and AI search (natural-language filter conditions using the in-browser model or a provider).",
               },
             }}
           />

--- a/app/src/components/core/icon/Icons.tsx
+++ b/app/src/components/core/icon/Icons.tsx
@@ -2047,6 +2047,22 @@ export const Sparkle = () => (
   </svg>
 );
 
+export const Sparkles = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    style={{ fill: "none", stroke: "currentColor" }}
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" />
+    <path d="M20 2v4" />
+    <path d="M22 4h-4" />
+    <circle cx="4" cy="20" r="2" />
+  </svg>
+);
+
 export const Split = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/app/src/components/filter/DSLFilterConditionField.tsx
@@ -6,6 +6,7 @@ import type {
 import {
   acceptCompletion,
   autocompletion,
+  completionStatus,
   snippetCompletion,
   startCompletion,
 } from "@codemirror/autocomplete";
@@ -35,12 +36,20 @@ import {
   TooltipTrigger,
   VisuallyHidden,
 } from "@phoenix/components";
+import { PxiOutline, type PxiOutlineState } from "@phoenix/components/agent";
 import { pierreDark, pierreLight } from "@phoenix/components/code";
 import { useTheme } from "@phoenix/contexts";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import { classNames } from "@phoenix/utils/classNames";
 
+import { AISearchSettingsButton } from "./ai/AISearchSettingsButton";
+import { looksLikeDSLExpression } from "./ai/detectFilterExpression";
+import type { AISearchDSL } from "./ai/types";
+import type { AISearchGenerateResult, AISearchStatus } from "./ai/useAISearch";
+import { useAISearch } from "./ai/useAISearch";
 import { createDSLFilterCompletionSource } from "./dslFilterConditionFieldUtils";
 import {
+  dslFilterAIOutlineCSS,
   dslFilterCodeMirrorCSS,
   dslFilterErrorTooltipCSS,
   dslFilterFieldCSS,
@@ -145,6 +154,63 @@ export type DSLFilterValidConditionArgs<
 
 export type DSLFilterValidationFailureReason = "invalid" | "transport";
 
+/**
+ * Opts a filter field into AI search. The field then shows the AI search
+ * settings entry point and — once the user enables the feature — detects
+ * natural-language drafts, converts them to DSL on Enter with the
+ * configured model (on-device browser AI by default), and offers an undo.
+ */
+export type DSLFilterAISearchProps = {
+  /**
+   * The DSL description handed to the model — typically derived from the
+   * field's own completions and snippets via `createAISearchDSL` so the
+   * model's vocabulary can never drift from the typeahead's.
+   */
+  dsl: AISearchDSL;
+  /**
+   * Placeholder shown while AI search is enabled, e.g.
+   * "filter spans — DSL or plain English". Falls back to the field's
+   * regular placeholder.
+   */
+  placeholder?: string;
+};
+
+/**
+ * The lifecycle of one natural-language → DSL conversion. `query` is the
+ * user's original phrasing, kept so a finished (or failed) conversion can
+ * always be undone back to it.
+ */
+type AISearchPhase =
+  | { name: "idle" }
+  | { name: "converting"; query: string }
+  | { name: "generated"; query: string }
+  | { name: "failed"; query: string; message: string };
+
+const AI_SEARCH_IDLE: AISearchPhase = { name: "idle" };
+
+/**
+ * The resolved AI-search capability handed to the inner field. Assembled by
+ * a wrapper component so the field itself never touches the preferences or
+ * credentials contexts — a field without `aiSearch` renders with no
+ * provider requirements at all.
+ */
+type AISearchRuntime = {
+  /**
+   * The user's AI-search preference. The settings entry point renders
+   * regardless (it is how the feature gets enabled); the conversion
+   * behaviors only engage when this is true.
+   */
+  isEnabled: boolean;
+  status: AISearchStatus;
+  downloadProgress: number;
+  generate: (
+    query: string,
+    options?: { onDelta?: (partialExpression: string) => void }
+  ) => Promise<AISearchGenerateResult>;
+  cancel: () => void;
+  placeholder?: string;
+};
+
 export type DSLFilterConditionFieldProps<
   TValidationResult extends DSLFilterConditionValidationResult =
     DSLFilterConditionValidationResult,
@@ -224,6 +290,13 @@ export type DSLFilterConditionFieldProps<
   onValidationStateChange?: (isValid: boolean) => void;
   placeholder?: string;
   /**
+   * Opts the field into AI search — natural-language drafts convert to DSL
+   * on Enter using the model configured in the AI search settings. The
+   * feature stays invisible (beyond its settings entry point) until the
+   * user enables it there.
+   */
+  aiSearch?: DSLFilterAISearchProps;
+  /**
    * Accessible name for the condition input
    */
   "aria-label"?: string;
@@ -248,6 +321,54 @@ export type DSLFilterConditionFieldProps<
 export function DSLFilterConditionField<
   TValidationResult extends DSLFilterConditionValidationResult,
 >(props: DSLFilterConditionFieldProps<TValidationResult>) {
+  const { aiSearch, ...rest } = props;
+  if (aiSearch != null) {
+    return (
+      <DSLFilterConditionFieldWithAISearch {...rest} aiSearch={aiSearch} />
+    );
+  }
+  return <DSLFilterConditionFieldImpl {...rest} />;
+}
+
+/**
+ * Resolves the AI-search capability from the preferences and credentials
+ * contexts, keeping those provider requirements out of the base field.
+ */
+function DSLFilterConditionFieldWithAISearch<
+  TValidationResult extends DSLFilterConditionValidationResult,
+>(
+  props: Omit<DSLFilterConditionFieldProps<TValidationResult>, "aiSearch"> & {
+    aiSearch: DSLFilterAISearchProps;
+  }
+) {
+  const { aiSearch, ...rest } = props;
+  const isEnabled = usePreferencesContext((state) => state.isAISearchEnabled);
+  const { status, downloadProgress, generate, cancel } = useAISearch({
+    dsl: aiSearch.dsl,
+    validate: props.validateCondition,
+  });
+  return (
+    <DSLFilterConditionFieldImpl
+      {...rest}
+      ai={{
+        isEnabled,
+        status,
+        downloadProgress,
+        generate,
+        cancel,
+        placeholder: aiSearch.placeholder,
+      }}
+    />
+  );
+}
+
+function DSLFilterConditionFieldImpl<
+  TValidationResult extends DSLFilterConditionValidationResult,
+>(
+  props: Omit<DSLFilterConditionFieldProps<TValidationResult>, "aiSearch"> & {
+    ai?: AISearchRuntime;
+  }
+) {
   const {
     value,
     onChange,
@@ -261,10 +382,13 @@ export function DSLFilterConditionField<
     validationRetryKey,
     onValidationStateChange,
     placeholder = "filter condition",
+    ai,
     "aria-label": ariaLabel = "filter condition",
     className,
   } = props;
   const [isFocused, setIsFocused] = useState<boolean>(false);
+  const [aiPhase, setAIPhase] = useState<AISearchPhase>(AI_SEARCH_IDLE);
+  const isAIActive = ai?.isEnabled === true;
   const hasSettled = useRef<boolean>(false);
   const previousValidationRetryKey = useRef(validationRetryKey);
   // null means the condition is not known to be invalid; the empty string
@@ -282,6 +406,101 @@ export function DSLFilterConditionField<
 
   const hasError = errorMessage !== null;
   const hasCondition = value !== "";
+
+  // A non-empty draft that reads as prose is the AI's input; a draft with
+  // DSL syntax is the user writing the expression themselves
+  const isNaturalLanguageDraft =
+    isAIActive &&
+    aiPhase.name === "idle" &&
+    value.trim() !== "" &&
+    !looksLikeDSLExpression(value);
+  const isConverting = aiPhase.name === "converting";
+  // The validation effect keys on the phase *name* — keying on the phase
+  // object would re-run validation on every object identity change
+  const aiPhaseName = aiPhase.name;
+
+  const handleChange = (nextValue: string) => {
+    // Any real edit ends the post-conversion affordances — the text is the
+    // user's again. Streamed updates echo back from the editor with the
+    // value they were set to, so an identity check tells the two apart.
+    if (aiPhase.name !== "idle" && !isConverting && nextValue !== value) {
+      setAIPhase(AI_SEARCH_IDLE);
+    }
+    onChange(nextValue);
+  };
+
+  // Identifies the conversion whose resolution is still welcome. Clearing
+  // the field bumps this so a cancelled run's "restore the query" behavior
+  // can't clobber the clear; Escape cancels WITHOUT bumping, because there
+  // the restoration is the point.
+  const aiRunIdRef = useRef(0);
+
+  const startAIConversion = (query: string) => {
+    if (ai == null) {
+      return;
+    }
+    const runId = ++aiRunIdRef.current;
+    setAIPhase({ name: "converting", query });
+    void ai.generate(query, { onDelta: onChange }).then((result) => {
+      if (aiRunIdRef.current !== runId) {
+        return;
+      }
+      if (result.outcome === "success") {
+        onChange(result.condition);
+        setAIPhase({ name: "generated", query });
+      } else if (result.outcome === "error") {
+        onChange(query);
+        setAIPhase({ name: "failed", query, message: result.message });
+      } else {
+        onChange(query);
+        setAIPhase(AI_SEARCH_IDLE);
+      }
+    });
+  };
+
+  const undoAIConversion = (query: string) => {
+    onChange(query);
+    setAIPhase(AI_SEARCH_IDLE);
+    editorViewRef.current?.focus();
+  };
+
+  // The CodeMirror keymap must stay referentially stable (see the
+  // extensions memo below), so key handlers reach the current AI state
+  // through this ref rather than closing over it
+  const aiRuntimeRef = useRef<{
+    maybeConvert: () => boolean;
+    handleEscape: () => boolean;
+  } | null>(null);
+  useEffect(() => {
+    aiRuntimeRef.current = {
+      maybeConvert: () => {
+        if (!isAIActive || isConverting) {
+          return false;
+        }
+        const query = value.trim();
+        if (!query || looksLikeDSLExpression(query)) {
+          return false;
+        }
+        startAIConversion(query);
+        return true;
+      },
+      handleEscape: () => {
+        switch (aiPhase.name) {
+          case "converting":
+            ai?.cancel();
+            return true;
+          case "generated":
+            undoAIConversion(aiPhase.query);
+            return true;
+          case "failed":
+            setAIPhase(AI_SEARCH_IDLE);
+            return true;
+          default:
+            return false;
+        }
+      },
+    };
+  });
 
   // A cached result from a previous loader no longer describes the data
   useEffect(() => {
@@ -321,9 +540,24 @@ export function DSLFilterConditionField<
           key: "Enter",
           run: (editorView: EditorView) => {
             // Insert the highlighted completion if the dropdown is open;
-            // always swallow the key so no newline is inserted
-            acceptCompletion(editorView);
+            // otherwise a natural-language draft converts via AI search.
+            // Always swallow the key so no newline is inserted.
+            if (!acceptCompletion(editorView)) {
+              aiRuntimeRef.current?.maybeConvert();
+            }
             return true;
+          },
+        },
+        {
+          key: "Escape",
+          run: (editorView: EditorView) => {
+            // With the typeahead open, Escape belongs to it; otherwise it
+            // walks back whatever AI search last did — cancels an in-flight
+            // conversion, undoes a finished one, dismisses a failure
+            if (completionStatus(editorView.state) !== null) {
+              return false;
+            }
+            return aiRuntimeRef.current?.handleEscape() ?? false;
           },
         },
       ]),
@@ -433,6 +667,19 @@ export function DSLFilterConditionField<
 
     reportValidationState(false);
 
+    // A natural-language draft is the AI's input, not a DSL expression —
+    // asking the validator about English only flags the field red while
+    // the user is mid-thought. The same goes for the partial expression
+    // streaming in during a conversion; the finished expression validates
+    // normally once the conversion settles.
+    if (
+      (isAIActive && !looksLikeDSLExpression(value)) ||
+      aiPhaseName === "converting"
+    ) {
+      hasSettled.current = true;
+      return undefined;
+    }
+
     // Debounce so intermediate keystrokes neither hit the server nor flash
     // the field red while a valid expression is being typed. A non-empty value
     // at mount was not typed -- it arrives from a URL or a caller's default --
@@ -484,88 +731,204 @@ export function DSLFilterConditionField<
       isCancelled = true;
       clearTimeout(timeout);
     };
-  }, [value, validateCondition, validationRetryKey]);
+  }, [value, validateCondition, validationRetryKey, isAIActive, aiPhaseName]);
+
+  // The PXI treatment reflects how engaged AI search is: a resting stroke
+  // once a natural-language draft is detected, the full animated glow while
+  // a conversion is in flight. Fields without AI search stay permanently
+  // idle, where the outline is invisible.
+  const aiOutlineState: PxiOutlineState = isConverting
+    ? "active"
+    : isNaturalLanguageDraft
+      ? "eligible"
+      : "idle";
 
   return (
-    <div
-      data-is-focused={isFocused}
-      data-is-invalid={hasError}
-      data-has-condition={hasCondition}
-      className={classNames("dsl-filter-condition-field", className)}
-      css={dslFilterFieldCSS}
+    <PxiOutline
+      isFullWidth
+      glowMode="contained"
+      state={aiOutlineState}
+      shouldFlash
+      css={dslFilterAIOutlineCSS}
     >
-      <Flex direction="row" alignItems="center">
-        <Icon svg={<Icons.ListFilter />} className="filter-icon" />
-        <CodeMirror
-          css={dslFilterCodeMirrorCSS}
-          indentWithTab={false}
-          basicSetup={basicSetupOptions}
-          onCreateEditor={(editorView) => {
-            editorViewRef.current = editorView;
-          }}
-          onFocus={() => {
-            // Refresh the loaded completions each time the user returns to
-            // the field — the underlying names may have changed since
-            loadedCompletionsRef.current = null;
-            setIsFocused(true);
-          }}
-          onBlur={() => setIsFocused(false)}
-          value={value}
-          onChange={onChange}
-          height="36px"
-          width="100%"
-          theme={codeMirrorTheme}
-          placeholder={placeholder}
-          extensions={extensions}
-        />
-        {hasError ? (
-          <TooltipTrigger delay={0}>
-            <Pressable>
-              <div
-                role="button"
-                tabIndex={0}
-                className="error-badge"
-                aria-label="Filter condition error"
-              >
-                <Icon svg={<Icons.AlertCircle />} color="danger" />
-                <span className="error-badge__message">
-                  {errorMessage || "Invalid filter condition"}
-                </span>
-              </div>
-            </Pressable>
-            <Tooltip placement="bottom end" css={dslFilterErrorTooltipCSS}>
-              <Flex direction="row" gap="size-100" alignItems="start">
-                <Icon svg={<Icons.AlertCircle />} color="danger" />
-                <Flex direction="column" gap="size-25">
-                  <Text size="S" weight="heavy">
-                    Invalid filter condition
-                  </Text>
-                  {errorMessage ? (
-                    <Text size="S" color="text-700">
-                      {errorMessage}
+      <div
+        data-is-focused={isFocused}
+        data-is-invalid={hasError}
+        data-has-condition={hasCondition}
+        data-ai-natural-language={isNaturalLanguageDraft}
+        className={classNames("dsl-filter-condition-field", className)}
+        css={dslFilterFieldCSS}
+      >
+        <Flex direction="row" alignItems="center">
+          <Icon svg={<Icons.ListFilter />} className="filter-icon" />
+          <CodeMirror
+            css={dslFilterCodeMirrorCSS}
+            indentWithTab={false}
+            basicSetup={basicSetupOptions}
+            readOnly={isConverting}
+            onCreateEditor={(editorView) => {
+              editorViewRef.current = editorView;
+            }}
+            onFocus={() => {
+              // Refresh the loaded completions each time the user returns to
+              // the field — the underlying names may have changed since
+              loadedCompletionsRef.current = null;
+              setIsFocused(true);
+            }}
+            onBlur={() => setIsFocused(false)}
+            value={value}
+            onChange={handleChange}
+            height="36px"
+            width="100%"
+            theme={codeMirrorTheme}
+            placeholder={
+              isAIActive && ai?.placeholder ? ai.placeholder : placeholder
+            }
+            extensions={extensions}
+          />
+          {hasError ? (
+            <TooltipTrigger delay={0}>
+              <Pressable>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className="error-badge"
+                  aria-label="Filter condition error"
+                >
+                  <Icon svg={<Icons.AlertCircle />} color="danger" />
+                  <span className="error-badge__message">
+                    {errorMessage || "Invalid filter condition"}
+                  </span>
+                </div>
+              </Pressable>
+              <Tooltip placement="bottom end" css={dslFilterErrorTooltipCSS}>
+                <Flex direction="row" gap="size-100" alignItems="start">
+                  <Icon svg={<Icons.AlertCircle />} color="danger" />
+                  <Flex direction="column" gap="size-25">
+                    <Text size="S" weight="heavy">
+                      Invalid filter condition
                     </Text>
-                  ) : null}
+                    {errorMessage ? (
+                      <Text size="S" color="text-700">
+                        {errorMessage}
+                      </Text>
+                    ) : null}
+                  </Flex>
                 </Flex>
-              </Flex>
-            </Tooltip>
-          </TooltipTrigger>
-        ) : null}
-        <button
-          onClick={() => {
-            onChange("");
-            editorViewRef.current?.focus();
-          }}
-          className="button--reset clear-button"
-          aria-label="Clear filter condition"
-        >
-          <Icon svg={<Icons.Close />} />
-        </button>
-      </Flex>
-      <VisuallyHidden>
-        <span id={errorId} role="status">
-          {hasError ? `Invalid filter condition. ${errorMessage}`.trim() : ""}
-        </span>
-      </VisuallyHidden>
-    </div>
+              </Tooltip>
+            </TooltipTrigger>
+          ) : null}
+          {isNaturalLanguageDraft ? (
+            <span
+              className="ai-badge"
+              title="Press Enter to convert to a filter expression"
+            >
+              <Icon svg={<Icons.Sparkles />} />
+              AI · ⏎
+            </span>
+          ) : null}
+          {isConverting ? (
+            <span className="ai-badge">
+              <Icon svg={<Icons.Loader />} className="ai-badge__spinner" />
+              {ai?.status === "downloading"
+                ? `Downloading model… ${Math.round((ai?.downloadProgress ?? 0) * 100)}%`
+                : "Converting…"}
+            </span>
+          ) : null}
+          {aiPhase.name === "generated" ? (
+            <span className="ai-badge">
+              <Icon svg={<Icons.Sparkles />} />
+              <TooltipTrigger delay={0}>
+                <Pressable>
+                  <button
+                    onClick={() => undoAIConversion(aiPhase.query)}
+                    className="button--reset ai-undo-button"
+                    aria-label="Undo AI conversion and restore your query"
+                  >
+                    Undo
+                  </button>
+                </Pressable>
+                <Tooltip placement="bottom end" css={dslFilterErrorTooltipCSS}>
+                  <Flex direction="column" gap="size-25">
+                    <Text size="S" weight="heavy">
+                      Generated from “{aiPhase.query}”
+                    </Text>
+                    <Text size="S" color="text-700">
+                      Edit the expression freely, or undo to get your words
+                      back.
+                    </Text>
+                  </Flex>
+                </Tooltip>
+              </TooltipTrigger>
+            </span>
+          ) : null}
+          {aiPhase.name === "failed" ? (
+            <TooltipTrigger delay={0}>
+              <Pressable>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className="error-badge"
+                  aria-label="AI search error"
+                >
+                  <Icon svg={<Icons.AlertCircle />} color="danger" />
+                  <span className="error-badge__message">
+                    Couldn’t convert to a filter
+                  </span>
+                </div>
+              </Pressable>
+              <Tooltip placement="bottom end" css={dslFilterErrorTooltipCSS}>
+                <Flex direction="row" gap="size-100" alignItems="start">
+                  <Icon svg={<Icons.AlertCircle />} color="danger" />
+                  <Flex direction="column" gap="size-25">
+                    <Text size="S" weight="heavy">
+                      Couldn’t convert to a filter
+                    </Text>
+                    <Text size="S" color="text-700">
+                      {aiPhase.message}
+                    </Text>
+                    <Text size="S" color="text-700">
+                      Rephrase the request, or write the expression directly.
+                    </Text>
+                  </Flex>
+                </Flex>
+              </Tooltip>
+            </TooltipTrigger>
+          ) : null}
+          {ai != null ? <AISearchSettingsButton /> : null}
+          <button
+            onClick={() => {
+              // Invalidate any in-flight conversion so its cancelled
+              // resolution can't restore the query over the clear
+              aiRunIdRef.current++;
+              if (isConverting) {
+                ai?.cancel();
+              }
+              setAIPhase(AI_SEARCH_IDLE);
+              onChange("");
+              editorViewRef.current?.focus();
+            }}
+            className="button--reset clear-button"
+            aria-label="Clear filter condition"
+          >
+            <Icon svg={<Icons.Close />} />
+          </button>
+        </Flex>
+        <VisuallyHidden>
+          <span id={errorId} role="status">
+            {hasError ? `Invalid filter condition. ${errorMessage}`.trim() : ""}
+          </span>
+          <span role="status">
+            {isConverting
+              ? "Converting to a filter expression"
+              : aiPhase.name === "generated"
+                ? "Filter expression generated. Press Escape to undo."
+                : aiPhase.name === "failed"
+                  ? `AI search failed. ${aiPhase.message}`
+                  : ""}
+          </span>
+        </VisuallyHidden>
+      </div>
+    </PxiOutline>
   );
 }

--- a/app/src/components/filter/DSLFilterConditionField.tsx
+++ b/app/src/components/filter/DSLFilterConditionField.tsx
@@ -36,7 +36,10 @@ import {
   TooltipTrigger,
   VisuallyHidden,
 } from "@phoenix/components";
-import { PxiOutline, type PxiOutlineState } from "@phoenix/components/agent";
+import {
+  PxiOutline,
+  type PxiOutlineState,
+} from "@phoenix/components/agent/PxiOutline";
 import { pierreDark, pierreLight } from "@phoenix/components/code";
 import { useTheme } from "@phoenix/contexts";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
@@ -468,16 +471,21 @@ function DSLFilterConditionFieldImpl<
   // extensions memo below), so key handlers reach the current AI state
   // through this ref rather than closing over it
   const aiRuntimeRef = useRef<{
-    maybeConvert: () => boolean;
+    maybeConvert: (currentText: string) => boolean;
     handleEscape: () => boolean;
   } | null>(null);
   useEffect(() => {
     aiRuntimeRef.current = {
-      maybeConvert: () => {
+      // The editor's own document is the query, not the `value` prop: a
+      // consumer whose onChange defers the update (e.g. through
+      // startTransition) can still be a render behind the keystroke that
+      // preceded Enter, and converting -- or restoring on cancel -- a stale
+      // draft would drop the user's last words
+      maybeConvert: (currentText: string) => {
         if (!isAIActive || isConverting) {
           return false;
         }
-        const query = value.trim();
+        const query = currentText.trim();
         if (!query || looksLikeDSLExpression(query)) {
           return false;
         }
@@ -543,7 +551,9 @@ function DSLFilterConditionFieldImpl<
             // otherwise a natural-language draft converts via AI search.
             // Always swallow the key so no newline is inserted.
             if (!acceptCompletion(editorView)) {
-              aiRuntimeRef.current?.maybeConvert();
+              aiRuntimeRef.current?.maybeConvert(
+                editorView.state.doc.toString()
+              );
             }
             return true;
           },

--- a/app/src/components/filter/__tests__/detectFilterExpression.test.ts
+++ b/app/src/components/filter/__tests__/detectFilterExpression.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { looksLikeDSLExpression } from "../ai/detectFilterExpression";
+
+describe("looksLikeDSLExpression", () => {
+  it("recognizes DSL syntax", () => {
+    expect(looksLikeDSLExpression("span_kind == 'LLM'")).toBe(true);
+    expect(looksLikeDSLExpression("latency_ms > 1000")).toBe(true);
+    expect(looksLikeDSLExpression("'error' in output.value")).toBe(true);
+    expect(looksLikeDSLExpression('"error" in output.value')).toBe(true);
+    expect(looksLikeDSLExpression("attributes['llm']['provider']")).toBe(true);
+    expect(looksLikeDSLExpression("parent_id is None")).toBe(true);
+    expect(looksLikeDSLExpression("metadata['key'] is not None")).toBe(true);
+  });
+
+  it("treats plain language as plain language", () => {
+    expect(looksLikeDSLExpression("llm spans that errored")).toBe(false);
+    expect(looksLikeDSLExpression("slow spans")).toBe(false);
+  });
+
+  it("does not mistake apostrophes for a string literal", () => {
+    // Two contractions in one sentence produce a pair of apostrophes; they
+    // are not a quoted literal, and reading them as one would withhold the
+    // AI affordance and flag the field invalid instead
+    expect(
+      looksLikeDSLExpression("spans that didn't error and weren't retried")
+    ).toBe(false);
+    expect(
+      looksLikeDSLExpression("spans where the user's request wasn't answered")
+    ).toBe(false);
+  });
+});

--- a/app/src/components/filter/__tests__/extractFilterExpression.test.ts
+++ b/app/src/components/filter/__tests__/extractFilterExpression.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { extractFilterExpression } from "../ai/extractFilterExpression";
+
+describe("extractFilterExpression", () => {
+  it("passes a bare expression through untouched", () => {
+    expect(extractFilterExpression("status_code == 'ERROR'")).toBe(
+      "status_code == 'ERROR'"
+    );
+  });
+
+  it("unwraps a fenced code block with a language tag", () => {
+    expect(extractFilterExpression("```python\nspan_kind == 'LLM'\n```")).toBe(
+      "span_kind == 'LLM'"
+    );
+  });
+
+  it("unwraps a fence without a language tag", () => {
+    expect(extractFilterExpression("```\nlatency_ms > 1000\n```")).toBe(
+      "latency_ms > 1000"
+    );
+  });
+
+  it("drops a leading label", () => {
+    expect(
+      extractFilterExpression(
+        "Expression: latency_ms > 1000 and span_kind == 'LLM'"
+      )
+    ).toBe("latency_ms > 1000 and span_kind == 'LLM'");
+    expect(extractFilterExpression("filter: name == 'OpenAI'")).toBe(
+      "name == 'OpenAI'"
+    );
+  });
+
+  it("unwraps single backticks around the whole expression", () => {
+    expect(extractFilterExpression("`status_code == 'OK'`")).toBe(
+      "status_code == 'OK'"
+    );
+  });
+
+  it("collapses a wrapped answer onto a single line", () => {
+    expect(
+      extractFilterExpression("status_code == 'ERROR'\n  and latency_ms > 500")
+    ).toBe("status_code == 'ERROR' and latency_ms > 500");
+  });
+
+  it("does not strip quotes that belong to the expression", () => {
+    expect(extractFilterExpression("'error' in output.value")).toBe(
+      "'error' in output.value"
+    );
+  });
+
+  it("returns an empty string for empty or whitespace output", () => {
+    expect(extractFilterExpression("   \n ")).toBe("");
+  });
+});

--- a/app/src/components/filter/ai/AISearchSettingsButton.tsx
+++ b/app/src/components/filter/ai/AISearchSettingsButton.tsx
@@ -1,0 +1,56 @@
+import { css } from "@emotion/react";
+
+import {
+  DialogTrigger,
+  Icon,
+  IconButton,
+  Icons,
+  Popover,
+  View,
+} from "@phoenix/components";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+
+import { AISearchSettingsForm } from "./AISearchSettingsForm";
+
+const settingsButtonCSS = css`
+  &[data-ai-enabled="true"] {
+    color: var(--pxi-treatment-color-middle);
+    &:hover {
+      color: var(--pxi-treatment-color-end);
+    }
+  }
+`;
+
+/**
+ * The AI-search entry point on a filter field: a sparkle button whose
+ * popover holds the AI search configuration. The setting is global —
+ * enabling AI search here enables it on every filter field that supports
+ * it, and the same configuration appears on the settings and profile pages.
+ */
+export function AISearchSettingsButton() {
+  const isEnabled = usePreferencesContext((state) => state.isAISearchEnabled);
+  return (
+    <DialogTrigger>
+      <IconButton
+        size="S"
+        aria-label="AI search settings"
+        className="ai-search-settings-button"
+        data-ai-enabled={isEnabled}
+        css={settingsButtonCSS}
+      >
+        <Icon svg={<Icons.Sparkles />} />
+      </IconButton>
+      <Popover
+        placement="bottom end"
+        css={css`
+          overflow: auto;
+          overscroll-behavior: none;
+        `}
+      >
+        <View padding="size-200" width="340px">
+          <AISearchSettingsForm />
+        </View>
+      </Popover>
+    </DialogTrigger>
+  );
+}

--- a/app/src/components/filter/ai/AISearchSettingsCard.tsx
+++ b/app/src/components/filter/ai/AISearchSettingsCard.tsx
@@ -1,0 +1,18 @@
+import { Card, View } from "@phoenix/components";
+
+import { AISearchSettingsForm } from "./AISearchSettingsForm";
+
+/**
+ * The AI search configuration presented as a settings card — the same form
+ * the filter field's sparkle popover shows, for the settings and profile
+ * pages. All surfaces read and write the same persisted preference.
+ */
+export function AISearchSettingsCard() {
+  return (
+    <Card title="AI Search">
+      <View padding="size-200">
+        <AISearchSettingsForm />
+      </View>
+    </Card>
+  );
+}

--- a/app/src/components/filter/ai/AISearchSettingsForm.tsx
+++ b/app/src/components/filter/ai/AISearchSettingsForm.tsx
@@ -1,0 +1,289 @@
+import { css } from "@emotion/react";
+import { useEffect, useState } from "react";
+
+import {
+  Button,
+  Flex,
+  Input,
+  Label,
+  ListBox,
+  Popover,
+  Radio,
+  RadioGroup,
+  Select,
+  SelectChevronUpDownIcon,
+  SelectItem,
+  SelectValue,
+  Switch,
+  Text,
+  TextField,
+} from "@phoenix/components";
+import { GenerativeProviderIcon } from "@phoenix/components/generative";
+import {
+  DEFAULT_MODEL_NAME,
+  DEFAULT_MODEL_PROVIDER,
+  ModelProviders,
+  ProviderToCredentialsConfigMap,
+} from "@phoenix/constants/generativeConstants";
+import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+import { isModelProvider } from "@phoenix/utils/generativeUtils";
+
+import type { BrowserModelAvailability } from "./browserModel";
+import { getBrowserModelAvailability } from "./browserModel";
+import { AI_SEARCH_PROVIDERS } from "./providerModels";
+import type { AISearchModelConfig } from "./types";
+
+const formCSS = css`
+  .ai-search-settings__description {
+    /* Sits under the switch label, aligned with its text */
+    margin-top: calc(-1 * var(--global-dimension-size-50));
+  }
+  .radio-group {
+    gap: var(--global-dimension-size-100);
+  }
+  /* Plain spans rather than slotted <Text> — inside a RadioGroup, RAC
+     reserves Text for the group's description/errorMessage slots, and
+     these are per-option annotations */
+  .ai-search-settings__hint {
+    font-size: var(--global-font-size-xs);
+    line-height: var(--global-line-height-xs);
+    color: var(--global-text-color-700);
+    &[data-tone="success"] {
+      color: var(--global-color-success);
+    }
+    &[data-tone="warning"] {
+      color: var(--global-color-warning);
+    }
+  }
+`;
+
+function suggestedModelName(provider: ModelProvider): string {
+  return provider === "OPENAI" ? DEFAULT_MODEL_NAME : "";
+}
+
+/**
+ * Availability of the on-device model, fetched when the settings surface
+ * mounts (i.e. each time it opens, so a finished download is reflected on
+ * the next look).
+ */
+function BrowserModelAvailabilityText() {
+  const [availability, setAvailability] =
+    useState<BrowserModelAvailability | null>(null);
+  useEffect(() => {
+    let isCancelled = false;
+    void getBrowserModelAvailability().then((result) => {
+      if (!isCancelled) {
+        setAvailability(result);
+      }
+    });
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+  if (availability === null) {
+    return null;
+  }
+  switch (availability) {
+    case "available":
+      return (
+        <span className="ai-search-settings__hint" data-tone="success">
+          Ready to use
+        </span>
+      );
+    case "needs-download":
+      return (
+        <span className="ai-search-settings__hint">
+          The model downloads on first use
+        </span>
+      );
+    case "downloading":
+      return (
+        <span className="ai-search-settings__hint">
+          The model is downloading…
+        </span>
+      );
+    default:
+      return (
+        <span className="ai-search-settings__hint" data-tone="warning">
+          Not supported in this browser — use a model provider instead
+        </span>
+      );
+  }
+}
+
+/**
+ * Inline inputs for the selected provider's required credentials, written
+ * straight to the browser-held credentials store (the same store the
+ * playground reads) so a key entered here works everywhere and vice versa.
+ */
+function ProviderCredentialInputs({ provider }: { provider: ModelProvider }) {
+  const setCredential = useCredentialsContext((state) => state.setCredential);
+  const credentials = useCredentialsContext((state) => state[provider]);
+  const requirements = ProviderToCredentialsConfigMap[provider].filter(
+    (config) => config.isRequired
+  );
+  if (requirements.length === 0) {
+    return null;
+  }
+  return (
+    <Flex direction="column" gap="size-100">
+      {requirements.map(({ envVarName }) => (
+        <TextField
+          key={envVarName}
+          type="password"
+          size="S"
+          value={credentials?.[envVarName] ?? ""}
+          onChange={(value) => {
+            setCredential({
+              provider,
+              envVarName,
+              value: value.trim() || null,
+            });
+          }}
+        >
+          <Label>{envVarName}</Label>
+          <Input placeholder="stored only in this browser" />
+        </TextField>
+      ))}
+    </Flex>
+  );
+}
+
+function ProviderModelForm({
+  config,
+  onConfigChange,
+}: {
+  config: Extract<AISearchModelConfig, { kind: "provider" }>;
+  onConfigChange: (config: AISearchModelConfig) => void;
+}) {
+  return (
+    <Flex direction="column" gap="size-100" marginStart="size-300">
+      <Select
+        size="S"
+        value={config.provider}
+        onChange={(key) => {
+          if (typeof key === "string" && isModelProvider(key)) {
+            onConfigChange({
+              kind: "provider",
+              provider: key,
+              modelName: suggestedModelName(key),
+            });
+          }
+        }}
+        aria-label="Model provider"
+      >
+        <Button>
+          <SelectValue />
+          <SelectChevronUpDownIcon />
+        </Button>
+        <Popover>
+          <ListBox>
+            {AI_SEARCH_PROVIDERS.map((provider) => (
+              <SelectItem
+                key={provider}
+                id={provider}
+                textValue={ModelProviders[provider]}
+              >
+                <Flex direction="row" gap="size-100" alignItems="center">
+                  <GenerativeProviderIcon provider={provider} height={16} />
+                  {ModelProviders[provider]}
+                </Flex>
+              </SelectItem>
+            ))}
+          </ListBox>
+        </Popover>
+      </Select>
+      <TextField
+        size="S"
+        value={config.modelName}
+        onChange={(modelName) => {
+          onConfigChange({ ...config, modelName });
+        }}
+        aria-label="Model name"
+      >
+        <Input placeholder="model name (e.g. gpt-5-mini)" />
+      </TextField>
+      <ProviderCredentialInputs provider={config.provider} />
+    </Flex>
+  );
+}
+
+/**
+ * The AI search configuration: the feature switch and, when enabled, the
+ * model choice — on-device browser AI by default, or a provider called with
+ * credentials that never leave this browser. Bound to the persisted
+ * preferences store, so every surface that renders it (the filter field's
+ * popover, the settings page, the profile page) reads and writes the same
+ * setting.
+ */
+export function AISearchSettingsForm() {
+  const isEnabled = usePreferencesContext((state) => state.isAISearchEnabled);
+  const setIsEnabled = usePreferencesContext(
+    (state) => state.setIsAISearchEnabled
+  );
+  const modelConfig =
+    usePreferencesContext((state) => state.aiSearchModelConfig) ??
+    ({ kind: "browser" } satisfies AISearchModelConfig);
+  const setModelConfig = usePreferencesContext(
+    (state) => state.setAISearchModelConfig
+  );
+  return (
+    <div css={formCSS}>
+      <Flex direction="column" gap="size-150">
+        <Switch isSelected={isEnabled} onChange={setIsEnabled}>
+          AI Search
+        </Switch>
+        <Text
+          size="XS"
+          color="text-700"
+          className="ai-search-settings__description"
+        >
+          Describe a filter in plain language and press Enter to convert it to a
+          filter expression.
+        </Text>
+        {isEnabled ? (
+          <>
+            <RadioGroup
+              aria-label="AI search model"
+              direction="column"
+              value={modelConfig.kind}
+              onChange={(kind) => {
+                setModelConfig(
+                  kind === "browser"
+                    ? { kind: "browser" }
+                    : {
+                        kind: "provider",
+                        provider: DEFAULT_MODEL_PROVIDER,
+                        modelName: suggestedModelName(DEFAULT_MODEL_PROVIDER),
+                      }
+                );
+              }}
+            >
+              <Radio value="browser">
+                <Flex direction="column" gap="size-25">
+                  In-browser AI
+                  <span className="ai-search-settings__hint">
+                    Runs on-device — queries never leave your browser
+                  </span>
+                  <BrowserModelAvailabilityText />
+                </Flex>
+              </Radio>
+              <Radio value="provider">Model provider</Radio>
+            </RadioGroup>
+            {modelConfig.kind === "provider" ? (
+              <ProviderModelForm
+                config={modelConfig}
+                onConfigChange={setModelConfig}
+              />
+            ) : null}
+            <Text size="XS" color="text-300">
+              Only your query and the filter field vocabulary are sent to the
+              model.
+            </Text>
+          </>
+        ) : null}
+      </Flex>
+    </div>
+  );
+}

--- a/app/src/components/filter/ai/browserModel.ts
+++ b/app/src/components/filter/ai/browserModel.ts
@@ -1,0 +1,55 @@
+import { browserAI, doesBrowserSupportBrowserAI } from "@browser-ai/core";
+import type { LanguageModel } from "ai";
+
+/**
+ * Where the on-device browser model stands, normalized across the Prompt
+ * API's naming revisions ("available-after-download" vs. "downloadable"):
+ *
+ * - `unsupported` — the browser has no Prompt API (anything but Chrome/Edge)
+ * - `unavailable` — the API exists but no model can be provisioned
+ * - `needs-download` — usable once the model is downloaded
+ * - `downloading` — a download is already in flight
+ * - `available` — ready to use
+ */
+export type BrowserModelAvailability =
+  | "unsupported"
+  | "unavailable"
+  | "needs-download"
+  | "downloading"
+  | "available";
+
+export async function getBrowserModelAvailability(): Promise<BrowserModelAvailability> {
+  if (!doesBrowserSupportBrowserAI()) {
+    return "unsupported";
+  }
+  try {
+    const availability: string = await browserAI().availability();
+    switch (availability) {
+      case "available":
+        return "available";
+      case "downloading":
+        return "downloading";
+      case "downloadable":
+      case "available-after-download":
+        return "needs-download";
+      default:
+        return "unavailable";
+    }
+  } catch {
+    return "unavailable";
+  }
+}
+
+/**
+ * Starts (or joins) the on-device model download, reporting progress as a
+ * fraction from 0 to 1. Resolves when the model is ready to use.
+ */
+export async function downloadBrowserModel(
+  onProgress?: (fraction: number) => void
+): Promise<void> {
+  await browserAI().createSessionWithProgress(onProgress);
+}
+
+export function createBrowserModel(): LanguageModel {
+  return browserAI();
+}

--- a/app/src/components/filter/ai/buildAISearchPrompt.ts
+++ b/app/src/components/filter/ai/buildAISearchPrompt.ts
@@ -1,0 +1,41 @@
+import type { AISearchDSL } from "./types";
+
+/**
+ * Builds the system prompt that teaches the model a filter DSL. The DSL is
+ * described entirely by the caller — fields, examples, and dialect notes —
+ * so the same prompt shape serves every filter field.
+ */
+export function buildAISearchSystemPrompt(dsl: AISearchDSL): string {
+  const fieldLines = dsl.fields
+    .map((field) =>
+      field.description
+        ? `- ${field.name}: ${field.description}`
+        : `- ${field.name}`
+    )
+    .join("\n");
+  const exampleLines = dsl.examples
+    .map((example) => `- "${example.description}" -> ${example.expression}`)
+    .join("\n");
+  const notes = dsl.notes?.length
+    ? `\nAdditional notes:\n${dsl.notes.map((note) => `- ${note}`).join("\n")}\n`
+    : "";
+  return `You translate natural-language requests into filter expressions for ${dsl.noun}.
+
+The filter language is a Python-like boolean expression evaluated against each of the ${dsl.noun}; those for which it is true are kept. String literals use single quotes. Clauses combine with \`and\`, \`or\`, and \`not\`. Substring search is written \`'text' in field\`. Comparisons use \`==\`, \`!=\`, \`>\`, \`>=\`, \`<\`, \`<=\`.
+
+The expression may reference only these fields:
+${fieldLines}
+
+Examples of requests and their expressions:
+${exampleLines}
+${notes}
+Respond with the filter expression only — a single line, with no explanation, no code fences, and no surrounding quotes. If the request cannot be expressed with the fields above, respond with the closest expressible approximation.`;
+}
+
+/**
+ * The follow-up message sent when a generated expression fails validation,
+ * giving the model one round to correct itself with the validator's error.
+ */
+export function buildAISearchRepairPrompt(errorMessage: string): string {
+  return `That expression failed validation with the error: ${errorMessage || "invalid filter condition"}. Respond with a corrected filter expression only.`;
+}

--- a/app/src/components/filter/ai/createAISearchDSL.ts
+++ b/app/src/components/filter/ai/createAISearchDSL.ts
@@ -1,0 +1,37 @@
+import type { Completion } from "@codemirror/autocomplete";
+
+import type { DSLFilterSnippet } from "../DSLFilterConditionField";
+import type { AISearchDSL } from "./types";
+
+/**
+ * Derives the model-facing DSL description from the same completions and
+ * snippets that power a filter field's typeahead, so the vocabulary the
+ * model learns and the vocabulary the user autocompletes can never drift
+ * apart. Snippet placeholders (`${...}`) become plain text, exactly as the
+ * typeahead renders them.
+ */
+export function createAISearchDSL({
+  noun,
+  completions,
+  snippets,
+  notes,
+}: {
+  noun: string;
+  completions: Completion[];
+  snippets: DSLFilterSnippet[];
+  notes?: string[];
+}): AISearchDSL {
+  return {
+    noun,
+    fields: completions.map((completion) => ({
+      name: completion.label,
+      description:
+        typeof completion.info === "string" ? completion.info : undefined,
+    })),
+    examples: snippets.map((snippet) => ({
+      description: snippet.label,
+      expression: snippet.snippet.replace(/\$\{([^{}]*)\}/g, "$1"),
+    })),
+    notes,
+  };
+}

--- a/app/src/components/filter/ai/createAISearchModel.ts
+++ b/app/src/components/filter/ai/createAISearchModel.ts
@@ -1,0 +1,28 @@
+import type { LanguageModel } from "ai";
+
+import { createBrowserModel } from "./browserModel";
+import type { ProviderCredentials } from "./providerModels";
+import { createProviderModel } from "./providerModels";
+import type { AISearchModelConfig } from "./types";
+
+/**
+ * Resolves a model configuration to a runnable AI SDK model. The two kinds
+ * converge here — everything downstream (prompting, streaming, validation)
+ * is identical regardless of where the model runs.
+ */
+export async function createAISearchModel({
+  config,
+  credentials,
+}: {
+  config: AISearchModelConfig;
+  credentials?: Partial<Record<ModelProvider, ProviderCredentials>>;
+}): Promise<LanguageModel> {
+  if (config.kind === "browser") {
+    return createBrowserModel();
+  }
+  return createProviderModel({
+    provider: config.provider,
+    modelName: config.modelName,
+    credentials: credentials?.[config.provider],
+  });
+}

--- a/app/src/components/filter/ai/detectFilterExpression.ts
+++ b/app/src/components/filter/ai/detectFilterExpression.ts
@@ -1,0 +1,14 @@
+/**
+ * Heuristic for whether typed text reads as a DSL filter expression rather
+ * than plain language: comparison operators, quoted literals, subscripts,
+ * and `is None` checks are all syntax plain language doesn't produce.
+ * Deliberately does NOT key off bare words like "not" or "in", which are
+ * as common in English as in the DSL — a miss in that direction merely
+ * surfaces the AI affordance on something the user meant as DSL, and
+ * Enter still only converts when they ask it to.
+ */
+export function looksLikeDSLExpression(text: string): boolean {
+  return /(==|!=|<=|>=|<|>|'[^']*'|"[^"]*"|\[|\bis\s+(not\s+)?None\b)/.test(
+    text
+  );
+}

--- a/app/src/components/filter/ai/detectFilterExpression.ts
+++ b/app/src/components/filter/ai/detectFilterExpression.ts
@@ -1,4 +1,19 @@
 /**
+ * A quoted literal, i.e. a quote that opens and closes outside of a word.
+ * The word boundaries matter: without them, two apostrophes anywhere in a
+ * sentence ("spans that didn't error and weren't retried") read as a string
+ * literal, which would misclassify ordinary English as DSL — the direction
+ * that actually hurts, since it withholds the AI affordance and asks the
+ * validator about prose.
+ */
+const quotedLiteral =
+  /(?<![A-Za-z])'[^']*'(?![A-Za-z])|(?<![A-Za-z])"[^"]*"(?![A-Za-z])/;
+
+const dslSyntax = new RegExp(
+  `(==|!=|<=|>=|<|>|${quotedLiteral.source}|\\[|\\bis\\s+(not\\s+)?None\\b)`
+);
+
+/**
  * Heuristic for whether typed text reads as a DSL filter expression rather
  * than plain language: comparison operators, quoted literals, subscripts,
  * and `is None` checks are all syntax plain language doesn't produce.
@@ -8,7 +23,5 @@
  * Enter still only converts when they ask it to.
  */
 export function looksLikeDSLExpression(text: string): boolean {
-  return /(==|!=|<=|>=|<|>|'[^']*'|"[^"]*"|\[|\bis\s+(not\s+)?None\b)/.test(
-    text
-  );
+  return dslSyntax.test(text);
 }

--- a/app/src/components/filter/ai/extractFilterExpression.ts
+++ b/app/src/components/filter/ai/extractFilterExpression.ts
@@ -1,0 +1,28 @@
+/**
+ * Normalizes raw model output into a single-line filter expression. Models
+ * are instructed to answer with the bare expression, but smaller ones (the
+ * on-device browser model in particular) still wrap answers in code fences
+ * or prefix them with a label — strip the framing without touching the
+ * expression itself.
+ */
+export function extractFilterExpression(text: string): string {
+  let expression = text.trim();
+  // Unwrap a markdown code fence, with or without a language tag
+  const fenceMatch = expression.match(/^```[^\n`]*\n?([\s\S]*?)```$/);
+  if (fenceMatch) {
+    expression = fenceMatch[1].trim();
+  }
+  // Drop a leading label like "Expression:" or "Filter:"
+  expression = expression.replace(
+    /^(?:filter(?: expression)?|expression|condition)\s*:\s*/i,
+    ""
+  );
+  // Unwrap single backticks around the whole expression
+  const backtickMatch = expression.match(/^`([^`]*)`$/);
+  if (backtickMatch) {
+    expression = backtickMatch[1];
+  }
+  // The DSL is single-line; a multi-line answer is an expression wrapped by
+  // the model, not a multi-line expression
+  return expression.replace(/\s*\n\s*/g, " ").trim();
+}

--- a/app/src/components/filter/ai/generateFilterCondition.ts
+++ b/app/src/components/filter/ai/generateFilterCondition.ts
@@ -1,0 +1,122 @@
+import type { LanguageModel, ModelMessage } from "ai";
+import { streamText } from "ai";
+
+import type { DSLFilterConditionValidationResult } from "../DSLFilterConditionField";
+import {
+  buildAISearchRepairPrompt,
+  buildAISearchSystemPrompt,
+} from "./buildAISearchPrompt";
+import { extractFilterExpression } from "./extractFilterExpression";
+import type { AISearchDSL } from "./types";
+
+export type GenerateFilterConditionArgs = {
+  /**
+   * The AI SDK model that performs the translation — the on-device browser
+   * model or a configured provider model; the generation path is identical.
+   */
+  model: LanguageModel;
+  /**
+   * The DSL to translate into, described by the entity layer.
+   */
+  dsl: AISearchDSL;
+  /**
+   * The user's natural-language request, e.g. "llm spans that errored".
+   */
+  query: string;
+  /**
+   * Streams the expression as it is generated so the field can show the
+   * translation forming. Always called with the normalized expression so
+   * far, never raw model output.
+   */
+  onDelta?: (partialExpression: string) => void;
+  /**
+   * When provided, the generated expression is validated and, if rejected,
+   * the model gets one round to correct itself with the validator's error.
+   */
+  validate?: (
+    condition: string
+  ) => Promise<DSLFilterConditionValidationResult | null | undefined>;
+  abortSignal?: AbortSignal;
+};
+
+async function streamExpression({
+  model,
+  system,
+  messages,
+  onDelta,
+  abortSignal,
+}: {
+  model: LanguageModel;
+  system: string;
+  messages: ModelMessage[];
+  onDelta?: (partialExpression: string) => void;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  const result = streamText({ model, system, messages, abortSignal });
+  let text = "";
+  for await (const delta of result.textStream) {
+    text += delta;
+    const partial = extractFilterExpression(text);
+    if (partial) {
+      onDelta?.(partial);
+    }
+  }
+  return extractFilterExpression(text);
+}
+
+/**
+ * Translates a natural-language request into a filter expression via a
+ * single streaming completion, with one self-correction round when a
+ * validator rejects the result. Resolves to the final expression; the
+ * caller owns what happens to it (typically it flows into the field's
+ * normal validate-then-apply pipeline, exactly as if the user had typed it).
+ */
+export async function generateFilterCondition({
+  model,
+  dsl,
+  query,
+  onDelta,
+  validate,
+  abortSignal,
+}: GenerateFilterConditionArgs): Promise<string> {
+  const system = buildAISearchSystemPrompt(dsl);
+  const messages: ModelMessage[] = [{ role: "user", content: query }];
+  const expression = await streamExpression({
+    model,
+    system,
+    messages,
+    onDelta,
+    abortSignal,
+  });
+  if (!expression) {
+    throw new Error("The model did not return a filter expression");
+  }
+  if (!validate) {
+    return expression;
+  }
+  const validation = await validate(expression);
+  if (validation == null || validation.isValid) {
+    return expression;
+  }
+  // One repair round: hand the validator's complaint back to the model.
+  // More rounds add latency without observed benefit — a model that misses
+  // twice tends to keep missing.
+  const repaired = await streamExpression({
+    model,
+    system,
+    messages: [
+      ...messages,
+      { role: "assistant", content: expression },
+      {
+        role: "user",
+        content: buildAISearchRepairPrompt(validation.errorMessage ?? ""),
+      },
+    ],
+    onDelta,
+    abortSignal,
+  });
+  if (!repaired) {
+    throw new Error("The model did not return a filter expression");
+  }
+  return repaired;
+}

--- a/app/src/components/filter/ai/index.ts
+++ b/app/src/components/filter/ai/index.ts
@@ -1,0 +1,16 @@
+export * from "./types";
+export * from "./AISearchSettingsButton";
+export * from "./AISearchSettingsCard";
+export * from "./AISearchSettingsForm";
+export * from "./browserModel";
+export {
+  AI_SEARCH_PROVIDERS,
+  isAISearchProvider,
+  type ProviderCredentials,
+} from "./providerModels";
+export * from "./createAISearchDSL";
+export * from "./createAISearchModel";
+export * from "./buildAISearchPrompt";
+export * from "./extractFilterExpression";
+export * from "./generateFilterCondition";
+export * from "./useAISearch";

--- a/app/src/components/filter/ai/index.ts
+++ b/app/src/components/filter/ai/index.ts
@@ -5,7 +5,6 @@ export * from "./AISearchSettingsForm";
 export * from "./browserModel";
 export {
   AI_SEARCH_PROVIDERS,
-  isAISearchProvider,
   type ProviderCredentials,
 } from "./providerModels";
 export * from "./createAISearchDSL";

--- a/app/src/components/filter/ai/providerModels.ts
+++ b/app/src/components/filter/ai/providerModels.ts
@@ -1,0 +1,145 @@
+import type { LanguageModel } from "ai";
+
+import {
+  ModelProviders,
+  ProviderToCredentialsConfigMap,
+} from "@phoenix/constants/generativeConstants";
+
+/**
+ * The credentials stored in the browser for one provider, keyed by env var
+ * name — the shape held by the credentials store.
+ */
+export type ProviderCredentials = Record<string, string | null>;
+
+const OPENAI_COMPATIBLE_PROVIDERS = [
+  "DEEPSEEK",
+  "XAI",
+  "GROQ",
+  "CEREBRAS",
+  "FIREWORKS",
+  "MOONSHOT",
+  "PERPLEXITY",
+  "TOGETHER",
+  "OLLAMA",
+] as const satisfies readonly ModelProvider[];
+
+type OpenAICompatibleProviderKey = (typeof OPENAI_COMPATIBLE_PROVIDERS)[number];
+
+/**
+ * Providers whose HTTP surface is OpenAI-compatible, mapped to their API
+ * base URL. One adapter serves them all.
+ */
+const openAICompatibleBaseURLs: Record<OpenAICompatibleProviderKey, string> = {
+  DEEPSEEK: "https://api.deepseek.com/v1",
+  XAI: "https://api.x.ai/v1",
+  GROQ: "https://api.groq.com/openai/v1",
+  CEREBRAS: "https://api.cerebras.ai/v1",
+  FIREWORKS: "https://api.fireworks.ai/inference/v1",
+  MOONSHOT: "https://api.moonshot.ai/v1",
+  PERPLEXITY: "https://api.perplexity.ai",
+  TOGETHER: "https://api.together.xyz/v1",
+  OLLAMA: "http://localhost:11434/v1",
+};
+
+function isOpenAICompatibleProvider(
+  provider: ModelProvider
+): provider is OpenAICompatibleProviderKey {
+  return (OPENAI_COMPATIBLE_PROVIDERS as readonly ModelProvider[]).includes(
+    provider
+  );
+}
+
+/**
+ * Providers AI search can call directly from the browser. Azure OpenAI and
+ * AWS Bedrock are absent deliberately: both need per-deployment configuration
+ * (resource endpoints, SigV4 signing) beyond an API key, which the
+ * browser-held credentials don't carry.
+ */
+export const AI_SEARCH_PROVIDERS: ModelProvider[] = [
+  "OPENAI",
+  "ANTHROPIC",
+  "GOOGLE",
+  ...OPENAI_COMPATIBLE_PROVIDERS,
+];
+
+export function isAISearchProvider(provider: ModelProvider): boolean {
+  return AI_SEARCH_PROVIDERS.includes(provider);
+}
+
+/**
+ * Reads the provider's (first) required API key from the browser-held
+ * credentials, throwing a message that tells the user what to configure
+ * rather than letting the provider's 401 surface raw.
+ */
+function requireApiKey(
+  provider: ModelProvider,
+  credentials: ProviderCredentials | undefined
+): string | undefined {
+  const requirement = ProviderToCredentialsConfigMap[provider].find(
+    (config) => config.isRequired
+  );
+  if (!requirement) {
+    return undefined;
+  }
+  const value = credentials?.[requirement.envVarName];
+  if (!value) {
+    throw new Error(
+      `${ModelProviders[provider]} requires ${requirement.envVarName}. Add it to your provider credentials.`
+    );
+  }
+  return value;
+}
+
+/**
+ * Creates an AI SDK model that calls the provider directly from the browser
+ * using locally stored credentials. Provider SDKs load on demand so none of
+ * them weigh down the main bundle.
+ */
+export async function createProviderModel({
+  provider,
+  modelName,
+  credentials,
+}: {
+  provider: ModelProvider;
+  modelName: string;
+  credentials: ProviderCredentials | undefined;
+}): Promise<LanguageModel> {
+  switch (provider) {
+    case "OPENAI": {
+      const apiKey = requireApiKey(provider, credentials);
+      const { createOpenAI } = await import("@ai-sdk/openai");
+      return createOpenAI({ apiKey })(modelName);
+    }
+    case "ANTHROPIC": {
+      const apiKey = requireApiKey(provider, credentials);
+      const { createAnthropic } = await import("@ai-sdk/anthropic");
+      return createAnthropic({
+        apiKey,
+        // Anthropic rejects browser-origin requests unless explicitly opted
+        // in; the key never leaves this user's browser
+        headers: { "anthropic-dangerous-direct-browser-access": "true" },
+      })(modelName);
+    }
+    case "GOOGLE": {
+      const apiKey = requireApiKey(provider, credentials);
+      const { createGoogleGenerativeAI } = await import("@ai-sdk/google");
+      return createGoogleGenerativeAI({ apiKey })(modelName);
+    }
+    default: {
+      if (!isOpenAICompatibleProvider(provider)) {
+        throw new Error(
+          `${ModelProviders[provider]} is not supported for AI search`
+        );
+      }
+      const baseURL = openAICompatibleBaseURLs[provider];
+      const apiKey = requireApiKey(provider, credentials);
+      const { createOpenAICompatible } =
+        await import("@ai-sdk/openai-compatible");
+      return createOpenAICompatible({
+        name: ModelProviders[provider],
+        baseURL,
+        apiKey,
+      })(modelName);
+    }
+  }
+}

--- a/app/src/components/filter/ai/providerModels.ts
+++ b/app/src/components/filter/ai/providerModels.ts
@@ -62,10 +62,6 @@ export const AI_SEARCH_PROVIDERS: ModelProvider[] = [
   ...OPENAI_COMPATIBLE_PROVIDERS,
 ];
 
-export function isAISearchProvider(provider: ModelProvider): boolean {
-  return AI_SEARCH_PROVIDERS.includes(provider);
-}
-
 /**
  * Reads the provider's (first) required API key from the browser-held
  * credentials, throwing a message that tells the user what to configure
@@ -104,6 +100,14 @@ export async function createProviderModel({
   modelName: string;
   credentials: ProviderCredentials | undefined;
 }): Promise<LanguageModel> {
+  // Switching providers in the settings form clears the model name (only
+  // OpenAI has a sensible default), so an unfilled field would otherwise
+  // reach the provider as an empty model id and come back as an opaque 404
+  if (modelName.trim() === "") {
+    throw new Error(
+      `Choose a model name for ${ModelProviders[provider]} in the AI search settings.`
+    );
+  }
   switch (provider) {
     case "OPENAI": {
       const apiKey = requireApiKey(provider, credentials);

--- a/app/src/components/filter/ai/types.ts
+++ b/app/src/components/filter/ai/types.ts
@@ -1,0 +1,59 @@
+/**
+ * How AI search resolves the language model that translates natural language
+ * into a filter expression.
+ *
+ * - `browser` runs entirely on-device via the browser's built-in model
+ *   (Chrome / Edge Prompt API). No credentials and no network round trip.
+ * - `provider` calls a configured LLM provider directly from the browser
+ *   using the credentials stored locally (the same credentials the
+ *   playground uses).
+ */
+export type AISearchModelConfig =
+  | { kind: "browser" }
+  | { kind: "provider"; provider: ModelProvider; modelName: string };
+
+/**
+ * A field an expression of the DSL can reference, with the prose description
+ * shown to the model. Mirrors the shape of the typeahead completions so an
+ * entity layer can derive one from the other.
+ */
+export type AISearchField = {
+  name: string;
+  description?: string;
+};
+
+/**
+ * An example translation pair the model can generalize from — typically
+ * derived from the same snippets that power the typeahead suggestions.
+ */
+export type AISearchExample = {
+  description: string;
+  expression: string;
+};
+
+/**
+ * Everything the model needs to know about a filter DSL to translate a
+ * natural-language request into it. Built by the entity layer (spans,
+ * experiment runs, ...) — the AI layer itself knows nothing about any
+ * specific DSL.
+ */
+export type AISearchDSL = {
+  /**
+   * The plural noun for the filtered entity, e.g. "spans". Used in prose:
+   * "translate the request into a filter expression for spans".
+   */
+  noun: string;
+  /**
+   * The fields an expression can reference.
+   */
+  fields: AISearchField[];
+  /**
+   * Example request → expression pairs.
+   */
+  examples: AISearchExample[];
+  /**
+   * Additional dialect notes appended verbatim to the system prompt, e.g.
+   * entity-specific idioms the fields and examples don't convey.
+   */
+  notes?: string[];
+};

--- a/app/src/components/filter/ai/useAISearch.ts
+++ b/app/src/components/filter/ai/useAISearch.ts
@@ -1,0 +1,155 @@
+import { useRef, useState } from "react";
+
+import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+
+import type { DSLFilterConditionValidationResult } from "../DSLFilterConditionField";
+import {
+  downloadBrowserModel,
+  getBrowserModelAvailability,
+} from "./browserModel";
+import { createAISearchModel } from "./createAISearchModel";
+import { generateFilterCondition } from "./generateFilterCondition";
+import type { AISearchDSL, AISearchModelConfig } from "./types";
+
+const BROWSER_MODEL_CONFIG: AISearchModelConfig = { kind: "browser" };
+
+export type AISearchStatus = "idle" | "downloading" | "generating";
+
+/**
+ * How one translation run ended. `cancelled` covers both an explicit cancel
+ * and being superseded by a newer run — either way the caller should treat
+ * the run as if it never happened.
+ */
+export type AISearchGenerateResult =
+  | { outcome: "success"; condition: string }
+  | { outcome: "error"; message: string }
+  | { outcome: "cancelled" };
+
+export type UseAISearchArgs = {
+  /**
+   * The DSL to translate into, described by the entity layer.
+   */
+  dsl: AISearchDSL;
+  /**
+   * When provided, generated expressions are validated and the model gets
+   * one round to correct a rejected one. Typically the same validator the
+   * field itself uses.
+   */
+  validate?: (
+    condition: string
+  ) => Promise<DSLFilterConditionValidationResult | null | undefined>;
+};
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return "AI search failed";
+}
+
+/**
+ * Orchestrates one natural-language → filter-expression translation at a
+ * time: resolves the configured model (on-device browser model by default,
+ * a provider model with browser-held credentials otherwise), downloads the
+ * browser model on first use, streams the forming expression through
+ * `onDelta`, and resolves with a {@link AISearchGenerateResult} describing
+ * how the run ended.
+ */
+export function useAISearch({ dsl, validate }: UseAISearchArgs) {
+  const modelConfig =
+    usePreferencesContext((state) => state.aiSearchModelConfig) ??
+    BROWSER_MODEL_CONFIG;
+  const credentials = useCredentialsContext((state) =>
+    modelConfig.kind === "provider" ? state[modelConfig.provider] : undefined
+  );
+  const [status, setStatus] = useState<AISearchStatus>("idle");
+  const [downloadProgress, setDownloadProgress] = useState<number>(0);
+  const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const generate = async (
+    query: string,
+    { onDelta }: { onDelta?: (partialExpression: string) => void } = {}
+  ): Promise<AISearchGenerateResult> => {
+    // One translation at a time: a new request supersedes the previous one
+    abortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+    setError(null);
+    try {
+      if (modelConfig.kind === "browser") {
+        const availability = await getBrowserModelAvailability();
+        if (availability === "unsupported") {
+          throw new Error(
+            "This browser has no built-in AI model. Use Chrome or Edge, or configure a model provider."
+          );
+        }
+        if (availability === "unavailable") {
+          throw new Error(
+            "The browser's built-in AI model is unavailable on this device. Configure a model provider instead."
+          );
+        }
+        if (
+          availability === "needs-download" ||
+          availability === "downloading"
+        ) {
+          setStatus("downloading");
+          setDownloadProgress(0);
+          await downloadBrowserModel(setDownloadProgress);
+        }
+      }
+      if (abortController.signal.aborted) {
+        return { outcome: "cancelled" };
+      }
+      setStatus("generating");
+      const model = await createAISearchModel({
+        config: modelConfig,
+        credentials:
+          modelConfig.kind === "provider"
+            ? { [modelConfig.provider]: credentials }
+            : undefined,
+      });
+      const condition = await generateFilterCondition({
+        model,
+        dsl,
+        query,
+        onDelta,
+        validate,
+        abortSignal: abortController.signal,
+      });
+      return { outcome: "success", condition };
+    } catch (caught) {
+      if (abortController.signal.aborted) {
+        return { outcome: "cancelled" };
+      }
+      const message = toErrorMessage(caught);
+      setError(message);
+      return { outcome: "error", message };
+    } finally {
+      // A superseding run owns the status now — only the latest run resets it
+      if (abortControllerRef.current === abortController) {
+        abortControllerRef.current = null;
+        setStatus("idle");
+      }
+    }
+  };
+
+  const cancel = () => {
+    abortControllerRef.current?.abort();
+  };
+
+  const clearError = () => {
+    setError(null);
+  };
+
+  return {
+    status,
+    downloadProgress,
+    error,
+    modelConfig,
+    generate,
+    cancel,
+    clearError,
+  };
+}

--- a/app/src/components/filter/ai/useAISearch.ts
+++ b/app/src/components/filter/ai/useAISearch.ts
@@ -65,7 +65,6 @@ export function useAISearch({ dsl, validate }: UseAISearchArgs) {
   );
   const [status, setStatus] = useState<AISearchStatus>("idle");
   const [downloadProgress, setDownloadProgress] = useState<number>(0);
-  const [error, setError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const generate = async (
@@ -76,7 +75,6 @@ export function useAISearch({ dsl, validate }: UseAISearchArgs) {
     abortControllerRef.current?.abort();
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
-    setError(null);
     try {
       if (modelConfig.kind === "browser") {
         const availability = await getBrowserModelAvailability();
@@ -123,9 +121,7 @@ export function useAISearch({ dsl, validate }: UseAISearchArgs) {
       if (abortController.signal.aborted) {
         return { outcome: "cancelled" };
       }
-      const message = toErrorMessage(caught);
-      setError(message);
-      return { outcome: "error", message };
+      return { outcome: "error", message: toErrorMessage(caught) };
     } finally {
       // A superseding run owns the status now — only the latest run resets it
       if (abortControllerRef.current === abortController) {
@@ -139,17 +135,11 @@ export function useAISearch({ dsl, validate }: UseAISearchArgs) {
     abortControllerRef.current?.abort();
   };
 
-  const clearError = () => {
-    setError(null);
-  };
-
   return {
     status,
     downloadProgress,
-    error,
     modelConfig,
     generate,
     cancel,
-    clearError,
   };
 }

--- a/app/src/components/filter/index.tsx
+++ b/app/src/components/filter/index.tsx
@@ -1,4 +1,5 @@
 export * from "./Toolbar";
+export * from "./ai";
 export * from "./annotationCompletions";
 export * from "./DSLFilterConditionField";
 export {

--- a/app/src/components/filter/styles.ts
+++ b/app/src/components/filter/styles.ts
@@ -146,6 +146,26 @@ const errorBadgeIn = keyframes`
   }
 `;
 
+const aiBadgeSpin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+/**
+ * Sizes the PxiOutline wrapper like the bare field used to size itself and
+ * silences the outline's resting stroke — the field should look untouched
+ * until AI search actually engages (a natural-language draft or an
+ * in-flight conversion).
+ */
+export const dslFilterAIOutlineCSS = css`
+  flex: 1 1 auto;
+  min-width: 0;
+  &[data-state="idle"] .pxi-outline__stroke {
+    opacity: 0;
+  }
+`;
+
 export const dslFilterFieldCSS = css`
   flex: 1 1 auto;
   border-width: var(--global-border-size-thin);
@@ -227,5 +247,69 @@ export const dslFilterFieldCSS = css`
   }
   &[data-has-condition="true"] .clear-button {
     visibility: visible;
+  }
+  /* A natural-language draft reads as prose, not code — mirror that in the
+     editor while the AI affordance is showing */
+  &[data-ai-natural-language="true"] .cm-content {
+    font-family: var(--global-font-family-sans);
+  }
+  .ai-badge {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: var(--global-dimension-size-50);
+    padding: 2px var(--global-dimension-size-65);
+    margin-right: var(--global-dimension-size-50);
+    border-radius: var(--global-rounding-small);
+    border: 1px solid
+      color-mix(in srgb, var(--pxi-treatment-color-middle) 35%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--pxi-treatment-color-middle) 10%,
+      transparent
+    );
+    color: var(--pxi-treatment-color-middle);
+    font-size: var(--global-font-size-xs);
+    line-height: var(--global-line-height-xs);
+    white-space: nowrap;
+    cursor: default;
+    animation: ${errorBadgeIn} 0.25s ease-out;
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+    .ai-badge__spinner {
+      animation: ${aiBadgeSpin} 0.9s linear infinite;
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+    &:focus-visible {
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: var(--focus-ring-offset);
+    }
+  }
+  .ai-undo-button {
+    display: flex;
+    align-items: center;
+    gap: var(--global-dimension-size-25);
+    padding: 0 var(--global-dimension-size-50);
+    border-radius: var(--global-rounding-small);
+    color: inherit;
+    font-size: var(--global-font-size-xs);
+    cursor: pointer;
+    &:hover {
+      background-color: color-mix(
+        in srgb,
+        var(--pxi-treatment-color-middle) 18%,
+        transparent
+      );
+    }
+    &:focus-visible {
+      outline: var(--focus-ring-thickness) solid var(--focus-ring-color);
+      outline-offset: var(--focus-ring-offset);
+    }
+  }
+  .ai-search-settings-button {
+    margin-right: var(--global-dimension-size-25);
   }
 `;

--- a/app/src/components/search/__tests__/searchDestinations.test.tsx
+++ b/app/src/components/search/__tests__/searchDestinations.test.tsx
@@ -113,7 +113,7 @@ describe("search destinations", () => {
       {
         path: "/profile/preferences",
         label: "Preferences",
-        description: "Theme, timezone, and code defaults",
+        description: "Theme, timezone, code defaults, and AI search",
         icon: "Options",
         requiresViewer: false,
       },

--- a/app/src/pages/experiment/ExperimentRunFilterConditionField.tsx
+++ b/app/src/pages/experiment/ExperimentRunFilterConditionField.tsx
@@ -4,8 +4,10 @@ import { useSearchParams } from "react-router";
 import { fetchQuery, graphql } from "relay-runtime";
 
 import {
+  createAISearchDSL,
   createAnnotationMemberCompletions,
   DSLFilterConditionField,
+  type DSLFilterAISearchProps,
   type DSLFilterSnippet,
 } from "@phoenix/components/filter";
 import environment from "@phoenix/RelayEnvironment";
@@ -112,6 +114,24 @@ const experimentRunFilterSnippets: DSLFilterSnippet[] = [
     snippet: "latency_ms >= ${10_000}",
   },
 ];
+
+/**
+ * Everything the AI search model needs to translate plain language into the
+ * experiment run filter DSL — derived from the same vocabulary and examples
+ * that power the typeahead, so the two can never drift apart.
+ */
+const experimentRunFilterAISearch: DSLFilterAISearchProps = {
+  dsl: createAISearchDSL({
+    noun: "experiment runs",
+    completions: experimentRunFilterCompletions,
+    snippets: experimentRunFilterSnippets,
+    notes: [
+      "Evaluations are accessed by name, e.g. evals['Hallucination'], and expose .label, .score, and .explanation.",
+      "When experiments are compared side by side, experiments[i] scopes an expression to the i-th experiment, e.g. experiments[0].evals['name'].score.",
+    ],
+  }),
+  placeholder: "filter runs — DSL or plain English",
+};
 
 /**
  * Fetches the evaluation names that actually exist on the experiments so the
@@ -239,6 +259,7 @@ export function ExperimentRunFilterConditionField(
       loadCompletions={loadEvaluationCompletions}
       validateCondition={validateCondition}
       onValidCondition={onValidCondition}
+      aiSearch={experimentRunFilterAISearch}
     />
   );
 }

--- a/app/src/pages/profile/ProfilePreferencesPage.tsx
+++ b/app/src/pages/profile/ProfilePreferencesPage.tsx
@@ -1,5 +1,13 @@
+import { Flex } from "@phoenix/components";
+import { AISearchSettingsCard } from "@phoenix/components/filter";
+
 import { ViewerPreferences } from "./ViewerPreferences";
 
 export function ProfilePreferencesPage() {
-  return <ViewerPreferences />;
+  return (
+    <Flex direction="column" gap="size-200">
+      <ViewerPreferences />
+      <AISearchSettingsCard />
+    </Flex>
+  );
 }

--- a/app/src/pages/profile/__tests__/profileRouteInfo.test.ts
+++ b/app/src/pages/profile/__tests__/profileRouteInfo.test.ts
@@ -43,7 +43,7 @@ describe("profile route information", () => {
         path: "/profile/preferences",
         label: "Profile Preferences",
         description:
-          "Choose your theme, timezone, code language, and package manager defaults.",
+          "Choose your theme, timezone, code language, and package manager defaults, and configure AI search for filter fields (enable it and pick the in-browser model or a provider).",
       },
     ]);
   });

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -5,8 +5,10 @@ import { fetchQuery, graphql } from "relay-runtime";
 import type { AgentContext } from "@phoenix/agent/context/agentContextTypes";
 import { useAdvertiseAgentContext } from "@phoenix/agent/context/useAdvertiseAgentContext";
 import {
+  createAISearchDSL,
   createAnnotationMemberCompletions,
   DSLFilterConditionField,
+  type DSLFilterAISearchProps,
   type DSLFilterSnippet,
   type DSLFilterValidationFailureReason,
   type DSLFilterValidConditionArgs,
@@ -32,9 +34,12 @@ import {
 } from "./spanFilterValidation";
 
 /**
- * The fields of the span filter DSL that an expression can reference
+ * The core fields of the span filter DSL that an expression can reference.
+ * These double as the vocabulary taught to the AI search model, so each
+ * `info` string should describe the field well enough to translate plain
+ * language into it.
  */
-const spanFilterCompletions: Completion[] = [
+const coreSpanFilterCompletions: Completion[] = [
   {
     label: "span_kind",
     type: "variable",
@@ -140,6 +145,10 @@ const spanFilterCompletions: Completion[] = [
     type: "variable",
     info: "Sum of token count total (prompt + completion) from self and all child spans",
   },
+];
+
+const spanFilterCompletions: Completion[] = [
+  ...coreSpanFilterCompletions,
   ...openInferenceAttributeCompletions,
 ];
 
@@ -225,6 +234,28 @@ const spanFilterSnippets: DSLFilterSnippet[] = [
     snippet: "attributes['${key}'] == '${value}'",
   },
 ];
+
+/**
+ * Everything the AI search model needs to translate plain language into the
+ * span filter DSL — the same vocabulary and examples that power the
+ * typeahead, so the two can never drift apart. The OpenInference attribute
+ * expansion is deliberately summarized as a note instead of enumerated:
+ * hundreds of attribute paths would blow past the on-device model's small
+ * context window without teaching it anything the subscript idiom doesn't.
+ */
+const spanFilterAISearch: DSLFilterAISearchProps = {
+  dsl: createAISearchDSL({
+    noun: "spans",
+    completions: coreSpanFilterCompletions,
+    snippets: spanFilterSnippets,
+    notes: [
+      `Root spans are selected with \`${STRICT_ROOT_SPANS_CONDITION}\`.`,
+      "attributes and metadata are accessed by subscript, e.g. attributes['llm']['provider'] == 'openai'. Span attributes follow OpenInference semantic conventions (llm.model_name, llm.provider, retrieval.documents, embedding.model_name, tool.name, ...).",
+      "Durations are in milliseconds, e.g. 5 seconds is latency_ms > 5000.",
+    ],
+  }),
+  placeholder: "filter spans — DSL or plain English",
+};
 
 /**
  * Fetches the annotation names that actually exist on the project's spans so
@@ -395,6 +426,7 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
       onValidationFailed={onValidationFailed}
       validationRetryKey={validationRetryKey}
       onValidationStateChange={setIsConditionValid}
+      aiSearch={spanFilterAISearch}
     />
   );
 }

--- a/app/src/pages/settings/SettingsAIProvidersPage.tsx
+++ b/app/src/pages/settings/SettingsAIProvidersPage.tsx
@@ -2,6 +2,7 @@ import { usePreloadedQuery } from "react-relay";
 import { useLoaderData } from "react-router";
 
 import { Flex } from "@phoenix/components";
+import { AISearchSettingsCard } from "@phoenix/components/filter";
 import { AIProviderSettingsCard } from "@phoenix/pages/settings/AIProviderSettingsCard";
 import { CustomProvidersCard } from "@phoenix/pages/settings/CustomProvidersCard";
 import { GenerativeProvidersCard } from "@phoenix/pages/settings/GenerativeProvidersCard";
@@ -23,6 +24,7 @@ export function SettingsAIProvidersPage() {
       <GenerativeProvidersCard query={data} />
       <CustomProvidersCard query={data} />
       <AIProviderSettingsCard />
+      <AISearchSettingsCard />
     </Flex>
   );
 }

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
 import type { LastNTimeRangeKey } from "@phoenix/components/datetime/types";
+import type { AISearchModelConfig } from "@phoenix/components/filter/ai/types";
 import type { PackageManager, ProgrammingLanguage } from "@phoenix/types/code";
 import {
   pythonPackageManagers,
@@ -173,6 +174,16 @@ export interface PreferencesProps {
    * When undefined, falls back to {@link DEFAULT_MODEL_NAME}.
    */
   defaultModelName?: string;
+  /**
+   * Whether AI search is enabled on filter condition fields
+   * @default false
+   */
+  isAISearchEnabled: boolean;
+  /**
+   * How AI search on filter fields resolves its language model. When
+   * undefined, the on-device browser model is used.
+   */
+  aiSearchModelConfig?: AISearchModelConfig;
 }
 
 export interface PreferencesState extends PreferencesProps {
@@ -277,6 +288,17 @@ export interface PreferencesState extends PreferencesProps {
    * Pass `undefined` (or an empty string) to clear the preference.
    */
   setDefaultModelName: (defaultModelName: string | undefined) => void;
+  /**
+   * Setter for enabling/disabling AI search on filter condition fields
+   */
+  setIsAISearchEnabled: (isAISearchEnabled: boolean) => void;
+  /**
+   * Setter for how AI search resolves its language model. Pass `undefined`
+   * to fall back to the on-device browser model.
+   */
+  setAISearchModelConfig: (
+    aiSearchModelConfig: AISearchModelConfig | undefined
+  ) => void;
 }
 
 export const createPreferencesStore = (
@@ -418,6 +440,14 @@ export const createPreferencesStore = (
       set({ defaultModelName: trimmed ? trimmed : undefined }, false, {
         type: "setDefaultModelName",
       });
+    },
+    isAISearchEnabled: false,
+    setIsAISearchEnabled: (isAISearchEnabled) => {
+      set({ isAISearchEnabled }, false, { type: "setIsAISearchEnabled" });
+    },
+    aiSearchModelConfig: undefined,
+    setAISearchModelConfig: (aiSearchModelConfig) => {
+      set({ aiSearchModelConfig }, false, { type: "setAISearchModelConfig" });
     },
     ...initialProps,
   });

--- a/app/stories/DSLFilterConditionField.stories.tsx
+++ b/app/stories/DSLFilterConditionField.stories.tsx
@@ -6,10 +6,12 @@ import { fn } from "storybook/test";
 import { Flex, Text, View } from "@phoenix/components";
 import type { DSLFilterSnippet } from "@phoenix/components/filter";
 import {
+  createAISearchDSL,
   createAnnotationMemberCompletions,
   DSLFilterConditionField,
   type DSLFilterConditionFieldProps,
 } from "@phoenix/components/filter";
+import { CredentialsProvider } from "@phoenix/contexts/CredentialsContext";
 
 /**
  * An example DSL vocabulary: the fields an expression can reference
@@ -146,6 +148,49 @@ const Template: StoryFn<DSLFilterConditionFieldProps> = (args) => {
  */
 export const Default = {
   render: Template,
+};
+
+/**
+ * The field with AI search available. Open the sparkle button to enable the
+ * feature and pick a model — the on-device browser model by default (real
+ * conversions in Chrome/Edge), or a provider with an API key. With AI
+ * search on, plain-language drafts show the AI affordance and the PXI
+ * treatment on the field border; Enter converts them to the DSL, and the
+ * result can be undone from the badge or with Escape.
+ */
+export const WithAISearch: StoryFn<DSLFilterConditionFieldProps> = (args) => {
+  const [value, setValue] = useState<string>("");
+  const [validCondition, setValidCondition] = useState<string>("");
+  return (
+    <CredentialsProvider>
+      <View width="600px">
+        <Flex direction="column" gap="size-100">
+          <DSLFilterConditionField
+            {...args}
+            value={value}
+            onChange={setValue}
+            completions={completions}
+            snippets={snippets}
+            validateCondition={validateCondition}
+            onValidCondition={(args) => setValidCondition(args.condition)}
+            aiSearch={{
+              dsl: createAISearchDSL({
+                noun: "records",
+                completions,
+                snippets,
+              }),
+              placeholder: "filter records — DSL or plain English",
+            }}
+          />
+          <Text color="text-700" size="XS">
+            {validCondition
+              ? `Applied condition: ${validCondition}`
+              : "No condition applied"}
+          </Text>
+        </Flex>
+      </View>
+    </CredentialsProvider>
+  );
 };
 
 /**


### PR DESCRIPTION
Fixes the red `CI Typescript` check on `mikeldking/ai-search` (#14939).

`Routes.tsx` now describes the Preferences page as `"Theme, timezone, code defaults, and AI search"`, but `components/search/__tests__/searchDestinations.test.tsx` still expected the old `"Theme, timezone, and code defaults"`, so `provides a direct destination and icon for every profile section` failed. This updates the expectation to match.

This was pre-existing on the base branch, not introduced by the review fixes in #14941 — I found it when that PR's CI came back red.

Verified: `vitest run src/components/search` — 6 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019jvzL7StyYLmTHLBz2Groz)_