### PR TITLE
feat: Lift experiment chart selection limit

### DIFF
--- a/app/src/pages/dataset/constants.ts
+++ b/app/src/pages/dataset/constants.ts
@@ -51,12 +51,6 @@ export const isExperimentMetricChartKey = (
   ) || getExperimentAnnotationName(key) != null;
 
 /**
- * The maximum number of metric charts that can be shown above the experiments
- * table at once.
- */
-export const MAX_SELECTED_EXPERIMENT_METRIC_CHARTS = 3;
-
-/**
  * The default metric charts shown above the experiments table.
  */
 export const DEFAULT_EXPERIMENT_METRIC_CHART_KEYS: ExperimentMetricChartKey[] =

--- a/app/src/pages/dataset/metrics/chartCatalog.tsx
+++ b/app/src/pages/dataset/metrics/chartCatalog.tsx
@@ -1,7 +1,11 @@
 import type { ComponentType } from "react";
 import invariant from "tiny-invariant";
 
-import { ChartPanel, type ChartTypeIconType } from "@phoenix/components/chart";
+import {
+  ChartPanel,
+  type ChartTypeIconType,
+  DeferredChartPanel,
+} from "@phoenix/components/chart";
 import type {
   BuiltInExperimentMetricChartKey,
   ExperimentMetricChartKey,
@@ -139,6 +143,34 @@ function ExperimentAnnotationChartPanel({
       {...props}
       annotationName={annotationName}
     />
+  );
+}
+
+/**
+ * A catalog chart wrapped in a {@link DeferredChartPanel} so it doesn't fetch
+ * until scrolled into view. The placeholder uses the catalog title and
+ * subtitle so it matches the loaded panel.
+ */
+export function DeferredExperimentMetricPanel({
+  chart,
+  fillHeight = false,
+  ...props
+}: ExperimentMetricViewProps & {
+  chart: ExperimentMetricChart;
+  fillHeight?: boolean;
+}) {
+  return (
+    <DeferredChartPanel
+      title={chart.name}
+      subtitle={chart.description}
+      fillHeight={fillHeight}
+    >
+      <chart.Panel
+        {...props}
+        annotationName={chart.annotationName}
+        fillHeight={fillHeight}
+      />
+    </DeferredChartPanel>
   );
 }
 

--- a/app/src/pages/experiments/ExperimentsMetricsChartSelector.tsx
+++ b/app/src/pages/experiments/ExperimentsMetricsChartSelector.tsx
@@ -15,7 +15,6 @@ import {
   type ExperimentMetricChartKey,
   getExperimentAnnotationMetricChartKey,
   getExperimentAnnotationName,
-  MAX_SELECTED_EXPERIMENT_METRIC_CHARTS,
 } from "@phoenix/pages/dataset/constants";
 import {
   EXPERIMENT_METRIC_CHARTS,
@@ -97,7 +96,6 @@ function ExperimentChartSelectorMenu({
         ]),
       ]}
       selectedKeys={selectedChartKeys}
-      maxSelected={MAX_SELECTED_EXPERIMENT_METRIC_CHARTS}
       onSelectionChange={onSelectionChange}
     />
   );

--- a/app/src/pages/experiments/ExperimentsMetricsCharts.tsx
+++ b/app/src/pages/experiments/ExperimentsMetricsCharts.tsx
@@ -10,7 +10,10 @@ import {
 import { ChartPanelStrip } from "@phoenix/components/chart";
 import { transparentResizeHandleCSS } from "@phoenix/components/resize";
 import { useDatasetContext } from "@phoenix/contexts/DatasetContext";
-import { getExperimentMetricCharts } from "@phoenix/pages/dataset/metrics/chartCatalog";
+import {
+  DeferredExperimentMetricPanel,
+  getExperimentMetricCharts,
+} from "@phoenix/pages/dataset/metrics/chartCatalog";
 
 const CHARTS_PANEL_DEFAULT_SIZE_PIXELS = 230;
 const CHARTS_PANEL_MIN_SIZE_PIXELS = 160;
@@ -44,11 +47,11 @@ export function ExperimentsMetricsCharts() {
   const charts = getExperimentMetricCharts(selectedChartKeys);
   return (
     <ChartPanelStrip chartCount={charts.length}>
-      {charts.map(({ key, annotationName, Panel }) => (
-        <Panel
-          key={key}
+      {charts.map((chart) => (
+        <DeferredExperimentMetricPanel
+          key={chart.key}
+          chart={chart}
           datasetId={datasetId}
-          annotationName={annotationName}
           fillHeight
         />
       ))}

--- a/app/src/store/__tests__/datasetStore.test.ts
+++ b/app/src/store/__tests__/datasetStore.test.ts
@@ -1,8 +1,5 @@
 import { installTestStorage } from "@phoenix/__tests__/installTestStorage";
-import {
-  DEFAULT_EXPERIMENT_METRIC_CHART_KEYS,
-  MAX_SELECTED_EXPERIMENT_METRIC_CHARTS,
-} from "@phoenix/pages/dataset/constants";
+import { DEFAULT_EXPERIMENT_METRIC_CHART_KEYS } from "@phoenix/pages/dataset/constants";
 
 import { createDatasetStore } from "../datasetStore";
 
@@ -61,19 +58,20 @@ describe("datasetStore", () => {
       expect(store.getState().experimentsMetricChartKeys).toEqual(["latency"]);
     });
 
-    it("caps a persisted selection at the selection limit", () => {
+    it("hydrates a persisted selection without a chart limit", () => {
+      const persistedChartKeys = [
+        "annotation_scores",
+        "latency",
+        "cost",
+        "tokens",
+        "error_rate",
+      ] as const;
       seedPersistedState({
-        experimentsMetricChartKeys: [
-          "annotation_scores",
-          "latency",
-          "cost",
-          "tokens",
-          "error_rate",
-        ],
+        experimentsMetricChartKeys: persistedChartKeys,
       });
       const store = createStore();
-      expect(store.getState().experimentsMetricChartKeys).toHaveLength(
-        MAX_SELECTED_EXPERIMENT_METRIC_CHARTS
+      expect(store.getState().experimentsMetricChartKeys).toEqual(
+        persistedChartKeys
       );
     });
 

--- a/app/src/store/datasetStore.tsx
+++ b/app/src/store/datasetStore.tsx
@@ -6,7 +6,6 @@ import type { ExperimentMetricChartKey } from "@phoenix/pages/dataset/constants"
 import {
   DEFAULT_EXPERIMENT_METRIC_CHART_KEYS,
   isExperimentMetricChartKey,
-  MAX_SELECTED_EXPERIMENT_METRIC_CHARTS,
 } from "@phoenix/pages/dataset/constants";
 import RelayEnvironment from "@phoenix/RelayEnvironment";
 
@@ -106,13 +105,11 @@ export const createDatasetStore = (initialProps: InitialDatasetStoreProps) => {
             ...(persistedState as Partial<DatasetStoreState>),
           };
           // Persisted chart keys may reference charts that no longer exist in
-          // the chart catalog; drop them so stale keys don't count against the
-          // selection limit
+          // the chart catalog; drop them so stale keys don't render as empty
+          // panels
           const keys = merged.experimentsMetricChartKeys;
           merged.experimentsMetricChartKeys = Array.isArray(keys)
-            ? keys
-                .filter(isExperimentMetricChartKey)
-                .slice(0, MAX_SELECTED_EXPERIMENT_METRIC_CHARTS)
+            ? keys.filter(isExperimentMetricChartKey)
             : DEFAULT_EXPERIMENT_METRIC_CHART_KEYS;
           return merged;
         },


### PR DESCRIPTION
## What changed

- remove the three-chart selection cap from experiment pages
- preserve all valid experiment chart selections during store hydration
- defer experiment chart mounting with the shared intersection-observer wrapper so offscreen charts do not fetch eagerly
- update the persistence regression test for unlimited selections

## Why

Project pages already support an unlimited number of selected charts. Experiment pages should provide the same behavior without eagerly rendering every offscreen chart.

## Impact

Users can select any number of built-in and annotation metric charts on experiment pages. Previously persisted selections are no longer truncated to three charts.

## Validation

- `make test-frontend` (2,086 passed, 12 skipped)
- `make lint-frontend`
- `make typecheck-frontend`
- `git diff --check`
