### PR TITLE
fix(otel): merge positional OpenInference namespaces atomically (#14961)

### DIFF
--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -67,6 +67,42 @@ def coerce_otlp_span_attributes(
         yield key, value
 
 
+# OpenInference namespaces whose keys are positional (``<namespace>.<index>.…``).
+# Two mappings of the same data can disagree on the index base — a client-side
+# mapping that skips ``gen_ai.system_instructions`` numbers the first user message
+# 0, while the synthesized one numbers it 1 — so merging them key by key
+# interleaves them into entries that never existed. These namespaces are therefore
+# merged all-or-nothing.
+_POSITIONAL_NAMESPACES = (
+    SpanAttributes.LLM_INPUT_MESSAGES,
+    SpanAttributes.LLM_OUTPUT_MESSAGES,
+    SpanAttributes.LLM_TOOLS,
+    SpanAttributes.RETRIEVAL_DOCUMENTS,
+)
+
+
+def _merge_synthesized_attributes(
+    raw_attributes: dict[str, Any],
+    synthesized: Mapping[str, Any],
+) -> None:
+    """Merge synthesized OpenInference attributes into the span's own attributes.
+
+    Attributes already on the span always win. Scalar keys are filled in
+    individually; a positional namespace is skipped in full when the span already
+    carries any key under it, so a partial client-side mapping is kept internally
+    consistent rather than gap-filled from a differently indexed one.
+    """
+    occupied = tuple(
+        f"{namespace}."
+        for namespace in _POSITIONAL_NAMESPACES
+        if any(key.startswith(f"{namespace}.") for key in raw_attributes)
+    )
+    for key, value in synthesized.items():
+        if occupied and key.startswith(occupied):
+            continue
+        raw_attributes.setdefault(key, value)
+
+
 def decode_otlp_span(otlp_span: otlp.Span) -> Span:
     trace_id = cast(TraceID, _decode_identifier(otlp_span.trace_id))
     span_id = cast(SpanID, _decode_identifier(otlp_span.span_id))
@@ -77,10 +113,9 @@ def decode_otlp_span(otlp_span: otlp.Span) -> Span:
 
     raw_attributes = dict(_decode_key_values(otlp_span.attributes))
     # Synthesize OpenInference attrs from any OTel gen_ai.* semconv attributes.
-    # ``setdefault`` means existing OI attributes win — relevant for spans that
-    # were dual-emitted by an instrumentation that already set OI keys directly.
-    for key, value in get_openinference_attributes(raw_attributes).items():
-        raw_attributes.setdefault(key, value)
+    # Existing OI attributes win — relevant for spans that were dual-emitted by
+    # an instrumentation that already set OI keys directly.
+    _merge_synthesized_attributes(raw_attributes, get_openinference_attributes(raw_attributes))
     attributes = unflatten(load_json_strings(coerce_otlp_span_attributes(raw_attributes.items())))
     span_kind = SpanKind(get_attribute_value(attributes, OPENINFERENCE_SPAN_KIND))
 

--- a/tests/unit/trace/test_otel.py
+++ b/tests/unit/trace/test_otel.py
@@ -9,7 +9,11 @@ import numpy as np
 import opentelemetry.proto.trace.v1.trace_pb2 as otlp
 import pytest
 from google.protobuf.json_format import MessageToJson
-from openinference.semconv.trace import SpanAttributes
+from openinference.semconv.trace import (
+    MessageAttributes,
+    MessageContentAttributes,
+    SpanAttributes,
+)
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, ArrayValue, KeyValue
 from pytest import approx
 
@@ -565,6 +569,88 @@ def test_decode_otlp_span_existing_oi_attrs_win_over_gen_ai() -> None:
     decoded = decode_otlp_span(otlp_span)
 
     assert decoded.attributes["llm"]["model_name"] == "gpt-4-from-oi"
+
+
+def test_decode_otlp_span_does_not_interleave_partial_client_messages() -> None:
+    """A client-side mapping that already wrote part of ``llm.input_messages`` is kept
+    whole: the synthesized mapping numbers messages differently (it folds
+    ``gen_ai.system_instructions`` in at index 0), so gap-filling it key by key would
+    interleave the two into messages that were never emitted."""
+    system_instructions = json.dumps([{"type": "text", "content": "You translate requests."}])
+    input_messages = json.dumps(
+        [{"role": "user", "parts": [{"type": "text", "content": "only root spans"}]}]
+    )
+    otlp_span = otlp.Span(
+        name="invoke_agent",
+        trace_id=token_bytes(16),
+        span_id=token_bytes(8),
+        attributes=[
+            KeyValue(key="gen_ai.operation.name", value=AnyValue(string_value="chat")),
+            KeyValue(
+                key="gen_ai.system_instructions", value=AnyValue(string_value=system_instructions)
+            ),
+            KeyValue(key="gen_ai.input.messages", value=AnyValue(string_value=input_messages)),
+            # Partial client-side OI mapping: the user message only, at index 0.
+            KeyValue(
+                key=f"{SpanAttributes.LLM_INPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}",
+                value=AnyValue(string_value="user"),
+            ),
+            KeyValue(
+                key=(
+                    f"{SpanAttributes.LLM_INPUT_MESSAGES}.0"
+                    f".{MessageAttributes.MESSAGE_CONTENTS}.0"
+                    f".{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"
+                ),
+                value=AnyValue(string_value="only root spans"),
+            ),
+        ],
+    )
+
+    decoded = decode_otlp_span(otlp_span)
+
+    messages = decoded.attributes["llm"]["input_messages"]
+    assert len(messages) == 1
+    assert messages[0]["message"]["role"] == "user"
+    assert messages[0]["message"]["contents"][0]["message_content"]["text"] == "only root spans"
+    # The system prompt is not spliced into the client's message as its content.
+    assert "content" not in messages[0]["message"]
+
+
+def test_decode_otlp_span_synthesizes_namespaces_the_client_left_empty() -> None:
+    """Skipping a positional namespace the client already wrote does not suppress the
+    other namespaces the client did not write."""
+    input_messages = json.dumps([{"role": "user", "parts": [{"type": "text", "content": "hi"}]}])
+    output_messages = json.dumps(
+        [
+            {
+                "role": "assistant",
+                "finish_reason": "stop",
+                "parts": [{"type": "text", "content": "hello"}],
+            }
+        ]
+    )
+    otlp_span = otlp.Span(
+        name="chat",
+        trace_id=token_bytes(16),
+        span_id=token_bytes(8),
+        attributes=[
+            KeyValue(key="gen_ai.operation.name", value=AnyValue(string_value="chat")),
+            KeyValue(key="gen_ai.input.messages", value=AnyValue(string_value=input_messages)),
+            KeyValue(key="gen_ai.output.messages", value=AnyValue(string_value=output_messages)),
+            KeyValue(
+                key=f"{SpanAttributes.LLM_INPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}",
+                value=AnyValue(string_value="user"),
+            ),
+        ],
+    )
+
+    decoded = decode_otlp_span(otlp_span)
+
+    # Client owns the input messages ...
+    assert len(decoded.attributes["llm"]["input_messages"]) == 1
+    assert "content" not in decoded.attributes["llm"]["input_messages"][0]["message"]
+    # ... but the untouched output namespace is still synthesized.
+    assert decoded.attributes["llm"]["output_messages"][0]["message"]["content"] == "hello"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #14961.

`decode_otlp_span` merged the OpenInference attributes synthesized from `gen_ai.*`
into the span with a per-flattened-key `setdefault`:

```python
for key, value in get_openinference_attributes(raw_attributes).items():
    raw_attributes.setdefault(key, value)
```

That is safe for scalar attributes, but `llm.input_messages.*` and friends are
positional. On a dual-emitted span the client's mapping and the synthesized one
disagree on the index base — the client skips `gen_ai.system_instructions`, so its
first user message is index 0, while the synthesized mapping puts the system
message at 0 and shifts the user message to 1. Filling the "gaps" key by key then
splices the two together into messages that were never emitted.

## Change

Merge positional namespaces (`llm.input_messages`, `llm.output_messages`,
`llm.tools`, `retrieval.documents`) all-or-nothing: if the span already carries any
key under one of them, none of the synthesized keys for that namespace are applied.
The client's mapping, even when incomplete, is at least internally consistent.
Scalar attributes and namespaces the client left empty are still gap-filled exactly
as before.

Decoding the issue's span (`gen_ai.system_instructions` + `gen_ai.input.messages`,
plus a partial client-side mapping of the user message only):

```
# before — llm.input_messages
[{"message": {"role": "user",                       <- client
              "content": "<system prompt>",         <- server gap-fill
              "contents": [{"message_content": {"type": "text",
                                                "text": "only root spans"}}]}},
 {"message": {"role": "user", "content": "only root spans"}}]   <- server, duplicate

# after — llm.input_messages
[{"message": {"role": "user",
              "contents": [{"message_content": {"type": "text",
                                                "text": "only root spans"}}]}}]
```

## Tests

Two cases added to `tests/unit/trace/test_otel.py`:

- `test_decode_otlp_span_does_not_interleave_partial_client_messages` — the dual-emit
  span above; asserts a single input message with the client's contents and no
  system prompt spliced in as `message.content`.
- `test_decode_otlp_span_synthesizes_namespaces_the_client_left_empty` — skipping the
  namespace the client owns does not suppress the ones it did not write, so
  `llm.output_messages` is still synthesized.

Both fail on `main` and pass with this change; the other 32 tests in the module pass
unchanged. `ruff check` / `ruff format` (0.15.2, repo config) are clean on both files.

Note this is the server-side half of the corruption described in the issue; the
client-side gap (`openinference-genai` not mapping `gen_ai.system_instructions`) is
tracked separately in Arize-ai/openinference#3472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
