### PR TITLE
fix: render exception stack traces in span events

### DIFF
--- a/app/src/pages/trace/SpanEventsList.tsx
+++ b/app/src/pages/trace/SpanEventsList.tsx
@@ -2,10 +2,13 @@ import { css } from "@emotion/react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
 import {
+  Card,
+  CopyToClipboardButton,
   Disclosure,
   DisclosureGroup,
   DisclosurePanel,
   DisclosureTrigger,
+  ExpandableContent,
   Flex,
   Icon,
   Icons,
@@ -13,15 +16,21 @@ import {
   View,
 } from "@phoenix/components";
 import {
+  JSONViewBody,
+  JSONViewProvider,
+  JSONViewToolbar,
+  PreBlock,
+} from "@phoenix/components/code";
+import {
   EmptyState,
   EmptyStateArea,
   EmptyStateGraphic,
 } from "@phoenix/components/core/empty";
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 import { useTimeFormatters } from "@phoenix/hooks";
+import { isPlainObject } from "@phoenix/utils/jsonUtils";
 
 import type { SpanEventsListQuery } from "./__generated__/SpanEventsListQuery.graphql";
-import { ReadonlyJSONBlock } from "./ReadonlyJSONBlock";
 
 type SpanEventsListProps = {
   spanId: string;
@@ -62,6 +71,64 @@ type SpanEvent = {
   attributes: unknown;
 };
 
+const EXCEPTION_STACKTRACE = "exception.stacktrace";
+
+function EventAttributesJSONView({ attributes }: { attributes: unknown }) {
+  return (
+    <JSONViewProvider
+      value={attributes}
+      defaultMode="table"
+      indexNotation="dot"
+    >
+      <Card
+        title="Attributes"
+        extra={<JSONViewToolbar searchPlaceholder="Search event attributes" />}
+      >
+        <JSONViewBody />
+      </Card>
+    </JSONViewProvider>
+  );
+}
+
+export function SpanEventAttributes({ event }: { event: SpanEvent }) {
+  const exceptionAttributes =
+    event.name === "exception" && isPlainObject(event.attributes)
+      ? event.attributes
+      : {};
+  const { [EXCEPTION_STACKTRACE]: stacktrace, ...remainingAttributes } =
+    exceptionAttributes;
+  if (typeof stacktrace !== "string" || stacktrace.length === 0) {
+    return (
+      <View padding="size-200">
+        <EventAttributesJSONView attributes={event.attributes} />
+      </View>
+    );
+  }
+  return (
+    <View padding="size-200">
+      <Flex direction="column" gap="size-200">
+        <Card
+          title="Stack trace"
+          extra={
+            <CopyToClipboardButton
+              aria-label="Copy stack trace"
+              text={stacktrace}
+              tooltipText="Copy stack trace"
+            />
+          }
+        >
+          <ExpandableContent height={320} expandedBehavior="grow">
+            <PreBlock>{stacktrace}</PreBlock>
+          </ExpandableContent>
+        </Card>
+        {Object.keys(remainingAttributes).length > 0 ? (
+          <EventAttributesJSONView attributes={remainingAttributes} />
+        ) : null}
+      </Flex>
+    </View>
+  );
+}
+
 function SpanEventsListContent({ events }: { events: readonly SpanEvent[] }) {
   const { fullTimeFormatter } = useTimeFormatters();
 
@@ -89,7 +156,7 @@ function SpanEventsListContent({ events }: { events: readonly SpanEvent[] }) {
         const hasAttributes =
           event.attributes &&
           typeof event.attributes === "object" &&
-          Object.keys(event.attributes as object).length > 0;
+          Object.keys(event.attributes).length > 0;
 
         const eventHeader = (
           <Flex direction="row" gap="size-100" alignItems="center">
@@ -119,11 +186,7 @@ function SpanEventsListContent({ events }: { events: readonly SpanEvent[] }) {
             </DisclosureTrigger>
             {hasAttributes ? (
               <DisclosurePanel>
-                <ReadonlyJSONBlock
-                  basicSetup={{ lineNumbers: false, foldGutter: false }}
-                >
-                  {JSON.stringify(event.attributes, null, 2)}
-                </ReadonlyJSONBlock>
+                <SpanEventAttributes event={event} />
               </DisclosurePanel>
             ) : null}
           </Disclosure>

--- a/app/src/pages/trace/__tests__/SpanEventsList.test.tsx
+++ b/app/src/pages/trace/__tests__/SpanEventsList.test.tsx
@@ -1,0 +1,115 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installTestMatchMedia } from "@phoenix/__tests__/installTestMatchMedia";
+import { ThemeProvider } from "@phoenix/contexts";
+
+import { SpanEventAttributes } from "../SpanEventsList";
+
+installTestMatchMedia();
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function renderAttributes({
+  name,
+  attributes,
+}: {
+  name: string;
+  attributes: unknown;
+}) {
+  await act(async () => {
+    root.render(
+      <ThemeProvider themeMode="light" disableBodyTheme>
+        <SpanEventAttributes
+          event={{
+            name,
+            message: "",
+            timestamp: "2026-08-03T12:00:00.000Z",
+            attributes,
+          }}
+        />
+      </ThemeProvider>
+    );
+  });
+}
+
+describe("SpanEventAttributes", () => {
+  it("renders an exception stack trace as preformatted text", async () => {
+    const stacktrace = [
+      "Traceback (most recent call last):",
+      '  File "/app/main.py", line 10, in run',
+      "    result = 1 / 0",
+      "ZeroDivisionError: division by zero",
+    ].join("\n");
+
+    await renderAttributes({
+      name: "exception",
+      attributes: {
+        "exception.type": "ZeroDivisionError",
+        "exception.message": "division by zero",
+        "exception.stacktrace": stacktrace,
+      },
+    });
+
+    const stacktraceElement = container.querySelector(
+      "[data-testid='pre-block']"
+    );
+    expect(stacktraceElement?.textContent).toBe(stacktrace);
+    expect(
+      container.querySelector("button[aria-label='Copy stack trace']")
+    ).not.toBeNull();
+    expect(container.querySelector("table")?.textContent).not.toContain(
+      "exception.stacktrace"
+    );
+    expect(
+      container.querySelector("[aria-label='JSON view mode']")
+    ).not.toBeNull();
+    expect(container.querySelector("table")?.textContent).toContain(
+      "exception.type"
+    );
+  });
+
+  it("uses the shared attribute viewer for non-exception events", async () => {
+    await renderAttributes({
+      name: "retry",
+      attributes: {
+        attempt: 2,
+        context: '{"reason":"rate limit"}',
+      },
+    });
+
+    expect(container.querySelector("[data-testid='pre-block']")).toBeNull();
+    expect(
+      container.querySelector("[aria-label='JSON view mode']")
+    ).not.toBeNull();
+    expect(container.querySelector("table")?.textContent).toContain("attempt");
+    expect(container.querySelector("table")?.textContent).toContain(
+      '{"reason":"rate limit"}'
+    );
+  });
+
+  it("uses the shared attribute viewer when an exception has no stack trace", async () => {
+    await renderAttributes({
+      name: "exception",
+      attributes: { "exception.message": "division by zero" },
+    });
+
+    expect(container.querySelector("[data-testid='pre-block']")).toBeNull();
+    expect(container.querySelector("table")?.textContent).toContain(
+      "exception.message"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Render OpenTelemetry `exception.stacktrace` event attributes as readable, preformatted stack traces with copy and expand/collapse controls.
- Reuse the shared JSON attribute viewer for generic events and remaining exception attributes, including table/JSON and raw/un-nested views.
- Add focused coverage for exception events, generic events, and exceptions without stack traces.

## Why

`span.record_exception` records the traceback as a multiline string under the standard OpenTelemetry `exception.stacktrace` attribute. The previous generic JSON block serialized that string, displaying escaped newlines and quotes instead of a readable traceback.

Because the `exception` event name and `exception.stacktrace` attribute have defined OpenTelemetry semantics, Phoenix can render the stack trace appropriately without guessing about arbitrary multiline attributes.

## Screenshots

### Generic event attributes

Generic event attributes now use the same JSON controls as span attributes, including the un-nested JSON view.

![Generic event attributes](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15028-event-attributes-json.png)

### Exception stack trace

Exception stack traces render as preformatted text with a copy action, while the remaining exception attributes retain the shared attribute viewer.

![Exception stack trace](https://storage.googleapis.com/arize-phoenix-assets/pull-requests/15028-exception-stacktrace.png)

## Test plan

- `pnpm --dir app exec oxfmt --check src/pages/trace/SpanEventsList.tsx src/pages/trace/__tests__/SpanEventsList.test.tsx`
- `pnpm --dir app exec oxlint src/pages/trace/SpanEventsList.tsx src/pages/trace/__tests__/SpanEventsList.test.tsx`
- `pnpm --dir app typecheck`
- Targeted Vitest suite: 9 tests passed
- `pnpm --dir app build`
- Browser-tested generic and exception event rendering
