### PR TITLE
fix(ui): carry the time range forward from the project list into project details

### DIFF
--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -21,6 +21,7 @@ import {
   getMillisecondsUntilNextLastNTimeRangeRefresh,
   getTimeRangeFromSearchParams,
   getTimeRangeFromLastNTimeRangeKey,
+  getTimeRangeSearch,
   isLastNTimeRangeKey,
   setTimeRangeSearchParams,
 } from "./utils";
@@ -63,6 +64,17 @@ export function useTimeRange() {
     );
   }
   return context;
+}
+
+/**
+ * The active time range serialized as a URL search string (including the
+ * leading "?"), for building links to other time-scoped views so the range
+ * carries across the navigation. A live range serializes as just its last-N
+ * key so it stays live at the destination; a custom range as its bounds.
+ */
+export function useTimeRangeSearch(): string {
+  const { timeRange } = useTimeRange();
+  return getTimeRangeSearch(timeRange);
 }
 
 /**

--- a/app/src/components/datetime/__tests__/utils.test.ts
+++ b/app/src/components/datetime/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   getMillisecondsUntilNextLastNTimeRangeRefresh,
   getTimeRangeFromSearchParams,
   getTimeRangeFromLastNTimeRangeKey,
+  getTimeRangeSearch,
   getTimeRangeSearchSuggestions,
   isLastNTimeRangeKey,
   panTimeRangeLeft,
@@ -172,6 +173,39 @@ describe("datetime utils", () => {
     expect(presetParams.get("timeRangeStart")).toBeNull();
     expect(presetParams.get("timeRangeEnd")).toBeNull();
     expect(presetParams.get("selectedSpanNodeId")).toBe("span-1");
+  });
+
+  it("serializes the active time range into a search string for links", () => {
+    // A live range carries only its key so it stays live at the destination.
+    expect(
+      getTimeRangeSearch({
+        timeRangeKey: "1h",
+        ...getTimeRangeFromLastNTimeRangeKey(
+          "1h",
+          new Date("2026-06-09T10:20:30.000Z").getTime()
+        ),
+      })
+    ).toBe("?timeRangeKey=1h");
+
+    // A custom range carries its bounds verbatim.
+    expect(
+      getTimeRangeSearch({
+        timeRangeKey: "custom",
+        start: new Date("2026-06-09T09:00:00.000Z"),
+        end: new Date("2026-06-09T10:00:00.000Z"),
+      })
+    ).toBe(
+      "?timeRangeStart=2026-06-09T09%3A00%3A00.000Z&timeRangeEnd=2026-06-09T10%3A00%3A00.000Z"
+    );
+
+    // An open-sided custom range carries only its present bound.
+    expect(
+      getTimeRangeSearch({
+        timeRangeKey: "custom",
+        start: new Date("2026-06-09T09:00:00.000Z"),
+        end: null,
+      })
+    ).toBe("?timeRangeStart=2026-06-09T09%3A00%3A00.000Z");
   });
 });
 

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -214,6 +214,23 @@ export function setTimeRangeSearchParams({
   return nextSearchParams;
 }
 
+/**
+ * Serialize the given time range into a URL search string (including the
+ * leading "?") for building navigation targets that carry the active time
+ * range into another time-scoped view (e.g. the project list → project detail
+ * links). Uses the same declarative representation as
+ * {@link setTimeRangeSearchParams}: a live range serializes as just its last-N
+ * key so it stays live at the destination, and a custom range as just its
+ * bounds.
+ */
+export function getTimeRangeSearch(timeRange: OpenTimeRangeWithKey): string {
+  const search = setTimeRangeSearchParams({
+    searchParams: new URLSearchParams(),
+    timeRange,
+  }).toString();
+  return search ? `?${search}` : "";
+}
+
 const LAST_N_UNIT_LABELS: Record<
   LastNTimeRangeUnit,
   { singular: string; plural: string }

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -51,6 +51,7 @@ import {
   ConnectedTimeRangeSelector,
   type TimeRangeISOStrings,
   useTimeRange,
+  useTimeRangeSearch,
 } from "@phoenix/components/datetime";
 import { TopNavActions } from "@phoenix/components/nav";
 import { GradientCircle } from "@phoenix/components/project/GradientCircle";
@@ -437,6 +438,7 @@ function ProjectsGrid({
   loadNext,
   isLoadingNext,
 }: ProjectViewComponentProps) {
+  const timeRangeSearch = useTimeRangeSearch();
   return (
     <View padding="size-200" width="100%">
       <ul
@@ -463,7 +465,7 @@ function ProjectsGrid({
           >
             <Link
               title={project.name}
-              to={`/projects/${project.id}`}
+              to={`/projects/${project.id}${timeRangeSearch}`}
               css={css`
                 text-decoration: none;
                 display: flex;
@@ -744,6 +746,7 @@ function ProjectsTable({
 }: ProjectViewComponentProps) {
   const navigate = useNavigate();
   const canModify = useViewerCanModify();
+  const timeRangeSearch = useTimeRangeSearch();
   const columns: ColumnDef<
     ProjectsPageProjectsFragment$data["projects"]["edges"][number]["project"]
   >[] = useMemo(() => {
@@ -761,7 +764,7 @@ function ProjectsTable({
                 gradientStartColor={row.original.gradientStartColor}
                 gradientEndColor={row.original.gradientEndColor}
               />
-              <Link to={`/projects/${row.original.id}`}>
+              <Link to={`/projects/${row.original.id}${timeRangeSearch}`}>
                 <Truncate maxWidth="300px">{row.original.name}</Truncate>
               </Link>
             </Flex>
@@ -821,7 +824,14 @@ function ProjectsTable({
       });
     }
     return cols;
-  }, [timeRangeISOStrings, onClear, onDelete, onRemove, canModify]);
+  }, [
+    timeRangeISOStrings,
+    timeRangeSearch,
+    onClear,
+    onDelete,
+    onRemove,
+    canModify,
+  ]);
   const sortQueryParams = useProjectSortQueryParams();
   const { setProjectSortOrder } = usePreferencesContext((state) => ({
     setProjectSortOrder: state.setProjectSortOrder,
@@ -952,7 +962,7 @@ function ProjectsTable({
                 <tr
                   key={row.id}
                   onClick={() => {
-                    navigate(`/projects/${row.original.id}`);
+                    navigate(`/projects/${row.original.id}${timeRangeSearch}`);
                   }}
                 >
                   {row.getVisibleCells().map((cell) => (


### PR DESCRIPTION
## Problem

Setting a time range on `/projects` and clicking into a project didn't carry the range forward. The list → detail links dropped the URL search params, so the `TimeRangeProvider` fell back to the stored last-N preference on the detail page. Presets happened to survive via that preference, but **custom ranges were lost entirely**, and the links weren't self-describing.

## Mechanism

The time range is URL-canonical (a last-N key XOR explicit bounds — see `TimeRangeContext`), so the propagation mechanism is to put the range in the link itself, matching the existing idiom of `getTraceDetailsPath` / `getSessionDetailsPath` ("preserve recreatable URL state such as the time range"):

- **`getTimeRangeSearch(timeRange)`** (`components/datetime/utils.ts`) — pure helper that serializes the active range into a `?…` search string using the existing `setTimeRangeSearchParams` writer, so the link encoding can never drift from what the provider writes. A live range serializes as just its key (`?timeRangeKey=1h`) so it stays live at the destination; a custom range as its bounds.
- **`useTimeRangeSearch()`** (`components/datetime/TimeRangeContext.tsx`) — thin hook exposing that string from the active context range.
- **`ProjectsPage`** — the three list → detail navigation sites (grid card link, table name link, table row click) append the search string.

The detail page's internal navigation already preserves `location.search` (`ProjectIndexPage` default-tab redirect and the tab bar both forward it), so seeding the entry link closes the loop. Because the range rides in the `href`, cmd-click/new-tab and copied links carry it too.

## Testing

- Unit tests for `getTimeRangeSearch` (live key, closed custom bounds, open-sided custom) in `datetime/__tests__/utils.test.ts` — full datetime suite passes (31 tests).
- `pnpm typecheck`, lint, and `fmt:check` clean.
