### PR TITLE
fix(phoenix-otel): only remove the default processor when replacing it

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -307,16 +307,17 @@ class TracerProvider(_TracerProvider):
         self._default_processor = span_processor
 
     def _shutdown_default_processor(self) -> None:
-        default_processor = self._default_processor
-        if default_processor is not None:
-            default_processor.shutdown()
-            with self._active_span_processor._lock:
-                self._active_span_processor._span_processors = tuple(
-                    processor
-                    for processor in self._active_span_processor._span_processors
-                    if processor is not default_processor
-                )
+        with self._active_span_processor._lock:
+            default_processor = self._default_processor
+            if default_processor is None:
+                return
+            self._active_span_processor._span_processors = tuple(
+                processor
+                for processor in self._active_span_processor._span_processors
+                if processor is not default_processor
+            )
             self._default_processor = None
+        default_processor.shutdown()
 
     def _tracing_details(self) -> str:
         project = self.resource.attributes.get(PROJECT_NAME)

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -175,8 +175,7 @@ def register(
         span_processor = BatchSpanProcessor(endpoint=endpoint, headers=headers, protocol=protocol)
     else:
         span_processor = SimpleSpanProcessor(endpoint=endpoint, headers=headers, protocol=protocol)
-    tracer_provider.add_span_processor(span_processor)
-    tracer_provider._default_processor = True
+    tracer_provider._set_default_processor(span_processor)
 
     if set_global_tracer_provider:
         trace_api.set_tracer_provider(tracer_provider)
@@ -286,14 +285,34 @@ class TracerProvider(_TracerProvider):
         """
         Registers a new `SpanProcessor` for this `TracerProvider`.
 
-        If this `TracerProvider` has a default processor, it will be removed.
+        If this `TracerProvider` has a default processor, it will be removed
+        (and a warning emitted). Pass `replace_default_processor=False` to keep
+        the default processor alongside the newly added one.
         """
 
         if self._default_processor and replace_default_processor:
+            warnings.warn(
+                "The default span processor (the Phoenix exporter configured at "
+                "construction) is being replaced by the newly added span processor. "
+                "Spans will no longer be exported by the default processor. Pass "
+                "`replace_default_processor=False` to keep it alongside the new one.",
+                stacklevel=2,
+            )
+            self._shutdown_default_processor()
+        return super().add_span_processor(*args, **kwargs)
+
+    def _set_default_processor(self, span_processor: SpanProcessor) -> None:
+        # Internal setup path (e.g. `register`): replacing the default here is the
+        # intended configuration step, so it happens without a warning.
+        self._shutdown_default_processor()
+        super().add_span_processor(span_processor)
+        self._default_processor = True
+
+    def _shutdown_default_processor(self) -> None:
+        if self._default_processor:
             self._active_span_processor.shutdown()
             self._active_span_processor._span_processors = tuple()  # remove default processors
             self._default_processor = False
-        return super().add_span_processor(*args, **kwargs)
 
     def _tracing_details(self) -> str:
         project = self.resource.attributes.get(PROJECT_NAME)

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -263,19 +263,17 @@ class TracerProvider(_TracerProvider):
         validated_protocol = OTLPTransportProtocol(protocol)
         use_http = validated_protocol == OTLPTransportProtocol.HTTP_PROTOBUF
         parsed_url, endpoint = _normalized_endpoint(endpoint, use_http=use_http)
-        self._default_processor = False
+        self._default_processor: Optional[SpanProcessor] = None
 
         if (
             _maybe_http_endpoint(parsed_url)
             or validated_protocol == OTLPTransportProtocol.HTTP_PROTOBUF
         ):
             http_exporter: SpanExporter = HTTPSpanExporter(endpoint=endpoint)
-            self.add_span_processor(SimpleSpanProcessor(span_exporter=http_exporter))
-            self._default_processor = True
+            self._set_default_processor(SimpleSpanProcessor(span_exporter=http_exporter))
         elif _maybe_grpc_endpoint(parsed_url) or validated_protocol == OTLPTransportProtocol.GRPC:
             grpc_exporter: SpanExporter = GRPCSpanExporter(endpoint=endpoint)
-            self.add_span_processor(SimpleSpanProcessor(span_exporter=grpc_exporter))
-            self._default_processor = True
+            self._set_default_processor(SimpleSpanProcessor(span_exporter=grpc_exporter))
         if verbose:
             print(self._tracing_details())
 
@@ -290,7 +288,7 @@ class TracerProvider(_TracerProvider):
         the default processor alongside the newly added one.
         """
 
-        if self._default_processor and replace_default_processor:
+        if self._default_processor is not None and replace_default_processor:
             warnings.warn(
                 "The default span processor (the Phoenix exporter configured at "
                 "construction) is being replaced by the newly added span processor. "
@@ -306,13 +304,19 @@ class TracerProvider(_TracerProvider):
         # intended configuration step, so it happens without a warning.
         self._shutdown_default_processor()
         super().add_span_processor(span_processor)
-        self._default_processor = True
+        self._default_processor = span_processor
 
     def _shutdown_default_processor(self) -> None:
-        if self._default_processor:
-            self._active_span_processor.shutdown()
-            self._active_span_processor._span_processors = tuple()  # remove default processors
-            self._default_processor = False
+        default_processor = self._default_processor
+        if default_processor is not None:
+            default_processor.shutdown()
+            with self._active_span_processor._lock:
+                self._active_span_processor._span_processors = tuple(
+                    processor
+                    for processor in self._active_span_processor._span_processors
+                    if processor is not default_processor
+                )
+            self._default_processor = None
 
     def _tracing_details(self) -> str:
         project = self.resource.attributes.get(PROJECT_NAME)
@@ -377,7 +381,7 @@ class TracerProvider(_TracerProvider):
             f"|  Transport: {transport}\n"
             f"|  Transport Headers: {headers}\n"
             "|  \n"
-            f"{configuration_msg if self._default_processor else ''}"
+            f"{configuration_msg if self._default_processor is not None else ''}"
             f"{span_processor_warning if using_simple_processor else ''}"
         )
         return details_msg

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -283,25 +283,16 @@ class TracerProvider(_TracerProvider):
         """
         Registers a new `SpanProcessor` for this `TracerProvider`.
 
-        If this `TracerProvider` has a default processor, it will be removed
-        (and a warning emitted). Pass `replace_default_processor=False` to keep
-        the default processor alongside the newly added one.
+        If this `TracerProvider` has a default processor, it will be removed.
+        Pass `replace_default_processor=False` to keep the default processor
+        alongside the newly added one.
         """
 
         if self._default_processor is not None and replace_default_processor:
-            warnings.warn(
-                "The default span processor (the Phoenix exporter configured at "
-                "construction) is being replaced by the newly added span processor. "
-                "Spans will no longer be exported by the default processor. Pass "
-                "`replace_default_processor=False` to keep it alongside the new one.",
-                stacklevel=2,
-            )
             self._shutdown_default_processor()
         return super().add_span_processor(*args, **kwargs)
 
     def _set_default_processor(self, span_processor: SpanProcessor) -> None:
-        # Internal setup path (e.g. `register`): replacing the default here is the
-        # intended configuration step, so it happens without a warning.
         self._shutdown_default_processor()
         super().add_span_processor(span_processor)
         self._default_processor = span_processor

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -401,6 +401,19 @@ class TestTracerProvider:
         assert processors == (first_custom_processor, second_custom_processor)
         first_custom_processor.shutdown.assert_not_called()
 
+    def test_add_span_processor_removes_default_before_shutdown(self) -> None:
+        tracer_provider = TracerProvider(verbose=False)
+        default_processor = tracer_provider._default_processor
+        assert default_processor is not None
+
+        def assert_default_is_inactive() -> None:
+            assert default_processor not in tracer_provider._active_span_processor._span_processors
+            assert tracer_provider._default_processor is None
+
+        with patch.object(default_processor, "shutdown", side_effect=assert_default_is_inactive):
+            with pytest.warns(UserWarning, match="default span processor"):
+                tracer_provider.add_span_processor(Mock(spec=_SimpleSpanProcessor))
+
     def test_register_does_not_warn_on_default_processor_setup(self) -> None:
         # `register` replaces the provider's construction-time default internally as its
         # intended configuration step — that path must stay silent.

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from pathlib import Path
 from typing import Any, Generator, Optional
 from unittest.mock import MagicMock, Mock, patch
@@ -363,7 +364,8 @@ class TestTracerProvider:
         assert tracer_provider._default_processor
 
         custom_processor = Mock(spec=_SimpleSpanProcessor)
-        tracer_provider.add_span_processor(custom_processor)
+        with pytest.warns(UserWarning, match="default span processor"):
+            tracer_provider.add_span_processor(custom_processor)
 
         assert not tracer_provider._default_processor
         # The default processor should have been removed
@@ -376,11 +378,21 @@ class TestTracerProvider:
         initial_count = len(tracer_provider._active_span_processor._span_processors)
 
         custom_processor = Mock(spec=_SimpleSpanProcessor)
-        tracer_provider.add_span_processor(custom_processor, replace_default_processor=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # keeping the default must NOT warn
+            tracer_provider.add_span_processor(custom_processor, replace_default_processor=False)
 
         assert tracer_provider._default_processor
         # Both processors should be present
         assert len(tracer_provider._active_span_processor._span_processors) == initial_count + 1
+
+    def test_register_does_not_warn_on_default_processor_setup(self) -> None:
+        # `register` replaces the provider's construction-time default internally as its
+        # intended configuration step — that path must stay silent.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            tracer_provider = register(set_global_tracer_provider=False, verbose=False)
+        assert tracer_provider._default_processor
 
     @patch("builtins.print")
     def test_tracer_provider_verbose(self, mock_print: Any) -> None:

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -386,6 +386,21 @@ class TestTracerProvider:
         # Both processors should be present
         assert len(tracer_provider._active_span_processor._span_processors) == initial_count + 1
 
+    def test_add_span_processor_replaces_only_default(self) -> None:
+        tracer_provider = TracerProvider(verbose=False)
+        default_processor = tracer_provider._active_span_processor._span_processors[0]
+        first_custom_processor = Mock(spec=_SimpleSpanProcessor)
+        tracer_provider.add_span_processor(first_custom_processor, replace_default_processor=False)
+
+        second_custom_processor = Mock(spec=_SimpleSpanProcessor)
+        with pytest.warns(UserWarning, match="default span processor"):
+            tracer_provider.add_span_processor(second_custom_processor)
+
+        processors = tracer_provider._active_span_processor._span_processors
+        assert default_processor not in processors
+        assert processors == (first_custom_processor, second_custom_processor)
+        first_custom_processor.shutdown.assert_not_called()
+
     def test_register_does_not_warn_on_default_processor_setup(self) -> None:
         # `register` replaces the provider's construction-time default internally as its
         # intended configuration step — that path must stay silent.

--- a/packages/phoenix-otel/tests/test_otel.py
+++ b/packages/phoenix-otel/tests/test_otel.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Generator, Optional
 from unittest.mock import MagicMock, Mock, patch
@@ -364,8 +363,7 @@ class TestTracerProvider:
         assert tracer_provider._default_processor
 
         custom_processor = Mock(spec=_SimpleSpanProcessor)
-        with pytest.warns(UserWarning, match="default span processor"):
-            tracer_provider.add_span_processor(custom_processor)
+        tracer_provider.add_span_processor(custom_processor)
 
         assert not tracer_provider._default_processor
         # The default processor should have been removed
@@ -378,9 +376,7 @@ class TestTracerProvider:
         initial_count = len(tracer_provider._active_span_processor._span_processors)
 
         custom_processor = Mock(spec=_SimpleSpanProcessor)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")  # keeping the default must NOT warn
-            tracer_provider.add_span_processor(custom_processor, replace_default_processor=False)
+        tracer_provider.add_span_processor(custom_processor, replace_default_processor=False)
 
         assert tracer_provider._default_processor
         # Both processors should be present
@@ -393,8 +389,7 @@ class TestTracerProvider:
         tracer_provider.add_span_processor(first_custom_processor, replace_default_processor=False)
 
         second_custom_processor = Mock(spec=_SimpleSpanProcessor)
-        with pytest.warns(UserWarning, match="default span processor"):
-            tracer_provider.add_span_processor(second_custom_processor)
+        tracer_provider.add_span_processor(second_custom_processor)
 
         processors = tracer_provider._active_span_processor._span_processors
         assert default_processor not in processors
@@ -411,16 +406,7 @@ class TestTracerProvider:
             assert tracer_provider._default_processor is None
 
         with patch.object(default_processor, "shutdown", side_effect=assert_default_is_inactive):
-            with pytest.warns(UserWarning, match="default span processor"):
-                tracer_provider.add_span_processor(Mock(spec=_SimpleSpanProcessor))
-
-    def test_register_does_not_warn_on_default_processor_setup(self) -> None:
-        # `register` replaces the provider's construction-time default internally as its
-        # intended configuration step — that path must stay silent.
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            tracer_provider = register(set_global_tracer_provider=False, verbose=False)
-        assert tracer_provider._default_processor
+            tracer_provider.add_span_processor(Mock(spec=_SimpleSpanProcessor))
 
     @patch("builtins.print")
     def test_tracer_provider_verbose(self, mock_print: Any) -> None:


### PR DESCRIPTION
## Summary

Splits the bug fixes out of #14466 (thank you @ctkrug!) without the `UserWarning`.

While adding a warning to the default-processor replacement path in #14466, @ctkrug found and fixed two real defects in the existing replacement logic. Per the discussion there, the warning itself was declined — replacement-on-add is deliberate so `phoenix.otel` primitives behave identically to vanilla OTel when used as drop-in replacements — but the fixes stand on their own:

1. **Replacement removed every processor, not just the default.** `_default_processor` was a boolean, so "remove the default" was implemented as shutting down and clearing the entire composite processor. After `add_span_processor(a, replace_default_processor=False)`, a later `add_span_processor(b)` would silently shut down and discard `a` too — violating the documented contract of `replace_default_processor=False`. The provider now tracks the default processor by reference and removes/shuts down only that one.

2. **The default was shut down while still registered.** Shutdown ran before removal from `_span_processors`, so a concurrent `on_end` from another thread could hand a span to an exporter mid-teardown. Removal now happens under the composite processor's lock first, then shutdown — a processor whose teardown has begun can no longer receive spans, and concurrent replacement calls can't shut it down twice.

No changes to replacement semantics, flags, warnings, or the public API. `register()` and the constructor route default-processor setup through a `_set_default_processor` helper that maintains the reference.

This branch builds directly on the commits from #14466 so authorship is preserved; the final commit removes only the warning machinery.

## Testing

- `pytest packages/phoenix-otel/tests/test_otel.py` — 56 passed
- New regression tests (from #14466, warning assertions removed):
  - `test_add_span_processor_replaces_only_default` — kept processor survives a later replacement and is not shut down
  - `test_add_span_processor_removes_default_before_shutdown` — default is unregistered before its `shutdown()` runs

Closes #14466

https://claude.ai/code/session_01WPTE9JUC2GUBY1oUgfRg2R
