### PR TITLE
feat(sessions): add user.id filter to sessions tab

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2791,27 +2791,27 @@ type Project implements Node {
   """
   Sessions in the project. The time range filter uses interval-overlap semantics: a session is included iff [startTime, endTime] intersects [timeRange.start, timeRange.end), i.e. the session had activity inside the window. Long-running sessions therefore appear in every window they overlap.
   """
-  sessions(first: Int!, timeRange: TimeRange, after: String, sort: ProjectSessionSort, filterIoSubstring: String, sessionId: String): ProjectSessionConnection!
+  sessions(first: Int!, timeRange: TimeRange, after: String, sort: ProjectSessionSort, filterIoSubstring: String, sessionId: String, userId: String): ProjectSessionConnection!
 
   """
   Number of sessions in the project, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
   """
-  sessionCount(timeRange: TimeRange, filterIoSubstring: String, sessionId: String): Int!
+  sessionCount(timeRange: TimeRange, filterIoSubstring: String, sessionId: String, userId: String): Int!
 
   """
   Average session duration in milliseconds, i.e. the mean of end time minus start time across sessions, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
   """
-  averageSessionDurationMs(timeRange: TimeRange, filterIoSubstring: String, sessionId: String): Float
+  averageSessionDurationMs(timeRange: TimeRange, filterIoSubstring: String, sessionId: String, userId: String): Float
 
   """
   Average number of traces (e.g. conversation turns) per session, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
   """
-  averageTracesPerSession(timeRange: TimeRange, filterIoSubstring: String, sessionId: String): Float
+  averageTracesPerSession(timeRange: TimeRange, filterIoSubstring: String, sessionId: String, userId: String): Float
 
   """
   Quantile (e.g. p50, p99) of session duration in milliseconds, i.e. end time minus start time, optionally filtered by a time range and a substring of the session input/output. An exact session-ID match takes precedence over the other filters, mirroring the sessions table search.
   """
-  sessionDurationMsQuantile(probability: Float!, timeRange: TimeRange, filterIoSubstring: String, sessionId: String): Float
+  sessionDurationMsQuantile(probability: Float!, timeRange: TimeRange, filterIoSubstring: String, sessionId: String, userId: String): Float
 
   """
   Names of all available annotations for traces. (The list contains no duplicates.)

--- a/app/src/pages/project/SessionSearchContext.tsx
+++ b/app/src/pages/project/SessionSearchContext.tsx
@@ -10,6 +10,8 @@ import {
 export type SessionSearchContextType = {
   filterIoSubstringOrSessionId: string;
   setFilterIoSubstringOrSessionId: (condition: string) => void;
+  filterUserId: string;
+  setFilterUserId: (userId: string) => void;
 };
 
 export const SessionSearchContext =
@@ -32,11 +34,19 @@ export function SessionSearchProvider(props: PropsWithChildren) {
       _setSubstring(condition);
     });
   }, []);
+  const [userId, _setUserId] = useState<string>("");
+  const setUserId = useCallback((id: string) => {
+    startTransition(() => {
+      _setUserId(id);
+    });
+  }, []);
   return (
     <SessionSearchContext.Provider
       value={{
         filterIoSubstringOrSessionId: substring,
         setFilterIoSubstringOrSessionId: setSubstring,
+        filterUserId: userId,
+        setFilterUserId: setUserId,
       }}
     >
       {props.children}

--- a/app/src/pages/project/SessionSearchField.tsx
+++ b/app/src/pages/project/SessionSearchField.tsx
@@ -11,17 +11,31 @@ type SessionSearchFieldProps = {
 export function SessionSearchField({
   placeholder = "Search messages or session ID",
 }: SessionSearchFieldProps) {
-  const { filterIoSubstringOrSessionId, setFilterIoSubstringOrSessionId } =
-    useSessionSearchContext();
+  const {
+    filterIoSubstringOrSessionId,
+    setFilterIoSubstringOrSessionId,
+    filterUserId,
+    setFilterUserId,
+  } = useSessionSearchContext();
 
   return (
-    <SearchField
-      aria-label="Search sessions"
-      value={filterIoSubstringOrSessionId}
-      onChange={setFilterIoSubstringOrSessionId}
-    >
-      <SearchIcon />
-      <Input placeholder={placeholder} />
-    </SearchField>
+    <>
+      <SearchField
+        aria-label="Search sessions"
+        value={filterIoSubstringOrSessionId}
+        onChange={setFilterIoSubstringOrSessionId}
+      >
+        <SearchIcon />
+        <Input placeholder={placeholder} />
+      </SearchField>
+      <SearchField
+        aria-label="Filter by user ID"
+        value={filterUserId}
+        onChange={setFilterUserId}
+      >
+        <SearchIcon />
+        <Input placeholder="Filter by user ID" />
+      </SearchField>
+    </>
   );
 }

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -149,7 +149,7 @@ export function SessionsTable(props: SessionsTableProps) {
   // we need a reference to the scrolling element for pagination logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [sorting, setSorting] = useState<SortingState>([]);
-  const { filterIoSubstringOrSessionId } = useSessionSearchContext();
+  const { filterIoSubstringOrSessionId, filterUserId } = useSessionSearchContext();
   const { fetchKey } = useStreamState();
   // Source the time range directly here (rather than only via the preloaded
   // parent query) so a live window sliding forward refetches with the current
@@ -175,6 +175,7 @@ export function SessionsTable(props: SessionsTableProps) {
           }
           filterIoSubstring: { type: "String", defaultValue: null }
           sessionId: { type: "String", defaultValue: null }
+          userId: { type: "String", defaultValue: null }
         ) {
           name
           ...SessionColumnSelector_annotations
@@ -185,6 +186,7 @@ export function SessionsTable(props: SessionsTableProps) {
             filterIoSubstring: $filterIoSubstring
             timeRange: $timeRange
             sessionId: $sessionId
+            userId: $userId
           ) @connection(key: "SessionsTable_sessions") {
             edges {
               session: node {
@@ -496,6 +498,7 @@ export function SessionsTable(props: SessionsTableProps) {
           first: PAGE_SIZE,
           filterIoSubstring: filterIoSubstringOrSessionId,
           sessionId: filterIoSubstringOrSessionId,
+          userId: filterUserId || null,
           timeRange: timeRangeISOStrings,
         },
         { fetchPolicy: "store-and-network" }
@@ -505,6 +508,7 @@ export function SessionsTable(props: SessionsTableProps) {
     sorting,
     refetch,
     filterIoSubstringOrSessionId,
+    filterUserId,
     fetchKey,
     timeRangeISOStrings,
   ]);
@@ -745,6 +749,7 @@ export function SessionsTable(props: SessionsTableProps) {
           <TableAsidePanel>
             <SessionsTableAside
               filterIoSubstringOrSessionId={filterIoSubstringOrSessionId}
+              filterUserId={filterUserId || null}
             />
           </TableAsidePanel>
         </Group>

--- a/app/src/pages/project/SessionsTableAside.tsx
+++ b/app/src/pages/project/SessionsTableAside.tsx
@@ -37,9 +37,11 @@ export function SessionsTableAside(props: {
    * with an exact match taking precedence.
    */
   filterIoSubstringOrSessionId?: string | null;
+  filterUserId?: string | null;
 }) {
   const filterIoSubstringOrSessionId =
     props.filterIoSubstringOrSessionId || null;
+  const filterUserId = props.filterUserId || null;
   const projectId = useTracingContext((state) => state.projectId);
   const { timeRangeISOStrings } = useTimeRange();
   const { fetchKey } = useStreamState();
@@ -50,6 +52,7 @@ export function SessionsTableAside(props: {
         $timeRange: TimeRange!
         $filterIoSubstring: String
         $sessionId: String
+        $userId: String
       ) {
         project: node(id: $id) {
           ... on Project {
@@ -59,28 +62,33 @@ export function SessionsTableAside(props: {
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
               sessionId: $sessionId
+              userId: $userId
             )
             averageSessionDurationMs(
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
               sessionId: $sessionId
+              userId: $userId
             )
             averageTracesPerSession(
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
               sessionId: $sessionId
+              userId: $userId
             )
             sessionDurationMsP50: sessionDurationMsQuantile(
               probability: 0.5
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
               sessionId: $sessionId
+              userId: $userId
             )
             sessionDurationMsP99: sessionDurationMsQuantile(
               probability: 0.99
               timeRange: $timeRange
               filterIoSubstring: $filterIoSubstring
               sessionId: $sessionId
+              userId: $userId
             )
             sessionAnnotationNames
           }
@@ -92,6 +100,7 @@ export function SessionsTableAside(props: {
       timeRange: timeRangeISOStrings,
       filterIoSubstring: filterIoSubstringOrSessionId,
       sessionId: filterIoSubstringOrSessionId,
+      userId: filterUserId,
     },
     { fetchKey, fetchPolicy: "store-and-network" }
   );

--- a/app/src/pages/project/__generated__/ProjectPageQueriesSessionsQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageQueriesSessionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5c99a62b1db506c5c6c073aa443e6435>>
+ * @generated SignedSource<<489cc3649fc7e299ecea296f3aec64f8>>
  * @lightSyntaxTransform
  */
 
@@ -583,7 +583,8 @@ return {
                   "sort",
                   "filterIoSubstring",
                   "timeRange",
-                  "sessionId"
+                  "sessionId",
+                  "userId"
                 ],
                 "handle": "connection",
                 "key": "SessionsTable_sessions",

--- a/app/src/pages/project/__generated__/SessionsTableAsideQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTableAsideQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6eb513d36ee6bc67ea1636564427e9e7>>
+ * @generated SignedSource<<7d1046a31ee781999c6c76ec6415e33d>>
  * @lightSyntaxTransform
  */
 
@@ -17,6 +17,7 @@ export type SessionsTableAsideQuery$variables = {
   id: string;
   sessionId?: string | null;
   timeRange: TimeRange;
+  userId?: string | null;
 };
 export type SessionsTableAsideQuery$data = {
   readonly project: {
@@ -56,34 +57,45 @@ v3 = {
   "kind": "LocalArgument",
   "name": "timeRange"
 },
-v4 = [
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "userId"
+},
+v5 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v5 = {
+v6 = {
   "kind": "Variable",
   "name": "filterIoSubstring",
   "variableName": "filterIoSubstring"
 },
-v6 = {
+v7 = {
   "kind": "Variable",
   "name": "sessionId",
   "variableName": "sessionId"
 },
-v7 = {
+v8 = {
   "kind": "Variable",
   "name": "timeRange",
   "variableName": "timeRange"
 },
-v8 = [
-  (v5/*:: as any*/),
-  (v6/*:: as any*/),
-  (v7/*:: as any*/)
-],
 v9 = {
+  "kind": "Variable",
+  "name": "userId",
+  "variableName": "userId"
+},
+v10 = [
+  (v6/*:: as any*/),
+  (v7/*:: as any*/),
+  (v8/*:: as any*/),
+  (v9/*:: as any*/)
+],
+v11 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -102,21 +114,21 @@ v9 = {
     },
     {
       "alias": null,
-      "args": (v8/*:: as any*/),
+      "args": (v10/*:: as any*/),
       "kind": "ScalarField",
       "name": "sessionCount",
       "storageKey": null
     },
     {
       "alias": null,
-      "args": (v8/*:: as any*/),
+      "args": (v10/*:: as any*/),
       "kind": "ScalarField",
       "name": "averageSessionDurationMs",
       "storageKey": null
     },
     {
       "alias": null,
-      "args": (v8/*:: as any*/),
+      "args": (v10/*:: as any*/),
       "kind": "ScalarField",
       "name": "averageTracesPerSession",
       "storageKey": null
@@ -124,14 +136,15 @@ v9 = {
     {
       "alias": "sessionDurationMsP50",
       "args": [
-        (v5/*:: as any*/),
+        (v6/*:: as any*/),
         {
           "kind": "Literal",
           "name": "probability",
           "value": 0.5
         },
-        (v6/*:: as any*/),
-        (v7/*:: as any*/)
+        (v7/*:: as any*/),
+        (v8/*:: as any*/),
+        (v9/*:: as any*/)
       ],
       "kind": "ScalarField",
       "name": "sessionDurationMsQuantile",
@@ -140,14 +153,15 @@ v9 = {
     {
       "alias": "sessionDurationMsP99",
       "args": [
-        (v5/*:: as any*/),
+        (v6/*:: as any*/),
         {
           "kind": "Literal",
           "name": "probability",
           "value": 0.99
         },
-        (v6/*:: as any*/),
-        (v7/*:: as any*/)
+        (v7/*:: as any*/),
+        (v8/*:: as any*/),
+        (v9/*:: as any*/)
       ],
       "kind": "ScalarField",
       "name": "sessionDurationMsQuantile",
@@ -170,7 +184,8 @@ return {
       (v0/*:: as any*/),
       (v1/*:: as any*/),
       (v2/*:: as any*/),
-      (v3/*:: as any*/)
+      (v3/*:: as any*/),
+      (v4/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -178,13 +193,13 @@ return {
     "selections": [
       {
         "alias": "project",
-        "args": (v4/*:: as any*/),
+        "args": (v5/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v9/*:: as any*/)
+          (v11/*:: as any*/)
         ],
         "storageKey": null
       }
@@ -198,14 +213,15 @@ return {
       (v1/*:: as any*/),
       (v3/*:: as any*/),
       (v0/*:: as any*/),
-      (v2/*:: as any*/)
+      (v2/*:: as any*/),
+      (v4/*:: as any*/)
     ],
     "kind": "Operation",
     "name": "SessionsTableAsideQuery",
     "selections": [
       {
         "alias": "project",
-        "args": (v4/*:: as any*/),
+        "args": (v5/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -218,7 +234,7 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v9/*:: as any*/),
+          (v11/*:: as any*/),
           {
             "alias": null,
             "args": null,
@@ -232,16 +248,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "271432fa765dad968dfacd96dad900d6",
+    "cacheID": "3d447560f0b4833e311fa78c6eb0597e",
     "id": null,
     "metadata": {},
     "name": "SessionsTableAsideQuery",
     "operationKind": "query",
-    "text": "query SessionsTableAsideQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $filterIoSubstring: String\n  $sessionId: String\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      name\n      description\n      sessionCount(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      averageSessionDurationMs(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      averageTracesPerSession(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      sessionDurationMsP50: sessionDurationMsQuantile(probability: 0.5, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      sessionDurationMsP99: sessionDurationMsQuantile(probability: 0.99, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId)\n      sessionAnnotationNames\n    }\n    id\n  }\n}\n"
+    "text": "query SessionsTableAsideQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $filterIoSubstring: String\n  $sessionId: String\n  $userId: String\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      name\n      description\n      sessionCount(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId, userId: $userId)\n      averageSessionDurationMs(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId, userId: $userId)\n      averageTracesPerSession(timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId, userId: $userId)\n      sessionDurationMsP50: sessionDurationMsQuantile(probability: 0.5, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId, userId: $userId)\n      sessionDurationMsP99: sessionDurationMsQuantile(probability: 0.99, timeRange: $timeRange, filterIoSubstring: $filterIoSubstring, sessionId: $sessionId, userId: $userId)\n      sessionAnnotationNames\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "67d25925d174621807b12661e70110e6";
+(node as any).hash = "eb8be26ce495bddc8b8d771594243379";
 
 export default node;

--- a/app/src/pages/project/__generated__/SessionsTableQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c9dd230fd021c4e03f6594be1392cee6>>
+ * @generated SignedSource<<15a2a247e4f4ceb6c3b28215f940b61a>>
  * @lightSyntaxTransform
  */
 
@@ -33,6 +33,7 @@ export type SessionsTableQuery$variables = {
   sessionId?: string | null;
   sort?: ProjectSessionSort | null;
   timeRange?: TimeRange | null;
+  userId?: string | null;
 };
 export type SessionsTableQuery$data = {
   readonly node: {
@@ -83,72 +84,83 @@ v6 = {
   "kind": "LocalArgument",
   "name": "timeRange"
 },
-v7 = [
+v7 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "userId"
+},
+v8 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v8 = {
+v9 = {
   "kind": "Variable",
   "name": "after",
   "variableName": "after"
 },
-v9 = {
+v10 = {
   "kind": "Variable",
   "name": "filterIoSubstring",
   "variableName": "filterIoSubstring"
 },
-v10 = {
+v11 = {
   "kind": "Variable",
   "name": "first",
   "variableName": "first"
 },
-v11 = {
+v12 = {
   "kind": "Variable",
   "name": "sessionId",
   "variableName": "sessionId"
 },
-v12 = {
+v13 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v13 = {
+v14 = {
+  "kind": "Variable",
+  "name": "userId",
+  "variableName": "userId"
+},
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v14 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v15 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v16 = [
-  (v8/*:: as any*/),
+v18 = [
   (v9/*:: as any*/),
   (v10/*:: as any*/),
   (v11/*:: as any*/),
   (v12/*:: as any*/),
+  (v13/*:: as any*/),
   {
     "kind": "Variable",
     "name": "timeRange",
     "variableName": "timeRange"
-  }
+  },
+  (v14/*:: as any*/)
 ],
-v17 = [
+v19 = [
   {
     "alias": "value",
     "args": null,
@@ -157,14 +169,14 @@ v17 = [
     "storageKey": null
   }
 ],
-v18 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v19 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -180,7 +192,8 @@ return {
       (v3/*:: as any*/),
       (v4/*:: as any*/),
       (v5/*:: as any*/),
-      (v6/*:: as any*/)
+      (v6/*:: as any*/),
+      (v7/*:: as any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -188,7 +201,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v7/*:: as any*/),
+        "args": (v8/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -196,11 +209,12 @@ return {
         "selections": [
           {
             "args": [
-              (v8/*:: as any*/),
               (v9/*:: as any*/),
               (v10/*:: as any*/),
               (v11/*:: as any*/),
-              (v12/*:: as any*/)
+              (v12/*:: as any*/),
+              (v13/*:: as any*/),
+              (v14/*:: as any*/)
             ],
             "kind": "FragmentSpread",
             "name": "SessionsTable_sessions"
@@ -221,6 +235,7 @@ return {
       (v4/*:: as any*/),
       (v5/*:: as any*/),
       (v6/*:: as any*/),
+      (v7/*:: as any*/),
       (v3/*:: as any*/)
     ],
     "kind": "Operation",
@@ -228,18 +243,18 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v7/*:: as any*/),
+        "args": (v8/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v13/*:: as any*/),
-          (v14/*:: as any*/),
+          (v15/*:: as any*/),
+          (v16/*:: as any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v15/*:: as any*/),
+              (v17/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
@@ -249,7 +264,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v16/*:: as any*/),
+                "args": (v18/*:: as any*/),
                 "concreteType": "ProjectSessionConnection",
                 "kind": "LinkedField",
                 "name": "sessions",
@@ -271,7 +286,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v14/*:: as any*/),
+                          (v16/*:: as any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -314,7 +329,7 @@ return {
                             "kind": "LinkedField",
                             "name": "firstInput",
                             "plural": false,
-                            "selections": (v17/*:: as any*/),
+                            "selections": (v19/*:: as any*/),
                             "storageKey": null
                           },
                           {
@@ -324,7 +339,7 @@ return {
                             "kind": "LinkedField",
                             "name": "lastOutput",
                             "plural": false,
-                            "selections": (v17/*:: as any*/),
+                            "selections": (v19/*:: as any*/),
                             "storageKey": null
                           },
                           {
@@ -408,10 +423,10 @@ return {
                             "name": "sessionAnnotations",
                             "plural": true,
                             "selections": [
-                              (v14/*:: as any*/),
-                              (v15/*:: as any*/),
-                              (v18/*:: as any*/),
-                              (v19/*:: as any*/),
+                              (v16/*:: as any*/),
+                              (v17/*:: as any*/),
+                              (v20/*:: as any*/),
+                              (v21/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -441,7 +456,7 @@ return {
                                     "name": "profilePictureUrl",
                                     "storageKey": null
                                   },
-                                  (v14/*:: as any*/)
+                                  (v16/*:: as any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -471,7 +486,7 @@ return {
                                     "name": "fraction",
                                     "storageKey": null
                                   },
-                                  (v18/*:: as any*/)
+                                  (v20/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -482,7 +497,7 @@ return {
                                 "name": "meanScore",
                                 "storageKey": null
                               },
-                              (v15/*:: as any*/),
+                              (v17/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -515,7 +530,7 @@ return {
                             "name": "project",
                             "plural": false,
                             "selections": [
-                              (v14/*:: as any*/),
+                              (v16/*:: as any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -540,7 +555,7 @@ return {
                                         "name": "node",
                                         "plural": false,
                                         "selections": [
-                                          (v13/*:: as any*/),
+                                          (v15/*:: as any*/),
                                           {
                                             "kind": "InlineFragment",
                                             "selections": [
@@ -558,8 +573,8 @@ return {
                                           {
                                             "kind": "InlineFragment",
                                             "selections": [
-                                              (v14/*:: as any*/),
-                                              (v15/*:: as any*/),
+                                              (v16/*:: as any*/),
+                                              (v17/*:: as any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -575,8 +590,8 @@ return {
                                                 "name": "values",
                                                 "plural": true,
                                                 "selections": [
-                                                  (v18/*:: as any*/),
-                                                  (v19/*:: as any*/)
+                                                  (v20/*:: as any*/),
+                                                  (v21/*:: as any*/)
                                                 ],
                                                 "storageKey": null
                                               }
@@ -587,7 +602,7 @@ return {
                                           {
                                             "kind": "InlineFragment",
                                             "selections": [
-                                              (v14/*:: as any*/)
+                                              (v16/*:: as any*/)
                                             ],
                                             "type": "Node",
                                             "abstractKey": "__isNode"
@@ -622,8 +637,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v13/*:: as any*/),
-                          (v14/*:: as any*/)
+                          (v15/*:: as any*/),
+                          (v16/*:: as any*/)
                         ],
                         "storageKey": null
                       }
@@ -660,12 +675,13 @@ return {
               },
               {
                 "alias": null,
-                "args": (v16/*:: as any*/),
+                "args": (v18/*:: as any*/),
                 "filters": [
                   "sort",
                   "filterIoSubstring",
                   "timeRange",
-                  "sessionId"
+                  "sessionId",
+                  "userId"
                 ],
                 "handle": "connection",
                 "key": "SessionsTable_sessions",
@@ -682,16 +698,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "48cdf6875aee4fba823656b9c957f1b5",
+    "cacheID": "556083807c2231315f2903d03f737235",
     "id": null,
     "metadata": {},
     "name": "SessionsTableQuery",
     "operationKind": "query",
-    "text": "query SessionsTableQuery(\n  $after: String = null\n  $filterIoSubstring: String = null\n  $first: Int = 30\n  $sessionId: String = null\n  $sort: ProjectSessionSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionsTable_sessions_371pAD\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryGroup on ProjectSession {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  sessionAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  sessionAnnotationSummaries {\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionColumnSelector_annotations on Project {\n  sessionAnnotationNames\n}\n\nfragment SessionsTable_sessions_371pAD on Project {\n  name\n  ...SessionColumnSelector_annotations\n  sessions(first: $first, after: $after, sort: $sort, filterIoSubstring: $filterIoSubstring, timeRange: $timeRange, sessionId: $sessionId) {\n    edges {\n      session: node {\n        id\n        sessionId\n        userId\n        numTraces\n        startTime\n        endTime\n        firstInput {\n          value: truncatedValue\n        }\n        lastOutput {\n          value: truncatedValue\n        }\n        tokenUsage {\n          total\n        }\n        traceLatencyMsP50: traceLatencyMsQuantile(probability: 0.5)\n        traceLatencyMsP99: traceLatencyMsQuantile(probability: 0.99)\n        costSummary {\n          total {\n            cost\n          }\n        }\n        sessionAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          user {\n            username\n            profilePictureUrl\n            id\n          }\n        }\n        sessionAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        project {\n          id\n          annotationConfigs {\n            edges {\n              node {\n                __typename\n                ... on AnnotationConfigBase {\n                  __isAnnotationConfigBase: __typename\n                  annotationType\n                }\n                ... on CategoricalAnnotationConfig {\n                  id\n                  name\n                  optimizationDirection\n                  values {\n                    label\n                    score\n                  }\n                }\n                ... on Node {\n                  __isNode: __typename\n                  id\n                }\n              }\n            }\n          }\n        }\n        ...SessionAnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SessionsTableQuery(\n  $after: String = null\n  $filterIoSubstring: String = null\n  $first: Int = 30\n  $sessionId: String = null\n  $sort: ProjectSessionSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $userId: String = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionsTable_sessions_4yhO2g\n    id\n  }\n}\n\nfragment SessionAnnotationSummaryGroup on ProjectSession {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  sessionAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  sessionAnnotationSummaries {\n    count\n    scoreCount\n    labelCount\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionColumnSelector_annotations on Project {\n  sessionAnnotationNames\n}\n\nfragment SessionsTable_sessions_4yhO2g on Project {\n  name\n  ...SessionColumnSelector_annotations\n  sessions(first: $first, after: $after, sort: $sort, filterIoSubstring: $filterIoSubstring, timeRange: $timeRange, sessionId: $sessionId, userId: $userId) {\n    edges {\n      session: node {\n        id\n        sessionId\n        userId\n        numTraces\n        startTime\n        endTime\n        firstInput {\n          value: truncatedValue\n        }\n        lastOutput {\n          value: truncatedValue\n        }\n        tokenUsage {\n          total\n        }\n        traceLatencyMsP50: traceLatencyMsQuantile(probability: 0.5)\n        traceLatencyMsP99: traceLatencyMsQuantile(probability: 0.99)\n        costSummary {\n          total {\n            cost\n          }\n        }\n        sessionAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          user {\n            username\n            profilePictureUrl\n            id\n          }\n        }\n        sessionAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        project {\n          id\n          annotationConfigs {\n            edges {\n              node {\n                __typename\n                ... on AnnotationConfigBase {\n                  __isAnnotationConfigBase: __typename\n                  annotationType\n                }\n                ... on CategoricalAnnotationConfig {\n                  id\n                  name\n                  optimizationDirection\n                  values {\n                    label\n                    score\n                  }\n                }\n                ... on Node {\n                  __isNode: __typename\n                  id\n                }\n              }\n            }\n          }\n        }\n        ...SessionAnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "98b3aa82f458ea6c6dbba4f424f3c15e";
+(node as any).hash = "799d8a8aacbdd043bbb25c5810c9a24a";
 
 export default node;

--- a/app/src/pages/project/__generated__/SessionsTable_sessions.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTable_sessions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0b82baf799800f37768bc3937cc2cd08>>
+ * @generated SignedSource<<3f30896a409d0e570cb07f8c16111a06>>
  * @lightSyntaxTransform
  */
 
@@ -164,6 +164,11 @@ return {
     {
       "kind": "RootArgument",
       "name": "timeRange"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "userId"
     }
   ],
   "kind": "Fragment",
@@ -225,6 +230,11 @@ return {
           "kind": "Variable",
           "name": "timeRange",
           "variableName": "timeRange"
+        },
+        {
+          "kind": "Variable",
+          "name": "userId",
+          "variableName": "userId"
         }
       ],
       "concreteType": "ProjectSessionConnection",
@@ -621,6 +631,6 @@ return {
 };
 })();
 
-(node as any).hash = "98b3aa82f458ea6c6dbba4f424f3c15e";
+(node as any).hash = "799d8a8aacbdd043bbb25c5810c9a24a";
 
 export default node;

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -156,6 +156,7 @@ def _apply_project_session_filters(
     time_range: Optional[TimeRange],
     filter_io_substring: Optional[str],
     session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> Select[Any]:
     """Restrict a ``ProjectSession`` aggregation to the project, time range, and
     input/output substring filter used by the sessions table.
@@ -168,6 +169,10 @@ def _apply_project_session_filters(
     semantics: an exact session-ID match wins (ignoring the time range and
     substring filter); otherwise fall back to the substring/time-range filters,
     or to no sessions at all when there is no substring to fall back to.
+
+    ``user_id`` is an independent exact-match filter applied after session_id
+    logic: only sessions with at least one span whose user.id equals ``user_id``
+    are returned.
     """
     table = models.ProjectSession
     stmt = stmt.where(table.project_id == project_rowid)
@@ -186,20 +191,34 @@ def _apply_project_session_filters(
         )
         conditions.append(table.id.in_(filtered_session_rowids))
     if not session_id:
-        return stmt.where(*conditions)
-    exact_match = exists(
-        select(1).where(
-            table.project_id == project_rowid,
-            table.session_id == session_id,
+        stmt = stmt.where(*conditions)
+    else:
+        exact_match = exists(
+            select(1).where(
+                table.project_id == project_rowid,
+                table.session_id == session_id,
+            )
         )
-    )
-    fallback = and_(*conditions) if filter_io_substring else false()
-    return stmt.where(
-        or_(
-            and_(exact_match, table.session_id == session_id),
-            and_(~exact_match, fallback),
+        fallback = and_(*conditions) if filter_io_substring else false()
+        stmt = stmt.where(
+            or_(
+                and_(exact_match, table.session_id == session_id),
+                and_(~exact_match, fallback),
+            )
         )
-    )
+    if user_id:
+        stmt = stmt.where(
+            exists(
+                select(1)
+                .select_from(models.Trace)
+                .join(models.Span, models.Span.trace_rowid == models.Trace.id)
+                .where(
+                    models.Trace.project_session_rowid == table.id,
+                    models.Span.attributes[models.USER_ID].as_string() == user_id,
+                )
+            )
+        )
+    return stmt
 
 
 @strawberry.type
@@ -613,9 +632,10 @@ class Project(Node):
         sort: Optional[ProjectSessionSort] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
         session_id: Optional[str] = UNSET,
+        user_id: Optional[str] = UNSET,
     ) -> Connection[ProjectSession]:
         table = models.ProjectSession
-        if session_id:
+        if session_id and not user_id:
             async with info.context.db.read() as session:
                 ans = await session.scalar(
                     select(table).filter_by(
@@ -638,6 +658,8 @@ class Project(Node):
             project_rowid=self.id,
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
+            session_id=session_id or None,
+            user_id=user_id or None,
         )
         sort_config: Optional[ProjectSessionSortConfig] = None
         cursor_rowid_column: Any = table.id
@@ -705,12 +727,11 @@ class Project(Node):
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
         session_id: Optional[str] = UNSET,
+        user_id: Optional[str] = UNSET,
     ) -> int:
-        # When there is no substring / session-ID filter, the count depends only on
-        # the project and time range, so it can be batched across projects through
-        # the record_counts dataloader (this is the projects-list / project-card
-        # path, which would otherwise issue one query per project).
-        if not filter_io_substring and not session_id:
+        # When there is no substring / session-ID / user-ID filter, the count can be
+        # batched across projects through the record_counts dataloader.
+        if not filter_io_substring and not session_id and not (user_id or None):
             return await info.context.data_loaders.record_counts.load(
                 (
                     "session",
@@ -726,6 +747,7 @@ class Project(Node):
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
             session_id=session_id or None,
+            user_id=user_id or None,
         )
         async with info.context.db.read() as session:
             return await session.scalar(stmt) or 0
@@ -743,6 +765,7 @@ class Project(Node):
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
         session_id: Optional[str] = UNSET,
+        user_id: Optional[str] = UNSET,
     ) -> Optional[float]:
         stmt = _apply_project_session_filters(
             select(
@@ -757,6 +780,7 @@ class Project(Node):
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
             session_id=session_id or None,
+            user_id=user_id or None,
         )
         async with info.context.db.read() as session:
             average_duration_ms = await session.scalar(stmt)
@@ -774,6 +798,7 @@ class Project(Node):
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
         session_id: Optional[str] = UNSET,
+        user_id: Optional[str] = UNSET,
     ) -> Optional[float]:
         traces_per_session = _apply_project_session_filters(
             select(func.count(models.Trace.id).label("num_traces"))
@@ -787,6 +812,7 @@ class Project(Node):
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
             session_id=session_id or None,
+            user_id=user_id or None,
         ).subquery()
         stmt = select(func.avg(traces_per_session.c.num_traces))
         async with info.context.db.read() as session:
@@ -807,6 +833,7 @@ class Project(Node):
         time_range: Optional[TimeRange] = UNSET,
         filter_io_substring: Optional[str] = UNSET,
         session_id: Optional[str] = UNSET,
+        user_id: Optional[str] = UNSET,
     ) -> Optional[float]:
         if not 0 <= probability <= 1:
             raise BadRequest("Probability must be between 0 and 1 (inclusive)")
@@ -828,6 +855,7 @@ class Project(Node):
             time_range=time_range or None,
             filter_io_substring=filter_io_substring or None,
             session_id=session_id or None,
+            user_id=user_id or None,
         )
         async with info.context.db.read() as session:
             quantile_value = await session.scalar(stmt)


### PR DESCRIPTION
fixes #14171

The Sessions tab had a search field for message content and session ID but no way to filter by `user.id`. The `ix_spans_user_id` index already existed; it just wasn't wired up to the sessions query path.

**Backend:** added `user_id` arg to `sessions`, `sessionCount`, `averageSessionDurationMs`, `averageTracesPerSession`, and `sessionDurationMsQuantile` resolvers. `_apply_project_session_filters` appends a correlated EXISTS subquery joining `Trace → Span` on `attributes[["user","id"]].as_string()`, which hits the existing index. The `sessions` fast-path (direct session_id lookup) is bypassed when `user_id` is also set so both filters compose correctly.

**Frontend:** second `SearchField` ("Filter by user ID") alongside the existing search, state in `SessionSearchContext`, wired through the Relay fragment args, `refetch`, and the aside stats panel.

Most of the diff is auto-generated Relay artifacts (`__generated__/`); hand-written changes are ~130 lines.
