### PR TITLE
feat(project): defer annotation metric chart loading

### DIFF
--- a/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
+++ b/app/src/pages/project/metrics/ProjectAnnotationMetrics.tsx
@@ -10,6 +10,7 @@ import {
   AnnotationScoreLabelToggle,
   ChartPanel,
   ChartSkeleton,
+  DeferredChartPanel,
   TimeRangeChartBrush,
   compactTimeXAxisProps,
   compactYAxisProps,
@@ -18,6 +19,7 @@ import {
   useBinTimeTickFormatter,
 } from "@phoenix/components/chart";
 import { ErrorBoundary } from "@phoenix/components/exception";
+import { useFrozenWhileHidden } from "@phoenix/hooks/useFrozenWhileHidden";
 import { useTimeBinScale } from "@phoenix/hooks/useTimeBin";
 import { useTimeFormatters } from "@phoenix/hooks/useTimeFormatters";
 import { useUTCOffsetMinutes } from "@phoenix/hooks/useUTCOffsetMinutes";
@@ -88,7 +90,7 @@ function ProjectAnnotationMetricsGridView({
   return (
     <div css={annotationGridCSS}>
       {annotationNames.map((annotationName) => (
-        <ProjectAnnotationMetricPanel
+        <DeferredProjectAnnotationMetricPanel
           {...props}
           key={annotationName}
           annotationLevel={annotationLevel}
@@ -165,6 +167,38 @@ type ProjectAnnotationMetricPanelProps = ProjectMetricViewProps & {
   annotationName: string;
   fillHeight?: boolean;
 };
+
+function DeferredProjectAnnotationMetricPanel({
+  annotationName,
+  fillHeight = false,
+  ...props
+}: ProjectAnnotationMetricPanelProps) {
+  return (
+    <DeferredChartPanel
+      title={annotationName}
+      subtitle={PROJECT_ANNOTATION_METRIC_CHART_DESCRIPTION}
+      fillHeight={fillHeight}
+    >
+      <ProjectAnnotationMetricPanelWithFrozenTimeRange
+        {...props}
+        annotationName={annotationName}
+        fillHeight={fillHeight}
+      />
+    </DeferredChartPanel>
+  );
+}
+
+// Keep live query inputs frozen while an already-mounted chart is hidden.
+// This must render inside DeferredChartPanel's visibility context.
+function ProjectAnnotationMetricPanelWithFrozenTimeRange({
+  timeRange,
+  ...props
+}: ProjectAnnotationMetricPanelProps) {
+  const visibleTimeRange = useFrozenWhileHidden(timeRange);
+  return (
+    <ProjectAnnotationMetricPanel {...props} timeRange={visibleTimeRange} />
+  );
+}
 
 export function ProjectAnnotationMetricPanel({
   fillHeight = false,

--- a/app/src/pages/project/metrics/__tests__/ProjectAnnotationMetrics.test.tsx
+++ b/app/src/pages/project/metrics/__tests__/ProjectAnnotationMetrics.test.tsx
@@ -38,6 +38,70 @@ const TIME_RANGE_VARIABLE = {
   end: TIME_RANGE.end.toISOString(),
 };
 
+const observedElements = new Map<Element, ControlledIntersectionObserver>();
+
+class ControlledIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly scrollMargin = "";
+  readonly thresholds = [];
+  readonly #callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.#callback = callback;
+  }
+
+  observe(target: Element) {
+    observedElements.set(target, this);
+  }
+
+  unobserve(target: Element) {
+    if (observedElements.get(target) === this) {
+      observedElements.delete(target);
+    }
+  }
+
+  disconnect() {
+    for (const [target, observer] of observedElements) {
+      if (observer === this) {
+        observedElements.delete(target);
+      }
+    }
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  setIsIntersecting(target: Element, isIntersecting: boolean) {
+    const rect = target.getBoundingClientRect();
+    this.#callback(
+      [
+        {
+          boundingClientRect: rect,
+          intersectionRatio: isIntersecting ? 1 : 0,
+          intersectionRect: rect,
+          isIntersecting,
+          rootBounds: null,
+          target,
+          time: performance.now(),
+        },
+      ],
+      this
+    );
+  }
+}
+
+const defaultIntersectionObserver = globalThis.IntersectionObserver;
+
+function setIsIntersecting(target: Element, isIntersecting: boolean) {
+  const observer = observedElements.get(target);
+  if (observer == null) {
+    throw new Error("Element is not observed");
+  }
+  observer.setIsIntersecting(target, isIntersecting);
+}
+
 const LEVEL_CASES: ReadonlyArray<{
   annotationLevel: MetricChartTableView;
   namesOperationName: string;
@@ -69,6 +133,8 @@ describe("ProjectAnnotationMetricsGrid", () => {
   let root: Root;
 
   beforeEach(() => {
+    observedElements.clear();
+    globalThis.IntersectionObserver = ControlledIntersectionObserver;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -77,11 +143,12 @@ describe("ProjectAnnotationMetricsGrid", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    globalThis.IntersectionObserver = defaultIntersectionObserver;
     vi.restoreAllMocks();
   });
 
   it.each(LEVEL_CASES)(
-    "loads $annotationLevel annotation metrics independently",
+    "defers and independently loads $annotationLevel annotation metrics",
     async ({
       annotationLevel,
       namesOperationName,
@@ -140,7 +207,27 @@ describe("ProjectAnnotationMetricsGrid", () => {
         });
       });
 
-      const metricsOperations = requestedOperations.filter(
+      expect(requestedOperations).toHaveLength(1);
+      const deferredPanels = container.querySelectorAll(
+        ".deferred-chart-panel"
+      );
+      expect(deferredPanels).toHaveLength(2);
+
+      await act(async () => {
+        setIsIntersecting(deferredPanels[0]!, true);
+      });
+
+      let metricsOperations = requestedOperations.filter(
+        ({ name }) => name === metricsOperationName
+      );
+      expect(metricsOperations).toHaveLength(1);
+      expect(metricsOperations[0]?.variables.annotationName).toBe("quality");
+
+      await act(async () => {
+        setIsIntersecting(deferredPanels[1]!, true);
+      });
+
+      metricsOperations = requestedOperations.filter(
         ({ name }) => name === metricsOperationName
       );
       expect(metricsOperations).toHaveLength(2);


### PR DESCRIPTION
## Summary

- wrap every discovered project annotation metric panel in the shared `DeferredChartPanel` boundary
- keep annotation-name discovery eager while freezing time-range and stream-fetch inputs for mounted panels that become hidden
- update the focused Relay orchestration test to prove each chart waits for visibility and then issues its own filtered request

## Validation

- `pnpm --dir app exec vitest run src/pages/project/metrics/__tests__/ProjectAnnotationMetrics.test.tsx`
- `make typecheck-frontend`
- `make lint-frontend`
- targeted `oxlint` for the changed files
- browser network validation against 32 span, trace, and session annotation names over seven days: zero per-annotation metrics queries on page mount; filtered span queries began only as the corresponding panels approached the viewport

Depends on #14938