### PR TITLE
fix(traces): render ReasoningPart in gen_ai message flattening

### DIFF
--- a/src/phoenix/trace/gen_ai/conversion.py
+++ b/src/phoenix/trace/gen_ai/conversion.py
@@ -35,6 +35,7 @@ from phoenix.trace.gen_ai.__generated__.models import (
     InputMessages,
     OutputMessage,
     OutputMessages,
+    ReasoningPart,
     RetrievalDocument,
     RetrievalDocuments,
     Role,
@@ -478,7 +479,7 @@ def _flatten_message(
             flat[f"{base}.message.finish_reason"] = finish_reason
 
     text_parts: list[str] = []
-    content_parts: list[TextPart | UriPart | BlobPart] = []
+    content_parts: list[TextPart | UriPart | BlobPart | ReasoningPart] = []
     tool_calls: list[ToolCallRequestPart] = []
     tool_response_part: Optional[ToolCallResponsePart] = None
 
@@ -486,7 +487,7 @@ def _flatten_message(
         if isinstance(part, TextPart):
             text_parts.append(part.content)
             content_parts.append(part)
-        elif isinstance(part, (UriPart, BlobPart)):
+        elif isinstance(part, (UriPart, BlobPart, ReasoningPart)):
             content_parts.append(part)
         elif isinstance(part, ToolCallRequestPart):
             tool_calls.append(part)
@@ -509,6 +510,13 @@ def _flatten_message(
             content_prefix = f"{base}.{MessageAttributes.MESSAGE_CONTENTS}.{content_index}"
             if isinstance(content_part, TextPart):
                 flat[f"{content_prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"] = "text"
+                flat[f"{content_prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"] = (
+                    content_part.content
+                )
+            elif isinstance(content_part, ReasoningPart):
+                flat[f"{content_prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"] = (
+                    "reasoning"
+                )
                 flat[f"{content_prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"] = (
                     content_part.content
                 )

--- a/tests/unit/trace/gen_ai/test_conversion.py
+++ b/tests/unit/trace/gen_ai/test_conversion.py
@@ -433,6 +433,54 @@ def test_text_plus_uri_image_emits_structured_contents() -> None:
     )
 
 
+def test_reasoning_plus_text_emits_structured_contents() -> None:
+    out = get_openinference_message_attributes(
+        _output_messages(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {"type": "reasoning", "content": "thinking it through"},
+                        {"type": "text", "content": "the answer"},
+                    ],
+                    "finish_reason": "stop",
+                }
+            ]
+        )
+    )
+    base = f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0"
+    contents = MessageAttributes.MESSAGE_CONTENTS
+    content_type = MessageContentAttributes.MESSAGE_CONTENT_TYPE
+    content_text = MessageContentAttributes.MESSAGE_CONTENT_TEXT
+    assert out[f"{base}.{contents}.0.{content_type}"] == "reasoning"
+    assert out[f"{base}.{contents}.0.{content_text}"] == "thinking it through"
+    assert out[f"{base}.{contents}.1.{content_type}"] == "text"
+    assert out[f"{base}.{contents}.1.{content_text}"] == "the answer"
+
+
+def test_reasoning_only_message_is_not_dropped() -> None:
+    out = get_openinference_message_attributes(
+        _output_messages(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [{"type": "reasoning", "content": "pure reasoning"}],
+                    "finish_reason": "stop",
+                }
+            ]
+        )
+    )
+    base = f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0"
+    contents = MessageAttributes.MESSAGE_CONTENTS
+    assert (
+        out[f"{base}.{contents}.0.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"] == "reasoning"
+    )
+    assert (
+        out[f"{base}.{contents}.0.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"]
+        == "pure reasoning"
+    )
+
+
 def test_blob_part_becomes_data_url() -> None:
     out = get_openinference_message_attributes(
         _input_messages(


### PR DESCRIPTION
Fixes #14962.

`_flatten_message` in `src/phoenix/trace/gen_ai/conversion.py` handled `TextPart`, `UriPart`, `BlobPart`, `ToolCallRequestPart`, and `ToolCallResponsePart`, but `ReasoningPart` fell through every branch — omitted from both `message.content` and `message.contents.*`, so the model's reasoning was invisible in Phoenix for spans ingested via the gen_ai semconv path (e.g. `@ai-sdk/otel` with reasoning-capable models).

**Fix:** reasoning parts are rendered into the structured-contents path as `message_content.type = "reasoning"` with the part's content as text — matching the client-side convention (`phoenix-cli` already renders `part.type === "reasoning"` alongside text). Reasoning parts count as non-text content, so reasoning+text messages take the structured path and reasoning-only messages are no longer dropped.

**Tests:** two regression tests — reasoning+text (the issue's repro shape) and reasoning-only. Both fail on `main` (`KeyError`: the reasoning attribute never exists) and pass with the fix. Full `test_conversion.py` suite: 92/92 passing. Ruff check/format clean.
