### PR TITLE
feat(app): include span and trace annotations in span exports

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ai-sdk/react": "^4.0.40",
     "@apollo/client": "^4.2.8",
-    "@arizeai/openinference-semantic-conventions": "^2.5.0",
+    "@arizeai/openinference-semantic-conventions": "^2.6.0",
     "@codemirror/autocomplete": "6.20.3",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/lang-javascript": "^6.2.5",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^4.2.8
         version: 4.2.8(graphql@17.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
       '@arizeai/openinference-semantic-conventions':
-        specifier: ^2.5.0
-        version: 2.5.0
+        specifier: ^2.6.0
+        version: 2.6.0
       '@codemirror/autocomplete':
         specifier: 6.20.3
         version: 6.20.3
@@ -135,7 +135,7 @@ importers:
         version: 4.4.0
       just-bash:
         specifier: ^2.14.5
-        version: 2.14.5
+        version: 2.14.5(supports-color@10.2.2)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -229,7 +229,7 @@ importers:
         version: 4.0.11(zod@4.4.3)
       '@arizeai/phoenix-client':
         specifier: 6.12.1
-        version: 6.12.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.37(zod@4.4.3))(vitest@4.1.10)
+        version: 6.12.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.37(zod@4.4.3))(supports-color@10.2.2)(vitest@4.1.10)
       '@arizeai/phoenix-evals':
         specifier: ^1.2.0
         version: 1.2.0
@@ -238,7 +238,7 @@ importers:
         version: 10.0.1
       '@figma/code-connect':
         specifier: ^1.4.9
-        version: 1.4.9
+        version: 1.4.9(supports-color@10.2.2)
       '@lezer/generator':
         specifier: ^1.8.0
         version: 1.8.0
@@ -490,6 +490,9 @@ packages:
 
   '@arizeai/openinference-semantic-conventions@2.5.0':
     resolution: {integrity: sha512-4ZeSwiFX3YxB0WSE6x568wM4PVHiYmz3yiOxic6WGKVrE/KIGggMFP/eqUNQhikBKP68IDV0qiILlZAIYnheAQ==}
+
+  '@arizeai/openinference-semantic-conventions@2.6.0':
+    resolution: {integrity: sha512-0J1h97WG8K7cVVAtUKa7Tdv49yt0xZ+tebHcBzhSOdjJN5SWoc4CsoGadjO6G/nf+W4qYtRzraBOWKm7/20cyA==}
 
   '@arizeai/openinference-vercel@2.8.1':
     resolution: {integrity: sha512-gTgUSJd9HHTfNyI2ZoorPGHt1ID5LFtZZCDFmosXzdPzYoAzwknEC9Ja3iKKs+c27uvNiS6N5P8iyxf8qC+sDg==}
@@ -5956,6 +5959,8 @@ snapshots:
 
   '@arizeai/openinference-semantic-conventions@2.5.0': {}
 
+  '@arizeai/openinference-semantic-conventions@2.6.0': {}
+
   '@arizeai/openinference-vercel@2.8.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)':
     dependencies:
       '@arizeai/openinference-core': 2.3.0
@@ -5966,12 +5971,12 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/semantic-conventions'
 
-  '@arizeai/phoenix-client@6.12.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.37(zod@4.4.3))(vitest@4.1.10)':
+  '@arizeai/phoenix-client@6.12.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)(ai@7.0.37(zod@4.4.3))(supports-color@10.2.2)(vitest@4.1.10)':
     dependencies:
-      '@arizeai/openinference-semantic-conventions': 2.5.0
+      '@arizeai/openinference-semantic-conventions': 2.6.0
       '@arizeai/openinference-vercel': 2.8.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)
       '@arizeai/phoenix-config': 0.2.0
-      '@arizeai/phoenix-otel': 1.1.0(@opentelemetry/semantic-conventions@1.43.0)
+      '@arizeai/phoenix-otel': 1.1.0(@opentelemetry/semantic-conventions@1.43.0)(supports-color@10.2.2)
       async: 3.2.6
       openapi-fetch: 0.17.0
       tiny-invariant: 1.3.3
@@ -5995,17 +6000,17 @@ snapshots:
       mustache: 4.2.0
       zod: 4.4.3
 
-  '@arizeai/phoenix-otel@1.1.0(@opentelemetry/semantic-conventions@1.43.0)':
+  '@arizeai/phoenix-otel@1.1.0(@opentelemetry/semantic-conventions@1.43.0)(supports-color@10.2.2)':
     dependencies:
       '@arizeai/openinference-core': 2.4.0
-      '@arizeai/openinference-semantic-conventions': 2.5.0
+      '@arizeai/openinference-semantic-conventions': 2.6.0
       '@arizeai/openinference-vercel': 2.8.1(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.43.0)
       '@arizeai/phoenix-config': 0.2.0
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto': 0.218.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
@@ -6525,7 +6530,7 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@figma/code-connect@1.4.9':
+  '@figma/code-connect@1.4.9(supports-color@10.2.2)':
     dependencies:
       boxen: 5.1.1
       chalk: 4.1.2
@@ -6536,7 +6541,7 @@ snapshots:
       fast-fuzzy: 1.12.0
       find-up: 5.0.0
       glob: 11.1.0
-      jsdom: 24.1.3
+      jsdom: 24.1.3(supports-color@10.2.2)
       lodash: 4.18.1
       minimatch: 9.0.9
       ora: 5.4.1
@@ -6801,12 +6806,12 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.218.0
       import-in-the-middle: 3.3.2
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7594,7 +7599,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       token-types: 6.1.2
@@ -8912,9 +8917,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  file-type@21.3.4:
+  file-type@21.3.4(supports-color@10.2.2):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@10.2.2)
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -9171,7 +9176,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
@@ -9323,14 +9328,14 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@24.1.3:
+  jsdom@24.1.3(supports-color@10.2.2):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       form-data: 4.0.6
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.24
@@ -9411,11 +9416,11 @@ snapshots:
 
   junk@4.0.1: {}
 
-  just-bash@2.14.5:
+  just-bash@2.14.5(supports-color@10.2.2):
     dependencies:
       diff: 8.0.4
       fast-xml-parser: 5.10.1
-      file-type: 21.3.4
+      file-type: 21.3.4(supports-color@10.2.2)
       ini: 6.0.0
       minimatch: 10.2.5
       modern-tar: 0.7.7
@@ -10716,7 +10721,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       module-details-from-path: 1.0.4

--- a/app/src/components/trace/SpanDownloadDialog.tsx
+++ b/app/src/components/trace/SpanDownloadDialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import {
   Alert,
   Button,
+  Checkbox,
   ContextualHelp,
   Dialog,
   DialogCloseButton,
@@ -76,6 +77,8 @@ export function SpanDownloadDialog({
   const [error, setError] = useState<string | null>(null);
   const [scope, setScope] = useState<SpanDownloadScope>(initialScope);
   const [format, setFormat] = useState<SpanDownloadFormat>("jsonl");
+  const [includeSpanAnnotations, setIncludeSpanAnnotations] = useState(true);
+  const [includeTraceAnnotations, setIncludeTraceAnnotations] = useState(true);
   const [timestamp] = useState(() => getSpanDownloadTimestamp());
   const getDefaultFileName = (downloadScope: SpanDownloadScope) =>
     `${sanitizeSpanDownloadFileName(fileNamePrefix)}-${downloadScope}-${timestamp}`;
@@ -105,6 +108,8 @@ export function SpanDownloadDialog({
         ...idFilter,
         format,
         fileName: fullFileName,
+        includeSpanAnnotations,
+        includeTraceAnnotations,
       });
       close();
     } catch (error) {
@@ -205,6 +210,34 @@ export function SpanDownloadDialog({
                   </SegmentedControl>
                 </div>
               </Flex>
+              <div css={labeledGroupCSS}>
+                <Flex direction="row" alignItems="center" gap="size-50">
+                  <Label>Annotations</Label>
+                  <ContextualHelp variant="info">
+                    <Heading weight="heavy" level={4}>
+                      Include annotations
+                    </Heading>
+                    <Text>
+                      Adds span annotations to their spans and trace annotations
+                      once per trace as OpenInference semantic attributes.
+                    </Text>
+                  </ContextualHelp>
+                </Flex>
+                <Flex direction="row" gap="size-200">
+                  <Checkbox
+                    isSelected={includeSpanAnnotations}
+                    onChange={setIncludeSpanAnnotations}
+                  >
+                    Include span annotations
+                  </Checkbox>
+                  <Checkbox
+                    isSelected={includeTraceAnnotations}
+                    onChange={setIncludeTraceAnnotations}
+                  >
+                    Include trace annotations
+                  </Checkbox>
+                </Flex>
+              </div>
               <TextField
                 value={fileName}
                 onChange={(value) => {

--- a/app/src/components/trace/__tests__/spanDownloadUtils.test.ts
+++ b/app/src/components/trace/__tests__/spanDownloadUtils.test.ts
@@ -195,6 +195,8 @@ describe("spanDownloadUtils", () => {
       traceIds: ["trace-id"],
       format: "jsonl",
       fileName: "trace.jsonl",
+      includeSpanAnnotations: true,
+      includeTraceAnnotations: true,
     });
 
     expect(authApiFetch.GET).toHaveBeenNthCalledWith(
@@ -298,6 +300,8 @@ describe("spanDownloadUtils", () => {
       traceIds: ["trace-id"],
       format: "otlp-json",
       fileName: "trace.json",
+      includeSpanAnnotations: true,
+      includeTraceAnnotations: true,
     });
 
     await expect(readBlob(getDownloadedBlob())).resolves.toBe(
@@ -394,6 +398,7 @@ describe("spanDownloadUtils", () => {
       format: "jsonl",
       fileName: "trace.jsonl",
       includeSpanAnnotations: false,
+      includeTraceAnnotations: true,
     });
 
     const [exportedChild, exportedRoot] = (await readBlob(getDownloadedBlob()))

--- a/app/src/components/trace/__tests__/spanDownloadUtils.test.ts
+++ b/app/src/components/trace/__tests__/spanDownloadUtils.test.ts
@@ -84,6 +84,8 @@ describe("spanDownloadUtils", () => {
       spanId: "span-id",
       format: "json",
       fileName: "span.json",
+      includeSpanAnnotations: false,
+      includeTraceAnnotations: false,
     });
 
     expect(authApiFetch.GET).toHaveBeenCalledWith(
@@ -95,6 +97,7 @@ describe("spanDownloadUtils", () => {
         },
       }
     );
+    expect(authApiFetch.GET).toHaveBeenCalledTimes(1);
     await expect(readBlob(getDownloadedBlob())).resolves.toBe(
       `${JSON.stringify(span, null, 2)}\n`
     );
@@ -112,6 +115,8 @@ describe("spanDownloadUtils", () => {
       spanId: "span-id",
       format: "otlp-json",
       fileName: "span-otlp.json",
+      includeSpanAnnotations: false,
+      includeTraceAnnotations: false,
     });
 
     expect(authApiFetch.GET).toHaveBeenCalledWith(
@@ -123,6 +128,7 @@ describe("spanDownloadUtils", () => {
         },
       }
     );
+    expect(authApiFetch.GET).toHaveBeenCalledTimes(1);
     await expect(readBlob(getDownloadedBlob())).resolves.toBe(
       JSON.stringify({
         resource_spans: [{ scope_spans: [{ spans: [otlpSpan] }] }],
@@ -138,11 +144,51 @@ describe("spanDownloadUtils", () => {
       start_time: "2026-07-24T18:30:45Z",
       end_time: "2026-07-24T18:30:46Z",
       status_code: "OK",
+      attributes: { existing: "value" },
     };
-    vi.mocked(authApiFetch.GET).mockResolvedValueOnce({
-      data: { data: [span], next_cursor: null },
-      response: new Response(null, { status: 200 }),
-    });
+    const spanAnnotation = {
+      id: "span-annotation-id",
+      created_at: "2026-07-24T18:30:47Z",
+      updated_at: "2026-07-24T18:30:47Z",
+      source: "API" as const,
+      user_id: null,
+      name: "hallucination",
+      annotator_kind: "LLM" as const,
+      result: {
+        score: 0.25,
+        label: "likely",
+        explanation: "Unsupported claim",
+      },
+      metadata: { evaluator: "faithfulness" },
+      identifier: "eval-1",
+      span_id: "span-id",
+    };
+    const traceAnnotation = {
+      id: "trace-annotation-id",
+      created_at: "2026-07-24T18:30:48Z",
+      updated_at: "2026-07-24T18:30:48Z",
+      source: "APP" as const,
+      user_id: null,
+      name: "user_frustration",
+      annotator_kind: "HUMAN" as const,
+      result: { label: "high" },
+      metadata: {},
+      identifier: "",
+      trace_id: "trace-id",
+    };
+    vi.mocked(authApiFetch.GET)
+      .mockResolvedValueOnce({
+        data: { data: [span], next_cursor: null },
+        response: new Response(null, { status: 200 }),
+      })
+      .mockResolvedValueOnce({
+        data: { data: [spanAnnotation], next_cursor: null },
+        response: new Response(null, { status: 200 }),
+      })
+      .mockResolvedValueOnce({
+        data: { data: [traceAnnotation], next_cursor: null },
+        response: new Response(null, { status: 200 }),
+      });
 
     await downloadSpanCollection({
       projectId: "project-id",
@@ -151,7 +197,8 @@ describe("spanDownloadUtils", () => {
       fileName: "trace.jsonl",
     });
 
-    expect(authApiFetch.GET).toHaveBeenCalledWith(
+    expect(authApiFetch.GET).toHaveBeenNthCalledWith(
+      1,
       "/v1/projects/{project_identifier}/spans",
       {
         params: {
@@ -160,8 +207,209 @@ describe("spanDownloadUtils", () => {
         },
       }
     );
-    await expect(readBlob(getDownloadedBlob())).resolves.toBe(
-      `${JSON.stringify(span)}\n`
+    expect(authApiFetch.GET).toHaveBeenNthCalledWith(
+      2,
+      "/v1/projects/{project_identifier}/span_annotations",
+      {
+        params: {
+          path: { project_identifier: "project-id" },
+          query: { limit: 1000, span_ids: ["span-id"] },
+        },
+      }
     );
+    expect(authApiFetch.GET).toHaveBeenNthCalledWith(
+      3,
+      "/v1/projects/{project_identifier}/trace_annotations",
+      {
+        params: {
+          path: { project_identifier: "project-id" },
+          query: { limit: 1000, trace_ids: ["trace-id"] },
+        },
+      }
+    );
+    await expect(readBlob(getDownloadedBlob())).resolves.toBe(
+      `${JSON.stringify({
+        ...span,
+        attributes: {
+          existing: "value",
+          "annotations.0.annotation.name": "hallucination",
+          "annotations.0.annotation.annotator_kind": "LLM",
+          "annotations.0.annotation.score": 0.25,
+          "annotations.0.annotation.label": "likely",
+          "annotations.0.annotation.explanation": "Unsupported claim",
+          "annotations.0.annotation.identifier": "eval-1",
+          "annotations.0.annotation.metadata": '{"evaluator":"faithfulness"}',
+          "trace.annotations.0.annotation.name": "user_frustration",
+          "trace.annotations.0.annotation.annotator_kind": "HUMAN",
+          "trace.annotations.0.annotation.label": "high",
+        },
+      })}\n`
+    );
+  });
+
+  it("adds annotations as OTLP attributes", async () => {
+    const otlpSpan = {
+      span_id: "span-id",
+      trace_id: "trace-id",
+      attributes: [{ key: "existing", value: { string_value: "value" } }],
+    };
+    const spanAnnotation = {
+      id: "span-annotation-id",
+      created_at: "2026-07-24T18:30:47Z",
+      updated_at: "2026-07-24T18:30:47Z",
+      source: "API" as const,
+      user_id: null,
+      name: "hallucination",
+      annotator_kind: "CODE" as const,
+      result: { score: 0.5 },
+      metadata: {},
+      identifier: "",
+      span_id: "span-id",
+    };
+    const traceAnnotation = {
+      id: "trace-annotation-id",
+      created_at: "2026-07-24T18:30:48Z",
+      updated_at: "2026-07-24T18:30:48Z",
+      source: "APP" as const,
+      user_id: null,
+      name: "user_frustration",
+      annotator_kind: "HUMAN" as const,
+      result: { label: "high" },
+      metadata: {},
+      identifier: "",
+      trace_id: "trace-id",
+    };
+    vi.mocked(authApiFetch.GET)
+      .mockResolvedValueOnce({
+        data: { data: [otlpSpan], next_cursor: null },
+        response: new Response(null, { status: 200 }),
+      })
+      .mockResolvedValueOnce({
+        data: { data: [spanAnnotation], next_cursor: null },
+        response: new Response(null, { status: 200 }),
+      })
+      .mockResolvedValueOnce({
+        data: { data: [traceAnnotation], next_cursor: null },
+        response: new Response(null, { status: 200 }),
+      });
+
+    await downloadSpanCollection({
+      projectId: "project-id",
+      traceIds: ["trace-id"],
+      format: "otlp-json",
+      fileName: "trace.json",
+    });
+
+    await expect(readBlob(getDownloadedBlob())).resolves.toBe(
+      JSON.stringify({
+        resource_spans: [
+          {
+            scope_spans: [
+              {
+                spans: [
+                  {
+                    ...otlpSpan,
+                    attributes: [
+                      ...otlpSpan.attributes,
+                      {
+                        key: "annotations.0.annotation.name",
+                        value: { string_value: "hallucination" },
+                      },
+                      {
+                        key: "annotations.0.annotation.annotator_kind",
+                        value: { string_value: "CODE" },
+                      },
+                      {
+                        key: "annotations.0.annotation.score",
+                        value: { double_value: 0.5 },
+                      },
+                      {
+                        key: "trace.annotations.0.annotation.name",
+                        value: { string_value: "user_frustration" },
+                      },
+                      {
+                        key: "trace.annotations.0.annotation.annotator_kind",
+                        value: { string_value: "HUMAN" },
+                      },
+                      {
+                        key: "trace.annotations.0.annotation.label",
+                        value: { string_value: "high" },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    );
+  });
+
+  it("adds trace annotations only to the root span", async () => {
+    const childSpan = {
+      name: "child-span",
+      context: { span_id: "child-span-id", trace_id: "trace-id" },
+      span_kind: "LLM",
+      parent_id: "root-span-id",
+      start_time: "2026-07-24T18:30:45Z",
+      end_time: "2026-07-24T18:30:46Z",
+      status_code: "OK",
+    };
+    const rootSpan = {
+      name: "root-span",
+      context: { span_id: "root-span-id", trace_id: "trace-id" },
+      span_kind: "CHAIN",
+      parent_id: null,
+      start_time: "2026-07-24T18:30:44Z",
+      end_time: "2026-07-24T18:30:47Z",
+      status_code: "OK",
+    };
+    const traceAnnotation = {
+      id: "trace-annotation-id",
+      created_at: "2026-07-24T18:30:48Z",
+      updated_at: "2026-07-24T18:30:48Z",
+      source: "APP" as const,
+      user_id: null,
+      name: "user_frustration",
+      annotator_kind: "HUMAN" as const,
+      result: { label: "high" },
+      metadata: {},
+      identifier: "",
+      trace_id: "trace-id",
+    };
+    vi.mocked(authApiFetch.GET)
+      .mockResolvedValueOnce({
+        data: { data: [childSpan, rootSpan], next_cursor: null },
+        response: new Response(null, { status: 200 }),
+      })
+      .mockResolvedValueOnce({
+        data: { data: [traceAnnotation], next_cursor: null },
+        response: new Response(null, { status: 200 }),
+      });
+
+    await downloadSpanCollection({
+      projectId: "project-id",
+      traceIds: ["trace-id"],
+      format: "jsonl",
+      fileName: "trace.jsonl",
+      includeSpanAnnotations: false,
+    });
+
+    const [exportedChild, exportedRoot] = (await readBlob(getDownloadedBlob()))
+      .trim()
+      .split("\n");
+    expect(exportedChild).toBe(JSON.stringify(childSpan));
+    expect(exportedRoot).toBe(
+      JSON.stringify({
+        ...rootSpan,
+        attributes: {
+          "trace.annotations.0.annotation.name": "user_frustration",
+          "trace.annotations.0.annotation.annotator_kind": "HUMAN",
+          "trace.annotations.0.annotation.label": "high",
+        },
+      })
+    );
+    expect(authApiFetch.GET).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/src/components/trace/spanDownloadAnnotations.ts
+++ b/app/src/components/trace/spanDownloadAnnotations.ts
@@ -1,0 +1,382 @@
+import {
+  ANNOTATIONS,
+  ANNOTATION_ANNOTATOR_KIND,
+  ANNOTATION_EXPLANATION,
+  ANNOTATION_IDENTIFIER,
+  ANNOTATION_LABEL,
+  ANNOTATION_METADATA,
+  ANNOTATION_NAME,
+  ANNOTATION_SCORE,
+  TRACE_ANNOTATIONS,
+} from "@arizeai/openinference-semantic-conventions";
+import chunk from "lodash/chunk";
+
+import type { components } from "@phoenix/api/__generated__/v1";
+import { authApiFetch } from "@phoenix/api/authApiFetch";
+
+type OtlpSpan = components["schemas"]["OtlpSpan"];
+type OtlpKeyValue = components["schemas"]["OtlpKeyValue"];
+type PhoenixSpan = components["schemas"]["Span"];
+type SpanAnnotation = components["schemas"]["SpanAnnotation"];
+type TraceAnnotation = components["schemas"]["TraceAnnotation"];
+
+const PAGE_SIZE = 1000;
+
+// Cap IDs per request so the GET query string stays under common
+// server/proxy URL-length limits and the SQL IN() clause stays under database
+// bound-parameter limits.
+const ID_BATCH_SIZE = 100;
+
+type Annotation = SpanAnnotation | TraceAnnotation;
+type AnnotationAttributeValue = string | number;
+type AnnotationAttributes = Record<string, AnnotationAttributeValue>;
+
+type AnnotationSearchQuery = {
+  limit: number;
+  cursor?: string;
+};
+
+type AnnotationPage<Annotation> = {
+  data: Annotation[];
+  next_cursor?: string | null;
+};
+
+export type SpanAnnotationTarget = {
+  spanId: string;
+  traceId: string;
+  isRoot: boolean;
+};
+
+export type AnnotationLookup = {
+  spanAnnotationsBySpanId: Map<string, SpanAnnotation[]>;
+  traceAnnotationsByTraceId: Map<string, TraceAnnotation[]>;
+};
+
+/**
+ * Turns an openapi-fetch error into an Error that preserves the HTTP status
+ * and any server-provided detail.
+ */
+function toDownloadError({
+  status,
+  error,
+}: {
+  status: number;
+  error: unknown;
+}): Error {
+  const detail =
+    typeof error === "string"
+      ? error
+      : error && typeof error === "object" && "detail" in error
+        ? String((error as { detail: unknown }).detail)
+        : "";
+  return new Error(detail ? `HTTP ${status}: ${detail}` : `HTTP ${status}`);
+}
+
+/** Fetches annotations in bounded ID batches and follows every cursor. */
+async function fetchAnnotations<Annotation>({
+  ids,
+  fetchPage,
+}: {
+  ids: string[];
+  fetchPage: (params: {
+    ids: string[];
+    query: AnnotationSearchQuery;
+  }) => Promise<AnnotationPage<Annotation>>;
+}): Promise<Annotation[]> {
+  const annotations: Annotation[] = [];
+  for (const batch of chunk(ids, ID_BATCH_SIZE)) {
+    let cursor: string | null = null;
+    do {
+      const page = await fetchPage({
+        ids: batch,
+        query: {
+          limit: PAGE_SIZE,
+          ...(cursor ? { cursor } : {}),
+        },
+      });
+      annotations.push(...page.data);
+      cursor = page.next_cursor ?? null;
+    } while (cursor);
+  }
+  return annotations;
+}
+
+async function fetchSpanAnnotations({
+  projectId,
+  spanIds,
+}: {
+  projectId: string;
+  spanIds: string[];
+}): Promise<SpanAnnotation[]> {
+  return fetchAnnotations({
+    ids: spanIds,
+    fetchPage: async ({ ids, query }) => {
+      const { data, error, response } = await authApiFetch.GET(
+        "/v1/projects/{project_identifier}/span_annotations",
+        {
+          params: {
+            path: { project_identifier: projectId },
+            query: { span_ids: ids, ...query },
+          },
+        }
+      );
+      if (data == null) {
+        throw toDownloadError({ status: response.status, error });
+      }
+      return data;
+    },
+  });
+}
+
+async function fetchTraceAnnotations({
+  projectId,
+  traceIds,
+}: {
+  projectId: string;
+  traceIds: string[];
+}): Promise<TraceAnnotation[]> {
+  return fetchAnnotations({
+    ids: traceIds,
+    fetchPage: async ({ ids, query }) => {
+      const { data, error, response } = await authApiFetch.GET(
+        "/v1/projects/{project_identifier}/trace_annotations",
+        {
+          params: {
+            path: { project_identifier: projectId },
+            query: { trace_ids: ids, ...query },
+          },
+        }
+      );
+      if (data == null) {
+        throw toDownloadError({ status: response.status, error });
+      }
+      return data;
+    },
+  });
+}
+
+function groupAnnotationsByTargetId<Annotation>({
+  annotations,
+  getTargetId,
+}: {
+  annotations: Annotation[];
+  getTargetId: (annotation: Annotation) => string;
+}): Map<string, Annotation[]> {
+  const annotationsByTargetId = new Map<string, Annotation[]>();
+  for (const annotation of annotations) {
+    const targetId = getTargetId(annotation);
+    const targetAnnotations = annotationsByTargetId.get(targetId) ?? [];
+    targetAnnotations.push(annotation);
+    annotationsByTargetId.set(targetId, targetAnnotations);
+  }
+  return annotationsByTargetId;
+}
+
+/**
+ * Picks one carrier span per trace for trace-level annotations (prefer root).
+ * First-seen wins unless a later span is a root.
+ */
+function getTraceAnnotationCarrierSpanIds(
+  targets: SpanAnnotationTarget[]
+): Map<string, string> {
+  const carrierSpanIdsByTraceId = new Map<string, string>();
+  for (const target of targets) {
+    if (!carrierSpanIdsByTraceId.has(target.traceId) || target.isRoot) {
+      carrierSpanIdsByTraceId.set(target.traceId, target.spanId);
+    }
+  }
+  return carrierSpanIdsByTraceId;
+}
+
+function getAnnotationAttributes({
+  annotations,
+  prefix,
+}: {
+  annotations: Annotation[];
+  prefix: typeof ANNOTATIONS | typeof TRACE_ANNOTATIONS;
+}): AnnotationAttributes {
+  const attributes: AnnotationAttributes = {};
+  annotations.forEach((annotation, index) => {
+    const annotationPrefix = `${prefix}.${index}`;
+    attributes[`${annotationPrefix}.${ANNOTATION_NAME}`] = annotation.name;
+    attributes[`${annotationPrefix}.${ANNOTATION_ANNOTATOR_KIND}`] =
+      annotation.annotator_kind;
+
+    if (annotation.result?.score != null) {
+      attributes[`${annotationPrefix}.${ANNOTATION_SCORE}`] =
+        annotation.result.score;
+    }
+    if (annotation.result?.label != null) {
+      attributes[`${annotationPrefix}.${ANNOTATION_LABEL}`] =
+        annotation.result.label;
+    }
+    if (annotation.result?.explanation != null) {
+      attributes[`${annotationPrefix}.${ANNOTATION_EXPLANATION}`] =
+        annotation.result.explanation;
+    }
+    if (annotation.identifier) {
+      attributes[`${annotationPrefix}.${ANNOTATION_IDENTIFIER}`] =
+        annotation.identifier;
+    }
+    if (annotation.metadata && Object.keys(annotation.metadata).length > 0) {
+      attributes[`${annotationPrefix}.${ANNOTATION_METADATA}`] = JSON.stringify(
+        annotation.metadata
+      );
+    }
+  });
+  return attributes;
+}
+
+/** Builds OpenInference annotation attributes for one span. */
+function buildAnnotationAttributes({
+  spanAnnotations,
+  traceAnnotations,
+}: {
+  spanAnnotations: SpanAnnotation[];
+  traceAnnotations: TraceAnnotation[];
+}): AnnotationAttributes {
+  return {
+    ...getAnnotationAttributes({
+      annotations: spanAnnotations,
+      prefix: ANNOTATIONS,
+    }),
+    ...getAnnotationAttributes({
+      annotations: traceAnnotations,
+      prefix: TRACE_ANNOTATIONS,
+    }),
+  };
+}
+
+function toOtlpAttributes(attributes: AnnotationAttributes): OtlpKeyValue[] {
+  return Object.entries(attributes).map(([key, value]) => ({
+    key,
+    value:
+      typeof value === "number"
+        ? { double_value: value }
+        : { string_value: value },
+  }));
+}
+
+export function addAnnotationsToPhoenixSpan({
+  span,
+  spanAnnotations,
+  traceAnnotations,
+}: {
+  span: PhoenixSpan;
+  spanAnnotations: SpanAnnotation[];
+  traceAnnotations: TraceAnnotation[];
+}): PhoenixSpan {
+  const annotationAttributes = buildAnnotationAttributes({
+    spanAnnotations,
+    traceAnnotations,
+  });
+  if (Object.keys(annotationAttributes).length === 0) {
+    return span;
+  }
+  return {
+    ...span,
+    attributes: { ...span.attributes, ...annotationAttributes },
+  };
+}
+
+export function addAnnotationsToOtlpSpan({
+  span,
+  spanAnnotations,
+  traceAnnotations,
+}: {
+  span: OtlpSpan;
+  spanAnnotations: SpanAnnotation[];
+  traceAnnotations: TraceAnnotation[];
+}): OtlpSpan {
+  const annotationAttributes = toOtlpAttributes(
+    buildAnnotationAttributes({ spanAnnotations, traceAnnotations })
+  );
+  if (annotationAttributes.length === 0) {
+    return span;
+  }
+  const annotationAttributeKeys = new Set(
+    annotationAttributes.map(({ key }) => key)
+  );
+  return {
+    ...span,
+    attributes: [
+      ...(span.attributes ?? []).filter(
+        ({ key }) => key == null || !annotationAttributeKeys.has(key)
+      ),
+      ...annotationAttributes,
+    ],
+  };
+}
+
+/** Loads span/trace annotations for the given download targets. */
+export async function fetchAnnotationsForTargets({
+  projectId,
+  targets,
+  includeSpanAnnotations,
+  includeTraceAnnotations,
+}: {
+  projectId: string;
+  targets: SpanAnnotationTarget[];
+  includeSpanAnnotations: boolean;
+  includeTraceAnnotations: boolean;
+}): Promise<AnnotationLookup> {
+  const spanIds = [...new Set(targets.map((target) => target.spanId))];
+  const traceIds = [...new Set(targets.map((target) => target.traceId))];
+  const [spanAnnotations, traceAnnotations] = await Promise.all([
+    includeSpanAnnotations && spanIds.length > 0
+      ? fetchSpanAnnotations({ projectId, spanIds })
+      : [],
+    includeTraceAnnotations && traceIds.length > 0
+      ? fetchTraceAnnotations({ projectId, traceIds })
+      : [],
+  ]);
+  return {
+    spanAnnotationsBySpanId: groupAnnotationsByTargetId({
+      annotations: spanAnnotations,
+      getTargetId: (annotation) => annotation.span_id,
+    }),
+    traceAnnotationsByTraceId: groupAnnotationsByTargetId({
+      annotations: traceAnnotations,
+      getTargetId: (annotation) => annotation.trace_id,
+    }),
+  };
+}
+
+/**
+ * Attaches fetched annotations to spans. Trace annotations land once per
+ * trace on the carrier span (preferring the root).
+ */
+export function applyAnnotationsToSpans<Span>({
+  spans,
+  lookup,
+  getTarget,
+  withAnnotations,
+}: {
+  spans: Span[];
+  lookup: AnnotationLookup;
+  getTarget: (span: Span) => SpanAnnotationTarget | null;
+  withAnnotations: (
+    span: Span,
+    spanAnnotations: SpanAnnotation[],
+    traceAnnotations: TraceAnnotation[]
+  ) => Span;
+}): Span[] {
+  const targets = spans.map(getTarget);
+  const carrierSpanIdsByTraceId = getTraceAnnotationCarrierSpanIds(
+    targets.filter((target): target is SpanAnnotationTarget => target != null)
+  );
+  return spans.map((span, index) => {
+    const target = targets[index];
+    if (target == null) {
+      return withAnnotations(span, [], []);
+    }
+    const spanAnnotations =
+      lookup.spanAnnotationsBySpanId.get(target.spanId) ?? [];
+    const isCarrier =
+      carrierSpanIdsByTraceId.get(target.traceId) === target.spanId;
+    const traceAnnotations = isCarrier
+      ? (lookup.traceAnnotationsByTraceId.get(target.traceId) ?? [])
+      : [];
+    return withAnnotations(span, spanAnnotations, traceAnnotations);
+  });
+}

--- a/app/src/components/trace/spanDownloadAnnotations.ts
+++ b/app/src/components/trace/spanDownloadAnnotations.ts
@@ -348,20 +348,20 @@ export async function fetchAnnotationsForTargets({
  */
 export function applyAnnotationsToSpans<Span>({
   spans,
+  targets,
   lookup,
-  getTarget,
   withAnnotations,
 }: {
   spans: Span[];
+  /** Target for each span, positionally aligned with `spans`. */
+  targets: (SpanAnnotationTarget | null)[];
   lookup: AnnotationLookup;
-  getTarget: (span: Span) => SpanAnnotationTarget | null;
   withAnnotations: (
     span: Span,
     spanAnnotations: SpanAnnotation[],
     traceAnnotations: TraceAnnotation[]
   ) => Span;
 }): Span[] {
-  const targets = spans.map(getTarget);
   const carrierSpanIdsByTraceId = getTraceAnnotationCarrierSpanIds(
     targets.filter((target): target is SpanAnnotationTarget => target != null)
   );

--- a/app/src/components/trace/spanDownloadUtils.ts
+++ b/app/src/components/trace/spanDownloadUtils.ts
@@ -1,10 +1,24 @@
+import {
+  ANNOTATIONS,
+  ANNOTATION_ANNOTATOR_KIND,
+  ANNOTATION_EXPLANATION,
+  ANNOTATION_IDENTIFIER,
+  ANNOTATION_LABEL,
+  ANNOTATION_METADATA,
+  ANNOTATION_NAME,
+  ANNOTATION_SCORE,
+  TRACE_ANNOTATIONS,
+} from "@arizeai/openinference-semantic-conventions";
 import chunk from "lodash/chunk";
 
 import type { components } from "@phoenix/api/__generated__/v1";
 import { authApiFetch } from "@phoenix/api/authApiFetch";
 
 type OtlpSpan = components["schemas"]["OtlpSpan"];
+type OtlpKeyValue = components["schemas"]["OtlpKeyValue"];
 type PhoenixSpan = components["schemas"]["Span"];
+type SpanAnnotation = components["schemas"]["SpanAnnotation"];
+type TraceAnnotation = components["schemas"]["TraceAnnotation"];
 
 const PAGE_SIZE = 1000;
 
@@ -35,6 +49,20 @@ type SpanSearchQuery = {
 };
 
 type SpanPage<Span> = { data: Span[]; next_cursor?: string | null };
+
+type Annotation = SpanAnnotation | TraceAnnotation;
+type AnnotationAttributeValue = string | number;
+type AnnotationAttributes = Record<string, AnnotationAttributeValue>;
+
+type AnnotationSearchQuery = {
+  limit: number;
+  cursor?: string;
+};
+
+type AnnotationLookup = {
+  spanAnnotationsBySpanId: Map<string, SpanAnnotation[]>;
+  traceAnnotationsByTraceId: Map<string, TraceAnnotation[]>;
+};
 
 /** Makes a name safe to use in a file name. */
 export function sanitizeSpanDownloadFileName(name: string): string {
@@ -79,7 +107,7 @@ async function fetchSpans<Span>({
   spanIds?: string[];
   traceIds?: string[];
   fetchPage: (query: SpanSearchQuery) => Promise<SpanPage<Span>>;
-  onPage: (spans: Span[]) => void;
+  onPage: (spans: Span[]) => void | Promise<void>;
 }): Promise<void> {
   const useSpanIds = spanIds != null;
   const idList = spanIds ?? traceIds ?? [];
@@ -91,10 +119,39 @@ async function fetchSpans<Span>({
         ...(useSpanIds ? { span_id: batch } : { trace_id: batch }),
         ...(cursor ? { cursor } : {}),
       });
-      onPage(page.data);
+      await onPage(page.data);
       cursor = page.next_cursor ?? null;
     } while (cursor);
   }
+}
+
+/** Fetches annotations in bounded ID batches and follows every cursor. */
+async function fetchAnnotations<Annotation>({
+  ids,
+  fetchPage,
+}: {
+  ids: string[];
+  fetchPage: (params: {
+    ids: string[];
+    query: AnnotationSearchQuery;
+  }) => Promise<SpanPage<Annotation>>;
+}): Promise<Annotation[]> {
+  const annotations: Annotation[] = [];
+  for (const batch of chunk(ids, ID_BATCH_SIZE)) {
+    let cursor: string | null = null;
+    do {
+      const page = await fetchPage({
+        ids: batch,
+        query: {
+          limit: PAGE_SIZE,
+          ...(cursor ? { cursor } : {}),
+        },
+      });
+      annotations.push(...page.data);
+      cursor = page.next_cursor ?? null;
+    } while (cursor);
+  }
+  return annotations;
 }
 
 async function fetchOtlpSpanPage({
@@ -131,6 +188,264 @@ async function fetchSpanPage({
   return data;
 }
 
+async function fetchSpanAnnotations({
+  projectId,
+  spanIds,
+}: {
+  projectId: string;
+  spanIds: string[];
+}): Promise<SpanAnnotation[]> {
+  return fetchAnnotations({
+    ids: spanIds,
+    fetchPage: async ({ ids, query }) => {
+      const { data, error, response } = await authApiFetch.GET(
+        "/v1/projects/{project_identifier}/span_annotations",
+        {
+          params: {
+            path: { project_identifier: projectId },
+            query: { span_ids: ids, ...query },
+          },
+        }
+      );
+      if (data == null) {
+        throw toDownloadError({ status: response.status, error });
+      }
+      return data;
+    },
+  });
+}
+
+async function fetchTraceAnnotations({
+  projectId,
+  traceIds,
+}: {
+  projectId: string;
+  traceIds: string[];
+}): Promise<TraceAnnotation[]> {
+  return fetchAnnotations({
+    ids: traceIds,
+    fetchPage: async ({ ids, query }) => {
+      const { data, error, response } = await authApiFetch.GET(
+        "/v1/projects/{project_identifier}/trace_annotations",
+        {
+          params: {
+            path: { project_identifier: projectId },
+            query: { trace_ids: ids, ...query },
+          },
+        }
+      );
+      if (data == null) {
+        throw toDownloadError({ status: response.status, error });
+      }
+      return data;
+    },
+  });
+}
+
+function getAnnotationAttributes({
+  annotations,
+  prefix,
+}: {
+  annotations: Annotation[];
+  prefix: typeof ANNOTATIONS | typeof TRACE_ANNOTATIONS;
+}): AnnotationAttributes {
+  const attributes: AnnotationAttributes = {};
+  annotations.forEach((annotation, index) => {
+    const annotationPrefix = `${prefix}.${index}`;
+    attributes[`${annotationPrefix}.${ANNOTATION_NAME}`] = annotation.name;
+    attributes[`${annotationPrefix}.${ANNOTATION_ANNOTATOR_KIND}`] =
+      annotation.annotator_kind;
+
+    if (annotation.result?.score != null) {
+      attributes[`${annotationPrefix}.${ANNOTATION_SCORE}`] =
+        annotation.result.score;
+    }
+    if (annotation.result?.label != null) {
+      attributes[`${annotationPrefix}.${ANNOTATION_LABEL}`] =
+        annotation.result.label;
+    }
+    if (annotation.result?.explanation != null) {
+      attributes[`${annotationPrefix}.${ANNOTATION_EXPLANATION}`] =
+        annotation.result.explanation;
+    }
+    if (annotation.identifier) {
+      attributes[`${annotationPrefix}.${ANNOTATION_IDENTIFIER}`] =
+        annotation.identifier;
+    }
+    if (annotation.metadata && Object.keys(annotation.metadata).length > 0) {
+      attributes[`${annotationPrefix}.${ANNOTATION_METADATA}`] = JSON.stringify(
+        annotation.metadata
+      );
+    }
+  });
+  return attributes;
+}
+
+function groupAnnotationsByTargetId<Annotation>({
+  annotations,
+  getTargetId,
+}: {
+  annotations: Annotation[];
+  getTargetId: (annotation: Annotation) => string;
+}): Map<string, Annotation[]> {
+  const annotationsByTargetId = new Map<string, Annotation[]>();
+  annotations.forEach((annotation) => {
+    const targetId = getTargetId(annotation);
+    const targetAnnotations = annotationsByTargetId.get(targetId) ?? [];
+    targetAnnotations.push(annotation);
+    annotationsByTargetId.set(targetId, targetAnnotations);
+  });
+  return annotationsByTargetId;
+}
+
+function getTraceAnnotationCarrierSpanIds<Span>({
+  spans,
+  getSpanId,
+  getTraceId,
+  isRootSpan,
+}: {
+  spans: Span[];
+  getSpanId: (span: Span) => string | null | undefined;
+  getTraceId: (span: Span) => string | null | undefined;
+  isRootSpan: (span: Span) => boolean;
+}): Map<string, string> {
+  const carrierSpanIdsByTraceId = new Map<string, string>();
+  spans.forEach((span) => {
+    const spanId = getSpanId(span);
+    const traceId = getTraceId(span);
+    if (spanId == null || traceId == null) {
+      return;
+    }
+    if (!carrierSpanIdsByTraceId.has(traceId) || isRootSpan(span)) {
+      carrierSpanIdsByTraceId.set(traceId, spanId);
+    }
+  });
+  return carrierSpanIdsByTraceId;
+}
+
+function toOtlpAttributes(attributes: AnnotationAttributes): OtlpKeyValue[] {
+  return Object.entries(attributes).map(([key, value]) => ({
+    key,
+    value:
+      typeof value === "number"
+        ? { double_value: value }
+        : { string_value: value },
+  }));
+}
+
+function addAnnotationsToPhoenixSpan({
+  span,
+  spanAnnotations,
+  traceAnnotations,
+}: {
+  span: PhoenixSpan;
+  spanAnnotations: SpanAnnotation[];
+  traceAnnotations: TraceAnnotation[];
+}): PhoenixSpan {
+  const annotationAttributes = {
+    ...getAnnotationAttributes({
+      annotations: spanAnnotations,
+      prefix: ANNOTATIONS,
+    }),
+    ...getAnnotationAttributes({
+      annotations: traceAnnotations,
+      prefix: TRACE_ANNOTATIONS,
+    }),
+  };
+  if (Object.keys(annotationAttributes).length === 0) {
+    return span;
+  }
+  return {
+    ...span,
+    attributes: { ...span.attributes, ...annotationAttributes },
+  };
+}
+
+function addAnnotationsToOtlpSpan({
+  span,
+  spanAnnotations,
+  traceAnnotations,
+}: {
+  span: OtlpSpan;
+  spanAnnotations: SpanAnnotation[];
+  traceAnnotations: TraceAnnotation[];
+}): OtlpSpan {
+  const annotationAttributes = toOtlpAttributes({
+    ...getAnnotationAttributes({
+      annotations: spanAnnotations,
+      prefix: ANNOTATIONS,
+    }),
+    ...getAnnotationAttributes({
+      annotations: traceAnnotations,
+      prefix: TRACE_ANNOTATIONS,
+    }),
+  });
+  if (annotationAttributes.length === 0) {
+    return span;
+  }
+  const annotationAttributeKeys = new Set(
+    annotationAttributes.map(({ key }) => key)
+  );
+  return {
+    ...span,
+    attributes: [
+      ...(span.attributes ?? []).filter(
+        ({ key }) => key == null || !annotationAttributeKeys.has(key)
+      ),
+      ...annotationAttributes,
+    ],
+  };
+}
+
+async function fetchAnnotationsForSpans({
+  projectId,
+  spans,
+  includeSpanAnnotations,
+  includeTraceAnnotations,
+}: {
+  projectId: string;
+  spans: Array<PhoenixSpan | OtlpSpan>;
+  includeSpanAnnotations: boolean;
+  includeTraceAnnotations: boolean;
+}): Promise<AnnotationLookup> {
+  const spanIds = [
+    ...new Set(
+      spans
+        .map((span) =>
+          "context" in span ? span.context.span_id : span.span_id
+        )
+        .filter((spanId): spanId is string => spanId != null)
+    ),
+  ];
+  const traceIds = [
+    ...new Set(
+      spans
+        .map((span) =>
+          "context" in span ? span.context.trace_id : span.trace_id
+        )
+        .filter((traceId): traceId is string => traceId != null)
+    ),
+  ];
+  const [spanAnnotations, traceAnnotations] = await Promise.all([
+    includeSpanAnnotations && spanIds.length > 0
+      ? fetchSpanAnnotations({ projectId, spanIds })
+      : [],
+    includeTraceAnnotations && traceIds.length > 0
+      ? fetchTraceAnnotations({ projectId, traceIds })
+      : [],
+  ]);
+  return {
+    spanAnnotationsBySpanId: groupAnnotationsByTargetId({
+      annotations: spanAnnotations,
+      getTargetId: (annotation) => annotation.span_id,
+    }),
+    traceAnnotationsByTraceId: groupAnnotationsByTargetId({
+      annotations: traceAnnotations,
+      getTargetId: (annotation) => annotation.trace_id,
+    }),
+  };
+}
+
 /** Downloads blob parts without first joining them into one large JS string. */
 function downloadBlob({
   fileName,
@@ -156,54 +471,107 @@ export async function downloadSpanCollection({
   traceIds,
   format,
   fileName,
+  includeSpanAnnotations = true,
+  includeTraceAnnotations = true,
 }: {
   projectId: string;
   spanIds?: string[];
   traceIds?: string[];
   format: SpanDownloadFormat;
   fileName: string;
+  includeSpanAnnotations?: boolean;
+  includeTraceAnnotations?: boolean;
 }): Promise<void> {
-  const parts: BlobPart[] = [];
   if (format === "jsonl") {
+    const spans: PhoenixSpan[] = [];
     await fetchSpans<PhoenixSpan>({
       spanIds,
       traceIds,
       fetchPage: (query) => fetchSpanPage({ projectId, query }),
-      onPage: (spans) => {
-        if (spans.length === 0) {
-          return;
-        }
-        parts.push(spans.map((span) => JSON.stringify(span)).join("\n"));
-        parts.push("\n");
+      onPage: (pageSpans) => {
+        spans.push(...pageSpans);
       },
     });
+    const { spanAnnotationsBySpanId, traceAnnotationsByTraceId } =
+      await fetchAnnotationsForSpans({
+        projectId,
+        spans,
+        includeSpanAnnotations,
+        includeTraceAnnotations,
+      });
+    const traceAnnotationCarrierSpanIds = getTraceAnnotationCarrierSpanIds({
+      spans,
+      getSpanId: (span) => span.context.span_id,
+      getTraceId: (span) => span.context.trace_id,
+      isRootSpan: (span) => span.parent_id == null || span.parent_id === "",
+    });
+    const serializedSpans = spans.map((span) =>
+      JSON.stringify(
+        addAnnotationsToPhoenixSpan({
+          span,
+          spanAnnotations:
+            spanAnnotationsBySpanId.get(span.context.span_id) ?? [],
+          traceAnnotations:
+            traceAnnotationCarrierSpanIds.get(span.context.trace_id) ===
+            span.context.span_id
+              ? (traceAnnotationsByTraceId.get(span.context.trace_id) ?? [])
+              : [],
+        })
+      )
+    );
     downloadBlob({
       fileName,
-      parts,
+      parts:
+        serializedSpans.length > 0 ? [serializedSpans.join("\n"), "\n"] : [],
       type: "application/x-ndjson",
     });
     return;
   }
 
-  parts.push('{"resource_spans":[{"scope_spans":[{"spans":[');
-  let isFirstPage = true;
+  const spans: OtlpSpan[] = [];
   await fetchSpans<OtlpSpan>({
     spanIds,
     traceIds,
     fetchPage: (query) => fetchOtlpSpanPage({ projectId, query }),
-    onPage: (spans) => {
-      if (spans.length === 0) {
-        return;
-      }
-      const serialized = spans.map((span) => JSON.stringify(span)).join(",");
-      parts.push(isFirstPage ? serialized : `,${serialized}`);
-      isFirstPage = false;
+    onPage: (pageSpans) => {
+      spans.push(...pageSpans);
     },
   });
-  parts.push("]}]}]}");
+  const { spanAnnotationsBySpanId, traceAnnotationsByTraceId } =
+    await fetchAnnotationsForSpans({
+      projectId,
+      spans,
+      includeSpanAnnotations,
+      includeTraceAnnotations,
+    });
+  const traceAnnotationCarrierSpanIds = getTraceAnnotationCarrierSpanIds({
+    spans,
+    getSpanId: (span) => span.span_id,
+    getTraceId: (span) => span.trace_id,
+    isRootSpan: (span) =>
+      span.parent_span_id == null || span.parent_span_id === "",
+  });
+  const spansWithAnnotations = spans.map((span) =>
+    addAnnotationsToOtlpSpan({
+      span,
+      spanAnnotations:
+        span.span_id == null
+          ? []
+          : (spanAnnotationsBySpanId.get(span.span_id) ?? []),
+      traceAnnotations:
+        span.trace_id != null &&
+        traceAnnotationCarrierSpanIds.get(span.trace_id) === span.span_id
+          ? (traceAnnotationsByTraceId.get(span.trace_id) ?? [])
+          : [],
+    })
+  );
   downloadBlob({
     fileName,
-    parts,
+    parts: [
+      JSON.stringify({
+        resource_spans: [{ scope_spans: [{ spans: spansWithAnnotations }] }],
+      }),
+    ],
     type: "application/json",
   });
 }
@@ -214,11 +582,15 @@ export async function downloadSingleSpan({
   spanId,
   format,
   fileName,
+  includeSpanAnnotations = true,
+  includeTraceAnnotations = true,
 }: {
   projectId: string;
   spanId: string;
   format: SingleSpanDownloadFormat;
   fileName: string;
+  includeSpanAnnotations?: boolean;
+  includeTraceAnnotations?: boolean;
 }): Promise<void> {
   if (format === "otlp-json") {
     await downloadSpanCollection({
@@ -226,6 +598,8 @@ export async function downloadSingleSpan({
       spanIds: [spanId],
       format,
       fileName,
+      includeSpanAnnotations,
+      includeTraceAnnotations,
     });
     return;
   }
@@ -238,9 +612,22 @@ export async function downloadSingleSpan({
   if (span == null) {
     throw new Error("Span not found");
   }
+  const { spanAnnotationsBySpanId, traceAnnotationsByTraceId } =
+    await fetchAnnotationsForSpans({
+      projectId,
+      spans: [span],
+      includeSpanAnnotations,
+      includeTraceAnnotations,
+    });
+  const spanWithAnnotations = addAnnotationsToPhoenixSpan({
+    span,
+    spanAnnotations: spanAnnotationsBySpanId.get(span.context.span_id) ?? [],
+    traceAnnotations:
+      traceAnnotationsByTraceId.get(span.context.trace_id) ?? [],
+  });
   downloadBlob({
     fileName,
-    parts: [JSON.stringify(span, null, 2), "\n"],
+    parts: [JSON.stringify(spanWithAnnotations, null, 2), "\n"],
     type: "application/json",
   });
 }

--- a/app/src/components/trace/spanDownloadUtils.ts
+++ b/app/src/components/trace/spanDownloadUtils.ts
@@ -1,21 +1,17 @@
-import {
-  ANNOTATIONS,
-  ANNOTATION_ANNOTATOR_KIND,
-  ANNOTATION_EXPLANATION,
-  ANNOTATION_IDENTIFIER,
-  ANNOTATION_LABEL,
-  ANNOTATION_METADATA,
-  ANNOTATION_NAME,
-  ANNOTATION_SCORE,
-  TRACE_ANNOTATIONS,
-} from "@arizeai/openinference-semantic-conventions";
 import chunk from "lodash/chunk";
 
 import type { components } from "@phoenix/api/__generated__/v1";
 import { authApiFetch } from "@phoenix/api/authApiFetch";
 
+import {
+  addAnnotationsToOtlpSpan,
+  addAnnotationsToPhoenixSpan,
+  applyAnnotationsToSpans,
+  fetchAnnotationsForTargets,
+  type SpanAnnotationTarget,
+} from "./spanDownloadAnnotations";
+
 type OtlpSpan = components["schemas"]["OtlpSpan"];
-type OtlpKeyValue = components["schemas"]["OtlpKeyValue"];
 type PhoenixSpan = components["schemas"]["Span"];
 type SpanAnnotation = components["schemas"]["SpanAnnotation"];
 type TraceAnnotation = components["schemas"]["TraceAnnotation"];
@@ -50,18 +46,21 @@ type SpanSearchQuery = {
 
 type SpanPage<Span> = { data: Span[]; next_cursor?: string | null };
 
-type Annotation = SpanAnnotation | TraceAnnotation;
-type AnnotationAttributeValue = string | number;
-type AnnotationAttributes = Record<string, AnnotationAttributeValue>;
-
-type AnnotationSearchQuery = {
-  limit: number;
-  cursor?: string;
+type SpanDownloadIncludeAnnotations = {
+  includeSpanAnnotations: boolean;
+  includeTraceAnnotations: boolean;
 };
 
-type AnnotationLookup = {
-  spanAnnotationsBySpanId: Map<string, SpanAnnotation[]>;
-  traceAnnotationsByTraceId: Map<string, TraceAnnotation[]>;
+type SpanExportFormat<Span> = {
+  fetchPage: (query: SpanSearchQuery) => Promise<SpanPage<Span>>;
+  getTarget: (span: Span) => SpanAnnotationTarget | null;
+  withAnnotations: (
+    span: Span,
+    spanAnnotations: SpanAnnotation[],
+    traceAnnotations: TraceAnnotation[]
+  ) => Span;
+  toBlobParts: (spans: Span[]) => BlobPart[];
+  mimeType: string;
 };
 
 /** Makes a name safe to use in a file name. */
@@ -125,35 +124,6 @@ async function fetchSpans<Span>({
   }
 }
 
-/** Fetches annotations in bounded ID batches and follows every cursor. */
-async function fetchAnnotations<Annotation>({
-  ids,
-  fetchPage,
-}: {
-  ids: string[];
-  fetchPage: (params: {
-    ids: string[];
-    query: AnnotationSearchQuery;
-  }) => Promise<SpanPage<Annotation>>;
-}): Promise<Annotation[]> {
-  const annotations: Annotation[] = [];
-  for (const batch of chunk(ids, ID_BATCH_SIZE)) {
-    let cursor: string | null = null;
-    do {
-      const page = await fetchPage({
-        ids: batch,
-        query: {
-          limit: PAGE_SIZE,
-          ...(cursor ? { cursor } : {}),
-        },
-      });
-      annotations.push(...page.data);
-      cursor = page.next_cursor ?? null;
-    } while (cursor);
-  }
-  return annotations;
-}
-
 async function fetchOtlpSpanPage({
   projectId,
   query,
@@ -188,261 +158,84 @@ async function fetchSpanPage({
   return data;
 }
 
-async function fetchSpanAnnotations({
-  projectId,
-  spanIds,
-}: {
-  projectId: string;
-  spanIds: string[];
-}): Promise<SpanAnnotation[]> {
-  return fetchAnnotations({
-    ids: spanIds,
-    fetchPage: async ({ ids, query }) => {
-      const { data, error, response } = await authApiFetch.GET(
-        "/v1/projects/{project_identifier}/span_annotations",
-        {
-          params: {
-            path: { project_identifier: projectId },
-            query: { span_ids: ids, ...query },
-          },
-        }
-      );
-      if (data == null) {
-        throw toDownloadError({ status: response.status, error });
-      }
-      return data;
-    },
-  });
-}
-
-async function fetchTraceAnnotations({
-  projectId,
-  traceIds,
-}: {
-  projectId: string;
-  traceIds: string[];
-}): Promise<TraceAnnotation[]> {
-  return fetchAnnotations({
-    ids: traceIds,
-    fetchPage: async ({ ids, query }) => {
-      const { data, error, response } = await authApiFetch.GET(
-        "/v1/projects/{project_identifier}/trace_annotations",
-        {
-          params: {
-            path: { project_identifier: projectId },
-            query: { trace_ids: ids, ...query },
-          },
-        }
-      );
-      if (data == null) {
-        throw toDownloadError({ status: response.status, error });
-      }
-      return data;
-    },
-  });
-}
-
-function getAnnotationAttributes({
-  annotations,
-  prefix,
-}: {
-  annotations: Annotation[];
-  prefix: typeof ANNOTATIONS | typeof TRACE_ANNOTATIONS;
-}): AnnotationAttributes {
-  const attributes: AnnotationAttributes = {};
-  annotations.forEach((annotation, index) => {
-    const annotationPrefix = `${prefix}.${index}`;
-    attributes[`${annotationPrefix}.${ANNOTATION_NAME}`] = annotation.name;
-    attributes[`${annotationPrefix}.${ANNOTATION_ANNOTATOR_KIND}`] =
-      annotation.annotator_kind;
-
-    if (annotation.result?.score != null) {
-      attributes[`${annotationPrefix}.${ANNOTATION_SCORE}`] =
-        annotation.result.score;
-    }
-    if (annotation.result?.label != null) {
-      attributes[`${annotationPrefix}.${ANNOTATION_LABEL}`] =
-        annotation.result.label;
-    }
-    if (annotation.result?.explanation != null) {
-      attributes[`${annotationPrefix}.${ANNOTATION_EXPLANATION}`] =
-        annotation.result.explanation;
-    }
-    if (annotation.identifier) {
-      attributes[`${annotationPrefix}.${ANNOTATION_IDENTIFIER}`] =
-        annotation.identifier;
-    }
-    if (annotation.metadata && Object.keys(annotation.metadata).length > 0) {
-      attributes[`${annotationPrefix}.${ANNOTATION_METADATA}`] = JSON.stringify(
-        annotation.metadata
-      );
-    }
-  });
-  return attributes;
-}
-
-function groupAnnotationsByTargetId<Annotation>({
-  annotations,
-  getTargetId,
-}: {
-  annotations: Annotation[];
-  getTargetId: (annotation: Annotation) => string;
-}): Map<string, Annotation[]> {
-  const annotationsByTargetId = new Map<string, Annotation[]>();
-  annotations.forEach((annotation) => {
-    const targetId = getTargetId(annotation);
-    const targetAnnotations = annotationsByTargetId.get(targetId) ?? [];
-    targetAnnotations.push(annotation);
-    annotationsByTargetId.set(targetId, targetAnnotations);
-  });
-  return annotationsByTargetId;
-}
-
-function getTraceAnnotationCarrierSpanIds<Span>({
-  spans,
-  getSpanId,
-  getTraceId,
-  isRootSpan,
-}: {
-  spans: Span[];
-  getSpanId: (span: Span) => string | null | undefined;
-  getTraceId: (span: Span) => string | null | undefined;
-  isRootSpan: (span: Span) => boolean;
-}): Map<string, string> {
-  const carrierSpanIdsByTraceId = new Map<string, string>();
-  spans.forEach((span) => {
-    const spanId = getSpanId(span);
-    const traceId = getTraceId(span);
-    if (spanId == null || traceId == null) {
-      return;
-    }
-    if (!carrierSpanIdsByTraceId.has(traceId) || isRootSpan(span)) {
-      carrierSpanIdsByTraceId.set(traceId, spanId);
-    }
-  });
-  return carrierSpanIdsByTraceId;
-}
-
-function toOtlpAttributes(attributes: AnnotationAttributes): OtlpKeyValue[] {
-  return Object.entries(attributes).map(([key, value]) => ({
-    key,
-    value:
-      typeof value === "number"
-        ? { double_value: value }
-        : { string_value: value },
-  }));
-}
-
-function addAnnotationsToPhoenixSpan({
-  span,
-  spanAnnotations,
-  traceAnnotations,
-}: {
-  span: PhoenixSpan;
-  spanAnnotations: SpanAnnotation[];
-  traceAnnotations: TraceAnnotation[];
-}): PhoenixSpan {
-  const annotationAttributes = {
-    ...getAnnotationAttributes({
-      annotations: spanAnnotations,
-      prefix: ANNOTATIONS,
-    }),
-    ...getAnnotationAttributes({
-      annotations: traceAnnotations,
-      prefix: TRACE_ANNOTATIONS,
-    }),
+function getPhoenixSpanTarget(span: PhoenixSpan): SpanAnnotationTarget {
+  return {
+    spanId: span.context.span_id,
+    traceId: span.context.trace_id,
+    isRoot: span.parent_id == null || span.parent_id === "",
   };
-  if (Object.keys(annotationAttributes).length === 0) {
-    return span;
+}
+
+function getOtlpSpanTarget(span: OtlpSpan): SpanAnnotationTarget | null {
+  if (span.span_id == null || span.trace_id == null) {
+    return null;
   }
   return {
-    ...span,
-    attributes: { ...span.attributes, ...annotationAttributes },
+    spanId: span.span_id,
+    traceId: span.trace_id,
+    isRoot: span.parent_span_id == null || span.parent_span_id === "",
   };
 }
 
-function addAnnotationsToOtlpSpan({
-  span,
-  spanAnnotations,
-  traceAnnotations,
-}: {
-  span: OtlpSpan;
-  spanAnnotations: SpanAnnotation[];
-  traceAnnotations: TraceAnnotation[];
-}): OtlpSpan {
-  const annotationAttributes = toOtlpAttributes({
-    ...getAnnotationAttributes({
-      annotations: spanAnnotations,
-      prefix: ANNOTATIONS,
-    }),
-    ...getAnnotationAttributes({
-      annotations: traceAnnotations,
-      prefix: TRACE_ANNOTATIONS,
-    }),
-  });
-  if (annotationAttributes.length === 0) {
-    return span;
+/** Emits JSONL as page-sized BlobParts instead of one giant joined string. */
+function toJsonlBlobParts(spans: PhoenixSpan[]): BlobPart[] {
+  if (spans.length === 0) {
+    return [];
   }
-  const annotationAttributeKeys = new Set(
-    annotationAttributes.map(({ key }) => key)
-  );
-  return {
-    ...span,
-    attributes: [
-      ...(span.attributes ?? []).filter(
-        ({ key }) => key == null || !annotationAttributeKeys.has(key)
-      ),
-      ...annotationAttributes,
-    ],
-  };
+  const parts: BlobPart[] = [];
+  for (const batch of chunk(spans, PAGE_SIZE)) {
+    parts.push(batch.map((span) => JSON.stringify(span)).join("\n"));
+    parts.push("\n");
+  }
+  return parts;
 }
 
-async function fetchAnnotationsForSpans({
+/**
+ * Emits OTLP JSON with open/body/close framing so each page is its own
+ * BlobPart rather than one JSON.stringify of the full spans array.
+ */
+function toOtlpBlobParts(spans: OtlpSpan[]): BlobPart[] {
+  const parts: BlobPart[] = ['{"resource_spans":[{"scope_spans":[{"spans":['];
+  let isFirstBatch = true;
+  for (const batch of chunk(spans, PAGE_SIZE)) {
+    if (batch.length === 0) {
+      continue;
+    }
+    const serialized = batch.map((span) => JSON.stringify(span)).join(",");
+    parts.push(isFirstBatch ? serialized : `,${serialized}`);
+    isFirstBatch = false;
+  }
+  parts.push("]}]}]}");
+  return parts;
+}
+
+function createPhoenixJsonlFormat({
   projectId,
-  spans,
-  includeSpanAnnotations,
-  includeTraceAnnotations,
 }: {
   projectId: string;
-  spans: Array<PhoenixSpan | OtlpSpan>;
-  includeSpanAnnotations: boolean;
-  includeTraceAnnotations: boolean;
-}): Promise<AnnotationLookup> {
-  const spanIds = [
-    ...new Set(
-      spans
-        .map((span) =>
-          "context" in span ? span.context.span_id : span.span_id
-        )
-        .filter((spanId): spanId is string => spanId != null)
-    ),
-  ];
-  const traceIds = [
-    ...new Set(
-      spans
-        .map((span) =>
-          "context" in span ? span.context.trace_id : span.trace_id
-        )
-        .filter((traceId): traceId is string => traceId != null)
-    ),
-  ];
-  const [spanAnnotations, traceAnnotations] = await Promise.all([
-    includeSpanAnnotations && spanIds.length > 0
-      ? fetchSpanAnnotations({ projectId, spanIds })
-      : [],
-    includeTraceAnnotations && traceIds.length > 0
-      ? fetchTraceAnnotations({ projectId, traceIds })
-      : [],
-  ]);
+}): SpanExportFormat<PhoenixSpan> {
   return {
-    spanAnnotationsBySpanId: groupAnnotationsByTargetId({
-      annotations: spanAnnotations,
-      getTargetId: (annotation) => annotation.span_id,
-    }),
-    traceAnnotationsByTraceId: groupAnnotationsByTargetId({
-      annotations: traceAnnotations,
-      getTargetId: (annotation) => annotation.trace_id,
-    }),
+    fetchPage: (query) => fetchSpanPage({ projectId, query }),
+    getTarget: getPhoenixSpanTarget,
+    withAnnotations: (span, spanAnnotations, traceAnnotations) =>
+      addAnnotationsToPhoenixSpan({ span, spanAnnotations, traceAnnotations }),
+    toBlobParts: toJsonlBlobParts,
+    mimeType: "application/x-ndjson",
+  };
+}
+
+function createOtlpJsonFormat({
+  projectId,
+}: {
+  projectId: string;
+}): SpanExportFormat<OtlpSpan> {
+  return {
+    fetchPage: (query) => fetchOtlpSpanPage({ projectId, query }),
+    getTarget: getOtlpSpanTarget,
+    withAnnotations: (span, spanAnnotations, traceAnnotations) =>
+      addAnnotationsToOtlpSpan({ span, spanAnnotations, traceAnnotations }),
+    toBlobParts: toOtlpBlobParts,
+    mimeType: "application/json",
   };
 }
 
@@ -464,6 +257,52 @@ function downloadBlob({
   setTimeout(() => URL.revokeObjectURL(url), URL_REVOKE_DELAY_MS);
 }
 
+async function downloadWithFormat<Span>({
+  projectId,
+  spanIds,
+  traceIds,
+  exportFormat,
+  fileName,
+  includeSpanAnnotations,
+  includeTraceAnnotations,
+}: {
+  projectId: string;
+  spanIds?: string[];
+  traceIds?: string[];
+  exportFormat: SpanExportFormat<Span>;
+  fileName: string;
+} & SpanDownloadIncludeAnnotations): Promise<void> {
+  const spans: Span[] = [];
+  await fetchSpans({
+    spanIds,
+    traceIds,
+    fetchPage: exportFormat.fetchPage,
+    onPage: (pageSpans) => {
+      spans.push(...pageSpans);
+    },
+  });
+  const targets = spans.map(exportFormat.getTarget);
+  const lookup = await fetchAnnotationsForTargets({
+    projectId,
+    targets: targets.filter(
+      (target): target is SpanAnnotationTarget => target != null
+    ),
+    includeSpanAnnotations,
+    includeTraceAnnotations,
+  });
+  const spansWithAnnotations = applyAnnotationsToSpans({
+    spans,
+    lookup,
+    getTarget: exportFormat.getTarget,
+    withAnnotations: exportFormat.withAnnotations,
+  });
+  downloadBlob({
+    fileName,
+    parts: exportFormat.toBlobParts(spansWithAnnotations),
+    type: exportFormat.mimeType,
+  });
+}
+
 /** Downloads spans or complete traces in one of the bulk export formats. */
 export async function downloadSpanCollection({
   projectId,
@@ -471,108 +310,33 @@ export async function downloadSpanCollection({
   traceIds,
   format,
   fileName,
-  includeSpanAnnotations = true,
-  includeTraceAnnotations = true,
+  includeSpanAnnotations,
+  includeTraceAnnotations,
 }: {
   projectId: string;
   spanIds?: string[];
   traceIds?: string[];
   format: SpanDownloadFormat;
   fileName: string;
-  includeSpanAnnotations?: boolean;
-  includeTraceAnnotations?: boolean;
-}): Promise<void> {
+} & SpanDownloadIncludeAnnotations): Promise<void> {
+  const shared = {
+    projectId,
+    spanIds,
+    traceIds,
+    fileName,
+    includeSpanAnnotations,
+    includeTraceAnnotations,
+  };
   if (format === "jsonl") {
-    const spans: PhoenixSpan[] = [];
-    await fetchSpans<PhoenixSpan>({
-      spanIds,
-      traceIds,
-      fetchPage: (query) => fetchSpanPage({ projectId, query }),
-      onPage: (pageSpans) => {
-        spans.push(...pageSpans);
-      },
-    });
-    const { spanAnnotationsBySpanId, traceAnnotationsByTraceId } =
-      await fetchAnnotationsForSpans({
-        projectId,
-        spans,
-        includeSpanAnnotations,
-        includeTraceAnnotations,
-      });
-    const traceAnnotationCarrierSpanIds = getTraceAnnotationCarrierSpanIds({
-      spans,
-      getSpanId: (span) => span.context.span_id,
-      getTraceId: (span) => span.context.trace_id,
-      isRootSpan: (span) => span.parent_id == null || span.parent_id === "",
-    });
-    const serializedSpans = spans.map((span) =>
-      JSON.stringify(
-        addAnnotationsToPhoenixSpan({
-          span,
-          spanAnnotations:
-            spanAnnotationsBySpanId.get(span.context.span_id) ?? [],
-          traceAnnotations:
-            traceAnnotationCarrierSpanIds.get(span.context.trace_id) ===
-            span.context.span_id
-              ? (traceAnnotationsByTraceId.get(span.context.trace_id) ?? [])
-              : [],
-        })
-      )
-    );
-    downloadBlob({
-      fileName,
-      parts:
-        serializedSpans.length > 0 ? [serializedSpans.join("\n"), "\n"] : [],
-      type: "application/x-ndjson",
+    await downloadWithFormat({
+      ...shared,
+      exportFormat: createPhoenixJsonlFormat({ projectId }),
     });
     return;
   }
-
-  const spans: OtlpSpan[] = [];
-  await fetchSpans<OtlpSpan>({
-    spanIds,
-    traceIds,
-    fetchPage: (query) => fetchOtlpSpanPage({ projectId, query }),
-    onPage: (pageSpans) => {
-      spans.push(...pageSpans);
-    },
-  });
-  const { spanAnnotationsBySpanId, traceAnnotationsByTraceId } =
-    await fetchAnnotationsForSpans({
-      projectId,
-      spans,
-      includeSpanAnnotations,
-      includeTraceAnnotations,
-    });
-  const traceAnnotationCarrierSpanIds = getTraceAnnotationCarrierSpanIds({
-    spans,
-    getSpanId: (span) => span.span_id,
-    getTraceId: (span) => span.trace_id,
-    isRootSpan: (span) =>
-      span.parent_span_id == null || span.parent_span_id === "",
-  });
-  const spansWithAnnotations = spans.map((span) =>
-    addAnnotationsToOtlpSpan({
-      span,
-      spanAnnotations:
-        span.span_id == null
-          ? []
-          : (spanAnnotationsBySpanId.get(span.span_id) ?? []),
-      traceAnnotations:
-        span.trace_id != null &&
-        traceAnnotationCarrierSpanIds.get(span.trace_id) === span.span_id
-          ? (traceAnnotationsByTraceId.get(span.trace_id) ?? [])
-          : [],
-    })
-  );
-  downloadBlob({
-    fileName,
-    parts: [
-      JSON.stringify({
-        resource_spans: [{ scope_spans: [{ spans: spansWithAnnotations }] }],
-      }),
-    ],
-    type: "application/json",
+  await downloadWithFormat({
+    ...shared,
+    exportFormat: createOtlpJsonFormat({ projectId }),
   });
 }
 
@@ -582,16 +346,14 @@ export async function downloadSingleSpan({
   spanId,
   format,
   fileName,
-  includeSpanAnnotations = true,
-  includeTraceAnnotations = true,
+  includeSpanAnnotations,
+  includeTraceAnnotations,
 }: {
   projectId: string;
   spanId: string;
   format: SingleSpanDownloadFormat;
   fileName: string;
-  includeSpanAnnotations?: boolean;
-  includeTraceAnnotations?: boolean;
-}): Promise<void> {
+} & SpanDownloadIncludeAnnotations): Promise<void> {
   if (format === "otlp-json") {
     await downloadSpanCollection({
       projectId,
@@ -612,18 +374,17 @@ export async function downloadSingleSpan({
   if (span == null) {
     throw new Error("Span not found");
   }
-  const { spanAnnotationsBySpanId, traceAnnotationsByTraceId } =
-    await fetchAnnotationsForSpans({
-      projectId,
-      spans: [span],
-      includeSpanAnnotations,
-      includeTraceAnnotations,
-    });
+  const target = getPhoenixSpanTarget(span);
+  const lookup = await fetchAnnotationsForTargets({
+    projectId,
+    targets: [target],
+    includeSpanAnnotations,
+    includeTraceAnnotations,
+  });
   const spanWithAnnotations = addAnnotationsToPhoenixSpan({
     span,
-    spanAnnotations: spanAnnotationsBySpanId.get(span.context.span_id) ?? [],
-    traceAnnotations:
-      traceAnnotationsByTraceId.get(span.context.trace_id) ?? [],
+    spanAnnotations: lookup.spanAnnotationsBySpanId.get(target.spanId) ?? [],
+    traceAnnotations: lookup.traceAnnotationsByTraceId.get(target.traceId) ?? [],
   });
   downloadBlob({
     fileName,

--- a/app/src/components/trace/spanDownloadUtils.ts
+++ b/app/src/components/trace/spanDownloadUtils.ts
@@ -292,8 +292,8 @@ async function downloadWithFormat<Span>({
   });
   const spansWithAnnotations = applyAnnotationsToSpans({
     spans,
+    targets,
     lookup,
-    getTarget: exportFormat.getTarget,
     withAnnotations: exportFormat.withAnnotations,
   });
   downloadBlob({
@@ -384,7 +384,8 @@ export async function downloadSingleSpan({
   const spanWithAnnotations = addAnnotationsToPhoenixSpan({
     span,
     spanAnnotations: lookup.spanAnnotationsBySpanId.get(target.spanId) ?? [],
-    traceAnnotations: lookup.traceAnnotationsByTraceId.get(target.traceId) ?? [],
+    traceAnnotations:
+      lookup.traceAnnotationsByTraceId.get(target.traceId) ?? [],
   });
   downloadBlob({
     fileName,

--- a/app/src/pages/trace/SpanDownloadMenu.tsx
+++ b/app/src/pages/trace/SpanDownloadMenu.tsx
@@ -59,6 +59,8 @@ export function SpanDownloadMenu({
         spanId,
         format,
         fileName: `${safeTraceId}-span-${spanId}${formatSuffix}-${timestamp}.json`,
+        includeSpanAnnotations: true,
+        includeTraceAnnotations: true,
       });
     } catch (error) {
       setDownloadError(


### PR DESCRIPTION
Builds on the UI span/trace export from #10746: exported spans can now carry their annotations, so a trace pasted into an LLM or archived for review keeps the human and eval judgments attached to it.

## What changed

- **Download dialog** gains an "Annotations" group with two independent checkboxes — *Include span annotations* and *Include trace annotations* — both on by default, with contextual help explaining where the values land. Single-span download from the trace view opts into both.
- **Annotations are emitted as OpenInference semantic attributes**, so the export stays valid in both formats and round-trips through anything that already understands the conventions. Bumps `@arizeai/openinference-semantic-conventions` to `^2.6.0` for the `TRACE_ANNOTATIONS` prefix.
  - Phoenix JSONL: merged into `span.attributes`.
  - OTLP JSON: appended as `OtlpKeyValue` entries, with any pre-existing keys of the same name filtered out so the export never carries duplicates.
- **Trace annotations land exactly once per trace**, on a carrier span chosen per trace — the root span when one is present in the export, otherwise the first span seen. Without this a trace-scope export would repeat every trace annotation on all N of the trace's spans.
- **Annotation fetching** is factored into `spanDownloadAnnotations.ts`: bounded ID batches (100 per request, keeping the query string under proxy URL limits and the SQL `IN()` under bound-parameter limits), full cursor pagination, and span/trace annotation fetches issued concurrently.

## Tests

`spanDownloadUtils.test.ts` grows to cover the annotation paths — both formats, span-only and trace-only inclusion, carrier selection with and without a root span, OTLP duplicate-key filtering, and the both-disabled case skipping the annotation requests entirely.

## Known follow-up

Joining annotations requires the full span ID set, so the export now accumulates all spans in memory rather than streaming pages straight to the blob, and the annotation fetch is a second serialized wave of requests. Measured at roughly 2.5x the span payload in peak heap and ~1 sequential request per 100 spans. Filed as #14989 with the numbers and a proposed fix (bounded concurrency, earlier annotation fetch, streaming to disk via the File System Access API) — deliberately out of scope here to keep this reviewable.