### PR TITLE
fix(annotations): discard blank category rows on annotation config submit (#15022)

### DIFF
--- a/app/src/components/annotation/AnnotationConfigDialog.tsx
+++ b/app/src/components/annotation/AnnotationConfigDialog.tsx
@@ -34,6 +34,9 @@ import type {
 
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 
+const isBlankCategoryLabel = (label: string | null | undefined) =>
+  label == null || label.trim() === "";
+
 const optimizationDirections = [
   "MAXIMIZE",
   "MINIMIZE",
@@ -96,10 +99,15 @@ export const AnnotationConfigDialog = ({
     };
     switch (data.annotationType) {
       case "CATEGORICAL": {
+        // Discard fully blank rows (no label and no score) so that leaving a
+        // trailing default row empty does not block submission.
+        const values = data.values.filter(
+          (value) => !(isBlankCategoryLabel(value.label) && value.score == null)
+        );
         const config: AnnotationConfigCategorical = {
           annotationType: "CATEGORICAL",
           name: data.name,
-          values: data.values,
+          values,
           id: initialAnnotationConfig?.id || "",
           optimizationDirection: data.optimizationDirection,
           description: data.description,
@@ -359,7 +367,29 @@ export const AnnotationConfigDialog = ({
                           control={control}
                           name={`values.${index}.label`}
                           rules={{
-                            required: "Category label is required",
+                            validate: (value, formValues) => {
+                              if (!isBlankCategoryLabel(value)) {
+                                return true;
+                              }
+                              // This field only renders for CATEGORICAL, so the
+                              // form values always carry the `values` array.
+                              const rows =
+                                (formValues as AnnotationConfigCategorical)
+                                  .values ?? [];
+                              const rowScore = rows[index]?.score;
+                              // Allow a fully blank row to pass (it is dropped
+                              // on submit) as long as at least one other row
+                              // still defines a category.
+                              const hasAnotherLabeledRow = rows.some(
+                                (row, rowIndex) =>
+                                  rowIndex !== index &&
+                                  !isBlankCategoryLabel(row.label)
+                              );
+                              if (rowScore == null && hasAnotherLabeledRow) {
+                                return true;
+                              }
+                              return "Category label is required";
+                            },
                           }}
                           render={({ field, fieldState: { error } }) => (
                             <TextField


### PR DESCRIPTION
## Summary

When creating a **categorical** annotation config, the form starts with two blank `label`/`score` rows. It is easy to fill only the first row and leave the second at its default — the submit button stays enabled, but submission is rejected with *"Category label is required"* for the untouched row. The only way to submit is to manually delete the extra row first.

As requested in #15022, blank rows should be ignored and discarded for the purposes of submission.

## Changes

`app/src/components/annotation/AnnotationConfigDialog.tsx`:

- Replaced the label field's static `required` rule with a `validate` function: a **fully blank** row (no label *and* no score) now passes validation, provided at least one other row still defines a category. A row that carries a score but no label still requires a label.
- `onSubmit` now filters out fully blank rows before building the categorical config, so discarded placeholder rows never reach the mutation.

This preserves the existing guard against submitting a categorical config with no categories (an all-blank form still reports "Category label is required" instead of silently submitting zero categories).

## Testing

Reasoned through against `react-hook-form@^7.83.0` (the `(value, formValues)` `validate` signature is supported since 7.29). Manual scenarios covered by the logic:

| Rows | Before | After |
|---|---|---|
| Row 1 filled, Row 2 blank | ❌ blocked | ✅ submits with 1 category |
| All rows blank | ❌ blocked | ❌ still blocked (no regression) |
| Row with score but empty label | ❌ blocked | ❌ still blocked |
| All rows filled | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
