### PR TITLE
fix(gen_ai): render reasoning parts instead of dropping them (#14962)

### DIFF
--- a/src/phoenix/trace/gen_ai/conversion.py
+++ b/src/phoenix/trace/gen_ai/conversion.py
@@ -35,6 +35,7 @@ from phoenix.trace.gen_ai.__generated__.models import (
     InputMessages,
     OutputMessage,
     OutputMessages,
+    ReasoningPart,
     RetrievalDocument,
     RetrievalDocuments,
     Role,
@@ -478,7 +479,7 @@ def _flatten_message(
             flat[f"{base}.message.finish_reason"] = finish_reason
 
     text_parts: list[str] = []
-    content_parts: list[TextPart | UriPart | BlobPart] = []
+    content_parts: list[TextPart | UriPart | BlobPart | ReasoningPart] = []
     tool_calls: list[ToolCallRequestPart] = []
     tool_response_part: Optional[ToolCallResponsePart] = None
 
@@ -486,7 +487,7 @@ def _flatten_message(
         if isinstance(part, TextPart):
             text_parts.append(part.content)
             content_parts.append(part)
-        elif isinstance(part, (UriPart, BlobPart)):
+        elif isinstance(part, (UriPart, BlobPart, ReasoningPart)):
             content_parts.append(part)
         elif isinstance(part, ToolCallRequestPart):
             tool_calls.append(part)
@@ -509,6 +510,13 @@ def _flatten_message(
             content_prefix = f"{base}.{MessageAttributes.MESSAGE_CONTENTS}.{content_index}"
             if isinstance(content_part, TextPart):
                 flat[f"{content_prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"] = "text"
+                flat[f"{content_prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"] = (
+                    content_part.content
+                )
+            elif isinstance(content_part, ReasoningPart):
+                flat[f"{content_prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"] = (
+                    "reasoning"
+                )
                 flat[f"{content_prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"] = (
                     content_part.content
                 )

--- a/tests/unit/trace/gen_ai/test_conversion.py
+++ b/tests/unit/trace/gen_ai/test_conversion.py
@@ -459,6 +459,56 @@ def test_blob_part_becomes_data_url() -> None:
     )
 
 
+def test_reasoning_part_emits_structured_contents() -> None:
+    out = get_openinference_message_attributes(
+        _output_messages(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {"type": "reasoning", "content": "step one, then step two"},
+                        {"type": "text", "content": "parent_id is None"},
+                    ],
+                    "finish_reason": "stop",
+                }
+            ]
+        )
+    )
+    base = f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0"
+    contents = MessageAttributes.MESSAGE_CONTENTS
+    content_type = MessageContentAttributes.MESSAGE_CONTENT_TYPE
+    content_text = MessageContentAttributes.MESSAGE_CONTENT_TEXT
+    assert out[f"{base}.{contents}.0.{content_type}"] == "reasoning"
+    assert out[f"{base}.{contents}.0.{content_text}"] == "step one, then step two"
+    assert out[f"{base}.{contents}.1.{content_type}"] == "text"
+    assert out[f"{base}.{contents}.1.{content_text}"] == "parent_id is None"
+    # The reasoning text is not also duplicated into the flat message content.
+    assert f"{base}.{MessageAttributes.MESSAGE_CONTENT}" not in out
+
+
+def test_reasoning_only_message_keeps_reasoning() -> None:
+    out = get_openinference_message_attributes(
+        _output_messages(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [{"type": "reasoning", "content": "thinking out loud"}],
+                    "finish_reason": "stop",
+                }
+            ]
+        )
+    )
+    base = f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0"
+    contents = MessageAttributes.MESSAGE_CONTENTS
+    assert (
+        out[f"{base}.{contents}.0.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"] == "reasoning"
+    )
+    assert (
+        out[f"{base}.{contents}.0.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"]
+        == "thinking out loud"
+    )
+
+
 def test_blob_part_without_mime_type_uses_octet_stream() -> None:
     out = get_openinference_message_attributes(
         _input_messages(


### PR DESCRIPTION
## Summary

Fixes #14962.

`_flatten_message` in `src/phoenix/trace/gen_ai/conversion.py` branched on
`TextPart` / `UriPart` / `BlobPart` / `ToolCallRequestPart` / `ToolCallResponsePart`
only. A `ReasoningPart` — which the generated models already define — fell through
every branch, so it was written to neither `message.content` nor
`message.contents.*`. Reasoning emitted by a producer such as `@ai-sdk/otel`
disappeared entirely from spans synthesized server-side.

## Change

- Collect `ReasoningPart` alongside the other content parts.
- Render it as `message_content.type = "reasoning"` with `message_content.text`
  set to the part's `content`, matching the shape the client-side
  `@arizeai/openinference-genai` mapping is being fixed to emit
  (Arize-ai/openinference#3472).
- Because a reasoning part counts as non-text content, its presence already puts
  the message on the structured-contents path via the existing
  `has_non_text_content` check, so the reasoning text is not also duplicated into
  the flat `message.content`.

Before / after for the issue's repro (`gen_ai.output.messages` with a reasoning
part followed by a text part):

```
# before
llm.output_messages.0.message.role     = assistant
llm.output_messages.0.message.content  = parent_id is None      <- reasoning gone
llm.output_messages.0.message.finish_reason = stop

# after
llm.output_messages.0.message.role     = assistant
llm.output_messages.0.message.finish_reason = stop
llm.output_messages.0.message.contents.0.message_content.type = reasoning
llm.output_messages.0.message.contents.0.message_content.text = <reasoning text>
llm.output_messages.0.message.contents.1.message_content.type = text
llm.output_messages.0.message.contents.1.message_content.text = parent_id is None
```

## Tests

Two cases added to `tests/unit/trace/gen_ai/test_conversion.py`:

- `test_reasoning_part_emits_structured_contents` — reasoning + text, asserts both
  parts land in `message.contents.*` and that `message.content` is not also set.
- `test_reasoning_only_message_keeps_reasoning` — a message whose only part is
  reasoning still surfaces it.

Both fail on `main` with `KeyError` on the `message.contents.0.*` keys and pass
with this change; the other 90 tests in the module pass unchanged.
`ruff check` / `ruff format` (0.15.2, repo config) are clean on both files.

I have read the CLA Document and I hereby sign the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
