### PR TITLE
feat(agents): categorize recommended agent models with capability tags

### DIFF
--- a/app/src/components/agent/AgentModelMenu.tsx
+++ b/app/src/components/agent/AgentModelMenu.tsx
@@ -10,8 +10,13 @@ import {
   MenuItem,
   MenuSectionTitle,
   MenuTrigger,
+  RichTooltip,
+  RichTooltipDescription,
+  RichTooltipTitle,
   Separator,
   Text,
+  TooltipTrigger,
+  TriggerWrap,
 } from "@phoenix/components";
 import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
 import type {
@@ -30,6 +35,8 @@ import { useAgentContext } from "@phoenix/contexts/AgentContext";
 import { isModelProvider } from "@phoenix/utils/generativeUtils";
 
 import {
+  AGENT_MODEL_TAG_INFO,
+  type AgentModelTag,
   getCuratedBuiltInModels,
   isAgentCuratedBuiltInModel,
 } from "./agentCuratedModels";
@@ -49,11 +56,30 @@ function applyBedrockPrefix(modelName: string, prefix: string): string {
     : `${prefixDot}${modelName}`;
 }
 
+function AgentModelTagText({ tag }: { tag: AgentModelTag }) {
+  const { label, description } = AGENT_MODEL_TAG_INFO[tag];
+  return (
+    <TooltipTrigger delay={200}>
+      <TriggerWrap aria-label={`${label}: ${description}`}>
+        <Text size="S" color="text-500">
+          {label}
+        </Text>
+      </TriggerWrap>
+      <RichTooltip placement="end" offset={12}>
+        <RichTooltipTitle>{label}</RichTooltipTitle>
+        <RichTooltipDescription>{description}</RichTooltipDescription>
+      </RichTooltip>
+    </TooltipTrigger>
+  );
+}
+
 function AgentModelItem({
   model,
+  tag,
   onChange,
 }: {
   model: ModelMenuValue;
+  tag?: AgentModelTag;
   onChange?: (model: ModelMenuValue) => void;
 }) {
   return (
@@ -63,6 +89,7 @@ function AgentModelItem({
       onAction={() => {
         onChange?.(model);
       }}
+      trailingContent={tag ? <AgentModelTagText tag={tag} /> : undefined}
     >
       <Flex direction="row" gap="size-100" alignItems="center">
         <GenerativeProviderIcon provider={model.provider} height={16} />
@@ -79,7 +106,7 @@ function CuratedAndOtherModelMenuSections({
   modelProviders,
   onChange,
 }: {
-  curatedBuiltInModels: ModelMenuValue[];
+  curatedBuiltInModels: (ModelMenuValue & { tag: AgentModelTag })[];
   modelsByProvider: Map<string, string[]>;
   customProviders: CustomProviderInfo[];
   modelProviders: readonly ModelProviderInfo[];
@@ -93,6 +120,7 @@ function CuratedAndOtherModelMenuSections({
           <AgentModelItem
             key={`${model.provider}:${model.modelName}`}
             model={model}
+            tag={model.tag}
             onChange={onChange}
           />
         ))}
@@ -208,6 +236,7 @@ export function AgentModelMenu({
               <AgentModelItem
                 key={`${model.provider}:${model.modelName}`}
                 model={model}
+                tag={model.tag}
                 onChange={handleModelChange}
               />
             ))

--- a/app/src/components/agent/__tests__/agentCuratedModels.test.ts
+++ b/app/src/components/agent/__tests__/agentCuratedModels.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
 
 import {
+  AGENT_CURATED_BUILT_IN_MODELS,
+  AGENT_MODEL_TAG_INFO,
   getCuratedBuiltInModels,
   isAgentCuratedModelSelection,
 } from "../agentCuratedModels";
@@ -26,6 +28,15 @@ describe("agent curated models", () => {
     ).toBe(false);
   });
 
+  it("treats models culled from the recommended list as untested", () => {
+    expect(
+      isAgentCuratedModelSelection({
+        provider: "ANTHROPIC",
+        modelName: "claude-sonnet-4-6",
+      })
+    ).toBe(false);
+  });
+
   it("treats custom provider models as untested", () => {
     const customModel: ModelMenuValue = {
       provider: "OPENAI",
@@ -44,11 +55,19 @@ describe("agent curated models", () => {
       getCuratedBuiltInModels([
         { providerKey: "OPENAI", name: "gpt-5.6-sol" },
         { providerKey: "OPENAI", name: "gpt-4o" },
-        { providerKey: "ANTHROPIC", name: "claude-sonnet-4-6" },
+        { providerKey: "ANTHROPIC", name: "claude-sonnet-5" },
       ])
     ).toEqual([
-      { provider: "ANTHROPIC", modelName: "claude-sonnet-4-6" },
-      { provider: "OPENAI", modelName: "gpt-5.6-sol" },
+      { provider: "ANTHROPIC", modelName: "claude-sonnet-5", tag: "fastest" },
+      { provider: "OPENAI", modelName: "gpt-5.6-sol", tag: "advanced" },
     ]);
+  });
+
+  it("labels every curated model with a known tag", () => {
+    for (const model of AGENT_CURATED_BUILT_IN_MODELS) {
+      expect(AGENT_MODEL_TAG_INFO[model.tag]).toBeDefined();
+      expect(AGENT_MODEL_TAG_INFO[model.tag].label).toBeTruthy();
+      expect(AGENT_MODEL_TAG_INFO[model.tag].description).toBeTruthy();
+    }
   });
 });

--- a/app/src/components/agent/agentCuratedModels.ts
+++ b/app/src/components/agent/agentCuratedModels.ts
@@ -1,9 +1,42 @@
 import type { ModelMenuValue } from "@phoenix/components/generative/ModelMenu";
 import type { GenerativeProviderKey } from "@phoenix/components/generative/useModelMenuData";
 
+/**
+ * Capability tier tags for the curated agent model list. Each curated model
+ * is labeled with one tag to help users pick a model for their use case.
+ */
+export type AgentModelTag = "fastest" | "balanced" | "advanced";
+
+export type AgentModelTagInfo = {
+  readonly label: string;
+  readonly description: string;
+};
+
+export const AGENT_MODEL_TAG_INFO: Record<AgentModelTag, AgentModelTagInfo> = {
+  fastest: {
+    label: "Fastest",
+    description:
+      "Fast, low-cost models for quick questions and lightweight tasks.",
+  },
+  balanced: {
+    label: "Balanced",
+    description:
+      "Strong reasoning at reasonable cost — a good default for most investigations.",
+  },
+  advanced: {
+    label: "Advanced",
+    description:
+      "Frontier models for the hardest, open-ended problems. Slower and pricier.",
+  },
+};
+
 export type AgentBuiltInModelSelection = {
   provider: GenerativeProviderKey;
   modelName: string;
+};
+
+export type AgentCuratedModel = AgentBuiltInModelSelection & {
+  tag: AgentModelTag;
 };
 
 export type AgentPlaygroundModel = {
@@ -11,20 +44,16 @@ export type AgentPlaygroundModel = {
   readonly providerKey: GenerativeProviderKey;
 };
 
-export const AGENT_CURATED_BUILT_IN_MODELS: readonly AgentBuiltInModelSelection[] =
-  [
-    { provider: "ANTHROPIC", modelName: "claude-fable-5" },
-    { provider: "ANTHROPIC", modelName: "claude-opus-5" },
-    { provider: "ANTHROPIC", modelName: "claude-opus-4-8" },
-    { provider: "ANTHROPIC", modelName: "claude-opus-4-6" },
-    { provider: "ANTHROPIC", modelName: "claude-sonnet-4-6" },
-    { provider: "OPENAI", modelName: "gpt-5.6-sol" },
-    { provider: "OPENAI", modelName: "gpt-5.4" },
-    { provider: "OPENAI", modelName: "gpt-5.4-mini" },
-    { provider: "OPENAI", modelName: "gpt-5.5" },
-    { provider: "GOOGLE", modelName: "gemini-3.1-pro-preview" },
-    { provider: "GOOGLE", modelName: "gemini-3.5-flash" },
-  ];
+export const AGENT_CURATED_BUILT_IN_MODELS: readonly AgentCuratedModel[] = [
+  { provider: "ANTHROPIC", modelName: "claude-fable-5", tag: "advanced" },
+  { provider: "ANTHROPIC", modelName: "claude-opus-5", tag: "balanced" },
+  { provider: "ANTHROPIC", modelName: "claude-sonnet-5", tag: "fastest" },
+  { provider: "OPENAI", modelName: "gpt-5.6-sol", tag: "advanced" },
+  { provider: "OPENAI", modelName: "gpt-5.6-terra", tag: "balanced" },
+  { provider: "OPENAI", modelName: "gpt-5.6-luna", tag: "fastest" },
+  { provider: "GOOGLE", modelName: "gemini-3.6-flash", tag: "balanced" },
+  { provider: "GOOGLE", modelName: "gemini-3.5-flash-lite", tag: "fastest" },
+];
 
 export function isAgentCuratedBuiltInModel({
   provider,
@@ -38,7 +67,7 @@ export function isAgentCuratedBuiltInModel({
 
 export function getCuratedBuiltInModels(
   playgroundModels: readonly AgentPlaygroundModel[]
-): AgentBuiltInModelSelection[] {
+): AgentCuratedModel[] {
   return AGENT_CURATED_BUILT_IN_MODELS.filter(({ provider, modelName }) =>
     playgroundModels.some(
       (playgroundModel) =>

--- a/app/src/components/agent/agentModelConfig.ts
+++ b/app/src/components/agent/agentModelConfig.ts
@@ -33,7 +33,7 @@ export type AgentModelConfig = z.infer<typeof AGENT_MODEL_CONFIG_SCHEMA>;
 
 export const DEFAULT_MODEL_MENU_VALUE: ModelMenuValue = {
   provider: "ANTHROPIC",
-  modelName: "claude-opus-4-6",
+  modelName: "claude-opus-5",
 };
 
 /**

--- a/app/src/store/agentStore.ts
+++ b/app/src/store/agentStore.ts
@@ -152,7 +152,7 @@ export type AgentSession = {
 
 const DEFAULT_MODEL_CONFIG: ModelConfig = {
   provider: "ANTHROPIC",
-  modelName: "claude-opus-4-6",
+  modelName: "claude-opus-5",
   invocationParameters: getDefaultInvocationConfig("ANTHROPIC"),
 };
 


### PR DESCRIPTION
Closes #14717

Categorizes the PXI recommended model list so users can pick a model by use case.

## Changes

- Each curated model is tagged **Fastest**, **Balanced**, or **Advanced**, rendered as subdued trailing text in the model menu (both the curated-only menu and the Recommended section in settings)
- Hovering a tag shows a `RichTooltip` explaining the tier
- Culled the recommended list from 11 → 8 models — the latest two most powerful models plus a budget option per provider (`claude-fable-5/opus-5/sonnet-5`, `gpt-5.6-sol/terra/luna`, `gemini-3.6-flash/3.5-flash-lite`); `gemini-3.1-pro-preview` dropped as it is superseded by 3.6-flash on agentic benchmarks
- Bumped the default agent model `claude-opus-4-6` → `claude-opus-5` since the old default was culled
- Culled models remain available under "Other models" in agent settings

## Tests

- Updated `agentCuratedModels.test.ts` fixtures; added culled-model regression and tag-completeness tests