### PR TITLE
perf(agents): probe session sync state before refetching the transcript

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -107,6 +107,11 @@ type AgentSession implements Node {
   """
   isActive: Boolean!
 
+  """
+  The message ID of the most recently persisted transcript message, or null for an empty transcript.
+  """
+  lastMessageId: String
+
   """The persisted transcript as Vercel AI UIMessage JSON objects."""
   messages: JSON!
 }

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1736,7 +1736,7 @@ export interface components {
             is_active: boolean;
             /**
              * Last Message Id
-             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript. Combined with updated_at and is_active, this lets clients cheaply detect whether the transcript has changed without fetching messages.
+             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript.
              */
             last_message_id?: string | null;
             /**
@@ -11440,7 +11440,7 @@ export interface operations {
     getAgentSession: {
         parameters: {
             query?: {
-                /** @description Whether to include the persisted transcript in the response. Pass false for a cheap synchronization probe that returns only session metadata (including is_active and last_message_id). */
+                /** @description Whether to include the persisted transcript in the response. */
                 include_messages?: boolean;
             };
             header?: never;

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1598,7 +1598,7 @@ export interface paths {
         };
         /**
          * Get Session
-         * @description Retrieve an owned session and its persisted transcript.
+         * @description Retrieve an owned session and, optionally, its persisted transcript.
          */
         get: operations["getAgentSession"];
         put?: never;
@@ -1734,8 +1734,16 @@ export interface components {
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
              */
             is_active: boolean;
-            /** Messages */
-            messages: components["schemas"]["PhoenixUIMessage"][];
+            /**
+             * Last Message Id
+             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript. Combined with updated_at and is_active, this lets clients cheaply detect whether the transcript has changed without fetching messages.
+             */
+            last_message_id?: string | null;
+            /**
+             * Messages
+             * @description The persisted transcript. Omitted when the session is fetched with include_messages=false.
+             */
+            messages?: components["schemas"]["PhoenixUIMessage"][] | null;
         };
         /** AgentSessionSummary */
         AgentSessionSummary: {
@@ -11431,7 +11439,10 @@ export interface operations {
     };
     getAgentSession: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Whether to include the persisted transcript in the response. Pass false for a cheap synchronization probe that returns only session metadata (including is_active and last_message_id). */
+                include_messages?: boolean;
+            };
             header?: never;
             path: {
                 agent_id: string;

--- a/app/src/components/agent/__generated__/agentSessionRelaySessionQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/agentSessionRelaySessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b0711c282d7d41a0bef57d1a35a79a50>>
+ * @generated SignedSource<<76ecc2dd63a5a93ed11b40183dfcf50f>>
  * @lightSyntaxTransform
  */
 
@@ -19,6 +19,7 @@ export type agentSessionRelaySessionQuery$data = {
     readonly id: string;
     readonly isActive: boolean;
     readonly isTemporary: boolean;
+    readonly lastMessageId: string | null;
     readonly latestOutput: string | null;
     readonly messages: any;
     readonly title: string;
@@ -134,6 +135,13 @@ v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "lastMessageId",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "messages",
   "storageKey": null
 };
@@ -177,7 +185,8 @@ return {
                 ],
                 "storageKey": null
               },
-              (v13/*:: as any*/)
+              (v13/*:: as any*/),
+              (v14/*:: as any*/)
             ],
             "type": "AgentSession",
             "abstractKey": null
@@ -229,7 +238,8 @@ return {
                 ],
                 "storageKey": null
               },
-              (v13/*:: as any*/)
+              (v13/*:: as any*/),
+              (v14/*:: as any*/)
             ],
             "type": "AgentSession",
             "abstractKey": null
@@ -240,16 +250,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4836634597c05ab5b6a082d4fa40a454",
+    "cacheID": "39dfa76985b3d61bd873a6c0e40c8da9",
     "id": null,
     "metadata": {},
     "name": "agentSessionRelaySessionQuery",
     "operationKind": "query",
-    "text": "query agentSessionRelaySessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      title\n      isTemporary: isEphemeral\n      isActive\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      messages\n    }\n    id\n  }\n}\n"
+    "text": "query agentSessionRelaySessionQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      title\n      isTemporary: isEphemeral\n      isActive\n      createdAt\n      updatedAt\n      firstInput\n      latestOutput\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      lastMessageId\n      messages\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "898522d8afdc3e0dbb3ef55c2877b2bd";
+(node as any).hash = "0a93a9f87571952d003f5b8acf2d154f";
 
 export default node;

--- a/app/src/components/agent/__generated__/agentSessionRelaySessionSyncStateQuery.graphql.ts
+++ b/app/src/components/agent/__generated__/agentSessionRelaySessionSyncStateQuery.graphql.ts
@@ -1,0 +1,160 @@
+/**
+ * @generated SignedSource<<e694e62f2b3e9a185ab2ce493079db47>>
+ * @lightSyntaxTransform
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type agentSessionRelaySessionSyncStateQuery$variables = {
+  id: string;
+};
+export type agentSessionRelaySessionSyncStateQuery$data = {
+  readonly agentSession: {
+    readonly __typename: "AgentSession";
+    readonly id: string;
+    readonly isActive: boolean;
+    readonly lastMessageId: string | null;
+    readonly updatedAt: string;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type agentSessionRelaySessionSyncStateQuery = {
+  response: agentSessionRelaySessionSyncStateQuery$data;
+  variables: agentSessionRelaySessionSyncStateQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isActive",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastMessageId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "agentSessionRelaySessionSyncStateQuery",
+    "selections": [
+      {
+        "alias": "agentSession",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*:: as any*/),
+              (v4/*:: as any*/),
+              (v5/*:: as any*/),
+              (v6/*:: as any*/)
+            ],
+            "type": "AgentSession",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "agentSessionRelaySessionSyncStateQuery",
+    "selections": [
+      {
+        "alias": "agentSession",
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/),
+          (v3/*:: as any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v4/*:: as any*/),
+              (v5/*:: as any*/),
+              (v6/*:: as any*/)
+            ],
+            "type": "AgentSession",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "062e5918c25b25385d50796f2d9b6211",
+    "id": null,
+    "metadata": {},
+    "name": "agentSessionRelaySessionSyncStateQuery",
+    "operationKind": "query",
+    "text": "query agentSessionRelaySessionSyncStateQuery(\n  $id: ID!\n) {\n  agentSession: node(id: $id) {\n    __typename\n    ... on AgentSession {\n      id\n      isActive\n      updatedAt\n      lastMessageId\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f31e130176335ef210e39463bb3a58cf";
+
+export default node;

--- a/app/src/components/agent/agentSessionRelay.ts
+++ b/app/src/components/agent/agentSessionRelay.ts
@@ -1,6 +1,7 @@
 import { fetchQuery, graphql } from "react-relay";
 
 import type { agentSessionRelaySessionQuery } from "./__generated__/agentSessionRelaySessionQuery.graphql";
+import type { agentSessionRelaySessionSyncStateQuery } from "./__generated__/agentSessionRelaySessionSyncStateQuery.graphql";
 
 export const AGENT_SESSIONS_CONNECTION_KEY =
   "AgentSessionsResource_agentSessions";
@@ -35,11 +36,71 @@ export const agentSessionQuery = graphql`
           username
           profilePictureUrl
         }
+        lastMessageId
         messages
       }
     }
   }
 `;
+
+/**
+ * Cheap synchronization probe: whether another client's turn holds the
+ * session lock and where the persisted transcript's tail currently is.
+ * Polling fetches this first and only refetches the full transcript when the
+ * tail has moved, so idle sessions don't re-download megabytes of messages.
+ */
+export const agentSessionSyncStateQuery = graphql`
+  query agentSessionRelaySessionSyncStateQuery($id: ID!) {
+    agentSession: node(id: $id) {
+      __typename
+      ... on AgentSession {
+        id
+        isActive
+        updatedAt
+        lastMessageId
+      }
+    }
+  }
+`;
+
+/**
+ * The probe's change signal. `updatedAt` moves on every persistence path
+ * (turn persist, trailing-message rewrite, truncate, compact) and
+ * `lastMessageId` guards against timestamp-resolution collisions on appends.
+ */
+export type AgentSessionSyncState = {
+  updatedAt: string;
+  lastMessageId: string | null;
+};
+
+/**
+ * Fetches the cheap sync probe for a session (network-only), returning null
+ * when the node is missing or not an AgentSession.
+ */
+export async function fetchAgentSessionSyncState({
+  environment,
+  sessionId,
+}: {
+  environment: RelayEnvironment;
+  sessionId: string;
+}): Promise<(AgentSessionSyncState & { isActive: boolean }) | null> {
+  const data = await fetchQuery<agentSessionRelaySessionSyncStateQuery>(
+    environment,
+    agentSessionSyncStateQuery,
+    { id: sessionId },
+    { fetchPolicy: "network-only" }
+  ).toPromise();
+  const agentSession =
+    data?.agentSession.__typename === "AgentSession" ? data.agentSession : null;
+  if (!agentSession) {
+    return null;
+  }
+  return {
+    isActive: agentSession.isActive,
+    updatedAt: agentSession.updatedAt,
+    lastMessageId: agentSession.lastMessageId,
+  };
+}
 
 /**
  * Refetches a session's canonical record (title, timestamps, transcript) from

--- a/app/src/components/agent/useAgentChat.ts
+++ b/app/src/components/agent/useAgentChat.ts
@@ -54,6 +54,7 @@ import type { paths } from "@phoenix/api/__generated__/v1";
 import { authFetch } from "@phoenix/authFetch";
 import { useAgentChatRuntime } from "@phoenix/contexts/AgentChatRuntimeContext";
 import { useAgentContext, useAgentStore } from "@phoenix/contexts/AgentContext";
+import { useInterval } from "@phoenix/hooks/useInterval";
 import {
   DRAFT_SESSION_ID,
   type PendingAgentMessage,
@@ -67,7 +68,9 @@ import type { useAgentChatTruncateAgentSessionMutation } from "./__generated__/u
 import {
   AGENT_SESSIONS_CONNECTION_KEY,
   SETTINGS_AGENT_SESSIONS_CONNECTION_KEY,
+  fetchAgentSessionSyncState,
   refetchAgentSession,
+  type AgentSessionSyncState,
 } from "./agentSessionRelay";
 import { selectAgentModel } from "./useAgentChatPanelState";
 
@@ -247,6 +250,17 @@ export function useAgentChat({
   const [operationError, setOperationError] =
     useState<AgentChatOperationError | null>(null);
   const shouldSyncOnNextPollSetupRef = useRef(shouldSyncOnMount);
+  /**
+   * The persisted transcript's tail as of this client's last full fetch.
+   * Polling probes the cheap sync state first and skips the full transcript
+   * fetch while the tail hasn't moved, so idle sessions cost a tiny metadata
+   * read instead of re-downloading every message.
+   */
+  const lastSyncedSessionStateRef = useRef<
+    (AgentSessionSyncState & { sessionId: string }) | null
+  >(null);
+  /** Prevents overlapping poll requests on slow networks. */
+  const isPollInFlightRef = useRef(false);
   const [compactionStatus, setCompactionStatus] = useState<string | null>(null);
   const isDraft = sessionId == null || sessionId === DRAFT_SESSION_ID;
   const isCompacting = useAgentContext((state) =>
@@ -318,7 +332,25 @@ export function useAgentChat({
           void refetchAgentSession({
             environment: relayEnvironment,
             sessionId: targetSessionId,
-          });
+          })
+            .then((data) => {
+              // Record the refetched tail so the next poll's sync probe can
+              // recognize this client's own turn and skip the full fetch.
+              const agentSession =
+                data?.agentSession.__typename === "AgentSession"
+                  ? data.agentSession
+                  : null;
+              if (agentSession) {
+                lastSyncedSessionStateRef.current = {
+                  sessionId: targetSessionId,
+                  updatedAt: agentSession.updatedAt,
+                  lastMessageId: agentSession.lastMessageId,
+                };
+              }
+            })
+            .catch(() => {
+              // Transient failure: the next poll re-synchronizes.
+            });
         },
       });
       const chat = new Chat<AgentUIMessage>({
@@ -532,71 +564,119 @@ export function useAgentChat({
   const isSessionPollingPaused = isRequestActive(status) || isCompacting;
 
   // Keep idle sessions synchronized with turns completed by other clients.
+  // Each tick fetches the cheap sync probe (isActive + transcript tail) and
+  // only refetches the full transcript when the tail has moved since this
+  // client's last full fetch. This client's own generation disables polling
+  // so an older persisted transcript cannot replace its in-flight optimistic
+  // messages. Refetching through Relay normalizes session metadata into every
+  // mounted view as well as refreshing this chat runtime.
+  const pollSession = useCallback(async () => {
+    if (!persistedSessionId || !chatInstance || isPollInFlightRef.current) {
+      return;
+    }
+    isPollInFlightRef.current = true;
+    try {
+      const syncState = await fetchAgentSessionSyncState({
+        environment: relayEnvironment,
+        sessionId: persistedSessionId,
+      });
+      if (!syncState) {
+        return;
+      }
+      shouldSyncOnNextPollSetupRef.current = false;
+      if (syncState.isActive) {
+        store.getState().setSessionBusyElsewhere(persistedSessionId, true);
+        return;
+      }
+      // Read busy state fresh from the store: the probe may have set it on a
+      // previous tick and this closure could be stale.
+      const wasBusyElsewhere =
+        store.getState().isBusyElsewhereBySessionId[persistedSessionId] ??
+        false;
+      const lastSynced = lastSyncedSessionStateRef.current;
+      const isTranscriptUnchanged =
+        lastSynced != null &&
+        lastSynced.sessionId === persistedSessionId &&
+        lastSynced.updatedAt === syncState.updatedAt &&
+        lastSynced.lastMessageId === syncState.lastMessageId;
+      if (isTranscriptUnchanged && !wasBusyElsewhere) {
+        return;
+      }
+      const data = await refetchAgentSession({
+        environment: relayEnvironment,
+        sessionId: persistedSessionId,
+      });
+      const agentSession =
+        data?.agentSession.__typename === "AgentSession"
+          ? data.agentSession
+          : null;
+      if (!agentSession) {
+        return;
+      }
+      if (agentSession.isActive) {
+        // Another client claimed the turn lock between the probe and the
+        // full fetch; treat this tick as busy and let the next tick resync.
+        store.getState().setSessionBusyElsewhere(persistedSessionId, true);
+        return;
+      }
+      // This client started its own turn (or a compaction) while the fetch
+      // was in flight; never replace its in-flight optimistic messages.
+      if (
+        isRequestActive(chatInstance.status) ||
+        (store.getState().isCompactionPendingBySessionId[persistedSessionId] ??
+          false)
+      ) {
+        return;
+      }
+      // Clear a lingering conflict error only after the other client's turn
+      // has completed; the SDK can assign error state after onError runs.
+      if (wasBusyElsewhere) {
+        chatInstance.clearError();
+      }
+      chatInstance.messages = Array.isArray(agentSession.messages)
+        ? (agentSession.messages as AgentUIMessage[])
+        : [];
+      // Record the applied tail (from the full fetch, not the probe: the
+      // transcript may have moved again in between) so unchanged idle ticks
+      // stop at the probe.
+      lastSyncedSessionStateRef.current = {
+        sessionId: persistedSessionId,
+        updatedAt: agentSession.updatedAt,
+        lastMessageId: agentSession.lastMessageId,
+      };
+      store.getState().setSessionBusyElsewhere(persistedSessionId, false);
+    } catch {
+      // Transient failure: wait for the next poll tick.
+    } finally {
+      isPollInFlightRef.current = false;
+    }
+  }, [persistedSessionId, chatInstance, relayEnvironment, store]);
+
   // Poll slowly during normal use and switch to the existing faster cadence
-  // while another client holds the turn lock. This client's own generation
-  // disables polling so an older persisted transcript cannot replace its
-  // in-flight optimistic messages. Refetching through Relay normalizes session
-  // metadata into every mounted view as well as refreshing this chat runtime.
+  // while another client holds the turn lock. The visibility-aware interval
+  // pauses polling entirely in hidden tabs and fires immediately (with a
+  // fresh probe) when the tab becomes visible again.
+  const sessionPollDelay =
+    !persistedSessionId || !chatInstance || isSessionPollingPaused
+      ? null
+      : isBusyElsewhere
+        ? SESSION_BUSY_POLL_INTERVAL_MS
+        : SESSION_POLL_INTERVAL_MS;
+  useInterval(() => void pollSession(), sessionPollDelay);
+
   useEffect(() => {
-    if (!persistedSessionId || !chatInstance || isSessionPollingPaused) {
+    if (sessionPollDelay === null) {
       // A runtime first observed during its own generation will be canonicalized
       // by the turn-completion refetch, so it does not also need a mount sync.
       shouldSyncOnNextPollSetupRef.current = false;
-      return undefined;
+      return;
     }
-    let disposed = false;
-    const pollSession = async () => {
-      try {
-        const data = await refetchAgentSession({
-          environment: relayEnvironment,
-          sessionId: persistedSessionId,
-        });
-        const agentSession =
-          data?.agentSession.__typename === "AgentSession"
-            ? data.agentSession
-            : null;
-        if (!agentSession || disposed) {
-          return;
-        }
-        shouldSyncOnNextPollSetupRef.current = false;
-        if (agentSession.isActive) {
-          store.getState().setSessionBusyElsewhere(persistedSessionId, true);
-          return;
-        }
-        // Clear a lingering conflict error only after the other client's turn
-        // has completed; the SDK can assign error state after onError runs.
-        if (isBusyElsewhere) {
-          chatInstance.clearError();
-        }
-        chatInstance.messages = Array.isArray(agentSession.messages)
-          ? (agentSession.messages as AgentUIMessage[])
-          : [];
-        store.getState().setSessionBusyElsewhere(persistedSessionId, false);
-      } catch {
-        // Transient failure: wait for the next poll tick.
-      }
-    };
     // Resident runtimes skip the transcript loader when reopened, so refresh
     // those once on mount. Newly seeded runtimes already came from this query.
     if (shouldSyncOnNextPollSetupRef.current) {
       void pollSession();
     }
-    const intervalId = setInterval(
-      () => void pollSession(),
-      isBusyElsewhere ? SESSION_BUSY_POLL_INTERVAL_MS : SESSION_POLL_INTERVAL_MS
-    );
-    return () => {
-      disposed = true;
-      clearInterval(intervalId);
-    };
-  }, [
-    persistedSessionId,
-    chatInstance,
-    isBusyElsewhere,
-    isSessionPollingPaused,
-    relayEnvironment,
-    store,
-  ]);
+  }, [sessionPollDelay, pollSession]);
 
   // Anthropic doesn't accept unresolved tool calls, so we resolve them by
   // marking them as error before the next request goes out.

--- a/js/packages/phoenix-cli/src/pxi/App.tsx
+++ b/js/packages/phoenix-cli/src/pxi/App.tsx
@@ -41,6 +41,7 @@ import type {
   PxiMessage,
   PxiRuntimeOptions,
   PxiSessionClient,
+  PxiSession,
   PxiSessionSummary,
 } from "./types";
 
@@ -924,16 +925,37 @@ export function PxiApp({
    * the terminal equivalent of the web menu's store-and-network refetch.
    */
   const cachedSessionListRef = useRef<PxiSessionSummary[] | null>(null);
+  /**
+   * The persisted transcript's tail as of the last applied full fetch.
+   * Polling probes the cheap sync state first and skips the full transcript
+   * fetch while the tail hasn't moved, so idle sessions cost a tiny metadata
+   * read instead of re-downloading every message.
+   */
+  const lastSyncedSessionStateRef = useRef<{
+    sessionId: string;
+    updatedAt: string;
+    lastMessageId: string | null;
+  } | null>(null);
+  /** Records the applied transcript's tail after a full session fetch. */
+  const recordSyncedSessionState = (session: PxiSession) => {
+    lastSyncedSessionStateRef.current = {
+      sessionId: session.id,
+      updatedAt: session.updatedAt,
+      lastMessageId: session.lastMessageId ?? null,
+    };
+  };
   const serverSessionClient = useMemo(
     () => sessionClient ?? createPxiSessionClient({ config: options.config }),
     [options.config, sessionClient]
   );
 
   // Keep the active session synchronized with turns completed by other
-  // clients. Poll slowly during normal use and switch to the existing faster
-  // cadence while another client holds the turn lock. This client's own
-  // generation disables polling so its in-flight messages cannot be replaced
-  // by an older persisted transcript.
+  // clients. Each tick fetches the cheap sync probe (isActive + transcript
+  // tail) and only downloads the full transcript when the tail has moved
+  // since the last applied fetch. Poll slowly during normal use and switch
+  // to the existing faster cadence while another client holds the turn lock.
+  // This client's own generation disables polling so its in-flight messages
+  // cannot be replaced by an older persisted transcript.
   const activeSessionId = activeSession?.id ?? null;
   const isSessionPollingPaused = status === "streaming" || isCompacting;
   useEffect(() => {
@@ -943,15 +965,37 @@ export function PxiApp({
     let isStale = false;
     const pollSession = () => {
       void serverSessionClient
-        .getSession({ sessionId: activeSessionId })
-        .then((session) => {
+        .getSessionSyncState({ sessionId: activeSessionId })
+        .then(async (syncState) => {
+          if (isStale) {
+            return;
+          }
+          if (syncState.isActive) {
+            setIsSessionBusy(true);
+            return;
+          }
+          const lastSynced = lastSyncedSessionStateRef.current;
+          const isTranscriptUnchanged =
+            lastSynced != null &&
+            lastSynced.sessionId === activeSessionId &&
+            lastSynced.updatedAt === syncState.updatedAt &&
+            lastSynced.lastMessageId === syncState.lastMessageId;
+          if (isTranscriptUnchanged && !isSessionBusy) {
+            return;
+          }
+          const session = await serverSessionClient.getSession({
+            sessionId: activeSessionId,
+          });
           if (isStale) {
             return;
           }
           if (session.isActive) {
+            // Another client claimed the turn lock between the probe and the
+            // full fetch; treat this tick as busy and resync on the next one.
             setIsSessionBusy(true);
             return;
           }
+          recordSyncedSessionState(session);
           setActiveSession(session);
           setMessages(session.messages);
           setIsSessionBusy(false);
@@ -1006,6 +1050,7 @@ export function PxiApp({
     modelRequestIdRef.current += 1;
     sessionRequestIdRef.current += 1;
     setActiveSession(null);
+    lastSyncedSessionStateRef.current = null;
     setIsDraftTemporary(temporary);
     setIsSessionBusy(false);
     setShowStaleRefreshNotice(false);
@@ -1172,6 +1217,7 @@ export function PxiApp({
       .getSession({ sessionId: selectedSession.id })
       .then((session) => {
         if (sessionRequestIdRef.current !== requestId) return;
+        recordSyncedSessionState(session);
         setActiveSession(session);
         setIsDraftTemporary(session.isTemporary);
         // Another client's turn may already hold the restored session's lock;
@@ -1444,6 +1490,7 @@ export function PxiApp({
             .then((session) => {
               // A session switch or /new superseded this refresh.
               if (sessionRequestIdRef.current !== requestId) return;
+              recordSyncedSessionState(session);
               setActiveSession(session);
               setMessages(session.messages);
               setShowStaleRefreshNotice(true);

--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -22,6 +22,7 @@ import type {
   PxiSession,
   PxiSessionClient,
   PxiSessionSummary,
+  PxiSessionSyncState,
   PxiTransport,
 } from "./types";
 
@@ -213,11 +214,35 @@ export function createPxiSessionClient({
         title: session.title,
         updatedAt: session.updated_at,
         isTemporary: session.is_ephemeral,
-        // Read defensively: the CLI consumes phoenix-client's built types,
-        // which may not carry `is_active` until that package rebuilds.
-        // An absent field means no lock is held.
-        isActive: (session as { is_active?: unknown }).is_active === true,
-        messages: session.messages as PxiMessage[],
+        isActive: session.is_active === true,
+        lastMessageId: session.last_message_id ?? null,
+        messages: (session.messages ?? []) as PxiMessage[],
+      };
+    },
+    async getSessionSyncState({ sessionId }): Promise<PxiSessionSyncState> {
+      const client = createPhoenixClient({ config, fetch: fetchImpl });
+      const { data: payload } = await client.GET(
+        "/agents/{agent_id}/sessions/{session_id}",
+        {
+          params: {
+            path: { agent_id: SERVER_AGENT_ID, session_id: sessionId },
+            // Cheap synchronization probe: session metadata only, so idle
+            // polling doesn't re-download the whole transcript.
+            query: { include_messages: false },
+          },
+        }
+      );
+      if (!payload) {
+        throw new Error(
+          "Could not check the PXI session for updates because Phoenix " +
+            "returned no data."
+        );
+      }
+      const session = payload.data;
+      return {
+        isActive: session.is_active === true,
+        updatedAt: session.updated_at,
+        lastMessageId: session.last_message_id ?? null,
       };
     },
     async compactSession({ sessionId, model }) {

--- a/js/packages/phoenix-cli/src/pxi/types.ts
+++ b/js/packages/phoenix-cli/src/pxi/types.ts
@@ -115,6 +115,23 @@ export type PxiSession = PxiSessionSummary & {
    * Absent means no lock is held.
    */
   isActive?: boolean;
+  /**
+   * The message ID of the most recently persisted transcript message, or
+   * null for an empty transcript.
+   */
+  lastMessageId?: string | null;
+};
+
+/**
+ * Cheap synchronization probe for a session: whether another client's turn
+ * holds the lock and where the persisted transcript's tail currently is.
+ * Polling fetches this instead of the full transcript and only downloads
+ * messages when the tail has moved.
+ */
+export type PxiSessionSyncState = {
+  isActive: boolean;
+  updatedAt: string;
+  lastMessageId: string | null;
 };
 
 /**
@@ -132,6 +149,9 @@ export type PxiSessionClient = {
   createSession: (options: { temporary: boolean }) => Promise<PxiSession>;
   listSessions: () => Promise<PxiSessionSummary[]>;
   getSession: (options: { sessionId: string }) => Promise<PxiSession>;
+  getSessionSyncState: (options: {
+    sessionId: string;
+  }) => Promise<PxiSessionSyncState>;
   compactSession: (options: {
     sessionId: string;
     model: ModelSelection;

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -1092,6 +1092,9 @@ describe("PXI app", () => {
       getSession: async () => {
         throw new Error("not used");
       },
+      getSessionSyncState: async () => {
+        throw new Error("not used");
+      },
       compactSession: async () => {
         throw new Error("not used");
       },
@@ -1128,6 +1131,9 @@ describe("PXI app", () => {
       }),
       listSessions: async () => [],
       getSession: async () => {
+        throw new Error("not used");
+      },
+      getSessionSyncState: async () => {
         throw new Error("not used");
       },
       compactSession: async () => {
@@ -1189,6 +1195,9 @@ describe("PXI app", () => {
         },
       ],
       getSession,
+      getSessionSyncState: async () => {
+        throw new Error("not used");
+      },
       compactSession: async () => {
         throw new Error("not used");
       },
@@ -1233,14 +1242,35 @@ describe("PXI app", () => {
     let getSessionCallCount = 0;
     const getSession = vi.fn(async ({ sessionId }: { sessionId: string }) => {
       getSessionCallCount += 1;
+      const isSynchronized = getSessionCallCount >= 2;
       return {
         id: sessionId,
         title: "Shared session",
-        updatedAt: "2026-07-24T12:00:00Z",
+        updatedAt: isSynchronized
+          ? "2026-07-24T12:05:00Z"
+          : "2026-07-24T12:00:00Z",
         isTemporary: false,
-        isActive: getSessionCallCount === 2,
-        messages:
-          getSessionCallCount < 3 ? [originalMessage] : [synchronizedMessage],
+        isActive: false,
+        lastMessageId: isSynchronized
+          ? synchronizedMessage.id
+          : originalMessage.id,
+        messages: isSynchronized ? [synchronizedMessage] : [originalMessage],
+      };
+    });
+    let syncStateCallCount = 0;
+    const getSessionSyncState = vi.fn(async () => {
+      syncStateCallCount += 1;
+      // Probe 1: another client's turn holds the lock. Probes 2+: the turn
+      // completed and the transcript's tail moved once, then stays put.
+      const isSynchronized = syncStateCallCount >= 2;
+      return {
+        isActive: syncStateCallCount === 1,
+        updatedAt: isSynchronized
+          ? "2026-07-24T12:05:00Z"
+          : "2026-07-24T12:00:00Z",
+        lastMessageId: isSynchronized
+          ? synchronizedMessage.id
+          : originalMessage.id,
       };
     });
     const sessionClient: PxiSessionClient = {
@@ -1256,6 +1286,7 @@ describe("PXI app", () => {
         },
       ],
       getSession,
+      getSessionSyncState,
       compactSession: async () => {
         throw new Error("not used");
       },
@@ -1281,11 +1312,14 @@ describe("PXI app", () => {
       expect(getSession).toHaveBeenCalledTimes(1);
       expect(stripAnsi(lastFrame() ?? "")).toContain("original conversation");
 
+      // Probe 1: another client holds the lock. The cheap probe alone drives
+      // the busy state; the full transcript is not refetched.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(10_000);
       });
 
-      expect(getSession).toHaveBeenCalledTimes(2);
+      expect(getSessionSyncState).toHaveBeenCalledTimes(1);
+      expect(getSession).toHaveBeenCalledTimes(1);
       expect(stripAnsi(lastFrame() ?? "")).toContain(
         "Session is being used elsewhere"
       );
@@ -1293,23 +1327,36 @@ describe("PXI app", () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(2_999);
       });
-      expect(getSession).toHaveBeenCalledTimes(2);
+      expect(getSessionSyncState).toHaveBeenCalledTimes(1);
 
+      // Probe 2 (fast cadence): the turn completed and the tail moved, so the
+      // full transcript is fetched and swapped in.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1);
       });
-      expect(getSession).toHaveBeenCalledTimes(3);
+      expect(getSessionSyncState).toHaveBeenCalledTimes(2);
+      expect(getSession).toHaveBeenCalledTimes(2);
       expect(stripAnsi(lastFrame() ?? "")).toContain(
         "updated by another client"
       );
 
+      // Probe 3 (slow cadence): the tail has not moved since the last full
+      // fetch, so the transcript download is skipped.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(getSessionSyncState).toHaveBeenCalledTimes(3);
+      expect(getSession).toHaveBeenCalledTimes(2);
+
+      // Local generation pauses polling entirely.
       await writeInput({ stdin, input: "local question" });
       await writeInput({ stdin, input: "\r" });
       await act(async () => {
         await vi.advanceTimersByTimeAsync(10_000);
       });
 
-      expect(getSession).toHaveBeenCalledTimes(3);
+      expect(getSessionSyncState).toHaveBeenCalledTimes(3);
+      expect(getSession).toHaveBeenCalledTimes(2);
     } finally {
       unmount();
       vi.useRealTimers();
@@ -1341,6 +1388,9 @@ describe("PXI app", () => {
         });
       },
       getSession: async () => {
+        throw new Error("not used");
+      },
+      getSessionSyncState: async () => {
         throw new Error("not used");
       },
       compactSession: async () => {
@@ -1408,6 +1458,9 @@ describe("PXI app", () => {
       }),
       listSessions: async () => [],
       getSession: async () => {
+        throw new Error("not used");
+      },
+      getSessionSyncState: async () => {
         throw new Error("not used");
       },
       compactSession: async () => {

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1736,7 +1736,7 @@ export interface components {
             is_active: boolean;
             /**
              * Last Message Id
-             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript. Combined with updated_at and is_active, this lets clients cheaply detect whether the transcript has changed without fetching messages.
+             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript.
              */
             last_message_id?: string | null;
             /**
@@ -11440,7 +11440,7 @@ export interface operations {
     getAgentSession: {
         parameters: {
             query?: {
-                /** @description Whether to include the persisted transcript in the response. Pass false for a cheap synchronization probe that returns only session metadata (including is_active and last_message_id). */
+                /** @description Whether to include the persisted transcript in the response. */
                 include_messages?: boolean;
             };
             header?: never;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1598,7 +1598,7 @@ export interface paths {
         };
         /**
          * Get Session
-         * @description Retrieve an owned session and its persisted transcript.
+         * @description Retrieve an owned session and, optionally, its persisted transcript.
          */
         get: operations["getAgentSession"];
         put?: never;
@@ -1734,8 +1734,16 @@ export interface components {
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
              */
             is_active: boolean;
-            /** Messages */
-            messages: components["schemas"]["PhoenixUIMessage"][];
+            /**
+             * Last Message Id
+             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript. Combined with updated_at and is_active, this lets clients cheaply detect whether the transcript has changed without fetching messages.
+             */
+            last_message_id?: string | null;
+            /**
+             * Messages
+             * @description The persisted transcript. Omitted when the session is fetched with include_messages=false.
+             */
+            messages?: components["schemas"]["PhoenixUIMessage"][] | null;
         };
         /** AgentSessionSummary */
         AgentSessionSummary: {
@@ -11431,7 +11439,10 @@ export interface operations {
     };
     getAgentSession: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Whether to include the persisted transcript in the response. Pass false for a cheap synchronization probe that returns only session metadata (including is_active and last_message_id). */
+                include_messages?: boolean;
+            };
             header?: never;
             path: {
                 agent_id: string;

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1736,7 +1736,7 @@ export interface components {
             is_active: boolean;
             /**
              * Last Message Id
-             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript. Combined with updated_at and is_active, this lets clients cheaply detect whether the transcript has changed without fetching messages.
+             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript.
              */
             last_message_id?: string | null;
             /**
@@ -11440,7 +11440,7 @@ export interface operations {
     getAgentSession: {
         parameters: {
             query?: {
-                /** @description Whether to include the persisted transcript in the response. Pass false for a cheap synchronization probe that returns only session metadata (including is_active and last_message_id). */
+                /** @description Whether to include the persisted transcript in the response. */
                 include_messages?: boolean;
             };
             header?: never;

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1598,7 +1598,7 @@ export interface paths {
         };
         /**
          * Get Session
-         * @description Retrieve an owned session and its persisted transcript.
+         * @description Retrieve an owned session and, optionally, its persisted transcript.
          */
         get: operations["getAgentSession"];
         put?: never;
@@ -1734,8 +1734,16 @@ export interface components {
              * @description Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat.
              */
             is_active: boolean;
-            /** Messages */
-            messages: components["schemas"]["PhoenixUIMessage"][];
+            /**
+             * Last Message Id
+             * @description The message ID of the most recently persisted transcript message, or null for an empty transcript. Combined with updated_at and is_active, this lets clients cheaply detect whether the transcript has changed without fetching messages.
+             */
+            last_message_id?: string | null;
+            /**
+             * Messages
+             * @description The persisted transcript. Omitted when the session is fetched with include_messages=false.
+             */
+            messages?: components["schemas"]["PhoenixUIMessage"][] | null;
         };
         /** AgentSessionSummary */
         AgentSessionSummary: {
@@ -11431,7 +11439,10 @@ export interface operations {
     };
     getAgentSession: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Whether to include the persisted transcript in the response. Pass false for a cheap synchronization probe that returns only session metadata (including is_active and last_message_id). */
+                include_messages?: boolean;
+            };
             header?: never;
             path: {
                 agent_id: string;

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -1926,7 +1926,8 @@ class AgentSessionData(TypedDict):
     updated_at: str
     is_ephemeral: bool
     is_active: bool
-    messages: Sequence[PhoenixUIMessage]
+    last_message_id: NotRequired[str]
+    messages: NotRequired[Sequence[PhoenixUIMessage]]
 
 
 class ChatRequest(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -8185,7 +8185,7 @@
           "chat"
         ],
         "summary": "Get Session",
-        "description": "Retrieve an owned session and its persisted transcript.",
+        "description": "Retrieve an owned session and, optionally, its persisted transcript.",
         "operationId": "getAgentSession",
         "parameters": [
           {
@@ -8205,6 +8205,18 @@
               "type": "string",
               "title": "Session Id"
             }
+          },
+          {
+            "name": "include_messages",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to include the persisted transcript in the response.",
+              "default": true,
+              "title": "Include Messages"
+            },
+            "description": "Whether to include the persisted transcript in the response."
           }
         ],
         "responses": {
@@ -8474,12 +8486,32 @@
             "title": "Is Active",
             "description": "Whether a response is currently streaming on this session, i.e. its lock has a live (non-stale) heartbeat."
           },
+          "last_message_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Message Id",
+            "description": "The message ID of the most recently persisted transcript message, or null for an empty transcript."
+          },
           "messages": {
-            "items": {
-              "$ref": "#/components/schemas/PhoenixUIMessage"
-            },
-            "type": "array",
-            "title": "Messages"
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PhoenixUIMessage"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Messages",
+            "description": "The persisted transcript. Omitted when the session is fetched with include_messages=false."
           }
         },
         "type": "object",
@@ -8489,8 +8521,7 @@
           "created_at",
           "updated_at",
           "is_ephemeral",
-          "is_active",
-          "messages"
+          "is_active"
         ],
         "title": "AgentSessionData"
       },

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -386,7 +386,20 @@ class AgentSessionData(AgentSessionSummary):
             "lock has a live (non-stale) heartbeat."
         ),
     )
-    messages: list[PhoenixUIMessage]
+    last_message_id: str | None = Field(
+        default=None,
+        description=(
+            "The message ID of the most recently persisted transcript message, or "
+            "null for an empty transcript."
+        ),
+    )
+    messages: list[PhoenixUIMessage] | None = Field(
+        default=None,
+        description=(
+            "The persisted transcript. Omitted when the session is fetched with "
+            "include_messages=false."
+        ),
+    )
 
 
 class ListAgentSessionsResponseBody(PaginatedResponseBody[AgentSessionSummary]):
@@ -1812,8 +1825,12 @@ def create_agents_router(
         agent_id: str,
         session_id: str,
         request: Request,
+        include_messages: bool = Query(
+            True,
+            description=("Whether to include the persisted transcript in the response."),
+        ),
     ) -> GetAgentSessionResponseBody:
-        """Retrieve an owned session and its persisted transcript."""
+        """Retrieve an owned session and, optionally, its persisted transcript."""
         if agent_id not in (_ASSISTANT_AGENT_ID, _SERVER_AGENT_ID):
             raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id!r}")
         if agent_id == _SERVER_AGENT_ID and get_env_phoenix_agents_disable_bash():
@@ -1825,29 +1842,49 @@ def create_agents_router(
         except ValueError as error:
             raise HTTPException(status_code=422, detail="Invalid agent session ID") from error
 
-        statement = (
-            select(models.AgentSession)
-            .where(models.AgentSession.id == session_rowid)
-            .options(selectinload(models.AgentSession.messages))
+        statement = select(models.AgentSession).where(
+            models.AgentSession.id == session_rowid
         )
+        if include_messages:
+            statement = statement.options(selectinload(models.AgentSession.messages))
         if (user_id := _get_request_user_id(request)) is not None:
             statement = statement.where(models.AgentSession.user_id == user_id)
         async with request.app.state.db() as session:
             agent_session = await session.scalar(statement)
-        if agent_session is None:
-            raise HTTPException(status_code=404, detail="Agent session not found")
+            if agent_session is None:
+                raise HTTPException(status_code=404, detail="Agent session not found")
+            if include_messages:
+                message_rows = agent_session.messages
+                last_message_id = message_rows[-1].message_id if message_rows else None
+            else:
+                last_message_id = await session.scalar(
+                    select(models.AgentSessionMessage.message_id)
+                    .where(models.AgentSessionMessage.agent_session_id == session_rowid)
+                    .order_by(models.AgentSessionMessage.id.desc())
+                    .limit(1)
+                )
 
         summary = _to_agent_session_summary(agent_session)
-        return GetAgentSessionResponseBody(
-            data=AgentSessionData(
+        is_active = is_turn_active(
+            agent_session.heartbeat_at,
+            now=datetime.now(timezone.utc),
+        )
+        if include_messages:
+            data = AgentSessionData(
                 **summary.model_dump(),
-                is_active=is_turn_active(
-                    agent_session.heartbeat_at,
-                    now=datetime.now(timezone.utc),
-                ),
+                is_active=is_active,
+                last_message_id=last_message_id,
                 messages=[message.message for message in agent_session.messages],
             )
-        )
+        else:
+            # `messages` is deliberately left unset so response_model_exclude_unset
+            # drops it from the probe payload.
+            data = AgentSessionData(
+                **summary.model_dump(),
+                is_active=is_active,
+                last_message_id=last_message_id,
+            )
+        return GetAgentSessionResponseBody(data=data)
 
     @router.post(
         "/agents/{agent_id}/sessions/{session_id}/compact",

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -1842,9 +1842,7 @@ def create_agents_router(
         except ValueError as error:
             raise HTTPException(status_code=422, detail="Invalid agent session ID") from error
 
-        statement = select(models.AgentSession).where(
-            models.AgentSession.id == session_rowid
-        )
+        statement = select(models.AgentSession).where(models.AgentSession.id == session_rowid)
         if include_messages:
             statement = statement.options(selectinload(models.AgentSession.messages))
         if (user_id := _get_request_user_id(request)) is not None:

--- a/src/phoenix/server/api/types/AgentSession.py
+++ b/src/phoenix/server/api/types/AgentSession.py
@@ -122,6 +122,25 @@ class AgentSession(Node):
         return is_turn_active(heartbeat_at, now=datetime.now(timezone.utc))
 
     @strawberry.field(
+        description=(
+            "The message ID of the most recently persisted transcript message, or null "
+            "for an empty transcript."
+        ),
+        permission_classes=[CanAccessAgentSession],
+    )  # type: ignore
+    async def last_message_id(self, info: Info[Context, None]) -> Optional[str]:
+        stmt = (
+            select(models.AgentSessionMessage.message_id)
+            .where(models.AgentSessionMessage.agent_session_id == self.id)
+            .order_by(models.AgentSessionMessage.id.desc())
+            .limit(1)
+        )
+        async with info.context.db.read() as session:
+            last_message_id = await session.scalar(stmt)
+        assert last_message_id is None or isinstance(last_message_id, str)
+        return last_message_id
+
+    @strawberry.field(
         description="The persisted transcript as Vercel AI UIMessage JSON objects.",
         permission_classes=[CanAccessAgentSession],
     )  # type: ignore

--- a/tests/unit/server/agents/test_agent_session_routes.py
+++ b/tests/unit/server/agents/test_agent_session_routes.py
@@ -157,6 +157,64 @@ class TestGetAgentSession:
         ]
         assert data["messages"][0]["parts"] == [{"type": "text", "text": "Hello"}]
         assert data["messages"][1]["parts"] == [{"type": "text", "text": "Hi"}]
+        assert data["last_message_id"] == _message_uuid("assistant-message")
+
+    async def test_sync_probe_omits_messages_but_reports_transcript_tail(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        messages = [
+            PhoenixUIMessage(
+                id=_message_uuid("user-message"),
+                role="user",
+                parts=[TextUIPart(type="text", text="Hello")],
+            ),
+            PhoenixUIMessage(
+                id=_message_uuid("assistant-message"),
+                role="assistant",
+                parts=[TextUIPart(type="text", text="Hi")],
+            ),
+        ]
+        agent_session = await _insert_agent_session(
+            db,
+            title="Conversation",
+            updated_at=now,
+            messages=messages,
+        )
+        session_id = str(GlobalID("AgentSession", str(agent_session.id)))
+
+        response = await httpx_client.get(
+            f"/agents/assistant/sessions/{session_id}",
+            params={"include_messages": False},
+        )
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["id"] == session_id
+        assert data["is_active"] is False
+        assert data["last_message_id"] == _message_uuid("assistant-message")
+        assert "messages" not in data
+
+    async def test_sync_probe_reports_null_tail_for_empty_transcript(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        agent_session = await _insert_agent_session(db, title="Empty", updated_at=now)
+        session_id = str(GlobalID("AgentSession", str(agent_session.id)))
+
+        response = await httpx_client.get(
+            f"/agents/assistant/sessions/{session_id}",
+            params={"include_messages": False},
+        )
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["last_message_id"] is None
+        assert "messages" not in data
 
     async def test_gets_temporary_session(
         self,

--- a/tests/unit/server/api/types/test_AgentSession.py
+++ b/tests/unit/server/api/types/test_AgentSession.py
@@ -65,6 +65,7 @@ _DETAIL_QUERY = """
         user { username profilePictureUrl }
         firstInput
         latestOutput
+        lastMessageId
         messages
       }
     }
@@ -246,9 +247,35 @@ async def test_agent_session_loads_transcript_by_id(
             },
             "firstInput": "First question",
             "latestOutput": "Latest\nanswer",
+            "lastMessageId": _message_uuid("message-3"),
             "messages": messages,
         }
     }
+
+
+async def test_agent_session_last_message_id_is_null_for_empty_transcript(
+    db: DbSessionFactory,
+    gql_client: AsyncGraphQLClient,
+) -> None:
+    agent_session_id = await _seed_agent_session(
+        db,
+        title="Empty session",
+        updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    response = await gql_client.execute(
+        query="""
+          query ($id: ID!) {
+            agentSession: node(id: $id) {
+              ... on AgentSession { lastMessageId }
+            }
+          }
+        """,
+        variables={"id": agent_session_id},
+    )
+
+    assert not response.errors
+    assert response.data == {"agentSession": {"lastMessageId": None}}
 
 
 async def test_agent_session_node_returns_not_found_when_missing(


### PR DESCRIPTION
Fixes #14953

Session sync polling refetched the **entire transcript** every 10s per open client (3s while busy elsewhere), indefinitely — megabytes per poll for long sessions, even in hidden tabs.

## Changes

**Server**
- GraphQL: new `AgentSession.lastMessageId` field (single indexed scalar select).
- REST: `GET /agents/{agent_id}/sessions/{session_id}?include_messages=false` returns metadata only (`is_active`, `updated_at`, new `last_message_id`) and skips loading message rows.

**Browser (`useAgentChat`)**
- Each poll tick fetches the cheap sync probe first and only refetches the full transcript when `(updatedAt, lastMessageId)` differs from the last applied fetch (or the session was busy elsewhere). `updatedAt` catches in-place trailing-assistant rewrites; `lastMessageId` guards same-second timestamp collisions.
- Polling now uses the visibility-aware `useInterval`: hidden tabs stop polling and resync immediately on becoming visible.
- Turn-completion refetch records the tail so a client's own turns don't trigger a redundant fetch; an in-flight guard prevents overlapping polls.

**CLI (pxi)**
- Same probe-then-fetch flow via `getSessionSyncState`; synced tail recorded on restore/stale-refresh/poll and reset on `/new`.

Idle steady-state cost drops from the full transcript per tick per client to a ~100-byte metadata read (zero for hidden tabs).

## Tests
- GraphQL `lastMessageId` (populated + empty transcript), REST probe payload shape.
- CLI polling test asserts busy state from the probe alone, full fetch only when the tail moves, skip on unchanged ticks, pause during local generation.