### PR TITLE
feat(server): OpenAI-compatible v1/chat/completions proxy with server-side credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ codegen-python-client: ## Generate Python client types from OpenAPI
 codegen-ts-client: ## Generate TypeScript client types from OpenAPI
 	@echo -e "$(CYAN)Generating TypeScript client types...$(NC)"
 	@cd $(JS_DIR)/packages/phoenix-client && $(PNPM) run --silent generate
+	@cd $(JS_DIR)/packages/phoenix-testing && $(PNPM) run --silent generate
 	@echo -e "$(GREEN)✓ Done$(NC)"
 
 codegen-ts-app: ## Generate TypeScript OpenAPI types for app/

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -2219,7 +2219,22 @@ export interface components {
         CreateApiKeyResponseBody: {
             data: components["schemas"]["CreatedApiKey"];
         };
-        /** CreateChatCompletionRequestBody */
+        /**
+         * CreateChatCompletionRequestBody
+         * @example {
+         *       "messages": [
+         *         {
+         *           "content": "You are a helpful assistant.",
+         *           "role": "system"
+         *         },
+         *         {
+         *           "content": "Say hello.",
+         *           "role": "user"
+         *         }
+         *       ],
+         *       "model": "openai:gpt-4o"
+         *     }
+         */
         CreateChatCompletionRequestBody: {
             /**
              * Model

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1390,6 +1390,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/chat/completions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * OpenAI-compatible chat completions
+         * @description Creates a chat completion using the OpenAI wire format, proxying to the selected provider with credentials resolved on the server (secret store first, environment second) — callers never handle provider API keys. Model must be '{provider}:{model_name}' for a built-in provider (one of anthropic, aws, azure_openai, cerebras, deepseek, fireworks, google, groq, moonshot, ollama, openai, perplexity, together, xai) or 'custom:{provider_id}:{model_name}' for a stored custom provider, e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'. Set `stream: true` for server-sent events of `chat.completion.chunk` payloads terminated by `data: [DONE]`. Tool calling is not supported.
+         */
+        post: operations["createChatCompletion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/login": {
         parameters: {
             query?: never;
@@ -1933,6 +1953,75 @@ export interface components {
             /** Score */
             score?: number | null;
         };
+        /** ChatCompletion */
+        ChatCompletion: {
+            /** Id */
+            id: string;
+            /**
+             * Object
+             * @default chat.completion
+             * @constant
+             */
+            object?: "chat.completion";
+            /** Created */
+            created: number;
+            /** Model */
+            model: string;
+            /** Choices */
+            choices: components["schemas"]["ChatCompletionChoice"][];
+            usage: components["schemas"]["ChatCompletionUsage"];
+        };
+        /** ChatCompletionChoice */
+        ChatCompletionChoice: {
+            /**
+             * Index
+             * @default 0
+             */
+            index?: number;
+            message: components["schemas"]["ChatCompletionMessage"];
+            /** Finish Reason */
+            finish_reason: string;
+        };
+        /** ChatCompletionMessage */
+        ChatCompletionMessage: {
+            /**
+             * Role
+             * @default assistant
+             * @constant
+             */
+            role?: "assistant";
+            /** Content */
+            content: string;
+        };
+        /** ChatCompletionRequestMessage */
+        ChatCompletionRequestMessage: {
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "system" | "developer" | "user" | "assistant";
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionTextPart"][];
+        };
+        /** ChatCompletionTextPart */
+        ChatCompletionTextPart: {
+            /**
+             * Type
+             * @constant
+             */
+            type: "text";
+            /** Text */
+            text: string;
+        };
+        /** ChatCompletionUsage */
+        ChatCompletionUsage: {
+            /** Prompt Tokens */
+            prompt_tokens: number;
+            /** Completion Tokens */
+            completion_tokens: number;
+            /** Total Tokens */
+            total_tokens: number;
+        };
         /**
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
@@ -2106,6 +2195,51 @@ export interface components {
         /** CreateApiKeyResponseBody */
         CreateApiKeyResponseBody: {
             data: components["schemas"]["CreatedApiKey"];
+        };
+        /** CreateChatCompletionRequestBody */
+        CreateChatCompletionRequestBody: {
+            /**
+             * Model
+             * @description Model must be '{provider}:{model_name}' for a built-in provider (one of anthropic, aws, azure_openai, cerebras, deepseek, fireworks, google, groq, moonshot, ollama, openai, perplexity, together, xai) or 'custom:{provider_id}:{model_name}' for a stored custom provider, e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'.
+             */
+            model: string;
+            /** Messages */
+            messages: components["schemas"]["ChatCompletionRequestMessage"][];
+            /**
+             * Stream
+             * @default false
+             */
+            stream?: boolean;
+            /** Temperature */
+            temperature?: number | null;
+            /** Top P */
+            top_p?: number | null;
+            /** Max Tokens */
+            max_tokens?: number | null;
+            /** Max Completion Tokens */
+            max_completion_tokens?: number | null;
+            /** Stop */
+            stop?: string | string[] | null;
+            /** Frequency Penalty */
+            frequency_penalty?: number | null;
+            /** Presence Penalty */
+            presence_penalty?: number | null;
+            /** Seed */
+            seed?: number | null;
+            /** N */
+            n?: number | null;
+            /** Stream Options */
+            stream_options?: {
+                [key: string]: unknown;
+            } | null;
+            /** Tools */
+            tools?: unknown[] | null;
+            /** Tool Choice */
+            tool_choice?: unknown | null;
+            /** Response Format */
+            response_format?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** CreateDatasetLabelRequestBody */
         CreateDatasetLabelRequestBody: {
@@ -10655,6 +10789,66 @@ export interface operations {
                 };
             };
             /** @description System API key not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createChatCompletion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateChatCompletionRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatCompletion"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -1982,6 +1982,21 @@ export interface components {
             /** Finish Reason */
             finish_reason: string;
         };
+        /** ChatCompletionErrorDetail */
+        ChatCompletionErrorDetail: {
+            /** Message */
+            message: string;
+            /** Type */
+            type: string;
+            /** Param */
+            param?: string | null;
+            /** Code */
+            code?: string | null;
+        };
+        /** ChatCompletionErrorResponse */
+        ChatCompletionErrorResponse: {
+            error: components["schemas"]["ChatCompletionErrorDetail"];
+        };
         /** ChatCompletionMessage */
         ChatCompletionMessage: {
             /**
@@ -2002,6 +2017,14 @@ export interface components {
             role: "system" | "developer" | "user" | "assistant";
             /** Content */
             content: string | components["schemas"]["ChatCompletionTextPart"][];
+        };
+        /** ChatCompletionStreamOptions */
+        ChatCompletionStreamOptions: {
+            /**
+             * Include Usage
+             * @default false
+             */
+            include_usage?: boolean;
         };
         /** ChatCompletionTextPart */
         ChatCompletionTextPart: {
@@ -2228,10 +2251,7 @@ export interface components {
             seed?: number | null;
             /** N */
             n?: number | null;
-            /** Stream Options */
-            stream_options?: {
-                [key: string]: unknown;
-            } | null;
+            stream_options?: components["schemas"]["ChatCompletionStreamOptions"] | null;
             /** Tools */
             tools?: unknown[] | null;
             /** Tool Choice */
@@ -10836,7 +10856,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "text/plain": string;
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
                 };
             };
             /** @description Forbidden */
@@ -10854,7 +10874,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "text/plain": string;
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -10863,7 +10883,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "text/plain": string;
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
                 };
             };
         };

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2219,7 +2219,22 @@ export interface components {
         CreateApiKeyResponseBody: {
             data: components["schemas"]["CreatedApiKey"];
         };
-        /** CreateChatCompletionRequestBody */
+        /**
+         * CreateChatCompletionRequestBody
+         * @example {
+         *       "messages": [
+         *         {
+         *           "content": "You are a helpful assistant.",
+         *           "role": "system"
+         *         },
+         *         {
+         *           "content": "Say hello.",
+         *           "role": "user"
+         *         }
+         *       ],
+         *       "model": "openai:gpt-4o"
+         *     }
+         */
         CreateChatCompletionRequestBody: {
             /**
              * Model

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1390,6 +1390,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/chat/completions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * OpenAI-compatible chat completions
+         * @description Creates a chat completion using the OpenAI wire format, proxying to the selected provider with credentials resolved on the server (secret store first, environment second) — callers never handle provider API keys. Model must be '{provider}:{model_name}' for a built-in provider (one of anthropic, aws, azure_openai, cerebras, deepseek, fireworks, google, groq, moonshot, ollama, openai, perplexity, together, xai) or 'custom:{provider_id}:{model_name}' for a stored custom provider, e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'. Set `stream: true` for server-sent events of `chat.completion.chunk` payloads terminated by `data: [DONE]`. Tool calling is not supported.
+         */
+        post: operations["createChatCompletion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/login": {
         parameters: {
             query?: never;
@@ -1933,6 +1953,75 @@ export interface components {
             /** Score */
             score?: number | null;
         };
+        /** ChatCompletion */
+        ChatCompletion: {
+            /** Id */
+            id: string;
+            /**
+             * Object
+             * @default chat.completion
+             * @constant
+             */
+            object?: "chat.completion";
+            /** Created */
+            created: number;
+            /** Model */
+            model: string;
+            /** Choices */
+            choices: components["schemas"]["ChatCompletionChoice"][];
+            usage: components["schemas"]["ChatCompletionUsage"];
+        };
+        /** ChatCompletionChoice */
+        ChatCompletionChoice: {
+            /**
+             * Index
+             * @default 0
+             */
+            index?: number;
+            message: components["schemas"]["ChatCompletionMessage"];
+            /** Finish Reason */
+            finish_reason: string;
+        };
+        /** ChatCompletionMessage */
+        ChatCompletionMessage: {
+            /**
+             * Role
+             * @default assistant
+             * @constant
+             */
+            role?: "assistant";
+            /** Content */
+            content: string;
+        };
+        /** ChatCompletionRequestMessage */
+        ChatCompletionRequestMessage: {
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "system" | "developer" | "user" | "assistant";
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionTextPart"][];
+        };
+        /** ChatCompletionTextPart */
+        ChatCompletionTextPart: {
+            /**
+             * Type
+             * @constant
+             */
+            type: "text";
+            /** Text */
+            text: string;
+        };
+        /** ChatCompletionUsage */
+        ChatCompletionUsage: {
+            /** Prompt Tokens */
+            prompt_tokens: number;
+            /** Completion Tokens */
+            completion_tokens: number;
+            /** Total Tokens */
+            total_tokens: number;
+        };
         /**
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
@@ -2106,6 +2195,51 @@ export interface components {
         /** CreateApiKeyResponseBody */
         CreateApiKeyResponseBody: {
             data: components["schemas"]["CreatedApiKey"];
+        };
+        /** CreateChatCompletionRequestBody */
+        CreateChatCompletionRequestBody: {
+            /**
+             * Model
+             * @description Model must be '{provider}:{model_name}' for a built-in provider (one of anthropic, aws, azure_openai, cerebras, deepseek, fireworks, google, groq, moonshot, ollama, openai, perplexity, together, xai) or 'custom:{provider_id}:{model_name}' for a stored custom provider, e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'.
+             */
+            model: string;
+            /** Messages */
+            messages: components["schemas"]["ChatCompletionRequestMessage"][];
+            /**
+             * Stream
+             * @default false
+             */
+            stream?: boolean;
+            /** Temperature */
+            temperature?: number | null;
+            /** Top P */
+            top_p?: number | null;
+            /** Max Tokens */
+            max_tokens?: number | null;
+            /** Max Completion Tokens */
+            max_completion_tokens?: number | null;
+            /** Stop */
+            stop?: string | string[] | null;
+            /** Frequency Penalty */
+            frequency_penalty?: number | null;
+            /** Presence Penalty */
+            presence_penalty?: number | null;
+            /** Seed */
+            seed?: number | null;
+            /** N */
+            n?: number | null;
+            /** Stream Options */
+            stream_options?: {
+                [key: string]: unknown;
+            } | null;
+            /** Tools */
+            tools?: unknown[] | null;
+            /** Tool Choice */
+            tool_choice?: unknown | null;
+            /** Response Format */
+            response_format?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** CreateDatasetLabelRequestBody */
         CreateDatasetLabelRequestBody: {
@@ -10655,6 +10789,66 @@ export interface operations {
                 };
             };
             /** @description System API key not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    createChatCompletion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateChatCompletionRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatCompletion"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -1982,6 +1982,21 @@ export interface components {
             /** Finish Reason */
             finish_reason: string;
         };
+        /** ChatCompletionErrorDetail */
+        ChatCompletionErrorDetail: {
+            /** Message */
+            message: string;
+            /** Type */
+            type: string;
+            /** Param */
+            param?: string | null;
+            /** Code */
+            code?: string | null;
+        };
+        /** ChatCompletionErrorResponse */
+        ChatCompletionErrorResponse: {
+            error: components["schemas"]["ChatCompletionErrorDetail"];
+        };
         /** ChatCompletionMessage */
         ChatCompletionMessage: {
             /**
@@ -2002,6 +2017,14 @@ export interface components {
             role: "system" | "developer" | "user" | "assistant";
             /** Content */
             content: string | components["schemas"]["ChatCompletionTextPart"][];
+        };
+        /** ChatCompletionStreamOptions */
+        ChatCompletionStreamOptions: {
+            /**
+             * Include Usage
+             * @default false
+             */
+            include_usage?: boolean;
         };
         /** ChatCompletionTextPart */
         ChatCompletionTextPart: {
@@ -2228,10 +2251,7 @@ export interface components {
             seed?: number | null;
             /** N */
             n?: number | null;
-            /** Stream Options */
-            stream_options?: {
-                [key: string]: unknown;
-            } | null;
+            stream_options?: components["schemas"]["ChatCompletionStreamOptions"] | null;
             /** Tools */
             tools?: unknown[] | null;
             /** Tool Choice */
@@ -10836,7 +10856,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "text/plain": string;
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
                 };
             };
             /** @description Forbidden */
@@ -10854,7 +10874,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "text/plain": string;
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -10863,7 +10883,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "text/plain": string;
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
                 };
             };
         };

--- a/js/packages/phoenix-testing/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-testing/src/__generated__/api/v1.ts
@@ -1390,6 +1390,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/chat/completions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * OpenAI-compatible chat completions
+         * @description Creates a chat completion using the OpenAI wire format, proxying to the selected provider with credentials resolved on the server (secret store first, environment second) — callers never handle provider API keys. Model must be '{provider}:{model_name}' for a built-in provider (one of anthropic, aws, azure_openai, cerebras, deepseek, fireworks, google, groq, moonshot, ollama, openai, perplexity, together, xai) or 'custom:{provider_id}:{model_name}' for a stored custom provider, e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'. Set `stream: true` for server-sent events of `chat.completion.chunk` payloads terminated by `data: [DONE]`. Tool calling is not supported.
+         */
+        post: operations["createChatCompletion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/login": {
         parameters: {
             query?: never;
@@ -1933,6 +1953,98 @@ export interface components {
             /** Score */
             score?: number | null;
         };
+        /** ChatCompletion */
+        ChatCompletion: {
+            /** Id */
+            id: string;
+            /**
+             * Object
+             * @default chat.completion
+             * @constant
+             */
+            object?: "chat.completion";
+            /** Created */
+            created: number;
+            /** Model */
+            model: string;
+            /** Choices */
+            choices: components["schemas"]["ChatCompletionChoice"][];
+            usage: components["schemas"]["ChatCompletionUsage"];
+        };
+        /** ChatCompletionChoice */
+        ChatCompletionChoice: {
+            /**
+             * Index
+             * @default 0
+             */
+            index?: number;
+            message: components["schemas"]["ChatCompletionMessage"];
+            /** Finish Reason */
+            finish_reason: string;
+        };
+        /** ChatCompletionErrorDetail */
+        ChatCompletionErrorDetail: {
+            /** Message */
+            message: string;
+            /** Type */
+            type: string;
+            /** Param */
+            param?: string | null;
+            /** Code */
+            code?: string | null;
+        };
+        /** ChatCompletionErrorResponse */
+        ChatCompletionErrorResponse: {
+            error: components["schemas"]["ChatCompletionErrorDetail"];
+        };
+        /** ChatCompletionMessage */
+        ChatCompletionMessage: {
+            /**
+             * Role
+             * @default assistant
+             * @constant
+             */
+            role?: "assistant";
+            /** Content */
+            content: string;
+        };
+        /** ChatCompletionRequestMessage */
+        ChatCompletionRequestMessage: {
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "system" | "developer" | "user" | "assistant";
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionTextPart"][];
+        };
+        /** ChatCompletionStreamOptions */
+        ChatCompletionStreamOptions: {
+            /**
+             * Include Usage
+             * @default false
+             */
+            include_usage?: boolean;
+        };
+        /** ChatCompletionTextPart */
+        ChatCompletionTextPart: {
+            /**
+             * Type
+             * @constant
+             */
+            type: "text";
+            /** Text */
+            text: string;
+        };
+        /** ChatCompletionUsage */
+        ChatCompletionUsage: {
+            /** Prompt Tokens */
+            prompt_tokens: number;
+            /** Completion Tokens */
+            completion_tokens: number;
+            /** Total Tokens */
+            total_tokens: number;
+        };
         /**
          * ChatContext
          * @description Discriminated union of every UI-state context the agent understands.
@@ -2106,6 +2218,63 @@ export interface components {
         /** CreateApiKeyResponseBody */
         CreateApiKeyResponseBody: {
             data: components["schemas"]["CreatedApiKey"];
+        };
+        /**
+         * CreateChatCompletionRequestBody
+         * @example {
+         *       "messages": [
+         *         {
+         *           "content": "You are a helpful assistant.",
+         *           "role": "system"
+         *         },
+         *         {
+         *           "content": "Say hello.",
+         *           "role": "user"
+         *         }
+         *       ],
+         *       "model": "openai:gpt-4o"
+         *     }
+         */
+        CreateChatCompletionRequestBody: {
+            /**
+             * Model
+             * @description Model must be '{provider}:{model_name}' for a built-in provider (one of anthropic, aws, azure_openai, cerebras, deepseek, fireworks, google, groq, moonshot, ollama, openai, perplexity, together, xai) or 'custom:{provider_id}:{model_name}' for a stored custom provider, e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'.
+             */
+            model: string;
+            /** Messages */
+            messages: components["schemas"]["ChatCompletionRequestMessage"][];
+            /**
+             * Stream
+             * @default false
+             */
+            stream?: boolean;
+            /** Temperature */
+            temperature?: number | null;
+            /** Top P */
+            top_p?: number | null;
+            /** Max Tokens */
+            max_tokens?: number | null;
+            /** Max Completion Tokens */
+            max_completion_tokens?: number | null;
+            /** Stop */
+            stop?: string | string[] | null;
+            /** Frequency Penalty */
+            frequency_penalty?: number | null;
+            /** Presence Penalty */
+            presence_penalty?: number | null;
+            /** Seed */
+            seed?: number | null;
+            /** N */
+            n?: number | null;
+            stream_options?: components["schemas"]["ChatCompletionStreamOptions"] | null;
+            /** Tools */
+            tools?: unknown[] | null;
+            /** Tool Choice */
+            tool_choice?: unknown | null;
+            /** Response Format */
+            response_format?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** CreateDatasetLabelRequestBody */
         CreateDatasetLabelRequestBody: {
@@ -10670,6 +10839,66 @@ export interface operations {
                 };
                 content: {
                     "text/plain": string;
+                };
+            };
+        };
+    };
+    createChatCompletion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateChatCompletionRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatCompletion"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatCompletionErrorResponse"];
                 };
             };
         };

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -72,6 +72,22 @@ class CategoricalAnnotationValue(TypedDict):
     score: NotRequired[float]
 
 
+class ChatCompletionMessage(TypedDict):
+    content: str
+    role: NotRequired[str]
+
+
+class ChatCompletionTextPart(TypedDict):
+    type: Literal["text"]
+    text: str
+
+
+class ChatCompletionUsage(TypedDict):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
 class CodeEvaluatorContext(TypedDict):
     type: Literal["code_evaluator"]
     evaluatorNodeId: NotRequired[str]
@@ -1148,6 +1164,17 @@ class CategoricalAnnotationConfigData(TypedDict):
     description: NotRequired[str]
 
 
+class ChatCompletionChoice(TypedDict):
+    message: ChatCompletionMessage
+    finish_reason: str
+    index: NotRequired[int]
+
+
+class ChatCompletionRequestMessage(TypedDict):
+    role: Literal["system", "developer", "user", "assistant"]
+    content: Union[str, Sequence[ChatCompletionTextPart]]
+
+
 class ContinuousAnnotationConfig(TypedDict):
     type: Literal["CONTINUOUS"]
     name: str
@@ -1169,6 +1196,25 @@ class ContinuousAnnotationConfigData(TypedDict):
 
 class CreateApiKeyResponseBody(TypedDict):
     data: CreatedApiKey
+
+
+class CreateChatCompletionRequestBody(TypedDict):
+    model: str
+    messages: Sequence[ChatCompletionRequestMessage]
+    stream: NotRequired[bool]
+    temperature: NotRequired[float]
+    top_p: NotRequired[float]
+    max_tokens: NotRequired[int]
+    max_completion_tokens: NotRequired[int]
+    stop: NotRequired[Union[str, Sequence[str]]]
+    frequency_penalty: NotRequired[float]
+    presence_penalty: NotRequired[float]
+    seed: NotRequired[int]
+    n: NotRequired[int]
+    stream_options: NotRequired[Mapping[str, Any]]
+    tools: NotRequired[Sequence[Any]]
+    tool_choice: NotRequired[Any]
+    response_format: NotRequired[Mapping[str, Any]]
 
 
 class CreateDatasetLabelResponseBody(TypedDict):
@@ -1663,6 +1709,15 @@ class AssistantMessageMetadata(TypedDict):
     trace: NotRequired[AssistantMessageMetadataTraceIds]
     turnTraceContext: NotRequired[TurnTraceContext]
     usage: NotRequired[AssistantMessageMetadataUsage]
+
+
+class ChatCompletion(TypedDict):
+    id: str
+    created: int
+    model: str
+    choices: Sequence[ChatCompletionChoice]
+    usage: ChatCompletionUsage
+    object: NotRequired[str]
 
 
 class CreateAnnotationConfigResponseBody(TypedDict):

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -72,9 +72,24 @@ class CategoricalAnnotationValue(TypedDict):
     score: NotRequired[float]
 
 
+class ChatCompletionErrorDetail(TypedDict):
+    message: str
+    type: str
+    param: NotRequired[str]
+    code: NotRequired[str]
+
+
+class ChatCompletionErrorResponse(TypedDict):
+    error: ChatCompletionErrorDetail
+
+
 class ChatCompletionMessage(TypedDict):
     content: str
     role: NotRequired[str]
+
+
+class ChatCompletionStreamOptions(TypedDict):
+    include_usage: NotRequired[bool]
 
 
 class ChatCompletionTextPart(TypedDict):
@@ -1211,7 +1226,7 @@ class CreateChatCompletionRequestBody(TypedDict):
     presence_penalty: NotRequired[float]
     seed: NotRequired[int]
     n: NotRequired[int]
-    stream_options: NotRequired[Mapping[str, Any]]
+    stream_options: NotRequired[ChatCompletionStreamOptions]
     tools: NotRequired[Sequence[Any]]
     tool_choice: NotRequired[Any]
     response_format: NotRequired[Mapping[str, Any]]

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -9892,7 +9892,22 @@
           "model",
           "messages"
         ],
-        "title": "CreateChatCompletionRequestBody"
+        "title": "CreateChatCompletionRequestBody",
+        "examples": [
+          {
+            "messages": [
+              {
+                "content": "You are a helpful assistant.",
+                "role": "system"
+              },
+              {
+                "content": "Say hello.",
+                "role": "user"
+              }
+            ],
+            "model": "openai:gpt-4o"
+          }
+        ]
       },
       "CreateDatasetLabelRequestBody": {
         "properties": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -7656,6 +7656,78 @@
         }
       }
     },
+    "/v1/chat/completions": {
+      "post": {
+        "tags": [
+          "chat_completions"
+        ],
+        "summary": "OpenAI-compatible chat completions",
+        "description": "Creates a chat completion using the OpenAI wire format, proxying to the selected provider with credentials resolved on the server (secret store first, environment second) \u2014 callers never handle provider API keys. Model must be '{provider}:{model_name}' for a built-in provider (one of anthropic, aws, azure_openai, cerebras, deepseek, fireworks, google, groq, moonshot, ollama, openai, perplexity, together, xai) or 'custom:{provider_id}:{model_name}' for a stored custom provider, e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'. Set `stream: true` for server-sent events of `chat.completion.chunk` payloads terminated by `data: [DONE]`. Tool calling is not supported.",
+        "operationId": "createChatCompletion",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateChatCompletionRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatCompletion"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/auth/login": {
       "post": {
         "summary": " Login",
@@ -8912,6 +8984,164 @@
         ],
         "title": "CategoricalAnnotationValue"
       },
+      "ChatCompletion": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "chat.completion",
+            "title": "Object",
+            "default": "chat.completion"
+          },
+          "created": {
+            "type": "integer",
+            "title": "Created"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "choices": {
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionChoice"
+            },
+            "type": "array",
+            "title": "Choices"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ChatCompletionUsage"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "created",
+          "model",
+          "choices",
+          "usage"
+        ],
+        "title": "ChatCompletion"
+      },
+      "ChatCompletionChoice": {
+        "properties": {
+          "index": {
+            "type": "integer",
+            "title": "Index",
+            "default": 0
+          },
+          "message": {
+            "$ref": "#/components/schemas/ChatCompletionMessage"
+          },
+          "finish_reason": {
+            "type": "string",
+            "title": "Finish Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message",
+          "finish_reason"
+        ],
+        "title": "ChatCompletionChoice"
+      },
+      "ChatCompletionMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "const": "assistant",
+            "title": "Role",
+            "default": "assistant"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "title": "ChatCompletionMessage"
+      },
+      "ChatCompletionRequestMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "system",
+              "developer",
+              "user",
+              "assistant"
+            ],
+            "title": "Role"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatCompletionTextPart"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "ChatCompletionRequestMessage"
+      },
+      "ChatCompletionTextPart": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "text",
+            "title": "Type"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "text"
+        ],
+        "title": "ChatCompletionTextPart"
+      },
+      "ChatCompletionUsage": {
+        "properties": {
+          "prompt_tokens": {
+            "type": "integer",
+            "title": "Prompt Tokens"
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "title": "Completion Tokens"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "title": "Total Tokens"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens"
+        ],
+        "title": "ChatCompletionUsage"
+      },
       "ChatContext": {
         "oneOf": [
           {
@@ -9424,6 +9654,184 @@
           "data"
         ],
         "title": "CreateApiKeyResponseBody"
+      },
+      "CreateChatCompletionRequestBody": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model",
+            "description": "Model must be '{provider}:{model_name}' for a built-in provider (one of anthropic, aws, azure_openai, cerebras, deepseek, fireworks, google, groq, moonshot, ollama, openai, perplexity, together, xai) or 'custom:{provider_id}:{model_name}' for a stored custom provider, e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'."
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionRequestMessage"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Messages"
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "default": false
+          },
+          "temperature": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temperature"
+          },
+          "top_p": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top P"
+          },
+          "max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tokens"
+          },
+          "max_completion_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Completion Tokens"
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stop"
+          },
+          "frequency_penalty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Penalty"
+          },
+          "presence_penalty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Presence Penalty"
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed"
+          },
+          "n": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N"
+          },
+          "stream_options": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stream Options"
+          },
+          "tools": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tools"
+          },
+          "tool_choice": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Choice"
+          },
+          "response_format": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Format"
+          }
+        },
+        "type": "object",
+        "required": [
+          "model",
+          "messages"
+        ],
+        "title": "CreateChatCompletionRequestBody"
       },
       "CreateDatasetLabelRequestBody": {
         "properties": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -7698,9 +7698,9 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ChatCompletionErrorResponse"
                 }
               }
             }
@@ -7708,9 +7708,9 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ChatCompletionErrorResponse"
                 }
               }
             }
@@ -7718,9 +7718,9 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ChatCompletionErrorResponse"
                 }
               }
             }
@@ -9047,6 +9047,58 @@
         ],
         "title": "ChatCompletionChoice"
       },
+      "ChatCompletionErrorDetail": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "param": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Param"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message",
+          "type"
+        ],
+        "title": "ChatCompletionErrorDetail"
+      },
+      "ChatCompletionErrorResponse": {
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ChatCompletionErrorDetail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "title": "ChatCompletionErrorResponse"
+      },
       "ChatCompletionMessage": {
         "properties": {
           "role": {
@@ -9099,6 +9151,17 @@
           "content"
         ],
         "title": "ChatCompletionRequestMessage"
+      },
+      "ChatCompletionStreamOptions": {
+        "properties": {
+          "include_usage": {
+            "type": "boolean",
+            "title": "Include Usage",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "ChatCompletionStreamOptions"
       },
       "ChatCompletionTextPart": {
         "properties": {
@@ -9783,14 +9846,12 @@
           "stream_options": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "$ref": "#/components/schemas/ChatCompletionStreamOptions"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Stream Options"
+            ]
           },
           "tools": {
             "anyOf": [

--- a/src/phoenix/server/agents/model_factory.py
+++ b/src/phoenix/server/agents/model_factory.py
@@ -180,16 +180,10 @@ async def build_model(
             recognised by this builder.
     """
     if isinstance(model, CustomProviderModelSelection):
-        try:
-            provider_id = from_global_id_with_expected_type(
-                GlobalID.from_id(model.provider_id),
-                "GenerativeModelCustomProvider",
-            )
-        except ValueError:
-            # A malformed or wrong-typed Global ID means no such provider
-            # exists; keep the documented AgentError contract rather than
-            # leaking a raw ValueError to callers.
-            raise ProviderNotFoundError("Custom provider not found.") from None
+        provider_id = from_global_id_with_expected_type(
+            GlobalID.from_id(model.provider_id),
+            "GenerativeModelCustomProvider",
+        )
         provider = await session.get(
             models.GenerativeModelCustomProvider,
             provider_id,

--- a/src/phoenix/server/agents/model_factory.py
+++ b/src/phoenix/server/agents/model_factory.py
@@ -180,10 +180,16 @@ async def build_model(
             recognised by this builder.
     """
     if isinstance(model, CustomProviderModelSelection):
-        provider_id = from_global_id_with_expected_type(
-            GlobalID.from_id(model.provider_id),
-            "GenerativeModelCustomProvider",
-        )
+        try:
+            provider_id = from_global_id_with_expected_type(
+                GlobalID.from_id(model.provider_id),
+                "GenerativeModelCustomProvider",
+            )
+        except ValueError:
+            # A malformed or wrong-typed Global ID means no such provider
+            # exists; keep the documented AgentError contract rather than
+            # leaking a raw ValueError to callers.
+            raise ProviderNotFoundError("Custom provider not found.") from None
         provider = await session.get(
             models.GenerativeModelCustomProvider,
             provider_id,

--- a/src/phoenix/server/api/routers/v1/__init__.py
+++ b/src/phoenix/server/api/routers/v1/__init__.py
@@ -10,6 +10,7 @@ from phoenix.server.bearer_auth import is_authenticated
 from .annotation_configs import router as annotation_configs_router
 from .annotations import router as annotations_router
 from .api_keys import router as api_keys_router
+from .chat_completions import router as chat_completions_router
 from .dataset_labels import router as dataset_labels_router
 from .datasets import router as datasets_router
 from .documents import router as documents_router
@@ -77,4 +78,8 @@ def create_v1_router(authentication_enabled: bool) -> APIRouter:
     # API-key routes define their own viewer policy: viewers can manage their own user keys,
     # while system and organization-wide operations remain admin-gated.
     router.include_router(api_keys_router)
+    # The chat completions proxy writes nothing and powers read features like
+    # AI search, so — like the agents chat endpoints — it stays available to
+    # every authenticated role, viewers included.
+    router.include_router(chat_completions_router)
     return router

--- a/src/phoenix/server/api/routers/v1/chat_completions.py
+++ b/src/phoenix/server/api/routers/v1/chat_completions.py
@@ -94,11 +94,6 @@ class _ChatCompletionError(Exception):
         self.error_type = error_type
         self.code = code
 
-    def to_response(self) -> JSONResponse:
-        return _error_response(
-            str(self), status_code=self.status_code, error_type=self.error_type, code=self.code
-        )
-
 
 class ChatCompletionErrorDetail(V1RoutesBaseModel):
     message: str
@@ -115,9 +110,11 @@ def _error_response(
     message: str,
     *,
     status_code: int,
-    error_type: str,
+    error_type: Optional[str] = None,
     code: Optional[str] = None,
 ) -> JSONResponse:
+    if error_type is None:
+        error_type = "invalid_request_error" if status_code < 500 else "api_error"
     body = ChatCompletionErrorResponse(
         error=ChatCompletionErrorDetail(message=message, type=error_type, code=code)
     )
@@ -148,6 +145,10 @@ class _OpenAIErrorAPIRoute(APIRoute):
         async def handle_with_openai_errors(request: Request) -> Response:
             try:
                 return await handler(request)
+            except _ChatCompletionError as exc:
+                return _error_response(
+                    str(exc), status_code=exc.status_code, error_type=exc.error_type, code=exc.code
+                )
             except StarletteHTTPException:
                 # Auth and framework-level errors keep their app-wide handling.
                 raise
@@ -398,11 +399,8 @@ async def create_chat_completion(
     request: Request,
     body: CreateChatCompletionRequestBody,
 ) -> Response:
-    try:
-        selection = _parse_model_id(body.model)
-        _reject_unsupported_parameters(body)
-    except _ChatCompletionError as exc:
-        return exc.to_response()
+    selection = _parse_model_id(body.model)
+    _reject_unsupported_parameters(body)
     try:
         # The session is only needed to resolve the model definition and its
         # credentials; release it before any provider call so a slow LLM
@@ -414,32 +412,21 @@ async def create_chat_completion(
                 decrypt=request.app.state.decrypt,
             )
     except AgentError as exc:
-        return _error_response(
-            str(exc),
-            status_code=exc.status_code,
-            error_type="invalid_request_error" if exc.status_code < 500 else "api_error",
-        )
-    except ValueError:
-        # A malformed custom provider_id fails Global ID parsing inside
-        # build_model with a ValueError before any AgentError can be raised;
-        # to the caller it is simply an unknown model.
-        return _unknown_model_error(body.model).to_response()
+        return _error_response(str(exc), status_code=exc.status_code)
     messages = _to_pydantic_ai_messages(body.messages)
     # Honor settings attached to the model itself (e.g. the Anthropic
     # max_tokens floor) the same way an agent run would.
     settings = merge_model_settings(model.settings, _to_model_settings(body))
-    parameters = ModelRequestParameters()
     if body.stream:
         return await _create_streaming_response(
             model=model,
             messages=messages,
             settings=settings,
-            parameters=parameters,
             model_id=body.model,
-            include_usage=body.stream_options is not None and body.stream_options.include_usage,
+            include_usage=bool(body.stream_options and body.stream_options.include_usage),
         )
     try:
-        response = await model.request(messages, settings, parameters)
+        response = await model.request(messages, settings, ModelRequestParameters())
     except ModelAPIError as exc:
         return _provider_error_response(exc)
     completion = ChatCompletion(
@@ -454,7 +441,9 @@ async def create_chat_completion(
         ],
         usage=_to_openai_usage(response.usage),
     )
-    return JSONResponse(completion.model_dump())
+    # Serialize straight to JSON bytes in one pass rather than model_dump()
+    # into a dict that JSONResponse walks a second time.
+    return Response(completion.model_dump_json(), media_type="application/json")
 
 
 def _provider_error_response(exc: ModelAPIError) -> JSONResponse:
@@ -467,11 +456,10 @@ def _provider_error_response(exc: ModelAPIError) -> JSONResponse:
         # Connection-level failure (DNS, refused connection, timeout): the
         # provider never answered, which makes this proxy a bad gateway.
         status_code = 502
-    return _error_response(
-        str(exc),
-        status_code=status_code,
-        error_type="invalid_request_error" if status_code < 500 else "api_error",
-    )
+    # Pass the provider's message through verbatim — OpenAI-compatible callers
+    # handle these programmatically, unlike the agents surface, which rewrites
+    # them into UI-facing remediation text (``format_stream_error_text``).
+    return _error_response(str(exc), status_code=status_code)
 
 
 async def _stream_events(
@@ -520,7 +508,6 @@ async def _create_streaming_response(
     model: Model,
     messages: list[ModelMessage],
     settings: Optional[ModelSettings],
-    parameters: ModelRequestParameters,
     model_id: str,
     include_usage: bool,
 ) -> Response:
@@ -531,14 +518,14 @@ async def _create_streaming_response(
     # events over a queue, while ``startup`` lets connection and auth failures
     # still surface as proper HTTP errors instead of a 200 that errors
     # mid-body.
-    startup: asyncio.Future[Optional[JSONResponse]] = asyncio.get_running_loop().create_future()
-    # maxsize=1 preserves generator-style backpressure: the provider stream is
-    # consumed no faster than the client reads.
-    events: asyncio.Queue[Optional[str]] = asyncio.Queue(maxsize=1)
+    startup: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    # A small buffer keeps backpressure bounded (memory stays at a handful of
+    # short strings) without forcing a producer/consumer task switch per token.
+    events: asyncio.Queue[Optional[str]] = asyncio.Queue(maxsize=16)
 
     async def produce() -> None:
         try:
-            async with model.request_stream(messages, settings, parameters) as stream:
+            async with model.request_stream(messages, settings, ModelRequestParameters()) as stream:
                 startup.set_result(None)
                 try:
                     async for event in _stream_events(
@@ -556,10 +543,7 @@ async def _create_streaming_response(
             if not startup.done():
                 # Stream entry failed before anything was sent; let the
                 # endpoint turn it into a proper HTTP error response.
-                if isinstance(exc, ModelAPIError):
-                    startup.set_result(_provider_error_response(exc))
-                else:
-                    startup.set_exception(exc)
+                startup.set_exception(exc)
                 return
             logger.exception("Failed to close chat completion stream")
         await events.put("data: [DONE]\n\n")
@@ -567,8 +551,9 @@ async def _create_streaming_response(
 
     producer = asyncio.create_task(produce())
     try:
-        if (error := await startup) is not None:
-            return error
+        await startup
+    except ModelAPIError as exc:
+        return _provider_error_response(exc)
     except BaseException:
         # Startup failed or this request was cancelled; either way the
         # producer must not outlive the request.

--- a/src/phoenix/server/api/routers/v1/chat_completions.py
+++ b/src/phoenix/server/api/routers/v1/chat_completions.py
@@ -25,15 +25,18 @@ response-model-exclusion conventions: OpenAI compatibility fixes the wire
 format, defaults included.
 """
 
+import asyncio
 import json
-from contextlib import AsyncExitStack
+import logging
 from secrets import token_hex
-from typing import Annotated, Any, AsyncIterator, Literal, Optional, Union
+from typing import Annotated, Any, AsyncIterator, Callable, Coroutine, Literal, Optional, Union
 
 from fastapi import APIRouter, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from fastapi.routing import APIRoute
 from pydantic import Field
-from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 from pydantic_ai.messages import (
     FinishReason,
     ModelMessage,
@@ -48,9 +51,10 @@ from pydantic_ai.messages import (
 from pydantic_ai.messages import (
     ModelResponse as PydanticAIModelResponse,
 )
-from pydantic_ai.models import Model, ModelRequestParameters
+from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
 from pydantic_ai.settings import ModelSettings, merge_model_settings
 from pydantic_ai.usage import RequestUsage
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.agents.exceptions import AgentError
@@ -61,9 +65,8 @@ from phoenix.server.agents.model_selection import (
     CustomProviderModelSelection,
 )
 from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
-from phoenix.server.api.routers.v1.utils import add_errors_to_responses
 
-router = APIRouter(tags=["chat_completions"])
+logger = logging.getLogger(__name__)
 
 _CUSTOM_PROVIDER_PREFIX = "custom"
 
@@ -91,6 +94,22 @@ class _ChatCompletionError(Exception):
         self.error_type = error_type
         self.code = code
 
+    def to_response(self) -> JSONResponse:
+        return _error_response(
+            str(self), status_code=self.status_code, error_type=self.error_type, code=self.code
+        )
+
+
+class ChatCompletionErrorDetail(V1RoutesBaseModel):
+    message: str
+    type: str
+    param: Optional[str] = None
+    code: Optional[str] = None
+
+
+class ChatCompletionErrorResponse(V1RoutesBaseModel):
+    error: ChatCompletionErrorDetail
+
 
 def _error_response(
     message: str,
@@ -99,10 +118,55 @@ def _error_response(
     error_type: str,
     code: Optional[str] = None,
 ) -> JSONResponse:
-    return JSONResponse(
-        {"error": {"message": message, "type": error_type, "param": None, "code": code}},
-        status_code=status_code,
+    body = ChatCompletionErrorResponse(
+        error=ChatCompletionErrorDetail(message=message, type=error_type, code=code)
     )
+    return JSONResponse(body.model_dump(), status_code=status_code)
+
+
+def _validation_error_message(exc: RequestValidationError) -> str:
+    problems = []
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error.get("loc", ()) if part != "body")
+        message = error.get("msg", "Invalid value")
+        problems.append(f"{location}: {message}" if location else message)
+    return "; ".join(problems) or "Invalid request body."
+
+
+class _OpenAIErrorAPIRoute(APIRoute):
+    """Route class that keeps every failure in the OpenAI error shape.
+
+    FastAPI renders request-validation failures as ``{"detail": [...]}`` and
+    unhandled exceptions as bare 500s, neither of which OpenAI clients can
+    parse. Convert both into ``{"error": {...}}`` payloads here so the error
+    contract holds on every path out of the endpoint.
+    """
+
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        handler = super().get_route_handler()
+
+        async def handle_with_openai_errors(request: Request) -> Response:
+            try:
+                return await handler(request)
+            except StarletteHTTPException:
+                # Auth and framework-level errors keep their app-wide handling.
+                raise
+            except RequestValidationError as exc:
+                return _error_response(
+                    _validation_error_message(exc),
+                    status_code=422,
+                    error_type="invalid_request_error",
+                )
+            except Exception:
+                logger.exception("Unhandled error in chat completions endpoint")
+                return _error_response(
+                    "Internal server error.", status_code=500, error_type="api_error"
+                )
+
+        return handle_with_openai_errors
+
+
+router = APIRouter(tags=["chat_completions"], route_class=_OpenAIErrorAPIRoute)
 
 
 class ChatCompletionTextPart(V1RoutesBaseModel):
@@ -113,6 +177,10 @@ class ChatCompletionTextPart(V1RoutesBaseModel):
 class ChatCompletionRequestMessage(V1RoutesBaseModel):
     role: Literal["system", "developer", "user", "assistant"]
     content: Union[str, list[ChatCompletionTextPart]]
+
+
+class ChatCompletionStreamOptions(V1RoutesBaseModel):
+    include_usage: bool = False
 
 
 class CreateChatCompletionRequestBody(V1RoutesBaseModel):
@@ -128,7 +196,7 @@ class CreateChatCompletionRequestBody(V1RoutesBaseModel):
     presence_penalty: Optional[float] = None
     seed: Optional[int] = None
     n: Optional[int] = None
-    stream_options: Optional[dict[str, Any]] = None
+    stream_options: Optional[ChatCompletionStreamOptions] = None
     tools: Optional[list[Any]] = None
     tool_choice: Optional[Any] = None
     response_format: Optional[dict[str, Any]] = None
@@ -160,22 +228,22 @@ class ChatCompletion(V1RoutesBaseModel):
     usage: ChatCompletionUsage
 
 
+def _unknown_model_error(model_id: str) -> _ChatCompletionError:
+    return _ChatCompletionError(
+        f"Unknown model {model_id!r}. {_MODEL_FORMAT_HELP}",
+        status_code=404,
+        code="model_not_found",
+    )
+
+
 def _parse_model_id(model_id: str) -> AgentModelSelection:
     prefix, sep, remainder = model_id.partition(":")
     if not sep or not prefix or not remainder:
-        raise _ChatCompletionError(
-            f"Unknown model {model_id!r}. {_MODEL_FORMAT_HELP}",
-            status_code=404,
-            code="model_not_found",
-        )
-    if prefix == _CUSTOM_PROVIDER_PREFIX:
+        raise _unknown_model_error(model_id)
+    if prefix.lower() == _CUSTOM_PROVIDER_PREFIX:
         provider_id, sep, model_name = remainder.partition(":")
         if not sep or not provider_id or not model_name:
-            raise _ChatCompletionError(
-                f"Unknown model {model_id!r}. {_MODEL_FORMAT_HELP}",
-                status_code=404,
-                code="model_not_found",
-            )
+            raise _unknown_model_error(model_id)
         return CustomProviderModelSelection(
             provider_type="custom",
             provider_id=provider_id,
@@ -212,6 +280,11 @@ def _reject_unsupported_parameters(body: CreateChatCompletionRequestBody) -> Non
             "Only response_format of type 'text' is supported.",
             status_code=400,
         )
+    if body.stream_options is not None and not body.stream:
+        raise _ChatCompletionError(
+            "stream_options is only allowed when stream is true.",
+            status_code=400,
+        )
 
 
 def _content_to_text(content: Union[str, list[ChatCompletionTextPart]]) -> str:
@@ -237,7 +310,10 @@ def _to_pydantic_ai_messages(
 
 def _to_model_settings(body: CreateChatCompletionRequestBody) -> Optional[ModelSettings]:
     settings: ModelSettings = {}
-    if (max_tokens := body.max_completion_tokens or body.max_tokens) is not None:
+    max_tokens = (
+        body.max_completion_tokens if body.max_completion_tokens is not None else body.max_tokens
+    )
+    if max_tokens is not None:
         settings["max_tokens"] = max_tokens
     if body.temperature is not None:
         settings["temperature"] = body.temperature
@@ -290,7 +366,9 @@ def _sse_event(payload: dict[str, Any]) -> str:
     response_model=None,
     responses={
         200: {"model": ChatCompletion},
-        **add_errors_to_responses([400, 404, 422]),
+        400: {"model": ChatCompletionErrorResponse},
+        404: {"model": ChatCompletionErrorResponse},
+        422: {"model": ChatCompletionErrorResponse},
     },
     summary="OpenAI-compatible chat completions",
     description=(
@@ -310,9 +388,7 @@ async def create_chat_completion(
         selection = _parse_model_id(body.model)
         _reject_unsupported_parameters(body)
     except _ChatCompletionError as exc:
-        return _error_response(
-            str(exc), status_code=exc.status_code, error_type=exc.error_type, code=exc.code
-        )
+        return exc.to_response()
     try:
         # The session is only needed to resolve the model definition and its
         # credentials; release it before any provider call so a slow LLM
@@ -329,6 +405,11 @@ async def create_chat_completion(
             status_code=exc.status_code,
             error_type="invalid_request_error" if exc.status_code < 500 else "api_error",
         )
+    except ValueError:
+        # A malformed custom provider_id fails Global ID parsing inside
+        # build_model with a ValueError before any AgentError can be raised;
+        # to the caller it is simply an unknown model.
+        return _unknown_model_error(body.model).to_response()
     messages = _to_pydantic_ai_messages(body.messages)
     # Honor settings attached to the model itself (e.g. the Anthropic
     # max_tokens floor) the same way an agent run would.
@@ -341,10 +422,11 @@ async def create_chat_completion(
             settings=settings,
             parameters=parameters,
             model_id=body.model,
+            include_usage=body.stream_options is not None and body.stream_options.include_usage,
         )
     try:
         response = await model.request(messages, settings, parameters)
-    except ModelHTTPError as exc:
+    except ModelAPIError as exc:
         return _provider_error_response(exc)
     completion = ChatCompletion(
         id=_completion_id(response.provider_response_id),
@@ -361,15 +443,62 @@ async def create_chat_completion(
     return JSONResponse(completion.model_dump())
 
 
-def _provider_error_response(exc: ModelHTTPError) -> JSONResponse:
-    # Surface the provider's own status when it is a valid HTTP error code so
-    # callers can tell a bad model name (404) from bad server credentials (401).
-    status_code = exc.status_code if 400 <= exc.status_code < 600 else 502
+def _provider_error_response(exc: ModelAPIError) -> JSONResponse:
+    if isinstance(exc, ModelHTTPError):
+        # Surface the provider's own status when it is a valid HTTP error code
+        # so callers can tell a bad model name (404) from bad server
+        # credentials (401).
+        status_code = exc.status_code if 400 <= exc.status_code < 600 else 502
+    else:
+        # Connection-level failure (DNS, refused connection, timeout): the
+        # provider never answered, which makes this proxy a bad gateway.
+        status_code = 502
     return _error_response(
         str(exc),
         status_code=status_code,
         error_type="invalid_request_error" if status_code < 500 else "api_error",
     )
+
+
+async def _stream_events(
+    stream: StreamedResponse,
+    *,
+    model_id: str,
+    include_usage: bool,
+) -> AsyncIterator[str]:
+    """Render an entered model stream as OpenAI ``chat.completion.chunk`` SSE events."""
+    envelope: dict[str, Any] = {
+        "id": _completion_id(stream.provider_response_id),
+        "object": "chat.completion.chunk",
+        "created": int(stream.timestamp.timestamp()),
+        "model": model_id,
+    }
+
+    def chunk(delta: dict[str, Any], finish_reason: Optional[str] = None) -> str:
+        payload = {
+            **envelope,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+        if include_usage:
+            # Per stream_options.include_usage, every chunk carries a null
+            # usage; the numbers arrive in a dedicated final chunk.
+            payload["usage"] = None
+        return _sse_event(payload)
+
+    yield chunk({"role": "assistant", "content": ""})
+    async for event in stream:
+        text: Optional[str] = None
+        if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
+            text = event.part.content
+        elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+            text = event.delta.content_delta
+        if text:
+            yield chunk({"content": text})
+    yield chunk({}, finish_reason=_to_openai_finish_reason(stream.finish_reason))
+    if include_usage:
+        yield _sse_event(
+            {**envelope, "choices": [], "usage": _to_openai_usage(stream.usage).model_dump()}
+        )
 
 
 async def _create_streaming_response(
@@ -379,72 +508,70 @@ async def _create_streaming_response(
     settings: Optional[ModelSettings],
     parameters: ModelRequestParameters,
     model_id: str,
+    include_usage: bool,
 ) -> Response:
-    stack = AsyncExitStack()
+    # The OpenInference span inside ``model.request_stream`` attaches OTel
+    # context on entry and must detach it in the task that attached it, but
+    # starlette consumes streaming bodies in a child task. A dedicated producer
+    # task therefore owns the stream's entire lifecycle and hands rendered SSE
+    # events over a queue, while ``startup`` lets connection and auth failures
+    # still surface as proper HTTP errors instead of a 200 that errors
+    # mid-body.
+    startup: asyncio.Future[Optional[JSONResponse]] = asyncio.get_running_loop().create_future()
+    # maxsize=1 preserves generator-style backpressure: the provider stream is
+    # consumed no faster than the client reads.
+    events: asyncio.Queue[Optional[str]] = asyncio.Queue(maxsize=1)
+
+    async def produce() -> None:
+        try:
+            async with model.request_stream(messages, settings, parameters) as stream:
+                startup.set_result(None)
+                try:
+                    async for event in _stream_events(
+                        stream, model_id=model_id, include_usage=include_usage
+                    ):
+                        await events.put(event)
+                except Exception as exc:
+                    # The 200 header is already on the wire — surface the
+                    # failure as an OpenAI-style error event rather than
+                    # severing the connection.
+                    await events.put(
+                        _sse_event({"error": {"message": str(exc), "type": "api_error"}})
+                    )
+        except Exception as exc:
+            if not startup.done():
+                # Stream entry failed before anything was sent; let the
+                # endpoint turn it into a proper HTTP error response.
+                if isinstance(exc, ModelAPIError):
+                    startup.set_result(_provider_error_response(exc))
+                else:
+                    startup.set_exception(exc)
+                return
+            logger.exception("Failed to close chat completion stream")
+        await events.put("data: [DONE]\n\n")
+        await events.put(None)
+
+    producer = asyncio.create_task(produce())
     try:
-        # Enter the stream before responding so connection and auth failures
-        # surface as proper HTTP errors instead of a 200 that errors mid-body.
-        stream = await stack.enter_async_context(
-            model.request_stream(messages, settings, parameters)
-        )
-    except ModelHTTPError as exc:
-        await stack.aclose()
-        return _provider_error_response(exc)
+        if (error := await startup) is not None:
+            return error
     except BaseException:
-        await stack.aclose()
+        # Startup failed or this request was cancelled; either way the
+        # producer must not outlive the request.
+        producer.cancel()
         raise
 
-    completion_id = _completion_id(stream.provider_response_id)
-    created = int(stream.timestamp.timestamp())
-
-    def chunk(delta: dict[str, Any], finish_reason: Optional[str] = None) -> str:
-        return _sse_event(
-            {
-                "id": completion_id,
-                "object": "chat.completion.chunk",
-                "created": created,
-                "model": model_id,
-                "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
-            }
-        )
-
-    async def stream_chunks() -> AsyncIterator[str]:
+    async def stream_body() -> AsyncIterator[str]:
         try:
-            yield chunk({"role": "assistant", "content": ""})
-            async for event in stream:
-                text: Optional[str] = None
-                if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
-                    text = event.part.content
-                elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
-                    text = event.delta.content_delta
-                if text:
-                    yield chunk({"content": text})
-            yield _sse_event(
-                {
-                    "id": completion_id,
-                    "object": "chat.completion.chunk",
-                    "created": created,
-                    "model": model_id,
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {},
-                            "finish_reason": _to_openai_finish_reason(stream.finish_reason),
-                        }
-                    ],
-                    "usage": _to_openai_usage(stream.usage).model_dump(),
-                }
-            )
-        except Exception as exc:
-            # The 200 header is already on the wire — surface the failure as an
-            # OpenAI-style error event rather than severing the connection.
-            yield _sse_event({"error": {"message": str(exc), "type": "api_error"}})
+            while (event := await events.get()) is not None:
+                yield event
         finally:
-            await stack.aclose()
-        yield "data: [DONE]\n\n"
+            # Client disconnects cancel this generator; take the producer (and
+            # the provider stream it holds open) down with it.
+            producer.cancel()
 
     return StreamingResponse(
-        stream_chunks(),
+        stream_body(),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache"},
     )

--- a/src/phoenix/server/api/routers/v1/chat_completions.py
+++ b/src/phoenix/server/api/routers/v1/chat_completions.py
@@ -1,28 +1,23 @@
-"""
-OpenAI-compatible chat completions endpoint that proxies to configured LLM providers.
+"""OpenAI-compatible ``POST /v1/chat/completions`` proxy.
 
-``POST /v1/chat/completions`` speaks the OpenAI chat completions wire format —
-request and response bodies, SSE streaming, and ``{"error": {...}}`` payloads —
-so any OpenAI client (the openai SDKs, the Vercel AI SDK's ``openai-compatible``
-provider, curl) can point its base URL at ``{origin}/v1`` and call the models
-Phoenix knows about. Credentials never reach the caller: the ``model`` string
-selects a Phoenix model definition and the server resolves the provider
-credentials exactly like the agents endpoints do (secret store first, process
-environment second) via :func:`phoenix.server.agents.model_factory.build_model`.
+Speaks the OpenAI wire format (request/response bodies, SSE streaming, and
+``{"error": {...}}`` payloads) so any OpenAI client can point its base URL at
+``{origin}/v1``. The ``model`` string selects a Phoenix model definition; the
+server resolves provider credentials the same way the agents endpoints do
+(secret store first, environment second) via
+:func:`phoenix.server.agents.model_factory.build_model`, so callers never
+handle API keys.
 
-The ``model`` string formats:
+The ``model`` string has two formats:
 
-- ``{provider}:{model_name}`` — a built-in provider, e.g. ``openai:gpt-4o``,
-  ``anthropic:claude-sonnet-4-5``, ``ollama:llama3:8b``. The provider segment is
-  matched case-insensitively against :class:`ModelProvider`; everything after
-  the first colon is the provider's model name, so model names containing
-  colons survive intact.
-- ``custom:{provider_id}:{model_name}`` — a stored custom provider record,
-  where ``provider_id`` is the ``GenerativeModelCustomProvider`` Global ID.
+- ``{provider}:{model_name}`` — a built-in provider, e.g. ``openai:gpt-4o``.
+  The provider is matched case-insensitively against :class:`ModelProvider`;
+  everything after the first colon is the model name (colons survive intact).
+- ``custom:{provider_id}:{model_name}`` — a stored custom provider, where
+  ``provider_id`` is the ``GenerativeModelCustomProvider`` Global ID.
 
-This module deliberately deviates from the v1 ``{"data": ...}`` envelope and
-response-model-exclusion conventions: OpenAI compatibility fixes the wire
-format, defaults included.
+Unlike other v1 routes, this endpoint keeps the OpenAI wire format verbatim
+instead of the ``{"data": ...}`` envelope and default-exclusion conventions.
 """
 
 import asyncio

--- a/src/phoenix/server/api/routers/v1/chat_completions.py
+++ b/src/phoenix/server/api/routers/v1/chat_completions.py
@@ -1,24 +1,4 @@
-"""OpenAI-compatible ``POST /v1/chat/completions`` proxy.
-
-Speaks the OpenAI wire format (request/response bodies, SSE streaming, and
-``{"error": {...}}`` payloads) so any OpenAI client can point its base URL at
-``{origin}/v1``. The ``model`` string selects a Phoenix model definition; the
-server resolves provider credentials the same way the agents endpoints do
-(secret store first, environment second) via
-:func:`phoenix.server.agents.model_factory.build_model`, so callers never
-handle API keys.
-
-The ``model`` string has two formats:
-
-- ``{provider}:{model_name}`` — a built-in provider, e.g. ``openai:gpt-4o``.
-  The provider is matched case-insensitively against :class:`ModelProvider`;
-  everything after the first colon is the model name (colons survive intact).
-- ``custom:{provider_id}:{model_name}`` — a stored custom provider, where
-  ``provider_id`` is the ``GenerativeModelCustomProvider`` Global ID.
-
-Unlike other v1 routes, this endpoint keeps the OpenAI wire format verbatim
-instead of the ``{"data": ...}`` envelope and default-exclusion conventions.
-"""
+"""OpenAI-compatible ``POST /v1/chat/completions`` proxy."""
 
 import asyncio
 import json
@@ -50,6 +30,7 @@ from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
 from pydantic_ai.settings import ModelSettings, merge_model_settings
 from pydantic_ai.usage import RequestUsage
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_502_BAD_GATEWAY
 
 from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.agents.exceptions import AgentError
@@ -126,13 +107,7 @@ def _validation_error_message(exc: RequestValidationError) -> str:
 
 
 class _OpenAIErrorAPIRoute(APIRoute):
-    """Route class that keeps every failure in the OpenAI error shape.
-
-    FastAPI renders request-validation failures as ``{"detail": [...]}`` and
-    unhandled exceptions as bare 500s, neither of which OpenAI clients can
-    parse. Convert both into ``{"error": {...}}`` payloads here so the error
-    contract holds on every path out of the endpoint.
-    """
+    """Route class that keeps every failure in the OpenAI error shape."""
 
     def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
         handler = super().get_route_handler()
@@ -145,7 +120,6 @@ class _OpenAIErrorAPIRoute(APIRoute):
                     str(exc), status_code=exc.status_code, error_type=exc.error_type, code=exc.code
                 )
             except StarletteHTTPException:
-                # Auth and framework-level errors keep their app-wide handling.
                 raise
             except RequestValidationError as exc:
                 return _error_response(
@@ -238,6 +212,26 @@ class ChatCompletion(V1RoutesBaseModel):
     usage: ChatCompletionUsage
 
 
+class ChatCompletionChunkDelta(V1RoutesBaseModel):
+    role: Optional[Literal["assistant"]] = None
+    content: Optional[str] = None
+
+
+class ChatCompletionChunkChoice(V1RoutesBaseModel):
+    index: int = 0
+    delta: ChatCompletionChunkDelta
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionChunk(V1RoutesBaseModel):
+    id: str
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: list[ChatCompletionChunkChoice]
+    usage: Optional[ChatCompletionUsage] = None
+
+
 def _unknown_model_error(model_id: str) -> _ChatCompletionError:
     return _ChatCompletionError(
         f"Unknown model {model_id!r}. {_MODEL_FORMAT_HELP}",
@@ -271,8 +265,6 @@ def _parse_model_id(model_id: str) -> AgentModelSelection:
         provider_type="builtin",
         provider=provider,
         model_name=remainder,
-        # This surface *is* a chat completions API; bridge OpenAI through the
-        # same API type rather than translating to the Responses API.
         openai_api_type="chat_completions",
     )
 
@@ -341,8 +333,6 @@ def _to_model_settings(body: CreateChatCompletionRequestBody) -> Optional[ModelS
 
 
 def _to_openai_finish_reason(finish_reason: Optional[FinishReason]) -> str:
-    # Providers don't always report one; OpenAI clients expect a terminal
-    # finish_reason, so default to a normal stop.
     if finish_reason is None or finish_reason == "error":
         return "stop"
     if finish_reason == "tool_call":
@@ -397,9 +387,6 @@ async def create_chat_completion(
     selection = _parse_model_id(body.model)
     _reject_unsupported_parameters(body)
     try:
-        # The session is only needed to resolve the model definition and its
-        # credentials; release it before any provider call so a slow LLM
-        # response never holds a database connection.
         async with request.app.state.db() as session:
             model = await build_model(
                 selection,
@@ -409,16 +396,8 @@ async def create_chat_completion(
     except AgentError as exc:
         return _error_response(str(exc), status_code=exc.status_code)
     except ValueError:
-        # A malformed custom provider_id fails Global ID parsing inside
-        # build_model with a raw ValueError before any AgentError can be
-        # raised; to the caller it is simply an unknown model. TODO: move
-        # this into build_model (raise ProviderNotFoundError) in a follow-up
-        # PR — that change touches the shared agents module and is gated
-        # separately by the PXI eval suite.
         raise _unknown_model_error(body.model) from None
     messages = _to_pydantic_ai_messages(body.messages)
-    # Honor settings attached to the model itself (e.g. the Anthropic
-    # max_tokens floor) the same way an agent run would.
     settings = merge_model_settings(model.settings, _to_model_settings(body))
     if body.stream:
         return await _create_streaming_response(
@@ -444,25 +423,25 @@ async def create_chat_completion(
         ],
         usage=_to_openai_usage(response.usage),
     )
-    # Serialize straight to JSON bytes in one pass rather than model_dump()
-    # into a dict that JSONResponse walks a second time.
     return Response(completion.model_dump_json(), media_type="application/json")
+
+
+_HTTP_STATUS_CODE_LIMIT = 600
 
 
 def _provider_error_response(exc: ModelAPIError) -> JSONResponse:
     if isinstance(exc, ModelHTTPError):
-        # Surface the provider's own status when it is a valid HTTP error code
-        # so callers can tell a bad model name (404) from bad server
-        # credentials (401).
-        status_code = exc.status_code if 400 <= exc.status_code < 600 else 502
+        provider_status_code = exc.status_code
+        provider_status_is_forwardable = (
+            HTTP_400_BAD_REQUEST <= provider_status_code < _HTTP_STATUS_CODE_LIMIT
+        )
+        response_status_code = (
+            provider_status_code if provider_status_is_forwardable else HTTP_502_BAD_GATEWAY
+        )
     else:
-        # Connection-level failure (DNS, refused connection, timeout): the
-        # provider never answered, which makes this proxy a bad gateway.
-        status_code = 502
-    # Pass the provider's message through verbatim — OpenAI-compatible callers
-    # handle these programmatically, unlike the agents surface, which rewrites
-    # them into UI-facing remediation text (``format_stream_error_text``).
-    return _error_response(str(exc), status_code=status_code)
+        # The provider never answered (DNS failure, refused connection, timeout).
+        response_status_code = HTTP_502_BAD_GATEWAY
+    return _error_response(str(exc), status_code=response_status_code)
 
 
 async def _stream_events(
@@ -472,25 +451,33 @@ async def _stream_events(
     include_usage: bool,
 ) -> AsyncIterator[str]:
     """Render an entered model stream as OpenAI ``chat.completion.chunk`` SSE events."""
-    envelope: dict[str, Any] = {
-        "id": _completion_id(stream.provider_response_id),
-        "object": "chat.completion.chunk",
-        "created": int(stream.timestamp.timestamp()),
-        "model": model_id,
-    }
+    completion_id = _completion_id(stream.provider_response_id)
+    created = int(stream.timestamp.timestamp())
 
-    def chunk(delta: dict[str, Any], finish_reason: Optional[str] = None) -> str:
-        payload = {
-            **envelope,
-            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
-        }
+    def sse_chunk(
+        choices: list[ChatCompletionChunkChoice],
+        usage: Optional[ChatCompletionUsage] = None,
+    ) -> str:
+        chunk = ChatCompletionChunk(
+            id=completion_id,
+            object="chat.completion.chunk",
+            created=created,
+            model=model_id,
+            choices=choices,
+        )
         if include_usage:
-            # Per stream_options.include_usage, every chunk carries a null
-            # usage; the numbers arrive in a dedicated final chunk.
-            payload["usage"] = None
-        return _sse_event(payload)
+            chunk.usage = usage
+        return _sse_event(chunk.model_dump(exclude_unset=True))
 
-    yield chunk({"role": "assistant", "content": ""})
+    def delta_chunk(
+        delta: ChatCompletionChunkDelta,
+        finish_reason: Optional[str] = None,
+    ) -> str:
+        return sse_chunk(
+            [ChatCompletionChunkChoice(index=0, delta=delta, finish_reason=finish_reason)]
+        )
+
+    yield delta_chunk(ChatCompletionChunkDelta(role="assistant", content=""))
     async for event in stream:
         text: Optional[str] = None
         if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
@@ -498,12 +485,13 @@ async def _stream_events(
         elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
             text = event.delta.content_delta
         if text:
-            yield chunk({"content": text})
-    yield chunk({}, finish_reason=_to_openai_finish_reason(stream.finish_reason))
+            yield delta_chunk(ChatCompletionChunkDelta(content=text))
+    yield delta_chunk(
+        ChatCompletionChunkDelta(),
+        finish_reason=_to_openai_finish_reason(stream.finish_reason),
+    )
     if include_usage:
-        yield _sse_event(
-            {**envelope, "choices": [], "usage": _to_openai_usage(stream.usage).model_dump()}
-        )
+        yield sse_chunk([], usage=_to_openai_usage(stream.usage))
 
 
 async def _create_streaming_response(
@@ -514,62 +502,45 @@ async def _create_streaming_response(
     model_id: str,
     include_usage: bool,
 ) -> Response:
-    # The OpenInference span inside ``model.request_stream`` attaches OTel
-    # context on entry and must detach it in the task that attached it, but
-    # starlette consumes streaming bodies in a child task. A dedicated producer
-    # task therefore owns the stream's entire lifecycle and hands rendered SSE
-    # events over a queue, while ``startup`` lets connection and auth failures
-    # still surface as proper HTTP errors instead of a 200 that errors
-    # mid-body.
-    startup: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-    # A small buffer keeps backpressure bounded (memory stays at a handful of
-    # short strings) without forcing a producer/consumer task switch per token.
-    events: asyncio.Queue[Optional[str]] = asyncio.Queue(maxsize=16)
+    provider_stream_opened: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    sse_events: asyncio.Queue[Optional[str]] = asyncio.Queue(maxsize=16)
 
     async def produce() -> None:
         try:
             async with model.request_stream(messages, settings, ModelRequestParameters()) as stream:
-                startup.set_result(None)
+                provider_stream_opened.set_result(None)
                 try:
                     async for event in _stream_events(
                         stream, model_id=model_id, include_usage=include_usage
                     ):
-                        await events.put(event)
+                        await sse_events.put(event)
                 except Exception as exc:
-                    # The 200 header is already on the wire — surface the
-                    # failure as an OpenAI-style error event rather than
-                    # severing the connection.
-                    await events.put(
-                        _sse_event({"error": {"message": str(exc), "type": "api_error"}})
+                    error = ChatCompletionErrorResponse(
+                        error=ChatCompletionErrorDetail(message=str(exc), type="api_error")
                     )
+                    await sse_events.put(_sse_event(error.model_dump(exclude_unset=True)))
         except Exception as exc:
-            if not startup.done():
-                # Stream entry failed before anything was sent; let the
-                # endpoint turn it into a proper HTTP error response.
-                startup.set_exception(exc)
+            if not provider_stream_opened.done():
+                provider_stream_opened.set_exception(exc)
                 return
             logger.exception("Failed to close chat completion stream")
-        await events.put("data: [DONE]\n\n")
-        await events.put(None)
+        await sse_events.put("data: [DONE]\n\n")
+        await sse_events.put(None)
 
     producer = asyncio.create_task(produce())
     try:
-        await startup
+        await provider_stream_opened
     except ModelAPIError as exc:
         return _provider_error_response(exc)
     except BaseException:
-        # Startup failed or this request was cancelled; either way the
-        # producer must not outlive the request.
         producer.cancel()
         raise
 
     async def stream_body() -> AsyncIterator[str]:
         try:
-            while (event := await events.get()) is not None:
+            while (event := await sse_events.get()) is not None:
                 yield event
         finally:
-            # Client disconnects cancel this generator; take the producer (and
-            # the provider stream it holds open) down with it.
             producer.cancel()
 
     return StreamingResponse(

--- a/src/phoenix/server/api/routers/v1/chat_completions.py
+++ b/src/phoenix/server/api/routers/v1/chat_completions.py
@@ -35,7 +35,7 @@ from fastapi import APIRouter, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.routing import APIRoute
-from pydantic import Field
+from pydantic import ConfigDict, Field
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 from pydantic_ai.messages import (
     FinishReason,
@@ -200,6 +200,20 @@ class CreateChatCompletionRequestBody(V1RoutesBaseModel):
     tools: Optional[list[Any]] = None
     tool_choice: Optional[Any] = None
     response_format: Optional[dict[str, Any]] = None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "model": "openai:gpt-4o",
+                    "messages": [
+                        {"role": "system", "content": "You are a helpful assistant."},
+                        {"role": "user", "content": "Say hello."},
+                    ],
+                }
+            ]
+        }
+    )
 
 
 class ChatCompletionMessage(V1RoutesBaseModel):

--- a/src/phoenix/server/api/routers/v1/chat_completions.py
+++ b/src/phoenix/server/api/routers/v1/chat_completions.py
@@ -413,6 +413,14 @@ async def create_chat_completion(
             )
     except AgentError as exc:
         return _error_response(str(exc), status_code=exc.status_code)
+    except ValueError:
+        # A malformed custom provider_id fails Global ID parsing inside
+        # build_model with a raw ValueError before any AgentError can be
+        # raised; to the caller it is simply an unknown model. TODO: move
+        # this into build_model (raise ProviderNotFoundError) in a follow-up
+        # PR — that change touches the shared agents module and is gated
+        # separately by the PXI eval suite.
+        raise _unknown_model_error(body.model) from None
     messages = _to_pydantic_ai_messages(body.messages)
     # Honor settings attached to the model itself (e.g. the Anthropic
     # max_tokens floor) the same way an agent run would.

--- a/src/phoenix/server/api/routers/v1/chat_completions.py
+++ b/src/phoenix/server/api/routers/v1/chat_completions.py
@@ -1,0 +1,450 @@
+"""
+OpenAI-compatible chat completions endpoint that proxies to configured LLM providers.
+
+``POST /v1/chat/completions`` speaks the OpenAI chat completions wire format —
+request and response bodies, SSE streaming, and ``{"error": {...}}`` payloads —
+so any OpenAI client (the openai SDKs, the Vercel AI SDK's ``openai-compatible``
+provider, curl) can point its base URL at ``{origin}/v1`` and call the models
+Phoenix knows about. Credentials never reach the caller: the ``model`` string
+selects a Phoenix model definition and the server resolves the provider
+credentials exactly like the agents endpoints do (secret store first, process
+environment second) via :func:`phoenix.server.agents.model_factory.build_model`.
+
+The ``model`` string formats:
+
+- ``{provider}:{model_name}`` — a built-in provider, e.g. ``openai:gpt-4o``,
+  ``anthropic:claude-sonnet-4-5``, ``ollama:llama3:8b``. The provider segment is
+  matched case-insensitively against :class:`ModelProvider`; everything after
+  the first colon is the provider's model name, so model names containing
+  colons survive intact.
+- ``custom:{provider_id}:{model_name}`` — a stored custom provider record,
+  where ``provider_id`` is the ``GenerativeModelCustomProvider`` Global ID.
+
+This module deliberately deviates from the v1 ``{"data": ...}`` envelope and
+response-model-exclusion conventions: OpenAI compatibility fixes the wire
+format, defaults included.
+"""
+
+import json
+from contextlib import AsyncExitStack
+from secrets import token_hex
+from typing import Annotated, Any, AsyncIterator, Literal, Optional, Union
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+from pydantic import Field
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import (
+    FinishReason,
+    ModelMessage,
+    ModelRequest,
+    PartDeltaEvent,
+    PartStartEvent,
+    SystemPromptPart,
+    TextPart,
+    TextPartDelta,
+    UserPromptPart,
+)
+from pydantic_ai.messages import (
+    ModelResponse as PydanticAIModelResponse,
+)
+from pydantic_ai.models import Model, ModelRequestParameters
+from pydantic_ai.settings import ModelSettings, merge_model_settings
+from pydantic_ai.usage import RequestUsage
+
+from phoenix.db.types.model_provider import ModelProvider
+from phoenix.server.agents.exceptions import AgentError
+from phoenix.server.agents.model_factory import build_model
+from phoenix.server.agents.model_selection import (
+    AgentModelSelection,
+    BuiltInProviderModelSelection,
+    CustomProviderModelSelection,
+)
+from phoenix.server.api.routers.v1.models import V1RoutesBaseModel
+from phoenix.server.api.routers.v1.utils import add_errors_to_responses
+
+router = APIRouter(tags=["chat_completions"])
+
+_CUSTOM_PROVIDER_PREFIX = "custom"
+
+_MODEL_FORMAT_HELP = (
+    "Model must be '{provider}:{model_name}' for a built-in provider "
+    f"(one of {', '.join(sorted(p.value.lower() for p in ModelProvider))}) "
+    "or 'custom:{provider_id}:{model_name}' for a stored custom provider, "
+    "e.g. 'openai:gpt-4o' or 'anthropic:claude-sonnet-4-5'."
+)
+
+
+class _ChatCompletionError(Exception):
+    """Maps directly to an OpenAI-style ``{"error": {...}}`` response."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        error_type: str = "invalid_request_error",
+        code: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_type = error_type
+        self.code = code
+
+
+def _error_response(
+    message: str,
+    *,
+    status_code: int,
+    error_type: str,
+    code: Optional[str] = None,
+) -> JSONResponse:
+    return JSONResponse(
+        {"error": {"message": message, "type": error_type, "param": None, "code": code}},
+        status_code=status_code,
+    )
+
+
+class ChatCompletionTextPart(V1RoutesBaseModel):
+    type: Literal["text"]
+    text: str
+
+
+class ChatCompletionRequestMessage(V1RoutesBaseModel):
+    role: Literal["system", "developer", "user", "assistant"]
+    content: Union[str, list[ChatCompletionTextPart]]
+
+
+class CreateChatCompletionRequestBody(V1RoutesBaseModel):
+    model: str = Field(description=_MODEL_FORMAT_HELP)
+    messages: Annotated[list[ChatCompletionRequestMessage], Field(min_length=1)]
+    stream: bool = False
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    max_tokens: Optional[int] = None
+    max_completion_tokens: Optional[int] = None
+    stop: Optional[Union[str, list[str]]] = None
+    frequency_penalty: Optional[float] = None
+    presence_penalty: Optional[float] = None
+    seed: Optional[int] = None
+    n: Optional[int] = None
+    stream_options: Optional[dict[str, Any]] = None
+    tools: Optional[list[Any]] = None
+    tool_choice: Optional[Any] = None
+    response_format: Optional[dict[str, Any]] = None
+
+
+class ChatCompletionMessage(V1RoutesBaseModel):
+    role: Literal["assistant"] = "assistant"
+    content: str
+
+
+class ChatCompletionChoice(V1RoutesBaseModel):
+    index: int = 0
+    message: ChatCompletionMessage
+    finish_reason: str
+
+
+class ChatCompletionUsage(V1RoutesBaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class ChatCompletion(V1RoutesBaseModel):
+    id: str
+    object: Literal["chat.completion"] = "chat.completion"
+    created: int
+    model: str
+    choices: list[ChatCompletionChoice]
+    usage: ChatCompletionUsage
+
+
+def _parse_model_id(model_id: str) -> AgentModelSelection:
+    prefix, sep, remainder = model_id.partition(":")
+    if not sep or not prefix or not remainder:
+        raise _ChatCompletionError(
+            f"Unknown model {model_id!r}. {_MODEL_FORMAT_HELP}",
+            status_code=404,
+            code="model_not_found",
+        )
+    if prefix == _CUSTOM_PROVIDER_PREFIX:
+        provider_id, sep, model_name = remainder.partition(":")
+        if not sep or not provider_id or not model_name:
+            raise _ChatCompletionError(
+                f"Unknown model {model_id!r}. {_MODEL_FORMAT_HELP}",
+                status_code=404,
+                code="model_not_found",
+            )
+        return CustomProviderModelSelection(
+            provider_type="custom",
+            provider_id=provider_id,
+            model_name=model_name,
+        )
+    try:
+        provider = ModelProvider(prefix.upper())
+    except ValueError:
+        raise _ChatCompletionError(
+            f"Unknown model provider {prefix!r} in model {model_id!r}. {_MODEL_FORMAT_HELP}",
+            status_code=404,
+            code="model_not_found",
+        ) from None
+    return BuiltInProviderModelSelection(
+        provider_type="builtin",
+        provider=provider,
+        model_name=remainder,
+        # This surface *is* a chat completions API; bridge OpenAI through the
+        # same API type rather than translating to the Responses API.
+        openai_api_type="chat_completions",
+    )
+
+
+def _reject_unsupported_parameters(body: CreateChatCompletionRequestBody) -> None:
+    if body.tools or body.tool_choice is not None:
+        raise _ChatCompletionError(
+            "Tool calling is not supported by this endpoint.",
+            status_code=400,
+        )
+    if body.n is not None and body.n != 1:
+        raise _ChatCompletionError("Only n=1 is supported.", status_code=400)
+    if body.response_format is not None and body.response_format.get("type", "text") != "text":
+        raise _ChatCompletionError(
+            "Only response_format of type 'text' is supported.",
+            status_code=400,
+        )
+
+
+def _content_to_text(content: Union[str, list[ChatCompletionTextPart]]) -> str:
+    if isinstance(content, str):
+        return content
+    return "".join(part.text for part in content)
+
+
+def _to_pydantic_ai_messages(
+    messages: list[ChatCompletionRequestMessage],
+) -> list[ModelMessage]:
+    out: list[ModelMessage] = []
+    for message in messages:
+        text = _content_to_text(message.content)
+        if message.role in ("system", "developer"):
+            out.append(ModelRequest(parts=[SystemPromptPart(content=text)]))
+        elif message.role == "user":
+            out.append(ModelRequest(parts=[UserPromptPart(content=text)]))
+        else:
+            out.append(PydanticAIModelResponse(parts=[TextPart(content=text)]))
+    return out
+
+
+def _to_model_settings(body: CreateChatCompletionRequestBody) -> Optional[ModelSettings]:
+    settings: ModelSettings = {}
+    if (max_tokens := body.max_completion_tokens or body.max_tokens) is not None:
+        settings["max_tokens"] = max_tokens
+    if body.temperature is not None:
+        settings["temperature"] = body.temperature
+    if body.top_p is not None:
+        settings["top_p"] = body.top_p
+    if body.seed is not None:
+        settings["seed"] = body.seed
+    if body.frequency_penalty is not None:
+        settings["frequency_penalty"] = body.frequency_penalty
+    if body.presence_penalty is not None:
+        settings["presence_penalty"] = body.presence_penalty
+    if body.stop is not None:
+        settings["stop_sequences"] = [body.stop] if isinstance(body.stop, str) else body.stop
+    return settings or None
+
+
+def _to_openai_finish_reason(finish_reason: Optional[FinishReason]) -> str:
+    # Providers don't always report one; OpenAI clients expect a terminal
+    # finish_reason, so default to a normal stop.
+    if finish_reason is None or finish_reason == "error":
+        return "stop"
+    if finish_reason == "tool_call":
+        return "tool_calls"
+    return finish_reason
+
+
+def _to_openai_usage(usage: RequestUsage) -> ChatCompletionUsage:
+    return ChatCompletionUsage(
+        prompt_tokens=usage.input_tokens,
+        completion_tokens=usage.output_tokens,
+        total_tokens=usage.input_tokens + usage.output_tokens,
+    )
+
+
+def _response_text(response: PydanticAIModelResponse) -> str:
+    return "".join(part.content for part in response.parts if isinstance(part, TextPart))
+
+
+def _completion_id(provider_response_id: Optional[str]) -> str:
+    return provider_response_id or f"chatcmpl-{token_hex(12)}"
+
+
+def _sse_event(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
+
+
+@router.post(
+    "/chat/completions",
+    operation_id="createChatCompletion",
+    response_model=None,
+    responses={
+        200: {"model": ChatCompletion},
+        **add_errors_to_responses([400, 404, 422]),
+    },
+    summary="OpenAI-compatible chat completions",
+    description=(
+        "Creates a chat completion using the OpenAI wire format, proxying to the "
+        "selected provider with credentials resolved on the server (secret store "
+        "first, environment second) — callers never handle provider API keys. "
+        f"{_MODEL_FORMAT_HELP} "
+        "Set `stream: true` for server-sent events of `chat.completion.chunk` "
+        "payloads terminated by `data: [DONE]`. Tool calling is not supported."
+    ),
+)
+async def create_chat_completion(
+    request: Request,
+    body: CreateChatCompletionRequestBody,
+) -> Response:
+    try:
+        selection = _parse_model_id(body.model)
+        _reject_unsupported_parameters(body)
+    except _ChatCompletionError as exc:
+        return _error_response(
+            str(exc), status_code=exc.status_code, error_type=exc.error_type, code=exc.code
+        )
+    try:
+        # The session is only needed to resolve the model definition and its
+        # credentials; release it before any provider call so a slow LLM
+        # response never holds a database connection.
+        async with request.app.state.db() as session:
+            model = await build_model(
+                selection,
+                session=session,
+                decrypt=request.app.state.decrypt,
+            )
+    except AgentError as exc:
+        return _error_response(
+            str(exc),
+            status_code=exc.status_code,
+            error_type="invalid_request_error" if exc.status_code < 500 else "api_error",
+        )
+    messages = _to_pydantic_ai_messages(body.messages)
+    # Honor settings attached to the model itself (e.g. the Anthropic
+    # max_tokens floor) the same way an agent run would.
+    settings = merge_model_settings(model.settings, _to_model_settings(body))
+    parameters = ModelRequestParameters()
+    if body.stream:
+        return await _create_streaming_response(
+            model=model,
+            messages=messages,
+            settings=settings,
+            parameters=parameters,
+            model_id=body.model,
+        )
+    try:
+        response = await model.request(messages, settings, parameters)
+    except ModelHTTPError as exc:
+        return _provider_error_response(exc)
+    completion = ChatCompletion(
+        id=_completion_id(response.provider_response_id),
+        created=int(response.timestamp.timestamp()),
+        model=body.model,
+        choices=[
+            ChatCompletionChoice(
+                message=ChatCompletionMessage(content=_response_text(response)),
+                finish_reason=_to_openai_finish_reason(response.finish_reason),
+            )
+        ],
+        usage=_to_openai_usage(response.usage),
+    )
+    return JSONResponse(completion.model_dump())
+
+
+def _provider_error_response(exc: ModelHTTPError) -> JSONResponse:
+    # Surface the provider's own status when it is a valid HTTP error code so
+    # callers can tell a bad model name (404) from bad server credentials (401).
+    status_code = exc.status_code if 400 <= exc.status_code < 600 else 502
+    return _error_response(
+        str(exc),
+        status_code=status_code,
+        error_type="invalid_request_error" if status_code < 500 else "api_error",
+    )
+
+
+async def _create_streaming_response(
+    *,
+    model: Model,
+    messages: list[ModelMessage],
+    settings: Optional[ModelSettings],
+    parameters: ModelRequestParameters,
+    model_id: str,
+) -> Response:
+    stack = AsyncExitStack()
+    try:
+        # Enter the stream before responding so connection and auth failures
+        # surface as proper HTTP errors instead of a 200 that errors mid-body.
+        stream = await stack.enter_async_context(
+            model.request_stream(messages, settings, parameters)
+        )
+    except ModelHTTPError as exc:
+        await stack.aclose()
+        return _provider_error_response(exc)
+    except BaseException:
+        await stack.aclose()
+        raise
+
+    completion_id = _completion_id(stream.provider_response_id)
+    created = int(stream.timestamp.timestamp())
+
+    def chunk(delta: dict[str, Any], finish_reason: Optional[str] = None) -> str:
+        return _sse_event(
+            {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model_id,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+            }
+        )
+
+    async def stream_chunks() -> AsyncIterator[str]:
+        try:
+            yield chunk({"role": "assistant", "content": ""})
+            async for event in stream:
+                text: Optional[str] = None
+                if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
+                    text = event.part.content
+                elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+                    text = event.delta.content_delta
+                if text:
+                    yield chunk({"content": text})
+            yield _sse_event(
+                {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model_id,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": _to_openai_finish_reason(stream.finish_reason),
+                        }
+                    ],
+                    "usage": _to_openai_usage(stream.usage).model_dump(),
+                }
+            )
+        except Exception as exc:
+            # The 200 header is already on the wire — surface the failure as an
+            # OpenAI-style error event rather than severing the connection.
+            yield _sse_event({"error": {"message": str(exc), "type": "api_error"}})
+        finally:
+            await stack.aclose()
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        stream_chunks(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache"},
+    )

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2307,6 +2307,12 @@ _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS = (
 )
 
 
+# POST endpoints that write nothing and are intentionally available to every
+# authenticated role, viewers included — e.g. the OpenAI-compatible LLM proxy,
+# which powers read features like AI search.
+_VIEWER_ALLOWED_WRITE_OPERATIONS = ((422, "POST", "v1/chat/completions"),)
+
+
 # Credential issuance requires a human session (or, where supported, the admin secret).
 # A user API key cannot issue another credential, even when its owner has the required role.
 _SESSION_ONLY_CREDENTIAL_ISSUANCE_OPERATIONS = frozenset(
@@ -2375,6 +2381,7 @@ def _ensure_endpoint_coverage_is_exhaustive() -> None:
             _ADMIN_ONLY_ENDPOINTS,
             _VIEWER_BLOCKED_WRITE_OPERATIONS,
             _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS,
+            _VIEWER_ALLOWED_WRITE_OPERATIONS,
         )
     }
 
@@ -2411,7 +2418,8 @@ def _ensure_endpoint_coverage_is_exhaustive() -> None:
                 f"  - GET routes → _COMMON_RESOURCE_ENDPOINTS\n"
                 f"  - Admin-only routes (users, project CRUD) → _ADMIN_ONLY_ENDPOINTS\n"
                 f"  - Viewer-blocked writes → _VIEWER_BLOCKED_WRITE_OPERATIONS\n"
-                f"  - Viewer credential self-service → _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS\n\n"
+                f"  - Viewer credential self-service → _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS\n"
+                f"  - Viewer-allowed writes (e.g. LLM proxy) → _VIEWER_ALLOWED_WRITE_OPERATIONS\n\n"
                 f"Format: (expected_status_code, method, endpoint_path)\n"
                 f'Example: (404, "GET", "v1/projects/fake-id-{{}}") or (422, "POST", "v1/datasets/upload")'
             )
@@ -2422,8 +2430,8 @@ def _ensure_endpoint_coverage_is_exhaustive() -> None:
             error_parts.append(
                 f"Routes in test constants but NOT in server (removed?):\n{routes_str}\n\n"
                 f"Remove these from _COMMON_RESOURCE_ENDPOINTS, _ADMIN_ONLY_ENDPOINTS,\n"
-                f"_VIEWER_BLOCKED_WRITE_OPERATIONS, or "
-                f"_VIEWER_ALLOWED_CREDENTIAL_OPERATIONS in _helpers.py"
+                f"_VIEWER_BLOCKED_WRITE_OPERATIONS, _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS,\n"
+                f"or _VIEWER_ALLOWED_WRITE_OPERATIONS in _helpers.py"
             )
         raise AssertionError("Endpoint coverage is incomplete!\n\n" + "\n\n".join(error_parts))
 

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2308,8 +2308,7 @@ _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS = (
 
 
 # POST endpoints that write nothing and are intentionally available to every
-# authenticated role, viewers included — e.g. the OpenAI-compatible LLM proxy,
-# which powers read features like AI search.
+# authenticated role, viewers included
 _VIEWER_ALLOWED_WRITE_OPERATIONS = ((422, "POST", "v1/chat/completions"),)
 
 

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -2078,8 +2078,13 @@ class TestApiAccessViaCookiesOrApiKeys:
                         f"for {method} {endpoint}"
                     )
 
-            # Test 4: User credential self-service is available to every human role.
-            for expected_status_code, method, endpoint in _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS:
+            # Test 4: Operations available to every role — credential
+            # self-service and viewer-allowed writes (e.g. the LLM proxy) —
+            # except session-only credential issuance, which API keys cannot use.
+            for expected_status_code, method, endpoint in (
+                *_VIEWER_ALLOWED_CREDENTIAL_OPERATIONS,
+                *_VIEWER_ALLOWED_WRITE_OPERATIONS,
+            ):
                 if (
                     is_api_key
                     and (
@@ -2089,16 +2094,6 @@ class TestApiAccessViaCookiesOrApiKeys:
                     in _SESSION_ONLY_CREDENTIAL_ISSUANCE_OPERATIONS
                 ):
                     expected_status_code = 403
-                endpoint = endpoint.format(token_hex(4))
-                response = client.request(method, endpoint)
-                assert response.status_code == expected_status_code, (
-                    f"Expected {expected_status_code} but got {response.status_code} "
-                    f"for {method} {endpoint}"
-                )
-
-            # Test 5: Viewer-allowed writes (e.g. the LLM proxy) accept every
-            # authenticated principal, API keys included.
-            for expected_status_code, method, endpoint in _VIEWER_ALLOWED_WRITE_OPERATIONS:
                 endpoint = endpoint.format(token_hex(4))
                 response = client.request(method, endpoint)
                 assert response.status_code == expected_status_code, (

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -44,6 +44,7 @@ from .._helpers import (
     _SYSTEM_USER_GID,
     _VIEWER,
     _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS,
+    _VIEWER_ALLOWED_WRITE_OPERATIONS,
     _VIEWER_BLOCKED_WRITE_OPERATIONS,
     _AccessToken,
     _AdminSecret,
@@ -2088,6 +2089,16 @@ class TestApiAccessViaCookiesOrApiKeys:
                     in _SESSION_ONLY_CREDENTIAL_ISSUANCE_OPERATIONS
                 ):
                     expected_status_code = 403
+                endpoint = endpoint.format(token_hex(4))
+                response = client.request(method, endpoint)
+                assert response.status_code == expected_status_code, (
+                    f"Expected {expected_status_code} but got {response.status_code} "
+                    f"for {method} {endpoint}"
+                )
+
+            # Test 5: Viewer-allowed writes (e.g. the LLM proxy) accept every
+            # authenticated principal, API keys included.
+            for expected_status_code, method, endpoint in _VIEWER_ALLOWED_WRITE_OPERATIONS:
                 endpoint = endpoint.format(token_hex(4))
                 response = client.request(method, endpoint)
                 assert response.status_code == expected_status_code, (

--- a/tests/integration/server/test_launch_app.py
+++ b/tests/integration/server/test_launch_app.py
@@ -23,6 +23,7 @@ from .._helpers import (
     _AUTH_REQUIRED_ENDPOINTS,
     _COMMON_RESOURCE_ENDPOINTS,
     _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS,
+    _VIEWER_ALLOWED_WRITE_OPERATIONS,
     _VIEWER_BLOCKED_WRITE_OPERATIONS,
     _AppInfo,
     _get,
@@ -217,6 +218,7 @@ class TestLaunchApp:
             _ADMIN_ONLY_ENDPOINTS,
             _VIEWER_BLOCKED_WRITE_OPERATIONS,
             _VIEWER_ALLOWED_CREDENTIAL_OPERATIONS,
+            _VIEWER_ALLOWED_WRITE_OPERATIONS,
         ):
             # Credential-issuing endpoints fail closed when authentication is disabled,
             # rather than returning the status they would under an authenticated app.

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator, Union
+
+import httpx
+import pytest
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, DeltaToolCalls, FunctionModel
+from strawberry.relay import GlobalID
+
+import phoenix.server.api.routers.v1.chat_completions as chat_completions_module
+from phoenix.db.types.model_provider import ModelProvider
+from phoenix.server.agents.model_selection import (
+    AgentModelSelection,
+    BuiltInProviderModelSelection,
+    CustomProviderModelSelection,
+)
+
+_ANSWER = "span_kind == 'LLM'"
+_STREAM_DELTAS = ("span_kind ", "== ", "'LLM'")
+
+
+class _BuildModelSpy:
+    """Stands in for ``build_model``: records the parsed selection and the
+    messages the endpoint hands to the provider, and serves canned output."""
+
+    def __init__(self) -> None:
+        self.selections: list[AgentModelSelection] = []
+        self.messages: list[ModelMessage] = []
+
+    async def __call__(self, selection: AgentModelSelection, **_: Any) -> FunctionModel:
+        self.selections.append(selection)
+
+        def respond(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            self.messages = messages
+            return ModelResponse(parts=[TextPart(content=_ANSWER)])
+
+        async def respond_stream(
+            messages: list[ModelMessage], _info: AgentInfo
+        ) -> AsyncIterator[Union[str, DeltaToolCalls]]:
+            self.messages = messages
+            for delta in _STREAM_DELTAS:
+                yield delta
+
+        return FunctionModel(function=respond, stream_function=respond_stream)
+
+
+@pytest.fixture
+def build_model_spy(monkeypatch: pytest.MonkeyPatch) -> _BuildModelSpy:
+    spy = _BuildModelSpy()
+    monkeypatch.setattr(chat_completions_module, "build_model", spy)
+    return spy
+
+
+def _request_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": "anthropic:claude-sonnet-4-5",
+        "messages": [
+            {"role": "system", "content": "Translate the request into a filter expression."},
+            {"role": "user", "content": "llm spans"},
+        ],
+    }
+    body.update(overrides)
+    return body
+
+
+def _data_events(sse_text: str) -> list[str]:
+    return [line[len("data: ") :] for line in sse_text.splitlines() if line.startswith("data: ")]
+
+
+class TestCreateChatCompletion:
+    async def test_returns_openai_response_shape(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        response = await httpx_client.post("v1/chat/completions", json=_request_body())
+        assert response.status_code == 200, response.text
+        completion = response.json()
+        assert completion["id"].startswith("chatcmpl-")
+        assert completion["object"] == "chat.completion"
+        assert completion["model"] == "anthropic:claude-sonnet-4-5"
+        (choice,) = completion["choices"]
+        assert choice["index"] == 0
+        assert choice["message"] == {"role": "assistant", "content": _ANSWER}
+        assert choice["finish_reason"] == "stop"
+        usage = completion["usage"]
+        assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+    async def test_resolves_builtin_model_selection_and_messages(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        body = _request_body(
+            messages=[
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": [{"type": "text", "text": "llm spans"}]},
+                {"role": "assistant", "content": "span_kind"},
+                {"role": "user", "content": "fix it"},
+            ]
+        )
+        response = await httpx_client.post("v1/chat/completions", json=body)
+        assert response.status_code == 200, response.text
+
+        (selection,) = build_model_spy.selections
+        assert isinstance(selection, BuiltInProviderModelSelection)
+        assert selection.provider is ModelProvider.ANTHROPIC
+        assert selection.model_name == "claude-sonnet-4-5"
+        assert selection.openai_api_type == "chat_completions"
+
+        system, user, assistant, followup = build_model_spy.messages
+        assert isinstance(system, ModelRequest)
+        assert isinstance(system.parts[0], SystemPromptPart)
+        assert system.parts[0].content == "be terse"
+        assert isinstance(user, ModelRequest)
+        assert isinstance(user.parts[0], UserPromptPart)
+        assert user.parts[0].content == "llm spans"
+        assert isinstance(assistant, ModelResponse)
+        assert isinstance(assistant.parts[0], TextPart)
+        assert assistant.parts[0].content == "span_kind"
+        assert isinstance(followup, ModelRequest)
+        assert isinstance(followup.parts[0], UserPromptPart)
+
+    async def test_model_name_keeps_colons(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/chat/completions", json=_request_body(model="ollama:llama3:8b")
+        )
+        assert response.status_code == 200, response.text
+        (selection,) = build_model_spy.selections
+        assert isinstance(selection, BuiltInProviderModelSelection)
+        assert selection.provider is ModelProvider.OLLAMA
+        assert selection.model_name == "llama3:8b"
+
+    async def test_custom_provider_model_selection(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        provider_id = str(GlobalID("GenerativeModelCustomProvider", "7"))
+        response = await httpx_client.post(
+            "v1/chat/completions",
+            json=_request_body(model=f"custom:{provider_id}:my-model"),
+        )
+        assert response.status_code == 200, response.text
+        (selection,) = build_model_spy.selections
+        assert isinstance(selection, CustomProviderModelSelection)
+        assert selection.provider_id == provider_id
+        assert selection.model_name == "my-model"
+
+    async def test_streaming_emits_openai_chunks(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        response = await httpx_client.post("v1/chat/completions", json=_request_body(stream=True))
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        events = _data_events(response.text)
+        assert events[-1] == "[DONE]"
+        chunks = [json.loads(event) for event in events[:-1]]
+        assert all(chunk["object"] == "chat.completion.chunk" for chunk in chunks)
+        assert all(chunk["model"] == "anthropic:claude-sonnet-4-5" for chunk in chunks)
+        assert len({chunk["id"] for chunk in chunks}) == 1
+
+        assert chunks[0]["choices"][0]["delta"]["role"] == "assistant"
+        content = "".join(chunk["choices"][0]["delta"].get("content", "") for chunk in chunks)
+        assert content == "".join(_STREAM_DELTAS)
+
+        final = chunks[-1]["choices"][0]
+        assert final["delta"] == {}
+        assert final["finish_reason"] == "stop"
+        usage = chunks[-1]["usage"]
+        assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4o",  # no provider prefix
+            "not-a-provider:gpt-4o",
+            "custom:only-an-id",
+            "openai:",
+        ],
+    )
+    async def test_unknown_model_returns_openai_error(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+        model: str,
+    ) -> None:
+        response = await httpx_client.post("v1/chat/completions", json=_request_body(model=model))
+        assert response.status_code == 404, response.text
+        error = response.json()["error"]
+        assert error["code"] == "model_not_found"
+        assert error["type"] == "invalid_request_error"
+        assert model.partition(":")[0] in error["message"] or "Unknown model" in error["message"]
+        assert not build_model_spy.selections
+
+    async def test_tools_are_rejected(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/chat/completions",
+            json=_request_body(
+                tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}]
+            ),
+        )
+        assert response.status_code == 400, response.text
+        assert "Tool calling" in response.json()["error"]["message"]
+        assert not build_model_spy.selections
+
+    async def test_custom_provider_not_found_returns_404(
+        self,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        provider_id = str(GlobalID("GenerativeModelCustomProvider", "999999"))
+        response = await httpx_client.post(
+            "v1/chat/completions",
+            json=_request_body(model=f"custom:{provider_id}:my-model"),
+        )
+        assert response.status_code == 404, response.text
+        assert "not found" in response.json()["error"]["message"].lower()
+
+    async def test_missing_builtin_credentials_returns_openai_error(
+        self,
+        httpx_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        monkeypatch.delenv("DEEPSEEK_BASE_URL", raising=False)
+        response = await httpx_client.post(
+            "v1/chat/completions", json=_request_body(model="deepseek:deepseek-chat")
+        )
+        assert response.status_code == 400, response.text
+        error = response.json()["error"]
+        assert error["type"] == "invalid_request_error"
+        assert "DEEPSEEK" in error["message"].upper()

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -297,8 +297,8 @@ class TestCreateChatCompletion:
         )
         assert response.status_code == 404, response.text
         error = response.json()["error"]
-        assert error["type"] == "invalid_request_error"
-        assert "not found" in error["message"].lower()
+        assert error["code"] == "model_not_found"
+        assert "Unknown model" in error["message"]
 
     async def test_validation_failure_returns_openai_error_shape(
         self,

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -243,7 +243,7 @@ class TestCreateChatCompletion:
         error = response.json()["error"]
         assert error["code"] == "model_not_found"
         assert error["type"] == "invalid_request_error"
-        assert model.partition(":")[0] in error["message"] or "Unknown model" in error["message"]
+        assert model in error["message"]
         assert not build_model_spy.selections
 
     async def test_tools_are_rejected(
@@ -297,8 +297,8 @@ class TestCreateChatCompletion:
         )
         assert response.status_code == 404, response.text
         error = response.json()["error"]
-        assert error["code"] == "model_not_found"
-        assert "Unknown model" in error["message"]
+        assert error["type"] == "invalid_request_error"
+        assert "not found" in error["message"].lower()
 
     async def test_validation_failure_returns_openai_error_shape(
         self,

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -5,6 +5,8 @@ from typing import Any, AsyncIterator, Union
 
 import httpx
 import pytest
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionChunk as OpenAIChatCompletionChunk
 from pydantic_ai.exceptions import ModelAPIError
 from pydantic_ai.messages import (
     ModelMessage,
@@ -61,6 +63,16 @@ def build_model_spy(monkeypatch: pytest.MonkeyPatch) -> _BuildModelSpy:
     return spy
 
 
+@pytest.fixture
+def openai_client(httpx_client: httpx.AsyncClient) -> AsyncOpenAI:
+    return AsyncOpenAI(
+        base_url="http://test/v1",
+        api_key="sk-unused",  # the app under test runs with authentication disabled
+        http_client=httpx_client,
+        max_retries=0,  # surface the first response instead of retrying 5xx
+    )
+
+
 def _request_body(**overrides: Any) -> dict[str, Any]:
     body: dict[str, Any] = {
         "model": "anthropic:claude-sonnet-4-5",
@@ -77,24 +89,38 @@ def _data_events(sse_text: str) -> list[str]:
     return [line[len("data: ") :] for line in sse_text.splitlines() if line.startswith("data: ")]
 
 
+def _validated_chunks(sse_text: str) -> list[dict[str, Any]]:
+    events = _data_events(sse_text)
+    assert events[-1] == "[DONE]", events[-1]
+    payloads = [json.loads(event) for event in events[:-1]]
+    for payload in payloads:
+        OpenAIChatCompletionChunk.model_validate(payload)
+    return payloads
+
+
 class TestCreateChatCompletion:
     async def test_returns_openai_response_shape(
         self,
-        httpx_client: httpx.AsyncClient,
+        openai_client: AsyncOpenAI,
         build_model_spy: _BuildModelSpy,
     ) -> None:
-        response = await httpx_client.post("v1/chat/completions", json=_request_body())
-        assert response.status_code == 200, response.text
-        completion = response.json()
-        assert completion["id"].startswith("chatcmpl-")
-        assert completion["object"] == "chat.completion"
-        assert completion["model"] == "anthropic:claude-sonnet-4-5"
-        (choice,) = completion["choices"]
-        assert choice["index"] == 0
-        assert choice["message"] == {"role": "assistant", "content": _ANSWER}
-        assert choice["finish_reason"] == "stop"
-        usage = completion["usage"]
-        assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+        completion = await openai_client.chat.completions.create(
+            model="anthropic:claude-sonnet-4-5",
+            messages=[
+                {"role": "system", "content": "Translate the request into a filter expression."},
+                {"role": "user", "content": "llm spans"},
+            ],
+        )
+        assert completion.id.startswith("chatcmpl-")
+        assert completion.object == "chat.completion"
+        assert completion.model == "anthropic:claude-sonnet-4-5"
+        (choice,) = completion.choices
+        assert choice.index == 0
+        assert choice.message.role == "assistant"
+        assert choice.message.content == _ANSWER
+        assert choice.finish_reason == "stop"
+        assert (usage := completion.usage) is not None
+        assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
 
     async def test_resolves_builtin_model_selection_and_messages(
         self,
@@ -172,9 +198,7 @@ class TestCreateChatCompletion:
         assert response.status_code == 200, response.text
         assert response.headers["content-type"].startswith("text/event-stream")
 
-        events = _data_events(response.text)
-        assert events[-1] == "[DONE]"
-        chunks = [json.loads(event) for event in events[:-1]]
+        chunks = _validated_chunks(response.text)
         assert all(chunk["object"] == "chat.completion.chunk" for chunk in chunks)
         assert all(chunk["model"] == "anthropic:claude-sonnet-4-5" for chunk in chunks)
         assert len({chunk["id"] for chunk in chunks}) == 1
@@ -200,10 +224,7 @@ class TestCreateChatCompletion:
         )
         assert response.status_code == 200, response.text
 
-        events = _data_events(response.text)
-        assert events[-1] == "[DONE]"
-        chunks = [json.loads(event) for event in events[:-1]]
-        *deltas, usage_chunk = chunks
+        *deltas, usage_chunk = _validated_chunks(response.text)
         assert all(chunk["usage"] is None for chunk in deltas)
         assert deltas[-1]["choices"][0]["finish_reason"] == "stop"
         assert usage_chunk["choices"] == []
@@ -226,10 +247,10 @@ class TestCreateChatCompletion:
     @pytest.mark.parametrize(
         "model",
         [
-            "gpt-4o",  # no provider prefix
-            "not-a-provider:gpt-4o",
-            "custom:only-an-id",
-            "openai:",
+            pytest.param("gpt-4o", id="no_provider_prefix"),
+            pytest.param("not-a-provider:gpt-4o", id="unrecognized_provider"),
+            pytest.param("custom:only-an-id", id="custom_without_model_name"),
+            pytest.param("openai:", id="empty_model_name"),
         ],
     )
     async def test_unknown_model_returns_openai_error(

--- a/tests/unit/server/api/routers/v1/test_chat_completions.py
+++ b/tests/unit/server/api/routers/v1/test_chat_completions.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterator, Union
 
 import httpx
 import pytest
+from pydantic_ai.exceptions import ModelAPIError
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -144,15 +145,17 @@ class TestCreateChatCompletion:
         assert selection.provider is ModelProvider.OLLAMA
         assert selection.model_name == "llama3:8b"
 
+    @pytest.mark.parametrize("prefix", ["custom", "Custom"])
     async def test_custom_provider_model_selection(
         self,
         httpx_client: httpx.AsyncClient,
         build_model_spy: _BuildModelSpy,
+        prefix: str,
     ) -> None:
         provider_id = str(GlobalID("GenerativeModelCustomProvider", "7"))
         response = await httpx_client.post(
             "v1/chat/completions",
-            json=_request_body(model=f"custom:{provider_id}:my-model"),
+            json=_request_body(model=f"{prefix}:{provider_id}:my-model"),
         )
         assert response.status_code == 200, response.text
         (selection,) = build_model_spy.selections
@@ -183,8 +186,42 @@ class TestCreateChatCompletion:
         final = chunks[-1]["choices"][0]
         assert final["delta"] == {}
         assert final["finish_reason"] == "stop"
-        usage = chunks[-1]["usage"]
+        # Without stream_options.include_usage, no chunk reports usage.
+        assert all("usage" not in chunk for chunk in chunks)
+
+    async def test_streaming_with_include_usage_emits_final_usage_chunk(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/chat/completions",
+            json=_request_body(stream=True, stream_options={"include_usage": True}),
+        )
+        assert response.status_code == 200, response.text
+
+        events = _data_events(response.text)
+        assert events[-1] == "[DONE]"
+        chunks = [json.loads(event) for event in events[:-1]]
+        *deltas, usage_chunk = chunks
+        assert all(chunk["usage"] is None for chunk in deltas)
+        assert deltas[-1]["choices"][0]["finish_reason"] == "stop"
+        assert usage_chunk["choices"] == []
+        usage = usage_chunk["usage"]
         assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+    async def test_stream_options_without_stream_is_rejected(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/chat/completions",
+            json=_request_body(stream_options={"include_usage": True}),
+        )
+        assert response.status_code == 400, response.text
+        assert "stream_options" in response.json()["error"]["message"]
+        assert not build_model_spy.selections
 
     @pytest.mark.parametrize(
         "model",
@@ -222,6 +259,60 @@ class TestCreateChatCompletion:
         )
         assert response.status_code == 400, response.text
         assert "Tool calling" in response.json()["error"]["message"]
+        assert not build_model_spy.selections
+
+    @pytest.mark.parametrize("stream", [False, True])
+    async def test_provider_connection_failure_returns_openai_502(
+        self,
+        httpx_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        stream: bool,
+    ) -> None:
+        async def build_unreachable_model(*_: Any, **__: Any) -> FunctionModel:
+            def respond(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+                raise ModelAPIError("claude-sonnet-4-5", "connection refused")
+
+            async def respond_stream(
+                messages: list[ModelMessage], _info: AgentInfo
+            ) -> AsyncIterator[Union[str, DeltaToolCalls]]:
+                raise ModelAPIError("claude-sonnet-4-5", "connection refused")
+                yield ""
+
+            return FunctionModel(function=respond, stream_function=respond_stream)
+
+        monkeypatch.setattr(chat_completions_module, "build_model", build_unreachable_model)
+        response = await httpx_client.post("v1/chat/completions", json=_request_body(stream=stream))
+        assert response.status_code == 502, response.text
+        error = response.json()["error"]
+        assert error["type"] == "api_error"
+        assert "connection refused" in error["message"]
+
+    async def test_malformed_custom_provider_id_returns_404(
+        self,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        response = await httpx_client.post(
+            "v1/chat/completions",
+            json=_request_body(model="custom:not-a-global-id:gpt-4"),
+        )
+        assert response.status_code == 404, response.text
+        error = response.json()["error"]
+        assert error["code"] == "model_not_found"
+        assert "Unknown model" in error["message"]
+
+    async def test_validation_failure_returns_openai_error_shape(
+        self,
+        httpx_client: httpx.AsyncClient,
+        build_model_spy: _BuildModelSpy,
+    ) -> None:
+        body = _request_body(
+            messages=[{"role": "tool", "content": "result", "tool_call_id": "call_1"}]
+        )
+        response = await httpx_client.post("v1/chat/completions", json=body)
+        assert response.status_code == 422, response.text
+        error = response.json()["error"]
+        assert error["type"] == "invalid_request_error"
+        assert "role" in error["message"]
         assert not build_model_spy.selections
 
     async def test_custom_provider_not_found_returns_404(


### PR DESCRIPTION
POST /v1/chat/completions speaks the OpenAI chat completions wire format
(request/response bodies, SSE streaming, {"error": ...} payloads) and
proxies to the LLM providers Phoenix knows about. The model string selects
a Phoenix model definition — '{provider}:{model_name}' for built-in
providers or 'custom:{provider_id}:{model_name}' for stored custom
provider records — and credentials are resolved on the server exactly like
the agents endpoints do (secret store first, environment second) via the
agents' build_model factory. This lets browser clients such as the AI
SDK's openai-compatible provider call LLMs through Phoenix using
server-set credentials, e.g. for AI search.

The route is available to every authenticated role, viewers included,
matching the agents chat endpoints: it writes nothing and powers read
features.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>