### PR TITLE
fix(cli): paginate pxi session picker

### DIFF
--- a/js/packages/phoenix-cli/src/pxi/client.ts
+++ b/js/packages/phoenix-cli/src/pxi/client.ts
@@ -29,6 +29,7 @@ import type {
 const AGENT_SESSION_CHAT_PATH =
   "/agents/{agent_id}/sessions/{session_id}/chat" satisfies keyof pathsV1;
 const SERVER_AGENT_ID = "server";
+const AGENT_SESSION_PAGE_LIMIT = 100;
 /**
  * Error code the chat endpoint returns (HTTP 409) while another client's turn
  * holds the session lock.
@@ -170,28 +171,36 @@ export function createPxiSessionClient({
       createAgentSession({ config, temporary, fetchImpl }),
     async listSessions() {
       const client = createPhoenixClient({ config, fetch: fetchImpl });
-      const { data: payload } = await client.GET(
-        "/agents/{agent_id}/sessions",
-        {
-          params: {
-            path: { agent_id: SERVER_AGENT_ID },
-            query: { limit: 20 },
-          },
-        }
-      );
-      if (!payload) {
-        throw new Error(
-          "Could not load PXI sessions because Phoenix returned no data."
+      const sessions: PxiSessionSummary[] = [];
+      let cursor: string | undefined;
+      do {
+        const { data: payload } = await client.GET(
+          "/agents/{agent_id}/sessions",
+          {
+            params: {
+              path: { agent_id: SERVER_AGENT_ID },
+              query: { cursor, limit: AGENT_SESSION_PAGE_LIMIT },
+            },
+          }
         );
-      }
-      return payload.data.map(
-        ({ id, title, updated_at, is_ephemeral }): PxiSessionSummary => ({
-          id,
-          title,
-          updatedAt: updated_at,
-          isTemporary: is_ephemeral,
-        })
-      );
+        if (!payload) {
+          throw new Error(
+            "Could not load PXI sessions because Phoenix returned no data."
+          );
+        }
+        sessions.push(
+          ...payload.data.map(
+            ({ id, title, updated_at, is_ephemeral }): PxiSessionSummary => ({
+              id,
+              title,
+              updatedAt: updated_at,
+              isTemporary: is_ephemeral,
+            })
+          )
+        );
+        cursor = payload.next_cursor ?? undefined;
+      } while (cursor);
+      return sessions;
     },
     async getSession({ sessionId }) {
       const client = createPhoenixClient({ config, fetch: fetchImpl });

--- a/js/packages/phoenix-cli/test/pxiApp.test.tsx
+++ b/js/packages/phoenix-cli/test/pxiApp.test.tsx
@@ -1227,6 +1227,64 @@ describe("PXI app", () => {
     unmount();
   });
 
+  it("navigates beyond the first 20 persisted sessions", async () => {
+    const sessions: PxiSessionSummary[] = Array.from(
+      { length: 21 },
+      (_, index) => ({
+        id: `session-${index + 1}`,
+        title: `Session ${index + 1}`,
+        updatedAt: "2026-07-24T12:00:00Z",
+        isTemporary: false,
+      })
+    );
+    const getSession = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
+      id: sessionId,
+      title: "Session 21",
+      updatedAt: "2026-07-24T12:00:00Z",
+      isTemporary: false,
+      messages: [
+        {
+          id: "restored-user",
+          role: "user" as const,
+          parts: [{ type: "text" as const, text: "oldest conversation" }],
+        },
+      ],
+    }));
+    const sessionClient: PxiSessionClient = {
+      createSession: async () => {
+        throw new Error("not used");
+      },
+      listSessions: async () => sessions,
+      getSession,
+      compactSession: async () => {
+        throw new Error("not used");
+      },
+    };
+    const client: PxiChatClient = { sendMessage: async () => null };
+    const { lastFrame, stdin, unmount } = render(
+      <PxiApp
+        options={createOptions()}
+        client={client}
+        sessionClient={sessionClient}
+      />
+    );
+
+    await writeInput({ stdin, input: "/sessions" });
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+    for (let sessionIndex = 1; sessionIndex < sessions.length; sessionIndex++) {
+      await writeInput({ stdin, input: DOWN_ARROW });
+    }
+    expect(stripAnsi(lastFrame() ?? "")).toContain("Session 21");
+
+    await writeInput({ stdin, input: "\r" });
+    await act(async () => Promise.resolve());
+
+    expect(getSession).toHaveBeenCalledWith({ sessionId: "session-21" });
+    expect(stripAnsi(lastFrame() ?? "")).toContain("oldest conversation");
+    unmount();
+  });
+
   it("polls idle sessions for remote updates and pauses during local generation", async () => {
     vi.useFakeTimers();
     const originalMessage: PxiMessage = {

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -285,6 +285,63 @@ describe("PXI client", () => {
     ]);
   });
 
+  it("follows pagination when listing persisted sessions", async () => {
+    const capturedCursors: Array<string | null> = [];
+    const capturedLimits: Array<string | null> = [];
+    const firstPage = Array.from({ length: 20 }, (_, index) => ({
+      id: `session-${index + 1}`,
+      title: `Session ${index + 1}`,
+      created_at: "2026-07-24T11:00:00Z",
+      updated_at: "2026-07-24T12:00:00Z",
+      is_temporary: false,
+    }));
+    const fetchImpl = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const query = new URL(request.url).searchParams;
+        const cursor = query.get("cursor");
+        capturedCursors.push(cursor);
+        capturedLimits.push(query.get("limit"));
+        return new Response(
+          JSON.stringify(
+            cursor === null
+              ? { data: firstPage, next_cursor: "cursor-page-2" }
+              : {
+                  data: [
+                    {
+                      id: "session-21",
+                      title: "Session 21",
+                      created_at: "2026-07-24T10:00:00Z",
+                      updated_at: "2026-07-24T10:00:00Z",
+                      is_temporary: false,
+                    },
+                  ],
+                  next_cursor: null,
+                }
+          ),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+    ) as typeof fetch;
+    const sessionClient = createPxiSessionClient({
+      config: { endpoint: "http://localhost:6006" },
+      fetch: fetchImpl,
+    });
+
+    const sessions = await sessionClient.listSessions();
+
+    expect(capturedCursors).toEqual([null, "cursor-page-2"]);
+    expect(capturedLimits).toEqual(["100", "100"]);
+    expect(sessions).toHaveLength(21);
+    expect(sessions.at(-1)).toEqual({
+      id: "session-21",
+      title: "Session 21",
+      updatedAt: "2026-07-24T10:00:00Z",
+      isTemporary: false,
+    });
+  });
+
   it("compacts a session on the server-agent compact route", async () => {
     const checkpoint = {
       id: "checkpoint-1",

--- a/js/packages/phoenix-cli/test/pxiClient.test.ts
+++ b/js/packages/phoenix-cli/test/pxiClient.test.ts
@@ -293,7 +293,7 @@ describe("PXI client", () => {
       title: `Session ${index + 1}`,
       created_at: "2026-07-24T11:00:00Z",
       updated_at: "2026-07-24T12:00:00Z",
-      is_temporary: false,
+      is_ephemeral: false,
     }));
     const fetchImpl = vi.fn(
       async (input: string | URL | Request, init?: RequestInit) => {
@@ -314,7 +314,7 @@ describe("PXI client", () => {
                       title: "Session 21",
                       created_at: "2026-07-24T10:00:00Z",
                       updated_at: "2026-07-24T10:00:00Z",
-                      is_temporary: false,
+                      is_ephemeral: false,
                     },
                   ],
                   next_cursor: null,


### PR DESCRIPTION
## Summary

- follow `next_cursor` when listing persisted PXI sessions
- fetch all available sessions before displaying and filtering the session picker
- add coverage for paginated responses and restoring a session beyond the first 20 results

## Testing

- `pnpm test` (`js/packages/phoenix-cli`): 883 passed
- `pnpm --filter @arizeai/phoenix-cli typecheck`
- `make lint-ts`

Closes #14951
