### PR TITLE
feat(evals): add suggestion_accepted online eval for approval decisions

### DIFF
--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -26,7 +26,22 @@ Trace evaluators live in `evals/pxi/online_evals/evaluators/`; run the CLI
 with `--help` to list what is currently registered. They remain separate from
 `evals.pxi.evaluators` because the latter implements the experiment contract
 over `(output, expected)` pairs, while online evaluators consume a hydrated
-`(root_span, trace_spans)` pair and produce root-span annotations.
+`(target_span, trace_spans)` pair and annotate the target span.
+
+Each evaluator declares a `SpanSelector` saying which spans it targets, and
+the runner issues one discovery query per distinct selector:
+
+- **Root targets** — `tool_count_per_turn` and `user_friction` select
+  `names=("pxi.turn",)`, `span_kinds=("AGENT",)`, `parent_id="null"`, so they
+  score and annotate one turn root per trace. They share a single query.
+- **TOOL targets** — `suggestion_accepted` selects the approval-gated tool
+  names with `span_kinds=("TOOL",)` and no parent restriction, so it annotates
+  individual tool spans anywhere inside a turn.
+
+Targeting inner spans matters because one turn can contain several suggestions
+that the user decided differently; a turn-level annotation would collapse them
+into a single label. Sampling stays keyed on `trace_id`, so every target within
+one turn is sampled in or out together and a turn is never partly annotated.
 
 All LLM evaluators share one judge configuration:
 `PHOENIX_AGENTS_EVALS_PROVIDER` / `PHOENIX_AGENTS_EVALS_MODEL`, defaulting to
@@ -36,9 +51,60 @@ OpenAI `gpt-5.5`. Supported providers are `openai` (`OPENAI_API_KEY`),
 matching API key fail once at startup, before trace discovery.
 
 Evaluators consume a trace-shaped input and attach their result as a span
-annotation on the trace's root `pxi.turn` span. The runner does not create or
-update project annotation configs; configure display or optimization metadata
-in Phoenix separately when needed.
+annotation on their target span. The runner does not create or update project
+annotation configs; configure display or optimization metadata in Phoenix
+separately when needed.
+
+### `suggestion_accepted`
+
+A deterministic CODE evaluator (no LLM call, no new secret) that records
+whether a user **manually** accepted or rejected an approval-gated PXI
+suggestion. It annotates the TOOL span itself:
+
+| Recorded outcome | Annotation |
+|---|---|
+| `status: "rejected"` | `rejected` / `0.0` |
+| `acceptedBy: "user"` | `accepted` / `1.0` |
+| anything else | *no annotation* |
+
+Rejection is evaluated first: the reject path writes `status: "rejected"` and
+never sets `acceptedBy`, so a payload carrying both is contradictory and the
+explicit terminal rejection wins. Acceptance keys off `acceptedBy` rather than
+the status string because the success vocabulary is tool-specific (`accepted`,
+`saved`, `loaded`, `applied`, `removed`) while `acceptedBy` is the only field
+that separates a human click from an automatic bypass.
+
+Deliberately **not** annotated, because none is a user decision:
+
+- automatic/system accepts (`acceptedBy: "auto"`, i.e. bypass edit permission);
+- still-pending approvals (`awaiting_user`);
+- approvals cancelled by navigation, and errored tools (`output-error`);
+- missing, malformed, non-object, or unrecognized `output.value`;
+- any tool not on the allowlist.
+
+Classification is purely structural — the evaluator never searches message
+text for words like "accepted" or "rejected". Annotations carry only
+`{"tool_name": ...}`: never prompt text, tool arguments, raw output, user
+content, instance ids, or proposal diffs.
+
+The allowlist in `evaluators/suggestion_accepted.py` is an intentional
+**cross-language maintenance contract**: it lists exactly the frontend tools
+whose pending-action implementation records both outcomes. When a new
+approval-gated tool lands under `app/src/agent/tools/*/pending*.ts`, add it
+here too or its decisions go unmeasured. `submit_code_evaluator_draft` and
+`submit_llm_evaluator_draft` are excluded on purpose: they record only
+`awaiting_user`, and the dialog's real decision is never written back to the
+tool span.
+
+Preview it without writing anything:
+
+```bash
+PHOENIX_PROJECT=pxi_dev \
+uv run python -m evals.pxi.online_evals.run --eval suggestion_accepted --dry-run
+```
+
+Registering the evaluator was enough to add it to the existing scheduled job —
+no provider, secret, or workflow change is needed.
 
 Annotation identifiers are evaluator-specific versioned checkpoints. Increment
 an evaluator's `vN` identifier whenever its scoring semantics or rubric
@@ -90,9 +156,9 @@ runner on new-format development traces.
 
 ### Adding an online evaluator
 
-An evaluator is an async function that receives the root span and every
+An evaluator is an async function that receives one target span and every
 hydrated span in its trace. It returns a `phoenix.evals` `Score`, or `None`
-when the turn is not applicable:
+when the target is not applicable:
 
 ```python
 from collections.abc import Sequence
@@ -101,14 +167,15 @@ from phoenix.client.__generated__ import v1
 from phoenix.evals.evaluators import Score
 
 
-async def evaluate(root: v1.Span, spans: Sequence[v1.Span]) -> Score | None:
+async def evaluate(target: v1.Span, spans: Sequence[v1.Span]) -> Score | None:
     if not spans:
         return None
     return Score(score=1.0, label="example", explanation="why")
 ```
 
-Declare an `EvaluatorSpec` with a name, the expected root span name, the
-evaluate function, annotator kind, sampling rate, and a versioned identifier.
+Declare an `EvaluatorSpec` with a name, a `SpanSelector` (use the shared
+`PXI_TURN_ROOT_SELECTOR` for turn-level evaluators), the evaluate function,
+annotator kind, sampling rate, and a versioned identifier.
 The annotator kind is required rather than defaulted: declare every evaluator
 explicitly as `"CODE"` or `"LLM"` because it also controls judge credential
 validation and model-specific checkpointing.

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -88,8 +88,16 @@ content, instance ids, or proposal diffs.
 There is deliberately **no list of approval-gated tool names**. An earlier
 revision carried one and it went stale before shipping — every dataset-write
 tool is approval-gated and was missing from it. Discovery now keys off what a
-span *records*, so a newly gated tool is measured the day it ships, and a
-frontend drift guard fails the build if an approval payload ships unmarked.
+span *records*, so a newly gated tool is measured the day it ships. A frontend
+drift guard fails the build if a payload using the known accept/reject
+vocabulary ships unmarked; tools built on the shared `bindPendingApproval` core
+are covered by construction.
+
+Decisions recorded **before** the approval marker shipped carry no
+`pxi.approval.*` attributes. They are invisible to discovery — not annotated,
+not counted as not-applicable — and cannot be backfilled, since the marker is
+what identifies them. Expect the first runs after deploy to report low counts
+until marked traces accumulate.
 
 `submit_code_evaluator_draft` and `submit_llm_evaluator_draft` remain
 unmeasured: they resolve as `awaiting_user` and the dialog's real decision is

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -101,7 +101,9 @@ until marked traces accumulate.
 
 `submit_code_evaluator_draft` and `submit_llm_evaluator_draft` remain
 unmeasured: they resolve as `awaiting_user` and the dialog's real decision is
-never written back as tool output, so there is no marker to read.
+never written back as tool output, so there is no marker to read. Tracked in
+[#15033](https://github.com/Arize-ai/phoenix/issues/15033) — until it is fixed,
+accept/reject rates exclude these two tools entirely.
 
 Preview it without writing anything:
 

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -16,11 +16,11 @@ Fast unit coverage for the harness and evaluators lives under
 
 ## Online production evals
 
-The online runner evaluates recent `pxi.turn` traces after ingestion. It uses
-annotations as its checkpoint: before hydrating a trace or invoking an
-evaluator, it skips turn roots that already carry the evaluator's annotation
-name and identifier. The default 48-hour overlap therefore recovers from
-missed scheduled runs without evaluating the same turn twice.
+The online runner evaluates recent PXI spans after ingestion. It uses
+annotations as checkpoints: before hydrating a trace or invoking an evaluator,
+it skips targets that already carry the evaluator's annotation name and
+identifier. The default 48-hour overlap recovers missed scheduled runs without
+evaluating the same target twice.
 
 Trace evaluators live in `evals/pxi/online_evals/evaluators/`; run the CLI
 with `--help` to list what is currently registered. They remain separate from
@@ -28,8 +28,8 @@ with `--help` to list what is currently registered. They remain separate from
 over `(output, expected)` pairs, while online evaluators consume a hydrated
 `(target_span, trace_spans)` pair and annotate the target span.
 
-Each evaluator declares a `SpanSelector` saying which spans it targets, and
-the runner issues one discovery query per distinct selector:
+Each evaluator declares a `SpanSelector`; evaluators with the same selector
+share a discovery query:
 
 - **Root targets** — `tool_count_per_turn` and `user_friction` select
   `names=("pxi.turn",)`, `span_kinds=("AGENT",)`, `parent_id="null"`, so they
@@ -39,10 +39,8 @@ the runner issues one discovery query per distinct selector:
   restriction, so it annotates individual tool spans anywhere inside a turn.
   It names no tools at all.
 
-Targeting inner spans matters because one turn can contain several suggestions
-that the user decided differently; a turn-level annotation would collapse them
-into a single label. Sampling stays keyed on `trace_id`, so every target within
-one turn is sampled in or out together and a turn is never partly annotated.
+Sampling is keyed on `trace_id`, so all targets within a turn are sampled
+together.
 
 All LLM evaluators share one judge configuration:
 `PHOENIX_AGENTS_EVALS_PROVIDER` / `PHOENIX_AGENTS_EVALS_MODEL`, defaulting to
@@ -58,9 +56,9 @@ separately when needed.
 
 ### `suggestion_accepted`
 
-A deterministic CODE evaluator (no LLM call, no new secret) that records
-whether a user **manually** accepted or rejected an approval-gated PXI
-suggestion. It annotates the TOOL span itself:
+A deterministic CODE evaluator that records manual decisions on approval-gated
+PXI suggestions. It annotates each TOOL span separately because a turn can
+contain multiple decisions.
 
 | Recorded outcome | Annotation |
 |---|---|
@@ -68,42 +66,25 @@ suggestion. It annotates the TOOL span itself:
 | `pxi.approval.decision = "accepted"` | `accepted` / `1.0` |
 | anything else | *no annotation* |
 
-Approval-gated tools stamp a uniform `approval: {decision, source}` marker into
-their output, which the server promotes onto the span as `pxi.approval.decision`
-and `pxi.approval.source`. Classification reads only those attributes, so each
-tool's own success vocabulary (`accepted`, `saved`, `loaded`, `applied`,
-`removed`) is irrelevant.
+Approval-gated tools add `approval: {decision, source}` to their output. The
+server promotes it to `pxi.approval.decision` and `pxi.approval.source`, which
+the evaluator uses for discovery and classification.
 
-Deliberately **not** annotated, because none is a user decision:
+The evaluator does not annotate:
 
 - automatic accepts (`pxi.approval.source: "auto"`, i.e. bypass edit permission);
 - still-pending approvals, cancellations, and errored tools — all unmarked;
 - unknown or malformed decisions.
 
-Classification is purely structural — the evaluator never searches message
-text for words like "accepted" or "rejected". Annotations carry only
-`{"tool_name": ...}`: never prompt text, tool arguments, raw output, user
-content, instance ids, or proposal diffs.
+Annotations contain only `{"tool_name": ...}`. Discovery does not depend on a
+tool-name allowlist, so new tools are covered when they emit the marker.
 
-There is deliberately **no list of approval-gated tool names**. An earlier
-revision carried one and it went stale before shipping — every dataset-write
-tool is approval-gated and was missing from it. Discovery now keys off what a
-span *records*, so a newly gated tool is measured the day it ships. A frontend
-drift guard fails the build if a payload using the known accept/reject
-vocabulary ships unmarked; tools built on the shared `bindPendingApproval` core
-are covered by construction.
-
-Decisions recorded **before** the approval marker shipped carry no
-`pxi.approval.*` attributes. They are invisible to discovery — not annotated,
-not counted as not-applicable — and cannot be backfilled, since the marker is
-what identifies them. Expect the first runs after deploy to report low counts
-until marked traces accumulate.
+Spans recorded before the marker shipped cannot be discovered or backfilled.
 
 `submit_code_evaluator_draft` and `submit_llm_evaluator_draft` remain
-unmeasured: they resolve as `awaiting_user` and the dialog's real decision is
-never written back as tool output, so there is no marker to read. Tracked in
-[#15033](https://github.com/Arize-ai/phoenix/issues/15033) — until it is fixed,
-accept/reject rates exclude these two tools entirely.
+unmeasured because their dialog decisions are not written to tool output.
+Accept/reject rates therefore exclude them until
+[#15033](https://github.com/Arize-ai/phoenix/issues/15033) is resolved.
 
 Preview it without writing anything:
 
@@ -112,12 +93,9 @@ PHOENIX_PROJECT=pxi_dev \
 uv run python -m evals.pxi.online_evals.run --eval suggestion_accepted --dry-run
 ```
 
-Registering the evaluator was enough to add it to the existing scheduled job —
-no provider, secret, or workflow change is needed.
-
 Annotation identifiers are evaluator-specific versioned checkpoints. Increment
 an evaluator's `vN` identifier whenever its scoring semantics or rubric
-changes; the next overlapping run then backfills recent roots under the new
+changes; the next overlapping run then backfills recent targets under the new
 identity without overwriting the previous series. The runner appends
 `provider:model` to every LLM evaluator's identifier, so a judge change
 creates a distinct result series automatically. Only the runner's own
@@ -136,10 +114,10 @@ PHOENIX_PROJECT=pxi_dev \
 uv run python -m evals.pxi.online_evals.run --dry-run
 ```
 
-The runner waits five minutes before considering a turn settled and evaluates
-all applicable turns by default, running evaluations concurrently (bounded at
+The runner waits five minutes before considering a target settled and evaluates
+all applicable targets by default, running evaluations concurrently (bounded at
 8 in flight) so LLM judge calls are not serialized. An evaluator exception is
-contained to that turn: it is logged, counted in the summary's `errors`, and
+contained to that target: it is logged, counted in the summary's `errors`, and
 the run continues (the process exits non-zero so scheduled runs surface the
 failure). Structural trace anomalies (a tool span that does not descend from
 the turn root, missing ancestors, cycles) are deliberately loud: post-settle
@@ -182,12 +160,10 @@ async def evaluate(target: v1.Span, spans: Sequence[v1.Span]) -> Score | None:
     return Score(score=1.0, label="example", explanation="why")
 ```
 
-Declare an `EvaluatorSpec` with a name, a `SpanSelector` (use the shared
-`PXI_TURN_ROOT_SELECTOR` for turn-level evaluators), the evaluate function,
-annotator kind, sampling rate, and a versioned identifier.
-The annotator kind is required rather than defaulted: declare every evaluator
-explicitly as `"CODE"` or `"LLM"` because it also controls judge credential
-validation and model-specific checkpointing.
+Declare an `EvaluatorSpec` with a name, selector, evaluate function, annotator
+kind, sampling rate, and versioned identifier. Use `PXI_TURN_ROOT_SELECTOR` for
+turn-level evaluators. The annotator kind controls judge credential validation
+and model-specific checkpointing.
 LLM evaluators (`annotator_kind="LLM"`) automatically share the judge
 configuration from `evals/pxi/online_evals/judge.py`: the runner validates
 the judge credentials at startup and appends `provider:model` to their

--- a/evals/pxi/README.md
+++ b/evals/pxi/README.md
@@ -34,9 +34,10 @@ the runner issues one discovery query per distinct selector:
 - **Root targets** — `tool_count_per_turn` and `user_friction` select
   `names=("pxi.turn",)`, `span_kinds=("AGENT",)`, `parent_id="null"`, so they
   score and annotate one turn root per trace. They share a single query.
-- **TOOL targets** — `suggestion_accepted` selects the approval-gated tool
-  names with `span_kinds=("TOOL",)` and no parent restriction, so it annotates
-  individual tool spans anywhere inside a turn.
+- **TOOL targets** — `suggestion_accepted` selects on the approval attribute
+  `pxi.approval.source="user"` with `span_kinds=("TOOL",)` and no parent
+  restriction, so it annotates individual tool spans anywhere inside a turn.
+  It names no tools at all.
 
 Targeting inner spans matters because one turn can contain several suggestions
 that the user decided differently; a turn-level annotation would collapse them
@@ -63,38 +64,36 @@ suggestion. It annotates the TOOL span itself:
 
 | Recorded outcome | Annotation |
 |---|---|
-| `status: "rejected"` | `rejected` / `0.0` |
-| `acceptedBy: "user"` | `accepted` / `1.0` |
+| `pxi.approval.decision = "rejected"` | `rejected` / `0.0` |
+| `pxi.approval.decision = "accepted"` | `accepted` / `1.0` |
 | anything else | *no annotation* |
 
-Rejection is evaluated first: the reject path writes `status: "rejected"` and
-never sets `acceptedBy`, so a payload carrying both is contradictory and the
-explicit terminal rejection wins. Acceptance keys off `acceptedBy` rather than
-the status string because the success vocabulary is tool-specific (`accepted`,
-`saved`, `loaded`, `applied`, `removed`) while `acceptedBy` is the only field
-that separates a human click from an automatic bypass.
+Approval-gated tools stamp a uniform `approval: {decision, source}` marker into
+their output, which the server promotes onto the span as `pxi.approval.decision`
+and `pxi.approval.source`. Classification reads only those attributes, so each
+tool's own success vocabulary (`accepted`, `saved`, `loaded`, `applied`,
+`removed`) is irrelevant.
 
 Deliberately **not** annotated, because none is a user decision:
 
-- automatic/system accepts (`acceptedBy: "auto"`, i.e. bypass edit permission);
-- still-pending approvals (`awaiting_user`);
-- approvals cancelled by navigation, and errored tools (`output-error`);
-- missing, malformed, non-object, or unrecognized `output.value`;
-- any tool not on the allowlist.
+- automatic accepts (`pxi.approval.source: "auto"`, i.e. bypass edit permission);
+- still-pending approvals, cancellations, and errored tools — all unmarked;
+- unknown or malformed decisions.
 
 Classification is purely structural — the evaluator never searches message
 text for words like "accepted" or "rejected". Annotations carry only
 `{"tool_name": ...}`: never prompt text, tool arguments, raw output, user
 content, instance ids, or proposal diffs.
 
-The allowlist in `evaluators/suggestion_accepted.py` is an intentional
-**cross-language maintenance contract**: it lists exactly the frontend tools
-whose pending-action implementation records both outcomes. When a new
-approval-gated tool lands under `app/src/agent/tools/*/pending*.ts`, add it
-here too or its decisions go unmeasured. `submit_code_evaluator_draft` and
-`submit_llm_evaluator_draft` are excluded on purpose: they record only
-`awaiting_user`, and the dialog's real decision is never written back to the
-tool span.
+There is deliberately **no list of approval-gated tool names**. An earlier
+revision carried one and it went stale before shipping — every dataset-write
+tool is approval-gated and was missing from it. Discovery now keys off what a
+span *records*, so a newly gated tool is measured the day it ships, and a
+frontend drift guard fails the build if an approval payload ships unmarked.
+
+`submit_code_evaluator_draft` and `submit_llm_evaluator_draft` remain
+unmeasured: they resolve as `awaiting_user` and the dialog's real decision is
+never written back as tool output, so there is no marker to read.
 
 Preview it without writing anything:
 

--- a/evals/pxi/online_evals/OVERVIEW.md
+++ b/evals/pxi/online_evals/OVERVIEW.md
@@ -119,7 +119,11 @@ flowchart TD
 vocabulary — `accepted`, `saved`, `loaded`, `applied`, `removed` — and the
 marker is uniform across all of them, so a newly approval-gated tool is measured
 the day it ships with no change here. The frontend has a drift guard asserting
-every approval payload carries the marker.
+that payloads using the known accept/reject vocabulary carry the marker; tools
+built on the shared `bindPendingApproval` core are covered by construction.
+
+Spans ingested before the marker shipped carry no `pxi.approval.*` attributes,
+so they are never discovered and cannot be backfilled.
 
 Discovery filters on `source = user` rather than on the decision: it is a single
 server-side query, and it yields exactly the annotated set, since rejections are

--- a/evals/pxi/online_evals/OVERVIEW.md
+++ b/evals/pxi/online_evals/OVERVIEW.md
@@ -16,16 +16,11 @@ identical selector and issues **one discovery query per group**:
 | Turn root | `pxi.turn` | `AGENT` | `"null"` | — | `tool_count_per_turn`, `user_friction` |
 | Approval decision | — | `TOOL` | *(unset)* | `pxi.approval.source = user` | `suggestion_accepted` |
 
-Root evaluators score a whole turn. `suggestion_accepted` scores an individual
-action, because **one turn can contain several suggestions the user decided
-differently** — a rejected annotation-config change and its accepted revision
-routinely appear in the same turn. Annotating the root would collapse both into
-one label, so the annotation goes on the TOOL span itself.
+Root evaluators score a whole turn. `suggestion_accepted` scores each action so
+multiple decisions in one turn remain distinct.
 
-Everything downstream is target-agnostic: the settle delay applies to each
-target's own `end_time`, the checkpoint key is `(span_id, name, identifier)` on
-the target, and sampling stays keyed on `trace_id` so all targets in one turn
-are sampled together.
+The settle delay uses the target's `end_time`; checkpoints use
+`(span_id, name, identifier)`; sampling uses `trace_id`.
 
 ## The pipeline
 
@@ -44,10 +39,8 @@ flowchart TD
     F -- "exception" --> F3["errors++ · run continues ·<br/>process exits non-zero"]
 ```
 
-Every box feeds a counter in the run summary, so a scheduled run's log tells
-you exactly where each discovered target went (`discovered` counts matching
-**target spans**, so the tool evaluator's number is per-suggestion, not
-per-turn):
+`discovered` counts target spans, so `suggestion_accepted` reports suggestions,
+not turns:
 
 ```
 tool_count_per_turn: discovered=11 already_annotated=0 sampled_out=0 not_applicable=0 evaluated=11 errors=0 written=11
@@ -99,11 +92,8 @@ the user's click is stamped into the tool's output as a reserved marker:
 {"approval": {"decision": "accepted", "source": "user"}}
 ```
 
-The server promotes that marker onto the span as `pxi.approval.decision` and
-`pxi.approval.source` (see `src/phoenix/server/agents/approval.py`, written by
-`app/src/agent/shared/pendingApproval/approvalOutcome.ts`). The evaluator reads
-only those two attributes — it never parses `output.value` and never scans
-message text for the words "accepted" or "rejected".
+The server promotes that marker to `pxi.approval.decision` and
+`pxi.approval.source`. The evaluator reads only those attributes.
 
 ```mermaid
 flowchart TD
@@ -115,21 +105,16 @@ flowchart TD
     C -- other/absent --> N
 ```
 
-**There is no tool-name allowlist, by design.** Each tool keeps its own success
-vocabulary — `accepted`, `saved`, `loaded`, `applied`, `removed` — and the
-marker is uniform across all of them, so a newly approval-gated tool is measured
-the day it ships with no change here. The frontend has a drift guard asserting
-that payloads using the known accept/reject vocabulary carry the marker; tools
-built on the shared `bindPendingApproval` core are covered by construction.
+Discovery does not use a tool-name allowlist. New approval-gated tools are
+included when they emit the marker.
 
 Spans ingested before the marker shipped carry no `pxi.approval.*` attributes,
 so they are never discovered and cannot be backfilled.
 
-Discovery filters on `source = user` rather than on the decision: it is a single
-server-side query, and it yields exactly the annotated set, since rejections are
-always a user action and automatic accepts are never annotated.
+Discovery filters on `source = user`, covering both accepted and rejected
+manual decisions in one query.
 
-Everything else is left unannotated rather than guessed:
+Other outcomes remain unannotated:
 
 | Case | Recorded as | Why not annotated |
 |---|---|---|
@@ -140,13 +125,11 @@ Everything else is left unannotated rather than guessed:
 | Unknown or malformed decision | — | not a terminal user decision |
 | Non-approval tool | no marker | no approval gate exists |
 
-Annotations carry only `{"tool_name": ...}` — never prompt text, tool
-arguments, raw output, user content, instance ids, or proposal diffs.
+Annotations carry only `{"tool_name": ...}`.
 
-`submit_{code,llm}_evaluator_draft` remain unmeasured: they resolve as
-`awaiting_user` and the dialog's real decision is never written back as tool
-output, so no marker exists to read. Closing that gap needs a frontend change —
-tracked in [#15033](https://github.com/Arize-ai/phoenix/issues/15033).
+`submit_{code,llm}_evaluator_draft` remain unmeasured because their dialog
+decisions are not written to tool output. See
+[#15033](https://github.com/Arize-ai/phoenix/issues/15033).
 
 ## How `user_friction` finds its target
 
@@ -201,9 +184,8 @@ skips them:
 | `user_friction` | `pxi.turn` root | `pxi-online-evals:user-friction:v1:openai:gpt-5.5` |
 | `suggestion_accepted` | approval TOOL span | `pxi-online-evals:suggestion-accepted:v1` |
 
-The key is per target, so a checkpoint on one suggestion never suppresses
-another suggestion in the same turn, and the next overlapping run checkpoints
-prior terminal decisions instead of duplicating them.
+The key is per target, so one suggestion's checkpoint does not suppress another
+suggestion in the same turn.
 
 - The 48h lookback **overlaps** the 12h schedule ~4×, so missed or crashed
   runs self-heal without double-evaluating.
@@ -240,7 +222,7 @@ rate 0.25  █████                 subset of the 0.50 selection
 | Runaway judge input | 50k-char cap on rendered input | skip + warning |
 | Silent truncation when hydrating many traces | batch split-and-retry at the span limit; a single over-limit trace is an error | correctness over convenience |
 | Unbounded discovery | hard cap (5,000 spans) per selector query fails the run loudly, naming the selector | operator shrinks the window |
-| One bad turn poisoning the run | per-turn exception isolation | logged + counted; run continues; process exits non-zero so schedules go red |
+| One bad target poisoning the run | per-target exception isolation | logged + counted; run continues; process exits non-zero so schedules go red |
 | Bad judge config | provider/API-key validated at startup | fail fast, before any trace work |
 | Malformed topology (orphan tool span, missing ancestor, cycle) | skip as not-applicable + warning | incomplete traces cannot produce a trustworthy tool count and should not poison later scheduled runs |
 

--- a/evals/pxi/online_evals/OVERVIEW.md
+++ b/evals/pxi/online_evals/OVERVIEW.md
@@ -1,34 +1,58 @@
 # PXI Online Evals — How It Works
 
-A scheduled batch job that pulls recently ingested `pxi.turn` traces from
-Phoenix, runs quality evaluators over them, and writes results back as
-**idempotent span annotations** on each turn's root span. It runs as a plain
+A scheduled batch job that pulls recently ingested PXI spans from Phoenix,
+runs quality evaluators over them, and writes results back as **idempotent
+span annotations** on each evaluator's target span. It runs as a plain
 Phoenix API client — nothing executes in the server process or the ingestion
 path.
+
+## Target discovery: roots and TOOL spans
+
+Each evaluator declares a `SpanSelector`. The runner groups evaluators by
+identical selector and issues **one discovery query per group**:
+
+| Selector | `names` | `span_kinds` | `parent_id` | Evaluators |
+|---|---|---|---|---|
+| Turn root | `pxi.turn` | `AGENT` | `"null"` | `tool_count_per_turn`, `user_friction` |
+| Approval tool | the allowlist | `TOOL` | *(unset)* | `suggestion_accepted` |
+
+Root evaluators score a whole turn. `suggestion_accepted` scores an individual
+action, because **one turn can contain several suggestions the user decided
+differently** — a rejected annotation-config change and its accepted revision
+routinely appear in the same turn. Annotating the root would collapse both into
+one label, so the annotation goes on the TOOL span itself.
+
+Everything downstream is target-agnostic: the settle delay applies to each
+target's own `end_time`, the checkpoint key is `(span_id, name, identifier)` on
+the target, and sampling stays keyed on `trace_id` so all targets in one turn
+are sampled together.
 
 ## The pipeline
 
 ```mermaid
 flowchart TD
-    A["Discover roots<br/>name=pxi.turn, parent=null,<br/>last 48h"] --> B{"Settled?<br/>ended &gt; 5 min ago"}
+    A["Discover candidates<br/>one query per selector,<br/>last 48h"] --> B{"Settled?<br/>target ended &gt; 5 min ago"}
     B -- no --> B2["skip — next run's<br/>overlap picks it up"]
     B -- yes --> C{"Checkpoint exists?<br/>(span_id, name, identifier)"}
     C -- yes --> C2["already_annotated"]
     C -- no --> D{"Sampled?<br/>sha256(trace_id) &lt; rate"}
     D -- no --> D2["sampled_out"]
-    D -- yes --> E["Hydrate: fetch all spans<br/>of pending traces (batched)"]
+    D -- yes --> E["Hydrate: fetch all spans<br/>of pending traces<br/>(deduped by trace id)"]
     E --> F["Evaluate concurrently<br/>(≤ 8 in flight)"]
-    F -- "Score" --> G["Annotate root span<br/>(batches of ≤ 100)"]
+    F -- "Score" --> G["Annotate target span<br/>(batches of ≤ 100)"]
     F -- "None" --> F2["not_applicable"]
     F -- "exception" --> F3["errors++ · run continues ·<br/>process exits non-zero"]
 ```
 
 Every box feeds a counter in the run summary, so a scheduled run's log tells
-you exactly where each discovered turn went:
+you exactly where each discovered target went (`discovered` counts matching
+**target spans**, so the tool evaluator's number is per-suggestion, not
+per-turn):
 
 ```
 tool_count_per_turn: discovered=11 already_annotated=0 sampled_out=0 not_applicable=0 evaluated=11 errors=0 written=11
 user_friction:       discovered=11 already_annotated=0 sampled_out=0 not_applicable=6 evaluated=5  errors=0 written=5
+suggestion_accepted: discovered=34 already_annotated=0 sampled_out=0 not_applicable=8 evaluated=26 errors=0 written=26
 ```
 
 The CLI can also write the same counters as a versioned JSON report with
@@ -65,6 +89,58 @@ pxi.turn (AGENT, root)        input.value = "can you save this trace to a datase
 **`tool_count_per_turn`** counts every TOOL span in the trace, including tools
 nested beneath another tool such as `call_subagent`. Metadata partitions the
 chronological total into top-level and nested tool names.
+
+## How `suggestion_accepted` reads a decision
+
+Approval-gated tools stage a change, the UI renders an accept/reject card, and
+the user's click lands in that TOOL span's `output.value`. The evaluator reads
+that structured field — it never scans message text for the words "accepted"
+or "rejected".
+
+```mermaid
+flowchart TD
+    A["TOOL span"] --> B{"tool.name on<br/>the allowlist?"}
+    B -- no --> N["not applicable"]
+    B -- yes --> C{"output.value decodes<br/>to an object?<br/>(≤ 1 extra JSON layer)"}
+    C -- no --> N
+    C -- yes --> D{"status == 'rejected'?"}
+    D -- yes --> R["rejected / 0.0"]
+    D -- no --> E{"acceptedBy == 'user'?"}
+    E -- yes --> S["accepted / 1.0"]
+    E -- no --> N
+```
+
+Two ordering choices carry the semantics:
+
+- **Rejection first.** The reject path writes `status: "rejected"` and never
+  sets `acceptedBy`, so a payload carrying both is contradictory; the explicit
+  terminal rejection is the safer reading.
+- **`acceptedBy`, not `status`, proves acceptance.** The success vocabulary is
+  tool-specific — `accepted`, `saved`, `loaded`, `applied`, `removed` — while
+  `acceptedBy` is the one field distinguishing a human click (`"user"`) from an
+  automatic bypass (`"auto"`).
+
+Everything else is left unannotated rather than guessed:
+
+| Case | Recorded as | Why not annotated |
+|---|---|---|
+| Automatic accept | `acceptedBy: "auto"` | bypass permission, not a user decision |
+| Pending approval | `status: "awaiting_user"` | the user hasn't decided yet |
+| Cancelled by navigation | `state: "output-error"` | the card was dismissed, not decided |
+| Tool error | `state: "output-error"` | nothing was proposed to decide on |
+| Missing/malformed/non-object output | — | no decision is recorded |
+| Unknown status | e.g. `no_change` | not a terminal user decision |
+| Non-allowlisted tool | — | no approval gate exists |
+
+Annotations carry only `{"tool_name": ...}` — never prompt text, tool
+arguments, raw output, user content, instance ids, or proposal diffs.
+
+The allowlist is a **cross-language maintenance contract** with
+`app/src/agent/tools/*/pending*.ts` (and the shared
+`app/src/agent/shared/pendingApproval/bindPendingApproval.ts`). A new
+approval-gated frontend tool must be added on both sides or its decisions go
+unmeasured. `submit_{code,llm}_evaluator_draft` are excluded: they record only
+`awaiting_user`, and the dialog's real decision never reaches the tool span.
 
 ## How `user_friction` finds its target
 
@@ -110,12 +186,18 @@ The trace completed cleanly...
 ## Checkpointing: the annotation *is* the state
 
 There is no database or state file. Before evaluating, the runner asks
-Phoenix which roots already carry the evaluator's annotation and skips them:
+Phoenix which **target spans** already carry the evaluator's annotation and
+skips them:
 
-| Evaluator | Checkpoint identifier |
-|---|---|
-| `tool_count_per_turn` | `pxi-online-evals:tool-count-per-turn:v2` |
-| `user_friction` | `pxi-online-evals:user-friction:v1:openai:gpt-5.5` |
+| Evaluator | Target | Checkpoint identifier |
+|---|---|---|
+| `tool_count_per_turn` | `pxi.turn` root | `pxi-online-evals:tool-count-per-turn:v2` |
+| `user_friction` | `pxi.turn` root | `pxi-online-evals:user-friction:v1:openai:gpt-5.5` |
+| `suggestion_accepted` | approval TOOL span | `pxi-online-evals:suggestion-accepted:v1` |
+
+The key is per target, so a checkpoint on one suggestion never suppresses
+another suggestion in the same turn, and the next overlapping run checkpoints
+prior terminal decisions instead of duplicating them.
 
 - The 48h lookback **overlaps** the 12h schedule ~4×, so missed or crashed
   runs self-heal without double-evaluating.
@@ -143,13 +225,15 @@ rate 0.25  █████                 subset of the 0.50 selection
 
 | Considered failure | Safeguard | On trigger |
 |---|---|---|
-| Judging a still-running turn | 5-min settle delay on root **end** time | wait for next run |
+| Judging a still-running turn or in-flight action | 5-min settle delay on the **target's own end** time | wait for next run |
+| Guessing an outcome that was never a user decision (auto-accept, pending, cancelled, errored, malformed) | structured-field decision rules with an explicit not-applicable branch | no annotation written |
+| Frontend adds an approval tool without an eval | explicit allowlist, documented as a cross-language contract | new tool goes unmeasured until added — deliberately visible, never silently mislabeled |
 | Misattributed judgment: transcript's final turn isn't this trace's own message | target must be the final user-role message, be human-authored, **and equal the root's `input.value`** (independently recorded at ingestion) | skip + warning — never checkpoint a judgment on the wrong root (idempotency would make it permanent) |
 | Non-human "user" messages (legacy UI-context blocks, agent-loop continuations, tool-error payloads) | `is_human_message` classifier — same one used to build the gold labels | skip as not-applicable; **no fallback** to an earlier human turn |
 | Subagent's internal LLM span hijacking the transcript (it can start *after* the main agent's final call) | prefer LLM spans that are direct children of the root | main transcript wins |
 | Runaway judge input | 50k-char cap on rendered input | skip + warning |
 | Silent truncation when hydrating many traces | batch split-and-retry at the span limit; a single over-limit trace is an error | correctness over convenience |
-| Unbounded discovery | hard cap (5,000 roots) fails the run loudly | operator shrinks the window |
+| Unbounded discovery | hard cap (5,000 spans) per selector query fails the run loudly, naming the selector | operator shrinks the window |
 | One bad turn poisoning the run | per-turn exception isolation | logged + counted; run continues; process exits non-zero so schedules go red |
 | Bad judge config | provider/API-key validated at startup | fail fast, before any trace work |
 | Malformed topology (orphan tool span, missing ancestor, cycle) | skip as not-applicable + warning | incomplete traces cannot produce a trustworthy tool count and should not poison later scheduled runs |

--- a/evals/pxi/online_evals/OVERVIEW.md
+++ b/evals/pxi/online_evals/OVERVIEW.md
@@ -11,10 +11,10 @@ path.
 Each evaluator declares a `SpanSelector`. The runner groups evaluators by
 identical selector and issues **one discovery query per group**:
 
-| Selector | `names` | `span_kinds` | `parent_id` | Evaluators |
-|---|---|---|---|---|
-| Turn root | `pxi.turn` | `AGENT` | `"null"` | `tool_count_per_turn`, `user_friction` |
-| Approval tool | the allowlist | `TOOL` | *(unset)* | `suggestion_accepted` |
+| Selector | `names` | `span_kinds` | `parent_id` | `attributes` | Evaluators |
+|---|---|---|---|---|---|
+| Turn root | `pxi.turn` | `AGENT` | `"null"` | — | `tool_count_per_turn`, `user_friction` |
+| Approval decision | — | `TOOL` | *(unset)* | `pxi.approval.source = user` | `suggestion_accepted` |
 
 Root evaluators score a whole turn. `suggestion_accepted` scores an individual
 action, because **one turn can contain several suggestions the user decided
@@ -93,54 +93,55 @@ chronological total into top-level and nested tool names.
 ## How `suggestion_accepted` reads a decision
 
 Approval-gated tools stage a change, the UI renders an accept/reject card, and
-the user's click lands in that TOOL span's `output.value`. The evaluator reads
-that structured field — it never scans message text for the words "accepted"
-or "rejected".
+the user's click is stamped into the tool's output as a reserved marker:
+
+```json
+{"approval": {"decision": "accepted", "source": "user"}}
+```
+
+The server promotes that marker onto the span as `pxi.approval.decision` and
+`pxi.approval.source` (see `src/phoenix/server/agents/approval.py`, written by
+`app/src/agent/shared/pendingApproval/approvalOutcome.ts`). The evaluator reads
+only those two attributes — it never parses `output.value` and never scans
+message text for the words "accepted" or "rejected".
 
 ```mermaid
 flowchart TD
-    A["TOOL span"] --> B{"tool.name on<br/>the allowlist?"}
+    A["TOOL span"] --> B{"pxi.approval.source<br/>== 'user'?"}
     B -- no --> N["not applicable"]
-    B -- yes --> C{"output.value decodes<br/>to an object?<br/>(≤ 1 extra JSON layer)"}
-    C -- no --> N
-    C -- yes --> D{"status == 'rejected'?"}
-    D -- yes --> R["rejected / 0.0"]
-    D -- no --> E{"acceptedBy == 'user'?"}
-    E -- yes --> S["accepted / 1.0"]
-    E -- no --> N
+    B -- yes --> C{"pxi.approval.decision"}
+    C -- "'accepted'" --> S["accepted / 1.0"]
+    C -- "'rejected'" --> R["rejected / 0.0"]
+    C -- other/absent --> N
 ```
 
-Two ordering choices carry the semantics:
+**There is no tool-name allowlist, by design.** Each tool keeps its own success
+vocabulary — `accepted`, `saved`, `loaded`, `applied`, `removed` — and the
+marker is uniform across all of them, so a newly approval-gated tool is measured
+the day it ships with no change here. The frontend has a drift guard asserting
+every approval payload carries the marker.
 
-- **Rejection first.** The reject path writes `status: "rejected"` and never
-  sets `acceptedBy`, so a payload carrying both is contradictory; the explicit
-  terminal rejection is the safer reading.
-- **`acceptedBy`, not `status`, proves acceptance.** The success vocabulary is
-  tool-specific — `accepted`, `saved`, `loaded`, `applied`, `removed` — while
-  `acceptedBy` is the one field distinguishing a human click (`"user"`) from an
-  automatic bypass (`"auto"`).
+Discovery filters on `source = user` rather than on the decision: it is a single
+server-side query, and it yields exactly the annotated set, since rejections are
+always a user action and automatic accepts are never annotated.
 
 Everything else is left unannotated rather than guessed:
 
 | Case | Recorded as | Why not annotated |
 |---|---|---|
-| Automatic accept | `acceptedBy: "auto"` | bypass permission, not a user decision |
-| Pending approval | `status: "awaiting_user"` | the user hasn't decided yet |
-| Cancelled by navigation | `state: "output-error"` | the card was dismissed, not decided |
-| Tool error | `state: "output-error"` | nothing was proposed to decide on |
-| Missing/malformed/non-object output | — | no decision is recorded |
-| Unknown status | e.g. `no_change` | not a terminal user decision |
-| Non-allowlisted tool | — | no approval gate exists |
+| Automatic accept | `source: "auto"` | bypass permission, not a user decision |
+| Pending approval | no marker | the user hasn't decided yet |
+| Cancelled by navigation | no marker (`output-error`) | the card was dismissed, not decided |
+| Tool error | no marker (`output-error`) | nothing was proposed to decide on |
+| Unknown or malformed decision | — | not a terminal user decision |
+| Non-approval tool | no marker | no approval gate exists |
 
 Annotations carry only `{"tool_name": ...}` — never prompt text, tool
 arguments, raw output, user content, instance ids, or proposal diffs.
 
-The allowlist is a **cross-language maintenance contract** with
-`app/src/agent/tools/*/pending*.ts` (and the shared
-`app/src/agent/shared/pendingApproval/bindPendingApproval.ts`). A new
-approval-gated frontend tool must be added on both sides or its decisions go
-unmeasured. `submit_{code,llm}_evaluator_draft` are excluded: they record only
-`awaiting_user`, and the dialog's real decision never reaches the tool span.
+`submit_{code,llm}_evaluator_draft` remain unmeasured: they resolve as
+`awaiting_user` and the dialog's real decision is never written back as tool
+output, so no marker exists to read. Closing that gap needs a frontend change.
 
 ## How `user_friction` finds its target
 
@@ -227,7 +228,7 @@ rate 0.25  █████                 subset of the 0.50 selection
 |---|---|---|
 | Judging a still-running turn or in-flight action | 5-min settle delay on the **target's own end** time | wait for next run |
 | Guessing an outcome that was never a user decision (auto-accept, pending, cancelled, errored, malformed) | structured-field decision rules with an explicit not-applicable branch | no annotation written |
-| Frontend adds an approval tool without an eval | explicit allowlist, documented as a cross-language contract | new tool goes unmeasured until added — deliberately visible, never silently mislabeled |
+| Frontend adds an approval tool without an eval | tools stamp a uniform approval marker; discovery keys off it, not tool names | new tool is measured automatically; a frontend drift guard fails if it ships unmarked |
 | Misattributed judgment: transcript's final turn isn't this trace's own message | target must be the final user-role message, be human-authored, **and equal the root's `input.value`** (independently recorded at ingestion) | skip + warning — never checkpoint a judgment on the wrong root (idempotency would make it permanent) |
 | Non-human "user" messages (legacy UI-context blocks, agent-loop continuations, tool-error payloads) | `is_human_message` classifier — same one used to build the gold labels | skip as not-applicable; **no fallback** to an earlier human turn |
 | Subagent's internal LLM span hijacking the transcript (it can start *after* the main agent's final call) | prefer LLM spans that are direct children of the root | main transcript wins |

--- a/evals/pxi/online_evals/OVERVIEW.md
+++ b/evals/pxi/online_evals/OVERVIEW.md
@@ -145,7 +145,8 @@ arguments, raw output, user content, instance ids, or proposal diffs.
 
 `submit_{code,llm}_evaluator_draft` remain unmeasured: they resolve as
 `awaiting_user` and the dialog's real decision is never written back as tool
-output, so no marker exists to read. Closing that gap needs a frontend change.
+output, so no marker exists to read. Closing that gap needs a frontend change —
+tracked in [#15033](https://github.com/Arize-ai/phoenix/issues/15033).
 
 ## How `user_friction` finds its target
 

--- a/evals/pxi/online_evals/evaluators/__init__.py
+++ b/evals/pxi/online_evals/evaluators/__init__.py
@@ -1,9 +1,11 @@
+from evals.pxi.online_evals.evaluators.suggestion_accepted import SUGGESTION_ACCEPTED
 from evals.pxi.online_evals.evaluators.tool_count_per_turn import TOOL_COUNT_PER_TURN
 from evals.pxi.online_evals.evaluators.user_friction import USER_FRICTION
 
 EVALUATORS = {
+    SUGGESTION_ACCEPTED.name: SUGGESTION_ACCEPTED,
     TOOL_COUNT_PER_TURN.name: TOOL_COUNT_PER_TURN,
     USER_FRICTION.name: USER_FRICTION,
 }
 
-__all__ = ["EVALUATORS", "TOOL_COUNT_PER_TURN", "USER_FRICTION"]
+__all__ = ["EVALUATORS", "SUGGESTION_ACCEPTED", "TOOL_COUNT_PER_TURN", "USER_FRICTION"]

--- a/evals/pxi/online_evals/evaluators/suggestion_accepted.py
+++ b/evals/pxi/online_evals/evaluators/suggestion_accepted.py
@@ -33,6 +33,8 @@ from phoenix.evals.evaluators import Score
 
 ANNOTATION_NAME = "suggestion_accepted"
 
+# The server writes these attributes in its agents router. This evaluator reads
+# them through the public span-attribute contract, not a server-internal module.
 APPROVAL_DECISION_ATTRIBUTE = "pxi.approval.decision"
 APPROVAL_SOURCE_ATTRIBUTE = "pxi.approval.source"
 USER_APPROVAL_SOURCE = "user"

--- a/evals/pxi/online_evals/evaluators/suggestion_accepted.py
+++ b/evals/pxi/online_evals/evaluators/suggestion_accepted.py
@@ -1,0 +1,147 @@
+"""Online `suggestion_accepted` evaluator: did the user accept this suggestion?
+
+PXI proposes some changes behind an approval gate: the tool stages an edit,
+the UI renders an accept/reject card, and the user's click is recorded in
+that TOOL span's ``output.value``. This evaluator turns those recorded
+decisions into a deterministic CODE annotation on the TOOL span itself.
+
+It annotates **only manual user decisions**. Automatic accepts (edit
+permission set to bypass), still-pending approvals, approvals cancelled by
+navigation, errored tools, and malformed output are not evidence of what a
+user wanted, so they receive no annotation at all rather than a guessed one.
+
+Targeting the TOOL span rather than the turn root is deliberate: one turn can
+contain several suggestions that the user decides differently, and a
+turn-level annotation would collapse them into a single label.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from evals.pxi.online_evals.models import EvaluatorSpec, SpanSelector
+from phoenix.client.__generated__ import v1
+from phoenix.evals.evaluators import Score
+
+ANNOTATION_NAME = "suggestion_accepted"
+
+APPROVAL_GATED_TOOLS: tuple[str, ...] = (
+    "batch_span_annotate",
+    "create_annotation_config",
+    "edit_code_evaluator_draft",
+    "edit_llm_evaluator_draft",
+    "edit_prompt_instance",
+    "load_dataset",
+    "patch_experiment",
+    "remove_prompt_instance",
+    "save_prompt",
+    "update_annotation_config",
+    "write_prompt_tools",
+)
+"""Frontend tools whose pending-action implementation records BOTH outcomes.
+
+This list is a cross-language maintenance contract: when a new approval-gated
+tool is added on the frontend, add it here too or its decisions go unmeasured.
+The frontend counterparts live in:
+
+- ``app/src/agent/shared/pendingApproval/bindPendingApproval.ts`` (generic
+  accept/reject core, used by the annotation-config tools)
+- ``app/src/agent/tools/batchSpanAnnotate/pendingBatchSpanAnnotate.ts``
+- ``app/src/agent/tools/codeEvaluatorDraft/pendingCodeEvaluatorEdit.ts``
+- ``app/src/agent/tools/llmEvaluatorDraft/pendingLlmEvaluatorEdit.ts``
+- ``app/src/agent/tools/patchExperiment/pendingPatchExperiment.ts``
+- ``app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts``
+- ``app/src/agent/tools/playgroundPrompt/pendingPromptEdit.ts``
+- ``app/src/agent/tools/playgroundPrompt/pendingPromptInstanceRemoval.ts``
+- ``app/src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts``
+- ``app/src/agent/tools/playgroundSavePrompt/pendingSavePrompt.ts``
+
+Deliberately excluded: read-only, test, and navigation tools have nothing to
+approve, and ``submit_code_evaluator_draft`` / ``submit_llm_evaluator_draft``
+record only ``awaiting_user`` — their real decision happens in a dialog whose
+outcome is not written back to the tool span.
+"""
+
+REJECTED_STATUS = "rejected"
+USER_APPROVAL_SOURCE = "user"
+MAX_OUTPUT_DECODE_LAYERS = 2
+"""Real outputs are occasionally double-encoded (a JSON string inside JSON)."""
+
+
+def _tool_name(span: v1.Span) -> str:
+    value: Any = span.get("attributes", {}).get("tool.name")
+    return value if isinstance(value, str) and value else span["name"]
+
+
+def _decoded_output(span: v1.Span) -> Mapping[str, Any] | None:
+    """Decode ``output.value`` into a mapping, or ``None`` if it is not one.
+
+    Arrays, scalars, null, empty strings, and malformed JSON are all
+    not-applicable rather than errors: the point is to classify recorded
+    decisions, and anything that is not a decision object has none to read.
+    """
+    value: Any = span.get("attributes", {}).get("output.value")
+    for _ in range(MAX_OUTPUT_DECODE_LAYERS):
+        if isinstance(value, Mapping):
+            return value
+        if not isinstance(value, str) or not value.strip():
+            return None
+        try:
+            value = json.loads(value)
+        except (ValueError, TypeError):
+            return None
+    return value if isinstance(value, Mapping) else None
+
+
+def _decision(output: Mapping[str, Any]) -> tuple[str, float] | None:
+    """Map a recorded approval outcome to ``(label, score)``, or ``None``.
+
+    Rejection is checked first: a reject callback writes ``status="rejected"``
+    and never sets ``acceptedBy``, so a payload carrying both is contradictory
+    and the explicit terminal rejection is the safer reading.
+
+    Acceptance keys off ``acceptedBy == "user"`` rather than the status string
+    because the accept vocabulary is tool-specific (``accepted``, ``saved``,
+    ``loaded``, ``applied``, ``removed``), while ``acceptedBy`` is the one
+    field that distinguishes a human click from an automatic bypass.
+    """
+    if output.get("status") == REJECTED_STATUS:
+        return "rejected", 0.0
+    if output.get("acceptedBy") == USER_APPROVAL_SOURCE:
+        return "accepted", 1.0
+    return None
+
+
+async def evaluate_suggestion_accepted(target: v1.Span, _spans: Sequence[v1.Span]) -> Score | None:
+    tool_name = _tool_name(target)
+    if tool_name not in APPROVAL_GATED_TOOLS:
+        return None
+    output = _decoded_output(target)
+    if output is None:
+        return None
+    decision = _decision(output)
+    if decision is None:
+        return None
+    label, score = decision
+    return Score(
+        name=ANNOTATION_NAME,
+        score=score,
+        label=label,
+        explanation=f"user {label} the {tool_name} suggestion",
+        # Only the low-cardinality tool name: never prompt text, tool
+        # arguments, raw output, user content, instance ids, or diffs.
+        metadata={"tool_name": tool_name},
+        kind="code",
+    )
+
+
+SUGGESTION_ACCEPTED = EvaluatorSpec(
+    name=ANNOTATION_NAME,
+    selector=SpanSelector(names=APPROVAL_GATED_TOOLS, span_kinds=("TOOL",)),
+    evaluate=evaluate_suggestion_accepted,
+    annotator_kind="CODE",
+    sample_rate=1.0,
+    identifier="pxi-online-evals:suggestion-accepted:v1",
+)

--- a/evals/pxi/online_evals/evaluators/suggestion_accepted.py
+++ b/evals/pxi/online_evals/evaluators/suggestion_accepted.py
@@ -1,14 +1,21 @@
 """Online `suggestion_accepted` evaluator: did the user accept this suggestion?
 
 PXI proposes some changes behind an approval gate: the tool stages an edit,
-the UI renders an accept/reject card, and the user's click is recorded in
-that TOOL span's ``output.value``. This evaluator turns those recorded
-decisions into a deterministic CODE annotation on the TOOL span itself.
+the UI renders an accept/reject card, and the user's click is recorded in that
+TOOL span's approval attributes. This evaluator turns those recorded decisions
+into a deterministic CODE annotation on the TOOL span itself.
 
-It annotates **only manual user decisions**. Automatic accepts (edit
-permission set to bypass), still-pending approvals, approvals cancelled by
-navigation, errored tools, and malformed output are not evidence of what a
-user wanted, so they receive no annotation at all rather than a guessed one.
+Approval-gated tools stamp their decision into their tool output, and the
+server promotes it onto the span as ``pxi.approval.decision`` /
+``pxi.approval.source`` (see ``src/phoenix/server/agents/approval.py`` and
+``app/src/agent/shared/pendingApproval/approvalOutcome.ts``). Discovery and
+classification both key off those attributes, so this evaluator needs no list
+of approval-gated tool names: a newly gated tool is covered the day it ships.
+
+It annotates **only manual user decisions**. Automatic accepts (edit permission
+set to bypass) carry ``source="auto"`` and are excluded at discovery. Approvals
+that were never decided — still pending, cancelled by navigation, or errored —
+carry no marker at all, so they are never discovered either.
 
 Targeting the TOOL span rather than the turn root is deliberate: one turn can
 contain several suggestions that the user decides differently, and a
@@ -17,8 +24,7 @@ turn-level annotation would collapse them into a single label.
 
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 from evals.pxi.online_evals.models import EvaluatorSpec, SpanSelector
@@ -27,47 +33,15 @@ from phoenix.evals.evaluators import Score
 
 ANNOTATION_NAME = "suggestion_accepted"
 
-APPROVAL_GATED_TOOLS: tuple[str, ...] = (
-    "batch_span_annotate",
-    "create_annotation_config",
-    "edit_code_evaluator_draft",
-    "edit_llm_evaluator_draft",
-    "edit_prompt_instance",
-    "load_dataset",
-    "patch_experiment",
-    "remove_prompt_instance",
-    "save_prompt",
-    "update_annotation_config",
-    "write_prompt_tools",
-)
-"""Frontend tools whose pending-action implementation records BOTH outcomes.
-
-This list is a cross-language maintenance contract: when a new approval-gated
-tool is added on the frontend, add it here too or its decisions go unmeasured.
-The frontend counterparts live in:
-
-- ``app/src/agent/shared/pendingApproval/bindPendingApproval.ts`` (generic
-  accept/reject core, used by the annotation-config tools)
-- ``app/src/agent/tools/batchSpanAnnotate/pendingBatchSpanAnnotate.ts``
-- ``app/src/agent/tools/codeEvaluatorDraft/pendingCodeEvaluatorEdit.ts``
-- ``app/src/agent/tools/llmEvaluatorDraft/pendingLlmEvaluatorEdit.ts``
-- ``app/src/agent/tools/patchExperiment/pendingPatchExperiment.ts``
-- ``app/src/agent/tools/playgroundLoadDataset/pendingLoadDataset.ts``
-- ``app/src/agent/tools/playgroundPrompt/pendingPromptEdit.ts``
-- ``app/src/agent/tools/playgroundPrompt/pendingPromptInstanceRemoval.ts``
-- ``app/src/agent/tools/playgroundPromptTools/pendingPromptToolWrite.ts``
-- ``app/src/agent/tools/playgroundSavePrompt/pendingSavePrompt.ts``
-
-Deliberately excluded: read-only, test, and navigation tools have nothing to
-approve, and ``submit_code_evaluator_draft`` / ``submit_llm_evaluator_draft``
-record only ``awaiting_user`` — their real decision happens in a dialog whose
-outcome is not written back to the tool span.
-"""
-
-REJECTED_STATUS = "rejected"
+APPROVAL_DECISION_ATTRIBUTE = "pxi.approval.decision"
+APPROVAL_SOURCE_ATTRIBUTE = "pxi.approval.source"
 USER_APPROVAL_SOURCE = "user"
-MAX_OUTPUT_DECODE_LAYERS = 2
-"""Real outputs are occasionally double-encoded (a JSON string inside JSON)."""
+
+DECISION_SCORES: dict[str, tuple[str, float]] = {
+    "accepted": ("accepted", 1.0),
+    "rejected": ("rejected", 0.0),
+}
+"""Marker decision to ``(label, score)``. Unknown decisions are not applicable."""
 
 
 def _tool_name(span: v1.Span) -> str:
@@ -75,56 +49,18 @@ def _tool_name(span: v1.Span) -> str:
     return value if isinstance(value, str) and value else span["name"]
 
 
-def _decoded_output(span: v1.Span) -> Mapping[str, Any] | None:
-    """Decode ``output.value`` into a mapping, or ``None`` if it is not one.
-
-    Arrays, scalars, null, empty strings, and malformed JSON are all
-    not-applicable rather than errors: the point is to classify recorded
-    decisions, and anything that is not a decision object has none to read.
-    """
-    value: Any = span.get("attributes", {}).get("output.value")
-    for _ in range(MAX_OUTPUT_DECODE_LAYERS):
-        if isinstance(value, Mapping):
-            return value
-        if not isinstance(value, str) or not value.strip():
-            return None
-        try:
-            value = json.loads(value)
-        except (ValueError, TypeError):
-            return None
-    return value if isinstance(value, Mapping) else None
-
-
-def _decision(output: Mapping[str, Any]) -> tuple[str, float] | None:
-    """Map a recorded approval outcome to ``(label, score)``, or ``None``.
-
-    Rejection is checked first: a reject callback writes ``status="rejected"``
-    and never sets ``acceptedBy``, so a payload carrying both is contradictory
-    and the explicit terminal rejection is the safer reading.
-
-    Acceptance keys off ``acceptedBy == "user"`` rather than the status string
-    because the accept vocabulary is tool-specific (``accepted``, ``saved``,
-    ``loaded``, ``applied``, ``removed``), while ``acceptedBy`` is the one
-    field that distinguishes a human click from an automatic bypass.
-    """
-    if output.get("status") == REJECTED_STATUS:
-        return "rejected", 0.0
-    if output.get("acceptedBy") == USER_APPROVAL_SOURCE:
-        return "accepted", 1.0
-    return None
-
-
 async def evaluate_suggestion_accepted(target: v1.Span, _spans: Sequence[v1.Span]) -> Score | None:
-    tool_name = _tool_name(target)
-    if tool_name not in APPROVAL_GATED_TOOLS:
+    attributes = target.get("attributes", {})
+    # Re-checked locally rather than trusting the discovery filter, so the
+    # evaluator is still correct if called with an arbitrary span.
+    if attributes.get(APPROVAL_SOURCE_ATTRIBUTE) != USER_APPROVAL_SOURCE:
         return None
-    output = _decoded_output(target)
-    if output is None:
-        return None
-    decision = _decision(output)
+    recorded: Any = attributes.get(APPROVAL_DECISION_ATTRIBUTE)
+    decision = DECISION_SCORES.get(recorded) if isinstance(recorded, str) else None
     if decision is None:
         return None
     label, score = decision
+    tool_name = _tool_name(target)
     return Score(
         name=ANNOTATION_NAME,
         score=score,
@@ -139,7 +75,13 @@ async def evaluate_suggestion_accepted(target: v1.Span, _spans: Sequence[v1.Span
 
 SUGGESTION_ACCEPTED = EvaluatorSpec(
     name=ANNOTATION_NAME,
-    selector=SpanSelector(names=APPROVAL_GATED_TOOLS, span_kinds=("TOOL",)),
+    # Selecting on the approval source rather than the decision keeps discovery
+    # to a single query and yields exactly the annotated set: user accepts and
+    # user rejections, never an automatic bypass accept.
+    selector=SpanSelector(
+        span_kinds=("TOOL",),
+        attributes={APPROVAL_SOURCE_ATTRIBUTE: USER_APPROVAL_SOURCE},
+    ),
     evaluate=evaluate_suggestion_accepted,
     annotator_kind="CODE",
     sample_rate=1.0,

--- a/evals/pxi/online_evals/evaluators/suggestion_accepted.py
+++ b/evals/pxi/online_evals/evaluators/suggestion_accepted.py
@@ -1,26 +1,4 @@
-"""Online `suggestion_accepted` evaluator: did the user accept this suggestion?
-
-PXI proposes some changes behind an approval gate: the tool stages an edit,
-the UI renders an accept/reject card, and the user's click is recorded in that
-TOOL span's approval attributes. This evaluator turns those recorded decisions
-into a deterministic CODE annotation on the TOOL span itself.
-
-Approval-gated tools stamp their decision into their tool output, and the
-server promotes it onto the span as ``pxi.approval.decision`` /
-``pxi.approval.source`` (see ``src/phoenix/server/agents/approval.py`` and
-``app/src/agent/shared/pendingApproval/approvalOutcome.ts``). Discovery and
-classification both key off those attributes, so this evaluator needs no list
-of approval-gated tool names: a newly gated tool is covered the day it ships.
-
-It annotates **only manual user decisions**. Automatic accepts (edit permission
-set to bypass) carry ``source="auto"`` and are excluded at discovery. Approvals
-that were never decided — still pending, cancelled by navigation, or errored —
-carry no marker at all, so they are never discovered either.
-
-Targeting the TOOL span rather than the turn root is deliberate: one turn can
-contain several suggestions that the user decides differently, and a
-turn-level annotation would collapse them into a single label.
-"""
+"""Annotate manual approval decisions on suggestion TOOL spans."""
 
 from __future__ import annotations
 
@@ -33,17 +11,14 @@ from phoenix.evals.evaluators import Score
 
 ANNOTATION_NAME = "suggestion_accepted"
 
-# The server writes these attributes in its agents router. This evaluator reads
-# them through the public span-attribute contract, not a server-internal module.
 APPROVAL_DECISION_ATTRIBUTE = "pxi.approval.decision"
 APPROVAL_SOURCE_ATTRIBUTE = "pxi.approval.source"
 USER_APPROVAL_SOURCE = "user"
 
-DECISION_SCORES: dict[str, tuple[str, float]] = {
-    "accepted": ("accepted", 1.0),
-    "rejected": ("rejected", 0.0),
+DECISION_SCORES: dict[str, float] = {
+    "accepted": 1.0,
+    "rejected": 0.0,
 }
-"""Marker decision to ``(label, score)``. Unknown decisions are not applicable."""
 
 
 def _tool_name(span: v1.Span) -> str:
@@ -53,23 +28,18 @@ def _tool_name(span: v1.Span) -> str:
 
 async def evaluate_suggestion_accepted(target: v1.Span, _spans: Sequence[v1.Span]) -> Score | None:
     attributes = target.get("attributes", {})
-    # Re-checked locally rather than trusting the discovery filter, so the
-    # evaluator is still correct if called with an arbitrary span.
     if attributes.get(APPROVAL_SOURCE_ATTRIBUTE) != USER_APPROVAL_SOURCE:
         return None
     recorded: Any = attributes.get(APPROVAL_DECISION_ATTRIBUTE)
-    decision = DECISION_SCORES.get(recorded) if isinstance(recorded, str) else None
-    if decision is None:
+    score = DECISION_SCORES.get(recorded) if isinstance(recorded, str) else None
+    if score is None:
         return None
-    label, score = decision
     tool_name = _tool_name(target)
     return Score(
         name=ANNOTATION_NAME,
         score=score,
-        label=label,
-        explanation=f"user {label} the {tool_name} suggestion",
-        # Only the low-cardinality tool name: never prompt text, tool
-        # arguments, raw output, user content, instance ids, or diffs.
+        label=recorded,
+        explanation=f"user {recorded} the {tool_name} suggestion",
         metadata={"tool_name": tool_name},
         kind="code",
     )
@@ -77,9 +47,6 @@ async def evaluate_suggestion_accepted(target: v1.Span, _spans: Sequence[v1.Span
 
 SUGGESTION_ACCEPTED = EvaluatorSpec(
     name=ANNOTATION_NAME,
-    # Selecting on the approval source rather than the decision keeps discovery
-    # to a single query and yields exactly the annotated set: user accepts and
-    # user rejections, never an automatic bypass accept.
     selector=SpanSelector(
         span_kinds=("TOOL",),
         attributes={APPROVAL_SOURCE_ATTRIBUTE: USER_APPROVAL_SOURCE},

--- a/evals/pxi/online_evals/evaluators/suggestion_accepted.py
+++ b/evals/pxi/online_evals/evaluators/suggestion_accepted.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from evals.pxi.online_evals.models import EvaluatorSpec, SpanSelector
 from phoenix.client.__generated__ import v1
 from phoenix.evals.evaluators import Score
+
+from evals.pxi.online_evals.models import EvaluatorSpec, SpanSelector
 
 ANNOTATION_NAME = "suggestion_accepted"
 

--- a/evals/pxi/online_evals/evaluators/tool_count_per_turn.py
+++ b/evals/pxi/online_evals/evaluators/tool_count_per_turn.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from evals.pxi.online_evals.models import EvaluatorSpec
-from evals.pxi.online_evals.topology import PXI_TURN_ROOT_SELECTOR, classify_tool_spans
 from phoenix.client.__generated__ import v1
 from phoenix.evals.evaluators import Score
+
+from evals.pxi.online_evals.models import EvaluatorSpec
+from evals.pxi.online_evals.topology import PXI_TURN_ROOT_SELECTOR, classify_tool_spans
 
 
 def _tool_name(span: v1.Span) -> str:

--- a/evals/pxi/online_evals/evaluators/tool_count_per_turn.py
+++ b/evals/pxi/online_evals/evaluators/tool_count_per_turn.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+from evals.pxi.online_evals.models import EvaluatorSpec
+from evals.pxi.online_evals.topology import PXI_TURN_ROOT_SELECTOR, classify_tool_spans
 from phoenix.client.__generated__ import v1
 from phoenix.evals.evaluators import Score
-
-from evals.pxi.online_evals.models import EvaluatorSpec
-from evals.pxi.online_evals.topology import PXI_TURN_ROOT_NAME, classify_tool_spans
 
 
 def _tool_name(span: v1.Span) -> str:
@@ -43,7 +42,7 @@ async def evaluate_tool_count_per_turn(root: v1.Span, spans: Sequence[v1.Span]) 
 
 TOOL_COUNT_PER_TURN = EvaluatorSpec(
     name="tool_count_per_turn",
-    root_span_name=PXI_TURN_ROOT_NAME,
+    selector=PXI_TURN_ROOT_SELECTOR,
     evaluate=evaluate_tool_count_per_turn,
     annotator_kind="CODE",
     sample_rate=1.0,

--- a/evals/pxi/online_evals/evaluators/user_friction.py
+++ b/evals/pxi/online_evals/evaluators/user_friction.py
@@ -16,15 +16,14 @@ import logging
 from collections.abc import Sequence
 from functools import lru_cache
 
-from phoenix.client.__generated__ import v1
-from phoenix.evals.evaluators import Score
-
 from evals.pxi.online_evals import judge
 from evals.pxi.online_evals.conversation import Turn, segment_turns, transcript
 from evals.pxi.online_evals.message_origin import is_human_message
 from evals.pxi.online_evals.models import EvaluatorSpec
 from evals.pxi.online_evals.rendering import render_conversation
-from evals.pxi.online_evals.topology import PXI_TURN_ROOT_NAME
+from evals.pxi.online_evals.topology import PXI_TURN_ROOT_SELECTOR
+from phoenix.client.__generated__ import v1
+from phoenix.evals.evaluators import Score
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +106,7 @@ async def evaluate_user_friction(root: v1.Span, spans: Sequence[v1.Span]) -> Sco
 
 USER_FRICTION = EvaluatorSpec(
     name="user_friction",
-    root_span_name=PXI_TURN_ROOT_NAME,
+    selector=PXI_TURN_ROOT_SELECTOR,
     evaluate=evaluate_user_friction,
     annotator_kind="LLM",
     sample_rate=1.0,

--- a/evals/pxi/online_evals/evaluators/user_friction.py
+++ b/evals/pxi/online_evals/evaluators/user_friction.py
@@ -16,14 +16,15 @@ import logging
 from collections.abc import Sequence
 from functools import lru_cache
 
+from phoenix.client.__generated__ import v1
+from phoenix.evals.evaluators import Score
+
 from evals.pxi.online_evals import judge
 from evals.pxi.online_evals.conversation import Turn, segment_turns, transcript
 from evals.pxi.online_evals.message_origin import is_human_message
 from evals.pxi.online_evals.models import EvaluatorSpec
 from evals.pxi.online_evals.rendering import render_conversation
 from evals.pxi.online_evals.topology import PXI_TURN_ROOT_SELECTOR
-from phoenix.client.__generated__ import v1
-from phoenix.evals.evaluators import Score
 
 logger = logging.getLogger(__name__)
 

--- a/evals/pxi/online_evals/models.py
+++ b/evals/pxi/online_evals/models.py
@@ -8,11 +8,63 @@ from phoenix.client.__generated__ import v1
 from phoenix.evals.evaluators import Score
 
 EvaluateArtifact = Callable[[v1.Span, Sequence[v1.Span]], Awaitable[Optional[Score]]]
-"""Evaluate one turn given its root span and every hydrated span in its trace.
+"""Evaluate one target span given every hydrated span in its trace.
 
-Returns a :class:`phoenix.evals.evaluators.Score`, or ``None`` when the turn
-is not applicable to this evaluator.
+The first argument is the span the annotation will be written to — a turn
+root for turn-level evaluators, or an inner span (for example a TOOL span)
+for evaluators that score individual actions. The second argument is every
+hydrated span in that target's trace, so an evaluator can always reconstruct
+the surrounding turn.
+
+Returns a :class:`phoenix.evals.evaluators.Score`, or ``None`` when the
+target is not applicable to this evaluator.
 """
+
+
+@dataclass(frozen=True)
+class SpanSelector:
+    """Which spans an evaluator targets, expressed as ``get_spans`` filters.
+
+    Selectors are frozen and hashable so the runner can group evaluators that
+    want identical candidates and issue one discovery query per group.
+    """
+
+    names: tuple[str, ...]
+    """Span names to discover; at least one is required so discovery is bounded."""
+
+    span_kinds: tuple[str, ...] = ()
+    """Optional span kinds (``AGENT``, ``TOOL``, ...); empty omits the filter."""
+
+    parent_id: Optional[str] = None
+    """``"null"`` selects root spans only; ``None`` omits the filter entirely."""
+
+    def __init__(
+        self,
+        *,
+        names: Sequence[str],
+        span_kinds: Sequence[str] = (),
+        parent_id: Optional[str] = None,
+    ) -> None:
+        if not names:
+            raise ValueError("names must contain at least one span name")
+        object.__setattr__(self, "names", tuple(names))
+        object.__setattr__(self, "span_kinds", tuple(span_kinds))
+        object.__setattr__(self, "parent_id", parent_id)
+
+    def matches(self, span: v1.Span) -> bool:
+        """Whether a discovered span belongs to this selector.
+
+        Discovery groups selectors, so one query's results must be split back
+        out per evaluator; the server already applied these filters, but the
+        runner re-checks locally rather than trusting positional bookkeeping.
+        """
+        if span["name"] not in self.names:
+            return False
+        if self.span_kinds and span.get("span_kind") not in self.span_kinds:
+            return False
+        if self.parent_id == "null" and span.get("parent_id") is not None:
+            return False
+        return True
 
 
 @dataclass(frozen=True)
@@ -28,7 +80,9 @@ class EvaluatorSpec:
     """
 
     name: str
-    root_span_name: str
+    selector: SpanSelector
+    """Which spans this evaluator targets and annotates."""
+
     evaluate: EvaluateArtifact
     annotator_kind: Literal["CODE", "LLM"]
     sample_rate: float = 1.0

--- a/evals/pxi/online_evals/models.py
+++ b/evals/pxi/online_evals/models.py
@@ -58,8 +58,12 @@ class SpanSelector:
     ) -> None:
         if any(not isinstance(name, str) or not name for name in names):
             raise ValueError("names must contain only non-empty span names")
-        if any(not key for key in attributes):
+        if any(not key or not isinstance(key, str) for key in attributes):
             raise ValueError("attributes must contain only non-empty keys")
+        if any(not isinstance(value, str) for value in attributes.values()):
+            # A non-string would serialize into the query and then never match
+            # locally, silently discovering nothing.
+            raise ValueError("attributes must contain only string values")
         if not names and not attributes:
             # Without one of these, discovery would sweep every span in the
             # window and blow through the runner's candidate safety limit.

--- a/evals/pxi/online_evals/models.py
+++ b/evals/pxi/online_evals/models.py
@@ -47,6 +47,8 @@ class SpanSelector:
     ) -> None:
         if not names:
             raise ValueError("names must contain at least one span name")
+        if any(not isinstance(name, str) or not name for name in names):
+            raise ValueError("names must contain only non-empty span names")
         object.__setattr__(self, "names", tuple(names))
         object.__setattr__(self, "span_kinds", tuple(span_kinds))
         object.__setattr__(self, "parent_id", parent_id)
@@ -62,8 +64,10 @@ class SpanSelector:
             return False
         if self.span_kinds and span.get("span_kind") not in self.span_kinds:
             return False
-        if self.parent_id == "null" and span.get("parent_id") is not None:
-            return False
+        if self.parent_id is not None:
+            expected_parent_id = None if self.parent_id == "null" else self.parent_id
+            if span.get("parent_id") != expected_parent_id:
+                return False
         return True
 
 

--- a/evals/pxi/online_evals/models.py
+++ b/evals/pxi/online_evals/models.py
@@ -2,51 +2,26 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from types import MappingProxyType
 from typing import Literal, Optional
 
 from phoenix.client.__generated__ import v1
 from phoenix.evals.evaluators import Score
 
 EvaluateArtifact = Callable[[v1.Span, Sequence[v1.Span]], Awaitable[Optional[Score]]]
-"""Evaluate one target span given every hydrated span in its trace.
-
-The first argument is the span the annotation will be written to — a turn
-root for turn-level evaluators, or an inner span (for example a TOOL span)
-for evaluators that score individual actions. The second argument is every
-hydrated span in that target's trace, so an evaluator can always reconstruct
-the surrounding turn.
-
-Returns a :class:`phoenix.evals.evaluators.Score`, or ``None`` when the
-target is not applicable to this evaluator.
-"""
+"""Evaluate a target span with all hydrated spans from its trace."""
 
 
 @dataclass(frozen=True)
 class SpanSelector:
-    """Which spans an evaluator targets, expressed as ``get_spans`` filters.
-
-    Selectors are frozen and hashable so the runner can group evaluators that
-    want identical candidates and issue one discovery query per group.
-    """
+    """Hashable ``get_spans`` filters used for evaluator target discovery."""
 
     names: tuple[str, ...] = ()
-    """Span names to discover; empty omits the filter."""
 
     span_kinds: tuple[str, ...] = ()
-    """Optional span kinds (``AGENT``, ``TOOL``, ...); empty omits the filter."""
 
     parent_id: Optional[str] = None
-    """``"null"`` selects root spans only; ``None`` omits the filter entirely."""
 
     attributes: tuple[tuple[str, str], ...] = ()
-    """Exact attribute matches, AND-ed together; empty omits the filter.
-
-    Stored as pairs rather than a mapping to keep the selector hashable. This
-    lets an evaluator target spans by what they *record* rather than by which
-    tool produced them — for example every span carrying an approval decision,
-    without naming the approval-gated tools.
-    """
 
     def __init__(
         self,
@@ -54,19 +29,19 @@ class SpanSelector:
         names: Sequence[str] = (),
         span_kinds: Sequence[str] = (),
         parent_id: Optional[str] = None,
-        attributes: Mapping[str, str] = MappingProxyType({}),
+        attributes: Mapping[str, str] | None = None,
     ) -> None:
+        if attributes is None:
+            attributes = {}
         if any(not isinstance(name, str) or not name for name in names):
             raise ValueError("names must contain only non-empty span names")
-        if any(not key or not isinstance(key, str) for key in attributes):
+        if any(not isinstance(kind, str) or not kind for kind in span_kinds):
+            raise ValueError("span_kinds must contain only non-empty strings")
+        if any(not isinstance(key, str) or not key for key in attributes):
             raise ValueError("attributes must contain only non-empty keys")
         if any(not isinstance(value, str) for value in attributes.values()):
-            # A non-string would serialize into the query and then never match
-            # locally, silently discovering nothing.
             raise ValueError("attributes must contain only string values")
         if not names and not attributes:
-            # Without one of these, discovery would sweep every span in the
-            # window and blow through the runner's candidate safety limit.
             raise ValueError("a selector needs at least one name or attribute filter")
         object.__setattr__(self, "names", tuple(names))
         object.__setattr__(self, "span_kinds", tuple(span_kinds))
@@ -74,12 +49,6 @@ class SpanSelector:
         object.__setattr__(self, "attributes", tuple(sorted(attributes.items())))
 
     def matches(self, span: v1.Span) -> bool:
-        """Whether a discovered span belongs to this selector.
-
-        Discovery groups selectors, so one query's results must be split back
-        out per evaluator; the server already applied these filters, but the
-        runner re-checks locally rather than trusting positional bookkeeping.
-        """
         if self.names and span["name"] not in self.names:
             return False
         if self.span_kinds and span.get("span_kind") not in self.span_kinds:
@@ -97,25 +66,15 @@ class SpanSelector:
 
 @dataclass(frozen=True)
 class EvaluatorSpec:
-    """The scheduling policy that varies by evaluator.
-
-    Everything else — applicability, judge configuration, input extraction —
-    lives inside the ``evaluate`` function itself. LLM evaluators
-    (``annotator_kind="LLM"``) share one judge provider/model (see
-    :mod:`evals.pxi.online_evals.judge`); the runner validates the judge
-    credentials for them and appends ``provider:model`` to their checkpoint
-    identifier so a model change starts a new result series.
-    """
+    """An evaluator and its scheduling and checkpoint policy."""
 
     name: str
     selector: SpanSelector
-    """Which spans this evaluator targets and annotates."""
 
     evaluate: EvaluateArtifact
     annotator_kind: Literal["CODE", "LLM"]
     sample_rate: float = 1.0
     identifier: str = "pxi-online-evals"
-    """Versioned checkpoint identity; bump ``vN`` when scoring semantics change."""
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.sample_rate <= 1.0:

--- a/evals/pxi/online_evals/models.py
+++ b/evals/pxi/online_evals/models.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Literal, Optional
 
 from phoenix.client.__generated__ import v1
@@ -29,8 +30,8 @@ class SpanSelector:
     want identical candidates and issue one discovery query per group.
     """
 
-    names: tuple[str, ...]
-    """Span names to discover; at least one is required so discovery is bounded."""
+    names: tuple[str, ...] = ()
+    """Span names to discover; empty omits the filter."""
 
     span_kinds: tuple[str, ...] = ()
     """Optional span kinds (``AGENT``, ``TOOL``, ...); empty omits the filter."""
@@ -38,20 +39,35 @@ class SpanSelector:
     parent_id: Optional[str] = None
     """``"null"`` selects root spans only; ``None`` omits the filter entirely."""
 
+    attributes: tuple[tuple[str, str], ...] = ()
+    """Exact attribute matches, AND-ed together; empty omits the filter.
+
+    Stored as pairs rather than a mapping to keep the selector hashable. This
+    lets an evaluator target spans by what they *record* rather than by which
+    tool produced them — for example every span carrying an approval decision,
+    without naming the approval-gated tools.
+    """
+
     def __init__(
         self,
         *,
-        names: Sequence[str],
+        names: Sequence[str] = (),
         span_kinds: Sequence[str] = (),
         parent_id: Optional[str] = None,
+        attributes: Mapping[str, str] = MappingProxyType({}),
     ) -> None:
-        if not names:
-            raise ValueError("names must contain at least one span name")
         if any(not isinstance(name, str) or not name for name in names):
             raise ValueError("names must contain only non-empty span names")
+        if any(not key for key in attributes):
+            raise ValueError("attributes must contain only non-empty keys")
+        if not names and not attributes:
+            # Without one of these, discovery would sweep every span in the
+            # window and blow through the runner's candidate safety limit.
+            raise ValueError("a selector needs at least one name or attribute filter")
         object.__setattr__(self, "names", tuple(names))
         object.__setattr__(self, "span_kinds", tuple(span_kinds))
         object.__setattr__(self, "parent_id", parent_id)
+        object.__setattr__(self, "attributes", tuple(sorted(attributes.items())))
 
     def matches(self, span: v1.Span) -> bool:
         """Whether a discovered span belongs to this selector.
@@ -60,10 +76,14 @@ class SpanSelector:
         out per evaluator; the server already applied these filters, but the
         runner re-checks locally rather than trusting positional bookkeeping.
         """
-        if span["name"] not in self.names:
+        if self.names and span["name"] not in self.names:
             return False
         if self.span_kinds and span.get("span_kind") not in self.span_kinds:
             return False
+        if self.attributes:
+            span_attributes = span.get("attributes", {})
+            if any(span_attributes.get(key) != value for key, value in self.attributes):
+                return False
         if self.parent_id is not None:
             expected_parent_id = None if self.parent_id == "null" else self.parent_id
             if span.get("parent_id") != expected_parent_id:

--- a/evals/pxi/online_evals/run.py
+++ b/evals/pxi/online_evals/run.py
@@ -14,13 +14,14 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from phoenix.client import Client
+from phoenix.client.__generated__ import v1
+from phoenix.evals.evaluators import Score
+
 from evals.pxi.online_evals import judge
 from evals.pxi.online_evals.evaluators import EVALUATORS
 from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary, SpanSelector
 from evals.pxi.online_evals.topology import InvalidTurnTrace, span_id, trace_id
-from phoenix.client import Client
-from phoenix.client.__generated__ import v1
-from phoenix.evals.evaluators import Score
 
 logger = logging.getLogger(__name__)
 

--- a/evals/pxi/online_evals/run.py
+++ b/evals/pxi/online_evals/run.py
@@ -14,21 +14,20 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from evals.pxi.online_evals import judge
+from evals.pxi.online_evals.evaluators import EVALUATORS
+from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary, SpanSelector
+from evals.pxi.online_evals.topology import InvalidTurnTrace, span_id, trace_id
 from phoenix.client import Client
 from phoenix.client.__generated__ import v1
 from phoenix.evals.evaluators import Score
-
-from evals.pxi.online_evals import judge
-from evals.pxi.online_evals.evaluators import EVALUATORS
-from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary
-from evals.pxi.online_evals.topology import InvalidTurnTrace, span_id, trace_id
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_LOOKBACK = timedelta(hours=48)
 DEFAULT_SETTLE_DELAY = timedelta(minutes=5)
 DEFAULT_TIMEOUT_SECONDS = 120
-MAX_CANDIDATE_ROOTS = 5_000
+MAX_CANDIDATE_SPANS = 5_000
 MAX_SPANS_PER_BATCH = 10_000
 TRACE_ID_BATCH_SIZE = 100
 ANNOTATION_WRITE_BATCH_SIZE = 100
@@ -71,32 +70,67 @@ def _resolve_identifier(spec: EvaluatorSpec) -> str:
     return spec.identifier
 
 
-def _ended_before(root: v1.Span, cutoff: datetime) -> bool:
-    value = root.get("end_time")
+def _ended_before(span: v1.Span, cutoff: datetime) -> bool:
+    """Whether a candidate target span is settled enough to evaluate.
+
+    Applied to each target's own ``end_time``, not the turn root's, so an
+    inner span is only scored once it has itself finished.
+    """
+    value = span.get("end_time")
     if not isinstance(value, str):
-        logger.warning("skipping root %s without an end time", span_id(root))
+        logger.warning("skipping span %s without an end time", span_id(span))
         return False
     try:
         end_time = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
-        logger.warning("skipping root %s with invalid end time %r", span_id(root), value)
+        logger.warning("skipping span %s with invalid end time %r", span_id(span), value)
         return False
     if end_time.tzinfo is None:
         end_time = end_time.replace(tzinfo=timezone.utc)
     return end_time <= cutoff
 
 
+def _discover_candidates(
+    client: Client,
+    *,
+    project: str,
+    selector: SpanSelector,
+    start_time: datetime,
+    end_time: datetime,
+) -> list[v1.Span]:
+    """Run one discovery query for a selector shared by one or more evaluators."""
+    filters: dict[str, object] = {"name": sorted(selector.names)}
+    if selector.span_kinds:
+        filters["span_kind"] = sorted(selector.span_kinds)
+    if selector.parent_id is not None:
+        filters["parent_id"] = selector.parent_id
+    candidates = client.spans.get_spans(
+        project_identifier=project,
+        start_time=start_time,
+        end_time=end_time,
+        limit=MAX_CANDIDATE_SPANS,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+        **filters,  # type: ignore[arg-type]
+    )
+    if len(candidates) == MAX_CANDIDATE_SPANS:
+        raise RuntimeError(
+            f"candidate discovery for selector {selector} reached its safety limit "
+            f"({MAX_CANDIDATE_SPANS}); reduce the run window"
+        )
+    return list(candidates)
+
+
 def _existing_annotation_keys(
     client: Client,
     *,
     project: str,
-    roots: Sequence[v1.Span],
+    targets: Sequence[v1.Span],
     specs: Sequence[EvaluatorSpec],
 ) -> set[tuple[str, str, str]]:
-    if not roots:
+    if not targets:
         return set()
     annotations = client.spans.get_span_annotations(
-        spans=roots,
+        spans=list(targets),
         project_identifier=project,
         include_annotation_names=sorted({spec.name for spec in specs}),
         timeout=DEFAULT_TIMEOUT_SECONDS,
@@ -186,70 +220,87 @@ async def run_evaluators(
     identifiers = {spec.name: _resolve_identifier(spec) for spec in specs}
 
     current = now or datetime.now(timezone.utc)
-    roots = client.spans.get_spans(
-        project_identifier=project,
-        start_time=current - lookback,
-        end_time=current,
-        parent_id="null",
-        name=sorted({spec.root_span_name for spec in specs}),
-        limit=MAX_CANDIDATE_ROOTS,
-        timeout=DEFAULT_TIMEOUT_SECONDS,
-    )
-    if len(roots) == MAX_CANDIDATE_ROOTS:
-        raise RuntimeError("candidate discovery reached its safety limit; reduce the run window")
-    roots = [root for root in roots if _ended_before(root, current - settle_delay)]
+    settled_cutoff = current - settle_delay
 
-    summaries = {
-        spec.name: RunSummary(discovered=sum(root["name"] == spec.root_span_name for root in roots))
-        for spec in specs
-    }
-    existing = _existing_annotation_keys(client, project=project, roots=roots, specs=specs)
-    pending: list[tuple[EvaluatorSpec, v1.Span]] = []
+    # One discovery query per distinct selector: evaluators that target the
+    # same spans (both turn-root evaluators, say) share a single round trip.
+    by_selector: dict[SpanSelector, list[EvaluatorSpec]] = defaultdict(list)
     for spec in specs:
-        summary = summaries[spec.name]
-        for root in roots:
-            if root["name"] != spec.root_span_name:
-                continue
-            key = (span_id(root), spec.name, identifiers[spec.name])
-            if key in existing:
-                summary.already_annotated += 1
-            elif not _sampled(spec, trace_id(root)):
-                summary.sampled_out += 1
-            else:
-                pending.append((spec, root))
+        by_selector[spec.selector].append(spec)
+
+    summaries = {spec.name: RunSummary() for spec in specs}
+    candidates_by_selector: dict[SpanSelector, list[v1.Span]] = {}
+    for selector in by_selector:
+        discovered = _discover_candidates(
+            client,
+            project=project,
+            selector=selector,
+            start_time=current - lookback,
+            end_time=current,
+        )
+        candidates_by_selector[selector] = [
+            span for span in discovered if _ended_before(span, settled_cutoff)
+        ]
+
+    all_targets = [span for spans in candidates_by_selector.values() for span in spans]
+    existing = _existing_annotation_keys(client, project=project, targets=all_targets, specs=specs)
+    pending: list[tuple[EvaluatorSpec, v1.Span]] = []
+    for selector, selector_specs in by_selector.items():
+        for spec in selector_specs:
+            summary = summaries[spec.name]
+            for target in candidates_by_selector[selector]:
+                if not selector.matches(target):
+                    continue
+                summary.discovered += 1
+                key = (span_id(target), spec.name, identifiers[spec.name])
+                if key in existing:
+                    summary.already_annotated += 1
+                elif not _sampled(spec, trace_id(target)):
+                    # Keyed on the trace, so every target within one turn is
+                    # sampled in or out together.
+                    summary.sampled_out += 1
+                else:
+                    pending.append((spec, target))
 
     traces, oversized_trace_ids = _load_trace_spans(
-        client, project=project, trace_ids=(trace_id(root) for _, root in pending)
+        client, project=project, trace_ids=(trace_id(target) for _, target in pending)
     )
     evaluable: list[tuple[EvaluatorSpec, v1.Span]] = []
-    for spec, root in pending:
-        if trace_id(root) in oversized_trace_ids:
+    for spec, target in pending:
+        if trace_id(target) in oversized_trace_ids:
             summaries[spec.name].errors += 1
         else:
-            evaluable.append((spec, root))
+            evaluable.append((spec, target))
 
     semaphore = asyncio.Semaphore(MAX_CONCURRENT_EVALUATIONS)
 
-    async def _evaluate(spec: EvaluatorSpec, root: v1.Span) -> Score | None:
+    async def _evaluate(spec: EvaluatorSpec, target: v1.Span) -> Score | None:
         async with semaphore:
-            return await spec.evaluate(root, traces.get(trace_id(root), []))
+            return await spec.evaluate(target, traces.get(trace_id(target), []))
 
-    tasks = [(spec, root, asyncio.create_task(_evaluate(spec, root))) for spec, root in evaluable]
+    tasks = [
+        (spec, target, asyncio.create_task(_evaluate(spec, target))) for spec, target in evaluable
+    ]
     annotations: list[v1.SpanAnnotationData] = []
-    for spec, root, task in tasks:
+    for spec, target, task in tasks:
         try:
             result = await task
         except InvalidTurnTrace as error:
             logger.warning(
                 "%s: skipping trace %s because its topology is incomplete: %s",
                 spec.name,
-                trace_id(root),
+                trace_id(target),
                 error,
             )
             summaries[spec.name].record_not_applicable(INCOMPLETE_TOPOLOGY)
             continue
         except Exception:
-            logger.exception("%s failed on trace %s; continuing", spec.name, trace_id(root))
+            logger.exception(
+                "%s failed on trace %s span %s; continuing",
+                spec.name,
+                trace_id(target),
+                span_id(target),
+            )
             summaries[spec.name].errors += 1
             continue
         if result is None:
@@ -259,7 +310,7 @@ async def run_evaluators(
         annotation: v1.SpanAnnotationData = {
             "name": spec.name,
             "annotator_kind": spec.annotator_kind,
-            "span_id": span_id(root),
+            "span_id": span_id(target),
             "identifier": identifiers[spec.name],
             "result": {},
         }

--- a/evals/pxi/online_evals/run.py
+++ b/evals/pxi/online_evals/run.py
@@ -44,6 +44,15 @@ class OversizedTraceError(RuntimeError):
         )
 
 
+class CandidateLimitError(RuntimeError):
+    """Discovery hit its safety limit, so its candidate set is silently truncated.
+
+    Deliberately fatal rather than isolated to one selector: unlike a failed
+    query, this means the run's results would be quietly incomplete, and the
+    fix is to narrow the window rather than to continue.
+    """
+
+
 def _sampled(spec: EvaluatorSpec, artifact_id: str) -> bool:
     """Deterministic sampling keyed on the artifact alone, not the evaluator.
 
@@ -117,7 +126,7 @@ def _discover_candidates(
         **filters,  # type: ignore[arg-type]
     )
     if len(candidates) == MAX_CANDIDATE_SPANS:
-        raise RuntimeError(
+        raise CandidateLimitError(
             f"candidate discovery for selector {selector} reached its safety limit "
             f"({MAX_CANDIDATE_SPANS}); reduce the run window"
         )
@@ -235,13 +244,26 @@ async def run_evaluators(
     summaries = {spec.name: RunSummary() for spec in specs}
     candidates_by_selector: dict[SpanSelector, list[v1.Span]] = {}
     for selector in by_selector:
-        discovered = _discover_candidates(
-            client,
-            project=project,
-            selector=selector,
-            start_time=current - lookback,
-            end_time=current,
-        )
+        try:
+            discovered = _discover_candidates(
+                client,
+                project=project,
+                selector=selector,
+                start_time=current - lookback,
+                end_time=current,
+            )
+        except CandidateLimitError:
+            raise
+        except Exception:
+            # Selectors use different server features (attribute filtering needs
+            # a newer Phoenix than name filtering), so one selector's discovery
+            # failing must not take the other evaluators' results down with it.
+            # Counted as an error so the run still exits non-zero.
+            logger.exception("discovery failed for selector %s; skipping its evaluators", selector)
+            for spec in by_selector[selector]:
+                summaries[spec.name].errors += 1
+            candidates_by_selector[selector] = []
+            continue
         candidates_by_selector[selector] = [
             span for span in discovered if _ended_before(span, settled_cutoff)
         ]
@@ -289,6 +311,8 @@ async def run_evaluators(
     for spec, target, task in tasks:
         try:
             result = await task
+        except CandidateLimitError:
+            raise
         except InvalidTurnTrace as error:
             logger.warning(
                 "%s: skipping trace %s because its topology is incomplete: %s",

--- a/evals/pxi/online_evals/run.py
+++ b/evals/pxi/online_evals/run.py
@@ -45,12 +45,7 @@ class OversizedTraceError(RuntimeError):
 
 
 class CandidateLimitError(RuntimeError):
-    """Discovery hit its safety limit, so its candidate set is silently truncated.
-
-    Deliberately fatal rather than isolated to one selector: unlike a failed
-    query, this means the run's results would be quietly incomplete, and the
-    fix is to narrow the window rather than to continue.
-    """
+    """Raised when discovery may have truncated the candidate set."""
 
 
 def _sampled(spec: EvaluatorSpec, artifact_id: str) -> bool:
@@ -80,11 +75,7 @@ def _resolve_identifier(spec: EvaluatorSpec) -> str:
 
 
 def _ended_before(span: v1.Span, cutoff: datetime) -> bool:
-    """Whether a candidate target span is settled enough to evaluate.
-
-    Applied to each target's own ``end_time``, not the turn root's, so an
-    inner span is only scored once it has itself finished.
-    """
+    """Whether a target span ended before the settle cutoff."""
     value = span.get("end_time")
     if not isinstance(value, str):
         logger.warning("skipping span %s without an end time", span_id(span))
@@ -107,7 +98,6 @@ def _discover_candidates(
     start_time: datetime,
     end_time: datetime,
 ) -> list[v1.Span]:
-    """Run one discovery query for a selector shared by one or more evaluators."""
     filters: dict[str, object] = {}
     if selector.names:
         filters["name"] = sorted(selector.names)
@@ -235,8 +225,6 @@ async def run_evaluators(
     current = now or datetime.now(timezone.utc)
     settled_cutoff = current - settle_delay
 
-    # One discovery query per distinct selector: evaluators that target the
-    # same spans (both turn-root evaluators, say) share a single round trip.
     by_selector: dict[SpanSelector, list[EvaluatorSpec]] = defaultdict(list)
     for spec in specs:
         by_selector[spec.selector].append(spec)
@@ -255,10 +243,6 @@ async def run_evaluators(
         except CandidateLimitError:
             raise
         except Exception:
-            # Selectors use different server features (attribute filtering needs
-            # a newer Phoenix than name filtering), so one selector's discovery
-            # failing must not take the other evaluators' results down with it.
-            # Counted as an error so the run still exits non-zero.
             logger.exception("discovery failed for selector %s; skipping its evaluators", selector)
             for spec in by_selector[selector]:
                 summaries[spec.name].errors += 1
@@ -282,8 +266,6 @@ async def run_evaluators(
                 if key in existing:
                     summary.already_annotated += 1
                 elif not _sampled(spec, trace_id(target)):
-                    # Keyed on the trace, so every target within one turn is
-                    # sampled in or out together.
                     summary.sampled_out += 1
                 else:
                     pending.append((spec, target))

--- a/evals/pxi/online_evals/run.py
+++ b/evals/pxi/online_evals/run.py
@@ -99,11 +99,15 @@ def _discover_candidates(
     end_time: datetime,
 ) -> list[v1.Span]:
     """Run one discovery query for a selector shared by one or more evaluators."""
-    filters: dict[str, object] = {"name": sorted(selector.names)}
+    filters: dict[str, object] = {}
+    if selector.names:
+        filters["name"] = sorted(selector.names)
     if selector.span_kinds:
         filters["span_kind"] = sorted(selector.span_kinds)
     if selector.parent_id is not None:
         filters["parent_id"] = selector.parent_id
+    if selector.attributes:
+        filters["attributes"] = dict(selector.attributes)
     candidates = client.spans.get_spans(
         project_identifier=project,
         start_time=start_time,

--- a/evals/pxi/online_evals/topology.py
+++ b/evals/pxi/online_evals/topology.py
@@ -6,9 +6,17 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from operator import itemgetter
 
+from evals.pxi.online_evals.models import SpanSelector
 from phoenix.client.__generated__ import v1
 
 PXI_TURN_ROOT_NAME = "pxi.turn"
+
+PXI_TURN_ROOT_SELECTOR = SpanSelector(
+    names=(PXI_TURN_ROOT_NAME,),
+    span_kinds=("AGENT",),
+    parent_id="null",
+)
+"""Turn-level evaluators target the `pxi.turn` AGENT root of each trace."""
 
 
 class InvalidTurnTrace(ValueError):

--- a/evals/pxi/online_evals/topology.py
+++ b/evals/pxi/online_evals/topology.py
@@ -6,8 +6,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from operator import itemgetter
 
-from evals.pxi.online_evals.models import SpanSelector
 from phoenix.client.__generated__ import v1
+
+from evals.pxi.online_evals.models import SpanSelector
 
 PXI_TURN_ROOT_NAME = "pxi.turn"
 

--- a/tests/unit/pxi/evals/online_evals/fixtures/pxi_suggestion_traces.json
+++ b/tests/unit/pxi/evals/online_evals/fixtures/pxi_suggestion_traces.json
@@ -96,7 +96,9 @@
         "input.mime_type": "application/json",
         "input.value": "redacted input",
         "output.mime_type": "application/json",
-        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"instanceId\": 5, \"revision\": \"redacted revision\", \"summary\": {\"instanceIndex\": 0, \"instanceLabel\": \"redacted instanceLabel\", \"additions\": 16, \"deletions\": 2}, \"message\": \"redacted message\"}"
+        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"instanceId\": 5, \"revision\": \"redacted revision\", \"summary\": {\"instanceIndex\": 0, \"instanceLabel\": \"redacted instanceLabel\", \"additions\": 16, \"deletions\": 2}, \"message\": \"redacted message\", \"approval\": {\"decision\": \"accepted\", \"source\": \"user\"}}",
+        "pxi.approval.decision": "accepted",
+        "pxi.approval.source": "user"
       }
     },
     {
@@ -136,7 +138,9 @@
         "input.mime_type": "application/json",
         "input.value": "redacted input",
         "output.mime_type": "application/json",
-        "output.value": "{\"status\": \"saved\", \"mode\": \"redacted mode\", \"instanceId\": 5, \"label\": \"redacted label\", \"promptId\": \"redacted promptId\", \"promptName\": \"redacted promptName\", \"promptVersionId\": \"redacted promptVersionId\", \"tag\": null, \"dirtyBeforeSave\": true, \"message\": \"redacted message\", \"approvalStatus\": \"accepted\", \"acceptedBy\": \"user\"}"
+        "output.value": "{\"status\": \"saved\", \"mode\": \"redacted mode\", \"instanceId\": 5, \"label\": \"redacted label\", \"promptId\": \"redacted promptId\", \"promptName\": \"redacted promptName\", \"promptVersionId\": \"redacted promptVersionId\", \"tag\": null, \"dirtyBeforeSave\": true, \"message\": \"redacted message\", \"approvalStatus\": \"accepted\", \"acceptedBy\": \"user\", \"approval\": {\"decision\": \"accepted\", \"source\": \"user\"}}",
+        "pxi.approval.decision": "accepted",
+        "pxi.approval.source": "user"
       }
     },
     {
@@ -333,7 +337,9 @@
         "input.mime_type": "application/json",
         "input.value": "redacted input",
         "output.mime_type": "application/json",
-        "output.value": "{\"status\": \"rejected\", \"instanceId\": 5, \"message\": \"redacted message\"}"
+        "output.value": "{\"status\": \"rejected\", \"instanceId\": 5, \"message\": \"redacted message\", \"approval\": {\"decision\": \"rejected\", \"source\": \"user\"}}",
+        "pxi.approval.decision": "rejected",
+        "pxi.approval.source": "user"
       }
     },
     {
@@ -470,7 +476,9 @@
         "input.mime_type": "application/json",
         "input.value": "redacted input",
         "output.mime_type": "application/json",
-        "output.value": "{\"status\": \"rejected\", \"message\": \"redacted message\"}"
+        "output.value": "{\"status\": \"rejected\", \"message\": \"redacted message\", \"approval\": {\"decision\": \"rejected\", \"source\": \"user\"}}",
+        "pxi.approval.decision": "rejected",
+        "pxi.approval.source": "user"
       }
     },
     {
@@ -550,7 +558,9 @@
         "input.mime_type": "application/json",
         "input.value": "redacted input",
         "output.mime_type": "application/json",
-        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"message\": \"redacted message\"}"
+        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"message\": \"redacted message\", \"approval\": {\"decision\": \"accepted\", \"source\": \"user\"}}",
+        "pxi.approval.decision": "accepted",
+        "pxi.approval.source": "user"
       }
     },
     {
@@ -590,7 +600,9 @@
         "input.mime_type": "application/json",
         "input.value": "redacted input",
         "output.mime_type": "application/json",
-        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"count\": 5, \"annotations\": [{\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}], \"message\": \"redacted message\"}"
+        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"count\": 5, \"annotations\": [{\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}], \"message\": \"redacted message\", \"approval\": {\"decision\": \"accepted\", \"source\": \"user\"}}",
+        "pxi.approval.decision": "accepted",
+        "pxi.approval.source": "user"
       }
     },
     {

--- a/tests/unit/pxi/evals/online_evals/fixtures/pxi_suggestion_traces.json
+++ b/tests/unit/pxi/evals/online_evals/fixtures/pxi_suggestion_traces.json
@@ -1,0 +1,616 @@
+{
+  "accepted_prompt_edit": [
+    {
+      "name": "pxi.turn",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000000"
+      },
+      "span_kind": "AGENT",
+      "parent_id": null,
+      "start_time": "2026-07-24T12:00:00+00:00",
+      "end_time": "2026-07-24T12:00:01+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "text/plain",
+        "input.value": "redacted input",
+        "output.mime_type": "text/plain",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000001"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:02+00:00",
+      "end_time": "2026-07-24T12:00:03+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "read_prompt_instance",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000002"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:04+00:00",
+      "end_time": "2026-07-24T12:00:05+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "read_prompt_instance",
+        "session.id": "session-0000",
+        "tool.id": "call_0002",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000003"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:06+00:00",
+      "end_time": "2026-07-24T12:00:07+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "edit_prompt_instance",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000004"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:08+00:00",
+      "end_time": "2026-07-24T12:00:09+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "edit_prompt_instance",
+        "session.id": "session-0000",
+        "tool.id": "call_0004",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"instanceId\": 5, \"revision\": \"redacted revision\", \"summary\": {\"instanceIndex\": 0, \"instanceLabel\": \"redacted instanceLabel\", \"additions\": 16, \"deletions\": 2}, \"message\": \"redacted message\"}"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000005"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:10+00:00",
+      "end_time": "2026-07-24T12:00:11+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "save_prompt",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000006"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:12+00:00",
+      "end_time": "2026-07-24T12:00:13+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "save_prompt",
+        "session.id": "session-0000",
+        "tool.id": "call_0006",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "{\"status\": \"saved\", \"mode\": \"redacted mode\", \"instanceId\": 5, \"label\": \"redacted label\", \"promptId\": \"redacted promptId\", \"promptName\": \"redacted promptName\", \"promptVersionId\": \"redacted promptVersionId\", \"tag\": null, \"dirtyBeforeSave\": true, \"message\": \"redacted message\", \"approvalStatus\": \"accepted\", \"acceptedBy\": \"user\"}"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000007"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:14+00:00",
+      "end_time": "2026-07-24T12:00:15+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "open_llm_evaluator_form",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000008"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:16+00:00",
+      "end_time": "2026-07-24T12:00:17+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "open_llm_evaluator_form",
+        "session.id": "session-0000",
+        "tool.id": "call_0008",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "00000000000000000015bfc9bdc170aa",
+        "span_id": "0000000000000009"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:18+00:00",
+      "end_time": "2026-07-24T12:00:19+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    }
+  ],
+  "rejected_prompt_edit": [
+    {
+      "name": "pxi.turn",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000000"
+      },
+      "span_kind": "AGENT",
+      "parent_id": null,
+      "start_time": "2026-07-24T12:00:00+00:00",
+      "end_time": "2026-07-24T12:00:01+00:00",
+      "status_code": "ERROR",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "text/plain",
+        "input.value": "redacted input"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000001"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:02+00:00",
+      "end_time": "2026-07-24T12:00:03+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "load_skill",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000002"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:04+00:00",
+      "end_time": "2026-07-24T12:00:05+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "load_skill",
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "text/plain",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000003"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:06+00:00",
+      "end_time": "2026-07-24T12:00:07+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "read_prompt_instance",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000004"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:08+00:00",
+      "end_time": "2026-07-24T12:00:09+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "read_prompt_instance",
+        "session.id": "session-0000",
+        "tool.id": "call_0004",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000005"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:10+00:00",
+      "end_time": "2026-07-24T12:00:11+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "edit_prompt_instance",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000006"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:12+00:00",
+      "end_time": "2026-07-24T12:00:13+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "edit_prompt_instance",
+        "session.id": "session-0000",
+        "tool.id": "call_0006",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "{\"status\": \"rejected\", \"instanceId\": 5, \"message\": \"redacted message\"}"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000007"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:14+00:00",
+      "end_time": "2026-07-24T12:00:15+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "open_llm_evaluator_form",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000008"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:16+00:00",
+      "end_time": "2026-07-24T12:00:17+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "open_llm_evaluator_form",
+        "session.id": "session-0000",
+        "tool.id": "call_0008",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "0000000000000009"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:18+00:00",
+      "end_time": "2026-07-24T12:00:19+00:00",
+      "status_code": "UNSET",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input"
+      }
+    },
+    {
+      "name": "gpt-5.5",
+      "context": {
+        "trace_id": "000000000000000003e86c1ad72fb951",
+        "span_id": "000000000000000a"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:20+00:00",
+      "end_time": "2026-07-24T12:00:21+00:00",
+      "status_code": "UNSET",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    }
+  ],
+  "mixed_annotation_config": [
+    {
+      "name": "pxi.turn",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000000"
+      },
+      "span_kind": "AGENT",
+      "parent_id": null,
+      "start_time": "2026-07-24T12:00:00+00:00",
+      "end_time": "2026-07-24T12:00:01+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "text/plain",
+        "input.value": "redacted input",
+        "output.mime_type": "text/plain",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "gpt-5.6-sol",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000001"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:02+00:00",
+      "end_time": "2026-07-24T12:00:03+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "update_annotation_config",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000002"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:04+00:00",
+      "end_time": "2026-07-24T12:00:05+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "update_annotation_config",
+        "session.id": "session-0000",
+        "tool.id": "call_0002",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "{\"status\": \"rejected\", \"message\": \"redacted message\"}"
+      }
+    },
+    {
+      "name": "gpt-5.6-sol",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000003"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:06+00:00",
+      "end_time": "2026-07-24T12:00:07+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "ask_user",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000004"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:08+00:00",
+      "end_time": "2026-07-24T12:00:09+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "ask_user",
+        "session.id": "session-0000",
+        "tool.id": "call_0004",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "gpt-5.6-sol",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000005"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:10+00:00",
+      "end_time": "2026-07-24T12:00:11+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "update_annotation_config",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000006"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:12+00:00",
+      "end_time": "2026-07-24T12:00:13+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "update_annotation_config",
+        "session.id": "session-0000",
+        "tool.id": "call_0006",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"message\": \"redacted message\"}"
+      }
+    },
+    {
+      "name": "gpt-5.6-sol",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000007"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:14+00:00",
+      "end_time": "2026-07-24T12:00:15+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    },
+    {
+      "name": "batch_span_annotate",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000008"
+      },
+      "span_kind": "TOOL",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:16+00:00",
+      "end_time": "2026-07-24T12:00:17+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "tool.name": "batch_span_annotate",
+        "session.id": "session-0000",
+        "tool.id": "call_0008",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "{\"status\": \"accepted\", \"acceptedBy\": \"user\", \"count\": 5, \"annotations\": [{\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}, {\"spanId\": \"redacted spanId\", \"spanNodeId\": null, \"name\": \"redacted name\", \"label\": \"redacted label\", \"score\": 1, \"explanation\": \"redacted explanation\"}], \"message\": \"redacted message\"}"
+      }
+    },
+    {
+      "name": "gpt-5.6-sol",
+      "context": {
+        "trace_id": "00000000000000001bf57a831f82dc02",
+        "span_id": "0000000000000009"
+      },
+      "span_kind": "LLM",
+      "parent_id": "0000000000000000",
+      "start_time": "2026-07-24T12:00:18+00:00",
+      "end_time": "2026-07-24T12:00:19+00:00",
+      "status_code": "OK",
+      "attributes": {
+        "session.id": "session-0000",
+        "input.mime_type": "application/json",
+        "input.value": "redacted input",
+        "output.mime_type": "application/json",
+        "output.value": "redacted output"
+      }
+    }
+  ]
+}

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -11,6 +11,10 @@ from unittest import mock
 import pytest
 
 from evals.pxi.online_evals import run as run_module
+from evals.pxi.online_evals.evaluators.suggestion_accepted import (
+    APPROVAL_GATED_TOOLS,
+    SUGGESTION_ACCEPTED,
+)
 from evals.pxi.online_evals.evaluators.tool_count_per_turn import TOOL_COUNT_PER_TURN
 from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary
 from evals.pxi.online_evals.run import _fetch_batch_spans, _sampled, run_evaluators
@@ -46,11 +50,11 @@ def _span(
 class _FakeSpans:
     def __init__(
         self,
-        roots: list[v1.Span],
+        candidates: list[v1.Span],
         traces: dict[str, list[v1.Span]],
         annotations: list[v1.SpanAnnotation],
     ) -> None:
-        self.roots = roots
+        self.candidates = candidates
         self.traces = traces
         self.annotations = annotations
         self.hydrated_trace_ids: list[str] = []
@@ -65,7 +69,18 @@ class _FakeSpans:
         if trace_ids := kwargs.get("trace_ids"):
             self.hydrated_trace_ids.extend(trace_ids)
             return [span for trace_id in trace_ids for span in self.traces[trace_id]]
-        return self.roots
+        # Discovery: apply the same filters the server would, so a test with
+        # two selectors sees each query return only its own candidates.
+        names = kwargs.get("name")
+        kinds = kwargs.get("span_kind")
+        parent_id = kwargs.get("parent_id")
+        return [
+            span
+            for span in self.candidates
+            if (names is None or span["name"] in names)
+            and (kinds is None or span["span_kind"] in kinds)
+            and (parent_id != "null" or span.get("parent_id") is None)
+        ]
 
     def get_span_annotations(self, **_: Any) -> list[v1.SpanAnnotation]:
         return self.annotations
@@ -707,3 +722,280 @@ def test_project_defaults_from_environment(variable: str) -> None:
         args = run_module.build_arg_parser().parse_args([])
 
     assert args.project == "configured-project"
+
+
+# --- mixed root and TOOL targeting ---------------------------------------
+
+
+def _approval_tool(
+    span_id: str,
+    *,
+    trace_id: str,
+    parent_id: str,
+    output: dict[str, Any],
+    name: str = "edit_prompt_instance",
+) -> v1.Span:
+    span = _span(span_id, trace_id=trace_id, name=name, kind="TOOL", parent_id=parent_id)
+    span["attributes"] = {"tool.name": name, "output.value": output}
+    return span
+
+
+def _accepted(span_id: str, *, trace_id: str, parent_id: str) -> v1.Span:
+    return _approval_tool(
+        span_id,
+        trace_id=trace_id,
+        parent_id=parent_id,
+        output={"status": "accepted", "acceptedBy": "user"},
+    )
+
+
+def _rejected(span_id: str, *, trace_id: str, parent_id: str) -> v1.Span:
+    return _approval_tool(
+        span_id, trace_id=trace_id, parent_id=parent_id, output={"status": "rejected"}
+    )
+
+
+def _discovery_requests(spans: _FakeSpans) -> list[dict[str, Any]]:
+    return [request for request in spans.get_spans_requests if "trace_ids" not in request]
+
+
+def test_both_root_evaluators_share_one_discovery_query() -> None:
+    """Identical selectors are grouped, so two turn evaluators cost one query."""
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    spans = _FakeSpans([root], {"trace": [root]}, [])
+
+    async def stub(_target: v1.Span, _spans: Any) -> Score:
+        return Score(score=1.0)
+
+    specs = [
+        replace(TOOL_COUNT_PER_TURN, name="first", evaluate=stub),
+        replace(TOOL_COUNT_PER_TURN, name="second", evaluate=stub),
+    ]
+    summaries = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=specs,
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )
+
+    assert len(_discovery_requests(spans)) == 1
+    assert summaries["first"].discovered == 1
+    assert summaries["second"].discovered == 1
+
+
+def test_tool_selector_issues_its_own_unparented_query() -> None:
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    tool = _accepted("tool", trace_id="trace", parent_id="root")
+    spans = _FakeSpans([root, tool], {"trace": [root, tool]}, [])
+
+    _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[SUGGESTION_ACCEPTED],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )
+
+    (request,) = _discovery_requests(spans)
+    assert "parent_id" not in request
+    assert request["span_kind"] == ["TOOL"]
+    assert request["name"] == sorted(APPROVAL_GATED_TOOLS)
+
+
+def test_mixed_selectors_each_receive_only_their_own_candidates() -> None:
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    tool = _rejected("tool", trace_id="trace", parent_id="root")
+    spans = _FakeSpans([root, tool], {"trace": [root, tool]}, [])
+
+    summaries = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[TOOL_COUNT_PER_TURN, SUGGESTION_ACCEPTED],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )
+
+    assert len(_discovery_requests(spans)) == 2
+    assert summaries["tool_count_per_turn"].discovered == 1
+    assert summaries["suggestion_accepted"].discovered == 1
+    assert {(annotation["name"], annotation["span_id"]) for annotation in spans.writes} == {
+        ("tool_count_per_turn", "root"),
+        ("suggestion_accepted", "tool"),
+    }
+
+
+def test_multiple_targets_in_one_trace_hydrate_once_and_annotate_separately() -> None:
+    """One turn can contain suggestions the user decided differently; each
+    TOOL span keeps its own outcome rather than collapsing to a turn label."""
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    rejected = _rejected("tool-rejected", trace_id="trace", parent_id="root")
+    accepted = _accepted("tool-accepted", trace_id="trace", parent_id="root")
+    spans = _FakeSpans([root, rejected, accepted], {"trace": [root, rejected, accepted]}, [])
+
+    summary = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[SUGGESTION_ACCEPTED],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )["suggestion_accepted"]
+
+    assert spans.hydrated_trace_ids == ["trace"]
+    assert summary.discovered == 2
+    assert summary.evaluated == 2
+    assert {
+        annotation["span_id"]: annotation["result"]["label"] for annotation in spans.writes
+    } == {"tool-rejected": "rejected", "tool-accepted": "accepted"}
+
+
+def test_checkpoint_on_one_target_does_not_suppress_another_in_the_same_trace() -> None:
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    done = _accepted("tool-done", trace_id="trace", parent_id="root")
+    todo = _rejected("tool-todo", trace_id="trace", parent_id="root")
+    existing: v1.SpanAnnotation = {
+        **_existing("tool-done", identifier=SUGGESTION_ACCEPTED.identifier),
+        "name": "suggestion_accepted",
+    }
+    spans = _FakeSpans([root, done, todo], {"trace": [root, done, todo]}, [existing])
+
+    summary = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[SUGGESTION_ACCEPTED],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )["suggestion_accepted"]
+
+    assert summary.discovered == 2
+    assert summary.already_annotated == 1
+    assert summary.evaluated == 1
+    assert [annotation["span_id"] for annotation in spans.writes] == ["tool-todo"]
+
+
+@pytest.mark.parametrize("sample_rate", [1.0, 0.0])
+def test_sampling_includes_or_excludes_every_target_in_a_trace(sample_rate: float) -> None:
+    """Sampling is keyed on trace_id, so a turn is never partially annotated."""
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    first = _accepted("tool-1", trace_id="trace", parent_id="root")
+    second = _rejected("tool-2", trace_id="trace", parent_id="root")
+    spans = _FakeSpans([root, first, second], {"trace": [root, first, second]}, [])
+
+    summary = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[replace(SUGGESTION_ACCEPTED, sample_rate=sample_rate)],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )["suggestion_accepted"]
+
+    assert summary.discovered == 2
+    assert (summary.evaluated, summary.sampled_out) == ((2, 0) if sample_rate else (0, 2))
+
+
+def test_settle_delay_applies_to_a_non_root_target_end_time() -> None:
+    """An in-flight TOOL span waits for the next run even though its root settled."""
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    root["end_time"] = "2026-07-09T01:00:00+00:00"
+    settled = _accepted("tool-settled", trace_id="trace", parent_id="root")
+    settled["end_time"] = "2026-07-09T01:50:00+00:00"
+    recent = _accepted("tool-recent", trace_id="trace", parent_id="root")
+    recent["end_time"] = "2026-07-09T01:59:00+00:00"
+    spans = _FakeSpans([root, settled, recent], {"trace": [root, settled, recent]}, [])
+
+    summary = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[SUGGESTION_ACCEPTED],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )["suggestion_accepted"]
+
+    assert summary.discovered == 1
+    assert [annotation["span_id"] for annotation in spans.writes] == ["tool-settled"]
+
+
+def test_candidate_limit_failure_identifies_the_offending_selector() -> None:
+    tools = [
+        _accepted(f"tool-{index}", trace_id=f"trace-{index}", parent_id="root")
+        for index in range(2)
+    ]
+    spans = _FakeSpans(tools, {}, [])
+
+    with (
+        mock.patch.object(run_module, "MAX_CANDIDATE_SPANS", 2),
+        pytest.raises(RuntimeError, match="candidate discovery for selector .*TOOL"),
+    ):
+        _run(
+            _FakeClient(spans),
+            project="pxi_dev",
+            specs=[SUGGESTION_ACCEPTED],
+            now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+        )
+
+
+def test_failure_on_one_target_is_isolated_from_its_sibling() -> None:
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    failing = _accepted("tool-failing", trace_id="trace", parent_id="root")
+    healthy = _accepted("tool-healthy", trace_id="trace", parent_id="root")
+    spans = _FakeSpans([root, failing, healthy], {"trace": [root, failing, healthy]}, [])
+
+    async def evaluate(target: v1.Span, trace_spans: Any) -> Any:
+        if target["context"]["span_id"] == "tool-failing":
+            raise ValueError("malformed output")
+        return await SUGGESTION_ACCEPTED.evaluate(target, trace_spans)
+
+    summary = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[replace(SUGGESTION_ACCEPTED, evaluate=evaluate)],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )["suggestion_accepted"]
+
+    assert (summary.errors, summary.evaluated) == (1, 1)
+    assert [annotation["span_id"] for annotation in spans.writes] == ["tool-healthy"]
+
+
+def test_non_root_targets_batch_and_respect_dry_run() -> None:
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    tools = [_accepted(f"tool-{index}", trace_id="trace", parent_id="root") for index in range(3)]
+    spans = _FakeSpans([root, *tools], {"trace": [root, *tools]}, [])
+
+    with mock.patch.object(run_module, "ANNOTATION_WRITE_BATCH_SIZE", 2):
+        batched = _run(
+            _FakeClient(spans),
+            project="pxi_dev",
+            specs=[SUGGESTION_ACCEPTED],
+            now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+        )["suggestion_accepted"]
+
+    assert [len(batch) for batch in spans.write_batches] == [2, 1]
+    assert batched.annotations == 3
+
+    dry_spans = _FakeSpans([root, *tools], {"trace": [root, *tools]}, [])
+    dry = _run(
+        _FakeClient(dry_spans),
+        project="pxi_dev",
+        specs=[SUGGESTION_ACCEPTED],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+        dry_run=True,
+    )["suggestion_accepted"]
+
+    assert dry.annotations == 3
+    assert dry_spans.writes == []
+
+
+def test_suggestion_accepted_needs_no_judge_credentials() -> None:
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    tool = _accepted("tool", trace_id="trace", parent_id="root")
+    spans = _FakeSpans([root, tool], {"trace": [root, tool]}, [])
+
+    with mock.patch.dict("os.environ", {}, clear=True):
+        summary = _run(
+            _FakeClient(spans),
+            project="pxi_dev",
+            specs=[SUGGESTION_ACCEPTED],
+            now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+        )["suggestion_accepted"]
+
+    assert summary.evaluated == 1
+
+
+def test_cli_help_lists_the_suggestion_evaluator() -> None:
+    action = next(
+        action for action in run_module.build_arg_parser()._actions if action.dest == "eval"
+    )
+    assert "suggestion_accepted" in (action.choices or [])

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -70,8 +70,7 @@ class _FakeSpans:
         if trace_ids := kwargs.get("trace_ids"):
             self.hydrated_trace_ids.extend(trace_ids)
             return [span for trace_id in trace_ids for span in self.traces[trace_id]]
-        # Discovery: apply the same filters the server would, so a test with
-        # two selectors sees each query return only its own candidates.
+        # Mirror server-side discovery filtering.
         names = kwargs.get("name")
         kinds = kwargs.get("span_kind")
         parent_id = kwargs.get("parent_id")
@@ -248,9 +247,13 @@ def test_span_selector_rejects_empty_span_names(names: tuple[str, ...]) -> None:
 
 
 def test_span_selector_requires_a_bounding_filter() -> None:
-    """Without a name or attribute filter, discovery would sweep the whole window."""
     with pytest.raises(ValueError, match="at least one name or attribute"):
         SpanSelector(span_kinds=("TOOL",))
+
+
+def test_span_selector_rejects_empty_span_kinds() -> None:
+    with pytest.raises(ValueError, match="non-empty strings"):
+        SpanSelector(names=("pxi.turn",), span_kinds=("",))
 
 
 def test_span_selector_matches_on_attributes() -> None:
@@ -765,9 +768,6 @@ def test_project_defaults_from_environment(variable: str) -> None:
     assert args.project == "configured-project"
 
 
-# --- mixed root and TOOL targeting ---------------------------------------
-
-
 def _approval_tool(
     span_id: str,
     *,
@@ -799,7 +799,6 @@ def _discovery_requests(spans: _FakeSpans) -> list[dict[str, Any]]:
 
 
 def test_both_root_evaluators_share_one_discovery_query() -> None:
-    """Identical selectors are grouped, so two turn evaluators cost one query."""
     root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
     spans = _FakeSpans([root], {"trace": [root]}, [])
 
@@ -837,7 +836,6 @@ def test_tool_selector_issues_its_own_unparented_query() -> None:
     (request,) = _discovery_requests(spans)
     assert "parent_id" not in request
     assert request["span_kind"] == ["TOOL"]
-    # Discovery is by recorded decision, not by a hand-maintained tool list.
     assert "name" not in request
     assert request["attributes"] == {APPROVAL_SOURCE_ATTRIBUTE: "user"}
 
@@ -864,8 +862,6 @@ def test_mixed_selectors_each_receive_only_their_own_candidates() -> None:
 
 
 def test_multiple_targets_in_one_trace_hydrate_once_and_annotate_separately() -> None:
-    """One turn can contain suggestions the user decided differently; each
-    TOOL span keeps its own outcome rather than collapsing to a turn label."""
     root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
     rejected = _rejected("tool-rejected", trace_id="trace", parent_id="root")
     accepted = _accepted("tool-accepted", trace_id="trace", parent_id="root")
@@ -911,7 +907,6 @@ def test_checkpoint_on_one_target_does_not_suppress_another_in_the_same_trace() 
 
 @pytest.mark.parametrize("sample_rate", [1.0, 0.0])
 def test_sampling_includes_or_excludes_every_target_in_a_trace(sample_rate: float) -> None:
-    """Sampling is keyed on trace_id, so a turn is never partially annotated."""
     root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
     first = _accepted("tool-1", trace_id="trace", parent_id="root")
     second = _rejected("tool-2", trace_id="trace", parent_id="root")
@@ -929,7 +924,6 @@ def test_sampling_includes_or_excludes_every_target_in_a_trace(sample_rate: floa
 
 
 def test_settle_delay_applies_to_a_non_root_target_end_time() -> None:
-    """An in-flight TOOL span waits for the next run even though its root settled."""
     root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
     root["end_time"] = "2026-07-09T01:00:00+00:00"
     settled = _accepted("tool-settled", trace_id="trace", parent_id="root")
@@ -1042,12 +1036,7 @@ def test_cli_help_lists_the_suggestion_evaluator() -> None:
     assert "suggestion_accepted" in (action.choices or [])
 
 
-def test_one_selectors_discovery_failure_does_not_sink_the_other_evaluators() -> None:
-    """Selectors use different server features, so they can fail independently.
-
-    Attribute filtering needs a newer Phoenix than name filtering; a server that
-    rejects it must not take the turn-root evaluators down with it.
-    """
+def test_one_selector_discovery_failure_does_not_sink_other_evaluators() -> None:
     root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
     spans = _FakeSpans([root], {"trace": [root]}, [])
     real_get_spans = spans.get_spans

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -12,7 +12,8 @@ import pytest
 
 from evals.pxi.online_evals import run as run_module
 from evals.pxi.online_evals.evaluators.suggestion_accepted import (
-    APPROVAL_GATED_TOOLS,
+    APPROVAL_DECISION_ATTRIBUTE,
+    APPROVAL_SOURCE_ATTRIBUTE,
     SUGGESTION_ACCEPTED,
 )
 from evals.pxi.online_evals.evaluators.tool_count_per_turn import TOOL_COUNT_PER_TURN
@@ -236,10 +237,29 @@ def test_evaluator_spec_requires_explicit_annotator_kind() -> None:
         )
 
 
-@pytest.mark.parametrize("names", [(), ("",), ("pxi.turn", "")])
-def test_span_selector_requires_non_empty_names(names: tuple[str, ...]) -> None:
-    with pytest.raises(ValueError, match="non-empty span names|at least one span name"):
+@pytest.mark.parametrize("names", [("",), ("pxi.turn", "")])
+def test_span_selector_rejects_empty_span_names(names: tuple[str, ...]) -> None:
+    with pytest.raises(ValueError, match="non-empty span names"):
         SpanSelector(names=names)
+
+
+def test_span_selector_requires_a_bounding_filter() -> None:
+    """Without a name or attribute filter, discovery would sweep the whole window."""
+    with pytest.raises(ValueError, match="at least one name or attribute"):
+        SpanSelector(span_kinds=("TOOL",))
+
+
+def test_span_selector_matches_on_attributes() -> None:
+    selector = SpanSelector(attributes={APPROVAL_SOURCE_ATTRIBUTE: "user"})
+    matching = _accepted("matching", trace_id="trace", parent_id="root")
+    auto = _approval_tool(
+        "auto", trace_id="trace", parent_id="root", decision="accepted", source="auto"
+    )
+    unmarked = _span("plain", trace_id="trace", name="read_prompt", kind="TOOL", parent_id="root")
+
+    assert selector.matches(matching)
+    assert not selector.matches(auto)
+    assert not selector.matches(unmarked)
 
 
 def test_span_selector_matches_a_concrete_parent_id() -> None:
@@ -749,27 +769,25 @@ def _approval_tool(
     *,
     trace_id: str,
     parent_id: str,
-    output: dict[str, Any],
+    decision: str,
+    source: str = "user",
     name: str = "edit_prompt_instance",
 ) -> v1.Span:
     span = _span(span_id, trace_id=trace_id, name=name, kind="TOOL", parent_id=parent_id)
-    span["attributes"] = {"tool.name": name, "output.value": output}
+    span["attributes"] = {
+        "tool.name": name,
+        APPROVAL_DECISION_ATTRIBUTE: decision,
+        APPROVAL_SOURCE_ATTRIBUTE: source,
+    }
     return span
 
 
 def _accepted(span_id: str, *, trace_id: str, parent_id: str) -> v1.Span:
-    return _approval_tool(
-        span_id,
-        trace_id=trace_id,
-        parent_id=parent_id,
-        output={"status": "accepted", "acceptedBy": "user"},
-    )
+    return _approval_tool(span_id, trace_id=trace_id, parent_id=parent_id, decision="accepted")
 
 
 def _rejected(span_id: str, *, trace_id: str, parent_id: str) -> v1.Span:
-    return _approval_tool(
-        span_id, trace_id=trace_id, parent_id=parent_id, output={"status": "rejected"}
-    )
+    return _approval_tool(span_id, trace_id=trace_id, parent_id=parent_id, decision="rejected")
 
 
 def _discovery_requests(spans: _FakeSpans) -> list[dict[str, Any]]:
@@ -815,7 +833,9 @@ def test_tool_selector_issues_its_own_unparented_query() -> None:
     (request,) = _discovery_requests(spans)
     assert "parent_id" not in request
     assert request["span_kind"] == ["TOOL"]
-    assert request["name"] == sorted(APPROVAL_GATED_TOOLS)
+    # Discovery is by recorded decision, not by a hand-maintained tool list.
+    assert "name" not in request
+    assert request["attributes"] == {APPROVAL_SOURCE_ATTRIBUTE: "user"}
 
 
 def test_mixed_selectors_each_receive_only_their_own_candidates() -> None:

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -16,7 +16,7 @@ from evals.pxi.online_evals.evaluators.suggestion_accepted import (
     SUGGESTION_ACCEPTED,
 )
 from evals.pxi.online_evals.evaluators.tool_count_per_turn import TOOL_COUNT_PER_TURN
-from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary
+from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary, SpanSelector
 from evals.pxi.online_evals.run import _fetch_batch_spans, _sampled, run_evaluators
 from phoenix.client.__generated__ import v1
 from phoenix.evals.evaluators import Score
@@ -234,6 +234,23 @@ def test_evaluator_spec_requires_explicit_annotator_kind() -> None:
             selector=TOOL_COUNT_PER_TURN.selector,
             evaluate=TOOL_COUNT_PER_TURN.evaluate,
         )
+
+
+@pytest.mark.parametrize("names", [(), ("",), ("pxi.turn", "")])
+def test_span_selector_requires_non_empty_names(names: tuple[str, ...]) -> None:
+    with pytest.raises(ValueError, match="non-empty span names|at least one span name"):
+        SpanSelector(names=names)
+
+
+def test_span_selector_matches_a_concrete_parent_id() -> None:
+    selector = SpanSelector(names=("tool",), parent_id="expected-parent")
+    matching = _span(
+        "matching", trace_id="trace", name="tool", kind="TOOL", parent_id="expected-parent"
+    )
+    sibling = _span("sibling", trace_id="trace", name="tool", kind="TOOL", parent_id="other-parent")
+
+    assert selector.matches(matching)
+    assert not selector.matches(sibling)
 
 
 def test_filters_existing_annotations_before_hydrating_traces() -> None:

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -75,12 +75,16 @@ class _FakeSpans:
         names = kwargs.get("name")
         kinds = kwargs.get("span_kind")
         parent_id = kwargs.get("parent_id")
+        attributes: dict[str, str] = kwargs.get("attributes") or {}
         return [
             span
             for span in self.candidates
             if (names is None or span["name"] in names)
             and (kinds is None or span["span_kind"] in kinds)
             and (parent_id != "null" or span.get("parent_id") is None)
+            and all(
+                span.get("attributes", {}).get(key) == value for key, value in attributes.items()
+            )
         ]
 
     def get_span_annotations(self, **_: Any) -> list[v1.SpanAnnotation]:
@@ -1036,3 +1040,33 @@ def test_cli_help_lists_the_suggestion_evaluator() -> None:
         action for action in run_module.build_arg_parser()._actions if action.dest == "eval"
     )
     assert "suggestion_accepted" in (action.choices or [])
+
+
+def test_one_selectors_discovery_failure_does_not_sink_the_other_evaluators() -> None:
+    """Selectors use different server features, so they can fail independently.
+
+    Attribute filtering needs a newer Phoenix than name filtering; a server that
+    rejects it must not take the turn-root evaluators down with it.
+    """
+    root = _span("root", trace_id="trace", name="pxi.turn", kind="AGENT", parent_id=None)
+    spans = _FakeSpans([root], {"trace": [root]}, [])
+    real_get_spans = spans.get_spans
+
+    def failing_for_attribute_queries(**kwargs: Any) -> list[v1.Span]:
+        if kwargs.get("attributes"):
+            raise RuntimeError("server too old for attribute filtering")
+        return real_get_spans(**kwargs)
+
+    spans.get_spans = failing_for_attribute_queries  # type: ignore[method-assign]
+
+    summaries = _run(
+        _FakeClient(spans),
+        project="pxi_dev",
+        specs=[TOOL_COUNT_PER_TURN, SUGGESTION_ACCEPTED],
+        now=datetime(2026, 7, 9, 2, tzinfo=timezone.utc),
+    )
+
+    assert summaries["tool_count_per_turn"].discovered == 1
+    assert summaries["tool_count_per_turn"].annotations == 1
+    assert summaries["suggestion_accepted"].discovered == 0
+    assert summaries["suggestion_accepted"].errors == 1

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -9,13 +9,13 @@ from typing import Any
 from unittest import mock
 
 import pytest
-from phoenix.client.__generated__ import v1
-from phoenix.evals.evaluators import Score
 
 from evals.pxi.online_evals import run as run_module
 from evals.pxi.online_evals.evaluators.tool_count_per_turn import TOOL_COUNT_PER_TURN
 from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary
 from evals.pxi.online_evals.run import _fetch_batch_spans, _sampled, run_evaluators
+from phoenix.client.__generated__ import v1
+from phoenix.evals.evaluators import Score
 
 
 def _run(*args: Any, **kwargs: Any) -> dict[str, RunSummary]:
@@ -216,7 +216,7 @@ def test_evaluator_spec_requires_explicit_annotator_kind() -> None:
     with pytest.raises(TypeError, match="annotator_kind"):
         EvaluatorSpec(  # type: ignore[call-arg]
             name="ambiguous",
-            root_span_name="pxi.turn",
+            selector=TOOL_COUNT_PER_TURN.selector,
             evaluate=TOOL_COUNT_PER_TURN.evaluate,
         )
 

--- a/tests/unit/pxi/evals/online_evals/test_run.py
+++ b/tests/unit/pxi/evals/online_evals/test_run.py
@@ -9,6 +9,8 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from phoenix.client.__generated__ import v1
+from phoenix.evals.evaluators import Score
 
 from evals.pxi.online_evals import run as run_module
 from evals.pxi.online_evals.evaluators.suggestion_accepted import (
@@ -19,8 +21,6 @@ from evals.pxi.online_evals.evaluators.suggestion_accepted import (
 from evals.pxi.online_evals.evaluators.tool_count_per_turn import TOOL_COUNT_PER_TURN
 from evals.pxi.online_evals.models import EvaluatorSpec, RunSummary, SpanSelector
 from evals.pxi.online_evals.run import _fetch_batch_spans, _sampled, run_evaluators
-from phoenix.client.__generated__ import v1
-from phoenix.evals.evaluators import Score
 
 
 def _run(*args: Any, **kwargs: Any) -> dict[str, RunSummary]:

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
@@ -50,9 +50,6 @@ def _evaluate(span: v1.Span) -> Any:
     return asyncio.run(evaluate_suggestion_accepted(span, [span]))
 
 
-# --- spec / registration -------------------------------------------------
-
-
 def test_spec_configuration() -> None:
     assert SUGGESTION_ACCEPTED.name == "suggestion_accepted"
     assert SUGGESTION_ACCEPTED.annotator_kind == "CODE"
@@ -62,27 +59,6 @@ def test_spec_configuration() -> None:
         span_kinds=("TOOL",),
         attributes={APPROVAL_SOURCE_ATTRIBUTE: "user"},
     )
-
-
-def test_selector_names_no_tools() -> None:
-    """The point of the marker: discovery must not depend on a tool allowlist.
-
-    A newly approval-gated tool is covered the day it ships, with no change here.
-    """
-    assert SUGGESTION_ACCEPTED.selector.names == ()
-
-
-def test_selector_targets_tool_spans_anywhere_in_the_trace() -> None:
-    """Approval-gated tools are not roots, so discovery must not restrict parents."""
-    assert SUGGESTION_ACCEPTED.selector.parent_id is None
-
-
-def test_selector_excludes_automatic_accepts_at_discovery() -> None:
-    """Bypass-mode accepts are not evidence of what a user wanted."""
-    assert SUGGESTION_ACCEPTED.selector.attributes == ((APPROVAL_SOURCE_ATTRIBUTE, "user"),)
-
-
-# --- acceptance ----------------------------------------------------------
 
 
 def test_manual_acceptance_scores_one() -> None:
@@ -98,12 +74,7 @@ def test_manual_acceptance_scores_one() -> None:
 
 
 @pytest.mark.parametrize("tool_name", ["save_prompt", "load_dataset", "create_dataset"])
-def test_accept_vocabulary_no_longer_matters(tool_name: str) -> None:
-    """Tools disagree on their success word (`saved`, `loaded`, ...).
-
-    The marker is uniform, so classification is identical across all of them —
-    including tools that were missing from the old hand-maintained allowlist.
-    """
+def test_acceptance_uses_marker_across_tool_output_shapes(tool_name: str) -> None:
     score = _evaluate(
         _tool_span(
             tool_name=tool_name,
@@ -132,9 +103,6 @@ def test_tool_name_falls_back_to_the_span_name() -> None:
     assert score.metadata == {"tool_name": "load_dataset"}
 
 
-# --- rejection -----------------------------------------------------------
-
-
 def test_explicit_rejection_scores_zero() -> None:
     score = _evaluate(_tool_span(decision="rejected", source="user"))
 
@@ -143,9 +111,6 @@ def test_explicit_rejection_scores_zero() -> None:
     assert score.score == 0.0
     assert score.explanation == "user rejected the edit_prompt_instance suggestion"
     assert score.metadata == {"tool_name": "edit_prompt_instance"}
-
-
-# --- not applicable ------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -167,7 +132,6 @@ def test_non_user_decisions_are_not_annotated(case: str, decision: Any, source: 
     ["no marker at all", "decision only", "source only"],
 )
 def test_unmarked_spans_are_not_annotated(case: str) -> None:
-    """Cancellations, errors, and still-pending approvals carry no marker."""
     kwargs: dict[str, Any] = {}
     if case == "decision only":
         kwargs["decision"] = "accepted"
@@ -177,11 +141,6 @@ def test_unmarked_spans_are_not_annotated(case: str) -> None:
 
 
 def test_output_payload_never_drives_classification() -> None:
-    """Only the promoted attributes decide; a look-alike payload must not leak in.
-
-    This is what lets a read-only tool carry `status: "rejected"` in its own
-    output without being mistaken for an approval decision.
-    """
     assert (
         _evaluate(
             _tool_span(
@@ -212,21 +171,3 @@ def test_annotation_never_carries_the_raw_payload() -> None:
     assert score.metadata == {"tool_name": "edit_prompt_instance"}
     assert secret not in json.dumps({"e": score.explanation, "m": score.metadata})
     assert "prompt-abc123" not in json.dumps({"e": score.explanation, "m": score.metadata})
-
-
-def test_attribute_names_match_the_server_that_writes_them() -> None:
-    """The eval reads attributes the Phoenix server writes.
-
-    A drifted name would not raise — discovery would simply return nothing,
-    forever, and look like a quiet window. Pin the two constants together.
-    """
-    from phoenix.server.agents import approval as server_approval
-
-    assert APPROVAL_DECISION_ATTRIBUTE == server_approval.APPROVAL_DECISION_ATTRIBUTE
-    assert APPROVAL_SOURCE_ATTRIBUTE == server_approval.APPROVAL_SOURCE_ATTRIBUTE
-
-
-@pytest.mark.parametrize("decision", ["accepted", "rejected"])
-def test_every_decision_the_server_emits_is_classified(decision: str) -> None:
-    """The server only ever writes these two; neither may fall through as None."""
-    assert _evaluate(_tool_span(decision=decision, source="user")) is not None

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
@@ -212,3 +212,21 @@ def test_annotation_never_carries_the_raw_payload() -> None:
     assert score.metadata == {"tool_name": "edit_prompt_instance"}
     assert secret not in json.dumps({"e": score.explanation, "m": score.metadata})
     assert "prompt-abc123" not in json.dumps({"e": score.explanation, "m": score.metadata})
+
+
+def test_attribute_names_match_the_server_that_writes_them() -> None:
+    """The eval reads attributes the Phoenix server writes.
+
+    A drifted name would not raise — discovery would simply return nothing,
+    forever, and look like a quiet window. Pin the two constants together.
+    """
+    from phoenix.server.agents import approval as server_approval
+
+    assert APPROVAL_DECISION_ATTRIBUTE == server_approval.APPROVAL_DECISION_ATTRIBUTE
+    assert APPROVAL_SOURCE_ATTRIBUTE == server_approval.APPROVAL_SOURCE_ATTRIBUTE
+
+
+@pytest.mark.parametrize("decision", ["accepted", "rejected"])
+def test_every_decision_the_server_emits_is_classified(decision: str) -> None:
+    """The server only ever writes these two; neither may fall through as None."""
+    assert _evaluate(_tool_span(decision=decision, source="user")) is not None

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 
 import pytest
+from phoenix.client.__generated__ import v1
 
 from evals.pxi.online_evals.evaluators.suggestion_accepted import (
     APPROVAL_DECISION_ATTRIBUTE,
@@ -13,7 +14,6 @@ from evals.pxi.online_evals.evaluators.suggestion_accepted import (
     evaluate_suggestion_accepted,
 )
 from evals.pxi.online_evals.models import SpanSelector
-from phoenix.client.__generated__ import v1
 
 
 def _tool_span(

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+from phoenix.client.__generated__ import v1
+
+from evals.pxi.online_evals.evaluators.suggestion_accepted import (
+    APPROVAL_GATED_TOOLS,
+    SUGGESTION_ACCEPTED,
+    evaluate_suggestion_accepted,
+)
+from evals.pxi.online_evals.models import SpanSelector
+
+
+def _tool_span(
+    *,
+    tool_name: str | None = "edit_prompt_instance",
+    span_name: str = "edit_prompt_instance",
+    output: Any = ...,
+) -> v1.Span:
+    attributes: dict[str, Any] = {}
+    if tool_name is not None:
+        attributes["tool.name"] = tool_name
+    if output is not ...:
+        attributes["output.value"] = output
+    span: v1.Span = {
+        "name": span_name,
+        "context": {"trace_id": "trace-1", "span_id": "tool-1"},
+        "span_kind": "TOOL",
+        "parent_id": "root-1",
+        "start_time": "2026-07-24T00:00:00+00:00",
+        "end_time": "2026-07-24T00:00:01+00:00",
+        "status_code": "OK",
+        "attributes": attributes,
+    }
+    return span
+
+
+def _evaluate(span: v1.Span) -> Any:
+    return asyncio.run(evaluate_suggestion_accepted(span, [span]))
+
+
+# --- spec / registration -------------------------------------------------
+
+
+def test_spec_configuration() -> None:
+    assert SUGGESTION_ACCEPTED.name == "suggestion_accepted"
+    assert SUGGESTION_ACCEPTED.annotator_kind == "CODE"
+    assert SUGGESTION_ACCEPTED.sample_rate == 1.0
+    assert SUGGESTION_ACCEPTED.identifier == "pxi-online-evals:suggestion-accepted:v1"
+    assert SUGGESTION_ACCEPTED.selector == SpanSelector(
+        names=APPROVAL_GATED_TOOLS, span_kinds=("TOOL",)
+    )
+
+
+def test_selector_targets_tool_spans_anywhere_in_the_trace() -> None:
+    """Approval-gated tools are not roots, so discovery must not restrict parents."""
+    assert SUGGESTION_ACCEPTED.selector.parent_id is None
+
+
+def test_allowlist_is_sorted_and_unique() -> None:
+    assert list(APPROVAL_GATED_TOOLS) == sorted(set(APPROVAL_GATED_TOOLS))
+
+
+@pytest.mark.parametrize(
+    "excluded",
+    ["submit_code_evaluator_draft", "submit_llm_evaluator_draft"],
+)
+def test_manual_submit_tools_are_excluded(excluded: str) -> None:
+    """These record only `awaiting_user`; the dialog's decision never reaches the span."""
+    assert excluded not in APPROVAL_GATED_TOOLS
+
+
+# --- acceptance ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["accepted", "saved", "loaded", "applied", "removed"])
+@pytest.mark.parametrize("encoding", ["mapping", "json", "double_json"])
+def test_manual_acceptance_scores_one(status: str, encoding: str) -> None:
+    """`acceptedBy == "user"` is the acceptance signal, whatever the tool's
+    success vocabulary, and whichever encoding layer the output arrived in."""
+    payload: dict[str, Any] = {"status": status, "acceptedBy": "user"}
+    output: Any = payload
+    if encoding == "json":
+        output = json.dumps(payload)
+    elif encoding == "double_json":
+        output = json.dumps(json.dumps(payload))
+
+    score = _evaluate(_tool_span(output=output))
+
+    assert score is not None
+    assert score.label == "accepted"
+    assert score.score == 1.0
+    assert score.name == "suggestion_accepted"
+    assert score.kind == "code"
+    assert score.explanation == "user accepted the edit_prompt_instance suggestion"
+    assert score.metadata == {"tool_name": "edit_prompt_instance"}
+
+
+def test_save_prompt_object_output_with_approval_status_is_accepted() -> None:
+    score = _evaluate(
+        _tool_span(
+            tool_name="save_prompt",
+            output={"status": "saved", "approvalStatus": "accepted", "acceptedBy": "user"},
+        )
+    )
+
+    assert score is not None
+    assert (score.label, score.score) == ("accepted", 1.0)
+    assert score.metadata == {"tool_name": "save_prompt"}
+
+
+def test_tool_name_falls_back_to_the_span_name() -> None:
+    score = _evaluate(
+        _tool_span(
+            tool_name=None,
+            span_name="load_dataset",
+            output={"status": "loaded", "acceptedBy": "user"},
+        )
+    )
+
+    assert score is not None
+    assert score.metadata == {"tool_name": "load_dataset"}
+
+
+# --- rejection -----------------------------------------------------------
+
+
+def test_explicit_rejection_scores_zero() -> None:
+    """The reject callback writes `status: "rejected"` and never sets acceptedBy."""
+    score = _evaluate(_tool_span(output={"status": "rejected", "message": "user declined"}))
+
+    assert score is not None
+    assert score.label == "rejected"
+    assert score.score == 0.0
+    assert score.explanation == "user rejected the edit_prompt_instance suggestion"
+    assert score.metadata == {"tool_name": "edit_prompt_instance"}
+
+
+def test_contradictory_payload_follows_the_rejection_first_rule() -> None:
+    """A terminal rejection outranks an acceptance marker that should not co-occur."""
+    score = _evaluate(_tool_span(output={"status": "rejected", "acceptedBy": "user"}))
+
+    assert score is not None
+    assert (score.label, score.score) == ("rejected", 0.0)
+
+
+# --- not applicable ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("case", "output"),
+    [
+        ("automatic accept", {"status": "accepted", "acceptedBy": "auto"}),
+        ("system accept", {"status": "accepted", "acceptedBy": "system"}),
+        ("accept without a source", {"status": "accepted"}),
+        ("awaiting the user", {"status": "awaiting_user", "message": "review the draft"}),
+        ("navigation cancellation", {"state": "output-error", "errorText": "cancelled"}),
+        ("tool error", {"state": "output-error", "errorText": "boom"}),
+        ("unknown state", {"status": "no_change"}),
+        ("empty object", {}),
+        ("array output", [{"status": "rejected"}]),
+        ("scalar output", 7),
+        ("null output", None),
+        ("empty string", ""),
+        ("whitespace string", "   "),
+        ("malformed json", "{not json"),
+        ("json array string", "[1, 2]"),
+        ("json scalar string", '"accepted"'),
+    ],
+)
+def test_non_decisions_are_not_annotated(case: str, output: Any) -> None:
+    assert _evaluate(_tool_span(output=output)) is None, case
+
+
+def test_missing_output_is_not_annotated() -> None:
+    assert _evaluate(_tool_span(output=...)) is None
+
+
+def test_non_allowlisted_tool_is_not_annotated() -> None:
+    """A read tool can carry look-alike fields but has no approval to record."""
+    assert (
+        _evaluate(
+            _tool_span(
+                tool_name="query_phoenix",
+                output={"status": "rejected", "acceptedBy": "user"},
+            )
+        )
+        is None
+    )
+
+
+def test_message_text_never_drives_classification() -> None:
+    """Classification is structural: prose mentioning the words must not leak in."""
+    assert (
+        _evaluate(
+            _tool_span(
+                output={
+                    "status": "awaiting_user",
+                    "message": "the user accepted nothing yet; nothing was rejected either",
+                }
+            )
+        )
+        is None
+    )
+
+
+def test_annotation_never_carries_the_raw_payload() -> None:
+    secret = "SENSITIVE-PROMPT-BODY"
+    score = _evaluate(
+        _tool_span(
+            output={
+                "status": "accepted",
+                "acceptedBy": "user",
+                "promptId": "prompt-abc123",
+                "content": secret,
+                "diff": f"- old\n+ {secret}",
+            }
+        )
+    )
+
+    assert score is not None
+    assert score.metadata == {"tool_name": "edit_prompt_instance"}
+    assert secret not in json.dumps({"e": score.explanation, "m": score.metadata})
+    assert "prompt-abc123" not in json.dumps({"e": score.explanation, "m": score.metadata})

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_accepted.py
@@ -5,25 +5,32 @@ import json
 from typing import Any
 
 import pytest
-from phoenix.client.__generated__ import v1
 
 from evals.pxi.online_evals.evaluators.suggestion_accepted import (
-    APPROVAL_GATED_TOOLS,
+    APPROVAL_DECISION_ATTRIBUTE,
+    APPROVAL_SOURCE_ATTRIBUTE,
     SUGGESTION_ACCEPTED,
     evaluate_suggestion_accepted,
 )
 from evals.pxi.online_evals.models import SpanSelector
+from phoenix.client.__generated__ import v1
 
 
 def _tool_span(
     *,
     tool_name: str | None = "edit_prompt_instance",
     span_name: str = "edit_prompt_instance",
+    decision: Any = ...,
+    source: Any = ...,
     output: Any = ...,
 ) -> v1.Span:
     attributes: dict[str, Any] = {}
     if tool_name is not None:
         attributes["tool.name"] = tool_name
+    if decision is not ...:
+        attributes[APPROVAL_DECISION_ATTRIBUTE] = decision
+    if source is not ...:
+        attributes[APPROVAL_SOURCE_ATTRIBUTE] = source
     if output is not ...:
         attributes["output.value"] = output
     span: v1.Span = {
@@ -52,8 +59,17 @@ def test_spec_configuration() -> None:
     assert SUGGESTION_ACCEPTED.sample_rate == 1.0
     assert SUGGESTION_ACCEPTED.identifier == "pxi-online-evals:suggestion-accepted:v1"
     assert SUGGESTION_ACCEPTED.selector == SpanSelector(
-        names=APPROVAL_GATED_TOOLS, span_kinds=("TOOL",)
+        span_kinds=("TOOL",),
+        attributes={APPROVAL_SOURCE_ATTRIBUTE: "user"},
     )
+
+
+def test_selector_names_no_tools() -> None:
+    """The point of the marker: discovery must not depend on a tool allowlist.
+
+    A newly approval-gated tool is covered the day it ships, with no change here.
+    """
+    assert SUGGESTION_ACCEPTED.selector.names == ()
 
 
 def test_selector_targets_tool_spans_anywhere_in_the_trace() -> None:
@@ -61,35 +77,16 @@ def test_selector_targets_tool_spans_anywhere_in_the_trace() -> None:
     assert SUGGESTION_ACCEPTED.selector.parent_id is None
 
 
-def test_allowlist_is_sorted_and_unique() -> None:
-    assert list(APPROVAL_GATED_TOOLS) == sorted(set(APPROVAL_GATED_TOOLS))
-
-
-@pytest.mark.parametrize(
-    "excluded",
-    ["submit_code_evaluator_draft", "submit_llm_evaluator_draft"],
-)
-def test_manual_submit_tools_are_excluded(excluded: str) -> None:
-    """These record only `awaiting_user`; the dialog's decision never reaches the span."""
-    assert excluded not in APPROVAL_GATED_TOOLS
+def test_selector_excludes_automatic_accepts_at_discovery() -> None:
+    """Bypass-mode accepts are not evidence of what a user wanted."""
+    assert SUGGESTION_ACCEPTED.selector.attributes == ((APPROVAL_SOURCE_ATTRIBUTE, "user"),)
 
 
 # --- acceptance ----------------------------------------------------------
 
 
-@pytest.mark.parametrize("status", ["accepted", "saved", "loaded", "applied", "removed"])
-@pytest.mark.parametrize("encoding", ["mapping", "json", "double_json"])
-def test_manual_acceptance_scores_one(status: str, encoding: str) -> None:
-    """`acceptedBy == "user"` is the acceptance signal, whatever the tool's
-    success vocabulary, and whichever encoding layer the output arrived in."""
-    payload: dict[str, Any] = {"status": status, "acceptedBy": "user"}
-    output: Any = payload
-    if encoding == "json":
-        output = json.dumps(payload)
-    elif encoding == "double_json":
-        output = json.dumps(json.dumps(payload))
-
-    score = _evaluate(_tool_span(output=output))
+def test_manual_acceptance_scores_one() -> None:
+    score = _evaluate(_tool_span(decision="accepted", source="user"))
 
     assert score is not None
     assert score.label == "accepted"
@@ -100,17 +97,25 @@ def test_manual_acceptance_scores_one(status: str, encoding: str) -> None:
     assert score.metadata == {"tool_name": "edit_prompt_instance"}
 
 
-def test_save_prompt_object_output_with_approval_status_is_accepted() -> None:
+@pytest.mark.parametrize("tool_name", ["save_prompt", "load_dataset", "create_dataset"])
+def test_accept_vocabulary_no_longer_matters(tool_name: str) -> None:
+    """Tools disagree on their success word (`saved`, `loaded`, ...).
+
+    The marker is uniform, so classification is identical across all of them —
+    including tools that were missing from the old hand-maintained allowlist.
+    """
     score = _evaluate(
         _tool_span(
-            tool_name="save_prompt",
-            output={"status": "saved", "approvalStatus": "accepted", "acceptedBy": "user"},
+            tool_name=tool_name,
+            decision="accepted",
+            source="user",
+            output={"status": "saved", "approvalStatus": "accepted"},
         )
     )
 
     assert score is not None
     assert (score.label, score.score) == ("accepted", 1.0)
-    assert score.metadata == {"tool_name": "save_prompt"}
+    assert score.metadata == {"tool_name": tool_name}
 
 
 def test_tool_name_falls_back_to_the_span_name() -> None:
@@ -118,7 +123,8 @@ def test_tool_name_falls_back_to_the_span_name() -> None:
         _tool_span(
             tool_name=None,
             span_name="load_dataset",
-            output={"status": "loaded", "acceptedBy": "user"},
+            decision="accepted",
+            source="user",
         )
     )
 
@@ -130,8 +136,7 @@ def test_tool_name_falls_back_to_the_span_name() -> None:
 
 
 def test_explicit_rejection_scores_zero() -> None:
-    """The reject callback writes `status: "rejected"` and never sets acceptedBy."""
-    score = _evaluate(_tool_span(output={"status": "rejected", "message": "user declined"}))
+    score = _evaluate(_tool_span(decision="rejected", source="user"))
 
     assert score is not None
     assert score.label == "rejected"
@@ -140,48 +145,43 @@ def test_explicit_rejection_scores_zero() -> None:
     assert score.metadata == {"tool_name": "edit_prompt_instance"}
 
 
-def test_contradictory_payload_follows_the_rejection_first_rule() -> None:
-    """A terminal rejection outranks an acceptance marker that should not co-occur."""
-    score = _evaluate(_tool_span(output={"status": "rejected", "acceptedBy": "user"}))
-
-    assert score is not None
-    assert (score.label, score.score) == ("rejected", 0.0)
-
-
 # --- not applicable ------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    ("case", "output"),
+    ("case", "decision", "source"),
     [
-        ("automatic accept", {"status": "accepted", "acceptedBy": "auto"}),
-        ("system accept", {"status": "accepted", "acceptedBy": "system"}),
-        ("accept without a source", {"status": "accepted"}),
-        ("awaiting the user", {"status": "awaiting_user", "message": "review the draft"}),
-        ("navigation cancellation", {"state": "output-error", "errorText": "cancelled"}),
-        ("tool error", {"state": "output-error", "errorText": "boom"}),
-        ("unknown state", {"status": "no_change"}),
-        ("empty object", {}),
-        ("array output", [{"status": "rejected"}]),
-        ("scalar output", 7),
-        ("null output", None),
-        ("empty string", ""),
-        ("whitespace string", "   "),
-        ("malformed json", "{not json"),
-        ("json array string", "[1, 2]"),
-        ("json scalar string", '"accepted"'),
+        ("automatic accept", "accepted", "auto"),
+        ("unknown source", "accepted", "system"),
+        ("unknown decision", "deferred", "user"),
+        ("empty decision", "", "user"),
+        ("non-string decision", 1, "user"),
     ],
 )
-def test_non_decisions_are_not_annotated(case: str, output: Any) -> None:
-    assert _evaluate(_tool_span(output=output)) is None, case
+def test_non_user_decisions_are_not_annotated(case: str, decision: Any, source: Any) -> None:
+    assert _evaluate(_tool_span(decision=decision, source=source)) is None, case
 
 
-def test_missing_output_is_not_annotated() -> None:
-    assert _evaluate(_tool_span(output=...)) is None
+@pytest.mark.parametrize(
+    "case",
+    ["no marker at all", "decision only", "source only"],
+)
+def test_unmarked_spans_are_not_annotated(case: str) -> None:
+    """Cancellations, errors, and still-pending approvals carry no marker."""
+    kwargs: dict[str, Any] = {}
+    if case == "decision only":
+        kwargs["decision"] = "accepted"
+    elif case == "source only":
+        kwargs["source"] = "user"
+    assert _evaluate(_tool_span(**kwargs)) is None, case
 
 
-def test_non_allowlisted_tool_is_not_annotated() -> None:
-    """A read tool can carry look-alike fields but has no approval to record."""
+def test_output_payload_never_drives_classification() -> None:
+    """Only the promoted attributes decide; a look-alike payload must not leak in.
+
+    This is what lets a read-only tool carry `status: "rejected"` in its own
+    output without being mistaken for an approval decision.
+    """
     assert (
         _evaluate(
             _tool_span(
@@ -193,32 +193,18 @@ def test_non_allowlisted_tool_is_not_annotated() -> None:
     )
 
 
-def test_message_text_never_drives_classification() -> None:
-    """Classification is structural: prose mentioning the words must not leak in."""
-    assert (
-        _evaluate(
-            _tool_span(
-                output={
-                    "status": "awaiting_user",
-                    "message": "the user accepted nothing yet; nothing was rejected either",
-                }
-            )
-        )
-        is None
-    )
-
-
 def test_annotation_never_carries_the_raw_payload() -> None:
     secret = "SENSITIVE-PROMPT-BODY"
     score = _evaluate(
         _tool_span(
+            decision="accepted",
+            source="user",
             output={
                 "status": "accepted",
-                "acceptedBy": "user",
                 "promptId": "prompt-abc123",
                 "content": secret,
                 "diff": f"- old\n+ {secret}",
-            }
+            },
         )
     )
 

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from phoenix.client.__generated__ import v1
@@ -24,7 +24,7 @@ NOW = datetime(2026, 7, 24, 13, 0, tzinfo=timezone.utc)
 
 
 def _trace(name: str) -> list[v1.Span]:
-    return json.loads(FIXTURE.read_text())[name]
+    return cast(list[v1.Span], json.loads(FIXTURE.read_text())[name])
 
 
 class _FixtureSpans:

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
@@ -17,6 +17,12 @@ production identifier is replaced; span/trace ids are synthetic; timestamps
 are rebased while keeping their order. `input.value` and non-approval
 `output.value` payloads are collapsed to placeholders — this evaluator never
 reads them, and keeping them ballooned the fixture to megabytes.
+
+These traces predate the approval marker, so each gated span additionally
+carries the `approval` payload key and the `pxi.approval.*` attributes the
+server now promotes, derived from the decision the original payload recorded.
+Each tool's original status vocabulary is left intact, which is what makes
+these fixtures worth keeping: they prove classification no longer depends on it.
 """
 
 from __future__ import annotations
@@ -28,11 +34,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from phoenix.client.__generated__ import v1
 
 from evals.pxi.online_evals.evaluators.suggestion_accepted import SUGGESTION_ACCEPTED
 from evals.pxi.online_evals.run import run_evaluators
 from evals.pxi.online_evals.topology import span_id
+from phoenix.client.__generated__ import v1
 
 FIXTURE = Path(__file__).parent / "fixtures" / "pxi_suggestion_traces.json"
 # After the last fixture span (12:00:21) plus the runner's settle delay.
@@ -54,11 +60,15 @@ class _FixtureSpans:
         if kwargs.get("trace_ids"):
             return self.spans
         names, kinds = kwargs.get("name"), kwargs.get("span_kind")
+        attributes: dict[str, str] = kwargs.get("attributes") or {}
         return [
             span
             for span in self.spans
             if (names is None or span["name"] in names)
             and (kinds is None or span["span_kind"] in kinds)
+            and all(
+                span.get("attributes", {}).get(key) == value for key, value in attributes.items()
+            )
         ]
 
     def get_span_annotations(self, **_: Any) -> list[v1.SpanAnnotation]:
@@ -115,8 +125,9 @@ def test_rejected_prompt_edit_classifies_as_rejected() -> None:
 
 
 def test_real_save_prompt_dual_status_shape_is_accepted() -> None:
-    """`save_prompt` records `status: "saved"` alongside `approvalStatus`;
-    `acceptedBy` is what makes it a user decision."""
+    """`save_prompt` still records its own `status: "saved"` / `approvalStatus`
+    vocabulary; the promoted approval attributes are what classify it, so the
+    tool's payload shape no longer matters."""
     target = _tool_span("accepted_prompt_edit", "save_prompt")
     assert _annotate("accepted_prompt_edit")[span_id(target)] == ("accepted", 1.0)
 

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
@@ -13,11 +13,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from phoenix.client.__generated__ import v1
 
 from evals.pxi.online_evals.evaluators.suggestion_accepted import SUGGESTION_ACCEPTED
 from evals.pxi.online_evals.run import run_evaluators
 from evals.pxi.online_evals.topology import span_id
-from phoenix.client.__generated__ import v1
 
 FIXTURE = Path(__file__).parent / "fixtures" / "pxi_suggestion_traces.json"
 NOW = datetime(2026, 7, 24, 13, 0, tzinfo=timezone.utc)

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
@@ -1,28 +1,7 @@
-"""Regression tests over sanitized copies of real PXI approval traces.
+"""Tests over sanitized, real-shape PXI approval traces.
 
-Provenance (read-only, `phoenix-devs` space, `pxi_dev` project):
-
-- ``accepted_prompt_edit`` — trace ``3097dd10334213ca3cb0b8a26d17e771``,
-  approval span ``236ced0d91b66e77`` (a manually accepted prompt edit,
-  followed by a `save_prompt` that also records a user acceptance).
-- ``rejected_prompt_edit`` — trace ``12b4efd5656472be289562a526fa1a8d``,
-  approval span ``8496746e8b057155`` (a manually rejected prompt edit).
-- ``mixed_annotation_config`` — trace ``0863f2203b0b3af3bfe0a55a09d11e19``
-  (one turn where an annotation-config change was rejected, then a revised
-  one accepted, plus an accepted `batch_span_annotate`).
-
-The fixture preserves the real attribute keys, JSON encoding, span kinds,
-parent relationships, and relative ordering. Every free-text value and
-production identifier is replaced; span/trace ids are synthetic; timestamps
-are rebased while keeping their order. `input.value` and non-approval
-`output.value` payloads are collapsed to placeholders — this evaluator never
-reads them, and keeping them ballooned the fixture to megabytes.
-
-These traces predate the approval marker, so each gated span additionally
-carries the `approval` payload key and the `pxi.approval.*` attributes the
-server now promotes, derived from the decision the original payload recorded.
-Each tool's original status vocabulary is left intact, which is what makes
-these fixtures worth keeping: they prove classification no longer depends on it.
+Identifiers, text, and timestamps are replaced. Approval markers were added to
+the older traces while preserving each tool's original output vocabulary.
 """
 
 from __future__ import annotations
@@ -41,7 +20,6 @@ from evals.pxi.online_evals.topology import span_id
 from phoenix.client.__generated__ import v1
 
 FIXTURE = Path(__file__).parent / "fixtures" / "pxi_suggestion_traces.json"
-# After the last fixture span (12:00:21) plus the runner's settle delay.
 NOW = datetime(2026, 7, 24, 13, 0, tzinfo=timezone.utc)
 
 
@@ -50,8 +28,6 @@ def _trace(name: str) -> list[v1.Span]:
 
 
 class _FixtureSpans:
-    """Serves one fixture trace through the client surface the runner uses."""
-
     def __init__(self, spans: list[v1.Span]) -> None:
         self.spans = spans
         self.writes: list[v1.SpanAnnotationData] = []
@@ -125,16 +101,11 @@ def test_rejected_prompt_edit_classifies_as_rejected() -> None:
 
 
 def test_real_save_prompt_dual_status_shape_is_accepted() -> None:
-    """`save_prompt` still records its own `status: "saved"` / `approvalStatus`
-    vocabulary; the promoted approval attributes are what classify it, so the
-    tool's payload shape no longer matters."""
     target = _tool_span("accepted_prompt_edit", "save_prompt")
     assert _annotate("accepted_prompt_edit")[span_id(target)] == ("accepted", 1.0)
 
 
 def test_one_turn_keeps_independent_outcomes_per_suggestion() -> None:
-    """A rejected config change and its accepted revision live in the same
-    turn — a root-level annotation would collapse them into one label."""
     rejected = _tool_span("mixed_annotation_config", "update_annotation_config")
     accepted = _tool_span("mixed_annotation_config", "update_annotation_config", occurrence=1)
     batch = _tool_span("mixed_annotation_config", "batch_span_annotate")
@@ -155,8 +126,6 @@ def test_one_turn_keeps_independent_outcomes_per_suggestion() -> None:
     ],
 )
 def test_only_approval_tools_are_annotated(trace_name: str, expected: int) -> None:
-    """Non-approval tools in the same traces (`read_prompt_instance`,
-    `load_skill`, `ask_user`, `open_llm_evaluator_form`) stay unannotated."""
     assert len(_annotate(trace_name)) == expected
 
 

--- a/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
+++ b/tests/unit/pxi/evals/online_evals/test_suggestion_fixtures.py
@@ -1,0 +1,161 @@
+"""Regression tests over sanitized copies of real PXI approval traces.
+
+Provenance (read-only, `phoenix-devs` space, `pxi_dev` project):
+
+- ``accepted_prompt_edit`` — trace ``3097dd10334213ca3cb0b8a26d17e771``,
+  approval span ``236ced0d91b66e77`` (a manually accepted prompt edit,
+  followed by a `save_prompt` that also records a user acceptance).
+- ``rejected_prompt_edit`` — trace ``12b4efd5656472be289562a526fa1a8d``,
+  approval span ``8496746e8b057155`` (a manually rejected prompt edit).
+- ``mixed_annotation_config`` — trace ``0863f2203b0b3af3bfe0a55a09d11e19``
+  (one turn where an annotation-config change was rejected, then a revised
+  one accepted, plus an accepted `batch_span_annotate`).
+
+The fixture preserves the real attribute keys, JSON encoding, span kinds,
+parent relationships, and relative ordering. Every free-text value and
+production identifier is replaced; span/trace ids are synthetic; timestamps
+are rebased while keeping their order. `input.value` and non-approval
+`output.value` payloads are collapsed to placeholders — this evaluator never
+reads them, and keeping them ballooned the fixture to megabytes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from phoenix.client.__generated__ import v1
+
+from evals.pxi.online_evals.evaluators.suggestion_accepted import SUGGESTION_ACCEPTED
+from evals.pxi.online_evals.run import run_evaluators
+from evals.pxi.online_evals.topology import span_id
+
+FIXTURE = Path(__file__).parent / "fixtures" / "pxi_suggestion_traces.json"
+# After the last fixture span (12:00:21) plus the runner's settle delay.
+NOW = datetime(2026, 7, 24, 13, 0, tzinfo=timezone.utc)
+
+
+def _trace(name: str) -> list[v1.Span]:
+    return json.loads(FIXTURE.read_text())[name]
+
+
+class _FixtureSpans:
+    """Serves one fixture trace through the client surface the runner uses."""
+
+    def __init__(self, spans: list[v1.Span]) -> None:
+        self.spans = spans
+        self.writes: list[v1.SpanAnnotationData] = []
+
+    def get_spans(self, **kwargs: Any) -> list[v1.Span]:
+        if kwargs.get("trace_ids"):
+            return self.spans
+        names, kinds = kwargs.get("name"), kwargs.get("span_kind")
+        return [
+            span
+            for span in self.spans
+            if (names is None or span["name"] in names)
+            and (kinds is None or span["span_kind"] in kinds)
+        ]
+
+    def get_span_annotations(self, **_: Any) -> list[v1.SpanAnnotation]:
+        return []
+
+    def log_span_annotations(
+        self, *, span_annotations: list[v1.SpanAnnotationData], sync: bool
+    ) -> list[dict[str, str]]:
+        self.writes.extend(span_annotations)
+        return [{"id": "1"}]
+
+
+class _FixtureClient:
+    def __init__(self, spans: _FixtureSpans) -> None:
+        self.spans = spans
+
+
+def _annotate(trace_name: str) -> dict[str, tuple[str, float]]:
+    spans = _FixtureSpans(_trace(trace_name))
+    asyncio.run(
+        run_evaluators(
+            _FixtureClient(spans),  # type: ignore[arg-type]
+            project="pxi_dev",
+            specs=[SUGGESTION_ACCEPTED],
+            now=NOW,
+        )
+    )
+    return {
+        annotation["span_id"]: (
+            annotation["result"]["label"],
+            annotation["result"]["score"],
+        )
+        for annotation in spans.writes
+    }
+
+
+def _tool_span(trace_name: str, tool_name: str, *, occurrence: int = 0) -> v1.Span:
+    matches = [
+        span
+        for span in _trace(trace_name)
+        if span.get("attributes", {}).get("tool.name") == tool_name
+    ]
+    return matches[occurrence]
+
+
+def test_accepted_prompt_edit_classifies_as_accepted() -> None:
+    target = _tool_span("accepted_prompt_edit", "edit_prompt_instance")
+    assert _annotate("accepted_prompt_edit")[span_id(target)] == ("accepted", 1.0)
+
+
+def test_rejected_prompt_edit_classifies_as_rejected() -> None:
+    target = _tool_span("rejected_prompt_edit", "edit_prompt_instance")
+    assert _annotate("rejected_prompt_edit")[span_id(target)] == ("rejected", 0.0)
+
+
+def test_real_save_prompt_dual_status_shape_is_accepted() -> None:
+    """`save_prompt` records `status: "saved"` alongside `approvalStatus`;
+    `acceptedBy` is what makes it a user decision."""
+    target = _tool_span("accepted_prompt_edit", "save_prompt")
+    assert _annotate("accepted_prompt_edit")[span_id(target)] == ("accepted", 1.0)
+
+
+def test_one_turn_keeps_independent_outcomes_per_suggestion() -> None:
+    """A rejected config change and its accepted revision live in the same
+    turn — a root-level annotation would collapse them into one label."""
+    rejected = _tool_span("mixed_annotation_config", "update_annotation_config")
+    accepted = _tool_span("mixed_annotation_config", "update_annotation_config", occurrence=1)
+    batch = _tool_span("mixed_annotation_config", "batch_span_annotate")
+
+    annotations = _annotate("mixed_annotation_config")
+
+    assert annotations[span_id(rejected)] == ("rejected", 0.0)
+    assert annotations[span_id(accepted)] == ("accepted", 1.0)
+    assert annotations[span_id(batch)] == ("accepted", 1.0)
+
+
+@pytest.mark.parametrize(
+    ("trace_name", "expected"),
+    [
+        ("accepted_prompt_edit", 2),
+        ("rejected_prompt_edit", 1),
+        ("mixed_annotation_config", 3),
+    ],
+)
+def test_only_approval_tools_are_annotated(trace_name: str, expected: int) -> None:
+    """Non-approval tools in the same traces (`read_prompt_instance`,
+    `load_skill`, `ask_user`, `open_llm_evaluator_form`) stay unannotated."""
+    assert len(_annotate(trace_name)) == expected
+
+
+def test_fixture_carries_no_production_identifiers() -> None:
+    text = FIXTURE.read_text()
+    for leaked in (
+        "3097dd10334213ca3cb0b8a26d17e771",
+        "12b4efd5656472be289562a526fa1a8d",
+        "0863f2203b0b3af3bfe0a55a09d11e19",
+        "236ced0d91b66e77",
+        "8496746e8b057155",
+    ):
+        assert leaked not in text

--- a/tests/unit/pxi/evals/online_evals/test_user_friction.py
+++ b/tests/unit/pxi/evals/online_evals/test_user_friction.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from phoenix.client.__generated__ import v1
 
 from evals.pxi.online_evals.conversation import (
     Message,
@@ -17,7 +18,6 @@ from evals.pxi.online_evals.evaluators import user_friction
 from evals.pxi.online_evals.message_origin import is_human_message
 from evals.pxi.online_evals.models import SpanSelector
 from evals.pxi.online_evals.rendering import render_conversation, render_turn_detailed
-from phoenix.client.__generated__ import v1
 
 
 def _evaluate(root: v1.Span, spans: list[v1.Span]) -> Any:

--- a/tests/unit/pxi/evals/online_evals/test_user_friction.py
+++ b/tests/unit/pxi/evals/online_evals/test_user_friction.py
@@ -5,7 +5,6 @@ from typing import Any
 from unittest import mock
 
 import pytest
-from phoenix.client.__generated__ import v1
 
 from evals.pxi.online_evals.conversation import (
     Message,
@@ -16,7 +15,9 @@ from evals.pxi.online_evals.conversation import (
 )
 from evals.pxi.online_evals.evaluators import user_friction
 from evals.pxi.online_evals.message_origin import is_human_message
+from evals.pxi.online_evals.models import SpanSelector
 from evals.pxi.online_evals.rendering import render_conversation, render_turn_detailed
+from phoenix.client.__generated__ import v1
 
 
 def _evaluate(root: v1.Span, spans: list[v1.Span]) -> Any:
@@ -374,6 +375,8 @@ def test_spec_configuration() -> None:
     spec = user_friction.USER_FRICTION
     assert spec.name == "user_friction"
     assert spec.annotator_kind == "LLM"
-    assert spec.root_span_name == "pxi.turn"
+    assert spec.selector == SpanSelector(
+        names=("pxi.turn",), span_kinds=("AGENT",), parent_id="null"
+    )
     assert spec.sample_rate == 1.0
     assert spec.identifier == "pxi-online-evals:user-friction:v1"


### PR DESCRIPTION
> **Stacked on #15029** — review that first; this PR's diff is only meaningful on top of it. Base will retarget to `main` once #15029 merges.

Closes #14730.

## What

A deterministic CODE evaluator on the scheduled PXI online-eval job that records whether a user **manually** accepted or rejected an approval-gated suggestion, annotated on the suggestion's own TOOL span.

| Recorded outcome | Annotation |
|---|---|
| `pxi.approval.decision = "accepted"` | `accepted` / `1.0` |
| `pxi.approval.decision = "rejected"` | `rejected` / `0.0` |
| anything else | *no annotation* |

Annotating the TOOL span rather than the `pxi.turn` root is the point: one turn routinely contains several suggestions the user decided differently — a rejected annotation-config change and its accepted revision — and a turn-level annotation would collapse them into a single label. That required teaching the runner to target non-root spans, which is most of the first commits here.

## Why it looks different from the original design

The first version carried an `APPROVAL_GATED_TOOLS` allowlist and parsed `output.value` through a defensive multi-shape decoder, because each tool spells its outcome differently (`accepted`, `saved`, `loaded`, `applied`, `removed`, plus `save_prompt`'s `approvalStatus`).

**That list was already stale before shipping.** Every dataset-write tool is approval-gated via `stageDatasetWrite` and none were listed, so ~12 tools' user decisions would have gone unmeasured. Keeping it correct meant maintaining a cross-language contract with the frontend by hand, with nothing enforcing it — a guaranteed slow rot.

So the base PR makes PXI tools stamp a uniform approval marker that the server promotes onto the span, and this PR discovers spans by that attribute instead:

- **No tool names anywhere.** Discovery selects `pxi.approval.source = "user"` — a single server-side query yielding exactly the annotated set, since rejections are always a user action and automatic bypass accepts are never annotated.
- **No payload parsing.** Classification reads one attribute, so a tool's own status vocabulary is irrelevant and a look-alike `status: "rejected"` on a non-gated tool can no longer be misread.
- **`SpanSelector` gained hashable attribute filters**, letting an evaluator target spans by what they record rather than by which tool produced them. A selector still requires a name or attribute filter so discovery stays bounded.

A newly approval-gated tool is now measured the day it ships.

## Notes for review

- **Pre-marker spans are invisible.** Decisions recorded before the base PR deploys carry no `pxi.approval.*` attributes, so they are never discovered and cannot be backfilled. Expect low counts on the first runs. Documented in the README.
- **Discovery failures are now isolated per selector.** Attribute filtering needs Phoenix ≥ 14.9.0 while name filtering needs 13.15.0, so an old server would otherwise abort the whole job including the two turn-root evaluators. The candidate-limit guard stays deliberately fatal — a truncated candidate set makes results quietly incomplete.
- **Attribute names are imported from `phoenix.server.agents.approval`, not re-declared.** A drifted constant wouldn't raise; discovery would just return nothing forever and look like a quiet window. A test pins the two modules together.
- Auto-approved actions, still-pending approvals, navigation cancellations, and tool errors are all left unannotated rather than guessed — none is evidence of what a user wanted.
- Annotations carry only `{"tool_name": ...}` — never prompt text, tool arguments, raw output, user content, instance ids, or diffs. Two tests pin that.

## Testing

- `pytest tests/unit/pxi/evals/online_evals/` — 124 passed, including sanitized real-shape `pxi_dev` fixtures for an accepted prompt edit, a rejected prompt edit, and one turn with two differently-decided suggestions. The fixtures keep each tool's original status vocabulary alongside the marker, which is what makes them worth keeping: they prove classification no longer depends on it.
- `ruff`, `mypy` — clean

## Before merge

A 30-day `pxi_dev` dry run to verify accepted/rejected counts with zero writes. Deferred until the base PR is deployed, since no span carries the marker yet.