### PR TITLE
chore: Show assistant config at startup

### DIFF
--- a/src/phoenix/server/agents/config.py
+++ b/src/phoenix/server/agents/config.py
@@ -1,0 +1,57 @@
+"""Effective server-side assistant configuration.
+
+The ``PHOENIX_AGENTS_*`` environment variables are the deploy-time ceiling; the
+database-backed system settings are the admin-runtime knob below it. The GraphQL
+``agentsConfig`` resolver and the `phoenix serve` launch banner both derive the
+effective configuration from here so the two can never disagree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from phoenix.config import (
+    get_env_phoenix_agents_assistant_project_name,
+    get_env_phoenix_agents_collector_api_key,
+    get_env_phoenix_agents_collector_endpoint,
+    get_env_phoenix_agents_disable_bash,
+    get_env_phoenix_agents_force_tracing,
+    get_env_phoenix_agents_web_access_enabled,
+)
+from phoenix.server.settings.registry import AgentTraceRecordingSetting
+
+
+@dataclass(frozen=True)
+class AgentsEnvConfig:
+    """Assistant configuration sourced from the environment.
+
+    `phoenix serve` builds this eagerly at process start so a malformed
+    ``PHOENIX_AGENTS_*`` value fails before the server takes on any side effects.
+    """
+
+    assistant_project_name: str
+    collector_endpoint: Optional[str]
+    collector_api_key_configured: bool
+    force_tracing: bool
+    web_access_enabled: bool
+    server_bash_enabled: bool
+
+    @classmethod
+    def from_env(cls) -> AgentsEnvConfig:
+        return cls(
+            assistant_project_name=get_env_phoenix_agents_assistant_project_name(),
+            collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
+            collector_api_key_configured=bool(get_env_phoenix_agents_collector_api_key()),
+            force_tracing=get_env_phoenix_agents_force_tracing(),
+            web_access_enabled=get_env_phoenix_agents_web_access_enabled(),
+            server_bash_enabled=not get_env_phoenix_agents_disable_bash(),
+        )
+
+    def allows_local_traces(self, trace_recording: AgentTraceRecordingSetting) -> bool:
+        """Whether users may record assistant traces locally, given the admin ceiling."""
+        return self.force_tracing or trace_recording.allow_local_traces
+
+    def allows_remote_export(self, trace_recording: AgentTraceRecordingSetting) -> bool:
+        """Whether users may export assistant traces to the collector, given the admin ceiling."""
+        return self.force_tracing or trace_recording.allow_remote_export

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -18,10 +18,6 @@ from typing_extensions import TypeAlias, assert_never
 
 from phoenix.config import (
     get_env_database_allocated_storage_capacity_gibibytes,
-    get_env_phoenix_agents_assistant_project_name,
-    get_env_phoenix_agents_collector_endpoint,
-    get_env_phoenix_agents_force_tracing,
-    get_env_phoenix_agents_web_access_enabled,
 )
 from phoenix.db import models
 from phoenix.db.constants import DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID
@@ -34,6 +30,7 @@ from phoenix.db.helpers import (
 from phoenix.db.models import LatencyMs
 from phoenix.db.types.annotation_configs import OptimizationDirection
 from phoenix.db.types.prompts import PromptMessageRole
+from phoenix.server.agents.config import AgentsEnvConfig
 from phoenix.server.api.auth import MSG_ADMIN_ONLY, IsAdmin
 from phoenix.server.api.context import Context
 from phoenix.server.api.evaluators import (
@@ -1636,15 +1633,15 @@ class Query:
     def agents_config(self, info: Info[Context, None]) -> AgentsConfig:
         agent_assistant_enabled = info.context.settings.agent_assistant_enabled
         trace_recording = info.context.settings.agent_trace_recording
-        force_tracing = get_env_phoenix_agents_force_tracing()
+        env = AgentsEnvConfig.from_env()
         return AgentsConfig(
-            collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
-            assistant_project_name=get_env_phoenix_agents_assistant_project_name(),
-            force_tracing=force_tracing,
-            web_access_enabled=get_env_phoenix_agents_web_access_enabled(),
+            collector_endpoint=env.collector_endpoint,
+            assistant_project_name=env.assistant_project_name,
+            force_tracing=env.force_tracing,
+            web_access_enabled=env.web_access_enabled,
             assistant_enabled=agent_assistant_enabled.enabled,
-            allow_local_traces=force_tracing or trace_recording.allow_local_traces,
-            allow_remote_export=force_tracing or trace_recording.allow_remote_export,
+            allow_local_traces=env.allows_local_traces(trace_recording),
+            allow_remote_export=env.allows_remote_export(trace_recording),
         )
 
     @strawberry.field(description="The assistant skills available given the supplied UI context.")  # type: ignore

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -197,7 +197,7 @@ NEW_DB_AGE_THRESHOLD_MINUTES = 2
 
 ProjectName: TypeAlias = str
 _Callback: TypeAlias = Callable[[], Union[None, Awaitable[None]]]
-_WelcomeMessage: TypeAlias = Union[str, Callable[[SystemSettings], str]]
+_WelcomeMessage: TypeAlias = Callable[[SystemSettings], str]
 
 
 def import_object_from_file(file_path: str, object_name: str) -> Any:
@@ -731,12 +731,12 @@ def _lifespan(
                 await stack.enter_async_context(token_store)
             _warn_if_missing_aioboto3()
             if welcome_message:
-                rendered_welcome_message = (
-                    welcome_message(system_settings)
-                    if callable(welcome_message)
-                    else welcome_message
-                )
-                print(rendered_welcome_message, flush=True)
+                # The banner is cosmetic and renders after migrations have run and
+                # ports are bound, so a defect in it must not abort a started server.
+                try:
+                    print(welcome_message(system_settings), flush=True)
+                except Exception:
+                    logger.exception("Failed to render the startup banner")
             yield {
                 "event_queue": dml_event_handler,
                 "enqueue_annotations": enqueue_annotations,

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -197,6 +197,7 @@ NEW_DB_AGE_THRESHOLD_MINUTES = 2
 
 ProjectName: TypeAlias = str
 _Callback: TypeAlias = Callable[[], Union[None, Awaitable[None]]]
+_WelcomeMessage: TypeAlias = Union[str, Callable[[SystemSettings], str]]
 
 
 def import_object_from_file(file_path: str, object_name: str) -> Any:
@@ -641,7 +642,7 @@ def _lifespan(
     initial_annotation_precursors: Iterable[AnnotationPrecursor] = (),
     scaffolder_config: Optional[ScaffolderConfig] = None,
     grpc_interceptors: Iterable[ServerInterceptor] = (),
-    welcome_message: str | None = None,
+    welcome_message: Optional[_WelcomeMessage] = None,
     docs_mcp_server: Optional[MCPToolset[Any]] = None,
 ) -> StatefulLifespan[FastAPI]:
     @contextlib.asynccontextmanager
@@ -730,7 +731,12 @@ def _lifespan(
                 await stack.enter_async_context(token_store)
             _warn_if_missing_aioboto3()
             if welcome_message:
-                print(welcome_message, flush=True)
+                rendered_welcome_message = (
+                    welcome_message(system_settings)
+                    if callable(welcome_message)
+                    else welcome_message
+                )
+                print(rendered_welcome_message, flush=True)
             yield {
                 "event_queue": dml_event_handler,
                 "enqueue_annotations": enqueue_annotations,
@@ -928,7 +934,7 @@ def create_app(
     bulk_inserter_factory: Optional[Callable[..., BulkInserter]] = None,
     allowed_origins: Optional[list[str]] = None,
     management_url: Optional[str] = None,
-    welcome_message: str | None = None,
+    welcome_message: Optional[_WelcomeMessage] = None,
 ) -> FastAPI:
     verify_server_environment_variables()
     _validate_oauth2_idp_names(oauth2_client_configs or [])

--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -78,11 +78,27 @@ Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability 
 {% if disabled_sandboxes %}
   {{ disabled_sandbox_prefix }}{{ disabled_marker }}{{ disabled_sandboxes | join(", ") }}
 {% endif %}
+{% if not assistant_config %}
   Agent assistant     {{ enabled if agent_assistant_enabled else disabled }}
+{% endif %}
   Prometheus metrics  {{ enabled if prometheus_enabled else disabled }}
   Email (SMTP)        {{ smtp_hostname or not_configured }}
   Telemetry           {{ enabled if telemetry_enabled else disabled }}
 
+{% if assistant_config %}
+{{ header("✨", "Assistant") }}
+  Agent assistant     {{ enabled if agent_assistant_enabled else disabled }}
+  Trace project       {{ assistant_config.project_name }}
+  Local traces        {{ enabled if assistant_config.allow_local_traces else disabled }}
+  Remote export       {{ enabled if assistant_config.allow_remote_export else disabled }}
+  Remote collector    {{ assistant_config.collector_endpoint or not_configured }}
+{% set collector_api_key = configured if assistant_config.api_key_configured else not_configured %}
+  Collector API key   {{ collector_api_key }}
+  Force tracing       {{ enabled if assistant_config.force_tracing else disabled }}
+  Web access          {{ enabled if assistant_config.web_access_enabled else disabled }}
+  Server-side bash    {{ enabled if assistant_config.server_bash_enabled else disabled }}
+
+{% endif %}
 {% if dev_mode or debug_logging or dev_vite_url or debugpy_url %}
 {{ header("🐛", "Development") }}
 {% if dev_mode %}
@@ -124,6 +140,20 @@ Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability 
 
 
 @dataclass(frozen=True)
+class AssistantConfig:
+    """Effective server-side assistant configuration displayed at startup."""
+
+    project_name: str
+    allow_local_traces: bool
+    allow_remote_export: bool
+    collector_endpoint: Optional[str]
+    api_key_configured: bool
+    force_tracing: bool
+    web_access_enabled: bool
+    server_bash_enabled: bool
+
+
+@dataclass(frozen=True)
 class BootMessage:
     """Effective server configuration displayed when `phoenix serve` starts."""
 
@@ -154,6 +184,7 @@ class BootMessage:
     prometheus_enabled: bool
     smtp_hostname: str
     telemetry_enabled: bool
+    assistant_config: Optional[AssistantConfig] = None
     dev_mode: bool = False
     debug_logging: bool = False
     dev_vite_url: Optional[str] = None
@@ -176,6 +207,7 @@ class BootMessage:
                 enabled="✅ Enabled" if unicode_ok else "Enabled",
                 disabled="➖ Disabled" if unicode_ok else "Disabled",
                 not_configured="➖ Not configured" if unicode_ok else "Not configured",
+                configured="✅ Configured" if unicode_ok else "Configured",
                 enabled_marker="✅ " if unicode_ok else "Enabled: ",
                 disabled_marker="➖ " if unicode_ok else "Disabled: ",
                 enabled_sandboxes=enabled_sandboxes,

--- a/src/phoenix/server/cli/boot_message.py
+++ b/src/phoenix/server/cli/boot_message.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from jinja2 import BaseLoader, Environment
 
@@ -78,9 +79,6 @@ Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability 
 {% if disabled_sandboxes %}
   {{ disabled_sandbox_prefix }}{{ disabled_marker }}{{ disabled_sandboxes | join(", ") }}
 {% endif %}
-{% if not assistant_config %}
-  Agent assistant     {{ enabled if agent_assistant_enabled else disabled }}
-{% endif %}
   Prometheus metrics  {{ enabled if prometheus_enabled else disabled }}
   Email (SMTP)        {{ smtp_hostname or not_configured }}
   Telemetry           {{ enabled if telemetry_enabled else disabled }}
@@ -88,10 +86,10 @@ Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability 
 {% if assistant_config %}
 {{ header("✨", "Assistant") }}
   Agent assistant     {{ enabled if agent_assistant_enabled else disabled }}
-  Trace project       {{ assistant_config.project_name }}
+  Trace project       {{ assistant_config.project_name or not_configured }}
   Local traces        {{ enabled if assistant_config.allow_local_traces else disabled }}
   Remote export       {{ enabled if assistant_config.allow_remote_export else disabled }}
-  Remote collector    {{ assistant_config.collector_endpoint or not_configured }}
+  Remote collector    {{ assistant_config.printable_collector_endpoint or not_configured }}
 {% set collector_api_key = configured if assistant_config.api_key_configured else not_configured %}
   Collector API key   {{ collector_api_key }}
   Force tracing       {{ enabled if assistant_config.force_tracing else disabled }}
@@ -139,6 +137,23 @@ Arize Phoenix v{{ version }} {{ "·" if unicode_ok else "-" }} AI Observability 
 )
 
 
+def _hide_url_password(url: Optional[str]) -> Optional[str]:
+    """Mask a password embedded in a URL's userinfo so it never reaches stdout.
+
+    Mirrors how the banner prints the database URL, which goes through
+    SQLAlchemy's `render_as_string(hide_password=True)`.
+    """
+    if not url:
+        return url
+    parsed = urlsplit(url)
+    userinfo, separator, host = parsed.netloc.rpartition("@")
+    if not separator:
+        return url
+    username, has_password, _ = userinfo.partition(":")
+    redacted = f"{username}:***@{host}" if has_password else f"{username}@{host}"
+    return urlunsplit(parsed._replace(netloc=redacted))
+
+
 @dataclass(frozen=True)
 class AssistantConfig:
     """Effective server-side assistant configuration displayed at startup."""
@@ -151,6 +166,11 @@ class AssistantConfig:
     force_tracing: bool
     web_access_enabled: bool
     server_bash_enabled: bool
+
+    @property
+    def printable_collector_endpoint(self) -> Optional[str]:
+        """The collector endpoint with any embedded password masked."""
+        return _hide_url_password(self.collector_endpoint)
 
 
 @dataclass(frozen=True)
@@ -184,6 +204,9 @@ class BootMessage:
     prometheus_enabled: bool
     smtp_hostname: str
     telemetry_enabled: bool
+    # Depends on database-backed system settings, so it is only known once the
+    # server has started. `phoenix serve` fills it in at render time; until then
+    # the banner omits the Assistant section entirely.
     assistant_config: Optional[AssistantConfig] = None
     dev_mode: bool = False
     debug_logging: bool = False

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -39,12 +39,6 @@ from phoenix.config import (
     get_env_management_url,
     get_env_oauth2_settings,
     get_env_password_reset_token_expiry,
-    get_env_phoenix_agents_assistant_project_name,
-    get_env_phoenix_agents_collector_api_key,
-    get_env_phoenix_agents_collector_endpoint,
-    get_env_phoenix_agents_disable_bash,
-    get_env_phoenix_agents_force_tracing,
-    get_env_phoenix_agents_web_access_enabled,
     get_env_port,
     get_env_read_replica_url,
     get_env_refresh_token_expiry,
@@ -64,6 +58,7 @@ from phoenix.db import get_printable_db_url
 from phoenix.db.engines import create_engine
 from phoenix.db.insertion.types import AnnotationPrecursor
 from phoenix.server.agents.capabilities import MintlifyDocsMCPServer
+from phoenix.server.agents.config import AgentsEnvConfig
 from phoenix.server.app import (
     ScaffolderConfig,
     _db,
@@ -111,26 +106,37 @@ def _get_sandbox_provider_statuses() -> list[tuple[str, bool]]:
     return [(name, name in allowed) for name in sorted(SANDBOX_BACKEND_TYPES)]
 
 
-def _render_boot_message(boot_message: BootMessage, system_settings: SystemSettings) -> str:
-    """Render the launch banner after database-backed assistant settings are available."""
-    force_tracing = get_env_phoenix_agents_force_tracing()
+def _render_boot_message(
+    boot_message: BootMessage,
+    agents_env: AgentsEnvConfig,
+    system_settings: SystemSettings,
+) -> str:
+    """Render the launch banner once database-backed assistant settings are available.
+
+    Every environment variable this needs was already read in `run()`, before the
+    server took on any side effects — this only combines those values with the
+    admin system settings, so a banner defect cannot abort a started server.
+    """
     trace_recording = system_settings.agent_trace_recording
-    assistant_config = AssistantConfig(
-        project_name=get_env_phoenix_agents_assistant_project_name(),
-        allow_local_traces=force_tracing or trace_recording.allow_local_traces,
-        allow_remote_export=force_tracing or trace_recording.allow_remote_export,
-        collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
-        api_key_configured=bool(get_env_phoenix_agents_collector_api_key()),
-        force_tracing=force_tracing,
-        web_access_enabled=get_env_phoenix_agents_web_access_enabled(),
-        server_bash_enabled=not get_env_phoenix_agents_disable_bash(),
+    assistant_enabled = (
+        boot_message.agent_assistant_enabled and system_settings.agent_assistant_enabled.enabled
     )
     return replace(
         boot_message,
-        agent_assistant_enabled=(
-            boot_message.agent_assistant_enabled and system_settings.agent_assistant_enabled.enabled
+        agent_assistant_enabled=assistant_enabled,
+        # The docs MCP toolset only ever serves the assistant, so don't advertise
+        # it while telling the operator the assistant is off.
+        docs_mcp_url=boot_message.docs_mcp_url if assistant_enabled else None,
+        assistant_config=AssistantConfig(
+            project_name=agents_env.assistant_project_name,
+            allow_local_traces=agents_env.allows_local_traces(trace_recording),
+            allow_remote_export=agents_env.allows_remote_export(trace_recording),
+            collector_endpoint=agents_env.collector_endpoint,
+            api_key_configured=agents_env.collector_api_key_configured,
+            force_tracing=agents_env.force_tracing,
+            web_access_enabled=agents_env.web_access_enabled,
+            server_bash_enabled=agents_env.server_bash_enabled,
         ),
-        assistant_config=assistant_config,
     ).render()
 
 
@@ -283,6 +289,9 @@ def run(args: Namespace) -> None:
     oauth2_client_configs = get_env_oauth2_settings()
     smtp_hostname = get_env_smtp_hostname()
     agent_assistant_enabled = not get_env_disable_agent_assistant()
+    # Read eagerly so a malformed PHOENIX_AGENTS_* value fails here, before any
+    # migrations run or ports are bound, rather than when the banner renders.
+    agents_env = AgentsEnvConfig.from_env()
     # Dev tooling ports set by the frontend dev scripts (e.g. `pnpm dev:server`)
     vite_port = os.getenv("VITE_PORT") or (str(args.dev_vite_port) if args.dev else None)
     debugpy_port = os.getenv("DEBUGPY_PORT")
@@ -377,7 +386,7 @@ def run(args: Namespace) -> None:
         enable_prometheus=enable_prometheus,
         initial_spans=fixture_spans,
         initial_annotation_precursors=fixture_annotation_precursors,
-        welcome_message=partial(_render_boot_message, boot_message),
+        welcome_message=partial(_render_boot_message, boot_message, agents_env),
         shutdown_callbacks=shutdown_callbacks,
         secret=auth_settings.phoenix_secret,
         password_reset_token_expiry=get_env_password_reset_token_expiry(),

--- a/src/phoenix/server/cli/commands/serve.py
+++ b/src/phoenix/server/cli/commands/serve.py
@@ -4,6 +4,8 @@ import atexit
 import logging
 import os
 from argparse import SUPPRESS, ArgumentParser, Namespace
+from dataclasses import replace
+from functools import partial
 from pathlib import Path
 from ssl import CERT_REQUIRED
 from threading import Thread
@@ -37,6 +39,12 @@ from phoenix.config import (
     get_env_management_url,
     get_env_oauth2_settings,
     get_env_password_reset_token_expiry,
+    get_env_phoenix_agents_assistant_project_name,
+    get_env_phoenix_agents_collector_api_key,
+    get_env_phoenix_agents_collector_endpoint,
+    get_env_phoenix_agents_disable_bash,
+    get_env_phoenix_agents_force_tracing,
+    get_env_phoenix_agents_web_access_enabled,
     get_env_port,
     get_env_read_replica_url,
     get_env_refresh_token_expiry,
@@ -62,7 +70,8 @@ from phoenix.server.app import (
     create_app,
     instrument_engine_if_enabled,
 )
-from phoenix.server.cli.boot_message import BootMessage
+from phoenix.server.cli.boot_message import AssistantConfig, BootMessage
+from phoenix.server.daemons.system_settings import SystemSettings
 from phoenix.server.email.sender import SimpleEmailSender
 from phoenix.server.email.types import EmailSender
 from phoenix.server.types import DbSessionFactory
@@ -100,6 +109,29 @@ def _get_sandbox_provider_statuses() -> list[tuple[str, bool]]:
 
     allowed = get_env_allowed_sandbox_providers()
     return [(name, name in allowed) for name in sorted(SANDBOX_BACKEND_TYPES)]
+
+
+def _render_boot_message(boot_message: BootMessage, system_settings: SystemSettings) -> str:
+    """Render the launch banner after database-backed assistant settings are available."""
+    force_tracing = get_env_phoenix_agents_force_tracing()
+    trace_recording = system_settings.agent_trace_recording
+    assistant_config = AssistantConfig(
+        project_name=get_env_phoenix_agents_assistant_project_name(),
+        allow_local_traces=force_tracing or trace_recording.allow_local_traces,
+        allow_remote_export=force_tracing or trace_recording.allow_remote_export,
+        collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
+        api_key_configured=bool(get_env_phoenix_agents_collector_api_key()),
+        force_tracing=force_tracing,
+        web_access_enabled=get_env_phoenix_agents_web_access_enabled(),
+        server_bash_enabled=not get_env_phoenix_agents_disable_bash(),
+    )
+    return replace(
+        boot_message,
+        agent_assistant_enabled=(
+            boot_message.agent_assistant_enabled and system_settings.agent_assistant_enabled.enabled
+        ),
+        assistant_config=assistant_config,
+    ).render()
 
 
 def _add_server_args(parser: ArgumentParser) -> None:
@@ -254,7 +286,7 @@ def run(args: Namespace) -> None:
     # Dev tooling ports set by the frontend dev scripts (e.g. `pnpm dev:server`)
     vite_port = os.getenv("VITE_PORT") or (str(args.dev_vite_port) if args.dev else None)
     debugpy_port = os.getenv("DEBUGPY_PORT")
-    msg = BootMessage(
+    boot_message = BootMessage(
         version=phoenix_version,
         ui_url=display_root_path,
         rest_api_url=_join_url_path(display_root_path, "v1"),
@@ -298,7 +330,7 @@ def run(args: Namespace) -> None:
         debug_logging=args.debug,
         dev_vite_url=f"http://localhost:{vite_port}" if vite_port else None,
         debugpy_url=f"localhost:{debugpy_port}" if debugpy_port else None,
-    ).render()
+    )
 
     scaffolder_config = ScaffolderConfig(
         db=factory,
@@ -345,7 +377,7 @@ def run(args: Namespace) -> None:
         enable_prometheus=enable_prometheus,
         initial_spans=fixture_spans,
         initial_annotation_precursors=fixture_annotation_precursors,
-        welcome_message=msg,
+        welcome_message=partial(_render_boot_message, boot_message),
         shutdown_callbacks=shutdown_callbacks,
         secret=auth_settings.phoenix_secret,
         password_reset_token_expiry=get_env_password_reset_token_expiry(),

--- a/tests/unit/server/cli/commands/test_serve.py
+++ b/tests/unit/server/cli/commands/test_serve.py
@@ -1,5 +1,6 @@
 import inspect
 from argparse import Namespace
+from dataclasses import replace
 from datetime import datetime, timezone
 from secrets import token_hex
 from types import SimpleNamespace
@@ -12,6 +13,9 @@ from sqlalchemy import URL, text
 
 from phoenix.db import models
 from phoenix.db.insertion.types import Precursors
+from phoenix.server.agents.config import AgentsEnvConfig
+from phoenix.server.cli import boot_message as boot_message_module
+from phoenix.server.cli.boot_message import BootMessage
 from phoenix.server.cli.commands import serve
 from phoenix.server.cli.commands.serve import (
     _create_db_session_factory,
@@ -19,6 +23,10 @@ from phoenix.server.cli.commands.serve import (
     _load_trace_fixture_initial_batches,
     _render_boot_message,
     _resolve_grpc_port,
+)
+from phoenix.server.settings.registry import (
+    AgentAssistantEnabledSetting,
+    AgentTraceRecordingSetting,
 )
 from phoenix.trace.schemas import Span, SpanContext, SpanKind, SpanStatusCode
 from phoenix.trace.trace_dataset import TraceDataset
@@ -49,48 +57,162 @@ def test_join_url_path_preserves_deployment_root(path: str, expected_url: str) -
     assert _join_url_path("http://localhost:6006/phoenix", path) == expected_url
 
 
-def test_render_boot_message_adds_effective_assistant_config(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", "custom_assistant")
-    monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "http://collector.example:4318")
-    monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_API_KEY", "secret-api-key")
-    monkeypatch.setenv("PHOENIX_AGENTS_FORCE_TRACING", "false")
-    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "true")
-    monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", "false")
-    monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_BASH", "true")
-    boot_message = SimpleNamespace(agent_assistant_enabled=True)
-    system_settings = SimpleNamespace(
-        agent_assistant_enabled=SimpleNamespace(enabled=False),
-        agent_trace_recording=SimpleNamespace(
-            allow_local_traces=True,
-            allow_remote_export=False,
+@pytest.fixture
+def ascii_banner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Render banners without Unicode so assertions hold on every platform."""
+    monkeypatch.setattr(boot_message_module, "stdout_supports_unicode", lambda: False)
+
+
+def _boot_message(**changes: Any) -> BootMessage:
+    return replace(
+        BootMessage(
+            version="1.2.3",
+            ui_url="http://localhost:6006",
+            rest_api_url="http://localhost:6006/v1",
+            graphql_url="http://localhost:6006/graphql",
+            mcp_url=None,
+            read_only=False,
+            otlp_grpc_url="http://localhost:4317",
+            otlp_http_url="http://localhost:6006/v1/traces",
+            database="sqlite:///phoenix.db",
+            database_schema=None,
+            read_replica=None,
+            storage_capacity_gibibytes=None,
+            retention_policy_days=0,
+            auth_enabled=False,
+            basic_auth_disabled=False,
+            oauth2_idp_names=[],
+            ldap_enabled=False,
+            tls_enabled_for_http=False,
+            tls_enabled_for_grpc=False,
+            tls_verify_client=False,
+            allowed_origins=None,
+            sandbox_providers=[],
+            agent_assistant_enabled=True,
+            docs_mcp_url="https://docs.example/mcp",
+            prometheus_enabled=False,
+            smtp_hostname="",
+            telemetry_enabled=True,
+        ),
+        **changes,
+    )
+
+
+def _system_settings(
+    *,
+    assistant_enabled: bool = True,
+    allow_local_traces: bool = False,
+    allow_remote_export: bool = False,
+) -> Any:
+    return SimpleNamespace(
+        agent_assistant_enabled=AgentAssistantEnabledSetting(enabled=assistant_enabled),
+        agent_trace_recording=AgentTraceRecordingSetting(
+            allow_local_traces=allow_local_traces,
+            allow_remote_export=allow_remote_export,
         ),
     )
-    captured: dict[str, Any] = {}
 
-    class _RenderedBootMessage:
-        def render(self) -> str:
-            return "rendered"
 
-    def capture_replace(message: Any, **changes: Any) -> _RenderedBootMessage:
-        assert message is boot_message
-        captured.update(changes)
-        return _RenderedBootMessage()
+def test_render_boot_message_shows_effective_assistant_config(ascii_banner: None) -> None:
+    agents_env = AgentsEnvConfig(
+        assistant_project_name="custom_assistant",
+        collector_endpoint="http://collector.example:4318",
+        collector_api_key_configured=True,
+        force_tracing=False,
+        web_access_enabled=True,
+        server_bash_enabled=False,
+    )
 
-    monkeypatch.setattr(serve, "replace", capture_replace)
+    rendered = _render_boot_message(
+        _boot_message(),
+        agents_env,
+        _system_settings(allow_local_traces=True, allow_remote_export=False),
+    )
 
-    assert _render_boot_message(boot_message, system_settings) == "rendered"  # type: ignore[arg-type]
-    assert captured["agent_assistant_enabled"] is False
-    assistant_config = captured["assistant_config"]
-    assert assistant_config.project_name == "custom_assistant"
-    assert assistant_config.allow_local_traces is True
-    assert assistant_config.allow_remote_export is False
-    assert assistant_config.collector_endpoint == "http://collector.example:4318"
-    assert assistant_config.api_key_configured is True
-    assert assistant_config.force_tracing is False
-    assert assistant_config.web_access_enabled is True
-    assert assistant_config.server_bash_enabled is False
+    assert "Agent assistant     Enabled" in rendered
+    assert "Trace project       custom_assistant" in rendered
+    assert "Local traces        Enabled" in rendered
+    assert "Remote export       Disabled" in rendered
+    assert "Remote collector    http://collector.example:4318" in rendered
+    assert "Collector API key   Configured" in rendered
+    assert "Force tracing       Disabled" in rendered
+    assert "Web access          Enabled" in rendered
+    assert "Server-side bash    Disabled" in rendered
+
+
+def test_render_boot_message_force_tracing_overrides_admin_ceilings(ascii_banner: None) -> None:
+    agents_env = AgentsEnvConfig(
+        assistant_project_name="assistant_agent",
+        collector_endpoint=None,
+        collector_api_key_configured=False,
+        force_tracing=True,
+        web_access_enabled=False,
+        server_bash_enabled=True,
+    )
+
+    rendered = _render_boot_message(
+        _boot_message(),
+        agents_env,
+        _system_settings(allow_local_traces=False, allow_remote_export=False),
+    )
+
+    assert "Force tracing       Enabled" in rendered
+    assert "Local traces        Enabled" in rendered
+    assert "Remote export       Enabled" in rendered
+    assert "Remote collector    Not configured" in rendered
+    assert "Collector API key   Not configured" in rendered
+
+
+def test_render_boot_message_admin_kill_switch_also_hides_docs_mcp(ascii_banner: None) -> None:
+    agents_env = AgentsEnvConfig(
+        assistant_project_name="assistant_agent",
+        collector_endpoint=None,
+        collector_api_key_configured=False,
+        force_tracing=False,
+        web_access_enabled=True,
+        server_bash_enabled=True,
+    )
+
+    rendered = _render_boot_message(
+        _boot_message(),
+        agents_env,
+        _system_settings(assistant_enabled=False),
+    )
+
+    assert "Agent assistant     Disabled" in rendered
+    assert "Docs MCP            Disabled" in rendered
+    assert "https://docs.example/mcp" not in rendered
+
+
+def test_render_boot_message_masks_collector_endpoint_password(ascii_banner: None) -> None:
+    agents_env = AgentsEnvConfig(
+        assistant_project_name="assistant_agent",
+        collector_endpoint="https://otel:s3cr3t@collector.example/v1/traces",
+        collector_api_key_configured=False,
+        force_tracing=False,
+        web_access_enabled=True,
+        server_bash_enabled=True,
+    )
+
+    rendered = _render_boot_message(_boot_message(), agents_env, _system_settings())
+
+    assert "s3cr3t" not in rendered
+    assert "Remote collector    https://otel:***@collector.example/v1/traces" in rendered
+
+
+def test_render_boot_message_falls_back_when_project_name_is_blank(ascii_banner: None) -> None:
+    agents_env = AgentsEnvConfig(
+        assistant_project_name="",
+        collector_endpoint=None,
+        collector_api_key_configured=False,
+        force_tracing=False,
+        web_access_enabled=True,
+        server_bash_enabled=True,
+    )
+
+    rendered = _render_boot_message(_boot_message(), agents_env, _system_settings())
+
+    assert "Trace project       Not configured" in rendered
 
 
 async def _run_shutdown_callbacks(

--- a/tests/unit/server/cli/commands/test_serve.py
+++ b/tests/unit/server/cli/commands/test_serve.py
@@ -2,6 +2,7 @@ import inspect
 from argparse import Namespace
 from datetime import datetime, timezone
 from secrets import token_hex
+from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Iterator, NamedTuple
 
 import pandas as pd
@@ -16,6 +17,7 @@ from phoenix.server.cli.commands.serve import (
     _create_db_session_factory,
     _join_url_path,
     _load_trace_fixture_initial_batches,
+    _render_boot_message,
     _resolve_grpc_port,
 )
 from phoenix.trace.schemas import Span, SpanContext, SpanKind, SpanStatusCode
@@ -45,6 +47,50 @@ def test_resolve_grpc_port_uses_env_when_cli_flag_missing(monkeypatch: pytest.Mo
 )
 def test_join_url_path_preserves_deployment_root(path: str, expected_url: str) -> None:
     assert _join_url_path("http://localhost:6006/phoenix", path) == expected_url
+
+
+def test_render_boot_message_adds_effective_assistant_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", "custom_assistant")
+    monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "http://collector.example:4318")
+    monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_API_KEY", "secret-api-key")
+    monkeypatch.setenv("PHOENIX_AGENTS_FORCE_TRACING", "false")
+    monkeypatch.setenv("PHOENIX_ALLOW_EXTERNAL_RESOURCES", "true")
+    monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_WEB_ACCESS", "false")
+    monkeypatch.setenv("PHOENIX_AGENTS_DISABLE_BASH", "true")
+    boot_message = SimpleNamespace(agent_assistant_enabled=True)
+    system_settings = SimpleNamespace(
+        agent_assistant_enabled=SimpleNamespace(enabled=False),
+        agent_trace_recording=SimpleNamespace(
+            allow_local_traces=True,
+            allow_remote_export=False,
+        ),
+    )
+    captured: dict[str, Any] = {}
+
+    class _RenderedBootMessage:
+        def render(self) -> str:
+            return "rendered"
+
+    def capture_replace(message: Any, **changes: Any) -> _RenderedBootMessage:
+        assert message is boot_message
+        captured.update(changes)
+        return _RenderedBootMessage()
+
+    monkeypatch.setattr(serve, "replace", capture_replace)
+
+    assert _render_boot_message(boot_message, system_settings) == "rendered"  # type: ignore[arg-type]
+    assert captured["agent_assistant_enabled"] is False
+    assistant_config = captured["assistant_config"]
+    assert assistant_config.project_name == "custom_assistant"
+    assert assistant_config.allow_local_traces is True
+    assert assistant_config.allow_remote_export is False
+    assert assistant_config.collector_endpoint == "http://collector.example:4318"
+    assert assistant_config.api_key_configured is True
+    assert assistant_config.force_tracing is False
+    assert assistant_config.web_access_enabled is True
+    assert assistant_config.server_bash_enabled is False
 
 
 async def _run_shutdown_callbacks(

--- a/tests/unit/server/cli/test_boot_message.py
+++ b/tests/unit/server/cli/test_boot_message.py
@@ -3,7 +3,7 @@ from dataclasses import replace
 
 import pytest
 
-from phoenix.server.cli.boot_message import BootMessage
+from phoenix.server.cli.boot_message import AssistantConfig, BootMessage
 
 
 def _boot_message() -> BootMessage:
@@ -45,6 +45,36 @@ def test_render_displays_configured_urls() -> None:
     assert "http://localhost:6006/phoenix/graphql" in rendered
     assert "http://localhost:6006/phoenix/mcp" in rendered
     assert "http://localhost:6006/phoenix/v1/traces" in rendered
+
+
+def test_render_displays_effective_assistant_configuration() -> None:
+    message = replace(
+        _boot_message(),
+        agent_assistant_enabled=False,
+        assistant_config=AssistantConfig(
+            project_name="custom_assistant",
+            allow_local_traces=True,
+            allow_remote_export=False,
+            collector_endpoint="http://collector.example:4318",
+            api_key_configured=True,
+            force_tracing=False,
+            web_access_enabled=True,
+            server_bash_enabled=False,
+        ),
+    )
+
+    rendered = message.render(unicode_ok=False)
+
+    assert "-- Assistant " in rendered
+    assert "Agent assistant     Disabled" in rendered
+    assert "Trace project       custom_assistant" in rendered
+    assert "Local traces        Enabled" in rendered
+    assert "Remote export       Disabled" in rendered
+    assert "Remote collector    http://collector.example:4318" in rendered
+    assert "Collector API key   Configured" in rendered
+    assert "Force tracing       Disabled" in rendered
+    assert "Web access          Enabled" in rendered
+    assert "Server-side bash    Disabled" in rendered
 
 
 @pytest.mark.skipif(

--- a/tests/unit/server/cli/test_boot_message.py
+++ b/tests/unit/server/cli/test_boot_message.py
@@ -47,6 +47,13 @@ def test_render_displays_configured_urls() -> None:
     assert "http://localhost:6006/phoenix/v1/traces" in rendered
 
 
+def test_render_omits_assistant_section_before_system_settings_are_known() -> None:
+    rendered = _boot_message().render(unicode_ok=False)
+
+    assert "Assistant" not in rendered
+    assert "Agent assistant" not in rendered
+
+
 def test_render_displays_effective_assistant_configuration() -> None:
     message = replace(
         _boot_message(),


### PR DESCRIPTION
Issue: N/A — requested directly.

## Summary

- add an `Assistant` section to the Phoenix startup banner
- resolve `assistant_config` after database-backed system settings have bootstrapped
- display effective assistant enablement, trace policy, collector, web-access, and server-side bash settings
- report only whether the collector API key is configured, never its value

## Why

PXI configuration is currently split between environment variables and database-backed system settings, so operators cannot see the effective configuration when Phoenix starts. Rendering the banner after system settings bootstrap makes the startup output reflect the actual server policy.

## Impact

Operators can inspect effective Assistant configuration directly in the boot banner without querying GraphQL or checking each deployment setting separately.

## Validation

- `make doctest MODULES="tests/unit/server/cli/test_boot_message.py tests/unit/server/cli/commands/test_serve.py"` — 16 passed, 2 skipped
- `make lint-python` — passed
- `make typecheck-python` — passed
- `make test-python` — 5,438 passed, 1 unrelated failure in `test_sandbox_providers_returns_nested_configs[sqlite]` because the seeded default WASM config appeared alongside the fixture
