### PR TITLE
chore: phoenix-sqlean tooling exclusions, skill, and release-please paths

### DIFF
--- a/.agents/skills/phoenix-sqlean/SKILL.md
+++ b/.agents/skills/phoenix-sqlean/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: phoenix-sqlean
+user-invocable: false
+description: >
+  Maintaining packages/phoenix-sqlean, the vendored fork of nalgeon/sqlean.py published as
+  arize-phoenix-sqlean. Use when bumping the bundled SQLite, sqlean, or xxHash versions,
+  changing its wheel matrix, or touching its publish path. Trigger on any change under
+  packages/phoenix-sqlean/ or the sqlean jobs in .github/workflows/publish.yaml.
+---
+
+# phoenix-sqlean
+
+Vendored fork of [nalgeon/sqlean.py](https://github.com/nalgeon/sqlean.py). It exists because
+upstream dropped Windows wheels at SQLite 3.50.4 and ships none today.
+
+## Bumping a bundled version
+
+Pins live in `packages/phoenix-sqlean/Makefile`. Each has a partner that must move with it:
+
+| Pin | Lockstep partner |
+|---|---|
+| `SQLITE_VERSION` | `SQLITE_RELEASE_YEAR` — the download URL embeds both; a mismatch 404s at fetch time |
+| `SQLEAN_VERSION` | `SQLEAN_VERSION` in `setup.py` — compiled in as the macro `sqlean_version()` returns |
+| `XXHASH_VERSION` | whatever sqlean's own `Makefile` fetches for that release |
+
+Verify locally. **CI does not catch a pin mismatch.**
+
+```bash
+cd packages/phoenix-sqlean
+make prepare-src download-sqlite download-sqlean   # always the full chain:
+                                                   # download-sqlean APPENDS init.c to the
+                                                   # amalgamation, so running it alone double-appends
+python setup.py build_ext -i
+python -m tests
+```
+
+## Gotchas
+
+- **`src/test_windirent.h` is pinned at 3.50.4 — do not re-sync it.** SQLite removed the file in
+  3.51.0 and no newer tag has it. It is vendored deliberately, not downloaded.
+- **sqlean >= 0.28 needs `crypto/xxhash.impl.h`, which sqlean does not ship.** The Makefile fetches
+  it from xxHash. Any new third-party source needs a `THIRD_PARTY_LICENSES` section *and* its SPDX
+  identifier added to `license=` in `setup.py`.
+- **`patch(1)` failing on `src/sqlean-time-msvc.patch` is the intended tripwire**, not a breakage.
+  Regenerate the patch against the new sqlean sources.
+- **The `sqlean_version()` test is a tautology.** It compares the compiled macro against `setup.py`'s
+  own constant, so a Makefile/`setup.py` mismatch still passes.
+- **Keep the version plain SemVer.** release-please's version regex is unanchored, so `3.53.4.1` and
+  `3.53.4.post1` silently truncate to `3.53.4`, colliding with an existing tag and no error. The
+  package version is intentionally independent of the bundled SQLite version.
+- **pyright's `exclude` in the root `pyproject.toml` must restate all three defaults**
+  (`**/node_modules`, `**/__pycache__`, `**/.*`). Dropping `**/.*` makes pyright walk `.venv`.
+  Nothing in CI runs pyright, so this fails silently in editors only.
+
+## Wheels and publishing
+
+- Matrix is in `publish.yaml` (`build-sqlean`): cp310–cp314 across Linux x86_64/aarch64, macOS
+  x86_64/arm64, Windows AMD64/ARM64, plus an sdist carrying the C sources.
+- `phoenix-sqlean-ci.yml` covers every OS/arch pair the publish job ships. `windows-11-arm` skips
+  3.10 — CPython publishes no Windows ARM64 build for it.
+- Publishing is gated on the tag `arize-phoenix-sqlean-v<manifest version>`. Until release-please
+  creates it, `sqlean-sources` skips and nothing builds.
+- PyPI uses trusted publishing with **no** GitHub environment; the publisher's Environment field
+  must stay blank to match.
+
+## Release-please paths
+
+Changes under `packages/phoenix-sqlean/` and `.github/` are invisible to the root `arize-phoenix`
+component. `.agents/`, `pyproject.toml`, and `release-please-config.json` are **not** — a `feat:`
+or `fix:` touching those bumps `arize-phoenix`. Put them in a `chore:` commit, and note that this
+repo squash-merges, so the split must be by PR, not by commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -383,8 +383,16 @@ venvPath = "."
 venv = ".venv"
 extraPaths = ["src"]
 pythonVersion = "3.10"
+# Restating all three defaults is required because setting exclude replaces
+# them; omitting "**/.*" makes pyright walk .venv and every other
+# dot-directory. packages/phoenix-sqlean is a vendored fork of
+# nalgeon/sqlean.py and is not held to this repo's typing standards.
+exclude = ["**/node_modules", "**/__pycache__", "**/.*", "packages/phoenix-sqlean"]
 
 [tool.ruff]
+# Apply excludes even to files passed explicitly on the command line
+# (editor/hook integrations do this), so vendored code stays untouched.
+force-exclude = true
 exclude = [
   "api_reference",
   "dist/",
@@ -401,6 +409,9 @@ exclude = [
   ".github/**/*.md",
   "AGENTS.md",
   "CLAUDE.md",
+  # Vendored fork of nalgeon/sqlean.py — keep formatting identical to upstream
+  # so diffs against the imported source stay reviewable.
+  "packages/phoenix-sqlean",
 ]
 line-length = 100
 target-version = "py310"
@@ -441,6 +452,9 @@ override-dependencies = [
 
 [tool.uv.workspace]
 members = ["packages/*"]
+# phoenix-sqlean is a vendored setup.py-based C extension (fork of
+# nalgeon/sqlean.py), not a uv-managed project.
+exclude = ["packages/phoenix-sqlean"]
 
 [tool.uv.sources]
 arize-phoenix-client = { workspace = true }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,10 +6,17 @@
             "package-name": "arize-phoenix",
             "release-type": "python",
             "exclude-paths": [
+              ".agents",
+              ".claude",
+              ".codex",
+              ".cursor",
               ".github",
+              ".gitignore",
               ".tours",
               "api_reference",
               "docs",
+              "docs.json",
+              "evals",
               "examples",
               "internal_docs",
               "js",
@@ -32,6 +39,11 @@
         "packages/phoenix-otel": {
             "package-name": "arize-phoenix-otel",
             "release-type": "python"
+        },
+        "packages/phoenix-sqlean": {
+            "package-name": "arize-phoenix-sqlean",
+            "release-type": "python",
+            "extra-files": ["setup.py"]
         }
     }
 }


### PR DESCRIPTION
Base of the `arize-phoenix-sqlean` stack. Three non-releasable changes.

### 1. Tooling exclusions for the vendored package

Registers `packages/phoenix-sqlean` with release-please and exempts it from the repo's Python tooling. It is a fork of [nalgeon/sqlean.py](https://github.com/nalgeon/sqlean.py) kept formatted identically to upstream so diffs against the imported source stay reviewable, and it is a `setup.py`-based C extension rather than a uv-managed project. Without the exclusions ruff reports 9 files needing reformatting and 71 lint errors across the vendored tree.

Setting `[tool.pyright] exclude` **replaces** pyright's defaults, so all three are restated — omitting `**/.*` makes pyright walk `.venv` and every other dot-directory. Nothing in CI runs pyright, so that regression would surface only in editors.

### 2. A `phoenix-sqlean` skill

Covers how to bump the bundled SQLite / sqlean / xxHash pins and the gotchas: lockstep pins, the `test_windirent.h` pin that must *not* be re-synced, the MSVC patch tripwire, and why the package version must stay plain SemVer.

### 3. Release-please `exclude-paths` had gone stale

The list had not been touched since release-please moved to manifest mode in **Feb 2024**, and the repo layout moved on without it.

Measured over the last 800 commits on `main`: **19 of 407 releasable commits bumped `arize-phoenix` without changing anything that ships.**

| Path | Spurious bumps |
|---|---|
| `evals` | 10 |
| `.agents` | 7 |
| `docs.json` | 2 |
| `.gitignore` | 1 |

Adding those, plus `.claude` / `.codex` / `.cursor` (same category, same drift), takes the count to **zero** against the same 800 commits.

Left counted deliberately: `helm` and `Dockerfile`. `kustomize` is already excluded, which suggests deployment manifests are meant to be — but an image-only change may still be release-worthy. That is a policy call, not an oversight.

`app` stays counted on purpose too: it builds into the wheel's static assets, unlike `js`, which publishes to npm separately.

### Why this is a separate PR

`pyproject.toml`, `release-please-config.json`, and `.agents/` are the only paths in this stack that fall **outside** the root component's `exclude-paths`. Leaving them in #14511 would mean that PR — correctly typed `feat:` — also minor-bumps `arize-phoenix` on tooling config alone. Separating by *commit* would not work: this repo squash-merges, so the squash collapses to one commit with one type and the union of all paths.