### PR TITLE
fix(trace): stringify tool attributes rebuilt as objects (#14984)

### DIFF
--- a/app/src/openInference/tracing/types.ts
+++ b/app/src/openInference/tracing/types.ts
@@ -19,7 +19,11 @@ export type AttributeTool = {
 };
 
 export type AttributeLLMToolDefinition = {
-  [ToolAttributePostfixes.json_schema]?: string;
+  // Conventionally a JSON string, but an instrumentation that flattens
+  // `tool.json_schema.*` into dotted keys makes ingestion rebuild it as a
+  // nested object. Model it as unknown and narrow at the use site rather than
+  // asserting a shape the runtime value may not have.
+  [ToolAttributePostfixes.json_schema]?: unknown;
 };
 
 export type AttributeLLMTool = {

--- a/app/src/pages/trace/span/__tests__/utils.test.ts
+++ b/app/src/pages/trace/span/__tests__/utils.test.ts
@@ -233,7 +233,7 @@ describe("getToolAttributes", () => {
             type: "object",
             properties: { query: { type: "string" } },
             required: ["query"],
-          },
+          } as unknown as string,
         },
       })
     ).toEqual({

--- a/app/src/pages/trace/span/__tests__/utils.test.ts
+++ b/app/src/pages/trace/span/__tests__/utils.test.ts
@@ -77,6 +77,29 @@ describe("getLLMAttributes", () => {
     });
   });
 
+  it("stringifies a json_schema that ingestion rebuilt as an object", () => {
+    const result = getLLMAttributes({
+      llm: {
+        tools: [
+          {
+            tool: {
+              // An instrumentation that flattens `tool.json_schema.*` makes
+              // ingestion store json_schema as a nested object instead of a
+              // JSON string.
+              json_schema: {
+                name: "search",
+                parameters: { type: "object" },
+              } as unknown as string,
+            },
+          },
+        ],
+      },
+    });
+    expect(result.toolSchemas).toEqual([
+      '{"name":"search","parameters":{"type":"object"}}',
+    ]);
+  });
+
   it("ignores messages that do not conform to the messages shape", () => {
     const result = getLLMAttributes({
       llm: {

--- a/app/src/pages/trace/span/__tests__/utils.test.ts
+++ b/app/src/pages/trace/span/__tests__/utils.test.ts
@@ -85,11 +85,12 @@ describe("getLLMAttributes", () => {
             tool: {
               // An instrumentation that flattens `tool.json_schema.*` makes
               // ingestion store json_schema as a nested object instead of a
-              // JSON string.
+              // JSON string. json_schema is typed unknown, so this shape is
+              // supplied directly rather than asserted into a string.
               json_schema: {
                 name: "search",
                 parameters: { type: "object" },
-              } as unknown as string,
+              },
             },
           },
         ],

--- a/app/src/pages/trace/span/__tests__/utils.test.ts
+++ b/app/src/pages/trace/span/__tests__/utils.test.ts
@@ -220,6 +220,30 @@ describe("getToolAttributes", () => {
       parameters: '{"type": "object"}',
     });
   });
+
+  it("stringifies parameters that ingestion rebuilt as an object", () => {
+    // An instrumentation that emits flattened `tool.parameters.*` keys makes
+    // ingestion store `parameters` as a nested object instead of a JSON string.
+    expect(
+      getToolAttributes({
+        tool: {
+          name: "search_phoenix",
+          description: "Search the docs",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+            required: ["query"],
+          },
+        },
+      })
+    ).toEqual({
+      hasToolAttributes: true,
+      name: "search_phoenix",
+      description: "Search the docs",
+      parameters:
+        '{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}',
+    });
+  });
 });
 
 describe("groupDocumentEvaluationsByPosition", () => {

--- a/app/src/pages/trace/span/utils.ts
+++ b/app/src/pages/trace/span/utils.ts
@@ -124,7 +124,12 @@ export function getLLMAttributes(
     : [];
   const toolSchemas = toolDefinitions.reduce<string[]>((acc, tool) => {
     if (tool?.json_schema) {
-      acc.push(tool.json_schema);
+      // Same object-rebuilt-by-ingestion case as tool.parameters below: an
+      // instrumentation that flattens `tool.json_schema.*` into dotted keys
+      // makes ingestion store json_schema as a nested object. toolSchemas is
+      // typed string[] and handed to MimeTypeCodeBlock, so coerce any non-string
+      // value back to JSON text rather than letting an object reach the renderer.
+      acc.push(asToolAttributeString(tool.json_schema) as string);
     }
     return acc;
   }, []);

--- a/app/src/pages/trace/span/utils.ts
+++ b/app/src/pages/trace/span/utils.ts
@@ -123,13 +123,14 @@ export function getLLMAttributes(
         .filter(Boolean) as AttributeLLMToolDefinition[])
     : [];
   const toolSchemas = toolDefinitions.reduce<string[]>((acc, tool) => {
-    if (tool?.json_schema) {
-      // Same object-rebuilt-by-ingestion case as tool.parameters below: an
-      // instrumentation that flattens `tool.json_schema.*` into dotted keys
-      // makes ingestion store json_schema as a nested object. toolSchemas is
-      // typed string[] and handed to MimeTypeCodeBlock, so coerce any non-string
-      // value back to JSON text rather than letting an object reach the renderer.
-      acc.push(asToolAttributeString(tool.json_schema) as string);
+    // Same object-rebuilt-by-ingestion case as tool.parameters below: an
+    // instrumentation that flattens `tool.json_schema.*` into dotted keys makes
+    // ingestion store json_schema as a nested object, so it is typed unknown.
+    // asToolAttributeString narrows it and coerces any non-string value back to
+    // JSON text before it reaches MimeTypeCodeBlock, which expects string[].
+    const schema = asToolAttributeString(tool?.json_schema);
+    if (schema != null) {
+      acc.push(schema);
     }
     return acc;
   }, []);

--- a/app/src/pages/trace/span/utils.ts
+++ b/app/src/pages/trace/span/utils.ts
@@ -228,6 +228,21 @@ export type ToolSpanAttributes = {
 };
 
 /**
+ * Tool attributes are conventionally single string values, but an
+ * instrumentation that flattens e.g. `tool.parameters.*` into dotted keys makes
+ * Phoenix ingestion rebuild them as a nested object. The span view assumes a
+ * string (it re-parses `parameters` and renders the others as text), so coerce
+ * any non-string value back to its JSON text here rather than letting an object
+ * reach the renderer — where it throws `Objects are not valid as a React child`.
+ */
+function asToolAttributeString(value: unknown): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+/**
  * Extract the tool description from the parsed span attributes of a tool span.
  */
 export function getToolAttributes(
@@ -236,9 +251,13 @@ export function getToolAttributes(
   const toolAttributes = spanAttributes[SemanticAttributePrefixes.tool] || {};
   return {
     hasToolAttributes: Object.keys(toolAttributes).length > 0,
-    name: toolAttributes[ToolAttributePostfixes.name],
-    description: toolAttributes[ToolAttributePostfixes.description],
-    parameters: toolAttributes[ToolAttributePostfixes.parameters],
+    name: asToolAttributeString(toolAttributes[ToolAttributePostfixes.name]),
+    description: asToolAttributeString(
+      toolAttributes[ToolAttributePostfixes.description]
+    ),
+    parameters: asToolAttributeString(
+      toolAttributes[ToolAttributePostfixes.parameters]
+    ),
   };
 }
 

--- a/app/tests/server-evaluators.spec.ts
+++ b/app/tests/server-evaluators.spec.ts
@@ -271,8 +271,12 @@ test.describe.serial("Server Evaluators", () => {
     // Click the label text instead which properly toggles the switch.
     await page.getByText("Case sensitive", { exact: true }).click();
 
-    // Click Update button
-    await page.getByRole("button", { name: "Update" }).click();
+    // Click Update button. Scope to the dialog so the accessible name does not
+    // also match the "Dismiss update notification" button in the version notice.
+    await page
+      .getByTestId("dialog")
+      .getByRole("button", { name: "Update" })
+      .click();
 
     // Wait for dialog to close
     await expect(page.getByTestId("dialog")).not.toBeVisible();
@@ -378,8 +382,12 @@ test.describe.serial("Server Evaluators", () => {
     await descriptionInput.clear();
     await descriptionInput.fill(updatedDescription);
 
-    // Click Update button
-    await page.getByRole("button", { name: "Update" }).click();
+    // Click Update button. Scope to the dialog so the accessible name does not
+    // also match the "Dismiss update notification" button in the version notice.
+    await page
+      .getByTestId("dialog")
+      .getByRole("button", { name: "Update" })
+      .click();
 
     // Wait for dialog to close
     await expect(page.getByTestId("dialog")).not.toBeVisible();


### PR DESCRIPTION
## Summary

Fixes #14984. A TOOL span whose `tool.parameters` was instrumented as **flattened dotted sub-attributes** (`tool.parameters.type`, `tool.parameters.properties.query.type`, …) crashes the span details view with `Objects are not valid as a React child`.

Phoenix ingestion unflattens dotted keys into nested JSON, so the stored `tool.parameters` is an **object**, not the OpenInference-conventional JSON string. `getToolAttributes` typed it as `string` and passed it straight through, so `ToolMetadata` handed the object to `ReadonlyJSONBlock` → its `JSON.parse` throws → the plain-text fallback renders the object as a React child.

## Fix

Coerce any non-string tool attribute value back to its JSON text in `getToolAttributes` (`app/src/pages/trace/span/utils.ts`). `name` / `description` are guarded the same way — they degrade more gracefully but carry the same latent hazard. Spec-compliant string spans are untouched, and the card's copy button still re-parses the string as before.

```ts
function asToolAttributeString(value: unknown): string | undefined {
  if (value == null) return undefined;
  return typeof value === "string" ? value : JSON.stringify(value);
}
```

## Test

Added a `getToolAttributes` case in `__tests__/utils.test.ts` covering the object-shaped `parameters` path; existing string cases are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
