### PR TITLE
fix(agents): resolve dangling client tool calls on session resume

### DIFF
--- a/src/phoenix/server/agents/interrupted_tool_calls.py
+++ b/src/phoenix/server/agents/interrupted_tool_calls.py
@@ -1,0 +1,103 @@
+"""Resolving tool calls left dangling by an interrupted client tool execution.
+
+When a browser agent turn is interrupted while a client-executed tool call is
+pending (the user hits Stop, or the tab is closed/reloaded before the tool
+resolves), the browser only cleans up its own local state. The assistant
+message already persisted to the session carries the tool part in
+``input-available`` (or ``input-streaming``) state with no matching result.
+
+Because the server rebuilds model history from persisted messages on every
+send, resuming the session from a different surface (another browser tab, the
+CLI) turns that dangling part into a bare tool-call with no return value.
+Providers reject a tool call without a result, so the turn hard-fails with an
+opaque provider error and there is no way to clear it outside the original tab.
+
+This module sanitizes the history at load time: any unresolved tool-call part
+is replaced with a synthetic ``output-error`` result noting that the call was
+never serviced, so the turn can proceed instead of hard-failing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, TypeVar
+
+from pydantic_ai.ui.vercel_ai.request_types import (
+    ToolInputAvailablePart,
+    ToolInputStreamingPart,
+    ToolOutputErrorPart,
+    UIMessage,
+)
+
+UIMessageT = TypeVar("UIMessageT", bound=UIMessage)
+
+_UNRESOLVED_TOOL_CALL_ERROR = (
+    "This tool call was left unresolved by an interrupted session (execution "
+    "environment: {environment}) and cannot be completed from the current "
+    "session. Treat it as failed and, if needed, ask the user to retry."
+)
+
+
+def _tool_execution_environment(call_provider_metadata: dict[str, dict[str, Any]] | None) -> str:
+    """Read the execution environment Phoenix stamped on the tool call, if any."""
+    phoenix_metadata = (call_provider_metadata or {}).get("phoenix")
+    if isinstance(phoenix_metadata, dict):
+        environment = phoenix_metadata.get("tool_execution_environment")
+        if isinstance(environment, str):
+            return environment
+    return "unknown"
+
+
+def _resolve_unresolved_part(
+    part: ToolInputAvailablePart | ToolInputStreamingPart,
+) -> ToolOutputErrorPart:
+    """Turn a dangling tool-call part into a synthetic ``output-error`` result."""
+    return ToolOutputErrorPart(
+        type=part.type,
+        tool_call_id=part.tool_call_id,
+        title=part.title,
+        input=part.input,
+        error_text=_UNRESOLVED_TOOL_CALL_ERROR.format(
+            environment=_tool_execution_environment(part.call_provider_metadata)
+        ),
+        provider_executed=part.provider_executed,
+        call_provider_metadata=part.call_provider_metadata,
+    )
+
+
+def resolve_unresolved_tool_calls(
+    messages: Sequence[UIMessageT],
+) -> list[UIMessageT]:
+    """Replace dangling tool-call parts with a synthetic failed result.
+
+    Scans assistant messages for tool parts still in ``input-available`` or
+    ``input-streaming`` state - a call that was made (or was being made) but
+    never got a result and never will, since the session that would have
+    supplied one is gone. Approval-pending parts (``approval-requested``) are
+    left untouched: those are a distinct, still-resolvable state handled by
+    the deferred tool-result flow.
+
+    Args:
+        messages: The chat message history from the request body.
+
+    Returns:
+        A new message list with unresolved tool-call parts replaced in place.
+        Messages without one are returned unchanged. Returns a new list (with
+        the original messages untouched) even when nothing needed resolving.
+    """
+    result: list[UIMessageT] = []
+    for message in messages:
+        if message.role != "assistant" or not any(
+            isinstance(part, (ToolInputAvailablePart, ToolInputStreamingPart))
+            for part in message.parts
+        ):
+            result.append(message)
+            continue
+        new_parts = [
+            _resolve_unresolved_part(part)
+            if isinstance(part, (ToolInputAvailablePart, ToolInputStreamingPart))
+            else part
+            for part in message.parts
+        ]
+        result.append(message.model_copy(update={"parts": new_parts}))
+    return result

--- a/src/phoenix/server/api/routers/agents.py
+++ b/src/phoenix/server/api/routers/agents.py
@@ -95,6 +95,7 @@ from phoenix.server.agents.context import (
 )
 from phoenix.server.agents.data_stream_protocol import build_stream_error_chunk
 from phoenix.server.agents.exceptions import AgentError, SummarizationError
+from phoenix.server.agents.interrupted_tool_calls import resolve_unresolved_tool_calls
 from phoenix.server.agents.model_factory import build_model
 from phoenix.server.agents.model_selection import AgentModelSelection
 from phoenix.server.agents.prompts import AgentPrompts, ServerAgentPrompts
@@ -1449,6 +1450,7 @@ def create_agents_router(authentication_enabled: bool) -> APIRouter:
             user_id=user_id,
             is_viewer=is_viewer,
         )
+        body.messages = resolve_unresolved_tool_calls(body.messages)
         agent_prompts = AgentPrompts()
         forced_skills: list[Skill] = []
         if body.requested_skills:

--- a/tests/unit/server/agents/test_interrupted_tool_calls.py
+++ b/tests/unit/server/agents/test_interrupted_tool_calls.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pydantic_ai.messages import ToolCallPart, ToolReturnPart
+from pydantic_ai.ui.vercel_ai import VercelAIAdapter
+from pydantic_ai.ui.vercel_ai.request_types import (
+    TextUIPart,
+    ToolApprovalRequested,
+    ToolApprovalRequestedPart,
+    ToolInputAvailablePart,
+    ToolInputStreamingPart,
+    ToolOutputAvailablePart,
+    ToolOutputErrorPart,
+    UIMessage,
+)
+
+from phoenix.server.agents.interrupted_tool_calls import resolve_unresolved_tool_calls
+
+
+def _user_message(text: str) -> UIMessage:
+    return UIMessage(id="u1", role="user", parts=[TextUIPart(type="text", text=text)])
+
+
+def _assistant_message(*parts: object) -> UIMessage:
+    return UIMessage(id="a1", role="assistant", parts=list(parts))  # type: ignore[arg-type]
+
+
+class TestResolveUnresolvedToolCalls:
+    def test_non_assistant_messages_are_untouched(self) -> None:
+        messages = [_user_message("hi")]
+        result = resolve_unresolved_tool_calls(messages)
+        assert result == messages
+        assert result[0] is messages[0]
+
+    def test_assistant_message_without_tool_parts_is_untouched(self) -> None:
+        message = _assistant_message(TextUIPart(type="text", text="hello"))
+        result = resolve_unresolved_tool_calls([message])
+        assert result[0] is message
+
+    def test_resolved_tool_part_is_untouched(self) -> None:
+        message = _assistant_message(
+            ToolOutputAvailablePart(
+                type="tool-search",
+                tool_call_id="call1",
+                input={"query": "x"},
+                output="result",
+            )
+        )
+        result = resolve_unresolved_tool_calls([message])
+        assert result[0] is message
+
+    def test_approval_requested_part_is_untouched(self) -> None:
+        # Deferred approval is a distinct, still-resolvable state (see the
+        # `deferred_tool_results` flow) and must not be treated as dangling.
+        part = ToolApprovalRequestedPart(
+            type="tool-run_code",
+            tool_call_id="call1",
+            input={"code": "print(1)"},
+            approval=ToolApprovalRequested(id="call1"),
+        )
+        message = _assistant_message(part)
+        result = resolve_unresolved_tool_calls([message])
+        assert result[0].parts[0] is part
+
+    def test_input_available_part_becomes_output_error(self) -> None:
+        message = _assistant_message(
+            ToolInputAvailablePart(
+                type="tool-run_code",
+                tool_call_id="call1",
+                input={"code": "print(1)"},
+                call_provider_metadata={"phoenix": {"tool_execution_environment": "client"}},
+            )
+        )
+        result = resolve_unresolved_tool_calls([message])
+        part = result[0].parts[0]
+        assert isinstance(part, ToolOutputErrorPart)
+        assert part.tool_call_id == "call1"
+        assert part.input == {"code": "print(1)"}
+        assert "client" in part.error_text
+
+    def test_input_streaming_part_becomes_output_error(self) -> None:
+        message = _assistant_message(
+            ToolInputStreamingPart(type="tool-run_code", tool_call_id="call1")
+        )
+        result = resolve_unresolved_tool_calls([message])
+        part = result[0].parts[0]
+        assert isinstance(part, ToolOutputErrorPart)
+        assert part.tool_call_id == "call1"
+
+    def test_missing_execution_environment_reads_as_unknown(self) -> None:
+        message = _assistant_message(
+            ToolInputAvailablePart(type="tool-run_code", tool_call_id="call1")
+        )
+        result = resolve_unresolved_tool_calls([message])
+        part = result[0].parts[0]
+        assert isinstance(part, ToolOutputErrorPart)
+        assert "unknown" in part.error_text
+
+    def test_only_dangling_parts_in_a_mixed_message_are_replaced(self) -> None:
+        resolved_part = ToolOutputAvailablePart(
+            type="tool-search", tool_call_id="call1", input={}, output="ok"
+        )
+        dangling_part = ToolInputAvailablePart(type="tool-run_code", tool_call_id="call2")
+        message = _assistant_message(resolved_part, dangling_part)
+        result = resolve_unresolved_tool_calls([message])
+        parts = result[0].parts
+        assert parts[0] is resolved_part
+        assert isinstance(parts[1], ToolOutputErrorPart)
+
+    def test_unresolved_call_adapts_to_a_valid_pydantic_ai_history(self) -> None:
+        # This is the regression this module exists for: without resolution,
+        # `load_messages` emits a bare `ToolCallPart` with no `ToolReturnPart`,
+        # which providers like Anthropic reject on the next turn.
+        message = _assistant_message(
+            ToolInputAvailablePart(type="tool-run_code", tool_call_id="call1", input={"code": "1"})
+        )
+        history = VercelAIAdapter.load_messages(resolve_unresolved_tool_calls([message]))
+        parts = [part for msg in history for part in msg.parts]
+        tool_calls = [p for p in parts if isinstance(p, ToolCallPart)]
+        tool_returns = [p for p in parts if isinstance(p, ToolReturnPart)]
+        assert len(tool_calls) == 1
+        assert len(tool_returns) == 1
+        assert tool_returns[0].tool_call_id == "call1"
+        assert tool_returns[0].outcome == "failed"
+
+    def test_unresolved_call_without_this_fix_would_have_no_return(self) -> None:
+        # Documents the bug directly: an unresolved part loaded as-is produces
+        # a `ToolCallPart` with no matching `ToolReturnPart`.
+        message = _assistant_message(
+            ToolInputAvailablePart(type="tool-run_code", tool_call_id="call1", input={"code": "1"})
+        )
+        history = VercelAIAdapter.load_messages([message])
+        parts = [part for msg in history for part in msg.parts]
+        assert any(isinstance(p, ToolCallPart) for p in parts)
+        assert not any(isinstance(p, ToolReturnPart) for p in parts)


### PR DESCRIPTION
resolves #14948

When a client tool call is interrupted (Stop hit, tab closed/reloaded) before it resolves, the persisted assistant message keeps the tool part in `input-available` state with no result. Resuming the session from a different surface rebuilds history from that message, and the dangling part converts into a `ToolCallPart` with no matching `ToolReturnPart` - providers like Anthropic reject that outright, so the turn hard-fails with an opaque error.

This sanitizes the history at load time: any tool-call part still in `input-available`/`input-streaming` state gets replaced with a synthetic `output-error` result noting which execution environment never serviced it, so the turn can proceed instead of failing. Approval-pending parts are left untouched since that's a separate, still-resolvable state handled by the existing deferred tool-result flow.

Added `resolve_unresolved_tool_calls` in a new `interrupted_tool_calls.py`, wired in next to the existing `inject_requested_skills` sanitizer in `agents.py` (same call site, same pattern). Tests cover the resolved/untouched/approval-pending cases plus a direct regression test proving the before/after `ToolCallPart`/`ToolReturnPart` pairing.