### PR TITLE
fix(dsl): one NUL message on every Python

### DIFF
--- a/src/phoenix/server/api/helpers/experiment_run_filters.py
+++ b/src/phoenix/server/api/helpers/experiment_run_filters.py
@@ -146,6 +146,13 @@ def _compile_sqlalchemy_filter_condition(
     try:
         original_tree = ast.parse(filter_condition, mode="eval")
     except SyntaxError as error:
+        if "null bytes" in str(error):
+            # A NUL in the source, which CPython reports as `ValueError` on
+            # 3.10 (the branch below) and as `SyntaxError` from 3.11 on. One
+            # canonical message, whatever the interpreter.
+            raise ExperimentRunFilterConditionSyntaxError(
+                "Filter condition cannot contain a NUL character"
+            ) from error
         if "integer string conversion" in str(error):
             # CPython's 4300-digit guard, whose message advises
             # `sys.set_int_max_str_digits()` -- Python's remedy, not the

--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -1514,6 +1514,13 @@ def _format_syntax_error(error: SyntaxError) -> str:
     pass through as their message alone.
     """
     message = error.msg or "invalid syntax"
+    if "null bytes" in message:
+        # A NUL in the source. CPython reports it as `ValueError` on 3.10
+        # (handled at the parse site) and as `SyntaxError` from 3.11 on;
+        # either way the message is the tokenizer's ("source code string
+        # cannot contain null bytes"), which describes source code the user
+        # never wrote. One canonical message, whatever the interpreter.
+        return "condition cannot contain a NUL character"
     if "integer string conversion" in message:
         # CPython's 4300-digit guard fires during parsing, and its message
         # advises `sys.set_int_max_str_digits()` -- Python's remedy, not the

--- a/tests/unit/server/api/helpers/test_experiment_run_filters.py
+++ b/tests/unit/server/api/helpers/test_experiment_run_filters.py
@@ -963,8 +963,13 @@ class TestInheritedPythonSurface:
             compile_sqlalchemy_filter_condition(filter_condition=condition, experiment_ids=[1])
 
     def test_nul_in_the_source_is_not_a_server_error(self) -> None:
-        # `ast.parse` reports this as a `ValueError`, which callers do not
-        # catch, so it escaped the boundary that turns input into filter errors.
+        # `ast.parse` reports this as a `ValueError` on 3.10 and as a
+        # `SyntaxError` from 3.11 on; both must produce the same canonical
+        # message rather than escaping as a server error or surfacing the
+        # tokenizer's "null bytes" wording. Which branch this exercises
+        # depends on the interpreter running it -- on a >= 3.11 leg it is the
+        # real end-to-end check, and it fails if CPython changes the
+        # exception's type or wording again.
         with pytest.raises(
             ExperimentRunFilterConditionSyntaxError, match="cannot contain a NUL character"
         ):

--- a/tests/unit/trace/dsl/test_filter_error_messages.py
+++ b/tests/unit/trace/dsl/test_filter_error_messages.py
@@ -150,6 +150,18 @@ def test_messages_bound_echoed_fragments() -> None:
         SpanFilter("latency_ms == " + "9" * 5000)
 
 
+def test_nul_in_the_source_has_one_message_on_every_python() -> None:
+    """CPython reports a NUL in the source as `ValueError` on 3.10 and as
+    `SyntaxError` from 3.11 on. Both must read as the same condition error --
+    not the tokenizer's 'source code string cannot contain null bytes', which
+    describes source code the user never wrote. Which branch this exercises
+    depends on the interpreter running it, which is the point: on a >= 3.11
+    leg it is the real end-to-end check, and it fails loudly if CPython ever
+    changes the exception's type or wording again."""
+    with pytest.raises(SyntaxError, match="cannot contain a NUL character"):
+        SpanFilter("name == 'a\x00b'")
+
+
 def test_every_message_says_something() -> None:
     """A message has to carry more than a label. The bar is deliberately low --
     it catches placeholders, not prose quality."""


### PR DESCRIPTION
Follow-up to #14295 — this commit was authored on the branch but not pushed before the squash merge, so it missed the train.

CPython reports a NUL in the source as `ValueError` on 3.10 and as `SyntaxError` from 3.11 on. Both filter DSLs handled only the `ValueError` spelling, so on newer interpreters the tokenizer's `source code string cannot contain null bytes (<unknown>, line 1)` reached the filter field instead of the canonical message. Caught by `test_nul_in_the_source_is_not_a_server_error` failing on a ≥3.11 run — invisible to PR CI, which runs the unit suites on 3.10 only (the interpreter-version blind spot documented in the span-filter spec's CPython matrix row).

Both parse boundaries now normalize the `SyntaxError` form to the same canonical message the `ValueError` path produces, pinned by a real-NUL test on each surface. Which branch those tests exercise depends on the interpreter running them: on a ≥3.11 leg (the scheduled all-platforms 3.13/3.14 runs) they are the real end-to-end check, and they fail loudly if CPython ever changes the exception's type or wording again. Deliberately no simulated-exception tests — a fabricated `SyntaxError` can only re-assert the string literal the code already matches on, and cannot detect the interpreter drift that is the actual hazard. The honest guard for the 3.10-only PR gate is a ≥3.11 matrix leg, tracked separately.