### PR TITLE
test(security): add surface-organized security integration tests

### DIFF
--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -62,7 +62,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.trace import Span, Tracer, format_span_id
 from opentelemetry.util.types import AttributeValue
-from psutil import STATUS_ZOMBIE, Popen
+from psutil import STATUS_ZOMBIE, NoSuchProcess, Popen
 from sqlalchemy import URL, text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -796,7 +796,10 @@ def _server(app: _AppInfo) -> Iterator[_AppInfo]:
 def _is_alive(
     process: Popen,
 ) -> bool:
-    return process.is_running() and process.status() != STATUS_ZOMBIE
+    try:
+        return process.is_running() and process.status() != STATUS_ZOMBIE
+    except NoSuchProcess:
+        return False
 
 
 def _capture_stdout(
@@ -1383,7 +1386,10 @@ class _OIDCServer:
         self._name: str = f"oidc_server_{token_hex(8)}"
         self._client_id: str = f"client_id_{token_hex(8)}"
         self._client_secret: str = f"client_secret_{token_hex(8)}"
-        self._secret_key: str = f"secret_key_{token_hex(16)}"
+        self._secret_key: str = f"secret_key_{token_hex(24)}"
+        self._jwks_secret_key: str = self._secret_key
+        self._token_algorithm: str = "HS256"
+        self._id_token_claim_overrides: dict[str, Any] = {}
         self._host: str = "127.0.0.1"
         self._port: int = port
         self._use_pkce: bool = use_pkce
@@ -1668,6 +1674,7 @@ class _OIDCServer:
                 "picture": session["user_picture"],
                 "nonce": session["nonce"],
             }
+            id_token_claims.update(self._id_token_claim_overrides)
 
             # Add role if configured
             if session["session_role"]:
@@ -1680,7 +1687,7 @@ class _OIDCServer:
             id_token = jwt.encode(
                 payload=id_token_claims,
                 key=self._secret_key.encode(),
-                algorithm="HS256",
+                algorithm=self._token_algorithm,
             )
 
             # Return token response with all required fields
@@ -1794,7 +1801,7 @@ class _OIDCServer:
             this would typically use asymmetric keys (RS256).
             """
             # Base64url encode the secret key
-            encoded_key = urlsafe_b64encode(self._secret_key.encode()).decode().rstrip("=")
+            encoded_key = urlsafe_b64encode(self._jwks_secret_key.encode()).decode().rstrip("=")
             return JSONResponse(
                 {
                     "keys": [
@@ -1808,6 +1815,25 @@ class _OIDCServer:
                     ]
                 }
             )
+
+    def set_id_token_claim_overrides(self, **claims: Any) -> None:
+        """Apply deterministic claim overrides to subsequently issued test ID tokens."""
+        self._id_token_claim_overrides = claims
+
+    def set_token_signing_key(
+        self,
+        key: str,
+        *,
+        publish_in_jwks: bool = False,
+    ) -> None:
+        """Change the local token signer, optionally rotating the published JWKS key too."""
+        self._secret_key = key
+        if publish_in_jwks:
+            self._jwks_secret_key = key
+
+    def set_token_signing_algorithm(self, algorithm: str) -> None:
+        """Change the local token JWT algorithm without changing discovery or JWKS metadata."""
+        self._token_algorithm = algorithm
 
     def __enter__(self) -> Self:
         self._server = ThreadServer(

--- a/tests/integration/security/README.md
+++ b/tests/integration/security/README.md
@@ -1,0 +1,62 @@
+# Security Integration Tests
+
+Locally reproducible security-control tests for Phoenix's authentication,
+authorization, and protocol boundaries. Everything here is a normal
+`test_*.py` collected by CI and expected to pass.
+
+## Layout
+
+Tests are organized by **surface** — the protocol or entry point under test.
+Each directory owns the controls for one surface and grows as coverage does:
+
+| Directory    | Surface                                                        |
+|--------------|----------------------------------------------------------------|
+| `oauth/`     | OAuth 2.0 authorize/token/DCR/scope/redirect boundaries        |
+| `oidc/`      | OIDC login flow: issuer validation, flow integrity, callback origin |
+| `mcp/`       | MCP bearer/auth boundary and protocol disclosure               |
+| `ingestion/` | OTLP/gRPC ingestion authentication and role gates              |
+| `pxi/`       | Direct PXI server-agent route controls                         |
+| `session/`   | Cross-consumer session lifecycle (issuance, rotation, revocation) |
+
+The orthogonal **control class** of each test is expressed with markers
+(registered in `conftest.py`), applied at module scope via `pytestmark`:
+
+| Marker              | Control class                                        |
+|---------------------|------------------------------------------------------|
+| `authn`             | Authentication (credential/token/session establishment) |
+| `authz`             | Authorization (role, scope, audience, ownership)     |
+| `input_validation`  | Input validation and canonicalization                |
+| `session_management`| Session lifecycle (issuance, rotation, revocation)   |
+| `disclosure`        | Information disclosure / protocol exposure           |
+
+Surface is the directory; control class is the marker. A test never needs to
+live in two places.
+
+## Running
+
+```sh
+# Everything
+uv run pytest tests/integration/security -n auto
+
+# One surface
+uv run pytest tests/integration/security/oauth -n auto
+
+# One control class, across every surface
+uv run pytest tests/integration/security -m authz
+```
+
+## Remediation contracts (added as fixes land)
+
+Contracts for *confirmed, not-yet-fixed* issues are **not** part of this suite.
+They are fail-until-fixed regressions and are intentionally excluded from CI
+collection (they neither start with `test_` nor run by default) so that an
+open-source repository does not advertise unpatched behavior.
+
+As each fix lands, its contract graduates into the matching surface directory
+as a normal `test_*.py` in the same PR as the fix — so the contract ends up
+next to the control it proves.
+
+## House rules
+
+Never put real credentials, production payloads, or personal data in these
+fixtures. Use the local fixtures and helpers in `tests/integration/_helpers.py`.

--- a/tests/integration/security/conftest.py
+++ b/tests/integration/security/conftest.py
@@ -1,0 +1,56 @@
+"""Shared configuration for the security integration test suite.
+
+Directories under ``tests/integration/security`` are organized by **surface**
+(the protocol or entry point under test): ``oauth``, ``oidc``, ``mcp``,
+``ingestion``, ``pxi``, ``session``. The orthogonal **control class** of each
+test (authentication, authorization, input validation, ...) is expressed with
+the markers registered below, so a single property can be exercised across every
+surface at once::
+
+    pytest tests/integration/security -m authz
+
+Add a marker at module scope with ``pytestmark = [pytest.mark.<class>]``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The security suite reuses the OAuth/OIDC fixtures defined in the auth package's
+# conftest (`_app`, `_oauth_public_client`, `_oidc_server`, ...). That module is a
+# conftest, so it must NOT be pulled in via `pytest_plugins`: pytest would then
+# register the same module twice — once as a conftest, once as a named plugin —
+# and raise "Plugin already registered under a different name" whenever the full
+# tests/integration tree is collected (as CI does). Importing the fixture
+# callables here registers them for the security subtree without registering the
+# source module as a plugin. Their transitive dependencies resolve because every
+# auth fixture is re-exported below, and top-level fixtures stay visible via the
+# normal conftest scope chain.
+from tests.integration.auth import conftest as _auth_conftest
+
+# A fixture callable is marked differently across pytest versions
+# (`_fixture_function_marker` in pytest 9, `_pytestfixturefunction` earlier), so
+# accept either. Re-exporting every auth fixture — not just the leaves the tests
+# request — keeps their transitive dependency closure resolvable here.
+_FIXTURE_MARKERS = ("_fixture_function_marker", "_pytestfixturefunction")
+
+globals().update(
+    {
+        _name: _value
+        for _name, _value in vars(_auth_conftest).items()
+        if any(hasattr(_value, _marker) for _marker in _FIXTURE_MARKERS)
+    }
+)
+
+_CONTROL_CLASS_MARKERS: dict[str, str] = {
+    "authn": "authentication controls (credential/token/session establishment)",
+    "authz": "authorization controls (role, scope, audience, ownership boundaries)",
+    "input_validation": "input validation and canonicalization controls",
+    "session_management": "session lifecycle controls (issuance, rotation, revocation)",
+    "disclosure": "information-disclosure and protocol-exposure controls",
+}
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    for name, description in _CONTROL_CLASS_MARKERS.items():
+        config.addinivalue_line("markers", f"{name}: {description}")

--- a/tests/integration/security/ingestion/test_grpc_controls.py
+++ b/tests/integration/security/ingestion/test_grpc_controls.py
@@ -1,0 +1,114 @@
+"""Passing authentication and role controls at the OTLP gRPC ingestion boundary."""
+
+from __future__ import annotations
+
+from secrets import token_hex
+from time import monotonic, sleep
+
+import pytest
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from tests.integration._helpers import (
+    _MEMBER,
+    _VIEWER,
+    _AppInfo,
+    _GetUser,
+    _grpc_span_exporter,
+    _httpx_client,
+    _start_span,
+)
+from tests.integration.auth.test_mcp import _register_public_client
+
+pytestmark = [pytest.mark.authn, pytest.mark.authz]
+
+
+def _project_names(app: _AppInfo, project_name: str) -> set[str]:
+    response = _httpx_client(app, app.admin_secret).get(
+        "v1/projects",
+        params={"name_contains": project_name},
+    )
+    response.raise_for_status()
+    return {project["name"] for project in response.json()["data"]}
+
+
+def _wait_for_project(app: _AppInfo, project_name: str, timeout: float = 10) -> None:
+    deadline = monotonic() + timeout
+    while monotonic() < deadline:
+        if project_name in _project_names(app, project_name):
+            return
+        sleep(0.05)
+    raise AssertionError(f"project {project_name!r} was not persisted within {timeout} seconds")
+
+
+def _flush_ingestion_queue(app: _AppInfo) -> None:
+    project_name = f"security-grpc-barrier-{token_hex(8)}"
+    memory = InMemorySpanExporter()
+    _start_span(exporter=memory, project_name=project_name).end()
+    result = _grpc_span_exporter(
+        app,
+        headers={"authorization": f"Bearer {app.admin_secret}"},
+    ).export(memory.get_finished_spans())
+    assert result is SpanExportResult.SUCCESS
+    _wait_for_project(app, project_name)
+
+
+@pytest.mark.parametrize("credential_kind", ["missing", "invalid"], ids=["missing", "invalid"])
+def test_grpc_ingestion_rejects_missing_or_invalid_bearer_metadata(
+    _app: _AppInfo,
+    credential_kind: str,
+) -> None:
+    """No credentials and inert credentials fail before a synthetic span is accepted."""
+    headers = None if credential_kind == "missing" else {"authorization": "Bearer security-invalid"}
+    project_name = f"security-grpc-{credential_kind}-{token_hex(8)}"
+    memory = InMemorySpanExporter()
+    _start_span(exporter=memory, project_name=project_name).end()
+
+    result = _grpc_span_exporter(_app, headers=headers).export(memory.get_finished_spans())
+
+    assert result is SpanExportResult.FAILURE
+    _flush_ingestion_queue(_app)
+    assert project_name not in _project_names(_app, project_name)
+
+
+def test_grpc_ingestion_rejects_viewer_access_token(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """A valid viewer token authenticates but cannot write OTLP telemetry."""
+    viewer = _get_user(_app, _VIEWER).log_in(_app)
+    access_token = _register_public_client(_app).complete_flow(viewer)["access_token"]
+    project_name = f"security-grpc-viewer-{token_hex(8)}"
+    memory = InMemorySpanExporter()
+    _start_span(exporter=memory, project_name=project_name).end()
+
+    result = _grpc_span_exporter(
+        _app,
+        headers={"authorization": f"Bearer {access_token}"},
+    ).export(memory.get_finished_spans())
+    del access_token
+
+    assert result is SpanExportResult.FAILURE
+    _flush_ingestion_queue(_app)
+    assert project_name not in _project_names(_app, project_name)
+
+
+def test_grpc_ingestion_accepts_member_access_token(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """A member access token is the positive control for the same one-span fixture."""
+    member = _get_user(_app, _MEMBER).log_in(_app)
+    access_token = _register_public_client(_app).complete_flow(member)["access_token"]
+    project_name = f"security-grpc-member-{token_hex(8)}"
+    memory = InMemorySpanExporter()
+    _start_span(exporter=memory, project_name=project_name).end()
+
+    result = _grpc_span_exporter(
+        _app,
+        headers={"authorization": f"Bearer {access_token}"},
+    ).export(memory.get_finished_spans())
+    del access_token
+
+    assert result is SpanExportResult.SUCCESS
+    _wait_for_project(_app, project_name)

--- a/tests/integration/security/mcp/test_auth_boundary.py
+++ b/tests/integration/security/mcp/test_auth_boundary.py
@@ -1,0 +1,93 @@
+"""Passing MCP authentication and internal-principal boundary controls."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration._helpers import _MEMBER, _AppInfo, _GetUser, _httpx_client
+from tests.integration.auth.test_mcp import _mcp_token_for, _register_public_client
+
+pytestmark = [pytest.mark.authn, pytest.mark.authz]
+
+
+def _initialize_request() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "security-mcp-boundary", "version": "0"},
+        },
+    }
+
+
+@pytest.mark.parametrize("path", ["mcp", "mcp/", "mcp//"], ids=["bare", "slash", "double-slash"])
+def test_mcp_path_forms_cannot_bypass_bearer_authentication(
+    _app: _AppInfo,
+    path: str,
+) -> None:
+    """Every supported-looking mount-path form must challenge invalid credentials."""
+    response = _httpx_client(_app).post(
+        path,
+        headers={
+            "accept": "application/json, text/event-stream",
+            "authorization": "Bearer security-invalid-token",
+        },
+        json=_initialize_request(),
+    )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"].startswith("Bearer ")
+
+
+def test_wire_header_cannot_forge_the_internal_mcp_principal(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """Only an in-process ASGI scope can carry the MCP-to-REST principal."""
+    mcp_token = _mcp_token_for(_app, _get_user, _MEMBER)
+    response = _httpx_client(_app).get(
+        "v1/projects",
+        headers={
+            "authorization": f"Bearer {mcp_token}",
+            "phoenix.internal.principal": "synthetic-forgery",
+        },
+    )
+    del mcp_token
+
+    assert response.status_code == 401
+
+
+def test_revoked_oauth_access_token_is_denied_at_mcp(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """MCP must re-check token status instead of trusting an old session credential."""
+    oauth_client = _register_public_client(_app)
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    access_token = oauth_client.complete_flow(user)["access_token"]
+    client = _httpx_client(_app)
+    before_revoke = client.post(
+        "mcp",
+        headers={
+            "accept": "application/json, text/event-stream",
+            "authorization": f"Bearer {access_token}",
+        },
+        json=_initialize_request(),
+    )
+    revoke_response = client.post("oauth2/revoke", data={"token": access_token})
+    after_revoke = client.post(
+        "mcp",
+        headers={
+            "accept": "application/json, text/event-stream",
+            "authorization": f"Bearer {access_token}",
+        },
+        json=_initialize_request(),
+    )
+    del access_token
+
+    assert before_revoke.status_code == 200
+    assert revoke_response.status_code == 200
+    assert after_revoke.status_code == 401

--- a/tests/integration/security/mcp/test_protocol_disclosure.py
+++ b/tests/integration/security/mcp/test_protocol_disclosure.py
@@ -1,0 +1,47 @@
+"""Passing MCP protocol and progressive-disclosure security controls."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from tests.integration._helpers import _MEMBER, _AppInfo, _GetUser
+from tests.integration.auth.test_mcp import _mcp_token_for, _mcp_transport
+
+pytestmark = [pytest.mark.disclosure]
+
+
+async def test_hidden_group_tool_cannot_be_called_until_its_group_is_enabled(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """Tool visibility is a server-side session capability, not a UI convention."""
+    token = _mcp_token_for(_app, _get_user, _MEMBER)
+    async with Client(_mcp_transport(_app, token)) as client:
+        initially_visible = {tool.name for tool in await client.list_tools()}
+        hidden_result = await client.call_tool("getUsers", {}, raise_on_error=False)
+        await client.call_tool("enable_tool_group", {"group": "users"})
+        revealed = {tool.name for tool in await client.list_tools()}
+    del token
+
+    assert "getUsers" not in initially_visible
+    assert hidden_result.is_error
+    assert "getUsers" in revealed
+
+
+async def test_tool_group_enablement_does_not_leak_to_another_mcp_session(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """A group enabled in one authenticated session stays hidden in a second session."""
+    first_token = _mcp_token_for(_app, _get_user, _MEMBER)
+    second_token = _mcp_token_for(_app, _get_user, _MEMBER)
+    async with Client(_mcp_transport(_app, first_token)) as first_client:
+        await first_client.call_tool("enable_tool_group", {"group": "users"})
+        first_tools = {tool.name for tool in await first_client.list_tools()}
+        async with Client(_mcp_transport(_app, second_token)) as second_client:
+            second_tools = {tool.name for tool in await second_client.list_tools()}
+    del first_token, second_token
+
+    assert "getUsers" in first_tools
+    assert "getUsers" not in second_tools

--- a/tests/integration/security/oauth/test_pkce_authorization.py
+++ b/tests/integration/security/oauth/test_pkce_authorization.py
@@ -1,0 +1,59 @@
+"""PKCE downgrade controls enforced before OAuth consent."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from tests.integration._helpers import _MEMBER, _AppInfo, _GetUser, _httpx_client
+from tests.integration.auth.conftest import _active_grants, _OAuthPublicClient
+
+pytestmark = [pytest.mark.authz]
+
+
+@pytest.mark.parametrize(
+    "missing_parameter,overrides",
+    [
+        pytest.param("code_challenge", {}, id="missing-challenge"),
+        pytest.param("code_challenge_method", {}, id="missing-method"),
+        pytest.param(None, {"code_challenge_method": "plain"}, id="plain-method"),
+    ],
+)
+def test_pkce_downgrades_are_rejected_before_consent(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    _oauth_public_client: _OAuthPublicClient,
+    missing_parameter: str | None,
+    overrides: dict[str, str],
+) -> None:
+    """A request without an explicit S256 challenge cannot reach consent."""
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    grants_before = _active_grants(_app, user)
+    authorization = _oauth_public_client.authorization_params()
+    if missing_parameter is not None:
+        authorization.pop(missing_parameter)
+    authorization.update(overrides)
+
+    response = _httpx_client(_app, user).get(
+        "oauth2/authorize",
+        params=authorization,
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    redirect = urlparse(response.headers["location"])
+    expected_redirect = urlparse(_oauth_public_client.redirect_uri)
+    assert (redirect.scheme, redirect.netloc, redirect.path) == (
+        expected_redirect.scheme,
+        expected_redirect.netloc,
+        expected_redirect.path,
+    )
+    assert not redirect.path.endswith("/oauth2/consent")
+    query = parse_qs(redirect.query)
+    assert query == {
+        "error": ["invalid_request"],
+        "state": [authorization["state"]],
+    }
+    assert "code" not in query
+    assert _active_grants(_app, user) == grants_before

--- a/tests/integration/security/oauth/test_pkce_token_exchange.py
+++ b/tests/integration/security/oauth/test_pkce_token_exchange.py
@@ -1,0 +1,128 @@
+"""PKCE verifier binding at the OAuth token endpoint."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from secrets import token_urlsafe
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from tests.integration._helpers import (
+    _MEMBER,
+    _AppInfo,
+    _GetUser,
+    _httpx_client,
+    _LoggedInUser,
+)
+from tests.integration.auth.conftest import _active_grants, _OAuthPublicClient
+
+pytestmark = [pytest.mark.authz]
+
+
+def _challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def _issue_code(
+    app: _AppInfo,
+    client: _OAuthPublicClient,
+    user: _LoggedInUser,
+    verifier: str,
+) -> str:
+    authorization = client.authorization_params()
+    authorization["code_challenge"] = _challenge(verifier)
+    response = _httpx_client(app, user).get(
+        "oauth2/authorize",
+        params=authorization,
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert urlparse(response.headers["location"]).path.endswith("/oauth2/consent")
+    redirect_to = client.decide(user, authorization)
+    query = parse_qs(urlparse(redirect_to).query)
+    assert query["state"] == [authorization["state"]]
+    assert len(query["code"]) == 1
+    return query["code"][0]
+
+
+def _token_form(client: _OAuthPublicClient, code: str) -> dict[str, str]:
+    return {
+        "grant_type": "authorization_code",
+        "code": code,
+        "client_id": client.client_id,
+        "redirect_uri": client.redirect_uri,
+    }
+
+
+def test_missing_verifier_does_not_consume_authorization_code(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    _oauth_public_client: _OAuthPublicClient,
+) -> None:
+    """Omitting the verifier is denied without destroying a legitimate code."""
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    grants_before = _active_grants(_app, user)
+    code = _issue_code(_app, _oauth_public_client, user, _oauth_public_client.code_verifier)
+    form = _token_form(_oauth_public_client, code)
+
+    rejected = _httpx_client(_app).post("oauth2/token", data=form)
+
+    assert rejected.status_code == 400
+    assert rejected.json() == {"error": "invalid_grant"}
+    assert rejected.headers["cache-control"] == "no-store"
+    assert rejected.headers["pragma"] == "no-cache"
+    assert _active_grants(_app, user) == grants_before
+
+    accepted = _httpx_client(_app).post(
+        "oauth2/token",
+        data={**form, "code_verifier": _oauth_public_client.code_verifier},
+    )
+    accepted.raise_for_status()
+    assert accepted.json()["access_token"]
+    assert len(_active_grants(_app, user)) == len(grants_before) + 1
+
+
+def test_verifier_from_another_flow_cannot_redeem_code(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    _oauth_public_client: _OAuthPublicClient,
+) -> None:
+    """A verifier is bound to one authorization flow, even for the same client."""
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    grants_before = _active_grants(_app, user)
+    verifier_a = token_urlsafe(48)
+    verifier_b = token_urlsafe(48)
+    assert verifier_a != verifier_b
+    code_a = _issue_code(_app, _oauth_public_client, user, verifier_a)
+    code_b = _issue_code(_app, _oauth_public_client, user, verifier_b)
+    form_b = _token_form(_oauth_public_client, code_b)
+
+    rejected = _httpx_client(_app).post(
+        "oauth2/token",
+        data={**form_b, "code_verifier": verifier_a},
+    )
+
+    assert rejected.status_code == 400
+    assert rejected.json() == {"error": "invalid_grant"}
+    assert _active_grants(_app, user) == grants_before
+
+    accepted_b = _httpx_client(_app).post(
+        "oauth2/token",
+        data={**form_b, "code_verifier": verifier_b},
+    )
+    accepted_b.raise_for_status()
+    assert accepted_b.json()["access_token"]
+
+    accepted_a = _httpx_client(_app).post(
+        "oauth2/token",
+        data={
+            **_token_form(_oauth_public_client, code_a),
+            "code_verifier": verifier_a,
+        },
+    )
+    accepted_a.raise_for_status()
+    assert accepted_a.json()["access_token"]
+    assert len(_active_grants(_app, user)) == len(grants_before) + 2

--- a/tests/integration/security/oauth/test_policy_matrix.py
+++ b/tests/integration/security/oauth/test_policy_matrix.py
@@ -1,0 +1,234 @@
+"""OAuth scope, DCR metadata, and credential-boundary security controls."""
+
+from __future__ import annotations
+
+from secrets import token_hex
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from phoenix.server.api.input_types.UserRoleInput import UserRoleInput
+from tests.integration._helpers import (
+    _ADMIN,
+    _MEMBER,
+    _VIEWER,
+    _AppInfo,
+    _GetUser,
+    _httpx_client,
+)
+from tests.integration.auth.conftest import _OAuthPublicClient
+from tests.integration.auth.test_mcp import _register_public_client
+
+pytestmark = [pytest.mark.authn, pytest.mark.authz, pytest.mark.input_validation]
+
+
+def _oauth_tokens_with_requested_scope(
+    app: _AppInfo,
+    get_user: _GetUser,
+    role: UserRoleInput,
+) -> tuple[dict[str, Any], Any]:
+    client = _register_public_client(app)
+    user = get_user(app, role).log_in(app)
+    params = client.authorize(user)
+    params["scope"] = "admin root write delete_everything unknown"
+    redirect_to = client.decide(user, params)
+    return client.exchange_code(redirect_to), user
+
+
+@pytest.mark.parametrize(
+    "role,admin_status,write_status",
+    [
+        (_ADMIN, 200, 200),
+        (_MEMBER, 403, 200),
+        (_VIEWER, 403, 403),
+    ],
+    ids=["admin", "member", "viewer"],
+)
+def test_requested_scopes_cannot_override_role_permissions(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    role: UserRoleInput,
+    admin_status: int,
+    write_status: int,
+) -> None:
+    token_response, user = _oauth_tokens_with_requested_scope(_app, _get_user, role)
+    assert "scope" not in token_response
+    headers = {"authorization": f"Bearer {token_response['access_token']}"}
+    project_name = f"security-scope-project-{token_hex(8)}"
+
+    common_read = _httpx_client(_app).get("v1/projects", headers=headers)
+    admin_read = _httpx_client(_app).get("v1/users", headers=headers)
+    member_write = _httpx_client(_app).post(
+        "v1/projects",
+        headers=headers,
+        json={"name": project_name},
+    )
+    graphql_read = _httpx_client(_app).post(
+        "graphql",
+        headers=headers,
+        json={"query": "query SecurityScopeMatrix { viewer { id } }"},
+    )
+
+    assert common_read.status_code == 200
+    assert admin_read.status_code == admin_status
+    assert member_write.status_code == write_status
+    if write_status == 200:
+        assert member_write.json()["data"]["name"] == project_name
+    else:
+        projects = _httpx_client(_app).get(
+            "v1/projects",
+            headers=headers,
+            params={"name_contains": project_name},
+        )
+        assert projects.status_code == 200
+        assert projects.json()["data"] == []
+    assert graphql_read.status_code == 200
+    assert "errors" not in graphql_read.json()
+
+    grants, _ = user.gql(
+        _app,
+        "query SecurityScopeGrants { viewer { ... on User { oauth2Grants { scopes } } } }",
+    )
+    assert not grants.get("errors")
+    assert grants["data"]["viewer"]["oauth2Grants"][-1]["scopes"] == []
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"client_name": "x" * 201},
+        {"client_name": "line1\nline2"},
+        {"logo_uri": "x" * 2049},
+        {"grant_types": ["implicit"]},
+        {"response_types": ["token"]},
+        {"redirect_uris": []},
+    ],
+    ids=[
+        "oversized-name",
+        "non-printable-name",
+        "oversized-logo",
+        "unsupported-grant",
+        "unsupported-response",
+        "missing-redirect",
+    ],
+)
+def test_dcr_rejects_malformed_or_oversized_defined_metadata(
+    _app: _AppInfo,
+    metadata: dict[str, Any],
+) -> None:
+    payload: dict[str, Any] = {
+        "client_name": "Security DCR client",
+        "redirect_uris": ["http://127.0.0.1:8765/callback"],
+        **metadata,
+    }
+    response = _httpx_client(_app).post("oauth2/register", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_client_metadata"
+
+
+def test_unknown_dcr_metadata_remains_inert_through_authorization(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    client_name = "Unverified security client"
+    redirect_uri = "http://127.0.0.1:8765/callback"
+    registration = _httpx_client(_app).post(
+        "oauth2/register",
+        json={
+            "client_name": client_name,
+            "redirect_uris": [redirect_uri],
+            "is_first_party": True,
+            "trusted_client_name": "Phoenix CLI",
+            "authorization_override": "admin",
+        },
+    )
+    registration.raise_for_status()
+    registered = registration.json()
+    assert "is_first_party" not in registered
+    assert "trusted_client_name" not in registered
+    assert "authorization_override" not in registered
+
+    client = _OAuthPublicClient(
+        client_id=registered["client_id"],
+        name=client_name,
+        redirect_uri=redirect_uri,
+        app=_app,
+    )
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    params = client.authorization_params()
+    params["client_name"] = "Phoenix CLI"
+    params["is_first_party"] = "true"
+    response = _httpx_client(_app, user).get(
+        "oauth2/authorize",
+        params=params,
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    consent_query = parse_qs(urlparse(response.headers["location"]).query)
+    assert consent_query["client_name"] == [client_name]
+    assert consent_query["is_first_party"] == ["false"]
+
+
+@pytest.mark.parametrize(
+    "credential_kind,rest_status,graphql_status,agent_status",
+    [
+        ("oauth-access", 200, 200, 200),
+        ("api-key", 200, 200, 200),
+        ("refresh", 401, 401, 401),
+        ("mcp-access", 401, 401, 401),
+    ],
+    ids=["oauth-access", "api-key", "refresh", "mcp-audience-access"],
+)
+def test_http_credential_type_and_audience_matrix(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    credential_kind: str,
+    rest_status: int,
+    graphql_status: int,
+    agent_status: int,
+) -> None:
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    if credential_kind == "api-key":
+        credential = str(user.create_api_key(_app))
+    else:
+        resource = f"{_app.base_url.rstrip('/')}/mcp" if credential_kind == "mcp-access" else None
+        client = _register_public_client(_app, resource=resource)
+        tokens = client.complete_flow(user)
+        credential = (
+            tokens["refresh_token"] if credential_kind == "refresh" else tokens["access_token"]
+        )
+    headers = {"authorization": f"Bearer {credential}"}
+
+    rest_response = _httpx_client(_app).get("v1/projects", headers=headers)
+    graphql_response = _httpx_client(_app).post(
+        "graphql",
+        headers=headers,
+        json={"query": "query SecurityCredentialMatrix { viewer { id } }"},
+    )
+    agent_response = _httpx_client(_app).post(
+        "agents/assistant/sessions/security-matrix/chat",
+        headers=headers,
+        json={
+            "trigger": "submit-message",
+            "id": f"security-matrix-message-{token_hex(8)}",
+            "messages": [
+                {
+                    "id": f"security-matrix-user-message-{token_hex(8)}",
+                    "role": "user",
+                    "parts": [{"type": "text", "text": "verify credential boundary"}],
+                }
+            ],
+            "model": {
+                "providerType": "builtin",
+                "provider": "ANTHROPIC",
+                "modelName": "claude-3-5-sonnet-20241022",
+            },
+        },
+    )
+
+    assert rest_response.status_code == rest_status
+    assert graphql_response.status_code == graphql_status
+    assert agent_response.status_code == agent_status

--- a/tests/integration/security/oauth/test_redirect_canonicalization.py
+++ b/tests/integration/security/oauth/test_redirect_canonicalization.py
@@ -1,0 +1,54 @@
+"""HC-02 redirect-URI canonicalization controls at the authorize boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration._helpers import _MEMBER, _AppInfo, _GetUser, _httpx_client
+from tests.integration.auth.conftest import _OAuthPublicClient
+
+pytestmark = [pytest.mark.input_validation]
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "http://127.0.0.1:8765/callback/../callback",
+        "http://127.0.0.1:8765/callback%2Fother",
+        "http://attacker@127.0.0.1:8765/callback",
+        "http://127.0.0.1:8765/callback#fragment",
+        "http://127.0.0.1.:8765/callback",
+        "http://[::1]:8765/callback",
+        "http://localhost:8765/callback",
+        "http://127.0.0.1:8765/callback?next=https%3A%2F%2Fattacker.invalid",
+    ],
+    ids=[
+        "dot-segment",
+        "encoded-slash",
+        "userinfo",
+        "fragment",
+        "trailing-dot-loopback",
+        "ipv6-loopback",
+        "localhost-alias",
+        "unregistered-query",
+    ],
+)
+def test_equivalent_looking_unregistered_redirects_are_rejected(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    _oauth_public_client: _OAuthPublicClient,
+    redirect_uri: str,
+) -> None:
+    """Only the registered loopback host/path/query policy may authorize."""
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    authorization = _oauth_public_client.authorization_params()
+    authorization["redirect_uri"] = redirect_uri
+
+    response = _httpx_client(_app, user).get(
+        "oauth2/authorize",
+        params=authorization,
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert "Invalid redirect URI" in response.text

--- a/tests/integration/security/oauth/test_resource_boundaries.py
+++ b/tests/integration/security/oauth/test_resource_boundaries.py
@@ -1,0 +1,74 @@
+"""Passing OAuth credential-type and resource-audience security controls."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from tests.integration._helpers import (
+    _MEMBER,
+    _AppInfo,
+    _GetUser,
+    _grpc_span_exporter,
+    _httpx_client,
+    _start_span,
+)
+from tests.integration.auth.test_mcp import _register_public_client
+
+pytestmark = [pytest.mark.authn, pytest.mark.authz]
+
+
+def test_refresh_token_cannot_authenticate_as_resource_bearer(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """A refresh token is not an access token at either HTTP or OTLP gRPC."""
+    oauth_client = _register_public_client(
+        _app,
+        resource=f"{_app.base_url.rstrip('/')}/mcp",
+    )
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    refresh_token = oauth_client.complete_flow(user)["refresh_token"]
+
+    response = _httpx_client(_app).get(
+        "v1/projects",
+        headers={"authorization": f"Bearer {refresh_token}"},
+    )
+    assert response.status_code == 401
+
+    memory = InMemorySpanExporter()
+    _start_span(exporter=memory, project_name="security-green-refresh-token").end()
+    spans = memory.get_finished_spans()
+    assert len(spans) == 1
+    result = _grpc_span_exporter(
+        _app,
+        headers={"authorization": f"Bearer {refresh_token}"},
+    ).export(spans)
+    del refresh_token
+    assert result is SpanExportResult.FAILURE
+
+
+def test_mcp_audience_token_is_rejected_by_origin_http_resources(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """An MCP-scoped access token cannot be replayed at REST or GraphQL."""
+    oauth_client = _register_public_client(
+        _app,
+        resource=f"{_app.base_url.rstrip('/')}/mcp",
+    )
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    access_token = oauth_client.complete_flow(user)["access_token"]
+    headers = {"authorization": f"Bearer {access_token}"}
+
+    rest_response = _httpx_client(_app).get("v1/projects", headers=headers)
+    graphql_response = _httpx_client(_app).post(
+        "graphql",
+        headers=headers,
+        json={"query": "query SecurityGreen { viewer { id } }"},
+    )
+    del access_token
+
+    assert rest_response.status_code == 401
+    assert graphql_response.status_code == 401

--- a/tests/integration/security/oauth/test_scope_exchange.py
+++ b/tests/integration/security/oauth/test_scope_exchange.py
@@ -1,0 +1,96 @@
+"""OAuth token exchanges cannot upgrade role-based permissions through scope."""
+
+from __future__ import annotations
+
+from secrets import token_hex
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from tests.integration._helpers import _VIEWER, _AppInfo, _GetUser, _httpx_client
+from tests.integration.auth.conftest import _active_grants, _OAuthPublicClient
+
+pytestmark = [pytest.mark.authz]
+
+
+def _assert_viewer_cannot_create_project(app: _AppInfo, access_token: str) -> None:
+    project_name = f"scope-upgrade-project-{token_hex(8)}"
+    headers = {"authorization": f"Bearer {access_token}"}
+
+    creation = _httpx_client(app).post(
+        "v1/projects",
+        headers=headers,
+        json={"name": project_name},
+    )
+    assert creation.status_code == 403
+
+    projects = _httpx_client(app).get(
+        "v1/projects",
+        headers=headers,
+        params={"name_contains": project_name},
+    )
+    assert projects.status_code == 200
+    assert projects.json()["data"] == []
+
+
+def test_code_exchange_scope_cannot_upgrade_viewer_permissions(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    _oauth_public_client: _OAuthPublicClient,
+) -> None:
+    """Scope supplied only at code exchange cannot alter the consented grant."""
+    user = _get_user(_app, _VIEWER).log_in(_app)
+    grants_before = _active_grants(_app, user)
+    authorization = _oauth_public_client.authorize(user)
+    redirect_to = _oauth_public_client.decide(user, authorization)
+    code = parse_qs(urlparse(redirect_to).query)["code"][0]
+
+    response = _httpx_client(_app).post(
+        "oauth2/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": _oauth_public_client.client_id,
+            "redirect_uri": _oauth_public_client.redirect_uri,
+            "code_verifier": _oauth_public_client.code_verifier,
+            "scope": "admin write",
+        },
+    )
+
+    response.raise_for_status()
+    token_response = response.json()
+    assert "scope" not in token_response
+    grants_after = _active_grants(_app, user)
+    grant_ids_before = {grant["id"] for grant in grants_before}
+    new_grants = [grant for grant in grants_after if grant["id"] not in grant_ids_before]
+    assert len(new_grants) == 1
+    assert new_grants[0]["scopes"] == []
+    _assert_viewer_cannot_create_project(_app, token_response["access_token"])
+
+
+def test_refresh_exchange_scope_cannot_upgrade_viewer_permissions(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    _oauth_public_client: _OAuthPublicClient,
+) -> None:
+    """Scope supplied during rotation cannot expand an immutable OAuth grant."""
+    user = _get_user(_app, _VIEWER).log_in(_app)
+    initial_tokens = _oauth_public_client.complete_flow(user)
+    grants_before_refresh = _active_grants(_app, user)
+    assert grants_before_refresh[-1]["scopes"] == []
+
+    response = _httpx_client(_app).post(
+        "oauth2/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": initial_tokens["refresh_token"],
+            "client_id": _oauth_public_client.client_id,
+            "scope": "admin write",
+        },
+    )
+
+    response.raise_for_status()
+    rotated_tokens = response.json()
+    assert "scope" not in rotated_tokens
+    assert _active_grants(_app, user) == grants_before_refresh
+    _assert_viewer_cannot_create_project(_app, rotated_tokens["access_token"])

--- a/tests/integration/security/oidc/test_flow_integrity.py
+++ b/tests/integration/security/oidc/test_flow_integrity.py
@@ -1,0 +1,49 @@
+"""OIDC browser-flow correlation values are unique and correctly bound."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from phoenix.auth import (
+    PHOENIX_OAUTH2_CODE_VERIFIER_COOKIE_NAME,
+    PHOENIX_OAUTH2_NONCE_COOKIE_NAME,
+    PHOENIX_OAUTH2_STATE_COOKIE_NAME,
+)
+from tests.integration._helpers import _AppInfo, _httpx_client, _OIDCServer
+
+pytestmark = [pytest.mark.session_management]
+
+
+def _authorization_values(response: httpx.Response) -> tuple[str, str, str, str]:
+    assert response.status_code == 302
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    state = response.cookies[PHOENIX_OAUTH2_STATE_COOKIE_NAME]
+    nonce = response.cookies[PHOENIX_OAUTH2_NONCE_COOKIE_NAME]
+    verifier = response.cookies[PHOENIX_OAUTH2_CODE_VERIFIER_COOKIE_NAME]
+    assert query["state"] == [state]
+    assert query["nonce"] == [nonce]
+    assert query["code_challenge_method"] == ["S256"]
+    expected_challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    )
+    assert query["code_challenge"] == [expected_challenge]
+    return state, nonce, verifier, expected_challenge
+
+
+def test_parallel_oidc_flows_use_distinct_correlation_secrets(
+    _app: _AppInfo,
+    _oidc_server_pkce_public: _OIDCServer,
+) -> None:
+    """Two bounded flow starts cannot share state, nonce, or PKCE material."""
+    first_login = _httpx_client(_app).post(f"oauth2/{_oidc_server_pkce_public}/login")
+    second_login = _httpx_client(_app).post(f"oauth2/{_oidc_server_pkce_public}/login")
+
+    first_values = _authorization_values(first_login)
+    second_values = _authorization_values(second_login)
+
+    assert all(first != second for first, second in zip(first_values, second_values))

--- a/tests/integration/security/oidc/test_idp_callback_origin.py
+++ b/tests/integration/security/oidc/test_idp_callback_origin.py
@@ -1,0 +1,56 @@
+"""IdP callback-origin controls at the complete HTTP middleware boundary."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from phoenix.auth import (
+    PHOENIX_OAUTH2_CODE_VERIFIER_COOKIE_NAME,
+    PHOENIX_OAUTH2_NONCE_COOKIE_NAME,
+    PHOENIX_OAUTH2_STATE_COOKIE_NAME,
+)
+from tests.integration._helpers import _AppInfo, _httpx_client, _OIDCServer
+
+pytestmark = [pytest.mark.input_validation]
+
+
+def _callback_origin(response_location: str) -> tuple[str, str]:
+    authorization_query = parse_qs(urlparse(response_location).query)
+    callback = urlparse(authorization_query["redirect_uri"][0])
+    return callback.scheme, callback.netloc
+
+
+@pytest.mark.parametrize("headers", [{}, {"referer": "APP_ORIGIN/oauth-client"}])
+def test_missing_or_same_origin_referer_uses_phoenix_callback_origin(
+    _app: _AppInfo,
+    _oidc_server: _OIDCServer,
+    headers: dict[str, str],
+) -> None:
+    phoenix = urlparse(_app.base_url)
+    resolved_headers = {
+        key: value.replace("APP_ORIGIN", f"{phoenix.scheme}://{phoenix.netloc}")
+        for key, value in headers.items()
+    }
+    response = _httpx_client(_app, headers=resolved_headers).post(f"oauth2/{_oidc_server}/login")
+
+    assert response.status_code == 302
+    assert _callback_origin(response.headers["location"]) == (phoenix.scheme, phoenix.netloc)
+
+
+def test_foreign_referer_is_rejected_before_idp_flow_creation(
+    _app: _AppInfo,
+    _oidc_server: _OIDCServer,
+) -> None:
+    response = _httpx_client(
+        _app,
+        headers={"referer": "https://attacker.invalid/oauth-client"},
+    ).post(f"oauth2/{_oidc_server}/login")
+
+    assert response.status_code == 401
+    assert response.text == "untrusted referer"
+    assert "location" not in response.headers
+    assert PHOENIX_OAUTH2_STATE_COOKIE_NAME not in response.cookies
+    assert PHOENIX_OAUTH2_NONCE_COOKIE_NAME not in response.cookies
+    assert PHOENIX_OAUTH2_CODE_VERIFIER_COOKIE_NAME not in response.cookies

--- a/tests/integration/security/oidc/test_wrong_issuer.py
+++ b/tests/integration/security/oidc/test_wrong_issuer.py
@@ -1,0 +1,37 @@
+"""HC-07 regression: a signed token from a wrong issuer cannot create a session."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from phoenix.auth import PHOENIX_ACCESS_TOKEN_COOKIE_NAME
+from tests.integration._helpers import _AppInfo, _httpx_client, _OIDCServer
+
+pytestmark = [pytest.mark.authn]
+
+
+def test_wrong_issuer_signed_id_token_is_rejected_before_session_creation(
+    _app: _AppInfo,
+    _oidc_server: _OIDCServer,
+) -> None:
+    """An IdP signature is insufficient when its issuer claim is wrong."""
+    login = _httpx_client(_app).post(f"oauth2/{_oidc_server}/login")
+    assert login.status_code == 302
+    callback = _httpx_client(_app).get(login.headers["location"])
+    assert callback.status_code == 302
+
+    _oidc_server.set_id_token_claim_overrides(iss="https://wrong-issuer.invalid")
+    try:
+        response = _httpx_client(_app, cookies=dict(login.cookies)).get(
+            callback.headers["location"]
+        )
+    finally:
+        _oidc_server.set_id_token_claim_overrides()
+
+    assert response.status_code == 307
+    redirect = urlparse(response.headers["location"])
+    assert redirect.path == "/login"
+    assert parse_qs(redirect.query)["error"] == ["auth_failed"]
+    assert PHOENIX_ACCESS_TOKEN_COOKIE_NAME not in response.cookies

--- a/tests/integration/security/pxi/test_direct_route_controls.py
+++ b/tests/integration/security/pxi/test_direct_route_controls.py
@@ -1,0 +1,102 @@
+"""Passing authorization controls for the direct PXI server-agent route."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.integration._helpers import _MEMBER, _VIEWER, _AppInfo, _GetUser, _httpx_client
+from tests.integration.auth.test_mcp import _register_public_client
+
+pytestmark = [pytest.mark.authn, pytest.mark.authz]
+
+
+def _chat_request(*, contexts: list[dict[str, object]] | None = None) -> dict[str, Any]:
+    return {
+        "trigger": "submit-message",
+        "id": "security-pxi-direct-route-message",
+        "messages": [
+            {
+                "id": "security-pxi-direct-route-user-message",
+                "role": "user",
+                "parts": [{"type": "text", "text": "security authorization probe"}],
+            }
+        ],
+        "model": {
+            "providerType": "builtin",
+            "provider": "ANTHROPIC",
+            "modelName": "claude-3-5-sonnet-20241022",
+        },
+        "contexts": contexts or [],
+    }
+
+
+@pytest.mark.parametrize("credential_kind", ["refresh", "mcp-audience"], ids=["refresh", "mcp"])
+def test_direct_pxi_route_rejects_non_resource_access_credentials(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    credential_kind: str,
+) -> None:
+    """A refresh or MCP-resource token cannot initiate the origin-scoped PXI route."""
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    resource = f"{_app.base_url.rstrip('/')}/mcp" if credential_kind == "mcp-audience" else None
+    tokens = _register_public_client(_app, resource=resource).complete_flow(user)
+    credential = tokens["refresh_token"] if credential_kind == "refresh" else tokens["access_token"]
+
+    response = _httpx_client(_app).post(
+        "agents/server/sessions/security-untrusted-session/chat",
+        headers={"authorization": f"Bearer {credential}"},
+        json=_chat_request(),
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize("credential_kind", ["oauth-access", "api-key"], ids=["oauth", "api-key"])
+def test_direct_pxi_route_accepts_intended_member_credentials(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+    credential_kind: str,
+) -> None:
+    """The direct route accepts ordinary member credentials, regardless of client session text."""
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    credential = (
+        _register_public_client(_app).complete_flow(user)["access_token"]
+        if credential_kind == "oauth-access"
+        else str(user.create_api_key(_app))
+    )
+
+    response = _httpx_client(_app).post(
+        "agents/server/sessions/attacker-chosen-but-unprivileged-id/chat",
+        headers={"authorization": f"Bearer {credential}"},
+        json=_chat_request(),
+    )
+
+    assert response.status_code == 200
+
+
+def test_viewer_cannot_enable_direct_pxi_graphql_mutations(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """The server, not the client UI, rejects a viewer's mutation capability request."""
+    viewer = _get_user(_app, _VIEWER).log_in(_app)
+    response = _httpx_client(_app, viewer.tokens).post(
+        "agents/server/sessions/security-viewer-session/chat",
+        json=_chat_request(contexts=[{"type": "graphql", "mutationsEnabled": True}]),
+    )
+
+    assert response.status_code == 403
+    assert response.text == "Viewer users cannot enable mutations"
+
+
+def test_direct_pxi_route_rejects_unauthenticated_caller(
+    _app: _AppInfo,
+) -> None:
+    response = _httpx_client(_app).post(
+        "agents/server/sessions/security-no-credential/chat",
+        json=_chat_request(),
+    )
+
+    assert response.status_code == 401

--- a/tests/integration/security/session/test_state_propagation.py
+++ b/tests/integration/security/session/test_state_propagation.py
@@ -1,0 +1,185 @@
+"""Cross-consumer lifecycle controls for HC-26 using only local fixtures."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from phoenix.server.api.input_types.UserRoleInput import UserRoleInput
+from tests.integration._helpers import (
+    _ADMIN,
+    _MEMBER,
+    _AppInfo,
+    _GetUser,
+    _grpc_span_exporter,
+    _httpx_client,
+    _start_span,
+)
+from tests.integration.auth.test_mcp import _register_public_client
+
+pytestmark = [pytest.mark.session_management]
+
+
+def _initialize_request() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "security-live-state", "version": "0"},
+        },
+    }
+
+
+def _agent_request() -> dict[str, Any]:
+    return {
+        "trigger": "submit-message",
+        "id": "security-live-state-message",
+        "messages": [
+            {
+                "id": "security-live-state-user-message",
+                "role": "user",
+                "parts": [{"type": "text", "text": "local authorization control"}],
+            }
+        ],
+        "model": {
+            "providerType": "builtin",
+            "provider": "ANTHROPIC",
+            "modelName": "claude-3-5-sonnet-20241022",
+        },
+        "contexts": [],
+    }
+
+
+def _assert_http_consumers(
+    app: _AppInfo,
+    credential: str,
+    *,
+    status_code: int,
+) -> None:
+    headers = {"authorization": f"Bearer {credential}"}
+    assert _httpx_client(app).get("v1/projects", headers=headers).status_code == status_code
+    assert (
+        _httpx_client(app)
+        .post("graphql", headers=headers, json={"query": "query { viewer { id } }"})
+        .status_code
+        == status_code
+    )
+    assert (
+        _httpx_client(app)
+        .post(
+            "mcp",
+            headers={"accept": "application/json, text/event-stream", **headers},
+            json=_initialize_request(),
+        )
+        .status_code
+        == status_code
+    )
+    assert (
+        _httpx_client(app)
+        .post(
+            "agents/server/sessions/security-live-state/chat",
+            headers=headers,
+            json=_agent_request(),
+        )
+        .status_code
+        == status_code
+    )
+
+
+def _grpc_result(app: _AppInfo, credential: str, project_name: str) -> SpanExportResult:
+    memory = InMemorySpanExporter()
+    _start_span(exporter=memory, project_name=project_name).end()
+    return _grpc_span_exporter(
+        app,
+        headers={"authorization": f"Bearer {credential}"},
+    ).export(memory.get_finished_spans())
+
+
+def _assert_credential_is_live(app: _AppInfo, credential: str, project_name: str) -> None:
+    _assert_http_consumers(app, credential, status_code=200)
+    assert _grpc_result(app, credential, project_name) is SpanExportResult.SUCCESS
+
+
+def _assert_credential_is_revoked(app: _AppInfo, credential: str, project_name: str) -> None:
+    _assert_http_consumers(app, credential, status_code=401)
+    assert _grpc_result(app, credential, project_name) is SpanExportResult.FAILURE
+
+
+def test_oauth_grant_revocation_propagates_to_all_local_consumers(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """A revoked OAuth access token cannot retain a consumer-specific capability."""
+    affected_user = _get_user(_app, _MEMBER).log_in(_app)
+    affected_token = _register_public_client(_app).complete_flow(affected_user)["access_token"]
+    control_user = _get_user(_app, _MEMBER).log_in(_app)
+    control_token = _register_public_client(_app).complete_flow(control_user)["access_token"]
+
+    _assert_credential_is_live(_app, affected_token, "security-live-oauth-before")
+    revoke_response = _httpx_client(_app).post("oauth2/revoke", data={"token": affected_token})
+    assert revoke_response.status_code == 200
+    _assert_credential_is_revoked(_app, affected_token, "security-live-oauth-after")
+    _assert_credential_is_live(_app, control_token, "security-live-oauth-control")
+
+
+def test_deleted_user_invalidates_api_key_at_all_local_consumers(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """Deleting an owner revokes their API key without affecting another member."""
+    affected_user = _get_user(_app, _MEMBER)
+    affected_key = str(affected_user.create_api_key(_app))
+    control_user = _get_user(_app, _MEMBER)
+    control_key = str(control_user.create_api_key(_app))
+
+    _assert_credential_is_live(_app, affected_key, "security-live-key-before")
+    _get_user(_app, _ADMIN).delete_users(_app, affected_user)
+    _assert_credential_is_revoked(_app, affected_key, "security-live-key-after")
+    _assert_credential_is_live(_app, control_key, "security-live-key-control")
+
+
+def test_role_downgrade_invalidates_preexisting_browser_access_token(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """A member's pre-change browser token cannot survive a viewer downgrade."""
+    affected_user = _get_user(_app, _MEMBER)
+    affected_token = str(affected_user.log_in(_app).tokens.access_token)
+    control_token = str(_get_user(_app, _MEMBER).log_in(_app).tokens.access_token)
+
+    _assert_credential_is_live(_app, affected_token, "security-live-role-before")
+    _get_user(_app, _ADMIN).patch_user(_app, affected_user, new_role=UserRoleInput.VIEWER)
+    _assert_credential_is_revoked(_app, affected_token, "security-live-role-after")
+    _assert_credential_is_live(_app, control_token, "security-live-role-control")
+
+
+def test_logout_and_refresh_rotation_do_not_leave_old_browser_tokens_live(
+    _app: _AppInfo,
+    _get_user: _GetUser,
+) -> None:
+    """Logout and refresh replace the session's usable browser credentials."""
+    user = _get_user(_app, _MEMBER).log_in(_app)
+    old_access_token = str(user.tokens.access_token)
+    old_refresh_token = user.tokens.refresh_token
+    rotated_tokens = user.tokens.refresh(_app)
+
+    _assert_credential_is_revoked(_app, old_access_token, "security-live-refresh-old-access")
+    assert _httpx_client(_app, old_refresh_token).post("auth/refresh").status_code == 401
+    _assert_credential_is_live(
+        _app,
+        str(rotated_tokens.access_token),
+        "security-live-refresh-new-access",
+    )
+
+    rotated_tokens.log_out(_app)
+    _assert_credential_is_revoked(
+        _app,
+        str(rotated_tokens.access_token),
+        "security-live-logout-access",
+    )


### PR DESCRIPTION
## Summary

Adds a security integration test suite under `tests/integration/security`, organized by **surface** (the protocol / entry point under test). All tests assert boundaries that are **already enforced on `main`** and pass today — this PR adds coverage, it does not change product behavior.

## Layout

| Directory | Surface |
|---|---|
| `oauth/` | OAuth authorize / token / DCR / scope / redirect boundaries (6 files) |
| `oidc/` | OIDC issuer validation, flow integrity, callback origin (3) |
| `mcp/` | MCP bearer/auth boundary and protocol disclosure (2) |
| `ingestion/` | OTLP/gRPC ingestion authn + role gates (1) |
| `pxi/` | Direct PXI server-agent route controls (1) |
| `session/` | Cross-consumer session lifecycle (1) |

Control class is orthogonal to surface and expressed with markers registered in `tests/integration/security/conftest.py` — `authn`, `authz`, `input_validation`, `session_management`, `disclosure` — so a property can be run across every surface:

```sh
uv run pytest tests/integration/security -n auto      # all
uv run pytest tests/integration/security/oauth        # one surface
uv run pytest tests/integration/security -m authz     # one control class, all surfaces
```

## Production-harness change

One additive change outside the new directory: `tests/integration/_helpers._OIDCServer` gains test hooks (ID-token claim overrides, signing-key/algorithm control) used by the OIDC tests, plus a `NoSuchProcess` guard in `_is_alive`. No non-test source is touched.

## Verification

- `pytest tests/integration/security` → **57 passed**
- `pytest -m authz` → 38/57 selected (marker filtering works; all markers registered, no unknown-marker warnings)
- `ruff check` + `ruff format --check` → clean
- `mypy` (strict) → clean

## Not in this PR

Remediation contracts for not-yet-fixed findings are intentionally excluded from CI collection and will graduate into the matching surface directory alongside each fix, in follow-up PRs.