### PR TITLE
fix(server): detach the docs MCP server after a failed startup warmup (#13599)

### DIFF
--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -699,6 +699,13 @@ def _lifespan(
                 try:
                     await stack.enter_async_context(docs_mcp_server)
                 except Exception:
+                    # Detach it so the degradation is real. The assistant reads
+                    # ``app.state.docs_mcp_server`` per request and attaches the
+                    # docs capability whenever it is not ``None``; leaving the
+                    # failed server there makes every turn re-attempt the
+                    # handshake, stall until the deadline, and then fail the
+                    # turn instead of answering without docs tools.
+                    app.state.docs_mcp_server = None
                     logger.warning(
                         "Failed to initialize docs MCP server; continuing without docs capability.",
                         exc_info=True,

--- a/tests/unit/server/test_app_docs_mcp_lifespan.py
+++ b/tests/unit/server/test_app_docs_mcp_lifespan.py
@@ -57,3 +57,33 @@ async def test_app_starts_up_when_docs_mcp_server_init_fails(
         assert isinstance(app.state.docs_mcp_server, _ExplodingDocsMCPServer)
         # Lifespan startup must not raise even though docs MCP init fails.
         await stack.enter_async_context(LifespanManager(app))
+
+
+async def test_failed_docs_mcp_init_detaches_the_server_from_app_state(
+    db: DbSessionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed handshake must leave no docs MCP server behind on app state.
+
+    The assistant reads ``app.state.docs_mcp_server`` on every request and
+    attaches the docs capability whenever it is not ``None``. If the failed
+    server stayed attached, each turn would re-attempt the handshake, stall
+    until the deadline, and fail -- which is not the graceful degradation the
+    startup guard promises.
+    """
+    monkeypatch.setattr("phoenix.server.app.get_env_disable_agent_assistant", lambda: False)
+    monkeypatch.setattr("phoenix.server.app.get_env_allow_external_resources", lambda: True)
+    monkeypatch.setattr("phoenix.server.app.MintlifyDocsMCPServer", _ExplodingDocsMCPServer)
+
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_batched_caller())
+        await stack.enter_async_context(patch_grpc_server())
+        app = create_app(
+            db=db,
+            authentication_enabled=False,
+            serve_ui=False,
+            bulk_inserter_factory=TestBulkInserter,
+        )
+        assert isinstance(app.state.docs_mcp_server, _ExplodingDocsMCPServer)
+        await stack.enter_async_context(LifespanManager(app))
+        assert app.state.docs_mcp_server is None


### PR DESCRIPTION
Fixes #13599.

## Problem

#13595 guarded the **startup** path so an unreachable docs-MCP host can no longer crash-loop the server. The guard's own comment states the intent — "degrade to the assistant running without docs tools instead" — but the degradation never actually happens, because the failed server is left attached to app state:

```python
if docs_mcp_server is not None:
    try:
        await stack.enter_async_context(docs_mcp_server)
    except Exception:
        logger.warning("Failed to initialize docs MCP server; ...")
```

`app.state.docs_mcp_server` is assigned unconditionally in `create_app` (`src/phoenix/server/app.py`), and the assistant router reads it back on **every** request — three call sites in `src/phoenix/server/api/routers/agents.py` pass `request.app.state.docs_mcp_server` into `build_agent`, which attaches the docs capability whenever the value is not `None` (`src/phoenix/server/agents/agent_factory.py`).

So with egress blocked, each assistant turn re-enters the toolset, re-attempts the MCP handshake (nothing is cached on failure), stalls until the init deadline, and then fails the turn — instead of answering without docs tools.

## Fix

Null out `app.state.docs_mcp_server` in the existing `except` branch, so the value the request path reads back matches what the startup guard already decided. One functional line; no other behavior changes.

The success path is untouched: when the handshake succeeds, the server stays attached and is torn down by the same `AsyncExitStack` as before. Since a failed `__aenter__` was never registered on the stack, there is nothing to unwind on the failure path either.

## Test

`tests/unit/server/test_app_docs_mcp_lifespan.py` already has the harness for this — `_ExplodingDocsMCPServer` raises `TimeoutError` from `__aenter__`, exactly the blocked-egress shape. Added a second case that runs the lifespan and asserts the server is gone from app state afterwards. The existing startup test is unchanged (its `isinstance` assertion runs before lifespan startup, so it still sees the constructed server).

Scoped to the chat-time resiliency point in #13599; the issue also mentions surfacing the degraded state in the UI, which is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
